### PR TITLE
[OTE_SDK_TEST_SUITE] Changes due adding deep-object-reid training tests

### DIFF
--- a/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
+++ b/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
@@ -19,10 +19,7 @@ from ote_sdk.entities.model import (
     ModelOptimizationType,
     ModelStatus,
 )
-from ote_sdk.ote_sdk.utils.importing import (
-    get_task_class,
-    is_nncf_enabled,
-)
+from ote_sdk.ote_sdk.utils.importing import get_impl_class
 from ote_sdk.entities.model_template import parse_model_template
 from ote_sdk.entities.optimization_parameters import OptimizationParameters
 from ote_sdk.entities.resultset import ResultSetEntity
@@ -103,7 +100,7 @@ class OTETestTrainingAction(BaseOTETestAction):
         )
         logger.info("Create base Task")
         task_impl_path = model_template.entrypoints.base
-        task_cls = get_task_class(task_impl_path)
+        task_cls = get_impl_class(task_impl_path)
         task = task_cls(task_environment=environment)
         return environment, task
 
@@ -188,6 +185,8 @@ class OTETestTrainingAction(BaseOTETestAction):
         }
         return results
 
+def is_nncf_enabled():
+    return importlib.util.find_spec('nncf') is not None
 
 def run_evaluation(dataset, task, model):
     logger.debug("Evaluation: Get predictions on the dataset")
@@ -308,7 +307,7 @@ class OTETestExportAction(BaseOTETestAction):
 def create_openvino_task(model_template, environment):
     logger.debug("Create OpenVINO Task")
     openvino_task_impl_path = model_template.entrypoints.openvino
-    openvino_task_cls = get_task_class(openvino_task_impl_path)
+    openvino_task_cls = get_impl_class(openvino_task_impl_path)
     openvino_task = openvino_task_cls(environment)
     return openvino_task
 
@@ -478,7 +477,7 @@ class OTETestNNCFAction(BaseOTETestAction):
 
         self.environment_for_nncf.model = self.nncf_model
 
-        nncf_task_cls = get_task_class(nncf_task_class_impl_path)
+        nncf_task_cls = get_impl_class(nncf_task_class_impl_path)
         self.nncf_task = nncf_task_cls(task_environment=self.environment_for_nncf)
 
         logger.info("Run NNCF optimization")

--- a/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
+++ b/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
@@ -19,7 +19,6 @@ from ote_sdk.entities.model import (
     ModelOptimizationType,
     ModelStatus,
 )
-from ote_sdk.utils.importing import get_impl_class
 from ote_sdk.entities.model_template import parse_model_template
 from ote_sdk.entities.optimization_parameters import OptimizationParameters
 from ote_sdk.entities.resultset import ResultSetEntity
@@ -27,6 +26,7 @@ from ote_sdk.entities.subset import Subset
 from ote_sdk.entities.task_environment import TaskEnvironment
 from ote_sdk.usecases.tasks.interfaces.export_interface import ExportType
 from ote_sdk.usecases.tasks.interfaces.optimization_interface import OptimizationType
+from ote_sdk.utils.importing import get_impl_class
 
 from .e2e_test_system import DataCollector
 from .training_tests_common import (
@@ -185,8 +185,10 @@ class OTETestTrainingAction(BaseOTETestAction):
         }
         return results
 
+
 def is_nncf_enabled():
-    return importlib.util.find_spec('nncf') is not None
+    return importlib.util.find_spec("nncf") is not None
+
 
 def run_evaluation(dataset, task, model):
     logger.debug("Evaluation: Get predictions on the dataset")
@@ -481,9 +483,7 @@ class OTETestNNCFAction(BaseOTETestAction):
         self.nncf_task = nncf_task_cls(task_environment=self.environment_for_nncf)
 
         logger.info("Run NNCF optimization")
-        self.nncf_task.optimize(
-            OptimizationType.NNCF, dataset, self.nncf_model, None
-        )
+        self.nncf_task.optimize(OptimizationType.NNCF, dataset, self.nncf_model, None)
         assert (
             self.nncf_model.model_status == ModelStatus.SUCCESS
         ), "NNCF optimization was not successful"

--- a/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
+++ b/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
@@ -19,7 +19,7 @@ from ote_sdk.entities.model import (
     ModelOptimizationType,
     ModelStatus,
 )
-from ote_sdk.ote_sdk.utils.importing import get_impl_class
+from ote_sdk.utils.importing import get_impl_class
 from ote_sdk.entities.model_template import parse_model_template
 from ote_sdk.entities.optimization_parameters import OptimizationParameters
 from ote_sdk.entities.resultset import ResultSetEntity

