### PR TITLE
[OTE_SDK_TESTS] Increase code coverage utils.py, url.py, etc

### DIFF
--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_elements_utils.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_elements_utils.py
@@ -1,0 +1,428 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from types import FunctionType
+
+import pytest
+from attr import fields
+
+from ote_sdk.configuration import ConfigurableParameters
+from ote_sdk.configuration.elements.parameter_group import ParameterGroup
+from ote_sdk.configuration.elements.utils import (
+    _convert_enum_selectable_value,
+    _validate_and_convert_float,
+    attr_enum_to_str_serializer,
+    attr_strict_float_converter,
+    attr_strict_float_on_setattr,
+    attr_strict_int_validator,
+    construct_attr_enum_selectable_converter,
+    construct_attr_enum_selectable_onsetattr,
+    construct_attr_selectable_validator,
+    construct_attr_value_validator,
+    convert_string_to_id,
+)
+from ote_sdk.configuration.enums.config_element_type import ElementCategory
+from ote_sdk.entities.id import ID
+from ote_sdk.tests.configuration.dummy_config import SomeEnumSelectable
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestUtilsFunctions:
+    parameter_group = ParameterGroup(header="test header")
+    attribute = fields(ConfigurableParameters)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_utils_attr_enum_to_str_serializer(self):
+        """
+        <b>Description:</b>
+        Check "attr_enum_to_str_serializer" function
+
+        <b>Input data:</b>
+        "instance" Enum object, "attribute" Attribute object, "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if value returned by "attr_enum_to_str_serializer" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "attr_enum_to_str_serializer" function when "Enum" object is specified as "value"
+        parameter
+        2. Check value returned by "attr_enum_to_str_serializer" function when "str" object is specified as "value"
+        parameter
+        """
+        # Checking value returned by "attr_enum_to_str_serializer" when "Enum" object is specified as "value"
+        assert (
+            attr_enum_to_str_serializer(
+                instance=ElementCategory,
+                attribute=ElementCategory.PRIMITIVES.name,
+                value=ElementCategory.PRIMITIVES,
+            )
+            == "PRIMITIVES"
+        )
+        assert (
+            attr_enum_to_str_serializer(
+                instance=ElementCategory,
+                attribute=ElementCategory.RULES.name,
+                value=ElementCategory.RULES,
+            )
+            == "RULES"
+        )
+        # Checking value returned by "attr_enum_to_str_serializer" when "str" object is specified as "value"
+        assert (
+            attr_enum_to_str_serializer(
+                instance=ElementCategory,
+                attribute=self.attribute.id,
+                value="non enum string",
+            )
+            == "non enum string"
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_convert_enum_selectable_value(self):
+        """
+        <b>Description:</b>
+        Check "_convert_enum_selectable_value" function
+
+        <b>Input data:</b>
+        "value" parameter, "enum_class" ConfigurableEnum object
+
+        <b>Expected results:</b>
+        Test passes if ConfigurableEnum class element returned by "_convert_enum_selectable_value" function is
+        equal to expected
+
+        <b>Steps</b>
+        1. Check ConfigurableEnum class element returned by "_convert_enum_selectable_value" function when string
+        is specified as "value" parameter
+        2. Check ConfigurableEnum class element returned by "_convert_enum_selectable_value" function when
+        ConfigurableEnum class element is specified as "value" parameter
+        3. Check that ValueError exception is raised by "_convert_enum_selectable_value" function when unexpected string
+        is specified as "value" parameter
+        """
+        # Checking ConfigurableEnum element returned by "_convert_enum_selectable_value" when string is specified as
+        # "value"
+        assert (
+            _convert_enum_selectable_value(
+                value="test_2_test", enum_class=SomeEnumSelectable
+            )
+            == SomeEnumSelectable.TEST_2
+        )
+        # Checking ConfigurableEnum element returned by "_convert_enum_selectable_value" when ConfigurableEnum element
+        # is specified as "value"
+        assert (
+            _convert_enum_selectable_value(
+                value=SomeEnumSelectable.OPTION_C, enum_class=SomeEnumSelectable
+            )
+            == SomeEnumSelectable.OPTION_C
+        )
+        # Checking that ValueError exception is raised by "_convert_enum_selectable_value" when unexpected string is
+        # specified as "value"
+        with pytest.raises(ValueError):
+            _convert_enum_selectable_value(
+                value="some string", enum_class=SomeEnumSelectable
+            )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_construct_attr_enum_selectable_converter(self):
+        """
+        <b>Description:</b>
+        Check "construct_attr_enum_selectable_converter" function
+
+        <b>Input data:</b>
+        "default_value" ConfigurableEnum element
+
+        <b>Expected results:</b>
+        Test passes if function returned by "construct_attr_enum_selectable_converter" function is equal to expected
+        """
+        converter = construct_attr_enum_selectable_converter(
+            default_value=SomeEnumSelectable.TEST_NAME1
+        )
+        assert isinstance(converter, FunctionType)
+        assert converter(SomeEnumSelectable.BOGUS_NAME) == SomeEnumSelectable.BOGUS_NAME
+        assert converter("test_2_test") == SomeEnumSelectable.TEST_2
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_construct_attr_enum_selectable_onsetattr(self):
+        """
+        <b>Description:</b>
+        Check "construct_attr_enum_selectable_onsetattr" function
+
+        <b>Input data:</b>
+        "default_value" ConfigurableEnum element, "parameter_group" ParameterGroup object, "attribute" Attribute object,
+        "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if function returned by "construct_attr_enum_selectable_onsetattr" function is equal to expected
+        """
+        on_set_attr = construct_attr_enum_selectable_onsetattr(
+            default_value=SomeEnumSelectable.TEST_2
+        )
+        assert isinstance(on_set_attr, FunctionType)
+        assert (
+            on_set_attr(
+                self.parameter_group,
+                SomeEnumSelectable.TEST_2.value,
+                SomeEnumSelectable.TEST_2,
+            )
+            == SomeEnumSelectable.TEST_2
+        )
+        assert (
+            on_set_attr(
+                self.parameter_group, SomeEnumSelectable.OPTION_C.value, "option_c"
+            )
+            == SomeEnumSelectable.OPTION_C
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_construct_attr_value_validator(self):
+        """
+        <b>Description:</b>
+        Check "construct_attr_value_validator" function
+
+        <b>Input data:</b>
+        "min_value" and "max_value" parameters, "parameter_group" ParameterGroup object, "attribute" Attribute object,
+        "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if validator returned by "construct_attr_value_validator" function is equal to expected
+
+        <b>Steps</b>
+        1. Check that ValueError exception is not raised by validator returned by "construct_attr_value_validator"
+        function for values within specified bounds
+        2. Check that ValueError exception is raised by validator returned by "construct_attr_value_validator" function
+        for values out of specified bounds
+        """
+        attr_value_validator = construct_attr_value_validator(min_value=1, max_value=4)
+        # Checking that ValueError exception is not raised by validator returned by "construct_attr_value_validator"
+        # for values within specified bounds
+        for value_within in range(1, 5):
+            attr_value_validator(self.parameter_group, self.attribute.id, value_within)
+        # Checking that ValueError exception is raised by validator returned by "construct_attr_value_validator" for
+        # values out of specified bounds
+        for out_of_bounds_value in [0, 5]:
+            with pytest.raises(ValueError):
+                attr_value_validator(
+                    self.parameter_group, self.attribute.id, out_of_bounds_value
+                )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_construct_attr_selectable_validator(self):
+        """
+        <b>Description:</b>
+        Check "construct_attr_selectable_validator" function
+
+        <b>Input data:</b>
+        "options" list
+
+        <b>Expected results:</b>
+        Test passes if validator returned by "construct_attr_selectable_validator" function is equal to expected
+
+        <b>Steps</b>
+        1. Check that ValueError exception is not raised by validator returned by "construct_attr_selectable_validator"
+        function for values included in "options" list
+        2. Check that ValueError exception is raised by validator returned by "construct_attr_selectable_validator"
+        function for values not included in "options" list
+        """
+        attr_selectable_validator = construct_attr_selectable_validator(
+            options=["str_option", 2]
+        )
+        # Checking that ValueError exception is not raised by validator returned by
+        # "construct_attr_selectable_validator" for values included in "options"
+        for value_within in ["str_option", 2]:
+            attr_selectable_validator(
+                self.parameter_group, self.attribute.id, value_within
+            )
+        # Checking that ValueError exception is raised by validator returned by "construct_attr_selectable_validator"
+        # for values not included in "options"
+        for out_of_bounds_value in ["other_str_option", 3]:
+            with pytest.raises(ValueError):
+                attr_selectable_validator(
+                    self.parameter_group, self.attribute.id, out_of_bounds_value
+                )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_convert_string_to_id(self):
+        """
+        <b>Description:</b>
+        Check "convert_string_to_id" function
+
+        <b>Input data:</b>
+        "id_string" string or ID object
+
+        <b>Expected results:</b>
+        Test passes if ID object returned by "convert_string_to_id" function is equal to expected
+
+        <b>Steps</b>
+        1. Check ID object returned by "convert_string_to_id" function for string "id_string" parameter
+        2. Check ID object returned by "convert_string_to_id" function for ID "id_string" parameter
+        3. Check ID object returned by "convert_string_to_id" function for "id_string" parameter equal to None
+        4. Check ID object returned by "convert_string_to_id" function for int "id_string" parameter
+        """
+        # Checking ID returned by "convert_string_to_id" for string "id_string"
+        assert convert_string_to_id("some_id") == ID("some_id")
+        # Checking ID returned by "convert_string_to_id" for ID "id_string"
+        assert convert_string_to_id(ID("id_string")) == ID("id_string")
+        # Checking ID returned by "convert_string_to_id" for "id_string" equal to None
+        assert convert_string_to_id(None) == ID()
+        # Checking ID returned by "convert_string_to_id" for int "id_string"
+        assert convert_string_to_id(4) == 4  # type: ignore
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_attr_strict_int_validator(self):
+        """
+        <b>Description:</b>
+        Check "attr_strict_int_validator" function
+
+        <b>Input data:</b>
+        "parameter_group" ParameterGroup object, "attribute" Attribute object, "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if "attr_strict_int_validator" function raises TypeError exception for non-int "value"
+        parameter
+
+        <b>Steps</b>
+        1. Check that "attr_strict_int_validator" function not raises TypeError exception for int "value" parameter
+        2. Check that "attr_strict_int_validator" function raises TypeError exception for bool "value" parameter
+        3. Check that "attr_strict_int_validator" function raises TypeError exception for string "value" parameter
+        """
+        # Checking that "attr_strict_int_validator" not raises TypeError exception for int "value"
+        attr_strict_int_validator(
+            instance=self.parameter_group, attribute=self.attribute.id, value=1
+        )
+        # Checking that "attr_strict_int_validator" raises TypeError exception for bool "value"
+        with pytest.raises(TypeError):
+            attr_strict_int_validator(
+                instance=self.parameter_group, attribute=self.attribute.id, value=True
+            )
+        # Checking that "attr_strict_int_validator" raises TypeError exception for string "value"
+        with pytest.raises(TypeError):
+            attr_strict_int_validator(
+                instance=self.parameter_group,
+                attribute=self.attribute.id,
+                value="some string",  # type: ignore
+            )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_validate_and_convert_float(self):
+        """
+        <b>Description:</b>
+        Check "_validate_and_convert_float" function
+
+        <b>Input data:</b>
+        "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if value returned by "_validate_and_convert_float" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "_validate_and_convert_float" function for float "value" parameter
+        2. Check value returned by "_validate_and_convert_float" function for int "value" parameter
+        3. Check value returned by "_validate_and_convert_float" function for bool "value" parameter
+        4. Check value returned by "_validate_and_convert_float" function for str "value" parameter
+        """
+        # Checking value returned by "_validate_and_convert_float" for float "value"
+        assert _validate_and_convert_float(value=1.3) == 1.3
+        # Checking value returned by "_validate_and_convert_float" for int "value"
+        converted_value = _validate_and_convert_float(value=2)
+        assert isinstance(converted_value, float)
+        assert converted_value == float(2)
+        # Checking value returned by "_validate_and_convert_float" for bool "value"
+        assert not _validate_and_convert_float(value=True)
+        assert not _validate_and_convert_float(value=False)
+        # Checking value returned by "_validate_and_convert_float" for str "value"
+        assert not _validate_and_convert_float(value="some string")  # type: ignore
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_attr_strict_float_on_setattr(self):
+        """
+        <b>Description:</b>
+        Check "attr_strict_float_on_setattr" function
+
+        <b>Input data:</b>
+        "parameter_group" ParameterGroup object, "attribute" Attribute object, "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if value returned by "attr_strict_float_on_setattr" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "attr_strict_float_on_setattr" function for float "value" parameter
+        2. Check value returned by "attr_strict_float_on_setattr" function for int "value" parameter
+        3. Check that "attr_strict_float_on_setattr" function raises TypeError exception for bool "value" parameter
+        4. Check that "attr_strict_float_on_setattr" function raises TypeError exception for str "value" parameter
+        """
+        # Checking value returned by "attr_strict_float_on_setattr" for float "value"
+        assert (
+            attr_strict_float_on_setattr(
+                instance=self.parameter_group, attribute=self.attribute.id, value=10.7
+            )
+            == 10.7
+        )
+        # Checking value returned by "attr_strict_float_on_setattr" for int "value"
+        converted_value = attr_strict_float_on_setattr(
+            instance=self.parameter_group, attribute=self.attribute.id, value=2
+        )
+        assert isinstance(converted_value, float)
+        assert converted_value == float(2)
+        # Checking that "attr_strict_float_on_setattr" raises TypeError exception for bool "value"
+        with pytest.raises(TypeError):
+            attr_strict_float_on_setattr(
+                instance=self.parameter_group, attribute=self.attribute.id, value=True
+            )
+        # Checking that "attr_strict_float_on_setattr" raises TypeError exception for str "value"
+        with pytest.raises(TypeError):
+            attr_strict_float_on_setattr(
+                instance=self.parameter_group,
+                attribute=self.attribute.id,
+                value="some string",  # type: ignore
+            )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_attr_strict_float_converter(self):
+        """
+        <b>Description:</b>
+        Check "attr_strict_float_converter" function
+
+        <b>Input data:</b>
+        "value" parameter
+
+        <b>Expected results:</b>
+        Test passes if value returned by "attr_strict_float_converter" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "attr_strict_float_converter" function for float "value" parameter
+        2. Check value returned by "attr_strict_float_converter" function for int "value" parameter
+        3. Check value returned by "attr_strict_float_converter" function for bool or str "value" parameter
+        """
+        # Checking value returned by "attr_strict_float_converter" for float "value"
+        assert attr_strict_float_converter(value=20.1) == 20.1
+        # Checking value returned by "attr_strict_float_converter" for int "value"
+        converted_value = attr_strict_float_converter(value=0)
+        assert isinstance(converted_value, float)
+        assert converted_value == float(0)
+        # Checking that "attr_strict_float_converter" raises TypeError for bool or str "value"
+        for non_bool_value in [True, False, "some string"]:
+            with pytest.raises(TypeError):
+                attr_strict_float_converter(non_bool_value)  # type: ignore

--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_metadata_keys.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_metadata_keys.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+
+from ote_sdk.configuration.elements.metadata_keys import (
+    AFFECTS_OUTCOME_OF,
+    DEFAULT_VALUE,
+    DESCRIPTION,
+    EDITABLE,
+    ENUM_NAME,
+    HEADER,
+    MAX_VALUE,
+    MIN_VALUE,
+    OPTIONS,
+    TYPE,
+    UI_RULES,
+    VISIBLE_IN_UI,
+    WARNING,
+    allows_dictionary_values,
+    allows_model_template_override,
+)
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestMetadataKeys:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_metadata_keys_constants(self):
+        """
+        <b>Description:</b>
+        Check metadata_keys constants
+
+        <b>Input data:</b>
+        metadata_keys constants
+
+        <b>Expected results:</b>
+        Test passes if values of metadata_keys constants are equal to expected
+        """
+        assert DEFAULT_VALUE == "default_value"
+        assert MIN_VALUE == "min_value"
+        assert MAX_VALUE == "max_value"
+        assert DESCRIPTION == "description"
+        assert HEADER == "header"
+        assert WARNING == "warning"
+        assert EDITABLE == "editable"
+        assert VISIBLE_IN_UI == "visible_in_ui"
+        assert AFFECTS_OUTCOME_OF == "affects_outcome_of"
+        assert UI_RULES == "ui_rules"
+        assert TYPE == "type"
+        assert OPTIONS == "options"
+        assert ENUM_NAME == "enum_name"
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_allows_model_template_override(self):
+        """
+        <b>Description:</b>
+        Check "allows_model_template_override" function
+
+        <b>Input data:</b>
+        "keyword" constant
+
+        <b>Expected results:</b>
+        Test passes if value returned by "allows_model_template_override" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "allows_model_template_override" function for "keyword" that can be overridden
+        2. Check value returned by "allows_model_template_override" function for "keyword" that can not be overridden
+        """
+        # Checking value returned by "allows_model_template_override" for "keyword" that can be overridden
+        for keyword in [
+            DEFAULT_VALUE,
+            MIN_VALUE,
+            MAX_VALUE,
+            DESCRIPTION,
+            HEADER,
+            EDITABLE,
+            WARNING,
+            VISIBLE_IN_UI,
+            OPTIONS,
+            ENUM_NAME,
+            UI_RULES,
+            AFFECTS_OUTCOME_OF,
+        ]:
+            assert allows_model_template_override(keyword)
+        # Checking value returned by "allows_model_template_override" for "keyword" that can not be overridden
+        for keyword in [TYPE, "non-constant keyword"]:
+            assert not allows_model_template_override(keyword)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_allows_dictionary_values(self):
+        """
+        <b>Description:</b>
+        Check "allows_dictionary_values" function
+
+        <b>Input data:</b>
+        "keyword" constant
+
+        <b>Expected results:</b>
+        Test passes if value returned by "allows_dictionary_values" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "allows_dictionary_values" function for "keyword" that allowed to have a dictionary
+        as its value
+        2. Check value returned by "allows_dictionary_values" function for "keyword" that not allowed to have a
+        dictionary as its value
+        """
+        # Checking value returned by "allows_dictionary_values" for "keyword" that allowed to have a dictionary as its
+        # value
+        for keyword in [UI_RULES, OPTIONS]:
+            assert allows_dictionary_values(keyword)
+        # Checking value returned by "allows_dictionary_values" for "keyword" that not allowed to have a dictionary as
+        # its value
+        for keyword in [
+            DEFAULT_VALUE,
+            MIN_VALUE,
+            MAX_VALUE,
+            DESCRIPTION,
+            HEADER,
+            WARNING,
+            EDITABLE,
+            VISIBLE_IN_UI,
+            AFFECTS_OUTCOME_OF,
+            TYPE,
+            ENUM_NAME,
+            "non-constant keyword",
+        ]:
+            assert not allows_dictionary_values(keyword)

--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
@@ -1,0 +1,580 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+from attr import _make, validators
+
+from ote_sdk.configuration.elements.configurable_enum import ConfigurableEnum
+from ote_sdk.configuration.elements.primitive_parameters import (
+    boolean_attribute,
+    configurable_boolean,
+    configurable_float,
+    configurable_integer,
+    float_selectable,
+    selectable,
+    set_common_metadata,
+    string_attribute,
+)
+from ote_sdk.configuration.elements.utils import attr_strict_int_validator
+from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle
+from ote_sdk.configuration.ui_rules import NullUIRules, Rule, UIRules
+from ote_sdk.tests.configuration.dummy_config import SomeEnumSelectable
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestPrimitiveParameters:
+    ui_rules = UIRules(rules=[Rule(parameter="rule parameter", value=1)])
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_set_common_metadata(self):
+        """
+        <b>Description:</b>
+        Check "set_common_metadata" function
+
+        <b>Input data:</b>
+        "default_value" int, float, str, bool or ConfigurableEnum element, "header" string, "description" string,
+        "warning" string, "editable" bool value, "affects_outcome_of" ModelLifecycle element, "ui_rules" UIRules object,
+        "visible_in_ui" bool value, "parameter_type" ConfigElementType element
+
+        <b>Expected results:</b>
+        Test passes if dictionary returned by "set_common_metadata" function is equal to expected
+        """
+        header = "test header"
+        description = "test description"
+        warning = "test warning"
+        editable = False
+        affects_outcome_of = ModelLifecycle.TESTING
+        ui_rules = self.ui_rules
+        visible_in_ui = True
+        parameter_type = ConfigElementType.CONFIGURABLE_PARAMETERS
+        for default_value in [
+            5,  # int "default_value"
+            1.3,  # float "default_value"
+            "default value string",  # str "default_value"
+            False,  # bool "default_value"
+            SomeEnumSelectable.TEST_2,  # ConfigurableEnum "default_value"
+        ]:
+            assert set_common_metadata(
+                default_value=default_value,
+                header=header,
+                description=description,
+                warning=warning,
+                editable=editable,
+                affects_outcome_of=affects_outcome_of,
+                ui_rules=ui_rules,
+                visible_in_ui=visible_in_ui,
+                parameter_type=parameter_type,
+            ) == {
+                "default_value": default_value,
+                "description": description,
+                "header": header,
+                "warning": warning,
+                "editable": editable,
+                "visible_in_ui": visible_in_ui,
+                "affects_outcome_of": affects_outcome_of,
+                "ui_rules": ui_rules,
+                "type": parameter_type,
+            }
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_configurable_integer(self):
+        """
+        <b>Description:</b>
+        Check "configurable_integer" function
+
+        <b>Input data:</b>
+        "default_value" int, "header" string, "min_value" int, "max_value": int, "description" string, "warning" string,
+        "editable" bool, "visible_in_ui" bool, "affects_outcome_of" ModelLifecycle element, "ui_rules" UIRules object
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "configurable_integer" function is equal to expected
+
+        <b>Steps</b>
+        1. Check _CountingAttr object returned by "configurable_integer" function for default values of optional
+        parameters
+        2. Check _CountingAttr object returned by "configurable_integer" function for specified values of optional
+        parameters
+        """
+
+        def check_configurable_integer(
+            integer_instance,
+            expected_min_value: int = 0,
+            expected_max_value: int = 255,
+            expected_description: str = "Default integer description",
+            expected_warning: str = None,
+            expected_editable: bool = True,
+            expected_visible_in_ui: bool = True,
+            expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
+            expected_ui_rules: UIRules = NullUIRules(),
+        ):
+            expected_metadata = {
+                "default_value": 100,
+                "description": expected_description,
+                "header": "configurable_integer header",
+                "warning": expected_warning,
+                "editable": expected_editable,
+                "visible_in_ui": expected_visible_in_ui,
+                "affects_outcome_of": expected_affects_outcome_of,
+                "ui_rules": expected_ui_rules,
+                "type": ConfigElementType.INTEGER,
+                "min_value": expected_min_value,
+                "max_value": expected_max_value,
+            }
+            assert isinstance(integer_instance, _make._CountingAttr)
+            assert integer_instance._default == 100
+            assert integer_instance.type == int
+            assert len(integer_instance._validator._validators) == 2
+            assert (
+                integer_instance._validator._validators[0] == attr_strict_int_validator
+            )
+            assert (
+                integer_instance._validator._validators[1].__name__
+                == "attr_validate_value"
+            )
+            assert integer_instance.metadata == expected_metadata
+
+        # Checking _CountingAttr object returned by "configurable_integer" for default values of optional parameters
+        default_value = 100
+        header = "configurable_integer header"
+        actual_integer = configurable_integer(
+            default_value=default_value, header=header
+        )
+        check_configurable_integer(integer_instance=actual_integer)  # type: ignore
+        # Checking _CountingAttr object returned by "configurable_integer" for specified values of optional parameters
+        min_value = 10
+        max_value = 200
+        description = "configurable_integer description"
+        warning = "configurable_integer warning"
+        editable = False
+        visible_in_ui = False
+        affects_outcome_of = ModelLifecycle.TESTING
+        ui_rules = self.ui_rules
+
+        actual_integer = configurable_integer(
+            default_value=default_value,
+            header=header,
+            min_value=min_value,
+            max_value=max_value,
+            description=description,
+            warning=warning,
+            editable=editable,
+            visible_in_ui=visible_in_ui,
+            affects_outcome_of=affects_outcome_of,
+            ui_rules=ui_rules,
+        )
+        check_configurable_integer(
+            integer_instance=actual_integer,  # type: ignore
+            expected_min_value=min_value,
+            expected_max_value=max_value,
+            expected_description=description,
+            expected_warning=warning,
+            expected_editable=editable,
+            expected_visible_in_ui=visible_in_ui,
+            expected_affects_outcome_of=affects_outcome_of,
+            expected_ui_rules=ui_rules,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_configurable_float(self):
+        """
+        <b>Description:</b>
+        Check "configurable_float" function
+
+        <b>Input data:</b>
+        "default_value" float, "header" string, "min_value" float, "max_value": float, "description" string,
+        "warning" string, "editable" bool, "visible_in_ui" bool, "affects_outcome_of" ModelLifecycle element,
+        "ui_rules" UIRules object
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "configurable_float" function is equal to expected
+
+        <b>Steps</b>
+        1. Check _CountingAttr object returned by "configurable_float" function for default values of optional
+        parameters
+        2. Check _CountingAttr object returned by "configurable_float" function for specified values of optional
+        parameters
+        """
+
+        def check_configurable_float(
+            float_instance,
+            expected_min_value: float = 0.0,
+            expected_max_value: float = 255.0,
+            expected_description: str = "Default float description",
+            expected_warning: str = None,
+            expected_editable: bool = True,
+            expected_visible_in_ui: bool = True,
+            expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
+            expected_ui_rules: UIRules = NullUIRules(),
+        ):
+            expected_metadata = {
+                "default_value": 100.1,
+                "description": expected_description,
+                "header": "configurable_float header",
+                "warning": expected_warning,
+                "editable": expected_editable,
+                "visible_in_ui": expected_visible_in_ui,
+                "affects_outcome_of": expected_affects_outcome_of,
+                "ui_rules": expected_ui_rules,
+                "type": ConfigElementType.FLOAT,
+                "min_value": expected_min_value,
+                "max_value": expected_max_value,
+            }
+            assert isinstance(float_instance, _make._CountingAttr)
+            assert float_instance._default == 100.1
+            assert float_instance.type == float
+            assert float_instance._validator.__name__ == "attr_validate_value"
+            assert float_instance.metadata == expected_metadata
+
+        # Checking _CountingAttr object returned by "configurable_float" for default values of optional parameters
+        default_value = 100.1
+        header = "configurable_float header"
+        actual_float = configurable_float(default_value=default_value, header=header)
+        check_configurable_float(float_instance=actual_float)  # type: ignore
+        # Checking _CountingAttr object returned by "configurable_float" for specified values of optional parameters
+        min_value = 0.1
+        max_value = 160.2
+        description = "configurable_float description"
+        warning = "configurable_float warning"
+        editable = False
+        visible_in_ui = False
+        affects_outcome_of = ModelLifecycle.TESTING
+        ui_rules = self.ui_rules
+
+        actual_float = configurable_float(
+            default_value=default_value,
+            header=header,
+            min_value=min_value,
+            max_value=max_value,
+            description=description,
+            warning=warning,
+            editable=editable,
+            visible_in_ui=visible_in_ui,
+            affects_outcome_of=affects_outcome_of,
+            ui_rules=ui_rules,
+        )
+        check_configurable_float(
+            float_instance=actual_float,  # type: ignore
+            expected_min_value=min_value,
+            expected_max_value=max_value,
+            expected_description=description,
+            expected_warning=warning,
+            expected_editable=editable,
+            expected_visible_in_ui=visible_in_ui,
+            expected_affects_outcome_of=affects_outcome_of,
+            expected_ui_rules=ui_rules,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_configurable_boolean(self):
+        """
+        <b>Description:</b>
+        Check "configurable_boolean" function
+
+        <b>Input data:</b>
+        "default_value" bool, "header" string, "description" string, "warning" string, "editable" bool,
+        "visible_in_ui" bool, "affects_outcome_of" ModelLifecycle element, "ui_rules" UIRules object
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "configurable_boolean" function is equal to expected
+
+        <b>Steps</b>
+        1. Check _CountingAttr object returned by "configurable_boolean" function for default values of optional
+        parameters
+        2. Check _CountingAttr object returned by "configurable_boolean" function for specified values of optional
+        parameters
+        """
+
+        def check_configurable_boolean(
+            boolean_instance,
+            expected_description: str = "Default configurable boolean description",
+            expected_warning: str = None,
+            expected_editable: bool = True,
+            expected_visible_in_ui: bool = True,
+            expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
+            expected_ui_rules: UIRules = NullUIRules(),
+        ):
+            expected_metadata = {
+                "default_value": True,
+                "description": expected_description,
+                "header": "configurable_boolean header",
+                "warning": expected_warning,
+                "editable": expected_editable,
+                "visible_in_ui": expected_visible_in_ui,
+                "affects_outcome_of": expected_affects_outcome_of,
+                "ui_rules": expected_ui_rules,
+                "type": ConfigElementType.BOOLEAN,
+            }
+            assert isinstance(boolean_instance, _make._CountingAttr)
+            assert boolean_instance._default
+            assert boolean_instance.type == bool
+            assert isinstance(
+                boolean_instance._validator, validators._InstanceOfValidator  # type: ignore
+            )
+            assert boolean_instance._validator.type == bool
+            assert boolean_instance.metadata == expected_metadata
+
+        # Checking _CountingAttr object returned by "configurable_boolean" for default values of optional parameters
+        default_value = True
+        header = "configurable_boolean header"
+        actual_boolean = configurable_boolean(
+            default_value=default_value, header=header
+        )
+        check_configurable_boolean(boolean_instance=actual_boolean)  # type: ignore
+        # Checking _CountingAttr object returned by "configurable_boolean" for specified values of optional parameters
+        description = "configurable_boolean description"
+        warning = "configurable_boolean warning"
+        editable = False
+        visible_in_ui = False
+        affects_outcome_of = ModelLifecycle.TESTING
+        ui_rules = self.ui_rules
+        actual_boolean = configurable_boolean(
+            default_value=default_value,
+            header=header,
+            description=description,
+            warning=warning,
+            editable=editable,
+            visible_in_ui=visible_in_ui,
+            affects_outcome_of=affects_outcome_of,
+            ui_rules=ui_rules,
+        )
+        check_configurable_boolean(
+            boolean_instance=actual_boolean,  # type: ignore
+            expected_description=description,
+            expected_warning=warning,
+            expected_editable=editable,
+            expected_visible_in_ui=visible_in_ui,
+            expected_affects_outcome_of=affects_outcome_of,
+            expected_ui_rules=ui_rules,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_float_selectable(self):
+        """
+        <b>Description:</b>
+        Check "float_selectable" function
+
+        <b>Input data:</b>
+        "default_value" float, "header" string, "options" list, "description" string, "warning" string, "editable" bool,
+        "visible_in_ui" bool, "affects_outcome_of" ModelLifecycle element, "ui_rules" UIRules object
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "float_selectable" function is equal to expected
+
+        <b>Steps</b>
+        1. Check _CountingAttr object returned by "float_selectable" function for default values of optional parameters
+        2. Check _CountingAttr object returned by "float_selectable" function for specified values of optional
+        parameters
+        """
+
+        def check_float_selectable(
+            float_selectable_instance,
+            expected_description: str = "Default selectable description",
+            expected_warning: str = None,
+            expected_editable: bool = True,
+            expected_visible_in_ui: bool = True,
+            expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
+            expected_ui_rules: UIRules = NullUIRules(),
+        ):
+            expected_metadata = {
+                "default_value": 0.1,
+                "description": expected_description,
+                "header": "float_selectable header",
+                "warning": expected_warning,
+                "editable": expected_editable,
+                "visible_in_ui": expected_visible_in_ui,
+                "affects_outcome_of": expected_affects_outcome_of,
+                "ui_rules": expected_ui_rules,
+                "type": ConfigElementType.FLOAT_SELECTABLE,
+                "options": [0.2, 1.4, 2.8],
+            }
+            assert isinstance(float_selectable_instance, _make._CountingAttr)
+            assert float_selectable_instance._default
+            assert float_selectable_instance.type == float
+            assert (
+                float_selectable_instance._validator.__name__
+                == "attr_validate_selectable"
+            )
+            assert float_selectable_instance.metadata == expected_metadata
+
+        # Checking _CountingAttr object returned by "float_selectable" for default values of optional parameters
+        default_value = 0.1
+        header = "float_selectable header"
+        options = [0.2, 1.4, 2.8]
+        actual_float_selectable = float_selectable(
+            default_value=default_value, options=options, header=header
+        )
+        check_float_selectable(float_selectable_instance=actual_float_selectable)  # type: ignore
+        # Checking _CountingAttr object returned by "float_selectable" for specified values of optional parameters
+        description = "float_selectable description"
+        warning = "float_selectable warning"
+        editable = False
+        visible_in_ui = False
+        affects_outcome_of = ModelLifecycle.TESTING
+        ui_rules = self.ui_rules
+        actual_float_selectable = float_selectable(
+            default_value=default_value,
+            options=options,
+            header=header,
+            description=description,
+            warning=warning,
+            editable=editable,
+            visible_in_ui=visible_in_ui,
+            affects_outcome_of=affects_outcome_of,
+            ui_rules=ui_rules,
+        )
+        check_float_selectable(
+            float_selectable_instance=actual_float_selectable,  # type: ignore
+            expected_description=description,
+            expected_warning=warning,
+            expected_editable=editable,
+            expected_visible_in_ui=visible_in_ui,
+            expected_affects_outcome_of=affects_outcome_of,
+            expected_ui_rules=ui_rules,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_selectable(self):
+        """
+        <b>Description:</b>
+        Check "selectable" function
+
+        <b>Input data:</b>
+        "default_value" ConfigurableEnum element, "header" string, "description" string, "warning" string, "editable"
+        bool, "visible_in_ui" bool, "affects_outcome_of" ModelLifecycle element, "ui_rules" UIRules object
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "selectable" function is equal to expected
+
+        <b>Steps</b>
+        1. Check _CountingAttr object returned by "selectable" function for default values of optional parameters
+        2. Check _CountingAttr object returned by "selectable" function for specified values of optional parameters
+        """
+
+        def check_selectable(
+            selectable_instance,
+            expected_description: str = "Default selectable description",
+            expected_warning: str = None,
+            expected_editable: bool = True,
+            expected_visible_in_ui: bool = True,
+            expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
+            expected_ui_rules: UIRules = NullUIRules(),
+        ):
+            expected_metadata = {
+                "default_value": SomeEnumSelectable.OPTION_C,
+                "description": expected_description,
+                "header": "selectable header",
+                "warning": expected_warning,
+                "editable": expected_editable,
+                "visible_in_ui": expected_visible_in_ui,
+                "affects_outcome_of": expected_affects_outcome_of,
+                "ui_rules": expected_ui_rules,
+                "type": ConfigElementType.SELECTABLE,
+                "enum_name": "SomeEnumSelectable",
+                "options": {
+                    "TEST_NAME1": "test_name_1",
+                    "TEST_2": "test_2_test",
+                    "BOGUS_NAME": "bogus",
+                    "OPTION_C": "option_c",
+                },
+            }
+            assert isinstance(selectable_instance, _make._CountingAttr)
+            assert selectable_instance._default == SomeEnumSelectable.OPTION_C
+            assert selectable_instance.type == ConfigurableEnum
+            assert isinstance(
+                selectable_instance._validator, validators._InstanceOfValidator  # type: ignore
+            )
+            assert selectable_instance._validator.type == ConfigurableEnum
+            assert selectable_instance.metadata == expected_metadata
+
+        # Checking _CountingAttr object returned by "selectable" for default values of optional parameters
+        default_value = SomeEnumSelectable.OPTION_C
+        header = "selectable header"
+        actual_selectable = selectable(default_value=default_value, header=header)
+        check_selectable(selectable_instance=actual_selectable)  # type: ignore
+
+        # Checking _CountingAttr object returned by "selectable" for specified values of optional parameters
+        description = "selectable description"
+        warning = "selectable warning"
+        editable = False
+        visible_in_ui = False
+        affects_outcome_of = ModelLifecycle.TESTING
+        ui_rules = self.ui_rules
+
+        actual_selectable = selectable(
+            default_value=default_value,
+            header=header,
+            description=description,
+            warning=warning,
+            editable=editable,
+            visible_in_ui=visible_in_ui,
+            affects_outcome_of=affects_outcome_of,
+            ui_rules=ui_rules,
+        )
+        check_selectable(
+            selectable_instance=actual_selectable,  # type: ignore
+            expected_description=description,
+            expected_warning=warning,
+            expected_editable=editable,
+            expected_visible_in_ui=visible_in_ui,
+            expected_affects_outcome_of=affects_outcome_of,
+            expected_ui_rules=ui_rules,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_string_attribute(self):
+        """
+        <b>Description:</b>
+        Check "string_attribute" function
+
+        <b>Input data:</b>
+        "value" string
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "string_attribute" function is equal to expected
+        """
+        value = "some string"
+        actual_string = string_attribute(value=value)
+        assert isinstance(actual_string, _make._CountingAttr)
+        assert actual_string._default == value  # type: ignore
+        assert actual_string.kw_only  # type: ignore
+        assert actual_string.type == str  # type: ignore
+        assert not actual_string._validator  # type: ignore
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_boolean_attribute(self):
+        """
+        <b>Description:</b>
+        Check "boolean_attribute" function
+
+        <b>Input data:</b>
+        "value" bool
+
+        <b>Expected results:</b>
+        Test passes if _CountingAttr object returned by "boolean_attribute" function is equal to expected
+        """
+        value = True
+        actual_boolean = boolean_attribute(value=value)
+        assert isinstance(actual_boolean, _make._CountingAttr)
+        assert actual_boolean._default == value  # type: ignore
+        assert actual_boolean.kw_only  # type: ignore
+        assert actual_boolean.type == bool  # type: ignore
+        assert not actual_boolean._validator  # type: ignore

--- a/ote_sdk/ote_sdk/tests/configuration/enums/test_enum_utils.py
+++ b/ote_sdk/ote_sdk/tests/configuration/enums/test_enum_utils.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+
+from ote_sdk.configuration.enums.config_element_type import ConfigElementType
+from ote_sdk.configuration.enums.utils import get_enum_names
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestMetadataKeys:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_get_enum_names(self):
+        """
+        <b>Description:</b>
+        Check "get_enum_names" function
+
+        <b>Input data:</b>
+        Enum object
+
+        <b>Expected results:</b>
+        Test passes if list returned by "get_enum_names" function is equal to expected
+        """
+        assert get_enum_names(ConfigElementType) == [
+            "INTEGER",
+            "FLOAT",
+            "BOOLEAN",
+            "FLOAT_SELECTABLE",
+            "SELECTABLE",
+            "PARAMETER_GROUP",
+            "CONFIGURABLE_PARAMETERS",
+            "RULE",
+            "UI_RULES",
+        ]

--- a/ote_sdk/ote_sdk/tests/configuration/helper/test_helper_utils.py
+++ b/ote_sdk/ote_sdk/tests/configuration/helper/test_helper_utils.py
@@ -1,0 +1,384 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from enum import Enum
+from pathlib import Path
+
+import pytest
+import yaml
+from omegaconf import DictConfig
+
+from ote_sdk.configuration.helper.utils import (
+    _search_in_config_dict_inner,
+    deserialize_enum_value,
+    ids_to_strings,
+    input_to_config_dict,
+    search_in_config_dict,
+)
+from ote_sdk.entities.id import ID
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestUtilsFunctions:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_utils_search_in_config_dict_inner(self):
+        """
+        <b>Description:</b>
+        Check "_search_in_config_dict_inner" function
+
+        <b>Input data:</b>
+        "config_dict" dictionary, "key_to_search" string, "prior_keys" list, "results" list
+
+        <b>Expected results:</b>
+        Test passes if list returned by "_search_in_config_dict_inner" function is equal to expected
+
+        <b>Steps</b>
+        1. Check list returned by "_search_in_config_dict_inner" function with default values of optional parameters
+        2. Check list returned by "_search_in_config_dict_inner" function with specified "prior_keys" parameter
+        3. Check list returned by "_search_in_config_dict_inner" function with specified "results" parameter
+        4. Check list returned by "_search_in_config_dict_inner" function with specified both optional parameters
+        5. Check list returned by "_search_in_config_dict_inner" function with list object specified as "config_dict"
+        parameter
+        """
+        # Checking list returned by "_search_in_config_dict_inner" with default values of optional parameters
+        config_dict = {"key_1": 2, "key_2": 4, "key_3": 8}
+        # Checking search of existing key
+        assert _search_in_config_dict_inner(
+            config_dict=config_dict, key_to_search="key_2"
+        ) == [(4, [])]
+        # Checking search of non-existing key
+        assert (
+            _search_in_config_dict_inner(config_dict=config_dict, key_to_search="key_4")
+            == []
+        )
+
+        # Checking list returned by "_search_in_config_dict_inner" with specified "prior_keys"
+        prior_keys = ["prior_key_1", "prior_key_2"]
+        # Checking search of existing key
+        assert _search_in_config_dict_inner(
+            config_dict=config_dict, key_to_search="key_2", prior_keys=prior_keys
+        ) == [(4, prior_keys)]
+        # Checking search of non-existing key
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_dict, key_to_search="key_4", prior_keys=prior_keys
+            )
+            == []
+        )
+        # Checking list returned by "_search_in_config_dict_inner" with specified "results"
+        # Checking search of existing key
+        results = [(4, ["result_key", "other_result_key"])]
+        expected_results = [(4, ["result_key", "other_result_key"]), (2, [])]
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_dict, key_to_search="key_1", results=results
+            )
+            == expected_results
+        )
+        assert results == expected_results
+        # Checking search of non-existing key
+        results = [(4, ["result_key", "other_result_key"])]
+        expected_results = list(results)
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_dict, key_to_search="key_4", results=results
+            )
+            == expected_results
+        )
+        assert results == expected_results
+        # Checking list returned by "_search_in_config_dict_inner" with specified "prior_keys" and "results"
+        # Checking search of existing key
+        results = [(4, ["result_key", "other_result_key"])]
+        expected_results = [
+            (4, ["result_key", "other_result_key"]),
+            (8, ["prior_key_1", "prior_key_2"]),
+        ]
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_dict,
+                key_to_search="key_3",
+                prior_keys=prior_keys,
+                results=results,
+            )
+            == expected_results
+        )
+        assert results == expected_results
+        # Checking search of non-existing key
+        results = [(4, ["result_key", "other_result_key"])]
+        expected_results = list(results)
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_dict,
+                key_to_search="key_4",
+                prior_keys=prior_keys,
+                results=results,
+            )
+            == expected_results
+        )
+        assert results == expected_results
+        # Checking list returned by "_search_in_config_dict_inner" with list specified as "config_dict"
+        # Checking search of existing key
+        config_list = [1, 3, 9]
+        results = [(4, ["result_key", "other_result_key"])]
+        expected_results = [
+            (4, ["result_key", "other_result_key"]),
+            (3, ["prior_key_1", "prior_key_2"]),
+        ]
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_list,  # type: ignore
+                key_to_search=1,  # type: ignore
+                prior_keys=prior_keys,
+                results=results,
+            )
+            == expected_results
+        )
+        assert results == expected_results
+        # Checking search of non-existing key
+        results = [(4, ["result_key", "other_result_key"])]
+        expected_results = list(results)
+        assert (
+            _search_in_config_dict_inner(
+                config_dict=config_list,  # type: ignore
+                key_to_search=5,  # type: ignore
+                prior_keys=prior_keys,
+                results=results,
+            )
+            == expected_results
+        )
+        assert results == expected_results
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_utils_search_in_config_dict(self):
+        """
+        <b>Description:</b>
+        Check "search_in_config_dict" function
+
+        <b>Input data:</b>
+        "config_dict" dictionary, "key_to_search" string
+
+        <b>Expected results:</b>
+        Test passes if list returned by "search_in_config_dict" function is equal to expected
+
+        <b>Steps</b>
+        1. Check list returned by "search_in_config_dict" function when searching key in "config_dict" dictionary
+        2. Check list returned by "search_in_config_dict" function when searching key in "config_dict" list
+        """
+        # Checking list returned by "search_in_config_dict" when searching key in dictionary "config_dict"
+        config_dict = {"key_1": 2, "key_2": 4, "key_3": 8}
+        assert search_in_config_dict(config_dict, "key_1") == [(2, [])]
+        # Checking search of non-existing key
+        assert search_in_config_dict(config_dict, "key_4") == []
+        # Checking list returned by "search_in_config_dict" when searching key in list "config_dict"
+        config_dict = [1, 3, 9]
+        assert search_in_config_dict(config_dict, 1) == [(3, [])]  # type: ignore
+        # Checking search of non-existing key
+        assert search_in_config_dict(config_dict, "key_1") == []  # type: ignore
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_utils_input_to_config_dict(self):
+        """
+        <b>Description:</b>
+        Check "input_to_config_dict" function
+
+        <b>Input data:</b>
+        "input_config" string, DictConfig or dictionary object, "check_config_type" bool value
+
+        <b>Expected results:</b>
+        Test passes if dictionary returned by "input_to_config_dict" function is equal to expected
+
+        <b>Steps</b>
+        1. Check dictionary returned by "input_to_config_dict" function when "check_config_type" parameter is "True"
+        2. Check dictionary returned by "input_to_config_dict" function when "check_config_type" parameter is "False"
+        and "type" key is not specified in "input_config" parameter
+        3. Check that ValueError exception is raised when type of "input_config" parameter is not equal to string,
+        DictConfig or dictionary
+        4. Check that ValueError exception is raised by "input_to_config_dict" function when "check_config_type"
+        parameter is "True" and "type" key is not specified in "input_config" parameter
+        5. Check that ValueError exception is raised by "input_to_config_dict" function when "check_config_type"
+        parameter is "True" and "type" key in "input_config" parameter is equal to unexpected value
+        """
+        # Checking dictionary returned by "input_to_config_dict" when "check_config_type" is "True"
+        path_to_config = str(Path(__file__).parent / Path(r"../dummy_config.yaml"))
+        with open(path_to_config, "r", encoding="UTF-8") as file:
+            expected_path_to_config_dict = yaml.safe_load(file)
+        string_config = (
+            "{'str_key_1': 2, 'str_key_2': 4, 'str_key_3': 8, 'type': PARAMETER_GROUP}"
+        )
+        expected_string_config_dict = {
+            "str_key_1": 2,
+            "str_key_2": 4,
+            "str_key_3": 8,
+            "type": "PARAMETER_GROUP",
+        }
+        dict_config = {
+            "dict_key_1": 2,
+            "dict_key_2": 4,
+            "dict_key_3": 8,
+            "type": "PARAMETER_GROUP",
+        }
+        expected_dict_config = {
+            "dict_key_1": 2,
+            "dict_key_2": 4,
+            "dict_key_3": 8,
+            "type": "PARAMETER_GROUP",
+        }
+        dict_config_instance = DictConfig(
+            content={
+                "DictConfig_key_1": 2,
+                "DictConfig_key_2": 4,
+                "DictConfig_key_3": 8,
+                "type": "PARAMETER_GROUP",
+            }
+        )
+        expected_dict_config_instance_dict = {
+            "DictConfig_key_1": 2,
+            "DictConfig_key_2": 4,
+            "DictConfig_key_3": 8,
+            "type": "PARAMETER_GROUP",
+        }
+
+        for input_config, expected_dict in [
+            (path_to_config, expected_path_to_config_dict),
+            (string_config, expected_string_config_dict),
+            (dict_config, expected_dict_config),
+            (dict_config_instance, expected_dict_config_instance_dict),
+        ]:
+            assert (
+                input_to_config_dict(input_config=input_config, check_config_type=True)
+                == expected_dict
+            )
+        # Checking dictionary returned by "input_to_config_dict" when "check_config_type" is "False" and "type" key
+        # is not specified in "input_config"
+        string_config = "{'str_key_1': 2, 'str_key_2': 4, 'str_key_3': 8}"
+        expected_string_config_dict = {"str_key_1": 2, "str_key_2": 4, "str_key_3": 8}
+        dict_config = {"dict_key_1": 2, "dict_key_2": 4, "dict_key_3": 8}
+        expected_dict_config = {"dict_key_1": 2, "dict_key_2": 4, "dict_key_3": 8}
+        dict_config_instance = DictConfig(
+            content={
+                "DictConfig_key_1": 2,
+                "DictConfig_key_2": 4,
+                "DictConfig_key_3": 8,
+            }
+        )
+        expected_dict_config_instance_dict = {
+            "DictConfig_key_1": 2,
+            "DictConfig_key_2": 4,
+            "DictConfig_key_3": 8,
+        }
+
+        for input_config, expected_dict in [
+            (path_to_config, expected_path_to_config_dict),
+            (string_config, expected_string_config_dict),
+            (dict_config, expected_dict_config),
+            (dict_config_instance, expected_dict_config_instance_dict),
+        ]:
+            assert (
+                input_to_config_dict(input_config=input_config, check_config_type=False)
+                == expected_dict
+            )
+        # Checking that ValueError exception is raised when type of "input_config" is not equal to string, DictConfig or
+        # dictionary
+        with pytest.raises(ValueError):
+            input_to_config_dict(input_config=1)  # type: ignore
+        # Checking that ValueError exception is raised by "input_to_config_dict" when "check_config_type" is "True" and
+        # "type" key is not specified in "input_config"
+        for none_type_input_config in [
+            "{'key_1': 2, 'key_2': 4, 'key_3': 8}",
+            {"key_1": 2, "key_2": 4, "key_3": 8},
+            DictConfig(content={"key_1": 2, "key_2": 4, "key_3": 8}),
+        ]:
+            with pytest.raises(ValueError):
+                input_to_config_dict(input_config=none_type_input_config)
+        # Check that ValueError exception is raised by "input_to_config_dict" when "check_config_type" is "True" and
+        # "type" key in "input_config" is equal to unexpected value
+        for none_type_input_config in [
+            "{'key_1': 2, 'key_2': 4, 'key_3': 8, 'type': unexpected_type}",
+            {"key_1": 2, "key_2": 4, "key_3": 8, "type": "unexpected_type"},
+            DictConfig(
+                content={"key_1": 2, "key_2": 4, "key_3": 8, "type": "unexpected_type"}
+            ),
+        ]:
+            with pytest.raises(ValueError):
+                input_to_config_dict(input_config=none_type_input_config)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_utils_deserialize_enum_value(self):
+        """
+        <b>Description:</b>
+        Check "deserialize_enum_value" function
+
+        <b>Input data:</b>
+        "enum_type" Enum object, "value" Enum element or string object
+
+        <b>Expected results:</b>
+        Test passes if value returned by "deserialize_enum_value" function is equal to expected
+
+        <b>Steps</b>
+        1. Check value returned by "deserialize_enum_value" function when Enum class element is specified as "value"
+        parameter
+        2. Check value returned by "deserialize_enum_value" function when string is specified as "value" parameter
+        3. Check that ValueError exception is raised when type of "value" parameter for "deserialize_enum_value"
+        function is not equal to Enum or string
+        """
+
+        class ValidationEnum(Enum):
+            FIRST = "first element"
+            SECOND = "second element"
+
+        # Checking value returned by "deserialize_enum_value" when Enum class element is specified as "value"
+        assert (
+            deserialize_enum_value(value=ValidationEnum.FIRST, enum_type=ValidationEnum)
+            == ValidationEnum.FIRST
+        )
+        # Checking value returned by "deserialize_enum_value" when string is specified as "value"
+        assert (
+            deserialize_enum_value(value="SECOND", enum_type=ValidationEnum)
+            == ValidationEnum.SECOND
+        )
+        with pytest.raises(KeyError):
+            deserialize_enum_value(value="THIRD", enum_type=ValidationEnum)
+        # Checking that ValueError exception is raised when type of "value" for "deserialize_enum_value" is not equal to
+        # Enum or string
+        with pytest.raises(ValueError):
+            deserialize_enum_value(value=1, enum_type=ValidationEnum)  # type: ignore
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_utils_ids_to_strings(self):
+        """
+        <b>Description:</b>
+        Check "ids_to_strings" function
+
+        <b>Input data:</b>
+        "config_dict" dictionary
+
+        <b>Expected results:</b>
+        Test passes if dictionary returned by "ids_to_strings" function is equal to expected
+        """
+        config_dict = {
+            "id_key_1": ID("1"),
+            "not_id_key_1": 2,
+            "not_id_key_2": 3,
+            "id_key_2": ID("4"),
+        }
+        expected_dict = {
+            "id_key_1": "1",
+            "not_id_key_1": 2,
+            "not_id_key_2": 3,
+            "id_key_2": "4",
+        }
+        assert ids_to_strings(config_dict) == expected_dict
+        assert config_dict == expected_dict

