### PR TITLE
Hotfix to Address Model Optimizing Error for Anomaly Tasks

### DIFF
--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -86,10 +86,7 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
         config (Union[DictConfig, ListConfig]): configuration file
     """
 
-    def __init__(
-        self,
-        task_environment: TaskEnvironment,
-    ) -> None:
+    def __init__(self, task_environment: TaskEnvironment) -> None:
         self.task_environment = task_environment
         self.config = self.get_config()
         self.inferencer = self.load_inferencer()

--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -121,10 +121,7 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             pred_score = anomaly_map.reshape(-1).max()
             pred_label = pred_score >= threshold
             assigned_label = self.anomalous_label if pred_label else self.normal_label
-            shape = Annotation(
-                Rectangle(x1=0, y1=0, x2=1, y2=1),
-                labels=[ScoredLabel(assigned_label, probability=float(pred_score))],
-            )
+            shape = Annotation(Rectangle(x1=0, y1=0, x2=1, y2=1), labels=[ScoredLabel(assigned_label, probability=float(pred_score))])
             dataset_item.append_annotations([shape])
 
         return dataset
@@ -151,11 +148,7 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             self.__save_weights(xml_path, self.task_environment.model.get_data("openvino.xml"))
             self.__save_weights(bin_path, self.task_environment.model.get_data("openvino.bin"))
 
-            model_config = {
-                "model_name": "openvino_model",
-                "model": xml_path,
-                "weights": bin_path,
-            }
+            model_config = {"model_name": "openvino_model", "model": xml_path, "weights": bin_path}
             model = load_model(model_config)
 
             if get_nodes_by_type(model, ["FakeQuantize"]):
@@ -183,16 +176,8 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
 
         with tempfile.TemporaryDirectory() as tempdir:
             save_model(compressed_model, tempdir, model_name="model")
-            self.__load_weights(
-                path=os.path.join(tempdir, "model.xml"),
-                output_model=output_model,
-                key="openvino.xml",
-            )
-            self.__load_weights(
-                path=os.path.join(tempdir, "model.bin"),
-                output_model=output_model,
-                key="openvino.bin",
-            )
+            self.__load_weights(path=os.path.join(tempdir, "model.xml"), output_model=output_model, key="openvino.xml")
+            self.__load_weights(path=os.path.join(tempdir, "model.bin"), output_model=output_model, key="openvino.bin")
         output_model.model_status = ModelStatus.SUCCESS
 
         self.task_environment.model = output_model

--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -31,6 +31,7 @@ from compression.graph.model_utils import compress_model_weights, get_nodes_by_t
 from compression.pipeline.initializer import create_pipeline
 from omegaconf import ListConfig
 from omegaconf.dictconfig import DictConfig
+from ote_anomalib.config import get_anomalib_config
 from ote_anomalib.data import LabelNames
 from ote_sdk.entities.annotation import Annotation
 from ote_sdk.entities.datasets import DatasetEntity

--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -89,14 +89,25 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
     def __init__(
         self,
         task_environment: TaskEnvironment,
-        config: Union[DictConfig, ListConfig],
     ) -> None:
         self.task_environment = task_environment
-        self.config = config
+        self.config = self.get_config()
         self.inferencer = self.load_inferencer()
         labels = task_environment.get_labels()
         self.normal_label = [label for label in labels if label.name == LabelNames.normal][0]
         self.anomalous_label = [label for label in labels if label.name == LabelNames.anomalous][0]
+
+    def get_config(self) -> Union[DictConfig, ListConfig]:
+        """
+        Get Anomalib Config from task environment
+
+        Returns:
+            Union[DictConfig, ListConfig]: Anomalib config
+        """
+        task_name = self.task_environment.model_template.name
+        ote_config = self.task_environment.get_hyper_parameters()
+        config = get_anomalib_config(task_name=task_name, ote_config=ote_config)
+        return config
 
     def infer(self, dataset: DatasetEntity, inference_parameters: InferenceParameters) -> DatasetEntity:
         if self.task_environment.model is None:

--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -61,7 +61,12 @@ class OTEOpenVINOAnomalyDataloader(DataLoader):
         inferencer (OpenVINOInferencer): OpenVINO Inferencer
     """
 
-    def __init__(self, config: Union[DictConfig, ListConfig], dataset: DatasetEntity, inferencer: OpenVINOInferencer):
+    def __init__(
+        self,
+        config: Union[DictConfig, ListConfig],
+        dataset: DatasetEntity,
+        inferencer: OpenVINOInferencer,
+    ):
         super().__init__(config=config)
         self.dataset = dataset
         self.inferencer = inferencer
