### PR TITLE
[OTE_SDK_TESTS] Increase code coverage dice.py, config_element_type.py, label_mapper.py, visualization.py, prediction_to_annotation_converter.py

### DIFF
--- a/ote_sdk/ote_sdk/tests/configuration/enums/test_config_element_type.py
+++ b/ote_sdk/ote_sdk/tests/configuration/enums/test_config_element_type.py
@@ -1,16 +1,6 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
 
 import pytest
 

--- a/ote_sdk/ote_sdk/tests/configuration/enums/test_config_element_type.py
+++ b/ote_sdk/ote_sdk/tests/configuration/enums/test_config_element_type.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import pytest
+
+from ote_sdk.configuration.enums.config_element_type import (
+    ConfigElementType,
+    ElementCategory,
+)
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestElementCategory:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_element_category(self):
+        """
+        <b>Description:</b>
+        Check "ElementCategory" Enum class elements
+
+        <b>Expected results:</b>
+        Test passes if "ElementCategory" Enum class length is equal to expected value and its elements have expected
+        sequence numbers, "name" attributes and values returned by __str__ method
+        """
+        assert len(ElementCategory) == 3
+        assert ElementCategory.PRIMITIVES.value == 1
+        assert ElementCategory.PRIMITIVES.name == "PRIMITIVES"
+        assert str(ElementCategory.PRIMITIVES) == "PRIMITIVES"
+        assert ElementCategory.GROUPS.value == 2
+        assert ElementCategory.GROUPS.name == "GROUPS"
+        assert str(ElementCategory.GROUPS) == "GROUPS"
+        assert ElementCategory.RULES.value == 3
+        assert ElementCategory.RULES.name == "RULES"
+        assert str(ElementCategory.RULES) == "RULES"
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestConfigElementType:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_element_category(self):
+        """
+        <b>Description:</b>
+        Check "ConfigElementType" Enum class elements
+
+        <b>Expected results:</b>
+        Test passes if "ConfigElementType" Enum class length is equal to expected value and its elements have expected
+        sequence numbers, "names" attributes, "category" properties and values returned by and __str__ method
+        """
+        assert len(ConfigElementType) == 9
+        # Checking "INTEGER" element
+        assert ConfigElementType.INTEGER.category == ElementCategory.PRIMITIVES
+        assert ConfigElementType.INTEGER.name == "INTEGER"
+        assert ConfigElementType.INTEGER.value == 0
+        assert str(ConfigElementType.INTEGER) == "INTEGER"
+        # Checking "FLOAT" element
+        assert ConfigElementType.FLOAT.category == ElementCategory.PRIMITIVES
+        assert ConfigElementType.FLOAT.name == "FLOAT"
+        assert ConfigElementType.FLOAT.value == 1
+        assert str(ConfigElementType.FLOAT) == "FLOAT"
+        # Checking "BOOLEAN" element
+        assert ConfigElementType.BOOLEAN.category == ElementCategory.PRIMITIVES
+        assert ConfigElementType.BOOLEAN.name == "BOOLEAN"
+        assert ConfigElementType.BOOLEAN.value == 2
+        assert str(ConfigElementType.BOOLEAN) == "BOOLEAN"
+        # Checking "FLOAT_SELECTABLE" element
+        assert ConfigElementType.FLOAT_SELECTABLE.category == ElementCategory.PRIMITIVES
+        assert ConfigElementType.FLOAT_SELECTABLE.name == "FLOAT_SELECTABLE"
+        assert ConfigElementType.FLOAT_SELECTABLE.value == 3
+        assert str(ConfigElementType.FLOAT_SELECTABLE) == "FLOAT_SELECTABLE"
+        # Checking "SELECTABLE" element
+        assert ConfigElementType.SELECTABLE.category == ElementCategory.PRIMITIVES
+        assert ConfigElementType.SELECTABLE.name == "SELECTABLE"
+        assert ConfigElementType.SELECTABLE.value == 4
+        assert str(ConfigElementType.SELECTABLE) == "SELECTABLE"
+        # Checking "PARAMETER_GROUP" element
+        assert ConfigElementType.PARAMETER_GROUP.category == ElementCategory.GROUPS
+        assert ConfigElementType.PARAMETER_GROUP.name == "PARAMETER_GROUP"
+        assert ConfigElementType.PARAMETER_GROUP.value == 5
+        assert str(ConfigElementType.PARAMETER_GROUP) == "PARAMETER_GROUP"
+        # Checking "CONFIGURABLE_PARAMETERS" element
+        assert (
+            ConfigElementType.CONFIGURABLE_PARAMETERS.category == ElementCategory.GROUPS
+        )
+        assert (
+            ConfigElementType.CONFIGURABLE_PARAMETERS.name == "CONFIGURABLE_PARAMETERS"
+        )
+        assert ConfigElementType.CONFIGURABLE_PARAMETERS.value == 6
+        assert (
+            str(ConfigElementType.CONFIGURABLE_PARAMETERS) == "CONFIGURABLE_PARAMETERS"
+        )
+        # Checking "RULE" element
+        assert ConfigElementType.RULE.category == ElementCategory.RULES
+        assert ConfigElementType.RULE.name == "RULE"
+        assert ConfigElementType.RULE.value == 7
+        assert str(ConfigElementType.RULE) == "RULE"
+        # Checking "RULE" element
+        assert ConfigElementType.UI_RULES.category == ElementCategory.RULES
+        assert ConfigElementType.UI_RULES.name == "UI_RULES"
+        assert ConfigElementType.UI_RULES.value == 8
+        assert str(ConfigElementType.UI_RULES) == "UI_RULES"

--- a/ote_sdk/ote_sdk/tests/requirements.txt
+++ b/ote_sdk/ote_sdk/tests/requirements.txt
@@ -5,3 +5,4 @@ pylint==2.7.3
 pytest==6.2.*
 pytest-cov==2.11.*
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
+openvino==2021.4.2

--- a/ote_sdk/ote_sdk/tests/requirements.txt
+++ b/ote_sdk/ote_sdk/tests/requirements.txt
@@ -4,3 +4,4 @@ mypy==0.812
 pylint==2.7.3
 pytest==6.2.*
 pytest-cov==2.11.*
+openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python

--- a/ote_sdk/ote_sdk/tests/serialization/test_label_mapper.py
+++ b/ote_sdk/ote_sdk/tests/serialization/test_label_mapper.py
@@ -124,7 +124,7 @@ class TestLabelSchemaEntityMapper:
                 name=name,
                 domain=Domain.CLASSIFICATION,
                 creation_date=cur_date,
-                id=ID(str(i)),
+                id=ID(i),
                 color=colors[i],
             )
             for i, name in enumerate(names)

--- a/ote_sdk/ote_sdk/tests/serialization/test_label_mapper.py
+++ b/ote_sdk/ote_sdk/tests/serialization/test_label_mapper.py
@@ -15,18 +15,28 @@
 #
 
 
+import json
 from random import randint
 
 import pytest
 
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import Color, Domain, LabelEntity
-from ote_sdk.entities.label_schema import LabelSchemaEntity
+from ote_sdk.entities.label_schema import (
+    LabelGraph,
+    LabelGroup,
+    LabelGroupType,
+    LabelSchemaEntity,
+    LabelTree,
+)
 from ote_sdk.serialization.datetime_mapper import DatetimeMapper
 from ote_sdk.serialization.label_mapper import (
     ColorMapper,
+    LabelGraphMapper,
+    LabelGroupMapper,
     LabelMapper,
     LabelSchemaMapper,
+    label_schema_to_bytes,
 )
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
 from ote_sdk.tests.constants.requirements import Requirements
@@ -125,13 +135,13 @@ class TestLabelSchemaEntityMapper:
                 name=name,
                 domain=Domain.CLASSIFICATION,
                 creation_date=cur_date,
-                id=ID(i),
+                id=ID(str(i)),
                 color=colors[i],
             )
             for i, name in enumerate(names)
         ]