--- a/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
+++ b/ote_sdk/ote_sdk/test_suite/training_tests_actions.py
@@ -19,6 +19,10 @@ from ote_sdk.entities.model import (
     ModelOptimizationType,
     ModelStatus,
 )
+from ote_sdk.ote_sdk.utils.importing import (
+    get_task_class,
+    is_nncf_enabled,
+)
 from ote_sdk.entities.model_template import parse_model_template
 from ote_sdk.entities.optimization_parameters import OptimizationParameters
 from ote_sdk.entities.resultset import ResultSetEntity
@@ -309,16 +313,6 @@ def create_openvino_task(model_template, environment):
     return openvino_task
 
 
-def get_task_class(path):
-    module_name, class_name = path.rsplit('.', 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
-
-
-def is_nncf_enabled():
-    return importlib.util.find_spec('nncf') is not None
-
-
 class OTETestExportEvaluationAction(BaseOTETestAction):
     _name = "export_evaluation"
     _with_validation = True
@@ -399,10 +393,8 @@ class OTETestPotAction(BaseOTETestAction):
         assert (
             self.optimized_model_pot.model_format == ModelFormat.OPENVINO
         ), "Wrong model format after pot"
-        #TO DO: Model.OptimizationType is "int enum" class, and OptimizationType is "enum",
-        #  that why wee need to use here same classes. Submitted issue CVS-74657
         assert (
-            self.optimized_model_pot.optimization_type == OptimizationType.POT
+            self.optimized_model_pot.optimization_type == ModelOptimizationType.POT
         ), "Wrong optimization type"
         logger.info("POT optimization is finished")
 
@@ -491,7 +483,7 @@ class OTETestNNCFAction(BaseOTETestAction):
 
         logger.info("Run NNCF optimization")
         self.nncf_task.optimize(
-        OptimizationType.NNCF, dataset, self.nncf_model, None
+            OptimizationType.NNCF, dataset, self.nncf_model, None
         )
         assert (
             self.nncf_model.model_status == ModelStatus.SUCCESS

--- a/ote_sdk/ote_sdk/test_suite/training_tests_common.py
+++ b/ote_sdk/ote_sdk/test_suite/training_tests_common.py
@@ -16,7 +16,7 @@ DEFAULT_FIELD_VALUE_FOR_USING_IN_TEST = "DEFAULT_FIELD_VALUE_FOR_USING_IN_TEST"
 # This string constant will be used as a special constant for a config field value to point
 # that the field should NOT be changed in tests -- its value should be taken
 # from the template file or the config file of the model.
-KEEP_CONFIG_FIELD_VALUE = "KEEP_CONFIG_FIELD_VALUE"
+KEEP_CONFIG_FIELD_VALUE = "CONFIG"
 
 
 # This is a constant for pointing usecase for reallife training tests

--- a/ote_sdk/ote_sdk/utils/importing.py
+++ b/ote_sdk/ote_sdk/utils/importing.py
@@ -1,0 +1,38 @@
+"""
+Utils for dynamically importing stuff
+"""
+
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+
+import importlib
+
+
+def get_impl_class(impl_path):
+    """Returns a class by its path in package."""
+
+    task_impl_module_name, task_impl_class_name = impl_path.rsplit(".", 1)
+    task_impl_module = importlib.import_module(task_impl_module_name)
+    task_impl_class = getattr(task_impl_module, task_impl_class_name)
+
+    return task_impl_class
+
+def get_task_class(path):
+    module_name, class_name = path.rsplit('.', 1)
+    module = importlib.import_module(module_name)
+    return getattr(module, class_name)
+
+def is_nncf_enabled():
+    return importlib.util.find_spec('nncf') is not None

--- a/ote_sdk/ote_sdk/utils/importing.py
+++ b/ote_sdk/ote_sdk/utils/importing.py
@@ -28,11 +28,3 @@ def get_impl_class(impl_path):
     task_impl_class = getattr(task_impl_module, task_impl_class_name)
 
     return task_impl_class
-
-def get_task_class(path):
-    module_name, class_name = path.rsplit('.', 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, class_name)
-
-def is_nncf_enabled():
-    return importlib.util.find_spec('nncf') is not None


### PR DESCRIPTION
Changes due adding Real-life training tests for Deep-Object_REID.
Please see job 425 - EfficinetNet-B0 on LG-chem dataset.
This PR depends on https://github.com/openvinotoolkit/deep-object-reid/pull/131 PR in Deep-Object_REID.
Changed KEEP_CONFIG_FIELD_VALUE, need update mmdetection real-life tests (in progress)