### PR TITLE
[OTE_SDK] Default hotkey for empty label

### DIFF
--- a/ote_sdk/ote_sdk/entities/label.py
+++ b/ote_sdk/ote_sdk/entities/label.py
@@ -100,8 +100,6 @@ class LabelEntity:
         id = ID() if id is None else id
         color = Color.random() if color is None else color
         creation_date = now() if creation_date is None else creation_date
-        if not hotkey and is_empty:
-            hotkey = "ctrl+0"
 
         self._name = name
         self._color = color

--- a/ote_sdk/ote_sdk/tests/entities/test_annotation.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_annotation.py
@@ -188,7 +188,7 @@ class TestAnnotation:
         assert "color=Color(red=16, green=15," in str(
             annotation.get_labels(include_empty=True)
         )
-        assert "blue=56, alpha=255), hotkey=ctrl+0)," in str(
+        assert "blue=56, alpha=255), hotkey=)," in str(
             annotation.get_labels(include_empty=True)
         )
 

--- a/ote_sdk/ote_sdk/tests/entities/test_label.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_label.py
@@ -154,7 +154,7 @@ class TestLabelEntity:
         2. Check the processing of default values
         """
 
-        assert self.empty.hotkey == "ctrl+0"
+        assert self.empty.hotkey == ""
         assert self.empty.id == ID()
         assert type(self.empty.color) == Color
 

--- a/ote_sdk/ote_sdk/tests/entities/test_scored_label.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_scored_label.py
@@ -39,10 +39,10 @@ class TestScoredLabel:
         Test passes if the results match
         """
         car = LabelEntity(
-            id=ID(123456789), name="car", domain=Domain.DETECTION, is_empty=True
+            id=ID(123456789), name="car", domain=Domain.DETECTION, is_empty=False
         )
         person = LabelEntity(
-            id=ID(987654321), name="person", domain=Domain.DETECTION, is_empty=True
+            id=ID(987654321), name="person", domain=Domain.DETECTION, is_empty=False
         )
         car_label = ScoredLabel(car)
         person_label = ScoredLabel(person)
@@ -68,6 +68,6 @@ class TestScoredLabel:
             "ScoredLabel(123456789, name=car, probability=0.4, domain=DETECTION, color="
             in repr(car_label)
         )
-        assert "Color(red=16, green=15, blue=56, alpha=255), hotkey=ctrl+0)" in repr(
+        assert "Color(red=16, green=15, blue=56, alpha=255), hotkey=)" in repr(
             car_label
         )

--- a/ote_sdk/ote_sdk/tests/entities/test_task_environment.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_task_environment.py
@@ -49,10 +49,10 @@ def environment():
     Return TaskEnvironment
     """
     car = LabelEntity(
-        id=ID(123456789), name="car", domain=Domain.DETECTION, is_empty=True
+        id=ID(123456789), name="car", domain=Domain.DETECTION, is_empty=False
     )
     person = LabelEntity(
-        id=ID(987654321), name="person", domain=Domain.DETECTION, is_empty=True
+        id=ID(987654321), name="person", domain=Domain.DETECTION, is_empty=False
     )
     labels_list = [car, person]
     dummy_template = __get_path_to_file("./dummy_template.yaml")
@@ -101,7 +101,7 @@ class TestTaskEnvironment:
         )
         assert isinstance(env, TaskEnvironment)
         assert env != "Fail params"
-        assert env.get_labels() == []
+        assert len(env.get_labels()) == 2
 
         for i in ["header", "description", "visible_in_ui"]:
             assert (
@@ -123,12 +123,11 @@ class TestTaskEnvironment:
         assert "name=from_label_list" in repr(env)
         assert "group_type=LabelGroupType.EXCLUSIVE" in repr(env)
         assert (
-            "labels=[LabelEntity(123456789, name=car, hotkey=ctrl+0, domain=DETECTION"
+            "labels=[LabelEntity(123456789, name=car, hotkey=, domain=DETECTION"
             in repr(env)
         )
-        assert (
-            "LabelEntity(987654321, name=person, hotkey=ctrl+0, domain=DETECTION"
-            in repr(env)
+        assert "LabelEntity(987654321, name=person, hotkey=, domain=DETECTION" in repr(
+            env
         )
         assert (
             "CONFIGURABLE_PARAMETERS(header='Configuration for an object detection task -- TEST ONLY'"


### PR DESCRIPTION
In the task chain scenario there is more than one empty label and they can't use the same hotkey, so remove the default value.