### PR TITLE
[OTE_CLI] hpopt version changed.

### DIFF
--- a/ote_cli/requirements.txt
+++ b/ote_cli/requirements.txt
@@ -4,4 +4,4 @@ numpy
 nbmake
 pytest
 pytest-ordering
-hpopt@git+https://github.com/openvinotoolkit/hyper_parameter_optimization@07b94fe
+hpopt@git+https://github.com/openvinotoolkit/hyper_parameter_optimization@v0.1.0


### PR DESCRIPTION
1. hpopt version is tagged as v0.1.0

2. super.__init__() call is removed in HpoCallback