--- a/ote_sdk/ote_sdk/tests/entities/test_url.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_url.py
@@ -1,16 +1,6 @@
-# INTEL CONFIDENTIAL
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 #
-# Copyright (C) 2021 Intel Corporation
-#
-# This software and the related documents are Intel copyrighted materials, and
-# your use of them is governed by the express license under which they were provided to
-# you ("License"). Unless the License provides otherwise, you may not use, modify, copy,
-# publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is,
-# with no express or implied warranties, other than those that are expressly stated
-# in the License.
 
 import pytest
 
@@ -50,3 +40,217 @@ class TestURL:
 
         assert test_url.path == "/images/file_%20_whatever.jpg"
         assert test_url2.path == "/images/file_%20_whatever.jpg"
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_url_initialization(self):
+        """
+        <b>Description:</b>
+        Check initialized URL object attributes
+
+        <b>Input data:</b>
+        Initialized URL object
+
+        <b>Expected results:</b>
+        Test passes if attributes of initialized URL object are equal to expected
+
+        <b>Steps</b>
+        1. Check attributes of URL object initialized without special characters
+        2. Check attributes of URL object initialized with "#" special character
+        3. Check attributes of URL object initialized with "?" special character
+        4. Check attributes of URL object initialized with netloc
+        5. Check attributes of URL object initialized with unsupported character in URL-scheme
+        6. Check attributes of URL object initialized without URL-scheme
+        7. Check that ValueError exception is raised when initializing URL-class object with incorrect netloc
+        """
+
+        def check_url(
+            url: URL,
+            expected_path: str = "",
+            expected_extension: str = "",
+            expected_host: str = "",
+            expected_scheme: str = "",
+            expected_relative_path: str = "",
+        ):
+            assert url.path == expected_path
+            assert url.extension == expected_extension
+            assert url.host == expected_host
+            assert url.scheme == expected_scheme
+            if expected_relative_path == "":
+                expected_relative_path = expected_path[1:]
+            assert url.relative_path == expected_relative_path
+
+        # Checking attributes of URL initialized without special characters
+        check_url(
+            url=URL("binaryrepo:/images/file_%20_whatever.jpg"),
+            expected_path="/images/file_%20_whatever.jpg",
+            expected_extension="jpg",
+            expected_scheme="binaryrepo",
+        )
+        # Checking attributes of URL initialized with "#" special character
+        check_url(
+            url=URL("binaryrepo:/images/file_%20_whatever#.jpg"),
+            expected_path="/images/file_%20_whatever",
+            expected_scheme="binaryrepo",
+        )
+        # Checking attributes of URL initialized with "?" special character
+        check_url(
+            url=URL("binaryrepo:/i?mages/file_%20_whatever.jpg?some_text.png"),
+            expected_path="/i",
+            expected_scheme="binaryrepo",
+        )
+        # Checking attributes of URL initialized with netloc
+        check_url(
+            url=URL("https://www.some_host.com/images/file_%20_whatever.png"),
+            expected_path="/images/file_%20_whatever.png",
+            expected_extension="png",
+            expected_host="www.some_host.com",
+            expected_scheme="https",
+        )
+        # Checking attributes of URL initialized with unsupported character in URL-scheme
+        check_url(
+            url=URL("binary_repo:/images/file_%20_whatever.jpg"),
+            expected_path="binary_repo:/images/file_%20_whatever.jpg",
+            expected_extension="jpg",
+            expected_relative_path="binary_repo:/images/file_%20_whatever.jpg",
+        )
+        # Checking attributes of URL initialized without URL-scheme
+        check_url(
+            url=URL("images/file_%20_whatever.jpg"),
+            expected_path="images/file_%20_whatever.jpg",
+            expected_extension="jpg",
+            expected_relative_path="images/file_%20_whatever.jpg",
+        )
+        # Checking that ValueError exception is raised when initializing URL with incorrect netloc
+        for incorrect_netloc in [
+            "https://[www.some_host.com/images/file_%20_whatever.jpg?some_text.png",
+            "https://www.some_host.com]/images/file_%20_whatever.jpg?some_text.png",
+        ]:
+            with pytest.raises(ValueError):
+                URL(incorrect_netloc)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_url_str(self):
+        """
+        <b>Description:</b>
+        Check URL class __str__ method
+
+        <b>Input data:</b>
+        Initialized URL object
+
+        <b>Expected results:</b>
+        Test passes if string returned by __str__ method is equal to expected
+
+        <b>Steps</b>
+        1. Check string returned by __str__ method for URL object initialized with non-empty "scheme" and "host"
+        attributes
+        2. Check string returned by __str__ method for URL object initialized with non-empty "scheme" and empty "host"
+        attributes
+        3. Check string returned by __str__ method for URL object initialized with non-empty "host" and empty "scheme"
+        attributes
+        """
+        # Checking value returned by __str__ for URL initialized with non-empty "scheme" and "host"
+        assert str(URL("https://www.some_host.com/images/file_%20_whatever.png")) == (
+            "https://www.some_host.com/images/file_%20_whatever.png"
+        )
+        # Checking value returned by __str__ for URL initialized with non-empty "scheme" and empty "host"
+        assert (
+            str(URL("binaryrepo:/images/file_%20_whatever.jpg"))
+            == "binaryrepo:/images/file_%20_whatever.jpg"
+        )
+        # Checking value returned by __str__ for URL initialized with non-empty "host" and empty "scheme"
+        assert (
+            str(URL("//www.some_host.com/images/file_%20_whatever.jpg"))
+            == "/images/file_%20_whatever.jpg"
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_url_repr(self):
+        """
+        <b>Description:</b>
+        Check URL class __repr__ method
+
+        <b>Input data:</b>
+        Initialized URL object
+
+        <b>Expected results:</b>
+        Test passes if string returned by __repr__ method is equal to expected
+        """
+        assert repr(URL("https://www.some_host.com/images/file_%20_whatever.png")) == (
+            "URL(https://www.some_host.com/images/file_%20_whatever.png)"
+        )
+        assert repr(URL("binaryrepo:/i?mages/file_%20_whatever.jpg?some_text.png")) == (
+            "URL(binaryrepo:/i?mages/file_%20_whatever.jpg?some_text.png)"
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_url_hash(self):
+        """
+        <b>Description:</b>
+        Check URL class __hash__ method
+
+        <b>Input data:</b>
+        Initialized URL object
+
+        <b>Expected results:</b>
+        Test passes if value returned by __hash__ method is equal to expected
+        """
+        url = URL("https://www.some_host.com/images/file_%20_whatever.png")
+        assert hash(url) == hash(str(url))
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_url_length(self):
+        """
+        <b>Description:</b>
+        Check URL class __len__ method
+
+        <b>Input data:</b>
+        Initialized URL object
+
+        <b>Expected results:</b>
+        Test passes if value returned by __len__ method is equal to expected
+        """
+        assert len(URL("https://www.some_host.com/images/file_%20_whatever.png")) == 54
+        assert len(URL("binaryrepo:/i?mages/file_%20_whatever.jpg?some_text.png")) == 55
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_url_eq(self):
+        """
+        <b>Description:</b>
+        Check URL class __eq__ method
+
+        <b>Input data:</b>
+        Initialized URL object
+
+        <b>Expected results:</b>
+        Test passes if value returned by __eq__ method is equal to expected
+
+        1. Check value returned by __eq__ method for URL objects with equal "scheme", "host", and "path" properties
+        2. Check value returned by __eq__ method for URL objects with unequal "scheme" properties
+        3. Check value returned by __eq__ method for URL objects with unequal "host" properties
+        4. Check value returned by __eq__ method for URL objects with unequal "path" properties
+        """
+        # Checking value returned by __eq__ for URL with equal "scheme", "host", and "path"
+        url = URL("https://www.some_host.com/images/file_%20_whatever.png")
+        equal_url = URL("https://www.some_host.com/images/file_%20_whatever.png")
+        assert url == equal_url
+        # Checking value returned by __eq__ for URL with unequal "scheme"
+        unequal_url = URL("http://www.some_host.com/images/file_%20_whatever.png")
+        assert not url == unequal_url
+        # Checking value returned by __eq__ for URL with unequal "host"
+        unequal_url = URL("https://www.unequal_host.com/images/file_%20_whatever.png")
+        assert not url == unequal_url
+        # Checking value returned by __eq__ for URL with unequal "path"
+        unequal_url = URL("https://www.some_host.com/images/file_%20_whatever.jpg")
+        assert not url == unequal_url

--- a/ote_sdk/ote_sdk/tests/serialization/test_datetime_mapper.py
+++ b/ote_sdk/ote_sdk/tests/serialization/test_datetime_mapper.py
@@ -1,18 +1,8 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 #
-# INTEL CONFIDENTIAL
-#
-# Copyright (C) 2021 Intel Corporation
-#
-# This software and the related documents are Intel copyrighted materials, and
-# your use of them is governed by the express license under which they were provided to
-# you ("License"). Unless the License provides otherwise, you may not use, modify, copy,
-# publish, distribute, disclose or transmit this software or the related documents
-# without Intel's prior written permission.
-#
-# This software and the related documents are provided as is,
-# with no express or implied warranties, other than those that are expressly stated
-# in the License.
-#
+
+from datetime import datetime
 
 import pytest
 
@@ -38,3 +28,6 @@ class TestDatetimeMapper:
 
         deserialized_time = DatetimeMapper.backward(serialized_time)
         assert original_time == deserialized_time
+
+        deserialized_time = DatetimeMapper.backward(None)
+        assert isinstance(deserialized_time, datetime)

--- a/ote_sdk/ote_sdk/tests/usecases/adapters/test_model_adapter.py
+++ b/ote_sdk/ote_sdk/tests/usecases/adapters/test_model_adapter.py
@@ -1,0 +1,183 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+from ote_sdk.usecases.adapters.model_adapter import (
+    ExportableCodeAdapter,
+    IDataSource,
+    ModelAdapter,
+)
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestIDataSource:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_i_data_source_data(self):
+        """
+        <b>Description:</b>
+        Check IDataSource class "data" property
+
+        <b>Input data:</b>
+        IDataSource object
+
+        <b>Expected results:</b>
+        Test passes if IDataSource object "data" property raises NotImplementedError exception
+        """
+        with pytest.raises(NotImplementedError):
+            IDataSource().data()
+
+
+class TestDataSource(IDataSource):
+    def __init__(self, data: str):
+        self._data = data
+
+    @property
+    def data(self):
+        return self._data
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestModelAdapter:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_model_adapter_initialization(self):
+        """
+        <b>Description:</b>
+        Check ModelAdapter object initialization
+
+        <b>Input data:</b>
+        ModelAdapter object initialized with "data_source" IDataSource or bytes parameter
+
+        <b>Expected results:</b>
+        Test passes if properties of initialized ModelAdapter object are equal to expected
+
+        <b>Steps</b>
+        1. Check attributes of ModelAdapter object initialized with IDataSource "data_source" parameter
+        2. Check attributes of ModelAdapter object initialized with bytes "data_source" parameter
+        3. Check that ValueError exception is raised when initializing ModelAdapter object with "data_source" parameter
+        type not equal to bytes or IDataSource
+        """
+        # Checking properties of "ModelAdapter" initialized with IDataSource "data_source"
+        data = "some data"
+        data_source = TestDataSource(data=data)
+        model_adapter = ModelAdapter(data_source=data_source)
+        assert model_adapter.data_source == data_source
+        assert model_adapter.from_file_storage
+        assert model_adapter.data == data
+        # Checking properties of "ModelAdapter" initialized with bytes "data_source"
+        data_source = b"binaryrepo://localhost/repo/data_source/1"
+        model_adapter = ModelAdapter(data_source=data_source)
+        assert model_adapter.data_source == data_source
+        assert not model_adapter.from_file_storage
+        assert model_adapter.data == data_source
+        # Checking that ValueError exception is raised when initializing ModelAdapter with "data_source" type not equal
+        # to bytes or IDataSource
+        model_adapter = ModelAdapter(data_source=1)  # type: ignore
+        with pytest.raises(ValueError):
+            model_adapter.data()
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_model_adapter_data_source_setter(self):
+        """
+        <b>Description:</b>
+        Check ModelAdapter "data_source" property setter
+
+        <b>Input data:</b>
+        ModelAdapter object initialized with "data_source" parameter
+
+        <b>Expected results:</b>
+        Test passes if properties of ModelAdapter are equal to expected after manual setting "data_source" property
+
+        <b>Steps</b>
+        1. Check properties of ModelAdapter object after manual setting "data_source" property to other IDataSource
+        object
+        2. Check properties of ModelAdapter object after manual setting "data_source" property to bytes object
+        3. Check properties of ModelAdapter object after manual setting "data_source" property to other bytes object
+        4. Check properties of ModelAdapter object after manual setting "data_source" property to IDataSource object
+        """
+        model_adapter = ModelAdapter(data_source=TestDataSource(data="some data"))
+        # Checking properties of ModelAdapter after manual setting "data_source" to other IDataSource
+        other_data = "other data"
+        other_data_source = TestDataSource(data=other_data)
+        model_adapter.data_source = other_data_source
+        assert model_adapter.data_source == other_data_source
+        assert model_adapter.data == other_data
+        assert model_adapter.from_file_storage
+        # Checking properties of ModelAdapter after manual setting "data_source" to bytes
+        bytes_data_source = b"binaryrepo://localhost/repo/data_source/1"
+        model_adapter.data_source = bytes_data_source
+        assert model_adapter.data_source == bytes_data_source
+        assert model_adapter.data == bytes_data_source
+        assert not model_adapter.from_file_storage
+        # Checking properties of ModelAdapter after manual setting "data_source" to other bytes
+        other_bytes_data_source = b"binaryrepo://localhost/repo/data_source/2"
+        model_adapter.data_source = b"binaryrepo://localhost/repo/data_source/2"
+        assert model_adapter.data_source == other_bytes_data_source
+        assert model_adapter.data == other_bytes_data_source
+        assert not model_adapter.from_file_storage
+        # Checking properties of ModelAdapter after manual setting "data_source" to IDataSource
+        model_adapter.data_source = other_data_source
+        assert model_adapter.data_source == other_data_source
+        assert model_adapter.data == other_data
+        assert model_adapter.from_file_storage
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestExportableCodeAdapter:
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_exportable_code_adapter_initialization(self):
+        """
+        <b>Description:</b>
+        Check ExportableCodeAdapter object initialization
+
+        <b>Input data:</b>
+        ExportableCodeAdapter object initialized with "data_source" IDataSource or bytes parameter
+
+        <b>Expected results:</b>
+        Test passes if properties of initialized ExportableCodeAdapter object are equal to expected
+
+        <b>Steps</b>
+        1. Check attributes of ExportableCodeAdapter object initialized with IDataSource "data_source" parameter
+        2. Check attributes of ExportableCodeAdapter object initialized with bytes "data_source" parameter
+        3. Check that ValueError exception is raised when initializing ExportableCodeAdapter object with "data_source"
+        parameter type not equal to bytes or IDataSource
+        """
+        # Checking properties of "ExportableCodeAdapter" initialized with IDataSource "data_source"
+        data = "some_data"
+        data_source = TestDataSource(data=data)
+        exportable_code_adapter = ExportableCodeAdapter(data_source=data_source)
+        assert exportable_code_adapter.data_source == data_source
+        assert exportable_code_adapter.from_file_storage
+        assert exportable_code_adapter.data == data
+        # Checking properties after setting "data_source" to bytes
+        bytes_data_source = b"binaryrepo://localhost/repo/data_source/1"
+        exportable_code_adapter.data_source = bytes_data_source
+        assert exportable_code_adapter.data_source == bytes_data_source
+        assert not exportable_code_adapter.from_file_storage
+        assert exportable_code_adapter.data == bytes_data_source
+        # Checking properties of "ExportableCodeAdapter" initialized with bytes "data_source"
+        exportable_code_adapter = ExportableCodeAdapter(data_source=bytes_data_source)
+        assert exportable_code_adapter.data_source == bytes_data_source
+        assert not exportable_code_adapter.from_file_storage
+        assert exportable_code_adapter.data == bytes_data_source
+        # Checking properties after setting "data_source" to IDataSource
+        exportable_code_adapter.data_source = data_source
+        assert exportable_code_adapter.data_source == data_source
+        assert exportable_code_adapter.from_file_storage
+        assert exportable_code_adapter.data == data
+        # Checking that ValueError exception is raised when initializing ExportableCodeAdapter with "data_source" type
+        # not equal to bytes or IDataSource
+        exportable_code_adapter = ExportableCodeAdapter(data_source=1)  # type: ignore
+        with pytest.raises(ValueError):
+            exportable_code_adapter.data()


### PR DESCRIPTION
Test list:
ote_sdk/ote_sdk/tests/configuration/elements/test_elements_utils.py
ote_sdk/ote_sdk/tests/configuration/elements/test_metadata_keys.py
ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
ote_sdk/ote_sdk/tests/configuration/enums/test_enum_utils.py
ote_sdk/ote_sdk/tests/configuration/helper/test_helper_utils.py
ote_sdk/ote_sdk/tests/usecases/adapters/test_model_adapter.py
ote_sdk/ote_sdk/tests/entities/test_url.py (increased code coverage)
ote_sdk/ote_sdk/tests/serialization/test_datetime_mapper.py (added scenario with "None" parameter)


Task: CVS-75334