### PR TITLE
[ANOMALY CLASSIFICATION] - Remove logging `nvidia-smi` after initializing the task.

### DIFF
--- a/external/anomaly/anomaly_classification/task.py
+++ b/external/anomaly/anomaly_classification/task.py
@@ -61,10 +61,6 @@ class AnomalyClassificationTask(ITrainingTask, IInferenceTask, IEvaluationTask, 
             task_environment (TaskEnvironment): OTE Task environment.
         """
         logger.info("Initializing the task environment.")
-        logger.info(subprocess.call("nvidia-smi"))
-        logger.info("Torch Version '%s'", torch.__version__)
-        logger.info("Torch Cuda Version '%s'", torch.version.cuda)
-
         self.task_environment = task_environment
         self.model_name = task_environment.model_template.name
         self.labels = task_environment.get_labels()


### PR DESCRIPTION
# Description
- This is a fix to remove logging `nvidia-smi`, which may cause some issues if `nvidia-smi` is not available on CPU-based inference pods.
- This is to address [the bug](https://jira.devtools.intel.com/browse/CVS-76576) reported by the validation team for both develop and release.

# Build
- Here is the [link](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/23646) to the build. ⏳