### PR TITLE
[ANOMALY CLASSIFICATION] Improve anomalib-OTE integration workflow

### DIFF
--- a/external/anomaly/requirements.txt
+++ b/external/anomaly/requirements.txt
@@ -1,4 +1,4 @@
-anomalib @ git+https://github.com/openvinotoolkit/anomalib.git@v0.2.2
+anomalib @ git+https://github.com/openvinotoolkit/anomalib.git@f2d230aa8362b6e91109295355f91b1488ecb50b
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 openvino==2021.4.2
 openvino-dev==2021.4.2

--- a/external/anomaly/requirements.txt
+++ b/external/anomaly/requirements.txt
@@ -1,4 +1,4 @@
-anomalib==0.2.2
+anomalib @ git+https://github.com/openvinotoolkit/anomalib.git@v0.2.2
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 openvino==2021.4.2
 openvino-dev==2021.4.2

--- a/external/anomaly/setup.py
+++ b/external/anomaly/setup.py
@@ -36,7 +36,7 @@ def get_requirements() -> List[str]:
 
 setup(
     name="anomaly_classification",
-    version="ote_alpha",
+    version="ote-alpha",
     packages=find_packages(
         include=["anomaly_classification", "anomaly_classification.*", "ote_anomalib", "ote_anomalib.*"]
     ),

--- a/external/anomaly/setup.py
+++ b/external/anomaly/setup.py
@@ -18,7 +18,6 @@ Install anomalib wrapper for OTE
 
 from typing import List
 
-import anomalib
 from setuptools import find_packages, setup
 
 
@@ -37,7 +36,7 @@ def get_requirements() -> List[str]:
 
 setup(
     name="anomaly_classification",
-    version=anomalib.__version__,
+    version="ote_alpha",
     packages=find_packages(
         include=["anomaly_classification", "anomaly_classification.*", "ote_anomalib", "ote_anomalib.*"]
     ),


### PR DESCRIPTION
This PR improves the workflow of Anomalib-OTE integration. 

To make sure that the versions match, this PR should be merged at the same time as the corresponding PR on the IMPT repo: https://gitlab.devtools.intel.com/vmc-eip/IMPT/impt/-/merge_requests/4785.

- Change version of anomaly classification task to `ote-alpha`, to keep it constant until a stable version.
- anomalib will be pulled from a github commit instead of pypi. This way we don't have to wait for the platform team to update their pypi if we want to test our changes in the UI.

# BMM
This is the [link](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/22133/) to the BMM build, 💯