-        label_shema = LabelSchemaEntity.from_labels(labels)
-        serialized = LabelSchemaMapper.forward(label_shema)
+        label_schema = LabelSchemaEntity.from_labels(labels)
+        serialized = LabelSchemaMapper.forward(label_schema)
 
         assert serialized == {
             "label_tree": {"type": "tree", "directed": True, "nodes": [], "edges": []},
@@ -143,7 +153,7 @@ class TestLabelSchemaEntityMapper:
             },
             "label_groups": [
                 {
-                    "_id": label_shema.get_groups()[0].id,
+                    "_id": label_schema.get_groups()[0].id,
                     "name": "from_label_list",
                     "label_ids": ["0", "1", "2"],
                     "relation_type": "EXCLUSIVE",
@@ -181,4 +191,209 @@ class TestLabelSchemaEntityMapper:
         }
 
         deserialized = LabelSchemaMapper.backward(serialized)
-        assert label_shema == deserialized
+        assert label_schema == deserialized
+
+        # Checking value returned by "label_schema_to_bytes" function
+        expected_label_schema_to_bytes = json.dumps(serialized, indent=4).encode()
+        actual_label_schema_to_bytes = label_schema_to_bytes(label_schema)
+        assert actual_label_schema_to_bytes == expected_label_schema_to_bytes
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestLabelGroupMapper:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_label_group_serialization(self):
+        """
+        This test serializes flat LabelGroup and checks serialized representation.
+        Then it compares deserialized LabelGroup with original one.
+        """
+
+        names = ["cat", "dog", "mouse"]
+        labels = [
+            LabelEntity(
+                name=name,
+                domain=Domain.CLASSIFICATION,
+                id=ID(str(i)),
+            )
+            for i, name in enumerate(names)
+        ]
+        label_group = LabelGroup(
+            name="Test LabelGroup", labels=labels, group_type=LabelGroupType.EMPTY_LABEL
+        )
+        serialized = LabelGroupMapper.forward(label_group)
+        assert serialized == {
+            "_id": label_group.id,
+            "name": "Test LabelGroup",
+            "label_ids": ["0", "1", "2"],
+            "relation_type": "EMPTY_LABEL",
+        }
+        all_labels = {ID(str(i)): labels[i] for i in range(3)}
+
+        deserialized = LabelGroupMapper.backward(
+            instance=serialized, all_labels=all_labels
+        )
+        assert deserialized == label_group
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestLabelGraphMapper:
+    label_0 = LabelEntity(name="label_0", domain=Domain.SEGMENTATION, id=ID("0"))
+    label_0_1 = LabelEntity(name="label_0_1", domain=Domain.SEGMENTATION, id=ID("0_1"))
+    label_0_2 = LabelEntity(name="label_0_2", domain=Domain.SEGMENTATION, id=ID("0_2"))
+    label_0_1_1 = LabelEntity(
+        name="label_0_1_1", domain=Domain.SEGMENTATION, id=ID("0_1_1")
+    )
+    label_0_1_2 = LabelEntity(
+        name="label_0_1_2", domain=Domain.SEGMENTATION, id=ID("0_1_2")
+    )
+    label_0_2_1 = LabelEntity(
+        name="label_0_2_1", domain=Domain.SEGMENTATION, id=ID("0_2_1")
+    )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_label_graph_forward(self):
+        """
+        <b>Description:</b>
+        Check "LabelGraphMapper" class "forward" method
+
+        <b>Input data:</b>
+        "LabelGraph" and "LabelTree" objects
+
+        <b>Expected results:</b>
+        Test passes if dictionary returned by "forward" method is equal to expected
+
+        <b>Steps</b>
+        1. Check dictionary returned by "forward" method for "LabelGraph" object
+        2. Check dictionary returned by "forward" method for "LabelTree" object
+        """
+        # Checking dictionary returned by "forward" for "LabelGraph"
+        label_graph = LabelGraph(directed=False)
+        label_graph.add_edges(
+            [
+                (self.label_0, self.label_0_1),
+                (self.label_0, self.label_0_2),
+                (self.label_0_1, self.label_0_1_1),
+                (self.label_0_1, self.label_0_1_2),
+                (self.label_0_1_1, self.label_0_1_2),
+            ]
+        )
+        forward = LabelGraphMapper.forward(label_graph)
+        assert forward == {
+            "type": "graph",
+            "directed": False,
+            "nodes": ["0", "0_1", "0_2", "0_1_1", "0_1_2"],
+            "edges": [
+                ("0", "0_1"),
+                ("0", "0_2"),
+                ("0_1", "0_1_1"),
+                ("0_1", "0_1_2"),
+                ("0_1_1", "0_1_2"),
+            ],
+        }
+        # Checking dictionary returned by "forward" for "LabelTree"
+        label_tree = LabelTree()
+        for parent, child in [
+            (self.label_0, self.label_0_1),
+            (self.label_0, self.label_0_2),
+            (self.label_0_1, self.label_0_1_1),
+            (self.label_0_1, self.label_0_1_2),
+            (self.label_0_2, self.label_0_2_1),
+        ]:
+            label_tree.add_child(parent, child)
+        forward = LabelGraphMapper.forward(label_tree)
+        assert forward == {
+            "type": "tree",
+            "directed": True,
+            "nodes": ["0_1", "0", "0_2", "0_1_1", "0_1_2", "0_2_1"],
+            "edges": [
+                ("0_1", "0"),
+                ("0_2", "0"),
+                ("0_1_1", "0_1"),
+                ("0_1_2", "0_1"),
+                ("0_2_1", "0_2"),
+            ],
+        }
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_label_graph_backward(self):
+        """
+        <b>Description:</b>
+        Check "LabelGraphMapper" class "backward" method
+
+        <b>Input data:</b>
+        Dictionary object to deserialize, labels list
+
+        <b>Expected results:</b>
+        Test passes if "LabelGraph" or "LabelTree" object returned by "backward" method is equal to expected
+
+        <b>Steps</b>
+        1. Check dictionary returned by "backward" method for "LabelGraph" object
+        2. Check dictionary returned by "backward" method for "LabelTree" object
+        3. Check that "ValueError" exception is raised when unsupported type is specified as "type" key in dictionary
+        object of "instance" parameter for "backward" method
+        """
+        # Checking dictionary returned by "backward" for "LabelGraph"
+        forward = {
+            "type": "graph",
+            "directed": False,
+            "nodes": ["0", "0_1", "0_2", "0_1_1"],
+            "edges": [("0", "0_1"), ("0", "0_2"), ("0_1", "0_1_1"), ("0_1_1", "0_2")],
+        }
+        labels = {
+            ID("0"): self.label_0,
+            ID("0_1"): self.label_0_1,
+            ID("0_2"): self.label_0_2,
+            ID("0_1_1"): self.label_0_1_1,
+        }
+        expected_backward = LabelGraph(directed=False)
+        expected_backward.add_edges(
+            [
+                (self.label_0, self.label_0_1),
+                (self.label_0, self.label_0_2),
+                (self.label_0_1, self.label_0_1_1),
+                (self.label_0_1_1, self.label_0_2),
+            ]
+        )
+        actual_backward = LabelGraphMapper.backward(instance=forward, all_labels=labels)
+        assert actual_backward == expected_backward
+        # Checking dictionary returned by "backward" for "LabelTree"
+        forward = {
+            "type": "tree",
+            "directed": True,
+            "nodes": ["0_1", "0", "0_2", "0_1_1", "0_2_1"],
+            "edges": [("0_1", "0"), ("0_2", "0"), ("0_1_1", "0_1"), ("0_2_1", "0_2")],
+        }
+        labels = {
+            ID("0"): self.label_0,
+            ID("0_1"): self.label_0_1,
+            ID("0_2"): self.label_0_2,
+            ID("0_1_1"): self.label_0_1_1,
+            ID("0_1_2"): self.label_0_1_2,
+            ID("0_2_1"): self.label_0_2_1,
+        }
+        expected_backward = LabelTree()
+        for parent, child in [
+            (self.label_0, self.label_0_1),
+            (self.label_0, self.label_0_2),
+            (self.label_0_1, self.label_0_1_1),
+            (self.label_0_2, self.label_0_2_1),
+        ]:
+            expected_backward.add_child(parent, child)
+        actual_backward = LabelGraphMapper.backward(instance=forward, all_labels=labels)
+        assert actual_backward == expected_backward
+        # Checking "ValueError" exception raised when unsupported type specified as "type" in dictionary "instance" for
+        # "backward"
+        forward = {
+            "type": "rectangle",
+            "directed": True,
+            "nodes": ["0_1", "0", "0_2", "0_1_1", "0_2_1"],
+            "edges": [("0_1", "0"), ("0_2", "0"), ("0_1_1", "0_1"), ("0_2_1", "0_2")],
+        }
+        with pytest.raises(ValueError):
+            LabelGraphMapper.backward(instance=forward, all_labels=labels)

--- a/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
+++ b/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
@@ -1,0 +1,603 @@
+# Copyright (C) 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import datetime
+
+import numpy as np
+import pytest
+
+from ote_sdk.configuration import ConfigurableParameters
+from ote_sdk.entities.annotation import (
+    Annotation,
+    AnnotationSceneEntity,
+    AnnotationSceneKind,
+)
+from ote_sdk.entities.color import Color
+from ote_sdk.entities.dataset_item import DatasetItemEntity
+from ote_sdk.entities.datasets import DatasetEntity
+from ote_sdk.entities.id import ID
+from ote_sdk.entities.image import Image
+from ote_sdk.entities.label import Domain, LabelEntity
+from ote_sdk.entities.label_schema import LabelGroup, LabelSchemaEntity
+from ote_sdk.entities.metrics import (
+    BarChartInfo,
+    BarMetricsGroup,
+    ColorPalette,
+    Performance,
+    ScoreMetric,
+    VisualizationType,
+)
+from ote_sdk.entities.model import ModelConfiguration, ModelEntity
+from ote_sdk.entities.resultset import ResultSetEntity
+from ote_sdk.entities.scored_label import ScoredLabel
+from ote_sdk.entities.shapes.rectangle import Rectangle
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+from ote_sdk.usecases.evaluation.averaging import MetricAverageMethod
+from ote_sdk.usecases.evaluation.dice import DiceAverage
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestDice:
+    color = Color(0, 255, 0)
+    creation_date = datetime.datetime(year=2022, month=1, day=10)
+    image = Image(data=np.random.randint(low=0, high=255, size=(64, 32, 3)))
+    full_box_roi = Rectangle.generate_full_box()
+    car_label = LabelEntity(
+        name="car",
+        domain=Domain.DETECTION,
+        color=color,
+        creation_date=creation_date,
+        id=ID("car_label"),
+    )
+    human_label = LabelEntity(
+        name="human",
+        domain=Domain.DETECTION,
+        color=color,
+        creation_date=creation_date,
+        id=ID("human_label"),
+    )
+    dog_label = LabelEntity(
+        name="dog",
+        domain=Domain.DETECTION,
+        color=color,
+        creation_date=creation_date,
+        id=ID("dog_label"),
+    )
+    cat_label = LabelEntity(
+        name="cat",
+        domain=Domain.DETECTION,
+        color=color,
+        creation_date=creation_date,
+        id=ID("cat_label"),
+    )
+    configurable_params = ConfigurableParameters(
+        header="Test model configurable params"
+    )
+
+    def human_1_ground_truth(self) -> DatasetItemEntity:
+        human_roi = Annotation(
+            shape=self.full_box_roi, labels=[ScoredLabel(self.human_label)]
+        )
+        human_annotation = Annotation(
+            shape=Rectangle(x1=0.4, y1=0, x2=0.5, y2=0.2),
+            labels=[ScoredLabel(self.human_label)],
+        )
+        human_annotation_scene = AnnotationSceneEntity(
+            annotations=[human_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        human_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=human_annotation_scene, roi=human_roi
+        )
+        return human_dataset_item
+
+    def human_2_ground_truth(self) -> DatasetItemEntity:
+        human_roi = Annotation(
+            shape=self.full_box_roi, labels=[ScoredLabel(self.human_label)]
+        )
+        human_annotation = Annotation(
+            shape=Rectangle(x1=0.6, y1=0, x2=0.7, y2=0.2),
+            labels=[ScoredLabel(self.human_label)],
+        )
+        human_annotation_scene = AnnotationSceneEntity(
+            annotations=[human_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        human_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=human_annotation_scene, roi=human_roi
+        )
+        return human_dataset_item
+
+    def dog_ground_truth(self) -> DatasetItemEntity:
+        dog_roi = Annotation(
+            shape=self.full_box_roi, labels=[ScoredLabel(self.dog_label)]
+        )
+        dog_annotation = Annotation(
+            shape=Rectangle(x1=0.8, y1=0, x2=0.9, y2=0.1),
+            labels=[ScoredLabel(self.dog_label)],
+        )
+        dog_annotation_scene = AnnotationSceneEntity(
+            annotations=[dog_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        dog_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=dog_annotation_scene, roi=dog_roi
+        )
+        return dog_dataset_item
+
+    def human_1_predicted(self) -> DatasetItemEntity:
+        human_roi = Annotation(
+            shape=self.full_box_roi, labels=[ScoredLabel(self.human_label)]
+        )
+        human_annotation = Annotation(
+            shape=Rectangle(x1=0.4, y1=0, x2=0.5, y2=0.4),
+            labels=[ScoredLabel(self.human_label)],
+        )
+        human_annotation_scene = AnnotationSceneEntity(
+            annotations=[human_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        human_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=human_annotation_scene, roi=human_roi
+        )
+        return human_dataset_item
+
+    def human_2_predicted(self) -> DatasetItemEntity:
+        human_roi = Annotation(
+            shape=self.full_box_roi, labels=[ScoredLabel(self.human_label)]
+        )
+        human_annotation = Annotation(
+            shape=Rectangle(x1=0.6, y1=0, x2=0.7, y2=0.2),
+            labels=[ScoredLabel(self.human_label)],
+        )
+        human_annotation_scene = AnnotationSceneEntity(
+            annotations=[human_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        human_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=human_annotation_scene, roi=human_roi
+        )
+        return human_dataset_item
+
+    def cat_predicted(self) -> DatasetItemEntity:
+        cat_roi = Annotation(
+            shape=self.full_box_roi, labels=[ScoredLabel(self.cat_label)]
+        )
+        cat_annotation = Annotation(
+            shape=Rectangle(x1=0.9, y1=0, x2=1.0, y2=0.1),
+            labels=[ScoredLabel(self.cat_label)],
+        )
+        cat_annotation_scene = AnnotationSceneEntity(
+            annotations=[cat_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        cat_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=cat_annotation_scene, roi=cat_roi
+        )
+        return cat_dataset_item
+
+    def car_dataset_item(self) -> DatasetItemEntity:
+        car_roi = Annotation(
+            shape=self.full_box_roi,
+            labels=[ScoredLabel(self.car_label)],
+        )
+        car_annotation = Annotation(
+            shape=Rectangle(x1=0.1, y1=0, x2=0.3, y2=0.2),
+            labels=[ScoredLabel(self.car_label)],
+        )
+        car_annotation_scene = AnnotationSceneEntity(
+            annotations=[car_annotation], kind=AnnotationSceneKind.ANNOTATION
+        )
+        car_dataset_item = DatasetItemEntity(
+            media=self.image, annotation_scene=car_annotation_scene, roi=car_roi
+        )
+        return car_dataset_item
+
+    def model(self) -> ModelEntity:
+        labels_group = LabelGroup(
+            name="model_labels_group",
+            labels=[self.car_label, self.human_label, self.dog_label, self.cat_label],
+        )
+        model_configuration = ModelConfiguration(
+            configurable_parameters=self.configurable_params,
+            label_schema=LabelSchemaEntity(label_groups=[labels_group]),
+        )
+        model = ModelEntity(
+            train_dataset=DatasetEntity(), configuration=model_configuration
+        )
+        return model
+
+    @staticmethod
+    def check_score_metric_rounded(
+        score_metric: ScoreMetric, expected_name: str, expected_value: float
+    ):
+        assert isinstance(score_metric, ScoreMetric)
+        assert score_metric.name == expected_name
+        assert round(score_metric.value, 5) == expected_value
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_dice_initialization(self):
+        """
+        <b>Description:</b>
+        Check "DiceAverage" class object initialization
+
+        <b>Input data:</b>
+        "DiceAverage" object with specified "resultset" and "average" parameters
+
+        <b>Expected results:</b>
+        Test passes if attributes of initialized "DiceAverage" object are equal to expected
+
+        <b>Steps</b>
+        1. Check attributes of "DiceAverage" object initialized with default value of "average" parameter
+        2. Check attributes of "DiceAverage" object initialized with specified value of "average" parameter
+        3. Check that "ValueError" exception is raised when initializing "DiceAverage" object with empty list prediction
+        "resultset" attribute
+        4. Check "ValueError" exception is raised when initializing "DiceAverage" object with "resultset" attribute with
+        unequal length of "ground_truth_dataset" and "prediction_dataset"
+        """
+
+        def check_dice_attributes(
+            dice_actual: DiceAverage,
+            expected_average_type: MetricAverageMethod,
+            expected_overall_dice: float,
+        ):
+            assert dice_actual.average == expected_average_type
+            # Checking "overall_dice" attribute
+            self.check_score_metric_rounded(
+                score_metric=dice_actual.overall_dice,
+                expected_name="Dice Average",
+                expected_value=expected_overall_dice,
+            )
+            # Checking "dice_per_label" attribute
+            assert len(dice_actual.dice_per_label) == 4
+            self.check_score_metric_rounded(
+                score_metric=dice_actual.dice_per_label.get(self.car_label),
+                expected_name="car",
+                expected_value=1.0,
+            )
+            self.check_score_metric_rounded(
+                score_metric=dice_actual.dice_per_label.get(self.human_label),
+                expected_name="human",
+                expected_value=0.78261,
+            )
+            self.check_score_metric_rounded(
+                score_metric=dice_actual.dice_per_label.get(self.dog_label),
+                expected_name="dog",
+                expected_value=0,
+            )
+            self.check_score_metric_rounded(
+                score_metric=dice_actual.dice_per_label.get(self.cat_label),
+                expected_name="cat",
+                expected_value=0,
+            )
+
+        model = self.model()
+        human_1_ground_truth = self.human_1_ground_truth()
+        car_dataset_item = self.car_dataset_item()
+        ground_truth_dataset = DatasetEntity(
+            [
+                car_dataset_item,
+                human_1_ground_truth,
+                self.human_2_ground_truth(),
+                self.dog_ground_truth(),
+            ]
+        )
+        predicted_dataset = DatasetEntity(
+            [
+                car_dataset_item,
+                self.human_1_predicted(),
+                self.human_2_predicted(),
+                self.cat_predicted(),
+            ]
+        )
+        result_set = ResultSetEntity(
+            model=model,
+            ground_truth_dataset=ground_truth_dataset,
+            prediction_dataset=predicted_dataset,
+        )
+        # Checking attributes of "DiceAverage" initialized with default "average"
+        dice = DiceAverage(resultset=result_set)
+        check_dice_attributes(
+            dice_actual=dice,
+            expected_average_type=MetricAverageMethod.MACRO,
+            expected_overall_dice=0.44565,
+        )
+        # Checking attributes of "DiceAverage" initialized with specified "average"
+        dice = DiceAverage(resultset=result_set, average=MetricAverageMethod.MICRO)
+        check_dice_attributes(
+            dice_actual=dice,
+            expected_average_type=MetricAverageMethod.MICRO,
+            expected_overall_dice=0.77467,
+        )
+        # Checking "ValueError" exception raised when initializing "DiceAverage" with empty list prediction result_set
+        result_set = ResultSetEntity(
+            model=model,
+            ground_truth_dataset=ground_truth_dataset,
+            prediction_dataset=DatasetEntity(items=[]),
+        )
+        with pytest.raises(ValueError):
+            DiceAverage(resultset=result_set)
+
+        # Checking "ValueError" exception raised when initializing "DiceAverage" with "resultset" with unequal length of
+        # "ground_truth_dataset" and "prediction_dataset"
+        result_set = ResultSetEntity(
+            model=model,
+            ground_truth_dataset=DatasetEntity(
+                [car_dataset_item, human_1_ground_truth]
+            ),
+            prediction_dataset=DatasetEntity([car_dataset_item]),
+        )
+        with pytest.raises(ValueError):
+            DiceAverage(resultset=result_set)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_dice_get_performance(self):
+        """
+        <b>Description:</b>
+        Check "DiceAverage" class "get_performance" method
+
+        <b>Input data:</b>
+        "DiceAverage" object with specified "resultset" and "average" parameters
+
+        <b>Expected results:</b>
+        Test passes if "Performance" object returned by "get_performance" method is equal to expected
+
+        <b>Steps</b>
+        1. Check "Performance" object returned by "get_performance" method for "DiceAverage" class object with length of
+        "dice_per_label" attribute more than 0
+        2. Check "Performance" object returned by "get_performance" method for "DiceAverage" class object with length of
+        "dice_per_label" attribute equal to 0
+        """
+        human_1_ground_truth = self.human_1_ground_truth()
+        human_1_predicted = self.human_1_predicted()
+        car_dataset_item = self.car_dataset_item()
+        # Checking "Performance" returned by "get_performance" for "DiceAverage" with length of "dice_per_label" more
+        # than 0
+        configurable_params = self.configurable_params
+        labels_group = LabelGroup(
+            name="model_labels_group",
+            labels=[self.car_label, self.human_label, self.dog_label, self.cat_label],
+        )
+        model_configuration = ModelConfiguration(
+            configurable_parameters=configurable_params,
+            label_schema=LabelSchemaEntity(label_groups=[labels_group]),
+        )
+        model = ModelEntity(
+            train_dataset=DatasetEntity(), configuration=model_configuration
+        )
+        ground_truth_dataset = DatasetEntity(
+            [
+                car_dataset_item,
+                human_1_ground_truth,
+                self.human_2_ground_truth(),
+                self.dog_ground_truth(),
+            ]
+        )
+        predicted_dataset = DatasetEntity(
+            [
+                car_dataset_item,
+                human_1_predicted,
+                self.human_2_predicted(),
+                self.cat_predicted(),
+            ]
+        )
+        result_set = ResultSetEntity(
+            model=model,
+            ground_truth_dataset=ground_truth_dataset,
+            prediction_dataset=predicted_dataset,
+        )
+        dice = DiceAverage(resultset=result_set)
+        performance = dice.get_performance()
+        assert isinstance(performance, Performance)
+        # Checking "score" attribute
+        self.check_score_metric_rounded(
+            score_metric=performance.score,
+            expected_name="Dice Average",
+            expected_value=0.44565,
+        )
+        # Checking "dashboard_metrics" attribute
+        assert len(performance.dashboard_metrics) == 1
+        dashboard_metric = performance.dashboard_metrics[0]
+        assert isinstance(dashboard_metric, BarMetricsGroup)
+        # Checking "metrics" attribute
+        assert len(dashboard_metric.metrics) == 4
+        self.check_score_metric_rounded(
+            score_metric=dashboard_metric.metrics[0],
+            expected_name="car",
+            expected_value=1,
+        )
+        self.check_score_metric_rounded(
+            score_metric=dashboard_metric.metrics[1],
+            expected_name="cat",
+            expected_value=0,
+        )
+        self.check_score_metric_rounded(
+            score_metric=dashboard_metric.metrics[2],
+            expected_name="dog",
+            expected_value=0,
+        )
+        self.check_score_metric_rounded(
+            score_metric=dashboard_metric.metrics[3],
+            expected_name="human",
+            expected_value=0.78261,
+        )
+        # Checking "visualization_info" attribute
+        assert isinstance(dashboard_metric.visualization_info, BarChartInfo)
+        assert dashboard_metric.visualization_info.name == "Dice Average Per Label"
+        assert dashboard_metric.visualization_info.palette == ColorPalette.LABEL
+        assert dashboard_metric.visualization_info.type == VisualizationType.BAR
+        # Checking "Performance" returned by "get_performance" for "DiceAverage" with length of "dice_per_label" equal
+        # to 0
+        labels_group = LabelGroup(name="model_labels_group", labels=[self.car_label])
+        model_configuration = ModelConfiguration(
+            configurable_params, LabelSchemaEntity(label_groups=[labels_group])
+        )
+        model = ModelEntity(
+            train_dataset=DatasetEntity(), configuration=model_configuration
+        )
+        ground_truth_dataset = DatasetEntity([human_1_ground_truth])
+        predicted_dataset = DatasetEntity([human_1_predicted])
+        result_set = ResultSetEntity(
+            model=model,
+            ground_truth_dataset=ground_truth_dataset,
+            prediction_dataset=predicted_dataset,
+        )
+        dice = DiceAverage(resultset=result_set)
+        performance = dice.get_performance()
+        assert isinstance(performance, Performance)
+        # Checking "score" attribute
+        self.check_score_metric_rounded(
+            score_metric=performance.score,
+            expected_name="Dice Average",
+            expected_value=0.0,
+        )
+        # Checking "dashboard_metrics" attribute
+        assert performance.dashboard_metrics == []
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_dice_compute_dice_using_intersection_and_cardinality(self):
+        """
+        <b>Description:</b>
+        Check "DiceAverage" class "compute_dice_using_intersection_and_cardinality" method
+
+        <b>Input data:</b>
+        "DiceAverage" object, "all_intersection" dictionary, "all_cardinality" dictionary, "average" MetricAverageMethod
+        object
+
+        <b>Expected results:</b>
+        Test passes if tuple returned by "compute_dice_using_intersection_and_cardinality" method is equal to expected
+
+        <b>Steps</b>
+        1. Check tuple returned by "compute_dice_using_intersection_and_cardinality" method for MICRO "average"
+        parameter
+        2. Check tuple returned by "compute_dice_using_intersection_and_cardinality" method for MACRO "average"
+        parameter
+        3. Check tuple returned by "compute_dice_using_intersection_and_cardinality" method when "None" key is not
+        specified in "all_intersection" and "all_cardinality" dictionaries
+        4. Check "KeyError" exception is raised when keys of "all_intersection" and "all_cardinality" dictionaries are
+        not match
+        5. Check "ValueError" exception is raised when intersection of certain key is larger than its cardinality
+        """
+
+        def check_dice(dice_actual: tuple, expected_overall_dice: float):
+            assert len(dice_actual) == 2
+            self.check_score_metric_rounded(
+                score_metric=dice_actual[0],
+                expected_name="Dice Average",
+                expected_value=expected_overall_dice,
+            )
+            dice_per_label = dice_actual[1]
+            assert len(dice_per_label) == 4
+            self.check_score_metric_rounded(
+                score_metric=dice_per_label.get(self.car_label),
+                expected_name="car",
+                expected_value=2.0,
+            )
+            self.check_score_metric_rounded(
+                score_metric=dice_per_label.get(self.human_label),
+                expected_name="human",
+                expected_value=1.6,
+            )
+            self.check_score_metric_rounded(
+                score_metric=dice_per_label.get(self.dog_label),
+                expected_name="dog",
+                expected_value=0.5,
+            )
+            self.check_score_metric_rounded(
+                score_metric=dice_per_label.get(self.cat_label),
+                expected_name="cat",
+                expected_value=0.0,
+            )
+
+        # Checking tuple returned by "compute_dice_using_intersection_and_cardinality" for MICRO "average"
+        all_intersection = {
+            self.car_label: 10,
+            self.human_label: 8,
+            self.dog_label: 2,
+            self.cat_label: 0,
+            None: 9,
+        }
+        all_cardinality = {
+            self.car_label: 10,
+            self.human_label: 10,
+            self.dog_label: 8,
+            self.cat_label: 2,
+            None: 12,
+        }
+        dice = DiceAverage.compute_dice_using_intersection_and_cardinality(
+            all_intersection=all_intersection,
+            all_cardinality=all_cardinality,
+            average=MetricAverageMethod.MICRO,
+        )
+        check_dice(dice_actual=dice, expected_overall_dice=1.5)
+        # Checking tuple returned by "compute_dice_using_intersection_and_cardinality" for MACRO "average"
+        dice = DiceAverage.compute_dice_using_intersection_and_cardinality(
+            all_intersection=all_intersection,
+            all_cardinality=all_cardinality,
+            average=MetricAverageMethod.MACRO,
+        )
+        check_dice(dice_actual=dice, expected_overall_dice=1.025)
+        # Checking tuple returned by "compute_dice_using_intersection_and_cardinality" when "None" key is not
+        # specified in "all_intersection" and "all_cardinality" dictionaries
+        all_intersection = {
+            self.car_label: 10,
+            self.human_label: 8,
+            self.dog_label: 2,
+            self.cat_label: 0,
+        }
+        all_cardinality = {
+            self.car_label: 10,
+            self.human_label: 10,
+            self.dog_label: 8,
+            self.cat_label: 2,
+        }
+        # Check for MACRO "average" parameter
+        dice = DiceAverage.compute_dice_using_intersection_and_cardinality(
+            all_intersection=all_intersection,
+            all_cardinality=all_cardinality,
+            average=MetricAverageMethod.MACRO,
+        )
+        check_dice(dice_actual=dice, expected_overall_dice=1.025)
+        # Expected KeyError exception for MICRO "average" parameter
+        with pytest.raises(KeyError):
+            DiceAverage.compute_dice_using_intersection_and_cardinality(
+                all_intersection=all_intersection,
+                all_cardinality=all_cardinality,
+                average=MetricAverageMethod.MICRO,
+            )
+        # Checking "KeyError" exception is raised when keys of "all_intersection" and "all_cardinality" dictionaries are
+        # not match
+        all_intersection = {self.car_label: 10, self.human_label: 9, None: 9}
+        all_cardinality = {
+            self.car_label: 10,
+            self.dog_label: 8,
+            self.cat_label: 2,
+            None: 12,
+        }
+        with pytest.raises(KeyError):
+            DiceAverage.compute_dice_using_intersection_and_cardinality(
+                all_intersection=all_intersection,
+                all_cardinality=all_cardinality,
+                average=MetricAverageMethod.MACRO,
+            )
+        # Checking "ValueError" exception is raised when intersection of certain key is larger than its cardinality
+        all_intersection = {self.car_label: 10, self.human_label: 9, None: 12}
+        all_cardinality = {self.car_label: 10, self.human_label: 8, None: 12}
+        with pytest.raises(ValueError):
+            DiceAverage.compute_dice_using_intersection_and_cardinality(
+                all_intersection=all_intersection,
+                all_cardinality=all_cardinality,
+                average=MetricAverageMethod.MACRO,
+            )

--- a/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
+++ b/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
@@ -214,12 +214,10 @@ class TestDice:
         return model
 
     @staticmethod
-    def check_score_metric_rounded(
-        score_metric: ScoreMetric, expected_name: str, expected_value: float
-    ):
+    def check_score_metric_rounded(score_metric, expected_name, expected_value):
         assert isinstance(score_metric, ScoreMetric)
         assert score_metric.name == expected_name
-        assert round(score_metric.value, 5) == expected_value
+        assert round(score_metric.value, 5) == pytest.approx(expected_value)
 
     @pytest.mark.priority_medium
     @pytest.mark.component

--- a/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
+++ b/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
@@ -1,16 +1,6 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
 
 import datetime
 

--- a/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
+++ b/ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
@@ -204,10 +204,10 @@ class TestDice:
         return model
 
     @staticmethod
-    def check_score_metric_rounded(score_metric, expected_name, expected_value):
+    def check_score_metric(score_metric, expected_name, expected_value):
         assert isinstance(score_metric, ScoreMetric)
         assert score_metric.name == expected_name
-        assert round(score_metric.value, 5) == pytest.approx(expected_value)
+        assert score_metric.value == pytest.approx(expected_value)
 
     @pytest.mark.priority_medium
     @pytest.mark.component
@@ -239,32 +239,32 @@ class TestDice:
         ):
             assert dice_actual.average == expected_average_type
             # Checking "overall_dice" attribute
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_actual.overall_dice,
                 expected_name="Dice Average",
                 expected_value=expected_overall_dice,
             )
             # Checking "dice_per_label" attribute
             assert len(dice_actual.dice_per_label) == 4
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_actual.dice_per_label.get(self.car_label),
                 expected_name="car",
                 expected_value=1.0,
             )
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_actual.dice_per_label.get(self.human_label),
                 expected_name="human",
-                expected_value=0.78261,
+                expected_value=0.782608695652174,
             )
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_actual.dice_per_label.get(self.dog_label),
                 expected_name="dog",
-                expected_value=0,
+                expected_value=0.0,
             )
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_actual.dice_per_label.get(self.cat_label),
                 expected_name="cat",
-                expected_value=0,
+                expected_value=0.0,
             )
 
         model = self.model()
@@ -296,14 +296,14 @@ class TestDice:
         check_dice_attributes(
             dice_actual=dice,
             expected_average_type=MetricAverageMethod.MACRO,
-            expected_overall_dice=0.44565,
+            expected_overall_dice=0.44565217391304346,
         )
         # Checking attributes of "DiceAverage" initialized with specified "average"
         dice = DiceAverage(resultset=result_set, average=MetricAverageMethod.MICRO)
         check_dice_attributes(
             dice_actual=dice,
             expected_average_type=MetricAverageMethod.MICRO,
-            expected_overall_dice=0.77467,
+            expected_overall_dice=0.7746741154562383,
         )
         # Checking "ValueError" exception raised when initializing "DiceAverage" with empty list prediction result_set
         result_set = ResultSetEntity(
@@ -388,10 +388,10 @@ class TestDice:
         performance = dice.get_performance()
         assert isinstance(performance, Performance)
         # Checking "score" attribute
-        self.check_score_metric_rounded(
+        self.check_score_metric(
             score_metric=performance.score,
             expected_name="Dice Average",
-            expected_value=0.44565,
+            expected_value=0.44565217391304346,
         )
         # Checking "dashboard_metrics" attribute
         assert len(performance.dashboard_metrics) == 1
@@ -399,25 +399,25 @@ class TestDice:
         assert isinstance(dashboard_metric, BarMetricsGroup)
         # Checking "metrics" attribute
         assert len(dashboard_metric.metrics) == 4
-        self.check_score_metric_rounded(
+        self.check_score_metric(
             score_metric=dashboard_metric.metrics[0],
             expected_name="car",
-            expected_value=1,
+            expected_value=1.0,
         )
-        self.check_score_metric_rounded(
+        self.check_score_metric(
             score_metric=dashboard_metric.metrics[1],
             expected_name="cat",
-            expected_value=0,
+            expected_value=0.0,
         )
-        self.check_score_metric_rounded(
+        self.check_score_metric(
             score_metric=dashboard_metric.metrics[2],
             expected_name="dog",
-            expected_value=0,
+            expected_value=0.0,
         )
-        self.check_score_metric_rounded(
+        self.check_score_metric(
             score_metric=dashboard_metric.metrics[3],
             expected_name="human",
-            expected_value=0.78261,
+            expected_value=0.782608695652174,
         )
         # Checking "visualization_info" attribute
         assert isinstance(dashboard_metric.visualization_info, BarChartInfo)
@@ -444,7 +444,7 @@ class TestDice:
         performance = dice.get_performance()
         assert isinstance(performance, Performance)
         # Checking "score" attribute
-        self.check_score_metric_rounded(
+        self.check_score_metric(
             score_metric=performance.score,
             expected_name="Dice Average",
             expected_value=0.0,
@@ -481,29 +481,29 @@ class TestDice:
 
         def check_dice(dice_actual: tuple, expected_overall_dice: float):
             assert len(dice_actual) == 2
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_actual[0],
                 expected_name="Dice Average",
                 expected_value=expected_overall_dice,
             )
             dice_per_label = dice_actual[1]
             assert len(dice_per_label) == 4
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_per_label.get(self.car_label),
                 expected_name="car",
                 expected_value=2.0,
             )
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_per_label.get(self.human_label),
                 expected_name="human",
                 expected_value=1.6,
             )
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_per_label.get(self.dog_label),
                 expected_name="dog",
                 expected_value=0.5,
             )
-            self.check_score_metric_rounded(
+            self.check_score_metric(
                 score_metric=dice_per_label.get(self.cat_label),
                 expected_name="cat",
                 expected_value=0.0,

--- a/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py
+++ b/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py
@@ -11,157 +11,1051 @@
 # This software and the related documents are provided as is,
 # with no express or implied warranties, other than those that are expressly stated
 # in the License.
+from unittest.mock import patch
 
 import numpy as np
 import pytest
+from openvino.model_zoo.model_api.models.utils import Detection
 
-from ote_sdk.entities.label import Domain, LabelEntity
+from ote_sdk.entities.annotation import (
+    Annotation,
+    AnnotationSceneEntity,
+    AnnotationSceneKind,
+)
+from ote_sdk.entities.id import ID
+from ote_sdk.entities.label import Color, Domain, LabelEntity
+from ote_sdk.entities.label_schema import LabelGroup, LabelSchemaEntity
 from ote_sdk.entities.scored_label import ScoredLabel
+from ote_sdk.entities.shapes.polygon import Point, Polygon
+from ote_sdk.entities.shapes.rectangle import Rectangle
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
 from ote_sdk.tests.constants.requirements import Requirements
+from ote_sdk.usecases.exportable_code.prediction_to_annotation_converter import (
+    AnomalyClassificationToAnnotationConverter,
+    ClassificationToAnnotationConverter,
+    DetectionBoxToAnnotationConverter,
+    DetectionToAnnotationConverter,
+    IPredictionToAnnotationConverter,
+    SegmentationToAnnotationConverter,
+    create_converter,
+)
+from ote_sdk.utils.time_utils import now
 
-try:
-    from ote_sdk.usecases.exportable_code.prediction_to_annotation_converter import (
-        DetectionToAnnotationConverter,
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestDetectionToAnnotationConverter:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_detection_to_annotation_convert(self):
+        """
+        <b>Description:</b>
+        Check that DetectionToAnnotationConverter correctly converts Network output to list of Annotation
+
+        <b>Input data:</b>
+        Array of network output with shape [4,6]
+
+        <b>Expected results:</b>
+        Test passes if each Converted annotation has the same  values as the network output
+
+        <b>Steps</b>
+        1. Create mock network output
+        2. Convert network output to Annotation
+        3. Check Annotations
+        """
+        test_boxes = np.array(
+            (
+                (0, 0.6, 0.1, 0.1, 0.2, 0.3),
+                (1, 0.2, 0.2, 0.1, 0.3, 0.4),
+                (1, 0.7, 0.3, 0.2, 0.5, 0.6),
+                (0, 0.1, 0.1, 0.1, 0.2, 0.3),
+            )
+        )
+
+        labels = [
+            LabelEntity("Zero", domain=Domain.DETECTION),
+            LabelEntity("One", domain=Domain.DETECTION),
+        ]
+
+        converter = DetectionToAnnotationConverter(labels)
+
+        annotation_scene = converter.convert_to_annotation(test_boxes)
+
+        for i, annotation in enumerate(annotation_scene.annotations):
+            label: ScoredLabel = next(iter(annotation.get_labels()))
+            test_label = labels[int(test_boxes[i][0])]
+            assert test_label.name == label.name
+
+            assert test_boxes[i][1], label.probability
+
+            assert test_boxes[i][2] == annotation.shape.x1
+            assert test_boxes[i][3] == annotation.shape.y1
+            assert test_boxes[i][4] == annotation.shape.x2
+            assert test_boxes[i][5] == annotation.shape.y2
+
+        annotation_scene = converter.convert_to_annotation(np.ndarray((0, 6)))
+        assert 0 == len(annotation_scene.shapes)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_detection_to_annotation_convert_openvino_shape(self):
+        """
+        <b>Description:</b>
+        Check that DetectionToAnnotationConverter correctly converts OpenVINO Network output to annotations
+
+        <b>Input data:</b>
+        Array of network output with shape [4,7]
+
+        <b>Expected results:</b>
+        Test passes if each Converted annotation has the same values as the network output
+
+        <b>Steps</b>
+        1. Create mock network output
+        2. Convert network output to Annotation
+        3. Check Annotations
+        """
+        test_boxes = np.array(
+            (
+                (-12, 0, 0.6, 0.1, 0.1, 0.2, 0.3),
+                (12, 1, 0.2, 0.0, 0.1, 0.1, 0.2),
+                (1234, 1, 0.7, 0.2, 0.4, 0.7, 0.5),
+                (1251, 0, 0.1, 0.1, 0.1, 0.2, 0.3),
+            )
+        )
+
+        labels = [
+            LabelEntity("Zero", domain=Domain.DETECTION),
+            LabelEntity("One", domain=Domain.DETECTION),
+        ]
+
+        converter = DetectionToAnnotationConverter(labels)
+
+        annotation_scene = converter.convert_to_annotation(test_boxes)
+
+        for i, annotation in enumerate(annotation_scene.annotations):
+            label: ScoredLabel = next(iter(annotation.get_labels()))
+            test_label = labels[int(test_boxes[i][1])]
+            assert test_label.name == label.name
+
+            assert test_boxes[i][2] == label.probability
+
+            assert test_boxes[i][3] == annotation.shape.x1
+            assert test_boxes[i][4] == annotation.shape.y1
+            assert test_boxes[i][5] == annotation.shape.x2
+            assert test_boxes[i][6] == annotation.shape.y2
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_detection_to_annotation_convert_invalid_input(self):
+        """
+        <b>Description:</b>
+        Check that DetectionToAnnotationConverter raises an error if invalid inputs are provided
+
+        <b>Input data:</b>
+        Array of size [1203, 5]
+        Array of size [3, 8]
+
+        <b>Expected results:</b>
+        Test passes a ValueError is raised for both inputs
+
+        <b>Steps</b>
+        1. Create DetectionToAnnotationConverter
+        2. Attempt to convert array of [1203,5] to annotations
+        3. Attempt to convert array of [3, 8] to annotations
+        """
+        labels = [
+            LabelEntity("Zero", domain=Domain.DETECTION),
+            LabelEntity("One", domain=Domain.DETECTION),
+        ]
+        converter = DetectionToAnnotationConverter(labels)
+
+        with pytest.raises(ValueError):
+            converter.convert_to_annotation(np.ndarray((1203, 5)))
+
+        with pytest.raises(ValueError):
+            converter.convert_to_annotation(np.ndarray((3, 8)))
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestIPredictionToAnnotationConverter:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    @patch(
+        (
+            "ote_sdk.usecases.exportable_code.prediction_to_annotation_converter."
+            "IPredictionToAnnotationConverter.__abstractmethods__"
+        ),
+        set(),
     )
+    def test_i_prediction_to_annotation_converter_convert_to_annotation(self):
+        """
+        <b>Description:</b>
+        Check "IPredictionToAnnotationConverter" class "convert_to_annotation" method
+
+        <b>Input data:</b>
+        "IPredictionToAnnotationConverter" class object, "predictions" array, "metadata" dictionary
+
+        <b>Expected results:</b>
+        Test passes if "NotImplementedError" exception is raised by "convert_to_annotation" method
+        """
+        i_prediction_to_annotation_converter = IPredictionToAnnotationConverter()
+        with pytest.raises(NotImplementedError):
+            i_prediction_to_annotation_converter.convert_to_annotation(
+                predictions=np.random.randint(low=0, high=255, size=(5, 5, 3)),
+                metadata={},
+            )
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestCreateConverter:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_create_converter(self):
+        """
+        <b>Description:</b>
+        Check "create_converter" function
+
+        <b>Input data:</b>
+        "converter_type" Domain-class object, "labels" LabelSchemaEntity-class object
+
+        <b>Expected results:</b>
+        Test passes if "IPredictionToAnnotationConverter" object returned by "create_converter" function is equal
+        to expected
+
+        <b>Steps</b>
+        1. Check "DetectionBoxToAnnotationConverter" object returned by "create_converter" function when
+        "DETECTION" domain is specified as "converter_type" parameter
+        2. Check "SegmentationToAnnotationConverter" object returned by "create_converter" function when
+        "SEGMENTATION" domain is specified as "converter_type" parameter
+        3. Check "ClassificationToAnnotationConverter" object returned by "create_converter" function when
+        "CLASSIFICATION" domain is specified as "converter_type" parameter
+        4. Check "AnomalyClassificationToAnnotationConverter" object returned by "create_converter" function when
+        "ANOMALY_CLASSIFICATION" domain is specified as "converter_type" parameter
+        5. Check that "ValueError" exception is raised when "ANOMALY_DETECTION" or "ANOMALY_SEGMENTATION" domain is
+        specified as "converter_type" parameter
+        """
+        # Checking "DetectionBoxToAnnotationConverter" returned by "create_converter" function when "DETECTION" is
+        # specified as "converter_type"
+        labels = [
+            LabelEntity(name="Detection label", domain=Domain.DETECTION, id=ID("1")),
+            LabelEntity(
+                name="Other Detection label", domain=Domain.DETECTION, id=ID("2")
+            ),
+        ]
+        label_group = LabelGroup(name="Detection labels group", labels=labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = create_converter(
+            converter_type=Domain.DETECTION, labels=label_schema
+        )
+        assert isinstance(converter, DetectionBoxToAnnotationConverter)
+        assert converter.labels == labels
+        # Checking "SegmentationToAnnotationConverter" returned by "create_converter" function when "SEGMENTATION"is
+        # specified as "converter_type"
+        labels = [
+            LabelEntity(
+                name="Segmentation label", domain=Domain.SEGMENTATION, id=ID("1")
+            ),
+            LabelEntity(
+                name="Other Segmentation label",
+                domain=Domain.SEGMENTATION,
+                id=ID("2"),
+            ),
+        ]
+        label_group = LabelGroup(name="Segmentation labels group", labels=labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = create_converter(
+            converter_type=Domain.SEGMENTATION, labels=label_schema
+        )
+        assert isinstance(converter, SegmentationToAnnotationConverter)
+        assert converter.label_map == {1: labels[0], 2: labels[1]}
+        # Checking "ClassificationToAnnotationConverter" returned by "create_converter" function when
+        # "CLASSIFICATION" is specified as "converter_type"
+        labels = [
+            LabelEntity(
+                name="Classification label",
+                domain=Domain.CLASSIFICATION,
+                id=ID("1"),
+            ),
+            LabelEntity(
+                name="Other Classification label",
+                domain=Domain.CLASSIFICATION,
+                id=ID("2"),
+            ),
+        ]
+        label_group = LabelGroup(name="Classification labels group", labels=labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = create_converter(
+            converter_type=Domain.CLASSIFICATION, labels=label_schema
+        )
+        assert isinstance(converter, ClassificationToAnnotationConverter)
+        assert converter.labels == labels
+        # Checking that "AnomalyClassificationToAnnotationConverter" returned by "create_converter" function when
+        # "ANOMALY_CLASSIFICATION" is specified as "converter_type"
+        labels = [
+            LabelEntity(
+                name="Normal", domain=Domain.ANOMALY_CLASSIFICATION, id=ID("1")
+            ),
+            LabelEntity(
+                name="Anomalous", domain=Domain.ANOMALY_CLASSIFICATION, id=ID("2")
+            ),
+        ]
+        label_group = LabelGroup(
+            name="Anomaly classification labels group", labels=labels
+        )
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = create_converter(
+            converter_type=Domain.ANOMALY_CLASSIFICATION, labels=label_schema
+        )
+        assert isinstance(converter, AnomalyClassificationToAnnotationConverter)
+        assert converter.normal_label == labels[0]
+        assert converter.anomalous_label == labels[1]
+        # Checking that "ValueError" exception is raised when "ANOMALY_DETECTION" or "ANOMALY_SEGMENTATION" is
+        # specified as "converter_type"
+        with pytest.raises(ValueError):
+            for domain in [Domain.ANOMALY_DETECTION, Domain.ANOMALY_SEGMENTATION]:
+                create_converter(converter_type=domain, labels=label_schema)
+
+
+def check_annotation_scene(
+    annotation_scene: AnnotationSceneEntity, expected_length: int
+):
+    assert isinstance(annotation_scene, AnnotationSceneEntity)
+    assert annotation_scene.kind == AnnotationSceneKind.PREDICTION
+    assert len(annotation_scene.annotations) == expected_length
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestDetectionBoxToAnnotationConverter:
+    color = Color(red=180, green=230, blue=30)
+    creation_date = now()
+    labels = [
+        LabelEntity(
+            name="Detection label",
+            domain=Domain.DETECTION,
+            color=color,
+            creation_date=creation_date,
+            id=ID("1"),
+        ),
+        LabelEntity(
+            name="Other Detection label",
+            domain=Domain.DETECTION,
+            color=color,
+            creation_date=creation_date,
+            id=ID("2"),
+        ),
+    ]
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_detection_box_to_annotation_converter_initialization(self):
+        """
+        <b>Description:</b>
+        Check "DetectionBoxToAnnotationConverter" class object initialization
+
+        <b>Input data:</b>
+        "DetectionBoxToAnnotationConverter" class object with specified "labels" parameter
+
+        <b>Expected results:</b>
+        Test passes if attributes of initialized "DetectionBoxToAnnotationConverter" object are equal to expected
+
+        <b>Steps</b>
+        1. Check "labels" attribute of "DetectionBoxToAnnotationConverter" object initialized with non-empty labels
+        list
+        2. Check "labels" attribute of "DetectionBoxToAnnotationConverter" object initialized with empty labels list
+        3. Check "labels" attributes of "DetectionBoxToAnnotationConverter" object initialized with non-empty and
+        empty labels list
+        """
+        # Checking "labels" of "DetectionBoxToAnnotationConverter" initialized with non-empty labels list
+        non_empty_labels = self.labels
+        label_group = LabelGroup(name="Detection labels group", labels=non_empty_labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = DetectionBoxToAnnotationConverter(labels=label_schema)
+        assert converter.labels == non_empty_labels
+        # Checking "labels" of "DetectionBoxToAnnotationConverter" initialized with empty labels list
+        empty_labels = [
+            LabelEntity(
+                name="empty label",
+                domain=Domain.DETECTION,
+                is_empty=True,
+                id=ID("3"),
+            ),
+            LabelEntity(
+                name="other empty label",
+                domain=Domain.DETECTION,
+                is_empty=True,
+                id=ID("4"),
+            ),
+        ]
+        label_group = LabelGroup(name="Detection labels group", labels=empty_labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = DetectionBoxToAnnotationConverter(labels=label_schema)
+        assert converter.labels == []
+        # Checking "labels" of "DetectionBoxToAnnotationConverter" initialized with non-empty and empty labels list
+        label_group = LabelGroup(
+            name="Detection labels group", labels=non_empty_labels + empty_labels
+        )
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = DetectionBoxToAnnotationConverter(labels=label_schema)
+        assert converter.labels == non_empty_labels
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_detection_box_to_annotation_converter_convert_to_annotation(self):
+        """
+        <b>Description:</b>
+        Check "DetectionBoxToAnnotationConverter" class "convert_to_annotation" method
+
+        <b>Input data:</b>
+        "DetectionBoxToAnnotationConverter" class object, "predictions" list with Detection-class objects,
+        "metadata" dictionary
+
+        <b>Expected results:</b>
+        Test passes if "AnnotationSceneEntity" object returned by "convert_to_annotation" method is equal to
+        expected
+        """
+
+        def check_annotation(
+            actual_annotation: Annotation,
+            expected_label: LabelEntity,
+            expected_probability: float,
+            expected_x1: float,
+            expected_y1: float,
+            expected_x2: float,
+            expected_y2: float,
+        ):
+            assert isinstance(actual_annotation, Annotation)
+            assert actual_annotation.get_labels() == [
+                ScoredLabel(label=expected_label, probability=expected_probability)
+            ]
+            assert isinstance(actual_annotation.shape, Rectangle)
+            assert actual_annotation.shape.x1 == pytest.approx(expected_x1)
+            assert actual_annotation.shape.y1 == pytest.approx(expected_y1)
+            assert actual_annotation.shape.x2 == pytest.approx(expected_x2)
+            assert actual_annotation.shape.y2 == pytest.approx(expected_y2)
+
+        labels = self.labels
+        label_group = LabelGroup(name="Detection labels group", labels=labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = DetectionBoxToAnnotationConverter(labels=label_schema)
+        metadata = {
+            "non-required key": 1,
+            "other non-required key": 2,
+            "original_shape": [10, 20],
+        }
+        box_1 = Detection(xmin=2, ymin=2, xmax=4, ymax=6, score=0.8, id=0)
+        box_2 = Detection(xmin=6, ymin=4, xmax=10, ymax=9, score=0.9, id=1)
+        predictions = [box_1, box_2]
+        predictions_to_annotations = converter.convert_to_annotation(
+            predictions=predictions, metadata=metadata
+        )
+        check_annotation_scene(
+            annotation_scene=predictions_to_annotations, expected_length=2
+        )
+        check_annotation(
+            actual_annotation=predictions_to_annotations.annotations[0],
+            expected_label=labels[0],
+            expected_probability=0.8,
+            expected_x1=0.1,
+            expected_y1=0.2,
+            expected_x2=0.2,
+            expected_y2=0.6,
+        )
+        check_annotation(
+            actual_annotation=predictions_to_annotations.annotations[1],
+            expected_label=labels[1],
+            expected_probability=0.9,
+            expected_x1=0.3,
+            expected_y1=0.4,
+            expected_x2=0.5,
+            expected_y2=0.9,
+        )
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestSegmentationToAnnotationConverter:
+    color = Color(red=180, green=230, blue=30)
+    creation_date = now()
+    labels = [
+        LabelEntity(
+            name="Segmentation label",
+            domain=Domain.SEGMENTATION,
+            color=color,
+            creation_date=creation_date,
+            id=ID("0"),
+        ),
+        LabelEntity(
+            name="Other Segmentation label",
+            domain=Domain.SEGMENTATION,
+            color=color,
+            creation_date=creation_date,
+            id=ID("1"),
+        ),
+    ]
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_segmentation_to_annotation_converter_initialization(self):
+        """
+        <b>Description:</b>
+        Check "SegmentationToAnnotationConverter" class object initialization
+
+        <b>Input data:</b>
+        "SegmentationToAnnotationConverter" class object with specified "label_schema" parameter
+
+        <b>Expected results:</b>
+        Test passes if attributes of initialized "SegmentationToAnnotationConverter" object are equal to expected
+
+        <b>Steps</b>
+        1. Check "label_map" attribute of "SegmentationToAnnotationConverter" object initialized with non-empty
+        labels list
+        2. Check "label_map" attribute of "SegmentationToAnnotationConverter" object initialized with empty labels
+        list
+        3. Check "label_map" attributes of "SegmentationToAnnotationConverter" object initialized with non-empty and
+        empty labels list
+        """
+        # Checking "label_map" of "SegmentationToAnnotationConverter" initialized with non-empty labels list
+        non_empty_labels = self.labels
+        label_group = LabelGroup(
+            name="Segmentation labels group", labels=non_empty_labels
+        )
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = SegmentationToAnnotationConverter(label_schema=label_schema)
+        expected_non_empty_labels_map = {
+            1: non_empty_labels[0],
+            2: non_empty_labels[1],
+        }
+        assert converter.label_map == expected_non_empty_labels_map
+        # Checking "label_map" of "SegmentationToAnnotationConverter" initialized with empty labels list
+        empty_labels = [
+            LabelEntity(
+                name="empty label",
+                domain=Domain.SEGMENTATION,
+                is_empty=True,
+                id=ID("3"),
+            ),
+            LabelEntity(
+                name="other empty label",
+                domain=Domain.SEGMENTATION,
+                is_empty=True,
+                id=ID("4"),
+            ),
+        ]
+        label_group = LabelGroup(name="Segmentation labels group", labels=empty_labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = SegmentationToAnnotationConverter(label_schema=label_schema)
+        assert converter.label_map == {}
+        # Checking "label_map" of "SegmentationToAnnotationConverter" initialized with non-empty and empty labels list
+        label_group = LabelGroup(
+            name="Segmentation labels group", labels=non_empty_labels + empty_labels
+        )
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = SegmentationToAnnotationConverter(label_schema=label_schema)
+        assert converter.label_map == expected_non_empty_labels_map
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_segmentation_to_annotation_converter_convert_to_annotation(self):
+        """
+        <b>Description:</b>
+        Check "SegmentationToAnnotationConverter" class "convert_to_annotation" method
+
+        <b>Input data:</b>
+        "SegmentationToAnnotationConverter" class object, "predictions" array with hard predictions,
+        "metadata" dictionary
+
+        <b>Expected results:</b>
+        Test passes if "AnnotationSceneEntity" object returned by "convert_to_annotation" method is equal to
+        expected
+        """
+
+        def check_annotation(
+            actual_annotation: Annotation,
+            expected_label: LabelEntity,
+            expected_probability: float,
+            expected_points: list,
+        ):
+            assert isinstance(actual_annotation, Annotation)
+            annotation_labels = actual_annotation.get_labels()
+            # Checking Annotation ScoredLabel
+            assert len(annotation_labels) == 1
+            assert isinstance(annotation_labels[0], ScoredLabel)
+            assert annotation_labels[0].label == expected_label
+            assert annotation_labels[0].probability == pytest.approx(
+                expected_probability
+            )
+            # Checking Annotation Shape
+            assert isinstance(actual_annotation.shape, Polygon)
+            assert actual_annotation.shape.points == expected_points
+
+        labels = self.labels
+        label_group = LabelGroup(name="Segmentation labels group", labels=labels)
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = SegmentationToAnnotationConverter(label_schema=label_schema)
+        soft_predictions = np.array(
+            [
+                (
+                    [0.8, 0.1, 0.2],
+                    [0.9, 0.1, 0.2],
+                    [0.3, 0.2, 0.8],
+                    [0.1, 0.2, 0.8],
+                ),
+                (
+                    [0.1, 0.8, 0.3],
+                    [0.0, 0.8, 0.2],
+                    [0.2, 0.1, 0.9],
+                    [0.0, 0.2, 0.8],
+                ),
+                (
+                    [0.1, 0.7, 0.3],
+                    [0.3, 0.8, 0.2],
+                    [0.1, 0.2, 0.8],
+                    [0.4, 0.3, 0.7],
+                ),
+                (
+                    [0.0, 1.0, 0.0],
+                    [0.1, 0.9, 0.1],
+                    [0.1, 0.1, 0.9],
+                    [0.2, 0.2, 0.8],
+                ),
+            ]
+        )
+        hard_predictions = np.array(
+            [(0, 0, 2, 2), (1, 1, 2, 2), (1, 1, 2, 2), (1, 1, 2, 2)]
+        )
+
+        metadata = {
+            "non-required key": 1,
+            "other non-required key": 2,
+            "soft_predictions": soft_predictions,
+        }
+
+        predictions_to_annotations = converter.convert_to_annotation(
+            predictions=hard_predictions, metadata=metadata
+        )
+        check_annotation_scene(
+            annotation_scene=predictions_to_annotations, expected_length=2
+        )
+        check_annotation(
+            actual_annotation=predictions_to_annotations.annotations[0],
+            expected_label=labels[0],
+            expected_probability=0.8333333333333333,
+            expected_points=[
+                Point(0.0, 0.25),
+                Point(0.0, 0.5),
+                Point(0.0, 0.75),
+                Point(0.25, 0.75),
+                Point(0.25, 0.5),
+                Point(0.25, 0.25),
+            ],
+        )
+        check_annotation(
+            actual_annotation=predictions_to_annotations.annotations[1],
+            expected_label=labels[1],
+            expected_probability=0.8125,
+            expected_points=[
+                Point(0.5, 0.0),
+                Point(0.5, 0.25),
+                Point(0.5, 0.5),
+                Point(0.5, 0.75),
+                Point(0.75, 0.75),
+                Point(0.75, 0.5),
+                Point(0.75, 0.25),
+                Point(0.75, 0.0),
+            ],
+        )
 
     @pytest.mark.components(OteSdkComponent.OTE_SDK)
-    class TestPredictionToAnnotationConverter:
+    class TestClassificationToAnnotationConverter:
         @pytest.mark.priority_medium
         @pytest.mark.component
         @pytest.mark.reqids(Requirements.REQ_1)
-        def test_detection_to_annotation_convert(self):
+        def test_classification_to_annotation_converter_initialization(self):
             """
             <b>Description:</b>
-            Check that DetectionToAnnotationConverter correctly converts Network output to list of Annotation
+            Check "ClassificationToAnnotationConverter" class object initialization
 
             <b>Input data:</b>
-            Array of network output with shape [4,6]
+            "ClassificationToAnnotationConverter" class object with specified "label_schema" parameter
 
             <b>Expected results:</b>
-            Test passes if each Converted annotation has the same  values as the network output
+            Test passes if attributes of initialized "ClassificationToAnnotationConverter" object are equal to
+            expected
 
             <b>Steps</b>
-            1. Create mock network output
-            2. Convert network output to Annotation
-            3. Check Annotations
+            1. Check attributes of "ClassificationToAnnotationConverter" object initialized with one label group
+            with non-empty labels list length more than 1
+            2. Check attributes of "ClassificationToAnnotationConverter" object initialized with one label group
+            with non-empty labels list length equal to 1
+            3. Check attributes of "ClassificationToAnnotationConverter" object initialized with two label groups
+            with one label in each
+            4. Check attributes of "ClassificationToAnnotationConverter" object initialized with two label groups
+            with several labels in each
             """
-            test_boxes = np.array(
-                (
-                    (0, 0.6, 0.1, 0.1, 0.2, 0.3),
-                    (1, 0.2, 0.2, 0.1, 0.3, 0.4),
-                    (1, 0.7, 0.3, 0.2, 0.5, 0.6),
-                    (0, 0.1, 0.1, 0.1, 0.2, 0.3),
-                )
+            label_0 = LabelEntity(
+                name="label_0", domain=Domain.CLASSIFICATION, id=ID("0")
+            )
+            label_0_1 = LabelEntity(
+                name="label_0_1", domain=Domain.CLASSIFICATION, id=ID("0_1")
+            )
+            label_0_2 = LabelEntity(
+                name="label_0_2", domain=Domain.CLASSIFICATION, id=ID("0_2")
+            )
+            label_0_1_1 = LabelEntity(
+                name="label_0_1_1", domain=Domain.CLASSIFICATION, id=ID("0_1_1")
             )
 
-            labels = [
-                LabelEntity("Zero", domain=Domain.DETECTION),
-                LabelEntity("One", domain=Domain.DETECTION),
+            non_empty_labels = [label_0, label_0_1, label_0_1_1, label_0_2]
+            empty_labels = [
+                LabelEntity(
+                    name="empty label",
+                    domain=Domain.CLASSIFICATION,
+                    is_empty=True,
+                    id=ID("3"),
+                )
             ]
-
-            converter = DetectionToAnnotationConverter(labels)
-
-            annotation_scene = converter.convert_to_annotation(test_boxes)
-
-            for i, annotation in enumerate(annotation_scene.annotations):
-                label: ScoredLabel = next(iter(annotation.get_labels()))
-                test_label = labels[int(test_boxes[i][0])]
-                assert test_label.name == label.name
-
-                assert test_boxes[i][1], label.probability
-
-                assert test_boxes[i][2] == annotation.shape.x1
-                assert test_boxes[i][3] == annotation.shape.y1
-                assert test_boxes[i][4] == annotation.shape.x2
-                assert test_boxes[i][5] == annotation.shape.y2
-
-            annotation_scene = converter.convert_to_annotation(np.ndarray((0, 6)))
-            assert 0 == len(annotation_scene.shapes)
+            # Checking attributes of "ClassificationToAnnotationConverter" initialized with one label group with
+            # non-empty labels list length more than 1
+            label_group = LabelGroup(
+                name="Classification labels group",
+                labels=non_empty_labels + empty_labels,
+            )
+            label_schema = LabelSchemaEntity(label_groups=[label_group])
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            assert converter.labels == non_empty_labels
+            assert converter.empty_label == empty_labels[0]
+            assert converter.label_schema == label_schema
+            assert not converter.hierarchical
+            # Checking attributes of "ClassificationToAnnotationConverter" initialized with one label group with
+            # non-empty labels list length equal to 1
+            label_group = LabelGroup(
+                name="Classification labels group", labels=[label_0] + empty_labels
+            )
+            label_schema = LabelSchemaEntity(label_groups=[label_group])
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            assert converter.labels == [label_0] + empty_labels
+            assert converter.empty_label == empty_labels[0]
+            assert converter.label_schema == label_schema
+            assert not converter.hierarchical
+            # Checking attributes of "ClassificationToAnnotationConverter" initialized with two label groups with
+            # one label in each
+            label_group = LabelGroup(
+                name="Classification labels group", labels=[label_0_1]
+            )
+            other_label_group = LabelGroup(
+                name="Other Classification labels group", labels=[label_0_2]
+            )
+            label_schema = LabelSchemaEntity(
+                label_groups=[label_group, other_label_group]
+            )
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            assert converter.labels == [label_0_1, label_0_2]
+            assert not converter.empty_label
+            assert converter.label_schema == label_schema
+            assert not converter.hierarchical
+            # Checking attributes of "ClassificationToAnnotationConverter" initialized with two label groups with
+            # several labels in each
+            other_non_empty_labels = [
+                LabelEntity(name="label", domain=Domain.CLASSIFICATION, id=ID("3")),
+                LabelEntity(
+                    name="other label", domain=Domain.CLASSIFICATION, id=ID("4")
+                ),
+            ]
+            label_group = LabelGroup(
+                name="Classification labels group", labels=non_empty_labels
+            )
+            other_label_group = LabelGroup(
+                name="Other Classification labels group",
+                labels=other_non_empty_labels,
+            )
+            label_schema = LabelSchemaEntity(
+                label_groups=[label_group, other_label_group]
+            )
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            assert converter.labels == non_empty_labels + other_non_empty_labels
+            assert not converter.empty_label
+            assert converter.label_schema == label_schema
+            assert converter.hierarchical
 
         @pytest.mark.priority_medium
         @pytest.mark.component
         @pytest.mark.reqids(Requirements.REQ_1)
-        def test_detection_to_annotation_convert_openvino_shape(self):
+        def test_classification_to_annotation_converter_convert_to_annotation(self):
             """
             <b>Description:</b>
-            Check that DetectionToAnnotationConverter correctly converts OpenVINO Network output to annotations
+            Check "ClassificationToAnnotationConverter" class "convert_to_annotation" method
 
             <b>Input data:</b>
-            Array of network output with shape [4,7]
+            "ClassificationToAnnotationConverter" class object, "predictions" list, "metadata" dictionary
 
             <b>Expected results:</b>
-            Test passes if each Converted annotation has the same  values as the network output
+            Test passes if "AnnotationSceneEntity" object returned by "convert_to_annotation" method is equal to
+            expected
 
             <b>Steps</b>
-            1. Create mock network output
-            2. Convert network output to Annotation
-            3. Check Annotations
+            1. Check attributes of "AnnotationSceneEntity" object returned by "convert_to_annotation" method for
+            "ClassificationToAnnotationConverter" object initialized with label group with several non-empty labels
+            2. Check attributes of "AnnotationSceneEntity" object returned by "convert_to_annotation" method with
+            "predictions" parameter equal to empty list
+            3. Check attributes of "AnnotationSceneEntity" object returned by "convert_to_annotation" method for
+            "ClassificationToAnnotationConverter" object initialized with several LabelGroups
             """
-            test_boxes = np.array(
-                (
-                    (-12, 0, 0.6, 0.1, 0.1, 0.2, 0.3),
-                    (12, 1, 0.2, 0.0, 0.1, 0.1, 0.2),
-                    (1234, 1, 0.7, 0.2, 0.4, 0.7, 0.5),
-                    (1251, 0, 0.1, 0.1, 0.1, 0.2, 0.3),
+
+            def check_annotation(actual_annotation: Annotation, expected_labels: list):
+                assert isinstance(actual_annotation, Annotation)
+                assert (
+                    actual_annotation.get_labels(include_empty=True) == expected_labels
                 )
+                assert isinstance(actual_annotation.shape, Rectangle)
+                assert Rectangle.is_full_box(rectangle=actual_annotation.shape)
+
+            label_0 = LabelEntity(
+                name="label_0", domain=Domain.CLASSIFICATION, id=ID("0")
+            )
+            label_0_1 = LabelEntity(
+                name="label_0_1", domain=Domain.CLASSIFICATION, id=ID("0_1")
+            )
+            label_0_2 = LabelEntity(
+                name="label_0_2", domain=Domain.CLASSIFICATION, id=ID("0_2")
+            )
+            label_0_1_1 = LabelEntity(
+                name="label_0_1_1", domain=Domain.CLASSIFICATION, id=ID("0_1_1")
+            )
+            non_empty_labels = [label_0, label_0_1, label_0_1_1, label_0_2]
+            empty_labels = [
+                LabelEntity(
+                    name="empty label",
+                    domain=Domain.CLASSIFICATION,
+                    is_empty=True,
+                    id=ID("3"),
+                )
+            ]
+            # Checking "AnnotationSceneEntity" returned by "convert_to_annotation" for
+            # "ClassificationToAnnotationConverter" initialized with label group with several non-empty labels
+            label_group = LabelGroup(
+                name="Classification labels group",
+                labels=non_empty_labels + empty_labels,
+            )
+            label_schema = LabelSchemaEntity(label_groups=[label_group])
+            label_schema.add_child(parent=label_0, child=label_0_1)
+            label_schema.add_child(parent=label_0, child=label_0_2)
+            label_schema.add_child(parent=label_0_1, child=label_0_1_1)
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            predictions = [(0, 0.9), (1, 0.8), (2, 0.94), (3, 0.86)]
+            predictions_to_annotations = converter.convert_to_annotation(predictions)
+            check_annotation_scene(
+                annotation_scene=predictions_to_annotations, expected_length=1
+            )
+            check_annotation(
+                actual_annotation=predictions_to_annotations.annotations[0],
+                expected_labels=[
+                    ScoredLabel(label=label_0, probability=0.9),
+                    ScoredLabel(label=label_0_1, probability=0.8),
+                    ScoredLabel(label=label_0_1_1, probability=0.94),
+                    ScoredLabel(label=label_0_2, probability=0.86),
+                ],
+            )
+            # Checking attributes of "AnnotationSceneEntity" returned by "convert_to_annotation" method with
+            # "predictions" equal to empty list
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            predictions = []
+            predictions_to_annotations = converter.convert_to_annotation(predictions)
+            check_annotation_scene(
+                annotation_scene=predictions_to_annotations, expected_length=1
+            )
+            check_annotation(
+                actual_annotation=predictions_to_annotations.annotations[0],
+                expected_labels=[ScoredLabel(label=empty_labels[0], probability=1.0)],
+            )
+            # Checking attributes of "AnnotationSceneEntity" returned by "convert_to_annotation" for
+            # "ClassificationToAnnotationConverter" initialized with several LabelGroups
+            label_group = LabelGroup(
+                name="Classification labels group", labels=[label_0_1_1]
+            )
+            other_label_group = LabelGroup(
+                name="Other Classification labels group",
+                labels=[label_0_1, label_0_2],
+            )
+            label_schema = LabelSchemaEntity(
+                label_groups=[label_group, other_label_group]
+            )
+            label_schema.add_child(parent=label_0, child=label_0_1)
+            label_schema.add_child(parent=label_0, child=label_0_2)
+            label_schema.add_child(parent=label_0_1, child=label_0_1_1)
+            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            predictions = [(0, 0.9), (1, 0.8)]
+            predictions_to_annotations = converter.convert_to_annotation(predictions)
+            check_annotation_scene(
+                annotation_scene=predictions_to_annotations, expected_length=1
+            )
+            check_annotation(
+                predictions_to_annotations.annotations[0],
+                expected_labels=[
+                    ScoredLabel(label=label_0_1_1, probability=0.9),
+                    ScoredLabel(label=label_0_2, probability=0.8),
+                    ScoredLabel(label=label_0_1_1, probability=0.9),
+                    ScoredLabel(label=label_0_1, probability=0.9),
+                    ScoredLabel(label=label_0, probability=0.9),
+                ],
             )
 
-            labels = [
-                LabelEntity("Zero", domain=Domain.DETECTION),
-                LabelEntity("One", domain=Domain.DETECTION),
-            ]
-
-            converter = DetectionToAnnotationConverter(labels)
-
-            annotation_scene = converter.convert_to_annotation(test_boxes)
-
-            for i, annotation in enumerate(annotation_scene.annotations):
-                label: ScoredLabel = next(iter(annotation.get_labels()))
-                test_label = labels[int(test_boxes[i][1])]
-                assert test_label.name == label.name
-
-                assert test_boxes[i][2] == label.probability
-
-                assert test_boxes[i][3] == annotation.shape.x1
-                assert test_boxes[i][4] == annotation.shape.y1
-                assert test_boxes[i][5] == annotation.shape.x2
-                assert test_boxes[i][6] == annotation.shape.y2
-
+    @pytest.mark.components(OteSdkComponent.OTE_SDK)
+    class TestAnomalyClassificationToAnnotationConverter:
         @pytest.mark.priority_medium
         @pytest.mark.component
         @pytest.mark.reqids(Requirements.REQ_1)
-        def test_detection_to_annotation_convert_invalid_input(self):
+        def test_anomaly_classification_to_annotation_converter_initialization(
+            self,
+        ):
             """
             <b>Description:</b>
-            Check that DetectionToAnnotationConverter raises an error if invalid inputs are provided
+            Check "AnomalyClassificationToAnnotationConverter" class initialization
 
             <b>Input data:</b>
-            Array of size [1203, 5]
-            Array of size [3, 8]
+            "AnomalyClassificationToAnnotationConverter" class object with specified "label_schema" parameter
 
             <b>Expected results:</b>
-            Test passes a ValueError is raised for both inputs
+            Test passes if attributes of initialized "AnomalyClassificationToAnnotationConverter" object are equal
+            to expected
 
             <b>Steps</b>
-            1. Create DetectionToAnnotationConverter
-            2. Attempt to convert array of [1203,5] to annotations
-            3. Attempt to convert array of [3, 8] to annotations
+            1. Check attributes of "AnomalyClassificationToAnnotationConverter" object initialized with non-empty
+            labels list
+            2. Check attributes of "AnomalyClassificationToAnnotationConverter" object initialized with non-empty
+            and empty labels list
             """
-            labels = [
-                LabelEntity("Zero", domain=Domain.DETECTION),
-                LabelEntity("One", domain=Domain.DETECTION),
+            # Checking attributes of "AnomalyClassificationToAnnotationConverter" initialized with non-empty labels
+            # list
+            non_empty_labels = [
+                LabelEntity(name="Normal", domain=Domain.CLASSIFICATION, id=ID("1")),
+                LabelEntity(name="Normal", domain=Domain.CLASSIFICATION, id=ID("2")),
+                LabelEntity(name="Anomalous", domain=Domain.CLASSIFICATION, id=ID("1")),
+                LabelEntity(name="Anomalous", domain=Domain.CLASSIFICATION, id=ID("2")),
             ]
-            converter = DetectionToAnnotationConverter(labels)
+            label_group = LabelGroup(
+                name="Classification labels group", labels=non_empty_labels
+            )
+            label_schema = LabelSchemaEntity(label_groups=[label_group])
+            converter = AnomalyClassificationToAnnotationConverter(
+                label_schema=label_schema
+            )
+            assert converter.normal_label == non_empty_labels[0]
+            assert converter.anomalous_label == non_empty_labels[2]
+            # Checking attributes of "AnomalyClassificationToAnnotationConverter" initialized with non-empty and
+            # empty labels list
+            empty_labels = [
+                LabelEntity(
+                    name="Normal",
+                    domain=Domain.CLASSIFICATION,
+                    is_empty=True,
+                    id=ID("3"),
+                ),
+                LabelEntity(
+                    name="Normal",
+                    domain=Domain.CLASSIFICATION,
+                    is_empty=True,
+                    id=ID("4"),
+                ),
+                LabelEntity(
+                    name="Anomalous",
+                    domain=Domain.CLASSIFICATION,
+                    is_empty=True,
+                    id=ID("3"),
+                ),
+                LabelEntity(
+                    name="Anomalous",
+                    domain=Domain.CLASSIFICATION,
+                    is_empty=True,
+                    id=ID("4"),
+                ),
+            ]
+            label_group = LabelGroup(
+                name="Anomaly classification labels group",
+                labels=non_empty_labels + empty_labels,
+            )
+            label_schema = LabelSchemaEntity(label_groups=[label_group])
+            converter = AnomalyClassificationToAnnotationConverter(
+                label_schema=label_schema
+            )
+            assert converter.normal_label == non_empty_labels[0]
+            assert converter.anomalous_label == non_empty_labels[2]
 
-            with pytest.raises(ValueError):
-                converter.convert_to_annotation(np.ndarray((1203, 5)))
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_anomaly_classification_to_annotation_converter_convert_to_annotation(
+        self,
+    ):
+        """
+        <b>Description:</b>
+        Check "AnomalyClassificationToAnnotationConverter" class "convert_to_annotation" method
 
-            with pytest.raises(ValueError):
-                converter.convert_to_annotation(np.ndarray((3, 8)))
+        <b>Input data:</b>
+        "AnomalyClassificationToAnnotationConverter" class object, "predictions" array
 
+        <b>Expected results:</b>
+        Test passes if "AnnotationSceneEntity" object returned by "convert_to_annotation" method is equal to
+        expected
 
-except ImportError as e:
-    import warnings
+        <b>Steps</b>
+        1. Check attributes of "AnnotationSceneEntity" object returned by "convert_to_annotation" method for
+        "metadata" dictionary with specified "threshold" key
+        2. Check attributes of "AnnotationSceneEntity" object returned by "convert_to_annotation" method for
+        "metadata" dictionary without specified "threshold" key
+        """
 
-    warnings.warn("\nTODO(ikrylov): Add OpenVINO to requirerements.txt!\n" + str(e))
+        def check_annotation(actual_annotation: Annotation, expected_labels: list):
+            assert isinstance(actual_annotation, Annotation)
+            assert actual_annotation.get_labels() == expected_labels
+            assert isinstance(actual_annotation.shape, Rectangle)
+            assert Rectangle.is_full_box(rectangle=actual_annotation.shape)
+
+        non_empty_labels = [
+            LabelEntity(name="Normal", domain=Domain.CLASSIFICATION, id=ID("1")),
+            LabelEntity(name="Anomalous", domain=Domain.CLASSIFICATION, id=ID("2")),
+        ]
+        label_group = LabelGroup(
+            name="Anomaly classification labels group", labels=non_empty_labels
+        )
+        label_schema = LabelSchemaEntity(label_groups=[label_group])
+        converter = AnomalyClassificationToAnnotationConverter(
+            label_schema=label_schema
+        )
+        predictions = np.array([(0, 9, 5), (4, 8, 24)])
+        # Checking attributes of "AnnotationSceneEntity" returned by "convert_to_annotation" for "metadata" with
+        # specified "threshold" key
+        metadata = {
+            "non-required key": 1,
+            "other non-required key": 2,
+            "threshold": 60,
+        }
+        predictions_to_annotations = converter.convert_to_annotation(
+            predictions=predictions, metadata=metadata
+        )
+        check_annotation_scene(
+            annotation_scene=predictions_to_annotations, expected_length=1
+        )
+        check_annotation(
+            predictions_to_annotations.annotations[0],
+            expected_labels=[ScoredLabel(label=non_empty_labels[0], probability=24.0)],
+        )
+        # Checking attributes of "AnnotationSceneEntity" returned by "convert_to_annotation" for "metadata" without
+        # specified "threshold" key
+        metadata = {"non-required key": 1, "other non-required key": 2}
+        predictions_to_annotations = converter.convert_to_annotation(
+            predictions=predictions, metadata=metadata
+        )
+        check_annotation_scene(
+            annotation_scene=predictions_to_annotations, expected_length=1
+        )
+        check_annotation(
+            predictions_to_annotations.annotations[0],
+            expected_labels=[ScoredLabel(label=non_empty_labels[1], probability=24.0)],
+        )

--- a/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py
+++ b/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py
@@ -179,7 +179,7 @@ class TestDetectionToAnnotationConverter:
 
 
 @pytest.mark.components(OteSdkComponent.OTE_SDK)
-class TestIPredictionToAnnotationConverter:
+class TestIPredictionToAnnotation:
     @pytest.mark.priority_medium
     @pytest.mark.component
     @pytest.mark.reqids(Requirements.REQ_1)
@@ -190,7 +190,7 @@ class TestIPredictionToAnnotationConverter:
         ),
         set(),
     )
-    def test_i_prediction_to_annotation_converter_convert_to_annotation(self):
+    def test_i_prediction_to_annotation(self):
         """
         <b>Description:</b>
         Check "IPredictionToAnnotationConverter" class "convert_to_annotation" method
@@ -329,7 +329,7 @@ def check_annotation_scene(
 
 
 @pytest.mark.components(OteSdkComponent.OTE_SDK)
-class TestDetectionBoxToAnnotationConverter:
+class TestDetectionBoxToAnnotation:
     color = Color(red=180, green=230, blue=30)
     creation_date = now()
     labels = [
@@ -352,7 +352,7 @@ class TestDetectionBoxToAnnotationConverter:
     @pytest.mark.priority_medium
     @pytest.mark.component
     @pytest.mark.reqids(Requirements.REQ_1)
-    def test_detection_box_to_annotation_converter_initialization(self):
+    def test_detection_box_to_annotation_init(self):
         """
         <b>Description:</b>
         Check "DetectionBoxToAnnotationConverter" class object initialization
@@ -406,7 +406,7 @@ class TestDetectionBoxToAnnotationConverter:
     @pytest.mark.priority_medium
     @pytest.mark.component
     @pytest.mark.reqids(Requirements.REQ_1)
-    def test_detection_box_to_annotation_converter_convert_to_annotation(self):
+    def test_detection_box_to_annotation_convert(self):
         """
         <b>Description:</b>
         Check "DetectionBoxToAnnotationConverter" class "convert_to_annotation" method
@@ -478,7 +478,7 @@ class TestDetectionBoxToAnnotationConverter:
 
 
 @pytest.mark.components(OteSdkComponent.OTE_SDK)
-class TestSegmentationToAnnotationConverter:
+class TestSegmentationToAnnotation:
     color = Color(red=180, green=230, blue=30)
     creation_date = now()
     labels = [
@@ -501,7 +501,7 @@ class TestSegmentationToAnnotationConverter:
     @pytest.mark.priority_medium
     @pytest.mark.component
     @pytest.mark.reqids(Requirements.REQ_1)
-    def test_segmentation_to_annotation_converter_initialization(self):
+    def test_segmentation_to_annotation_init(self):
         """
         <b>Description:</b>
         Check "SegmentationToAnnotationConverter" class object initialization
@@ -562,7 +562,7 @@ class TestSegmentationToAnnotationConverter:
     @pytest.mark.priority_medium
     @pytest.mark.component
     @pytest.mark.reqids(Requirements.REQ_1)
-    def test_segmentation_to_annotation_converter_convert_to_annotation(self):
+    def test_segmentation_to_annotation_convert(self):
         """
         <b>Description:</b>
         Check "SegmentationToAnnotationConverter" class "convert_to_annotation" method
@@ -673,11 +673,11 @@ class TestSegmentationToAnnotationConverter:
         )
 
     @pytest.mark.components(OteSdkComponent.OTE_SDK)
-    class TestClassificationToAnnotationConverter:
+    class TestClassificationToAnnotation:
         @pytest.mark.priority_medium
         @pytest.mark.component
         @pytest.mark.reqids(Requirements.REQ_1)
-        def test_classification_to_annotation_converter_initialization(self):
+        def test_classification_to_annotation_init(self):
             """
             <b>Description:</b>
             Check "ClassificationToAnnotationConverter" class object initialization
@@ -787,7 +787,7 @@ class TestSegmentationToAnnotationConverter:
         @pytest.mark.priority_medium
         @pytest.mark.component
         @pytest.mark.reqids(Requirements.REQ_1)
-        def test_classification_to_annotation_converter_convert_to_annotation(self):
+        def test_classification_to_annotation_convert(self):
             """
             <b>Description:</b>
             Check "ClassificationToAnnotationConverter" class "convert_to_annotation" method
@@ -907,11 +907,11 @@ class TestSegmentationToAnnotationConverter:
             )
 
     @pytest.mark.components(OteSdkComponent.OTE_SDK)
-    class TestAnomalyClassificationToAnnotationConverter:
+    class TestAnomalyClassificationToAnnotation:
         @pytest.mark.priority_medium
         @pytest.mark.component
         @pytest.mark.reqids(Requirements.REQ_1)
-        def test_anomaly_classification_to_annotation_converter_initialization(
+        def test_anomaly_classification_to_annotation_init(
             self,
         ):
             """
@@ -990,7 +990,7 @@ class TestSegmentationToAnnotationConverter:
     @pytest.mark.priority_medium
     @pytest.mark.component
     @pytest.mark.reqids(Requirements.REQ_1)
-    def test_anomaly_classification_to_annotation_converter_convert_to_annotation(
+    def test_anomaly_classification_to_annotation_convert(
         self,
     ):
         """

--- a/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_visualization.py
+++ b/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_visualization.py
@@ -1,16 +1,6 @@
-# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
 
 import cv2
 import numpy as np
@@ -199,21 +189,3 @@ class TestVisualizer:
 
         actual_image = Visualizer().draw(image=image, annotation=annotation_scene)
         assert np.array_equal(actual_image, expected_image)
-
-    @pytest.mark.priority_medium
-    @pytest.mark.component
-    @pytest.mark.reqids(Requirements.REQ_1)
-    def test_visualizer_is_quit(self):
-        """
-        <b>Description:</b>
-        Check "Visualizer" class "is_quit" method
-
-        <b>Input data:</b>
-        "Visualizer" object with specified attributes
-
-        <b>Expected results:</b>
-        Test passes if bool value returned by "is_quit" method is equal to expected
-        """
-        visualizer = Visualizer(delay=1001)
-        is_quit = visualizer.is_quit()
-        assert not is_quit

--- a/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_visualization.py
+++ b/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_visualization.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2020-2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import cv2
+import numpy as np
+import pytest
+
+from ote_sdk.entities.annotation import (
+    Annotation,
+    AnnotationSceneEntity,
+    AnnotationSceneKind,
+)
+from ote_sdk.entities.color import Color
+from ote_sdk.entities.id import ID
+from ote_sdk.entities.label import Domain, LabelEntity
+from ote_sdk.entities.scored_label import ScoredLabel
+from ote_sdk.entities.shapes.ellipse import Ellipse
+from ote_sdk.entities.shapes.rectangle import Rectangle
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+from ote_sdk.usecases.exportable_code.streamer.streamer import MediaType
+from ote_sdk.usecases.exportable_code.visualization import Visualizer
+from ote_sdk.utils.shape_drawer import ShapeDrawer
+from ote_sdk.utils.time_utils import now
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestVisualizer:
+    image = np.random.randint(low=0, high=255, size=(480, 640, 3)).astype(np.float32)
+
+    @staticmethod
+    def annotation_scene() -> AnnotationSceneEntity:
+        creation_date = now()
+        annotation_color = Color(red=30, green=180, blue=70)
+        other_annotation_color = Color(red=240, green=30, blue=40)
+        detection_label = LabelEntity(
+            name="detection label",
+            domain=Domain.DETECTION,
+            color=annotation_color,
+            creation_date=creation_date,
+            id=ID("detection_1"),
+        )
+        segmentation_label = LabelEntity(
+            name="segmentation label",
+            domain=Domain.SEGMENTATION,
+            color=annotation_color,
+            creation_date=creation_date,
+            id=ID("segmentation_1"),
+        )
+        annotation = Annotation(
+            shape=Rectangle(x1=0.1, y1=0.1, x2=0.4, y2=0.5),
+            labels=[
+                ScoredLabel(detection_label, 0.9),
+                ScoredLabel(segmentation_label, 0.8),
+            ],
+        )
+
+        classification_label = LabelEntity(
+            name="classification label",
+            domain=Domain.CLASSIFICATION,
+            color=other_annotation_color,
+            creation_date=creation_date,
+            id=ID("classification_1"),
+        )
+        anomaly_segmentation_label = LabelEntity(
+            name="anomaly_segmentation label",
+            domain=Domain.ANOMALY_SEGMENTATION,
+            color=other_annotation_color,
+            creation_date=creation_date,
+            id=ID("anomaly_segmentation_1"),
+        )
+        other_annotation = Annotation(
+            shape=Ellipse(x1=0.6, y1=0.4, x2=0.7, y2=0.9),
+            labels=[
+                ScoredLabel(classification_label, 0.75),
+                ScoredLabel(anomaly_segmentation_label, 0.9),
+            ],
+        )
+        annotation_scene = AnnotationSceneEntity(
+            annotations=[annotation, other_annotation],
+            kind=AnnotationSceneKind.ANNOTATION,
+        )
+        return annotation_scene
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_visualizer_initialization(self):
+        """
+        <b>Description:</b>
+        Check "Visualizer" class object initialization
+
+        <b>Input data:</b>
+        "Visualizer" object with specified attributes
+
+        <b>Expected results:</b>
+        Test passes if attributes of initialized "Visualizer" object are equal to expected
+
+        <b>Steps</b>
+        1. Check attributes of "Visualizer" object initialized with default optional parameters
+        2. Check attributes of "Visualizer" object initialized with default optional parameters except "media_type" is
+        set to "IMAGE"
+        3. Check attributes of "Visualizer" object initialized with default optional parameters except "media_type" is
+        set to "VIDEO"
+        4. Check attributes of "Visualizer" object initialized with specified optional parameters
+        """
+
+        def check_visualizer_attributes(
+            actual_visualizer: Visualizer,
+            expected_name: str,
+            expected_delay: int,
+            expected_show_count: bool,
+            expected_is_one_label: bool,
+        ):
+            assert actual_visualizer.window_name == expected_name
+            assert actual_visualizer.delay == expected_delay
+            assert isinstance(actual_visualizer.shape_drawer, ShapeDrawer)
+            assert actual_visualizer.shape_drawer.show_count == expected_show_count
+            assert actual_visualizer.shape_drawer.is_one_label == expected_is_one_label
+
+        # Checking attributes of "Visualizer" initialized with default optional parameters
+        visualizer = Visualizer()
+        check_visualizer_attributes(
+            actual_visualizer=visualizer,
+            expected_name="Window",
+            expected_delay=0,
+            expected_show_count=False,
+            expected_is_one_label=False,
+        )
+        # Checking attributes of "Visualizer" initialized with default optional parameters except "media_type" is set
+        # to "IMAGE"
+        visualizer = Visualizer(media_type=MediaType.IMAGE)
+        check_visualizer_attributes(
+            actual_visualizer=visualizer,
+            expected_name="Window",
+            expected_delay=0,
+            expected_show_count=False,
+            expected_is_one_label=False,
+        )
+        # Checking attributes of "Visualizer" initialized with default optional parameters except "media_type" is set
+        # to "VIDEO"
+        visualizer = Visualizer(media_type=MediaType.VIDEO)
+        check_visualizer_attributes(
+            actual_visualizer=visualizer,
+            expected_name="Window",
+            expected_delay=1,
+            expected_show_count=False,
+            expected_is_one_label=False,
+        )
+        # Checking attributes of "Visualizer" initialized with specified optional parameters
+        visualizer = Visualizer(
+            media_type=MediaType.CAMERA,
+            window_name="Test Visualizer",
+            show_count=True,
+            is_one_label=True,
+            delay=5,
+        )
+        check_visualizer_attributes(
+            actual_visualizer=visualizer,
+            expected_name="Test Visualizer",
+            expected_delay=5,
+            expected_show_count=True,
+            expected_is_one_label=True,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_visualizer_draw(self):
+        """
+        <b>Description:</b>
+        Check "Visualizer" class "draw" method
+
+        <b>Input data:</b>
+        "Visualizer" object with specified attributes, "image" array, "annotation" AnnotationSceneEntity-type object
+
+        <b>Expected results:</b>
+        Test passes if array returned by "draw" method is equal to expected
+        """
+        annotation_scene = self.annotation_scene()
+        image = self.image
+        expected_image = image.copy()
+        expected_image = cv2.cvtColor(expected_image, cv2.COLOR_RGB2BGR)
+        shape_drawer = ShapeDrawer(show_count=False, is_one_label=False)
+        expected_image = shape_drawer.draw(
+            image=expected_image, entity=annotation_scene, labels=[]
+        )
+
+        actual_image = Visualizer().draw(image=image, annotation=annotation_scene)
+        assert np.array_equal(actual_image, expected_image)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_visualizer_is_quit(self):
+        """
+        <b>Description:</b>
+        Check "Visualizer" class "is_quit" method
+
+        <b>Input data:</b>
+        "Visualizer" object with specified attributes
+
+        <b>Expected results:</b>
+        Test passes if bool value returned by "is_quit" method is equal to expected
+        """
+        visualizer = Visualizer(delay=1001)
+        is_quit = visualizer.is_quit()
+        assert not is_quit


### PR DESCRIPTION
Test list:
•	ote_sdk/ote_sdk/tests/usecases/evaluation/test_dice.py
•	ote_sdk/ote_sdk/tests/configuration/enums/test_config_element_type.py
•	ote_sdk/ote_sdk/tests/serialization/test_label_mapper.py
•	ote_sdk/ote_sdk/tests/usecases/exportable_code/test_visualization.py: "show" and "is_quit" methods are uncovered due to requested "xcb" library
•	ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py

Task: CVS-74509