@@ -83,7 +88,6 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
 
     Args:
         task_environment (TaskEnvironment): task environment of the trained anomaly model
-        config (Union[DictConfig, ListConfig]): configuration file
     """
 
     def __init__(self, task_environment: TaskEnvironment) -> None:
@@ -117,7 +121,8 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             pred_label = pred_score >= threshold
             assigned_label = self.anomalous_label if pred_label else self.normal_label
             shape = Annotation(
-                Rectangle(x1=0, y1=0, x2=1, y2=1), labels=[ScoredLabel(assigned_label, probability=float(pred_score))]
+                Rectangle(x1=0, y1=0, x2=1, y2=1),
+                labels=[ScoredLabel(assigned_label, probability=float(pred_score))],
             )
             dataset_item.append_annotations([shape])
 
@@ -145,7 +150,11 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             self.__save_weights(xml_path, self.task_environment.model.get_data("openvino.xml"))
             self.__save_weights(bin_path, self.task_environment.model.get_data("openvino.bin"))
 
-            model_config = {"model_name": "openvino_model", "model": xml_path, "weights": bin_path}
+            model_config = {
+                "model_name": "openvino_model",
+                "model": xml_path,
+                "weights": bin_path,
+            }
             model = load_model(model_config)
 
             if get_nodes_by_type(model, ["FakeQuantize"]):
@@ -173,8 +182,16 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
 
         with tempfile.TemporaryDirectory() as tempdir:
             save_model(compressed_model, tempdir, model_name="model")
-            self.__load_weights(path=os.path.join(tempdir, "model.xml"), output_model=output_model, key="openvino.xml")
-            self.__load_weights(path=os.path.join(tempdir, "model.bin"), output_model=output_model, key="openvino.bin")
+            self.__load_weights(
+                path=os.path.join(tempdir, "model.xml"),
+                output_model=output_model,
+                key="openvino.xml",
+            )
+            self.__load_weights(
+                path=os.path.join(tempdir, "model.bin"),
+                output_model=output_model,
+                key="openvino.bin",
+            )
         output_model.model_status = ModelStatus.SUCCESS
 
         self.task_environment.model = output_model

--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -121,7 +121,10 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             pred_score = anomaly_map.reshape(-1).max()
             pred_label = pred_score >= threshold
             assigned_label = self.anomalous_label if pred_label else self.normal_label
-            shape = Annotation(Rectangle(x1=0, y1=0, x2=1, y2=1), labels=[ScoredLabel(assigned_label, probability=float(pred_score))])
+            shape = Annotation(
+                Rectangle(x1=0, y1=0, x2=1, y2=1),
+                labels=[ScoredLabel(assigned_label, probability=float(pred_score))],
+            )
             dataset_item.append_annotations([shape])
 
         return dataset
@@ -148,7 +151,11 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             self.__save_weights(xml_path, self.task_environment.model.get_data("openvino.xml"))
             self.__save_weights(bin_path, self.task_environment.model.get_data("openvino.bin"))
 
-            model_config = {"model_name": "openvino_model", "model": xml_path, "weights": bin_path}
+            model_config = {
+                "model_name": "openvino_model",
+                "model": xml_path,
+                "weights": bin_path,
+            }
             model = load_model(model_config)
 
             if get_nodes_by_type(model, ["FakeQuantize"]):
@@ -176,8 +183,16 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
 
         with tempfile.TemporaryDirectory() as tempdir:
             save_model(compressed_model, tempdir, model_name="model")
-            self.__load_weights(path=os.path.join(tempdir, "model.xml"), output_model=output_model, key="openvino.xml")
-            self.__load_weights(path=os.path.join(tempdir, "model.bin"), output_model=output_model, key="openvino.bin")
+            self.__load_weights(
+                path=os.path.join(tempdir, "model.xml"),
+                output_model=output_model,
+                key="openvino.xml",
+            )
+            self.__load_weights(
+                path=os.path.join(tempdir, "model.bin"),
+                output_model=output_model,
+                key="openvino.bin",
+            )
         output_model.model_status = ModelStatus.SUCCESS
 
         self.task_environment.model = output_model


### PR DESCRIPTION
This is to address model optimization issues caused by an incorrect argument in the constructor of the open vino task.

# Changes
- Remove `config` from `OpenVINOAnomalyClassificationTask` constructor and use `get_anomalib_config` instead.
- Apply black -l 120

# CI
- [Link](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/20695/) to the build on BMM ✔️ 