### PR TITLE
[OTE SDK] Input validation for numeric configurable parameters

### DIFF
--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -47,6 +47,7 @@ from .utils import (
     construct_attr_value_validator,
     attr_strict_int_validator,
     attr_strict_float_converter,
+    attr_strict_float_on_setattr
 )
 
 # pylint:disable=too-many-arguments
@@ -198,6 +199,7 @@ def configurable_float(
         type=float,
         validator=construct_attr_value_validator(min_value, max_value),
         converter=attr_strict_float_converter,
+        on_setattr=attr_strict_float_on_setattr,
         metadata=metadata,
     )
 
@@ -307,6 +309,7 @@ def float_selectable(
         type=float,
         validator=construct_attr_selectable_validator(options),
         converter=attr_strict_float_converter,
+        on_setattr=attr_strict_float_on_setattr,
         metadata=metadata,
     )
 

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -45,6 +45,8 @@ from .utils import (
     construct_attr_enum_selectable_onsetattr,
     construct_attr_selectable_validator,
     construct_attr_value_validator,
+    attr_strict_int_validator,
+    attr_strict_float_converter,
 )
 
 # pylint:disable=too-many-arguments
@@ -134,7 +136,7 @@ def configurable_integer(
         default=default_value,
         type=int,
         validator=[
-            attr.validators.instance_of(int),
+            attr_strict_int_validator,
             construct_attr_value_validator(min_value, max_value),
         ],
         metadata=metadata,
@@ -195,7 +197,7 @@ def configurable_float(
         default=default_value,
         type=float,
         validator=construct_attr_value_validator(min_value, max_value),
-        converter=float,
+        converter=attr_strict_float_converter,
         metadata=metadata,
     )
 
@@ -304,7 +306,7 @@ def float_selectable(
         default=default_value,
         type=float,
         validator=construct_attr_selectable_validator(options),
-        converter=float,
+        converter=attr_strict_float_converter,
         metadata=metadata,
     )
 

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -41,13 +41,13 @@ from .metadata_keys import (
     WARNING,
 )
 from .utils import (
+    attr_strict_float_converter,
+    attr_strict_float_on_setattr,
+    attr_strict_int_validator,
     construct_attr_enum_selectable_converter,
     construct_attr_enum_selectable_onsetattr,
     construct_attr_selectable_validator,
     construct_attr_value_validator,
-    attr_strict_int_validator,
-    attr_strict_float_converter,
-    attr_strict_float_on_setattr
 )
 
 # pylint:disable=too-many-arguments

--- a/ote_sdk/ote_sdk/configuration/elements/utils.py
+++ b/ote_sdk/ote_sdk/configuration/elements/utils.py
@@ -200,6 +200,46 @@ def attr_strict_int_validator(
         )
 
 
+def _validate_and_convert_float(value: float) -> Optional[float]:
+    """
+    Validate that a value is a float, or a number that can be converted to a float.
+    If the value is valid, this method will return the value as float. Otherwise, this
+    method returns None
+
+    :param value: Value to validate and convert
+    :return: Value as float if value is valid, None otherwise
+    """
+    valid = True
+    if not (isinstance(value, float) or isinstance(value, int)):
+        valid = False
+    if isinstance(value, bool):
+        valid = False
+    if valid:
+        return float(value)
+    return None
+
+
+def attr_strict_float_on_setattr(
+        instance: ParameterGroup, attribute: Attribute, value: float
+) -> float:
+    """
+    Validate that the value set for an attribute is a float, or a number that can be
+    converted to a float
+
+    :param instance: ParameterGroup to which the attribute belongs
+    :param attribute: Attribute for which to validate the value
+    :param value: Value to validate
+    :raises TypeError: if the value passed to the validator is not a float or number
+    """
+    float_value = _validate_and_convert_float(value)
+    if float_value is None:
+        raise TypeError(
+            f"Invalid argument type for {attribute.name}: {value} is not of type "
+            f"'float'"
+        )
+    return float_value
+
+
 def attr_strict_float_converter(value: float) -> float:
     """
     Converts a value to float.
@@ -208,8 +248,10 @@ def attr_strict_float_converter(value: float) -> float:
     :raises TypeError: if value cannot be converted to float
     :return: Value as float
     """
-    if isinstance(value, bool):
+    float_value = _validate_and_convert_float(value)
+    if float_value is None:
         raise TypeError(
-            f"Passing boolean values is not supported for numeric parameters."
+            f"Invalid value passed for parameter. Value {value} of type {type(value)} "
+            f"is not a float."
         )
-    return float(value)
+    return float_value

--- a/ote_sdk/ote_sdk/configuration/elements/utils.py
+++ b/ote_sdk/ote_sdk/configuration/elements/utils.py
@@ -183,9 +183,9 @@ def convert_string_to_id(id_string: Optional[Union[str, ID]]) -> ID:
 
 
 def attr_strict_int_validator(
-        instance: ParameterGroup,  # pylint: disable=unused-argument
-        attribute: Attribute,
-        value: int
+    instance: ParameterGroup,  # pylint: disable=unused-argument
+    attribute: Attribute,
+    value: int,
 ) -> None:
     """
     Validates that the value set for an attribute is an integer.
@@ -222,9 +222,9 @@ def _validate_and_convert_float(value: float) -> Optional[float]:
 
 
 def attr_strict_float_on_setattr(
-        instance: ParameterGroup,  # pylint: disable=unused-argument
-        attribute: Attribute,
-        value: float
+    instance: ParameterGroup,  # pylint: disable=unused-argument
+    attribute: Attribute,
+    value: float,
 ) -> float:
     """
     Validate that the value set for an attribute is a float, or a number that can be

--- a/ote_sdk/ote_sdk/configuration/elements/utils.py
+++ b/ote_sdk/ote_sdk/configuration/elements/utils.py
@@ -180,3 +180,36 @@ def convert_string_to_id(id_string: Optional[Union[str, ID]]) -> ID:
     else:
         output_id = id_string
     return output_id
+
+
+def attr_strict_int_validator(
+        instance: ParameterGroup, attribute: Attribute, value: int
+) -> None:  # pylint: disable=unused-argument
+    """
+    Validates that the value set for an attribute is an integer.
+
+    :param instance: ParameterGroup to which the attribute belongs
+    :param attribute: Attribute for which to validate the value
+    :param value: Value to validate
+    :raises TypeError: if the value passed to the validator is not an integer
+    """
+    is_strict_int = isinstance(value, int) and not isinstance(value, bool)
+    if not is_strict_int:
+        raise TypeError(
+            f"Invalid argument type for {attribute.name}: {value} is not of type 'int'"
+        )
+
+
+def attr_strict_float_converter(value: float) -> float:
+    """
+    Converts a value to float.
+
+    :param value: value to convert
+    :raises TypeError: if value cannot be converted to float
+    :return: Value as float
+    """
+    if isinstance(value, bool):
+        raise TypeError(
+            f"Passing boolean values is not supported for numeric parameters."
+        )
+    return float(value)

--- a/ote_sdk/ote_sdk/configuration/elements/utils.py
+++ b/ote_sdk/ote_sdk/configuration/elements/utils.py
@@ -183,8 +183,10 @@ def convert_string_to_id(id_string: Optional[Union[str, ID]]) -> ID:
 
 
 def attr_strict_int_validator(
-        instance: ParameterGroup, attribute: Attribute, value: int
-) -> None:  # pylint: disable=unused-argument
+        instance: ParameterGroup,  # pylint: disable=unused-argument
+        attribute: Attribute,
+        value: int
+) -> None:
     """
     Validates that the value set for an attribute is an integer.
 
@@ -210,7 +212,7 @@ def _validate_and_convert_float(value: float) -> Optional[float]:
     :return: Value as float if value is valid, None otherwise
     """
     valid = True
-    if not (isinstance(value, float) or isinstance(value, int)):
+    if not isinstance(value, (float, int)):
         valid = False
     if isinstance(value, bool):
         valid = False
@@ -220,7 +222,9 @@ def _validate_and_convert_float(value: float) -> Optional[float]:
 
 
 def attr_strict_float_on_setattr(
-        instance: ParameterGroup, attribute: Attribute, value: float
+        instance: ParameterGroup,  # pylint: disable=unused-argument
+        attribute: Attribute,
+        value: float
 ) -> float:
     """
     Validate that the value set for an attribute is a float, or a number that can be


### PR DESCRIPTION
This PR enables strict input validation for numeric configurable parameters, to make sure that only values of the proper type can be set.

I have built the SC platform with this change, all tests passed:

- SC build test results: http://validationreports.sclab.intel.com:8004/reports/build_number_report?test_session_build_number=IMPTOps-21501&environment=ljcornel_config_validation


This PR addresses the following ticket: https://jira.devtools.intel.com/browse/CVS-71717