### PR TITLE
[ANOMALY CLASSIFICATION] Set threshold for output model

### DIFF
--- a/external/anomaly/anomaly_classification/openvino.py
+++ b/external/anomaly/anomaly_classification/openvino.py
@@ -188,6 +188,7 @@ class OpenVINOAnomalyClassificationTask(IInferenceTask, IEvaluationTask, IOptimi
             self.__load_weights(path=os.path.join(tempdir, "model.bin"), output_model=output_model, key="openvino.bin")
 
         output_model.set_data("label_schema.json", label_schema_to_bytes(self.task_environment.label_schema))
+        output_model.set_data("threshold", self.task_environment.model.get_data("threshold"))
         output_model.model_status = ModelStatus.SUCCESS
 
         self.task_environment.model = output_model

--- a/external/anomaly/anomaly_classification/task.py
+++ b/external/anomaly/anomaly_classification/task.py
@@ -228,7 +228,7 @@ class AnomalyClassificationTask(ITrainingTask, IInferenceTask, IEvaluationTask, 
         with open(xml_file, "rb") as file:
             output_model.set_data("openvino.xml", file.read())
         output_model.set_data("label_schema.json", label_schema_to_bytes(self.task_environment.label_schema))
-        output_model.set_data("threshold", self.task_environment.model.get_data("threshold"))
+        output_model.set_data("threshold", bytes(struct.pack("f", self.model.threshold.item())))
 
     @staticmethod
     def _is_docker() -> bool:

--- a/external/anomaly/anomaly_classification/task.py
+++ b/external/anomaly/anomaly_classification/task.py
@@ -228,6 +228,7 @@ class AnomalyClassificationTask(ITrainingTask, IInferenceTask, IEvaluationTask, 
         with open(xml_file, "rb") as file:
             output_model.set_data("openvino.xml", file.read())
         output_model.set_data("label_schema.json", label_schema_to_bytes(self.task_environment.label_schema))
+        output_model.set_data("threshold", self.task_environment.model.get_data("threshold"))
 
     @staticmethod
     def _is_docker() -> bool:


### PR DESCRIPTION
In the anomaly classification task.py and openvino.py, the 'threshold' value was not set correctly for the output models generated after optimization. This caused inference for optimized models to fail. This PR makes sure that the threshold is set correctly on all output models.