### PR TITLE
[ANOMALY CLASSIFICATION] Improve early stopping for STFPM

### DIFF
--- a/external/anomaly/anomaly_classification/configs/configuration_enums.py
+++ b/external/anomaly/anomaly_classification/configs/configuration_enums.py
@@ -34,7 +34,7 @@ class EarlyStoppingMetrics(ConfigurableEnum):
     """
 
     IMAGE_ROC_AUC = "image_AUROC"
-    IMAGE_F1 = "image_OptimalF1"
+    IMAGE_F1 = "image_F1"
 
 
 class ModelName(ConfigurableEnum):

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
@@ -4,8 +4,7 @@ dataset:
   num_workers:
     affects_outcome_of: NONE
     default_value: 8
-    description:
-      Increasing this value might improve training speed however it might
+    description: Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading
       will happen in the main training thread.
     editable: true
@@ -18,14 +17,12 @@ dataset:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 8
     visible_in_ui: true
     warning: null
   train_batch_size:
     affects_outcome_of: TRAINING
     default_value: 32
-    description:
-      The number of training samples seen in each iteration of training.
+    description: The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -38,16 +35,13 @@ dataset:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 32
     visible_in_ui: true
-    warning:
-      Increasing this value may cause the system to use more memory than available,
+    warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
   type: PARAMETER_GROUP
   visible_in_ui: true
 description: Configuration for Padim
 header: Configuration for Padim
-id: ""
 pot_parameters:
   description: POT Parameters
   header: POT Parameters
@@ -67,7 +61,6 @@ pot_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: Performance
     visible_in_ui: true
     warning: null
   stat_subset_size:
@@ -84,7 +77,6 @@ pot_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 300
     visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP

--- a/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/padim/configuration.yaml
@@ -4,7 +4,8 @@ dataset:
   num_workers:
     affects_outcome_of: NONE
     default_value: 8
-    description: Increasing this value might improve training speed however it might
+    description:
+      Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading
       will happen in the main training thread.
     editable: true
@@ -22,7 +23,8 @@ dataset:
   train_batch_size:
     affects_outcome_of: TRAINING
     default_value: 32
-    description: The number of training samples seen in each iteration of training.
+    description:
+      The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -36,7 +38,8 @@ dataset:
       rules: []
       type: UI_RULES
     visible_in_ui: true
-    warning: Increasing this value may cause the system to use more memory than available,
+    warning:
+      Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -16,16 +16,15 @@ Configurable parameters for STFPM anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from attr import attrs
-
 from anomaly_classification.configs.configuration import BaseAnomalyClassificationConfig
 from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics
+from attr import attrs
 from ote_sdk.configuration.elements import (
     ParameterGroup,
     add_parameter_group,
+    configurable_integer,
     selectable,
     string_attribute,
-    configurable_integer,
 )
 from ote_sdk.configuration.model_lifecycle import ModelLifecycle
 
@@ -69,10 +68,10 @@ class STFPMConfig(BaseAnomalyClassificationConfig):
                 max_value=100,
                 header="Early Stopping Patience",
                 description="Number of epochs to wait for an improvement in the monitored metric. If the metric has "
-                            "not improved for this many epochs, the training will stop and the best model will be "
-                            "returned.",
+                "not improved for this many epochs, the training will stop and the best model will be "
+                "returned.",
                 warning="Setting this value too low might lead to underfitting. Setting the value too high will "
-                        "increase the training time and might lead to overfitting.",
+                "increase the training time and might lead to overfitting.",
                 affects_outcome_of=ModelLifecycle.TRAINING,
             )
 

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.py
@@ -16,15 +16,18 @@ Configurable parameters for STFPM anomaly classification task
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+from attr import attrs
+
 from anomaly_classification.configs.configuration import BaseAnomalyClassificationConfig
 from anomaly_classification.configs.configuration_enums import EarlyStoppingMetrics
-from attr import attrs
 from ote_sdk.configuration.elements import (
     ParameterGroup,
     add_parameter_group,
     selectable,
     string_attribute,
+    configurable_integer,
 )
+from ote_sdk.configuration.model_lifecycle import ModelLifecycle
 
 
 @attrs
@@ -55,9 +58,22 @@ class STFPMConfig(BaseAnomalyClassificationConfig):
             description = header
 
             metric = selectable(
-                default_value=EarlyStoppingMetrics.IMAGE_ROC_AUC,
+                default_value=EarlyStoppingMetrics.IMAGE_F1,
                 header="Early Stopping Metric",
                 description="The metric used to determine if the model should stop training",
+            )
+
+            patience = configurable_integer(
+                default_value=10,
+                min_value=1,
+                max_value=100,
+                header="Early Stopping Patience",
+                description="Number of epochs to wait for an improvement in the monitored metric. If the metric has "
+                            "not improved for this many epochs, the training will stop and the best model will be "
+                            "returned.",
+                warning="Setting this value too low might lead to underfitting. Setting the value too high will "
+                        "increase the training time and might lead to overfitting.",
+                affects_outcome_of=ModelLifecycle.TRAINING,
             )
 
         early_stopping = add_parameter_group(EarlyStoppingParameters)

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
@@ -4,8 +4,7 @@ dataset:
   num_workers:
     affects_outcome_of: NONE
     default_value: 8
-    description:
-      Increasing this value might improve training speed however it might
+    description: Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading
       will happen in the main training thread.
     editable: true
@@ -18,14 +17,12 @@ dataset:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 8
     visible_in_ui: true
     warning: null
   train_batch_size:
     affects_outcome_of: TRAINING
     default_value: 32
-    description:
-      The number of training samples seen in each iteration of training.
+    description: The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -38,16 +35,13 @@ dataset:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 32
     visible_in_ui: true
-    warning:
-      Increasing this value may cause the system to use more memory than available,
+    warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
   type: PARAMETER_GROUP
   visible_in_ui: true
 description: Configuration for STFPM
 header: Configuration for STFPM
-id: ""
 model:
   description: Model Parameters
   early_stopping:
@@ -55,13 +49,13 @@ model:
     header: Early Stopping Parameters
     metric:
       affects_outcome_of: NONE
-      default_value: image_AUROC
+      default_value: image_F1
       description: The metric used to determine if the model should stop training
       editable: true
       enum_name: EarlyStoppingMetrics
       header: Early Stopping Metric
       options:
-        IMAGE_F1: image_OptimalF1
+        IMAGE_F1: image_F1
         IMAGE_ROC_AUC: image_AUROC
       type: SELECTABLE
       ui_rules:
@@ -69,9 +63,27 @@ model:
         operator: AND
         rules: []
         type: UI_RULES
-      value: image_AUROC
       visible_in_ui: true
       warning: null
+    patience:
+      affects_outcome_of: TRAINING
+      default_value: 10
+      description: Number of epochs to wait for an improvement in the monitored metric.
+        If the metric has not improved for this many epochs, the training will stop
+        and the best model will be returned.
+      editable: true
+      header: Early Stopping Patience
+      max_value: 100
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      visible_in_ui: true
+      warning: Setting this value too low might lead to underfitting. Setting the
+        value too high will increase the training time and might lead to overfitting.
     type: PARAMETER_GROUP
     visible_in_ui: true
   header: Model Parameters
@@ -96,7 +108,6 @@ pot_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: Performance
     visible_in_ui: true
     warning: null
   stat_subset_size:
@@ -113,7 +124,6 @@ pot_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 300
     visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP

--- a/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
+++ b/external/anomaly/anomaly_classification/configs/stfpm/configuration.yaml
@@ -4,7 +4,8 @@ dataset:
   num_workers:
     affects_outcome_of: NONE
     default_value: 8
-    description: Increasing this value might improve training speed however it might
+    description:
+      Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading
       will happen in the main training thread.
     editable: true
@@ -22,7 +23,8 @@ dataset:
   train_batch_size:
     affects_outcome_of: TRAINING
     default_value: 32
-    description: The number of training samples seen in each iteration of training.
+    description:
+      The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -36,7 +38,8 @@ dataset:
       rules: []
       type: UI_RULES
     visible_in_ui: true
-    warning: Increasing this value may cause the system to use more memory than available,
+    warning:
+      Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
   type: PARAMETER_GROUP
   visible_in_ui: true
@@ -68,7 +71,8 @@ model:
     patience:
       affects_outcome_of: TRAINING
       default_value: 10
-      description: Number of epochs to wait for an improvement in the monitored metric.
+      description:
+        Number of epochs to wait for an improvement in the monitored metric.
         If the metric has not improved for this many epochs, the training will stop
         and the best model will be returned.
       editable: true
@@ -82,7 +86,8 @@ model:
         rules: []
         type: UI_RULES
       visible_in_ui: true
-      warning: Setting this value too low might lead to underfitting. Setting the
+      warning:
+        Setting this value too low might lead to underfitting. Setting the
         value too high will increase the training time and might lead to overfitting.
     type: PARAMETER_GROUP
     visible_in_ui: true


### PR DESCRIPTION
# Description
This PR improves early stopping for the STFPM Anomaly Classification algorithm.

# Changes:
- Make early stopping patience configurable
- Increase default early stopping patience from 3 epochs to 10 epochs
- Change default early stopping metric to F1 score
- Re-generate configuration yaml files

# Build
- [VM]( https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/23330/) ✅
- [BMM](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/23351/) ✅
- Manual Training ✅