### PR TITLE
[OTE SDK] Add auto hpo configuration flags to configurable parameters

### DIFF
--- a/ote_sdk/ote_sdk/configuration/elements/metadata_keys.py
+++ b/ote_sdk/ote_sdk/configuration/elements/metadata_keys.py
@@ -20,6 +20,7 @@ UI_RULES = "ui_rules"
 TYPE = "type"
 OPTIONS = "options"
 ENUM_NAME = "enum_name"
+AUTO_HPO_STATE = "auto_hpo_state"
 
 
 def allows_model_template_override(keyword: str) -> bool:
@@ -43,6 +44,7 @@ def allows_model_template_override(keyword: str) -> bool:
         ENUM_NAME,
         UI_RULES,
         AFFECTS_OUTCOME_OF,
+        AUTO_HPO_STATE
     ]
     return keyword in overrideable_keys
 

--- a/ote_sdk/ote_sdk/configuration/elements/metadata_keys.py
+++ b/ote_sdk/ote_sdk/configuration/elements/metadata_keys.py
@@ -6,6 +6,7 @@
 """
 This module contains the keys that can be used to retrieve parameter metadata
 """
+from typing import List
 
 DEFAULT_VALUE = "default_value"
 MIN_VALUE = "min_value"
@@ -21,6 +22,7 @@ TYPE = "type"
 OPTIONS = "options"
 ENUM_NAME = "enum_name"
 AUTO_HPO_STATE = "auto_hpo_state"
+AUTO_HPO_VALUE = "auto_hpo_value"
 
 
 def allows_model_template_override(keyword: str) -> bool:
@@ -59,3 +61,28 @@ def allows_dictionary_values(keyword: str) -> bool:
     """
     keys_allowing_dictionary_values = [OPTIONS, UI_RULES]
     return keyword in keys_allowing_dictionary_values
+
+
+def all_keys() -> List[str]:
+    """
+    Returns a list of all metadata keys.
+
+    :return: List of all available metadata keys
+    """
+    return [
+        DEFAULT_VALUE,
+        MIN_VALUE,
+        MAX_VALUE,
+        DESCRIPTION,
+        HEADER,
+        WARNING,
+        EDITABLE,
+        VISIBLE_IN_UI,
+        AFFECTS_OUTCOME_OF,
+        UI_RULES,
+        TYPE,
+        OPTIONS,
+        ENUM_NAME,
+        AUTO_HPO_STATE,
+        AUTO_HPO_VALUE,
+    ]

--- a/ote_sdk/ote_sdk/configuration/elements/metadata_keys.py
+++ b/ote_sdk/ote_sdk/configuration/elements/metadata_keys.py
@@ -46,7 +46,7 @@ def allows_model_template_override(keyword: str) -> bool:
         ENUM_NAME,
         UI_RULES,
         AFFECTS_OUTCOME_OF,
-        AUTO_HPO_STATE
+        AUTO_HPO_STATE,
     ]
     return keyword in overrideable_keys
 

--- a/ote_sdk/ote_sdk/configuration/elements/parameter_group.py
+++ b/ote_sdk/ote_sdk/configuration/elements/parameter_group.py
@@ -8,7 +8,7 @@ This module contains the definition of a ParameterGroup, which is the main class
 parameters together.
 """
 from enum import Enum
-from typing import List, Type, TypeVar, Union, Dict, Any
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
 

--- a/ote_sdk/ote_sdk/configuration/elements/parameter_group.py
+++ b/ote_sdk/ote_sdk/configuration/elements/parameter_group.py
@@ -51,7 +51,7 @@ class ParameterGroup:
         """
         groups: List[str] = []
         parameters: List[str] = []
-        self.__metadata_overrides: Dict[str, Any] = {}  # pylint:disable=attribute-defined-outside-init
+        self.__metadata_overrides: Dict[str, Any] = {}  # pylint: disable=attribute-defined-outside-init
 
         for attribute_or_method_name in dir(self):
             # Go over all attributes and methods of the class instance
@@ -122,7 +122,7 @@ class ParameterGroup:
         if metadata_key not in metadata_keys.all_keys():
             return False
         metadata_value = parameter_metadata[metadata_key]
-        if metadata_value is not None and type(metadata_value) != type(value):
+        if metadata_value is not None and type(metadata_value) is not type(value):  # pylint: disable=unidiomatic-typecheck
             return False
         existing_overrides = self.__metadata_overrides.get(parameter_name, None)
         if existing_overrides is None:

--- a/ote_sdk/ote_sdk/configuration/elements/parameter_group.py
+++ b/ote_sdk/ote_sdk/configuration/elements/parameter_group.py
@@ -51,7 +51,9 @@ class ParameterGroup:
         """
         groups: List[str] = []
         parameters: List[str] = []
-        self.__metadata_overrides: Dict[str, Any] = {}  # pylint: disable=attribute-defined-outside-init
+        self.__metadata_overrides: Dict[  # pylint:disable=attribute-defined-outside-init
+            str, Any
+        ] = {}
 
         for attribute_or_method_name in dir(self):
             # Go over all attributes and methods of the class instance
@@ -89,9 +91,7 @@ class ParameterGroup:
         if parameter is not None:
             parameter_metadata = getattr(parameter, "metadata", {})
             metadata_dict = dict(parameter_metadata)
-            parameter_overrides = self.__metadata_overrides.get(
-                parameter_name, None
-            )
+            parameter_overrides = self.__metadata_overrides.get(parameter_name, None)
             if parameter_overrides is not None:
                 for metadata_key, value_override in parameter_overrides.items():
                     metadata_dict.update({metadata_key: value_override})
@@ -99,10 +99,10 @@ class ParameterGroup:
         return {}
 
     def set_metadata_value(
-            self,
-            parameter_name: str,
-            metadata_key: str,
-            value: Union[int, float, str, bool, Enum]
+        self,
+        parameter_name: str,
+        metadata_key: str,
+        value: Union[int, float, str, bool, Enum],
     ) -> bool:
         """
         Sets the value of a specific metadata item `metadata_key` for the parameter
@@ -122,7 +122,9 @@ class ParameterGroup:
         if metadata_key not in metadata_keys.all_keys():
             return False
         metadata_value = parameter_metadata[metadata_key]
-        if metadata_value is not None and type(metadata_value) is not type(value):  # pylint: disable=unidiomatic-typecheck
+        if metadata_value is not None and type(metadata_value) is not type(
+            value
+        ):  # pylint: disable=unidiomatic-typecheck
             return False
         existing_overrides = self.__metadata_overrides.get(parameter_name, None)
         if existing_overrides is None:
@@ -149,10 +151,10 @@ class ParameterGroup:
             else:
                 auto_hpo_state = AutoHPOState.OPTIMIZED
             self.set_metadata_value(
-                    parameter_name=parameter_name,
-                    metadata_key=metadata_keys.AUTO_HPO_STATE,
-                    value=auto_hpo_state
-                )
+                parameter_name=parameter_name,
+                metadata_key=metadata_keys.AUTO_HPO_STATE,
+                value=auto_hpo_state,
+            )
         for group_name in self.groups:
             group = getattr(self, group_name)
             group.update_auto_hpo_states()

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -12,7 +12,11 @@ from typing import List, Optional, TypeVar, Union
 
 import attr
 
-from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle
+from ote_sdk.configuration.enums import (
+    ConfigElementType,
+    ModelLifecycle,
+    AutoHPOState
+)
 from ote_sdk.configuration.ui_rules import NullUIRules, UIRules
 
 from .configurable_enum import ConfigurableEnum
@@ -29,6 +33,7 @@ from .metadata_keys import (
     UI_RULES,
     VISIBLE_IN_UI,
     WARNING,
+    AUTO_HPO_STATE
 )
 from .utils import (
     attr_strict_float_converter,
@@ -55,6 +60,7 @@ def set_common_metadata(
     ui_rules: UIRules,
     visible_in_ui: bool,
     parameter_type: ConfigElementType,
+    auto_hpo_state: AutoHPOState,
 ) -> dict:
     """
     Function to construct the dictionary of metadata that is common for all parameter types
@@ -69,6 +75,7 @@ def set_common_metadata(
         AFFECTS_OUTCOME_OF: affects_outcome_of,
         UI_RULES: ui_rules,
         TYPE: parameter_type,
+        AUTO_HPO_STATE: auto_hpo_state
     }
     return metadata
 
@@ -84,6 +91,7 @@ def configurable_integer(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
 ) -> int:
     """
     Constructs a configurable integer attribute, with the appropriate metadata.
@@ -106,6 +114,8 @@ def configurable_integer(
     :param ui_rules: Set of rules to control UI behavior for this parameter. For example, the parameter can be shown or
         hidden from the UI based on the value of other parameters in the configuration. Have a look at the UIRules
         class for more details. Defaults to NullUIRules.
+    :param auto_hpo_state: This flag reflects whether the parameter can be (or has
+        been) optimized through automatic hyper parameter tuning (auto-HPO)
 
     :return: attrs Attribute of type `int`, with its metadata set according to the inputs
     """
@@ -119,6 +129,7 @@ def configurable_integer(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.INTEGER,
+        auto_hpo_state=auto_hpo_state
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
@@ -145,6 +156,7 @@ def configurable_float(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
 ) -> float:
     """
     Constructs a configurable float attribute, with the appropriate metadata.
@@ -167,6 +179,8 @@ def configurable_float(
     :param ui_rules: Set of rules to control UI behavior for this parameter. For example, the parameter can be shown or
         hidden from the UI based on the value of other parameters in the configuration. Have a look at the UIRules
         class for more details. Defaults to NullUIRules.
+    :param auto_hpo_state: This flag reflects whether the parameter can be (or has
+        been) optimized through automatic hyper parameter tuning (auto-HPO)
 
     :return: attrs Attribute of type `float`, with its metadata set according to the inputs
     """
@@ -180,6 +194,7 @@ def configurable_float(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.FLOAT,
+        auto_hpo_state=auto_hpo_state
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
@@ -203,6 +218,7 @@ def configurable_boolean(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
 ) -> bool:
     """
     Constructs a configurable boolean attribute, with the appropriate metadata.
@@ -223,6 +239,8 @@ def configurable_boolean(
     :param ui_rules: Set of rules to control UI behavior for this parameter. For example, the parameter can be shown or
         hidden from the UI based on the value of other parameters in the configuration. Have a look at the UIRules
         class for more details. Defaults to NullUIRules.
+    :param auto_hpo_state: This flag reflects whether the parameter can be (or has
+        been) optimized through automatic hyper parameter tuning (auto-HPO)
 
     :return: attrs Attribute of type `bool`, with its metadata set according to the inputs
     """
@@ -236,6 +254,7 @@ def configurable_boolean(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.BOOLEAN,
+        auto_hpo_state=auto_hpo_state
     )
 
     return attr.ib(
@@ -256,6 +275,7 @@ def float_selectable(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
 ) -> float:
     """
     Constructs a configurable float selectable attribute, with the appropriate metadata.
@@ -277,6 +297,8 @@ def float_selectable(
     :param ui_rules: Set of rules to control UI behavior for this parameter. For example, the parameter can be shown or
         hidden from the UI based on the value of other parameters in the configuration. Have a look at the UIRules
         class for more details. Defaults to NullUIRules.
+    :param auto_hpo_state: This flag reflects whether the parameter can be (or has
+        been) optimized through automatic hyper parameter tuning (auto-HPO)
 
     :return: attrs Attribute of type `float`, with its metadata set according to the inputs
     """
@@ -290,6 +312,7 @@ def float_selectable(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.FLOAT_SELECTABLE,
+        auto_hpo_state=auto_hpo_state
     )
 
     metadata.update({OPTIONS: options})
@@ -313,6 +336,7 @@ def selectable(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
 ) -> TConfigurableEnum:
     """
     Constructs a selectable attribute from a pre-defined Enum, with the appropriate metadata. The list of options for
@@ -334,6 +358,8 @@ def selectable(
     :param ui_rules: Set of rules to control UI behavior for this parameter. For example, the parameter can be shown or
         hidden from the UI based on the value of other parameters in the configuration. Have a look at the UIRules
         class for more details. Defaults to NullUIRules.
+    :param auto_hpo_state: This flag reflects whether the parameter can be (or has
+        been) optimized through automatic hyper parameter tuning (auto-HPO)
 
     :return: attrs Attribute, with its type matching the type of `default_value`, and its metadata set according to
         the inputs
@@ -348,6 +374,7 @@ def selectable(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.SELECTABLE,
+        auto_hpo_state=auto_hpo_state
     )
 
     metadata.update(default_value.get_class_info())

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -33,7 +33,8 @@ from .metadata_keys import (
     UI_RULES,
     VISIBLE_IN_UI,
     WARNING,
-    AUTO_HPO_STATE
+    AUTO_HPO_STATE,
+    AUTO_HPO_VALUE
 )
 from .utils import (
     attr_strict_float_converter,
@@ -61,6 +62,7 @@ def set_common_metadata(
     visible_in_ui: bool,
     parameter_type: ConfigElementType,
     auto_hpo_state: AutoHPOState,
+    auto_hpo_value: Union[int, float, str, bool, ConfigurableEnum],
 ) -> dict:
     """
     Function to construct the dictionary of metadata that is common for all parameter types
@@ -75,7 +77,8 @@ def set_common_metadata(
         AFFECTS_OUTCOME_OF: affects_outcome_of,
         UI_RULES: ui_rules,
         TYPE: parameter_type,
-        AUTO_HPO_STATE: auto_hpo_state
+        AUTO_HPO_STATE: auto_hpo_state,
+        AUTO_HPO_VALUE: auto_hpo_value
     }
     return metadata
 
@@ -91,7 +94,8 @@ def configurable_integer(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
-    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+    auto_hpo_value: Optional[int] = None
 ) -> int:
     """
     Constructs a configurable integer attribute, with the appropriate metadata.
@@ -116,6 +120,8 @@ def configurable_integer(
         class for more details. Defaults to NullUIRules.
     :param auto_hpo_state: This flag reflects whether the parameter can be (or has
         been) optimized through automatic hyper parameter tuning (auto-HPO)
+    :param auto_hpo_value: If auto-HPO has been executed for this parameter, this field
+        will hold the optimized value for the configurable integer
 
     :return: attrs Attribute of type `int`, with its metadata set according to the inputs
     """
@@ -129,7 +135,8 @@ def configurable_integer(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.INTEGER,
-        auto_hpo_state=auto_hpo_state
+        auto_hpo_state=auto_hpo_state,
+        auto_hpo_value=auto_hpo_value
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
@@ -156,7 +163,8 @@ def configurable_float(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
-    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+    auto_hpo_value: Optional[float] = None
 ) -> float:
     """
     Constructs a configurable float attribute, with the appropriate metadata.
@@ -181,6 +189,8 @@ def configurable_float(
         class for more details. Defaults to NullUIRules.
     :param auto_hpo_state: This flag reflects whether the parameter can be (or has
         been) optimized through automatic hyper parameter tuning (auto-HPO)
+    :param auto_hpo_value: If auto-HPO has been executed for this parameter, this field
+        will hold the optimized value for the configurable float
 
     :return: attrs Attribute of type `float`, with its metadata set according to the inputs
     """
@@ -194,7 +204,8 @@ def configurable_float(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.FLOAT,
-        auto_hpo_state=auto_hpo_state
+        auto_hpo_state=auto_hpo_state,
+        auto_hpo_value=auto_hpo_value
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
@@ -218,7 +229,8 @@ def configurable_boolean(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
-    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+    auto_hpo_value: Optional[bool] = None
 ) -> bool:
     """
     Constructs a configurable boolean attribute, with the appropriate metadata.
@@ -241,8 +253,11 @@ def configurable_boolean(
         class for more details. Defaults to NullUIRules.
     :param auto_hpo_state: This flag reflects whether the parameter can be (or has
         been) optimized through automatic hyper parameter tuning (auto-HPO)
+    :param auto_hpo_value: If auto-HPO has been executed for this parameter, this field
+        will hold the optimized value for the configurable boolean
 
-    :return: attrs Attribute of type `bool`, with its metadata set according to the inputs
+    :return: attrs Attribute of type `bool`, with its metadata set according to the
+        inputs
     """
     metadata = set_common_metadata(
         default_value=default_value,
@@ -254,7 +269,8 @@ def configurable_boolean(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.BOOLEAN,
-        auto_hpo_state=auto_hpo_state
+        auto_hpo_state=auto_hpo_state,
+        auto_hpo_value=auto_hpo_value
     )
 
     return attr.ib(
@@ -275,7 +291,8 @@ def float_selectable(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
-    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+    auto_hpo_value: Optional[float] = None
 ) -> float:
     """
     Constructs a configurable float selectable attribute, with the appropriate metadata.
@@ -299,6 +316,8 @@ def float_selectable(
         class for more details. Defaults to NullUIRules.
     :param auto_hpo_state: This flag reflects whether the parameter can be (or has
         been) optimized through automatic hyper parameter tuning (auto-HPO)
+    :param auto_hpo_value: If auto-HPO has been executed for this parameter, this field
+        will hold the optimized value for the float selectable
 
     :return: attrs Attribute of type `float`, with its metadata set according to the inputs
     """
@@ -312,7 +331,8 @@ def float_selectable(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.FLOAT_SELECTABLE,
-        auto_hpo_state=auto_hpo_state
+        auto_hpo_state=auto_hpo_state,
+        auto_hpo_value=auto_hpo_value
     )
 
     metadata.update({OPTIONS: options})
@@ -336,7 +356,8 @@ def selectable(
     visible_in_ui: bool = True,
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
-    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE
+    auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+    auto_hpo_value: Optional[str] = None
 ) -> TConfigurableEnum:
     """
     Constructs a selectable attribute from a pre-defined Enum, with the appropriate metadata. The list of options for
@@ -360,9 +381,11 @@ def selectable(
         class for more details. Defaults to NullUIRules.
     :param auto_hpo_state: This flag reflects whether the parameter can be (or has
         been) optimized through automatic hyper parameter tuning (auto-HPO)
+    :param auto_hpo_value: If auto-HPO has been executed for this parameter, this field
+        will hold the optimized value for the string selectable
 
-    :return: attrs Attribute, with its type matching the type of `default_value`, and its metadata set according to
-        the inputs
+    :return: attrs Attribute, with its type matching the type of `default_value`, and
+        its metadata set according to the inputs
     """
     metadata = set_common_metadata(
         default_value=default_value,
@@ -374,7 +397,8 @@ def selectable(
         ui_rules=ui_rules,
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.SELECTABLE,
-        auto_hpo_state=auto_hpo_state
+        auto_hpo_state=auto_hpo_state,
+        auto_hpo_value=auto_hpo_value
     )
 
     metadata.update(default_value.get_class_info())

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -62,7 +62,7 @@ def set_common_metadata(
     visible_in_ui: bool,
     parameter_type: ConfigElementType,
     auto_hpo_state: AutoHPOState,
-    auto_hpo_value: Union[int, float, str, bool, ConfigurableEnum],
+    auto_hpo_value: Optional[Union[int, float, str, bool, ConfigurableEnum]],
 ) -> dict:
     """
     Function to construct the dictionary of metadata that is common for all parameter types

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -12,12 +12,14 @@ from typing import List, Optional, TypeVar, Union
 
 import attr
 
-from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle, AutoHPOState
+from ote_sdk.configuration.enums import AutoHPOState, ConfigElementType, ModelLifecycle
 from ote_sdk.configuration.ui_rules import NullUIRules, UIRules
 
 from .configurable_enum import ConfigurableEnum
 from .metadata_keys import (
     AFFECTS_OUTCOME_OF,
+    AUTO_HPO_STATE,
+    AUTO_HPO_VALUE,
     DEFAULT_VALUE,
     DESCRIPTION,
     EDITABLE,
@@ -29,8 +31,6 @@ from .metadata_keys import (
     UI_RULES,
     VISIBLE_IN_UI,
     WARNING,
-    AUTO_HPO_STATE,
-    AUTO_HPO_VALUE,
 )
 from .utils import (
     attr_strict_float_converter,

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -12,11 +12,7 @@ from typing import List, Optional, TypeVar, Union
 
 import attr
 
-from ote_sdk.configuration.enums import (
-    ConfigElementType,
-    ModelLifecycle,
-    AutoHPOState
-)
+from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle, AutoHPOState
 from ote_sdk.configuration.ui_rules import NullUIRules, UIRules
 
 from .configurable_enum import ConfigurableEnum
@@ -34,7 +30,7 @@ from .metadata_keys import (
     VISIBLE_IN_UI,
     WARNING,
     AUTO_HPO_STATE,
-    AUTO_HPO_VALUE
+    AUTO_HPO_VALUE,
 )
 from .utils import (
     attr_strict_float_converter,
@@ -78,7 +74,7 @@ def set_common_metadata(
         UI_RULES: ui_rules,
         TYPE: parameter_type,
         AUTO_HPO_STATE: auto_hpo_state,
-        AUTO_HPO_VALUE: auto_hpo_value
+        AUTO_HPO_VALUE: auto_hpo_value,
     }
     return metadata
 
@@ -95,7 +91,7 @@ def configurable_integer(
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
     auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-    auto_hpo_value: Optional[int] = None
+    auto_hpo_value: Optional[int] = None,
 ) -> int:
     """
     Constructs a configurable integer attribute, with the appropriate metadata.
@@ -136,7 +132,7 @@ def configurable_integer(
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.INTEGER,
         auto_hpo_state=auto_hpo_state,
-        auto_hpo_value=auto_hpo_value
+        auto_hpo_value=auto_hpo_value,
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
@@ -164,7 +160,7 @@ def configurable_float(
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
     auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-    auto_hpo_value: Optional[float] = None
+    auto_hpo_value: Optional[float] = None,
 ) -> float:
     """
     Constructs a configurable float attribute, with the appropriate metadata.
@@ -205,7 +201,7 @@ def configurable_float(
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.FLOAT,
         auto_hpo_state=auto_hpo_state,
-        auto_hpo_value=auto_hpo_value
+        auto_hpo_value=auto_hpo_value,
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
@@ -230,7 +226,7 @@ def configurable_boolean(
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
     auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-    auto_hpo_value: Optional[bool] = None
+    auto_hpo_value: Optional[bool] = None,
 ) -> bool:
     """
     Constructs a configurable boolean attribute, with the appropriate metadata.
@@ -270,7 +266,7 @@ def configurable_boolean(
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.BOOLEAN,
         auto_hpo_state=auto_hpo_state,
-        auto_hpo_value=auto_hpo_value
+        auto_hpo_value=auto_hpo_value,
     )
 
     return attr.ib(
@@ -292,7 +288,7 @@ def float_selectable(
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
     auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-    auto_hpo_value: Optional[float] = None
+    auto_hpo_value: Optional[float] = None,
 ) -> float:
     """
     Constructs a configurable float selectable attribute, with the appropriate metadata.
@@ -332,7 +328,7 @@ def float_selectable(
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.FLOAT_SELECTABLE,
         auto_hpo_state=auto_hpo_state,
-        auto_hpo_value=auto_hpo_value
+        auto_hpo_value=auto_hpo_value,
     )
 
     metadata.update({OPTIONS: options})
@@ -357,7 +353,7 @@ def selectable(
     affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
     ui_rules: UIRules = NullUIRules(),
     auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-    auto_hpo_value: Optional[str] = None
+    auto_hpo_value: Optional[str] = None,
 ) -> TConfigurableEnum:
     """
     Constructs a selectable attribute from a pre-defined Enum, with the appropriate metadata. The list of options for
@@ -398,7 +394,7 @@ def selectable(
         affects_outcome_of=affects_outcome_of,
         parameter_type=ConfigElementType.SELECTABLE,
         auto_hpo_state=auto_hpo_state,
-        auto_hpo_value=auto_hpo_value
+        auto_hpo_value=auto_hpo_value,
     )
 
     metadata.update(default_value.get_class_info())

--- a/ote_sdk/ote_sdk/configuration/enums/__init__.py
+++ b/ote_sdk/ote_sdk/configuration/enums/__init__.py
@@ -8,5 +8,6 @@ This module contains Enums used in the configurable parameters within the OTE
 
 from .config_element_type import ConfigElementType
 from .model_lifecycle import ModelLifecycle
+from .auto_hpo_state import AutoHPOState
 
-__all__ = ["ConfigElementType", "ModelLifecycle"]
+__all__ = ["ConfigElementType", "ModelLifecycle", "AutoHPOState"]

--- a/ote_sdk/ote_sdk/configuration/enums/__init__.py
+++ b/ote_sdk/ote_sdk/configuration/enums/__init__.py
@@ -6,8 +6,8 @@ This module contains Enums used in the configurable parameters within the OTE
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from .auto_hpo_state import AutoHPOState
 from .config_element_type import ConfigElementType
 from .model_lifecycle import ModelLifecycle
-from .auto_hpo_state import AutoHPOState
 
 __all__ = ["ConfigElementType", "ModelLifecycle", "AutoHPOState"]

--- a/ote_sdk/ote_sdk/configuration/enums/auto_hpo_state.py
+++ b/ote_sdk/ote_sdk/configuration/enums/auto_hpo_state.py
@@ -1,0 +1,36 @@
+""" This module contains the AutoHPOState Enum """
+
+
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from enum import Enum, auto
+
+
+class AutoHPOState(Enum):
+    """
+    This Enum holds metadata related to automatic hyper parameter optimization
+    (auto-HPO) for a single configurable parameter. It contains the following values:
+
+    NOT_POSSIBLE  - This implies that the parameter cannot be optimized via auto-HPO
+    POSSIBLE      - This implies that the parameter can potentially be optimized via
+                    auto-HPO, but auto-HPO has not been carried out for this parameter
+                    yet
+    OPTIMIZED     - This implies that the parameter has been optimized via auto-HPO,
+                    such that the current value of the parameter reflects it's optimal
+                    value
+    OVERRIDDEN    - This implies that the parameter has previously been optimized via
+                    auto-HPO, but it's value has been manually overridden
+    """
+
+    NOT_POSSIBLE = 'not_possible'
+    POSSIBLE = 'possible'
+    OPTIMIZED = 'optimized'
+    OVERRIDDEN = 'overridden'
+
+    def __str__(self):
+        """
+        Retrieves the string representation of an instance of the Enum
+        """
+        return self.value

--- a/ote_sdk/ote_sdk/configuration/enums/auto_hpo_state.py
+++ b/ote_sdk/ote_sdk/configuration/enums/auto_hpo_state.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from enum import Enum, auto
+from enum import Enum
 
 
 class AutoHPOState(Enum):

--- a/ote_sdk/ote_sdk/configuration/enums/auto_hpo_state.py
+++ b/ote_sdk/ote_sdk/configuration/enums/auto_hpo_state.py
@@ -24,10 +24,10 @@ class AutoHPOState(Enum):
                     auto-HPO, but it's value has been manually overridden
     """
 
-    NOT_POSSIBLE = 'not_possible'
-    POSSIBLE = 'possible'
-    OPTIMIZED = 'optimized'
-    OVERRIDDEN = 'overridden'
+    NOT_POSSIBLE = "not_possible"
+    POSSIBLE = "possible"
+    OPTIMIZED = "optimized"
+    OVERRIDDEN = "overridden"
 
     def __str__(self):
         """

--- a/ote_sdk/ote_sdk/configuration/helper/convert.py
+++ b/ote_sdk/ote_sdk/configuration/helper/convert.py
@@ -43,16 +43,19 @@ def parameter_group_to_dict(
     values_only: bool = False,
 ) -> dict:
     """
-    Converts an instance of a `ParameterGroup` configuration element to its dictionary representation.
+    Converts an instance of a `ParameterGroup` configuration element to its dictionary
+    representation.
 
     :param parameter_group: ParameterGroup to convert to dictionary representation
     :param enum_to_str: Set to True to convert any Enum fields in the configuration to
         their string representation.
     :param values_only: True to keep only the parameter values, and remove all meta
         data from the output dictionary
-    :return: Nested dictionary with keys and values corresponding to the configuration defined in the instance of
-             `ParameterGroup` for which the `to_dict` method was called.
+    :return: Nested dictionary with keys and values corresponding to the configuration
+        defined in the instance of `ParameterGroup` for which the `to_dict` method was
+        called.
     """
+    parameter_group.update_auto_hpo_states()
     attribute_names = [attribute.name for attribute in parameter_group.__attrs_attrs__]  # type: ignore
     # The __attrs_attrs__ attribute is added through the attrs package, mypy doesn't recognize it so we can ignore the
     # type error

--- a/ote_sdk/ote_sdk/configuration/helper/create.py
+++ b/ote_sdk/ote_sdk/configuration/helper/create.py
@@ -26,7 +26,7 @@ from ote_sdk.configuration.enums.config_element_type import (
     ConfigElementType,
     ElementCategory,
 )
-from ote_sdk.configuration.enums.model_lifecycle import ModelLifecycle
+from ote_sdk.configuration.enums import ModelLifecycle, AutoHPOState
 from ote_sdk.configuration.enums.utils import get_enum_names
 from ote_sdk.configuration.ui_rules.rules import NullUIRules, Rule, UIRules
 
@@ -179,6 +179,12 @@ def gather_parameter_arguments_and_values_from_dict(
             parameter_affects = deserialize_enum_value(
                 parameter_affects, ModelLifecycle
             )
+            parameter_hpo_state = parameter_dict.pop(
+                metadata_keys.AUTO_HPO_STATE, AutoHPOState.NOT_POSSIBLE
+            )
+            parameter_hpo_state = deserialize_enum_value(
+                parameter_hpo_state, AutoHPOState
+            )
             parameter_ui_rules_dict = parameter_dict.pop(metadata_keys.UI_RULES, None)
             parameter_constructor = PrimitiveElementMapping[parameter_type].value
             parameter_ui_rules = construct_ui_rules_from_dict(parameter_ui_rules_dict)
@@ -187,6 +193,7 @@ def gather_parameter_arguments_and_values_from_dict(
                     **parameter_dict,
                     ui_rules=parameter_ui_rules,
                     affects_outcome_of=parameter_affects,
+                    auto_hpo_state=parameter_hpo_state
                 )
             }
             make_arguments.update(parameter_make_arguments)

--- a/ote_sdk/ote_sdk/configuration/helper/create.py
+++ b/ote_sdk/ote_sdk/configuration/helper/create.py
@@ -251,6 +251,7 @@ def create_parameter_group(
         if value is not None:
             setattr(parameter_group, parameter, value)
 
+    parameter_group.update_auto_hpo_states()
     return parameter_group
 
 

--- a/ote_sdk/ote_sdk/configuration/helper/create.py
+++ b/ote_sdk/ote_sdk/configuration/helper/create.py
@@ -23,11 +23,11 @@ from ote_sdk.configuration.elements import (
     ParameterGroup,
     metadata_keys,
 )
+from ote_sdk.configuration.enums import AutoHPOState, ModelLifecycle
 from ote_sdk.configuration.enums.config_element_type import (
     ConfigElementType,
     ElementCategory,
 )
-from ote_sdk.configuration.enums import ModelLifecycle, AutoHPOState
 from ote_sdk.configuration.enums.utils import get_enum_names
 from ote_sdk.configuration.ui_rules.rules import NullUIRules, Rule, UIRules
 

--- a/ote_sdk/ote_sdk/configuration/helper/create.py
+++ b/ote_sdk/ote_sdk/configuration/helper/create.py
@@ -43,7 +43,7 @@ ExposureTypeVar = TypeVar("ExposureTypeVar", UIRules, Rule)
 
 METADATA_ENUMS = {
     metadata_keys.AFFECTS_OUTCOME_OF: ModelLifecycle,
-    metadata_keys.AUTO_HPO_STATE: AutoHPOState
+    metadata_keys.AUTO_HPO_STATE: AutoHPOState,
 }
 
 
@@ -198,9 +198,7 @@ def gather_parameter_arguments_and_values_from_dict(
             parameter_ui_rules = construct_ui_rules_from_dict(parameter_ui_rules_dict)
             parameter_make_arguments = {
                 key: parameter_constructor(
-                    **parameter_dict,
-                    ui_rules=parameter_ui_rules,
-                    **metadata_enums
+                    **parameter_dict, ui_rules=parameter_ui_rules, **metadata_enums
                 )
             }
             make_arguments.update(parameter_make_arguments)

--- a/ote_sdk/ote_sdk/configuration/helper/create.py
+++ b/ote_sdk/ote_sdk/configuration/helper/create.py
@@ -160,6 +160,7 @@ def gather_parameter_arguments_and_values_from_dict(
         the constructor arguments
     :return: dictionary containing the make_arguments, call_arguments and values parsed from the config_dict_section
     """
+    # pylint: disable=too-many-locals
     make_arguments = {}
     call_arguments: dict = {}
     all_parameter_values = {}

--- a/ote_sdk/ote_sdk/configuration/helper/utils.py
+++ b/ote_sdk/ote_sdk/configuration/helper/utils.py
@@ -142,7 +142,16 @@ def deserialize_enum_value(value: Union[str, Enum], enum_type: Type[Enum]):
     if isinstance(value, enum_type):
         instance = value
     elif isinstance(value, str):
-        instance = enum_type[value.upper()]
+        try:
+            instance = enum_type[value.upper()]
+        except KeyError:
+            try:
+                instance = enum_type(value)  # type: ignore
+            except ValueError:
+                raise ValueError(
+                    f"Value `{value}` cannot be converted to an instance of "
+                    f"`{enum_type}`"
+                )
     else:
         raise ValueError(
             f"Invalid input data type, {type(value)} cannot be converted to an instance "

--- a/ote_sdk/ote_sdk/configuration/helper/utils.py
+++ b/ote_sdk/ote_sdk/configuration/helper/utils.py
@@ -147,11 +147,11 @@ def deserialize_enum_value(value: Union[str, Enum], enum_type: Type[Enum]):
         except KeyError:
             try:
                 instance = enum_type(value)  # type: ignore
-            except ValueError:
-                raise ValueError(
+            except ValueError as error:
+                raise KeyError(
                     f"Value `{value}` cannot be converted to an instance of "
                     f"`{enum_type}`"
-                )
+                ) from error
     else:
         raise ValueError(
             f"Invalid input data type, {type(value)} cannot be converted to an instance "

--- a/ote_sdk/ote_sdk/tests/configuration/dummy_config.py
+++ b/ote_sdk/ote_sdk/tests/configuration/dummy_config.py
@@ -25,6 +25,7 @@ from ote_sdk.configuration.elements import (
     selectable,
     string_attribute,
 )
+from ote_sdk.configuration.enums import AutoHPOState
 from ote_sdk.configuration.ui_rules import Action
 
 
@@ -148,6 +149,7 @@ class DatasetManagerConfig(ConfigurableParameters):
             header="Training set proportion",
             ui_rules=__ui_rules,
             affects_outcome_of=ModelLifecycle.TRAINING,
+            auto_hpo_state=AutoHPOState.POSSIBLE
         )
 
         validation_proportion = configurable_float(
@@ -170,7 +172,10 @@ class DatasetManagerConfig(ConfigurableParameters):
 
     # Add a selectable and float selectable parameter
     dummy_float_selectable = float_selectable(
-        options=[1.0, 2.0, 3.0, 4.0], default_value=2.0, header="Test float selectable"
+        options=[1.0, 2.0, 3.0, 4.0],
+        default_value=2.0,
+        header="Test float selectable",
+        auto_hpo_state=AutoHPOState.POSSIBLE
     )
 
     dummy_selectable = selectable(

--- a/ote_sdk/ote_sdk/tests/configuration/dummy_config.py
+++ b/ote_sdk/ote_sdk/tests/configuration/dummy_config.py
@@ -149,7 +149,7 @@ class DatasetManagerConfig(ConfigurableParameters):
             header="Training set proportion",
             ui_rules=__ui_rules,
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.POSSIBLE,
         )
 
         validation_proportion = configurable_float(
@@ -175,7 +175,7 @@ class DatasetManagerConfig(ConfigurableParameters):
         options=[1.0, 2.0, 3.0, 4.0],
         default_value=2.0,
         header="Test float selectable",
-        auto_hpo_state=AutoHPOState.POSSIBLE
+        auto_hpo_state=AutoHPOState.POSSIBLE,
     )
 
     dummy_selectable = selectable(

--- a/ote_sdk/ote_sdk/tests/configuration/dummy_config.yaml
+++ b/ote_sdk/ote_sdk/tests/configuration/dummy_config.yaml
@@ -96,6 +96,7 @@ subset_parameters:
           value: false
       action: SHOW
       type: UI_RULES
+    auto_hpo_state: possible
   validation_proportion:
     type: FLOAT
     min_value: 0.0
@@ -119,6 +120,7 @@ dummy_float_selectable:
     - 3.0
     - 4.0
   type: FLOAT_SELECTABLE
+  auto_hpo_state: possible
 dummy_selectable:
   default_value: bogus
   header: Test

--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
@@ -72,7 +72,7 @@ class TestPrimitiveParameters:
                 visible_in_ui=visible_in_ui,
                 parameter_type=parameter_type,
                 auto_hpo_state=auto_hpo_state,
-                auto_hpo_value=default_value
+                auto_hpo_value=default_value,
             ) == {
                 "default_value": default_value,
                 "description": description,
@@ -84,7 +84,7 @@ class TestPrimitiveParameters:
                 "ui_rules": ui_rules,
                 "type": parameter_type,
                 "auto_hpo_state": auto_hpo_state,
-                "auto_hpo_value": default_value
+                "auto_hpo_value": default_value,
             }
 
     @pytest.mark.priority_medium
@@ -120,7 +120,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
             expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-            expected_auto_hpo_value: int = None
+            expected_auto_hpo_value: int = None,
         ):
             expected_metadata = {
                 "default_value": 100,
@@ -135,7 +135,7 @@ class TestPrimitiveParameters:
                 "min_value": expected_min_value,
                 "max_value": expected_max_value,
                 "auto_hpo_state": expected_auto_hpo_state,
-                "auto_hpo_value": expected_auto_hpo_value
+                "auto_hpo_value": expected_auto_hpo_value,
             }
             assert isinstance(integer_instance, _make._CountingAttr)
             assert integer_instance._default == 100
@@ -181,7 +181,7 @@ class TestPrimitiveParameters:
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
             auto_hpo_value=auto_hpo_value,
-            auto_hpo_state=auto_hpo_state
+            auto_hpo_state=auto_hpo_state,
         )
         check_configurable_integer(
             integer_instance=actual_integer,  # type: ignore
@@ -194,7 +194,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
             expected_auto_hpo_state=auto_hpo_state,
-            expected_auto_hpo_value=auto_hpo_value
+            expected_auto_hpo_value=auto_hpo_value,
         )
 
     @pytest.mark.priority_medium
@@ -231,7 +231,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
             expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-            expected_auto_hpo_value: float = None
+            expected_auto_hpo_value: float = None,
         ):
             expected_metadata = {
                 "default_value": 100.1,
@@ -246,7 +246,7 @@ class TestPrimitiveParameters:
                 "min_value": expected_min_value,
                 "max_value": expected_max_value,
                 "auto_hpo_state": expected_auto_hpo_state,
-                "auto_hpo_value": expected_auto_hpo_value
+                "auto_hpo_value": expected_auto_hpo_value,
             }
             assert isinstance(float_instance, _make._CountingAttr)
             assert float_instance._default == 100.1
@@ -283,7 +283,7 @@ class TestPrimitiveParameters:
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
             auto_hpo_value=auto_hpo_value,
-            auto_hpo_state=auto_hpo_state
+            auto_hpo_state=auto_hpo_state,
         )
         check_configurable_float(
             float_instance=actual_float,  # type: ignore
@@ -296,7 +296,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
             expected_auto_hpo_state=auto_hpo_state,
-            expected_auto_hpo_value=auto_hpo_value
+            expected_auto_hpo_value=auto_hpo_value,
         )
 
     @pytest.mark.priority_medium
@@ -330,7 +330,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
             expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-            expected_auto_hpo_value: bool = None
+            expected_auto_hpo_value: bool = None,
         ):
             expected_metadata = {
                 "default_value": True,
@@ -343,7 +343,7 @@ class TestPrimitiveParameters:
                 "ui_rules": expected_ui_rules,
                 "type": ConfigElementType.BOOLEAN,
                 "auto_hpo_state": expected_auto_hpo_state,
-                "auto_hpo_value": expected_auto_hpo_value
+                "auto_hpo_value": expected_auto_hpo_value,
             }
             assert isinstance(boolean_instance, _make._CountingAttr)
             assert boolean_instance._default
@@ -381,7 +381,7 @@ class TestPrimitiveParameters:
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
             auto_hpo_value=auto_hpo_value,
-            auto_hpo_state=auto_hpo_state
+            auto_hpo_state=auto_hpo_state,
         )
         check_configurable_boolean(
             boolean_instance=actual_boolean,  # type: ignore
@@ -392,7 +392,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
             expected_auto_hpo_value=auto_hpo_value,
-            expected_auto_hpo_state=auto_hpo_state
+            expected_auto_hpo_state=auto_hpo_state,
         )
 
     @pytest.mark.priority_medium
@@ -425,7 +425,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
             expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-            expected_auto_hpo_value: float = None
+            expected_auto_hpo_value: float = None,
         ):
             expected_metadata = {
                 "default_value": 0.1,
@@ -439,7 +439,7 @@ class TestPrimitiveParameters:
                 "type": ConfigElementType.FLOAT_SELECTABLE,
                 "options": [0.2, 1.4, 2.8],
                 "auto_hpo_state": expected_auto_hpo_state,
-                "auto_hpo_value": expected_auto_hpo_value
+                "auto_hpo_value": expected_auto_hpo_value,
             }
             assert isinstance(float_selectable_instance, _make._CountingAttr)
             assert float_selectable_instance._default
@@ -479,7 +479,7 @@ class TestPrimitiveParameters:
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
             auto_hpo_value=auto_hpo_value,
-            auto_hpo_state=auto_hpo_state
+            auto_hpo_state=auto_hpo_state,
         )
         check_float_selectable(
             float_selectable_instance=actual_float_selectable,  # type: ignore
@@ -490,7 +490,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
             expected_auto_hpo_value=auto_hpo_value,
-            expected_auto_hpo_state=auto_hpo_state
+            expected_auto_hpo_state=auto_hpo_state,
         )
 
     @pytest.mark.priority_medium
@@ -522,7 +522,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
             expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
-            expected_auto_hpo_value: SomeEnumSelectable = None
+            expected_auto_hpo_value: SomeEnumSelectable = None,
         ):
             expected_metadata = {
                 "default_value": SomeEnumSelectable.OPTION_C,
@@ -542,7 +542,7 @@ class TestPrimitiveParameters:
                     "OPTION_C": "option_c",
                 },
                 "auto_hpo_state": expected_auto_hpo_state,
-                "auto_hpo_value": expected_auto_hpo_value
+                "auto_hpo_value": expected_auto_hpo_value,
             }
             assert isinstance(selectable_instance, _make._CountingAttr)
             assert selectable_instance._default == SomeEnumSelectable.OPTION_C
@@ -579,7 +579,7 @@ class TestPrimitiveParameters:
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
             auto_hpo_value=auto_hpo_value,
-            auto_hpo_state=auto_hpo_state
+            auto_hpo_state=auto_hpo_state,
         )
         check_selectable(
             selectable_instance=actual_selectable,  # type: ignore
@@ -590,7 +590,7 @@ class TestPrimitiveParameters:
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
             expected_auto_hpo_state=auto_hpo_state,
-            expected_auto_hpo_value=auto_hpo_value
+            expected_auto_hpo_value=auto_hpo_value,
         )
 
     @pytest.mark.priority_medium

--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
@@ -17,7 +17,7 @@ from ote_sdk.configuration.elements.primitive_parameters import (
     string_attribute,
 )
 from ote_sdk.configuration.elements.utils import attr_strict_int_validator
-from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle
+from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle, AutoHPOState
 from ote_sdk.configuration.ui_rules import NullUIRules, Rule, UIRules
 from ote_sdk.tests.configuration.dummy_config import SomeEnumSelectable
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
@@ -52,6 +52,8 @@ class TestPrimitiveParameters:
         ui_rules = self.ui_rules
         visible_in_ui = True
         parameter_type = ConfigElementType.CONFIGURABLE_PARAMETERS
+        auto_hpo_state = AutoHPOState.POSSIBLE
+
         for default_value in [
             5,  # int "default_value"
             1.3,  # float "default_value"
@@ -69,6 +71,8 @@ class TestPrimitiveParameters:
                 ui_rules=ui_rules,
                 visible_in_ui=visible_in_ui,
                 parameter_type=parameter_type,
+                auto_hpo_state=auto_hpo_state,
+                auto_hpo_value=default_value
             ) == {
                 "default_value": default_value,
                 "description": description,
@@ -79,6 +83,8 @@ class TestPrimitiveParameters:
                 "affects_outcome_of": affects_outcome_of,
                 "ui_rules": ui_rules,
                 "type": parameter_type,
+                "auto_hpo_state": auto_hpo_state,
+                "auto_hpo_value": default_value
             }
 
     @pytest.mark.priority_medium
@@ -113,6 +119,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui: bool = True,
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
+            expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+            expected_auto_hpo_value: int = None
         ):
             expected_metadata = {
                 "default_value": 100,
@@ -126,6 +134,8 @@ class TestPrimitiveParameters:
                 "type": ConfigElementType.INTEGER,
                 "min_value": expected_min_value,
                 "max_value": expected_max_value,
+                "auto_hpo_state": expected_auto_hpo_state,
+                "auto_hpo_value": expected_auto_hpo_value
             }
             assert isinstance(integer_instance, _make._CountingAttr)
             assert integer_instance._default == 100
@@ -156,6 +166,8 @@ class TestPrimitiveParameters:
         visible_in_ui = False
         affects_outcome_of = ModelLifecycle.TESTING
         ui_rules = self.ui_rules
+        auto_hpo_state = AutoHPOState.POSSIBLE
+        auto_hpo_value = min_value
 
         actual_integer = configurable_integer(
             default_value=default_value,
@@ -168,6 +180,8 @@ class TestPrimitiveParameters:
             visible_in_ui=visible_in_ui,
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
+            auto_hpo_value=auto_hpo_value,
+            auto_hpo_state=auto_hpo_state
         )
         check_configurable_integer(
             integer_instance=actual_integer,  # type: ignore
@@ -179,6 +193,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui=visible_in_ui,
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
+            expected_auto_hpo_state=auto_hpo_state,
+            expected_auto_hpo_value=auto_hpo_value
         )
 
     @pytest.mark.priority_medium
@@ -214,6 +230,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui: bool = True,
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
+            expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+            expected_auto_hpo_value: float = None
         ):
             expected_metadata = {
                 "default_value": 100.1,
@@ -227,6 +245,8 @@ class TestPrimitiveParameters:
                 "type": ConfigElementType.FLOAT,
                 "min_value": expected_min_value,
                 "max_value": expected_max_value,
+                "auto_hpo_state": expected_auto_hpo_state,
+                "auto_hpo_value": expected_auto_hpo_value
             }
             assert isinstance(float_instance, _make._CountingAttr)
             assert float_instance._default == 100.1
@@ -248,6 +268,8 @@ class TestPrimitiveParameters:
         visible_in_ui = False
         affects_outcome_of = ModelLifecycle.TESTING
         ui_rules = self.ui_rules
+        auto_hpo_state = AutoHPOState.POSSIBLE
+        auto_hpo_value = min_value
 
         actual_float = configurable_float(
             default_value=default_value,
@@ -260,6 +282,8 @@ class TestPrimitiveParameters:
             visible_in_ui=visible_in_ui,
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
+            auto_hpo_value=auto_hpo_value,
+            auto_hpo_state=auto_hpo_state
         )
         check_configurable_float(
             float_instance=actual_float,  # type: ignore
@@ -271,6 +295,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui=visible_in_ui,
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
+            expected_auto_hpo_state=auto_hpo_state,
+            expected_auto_hpo_value=auto_hpo_value
         )
 
     @pytest.mark.priority_medium
@@ -303,6 +329,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui: bool = True,
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
+            expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+            expected_auto_hpo_value: bool = None
         ):
             expected_metadata = {
                 "default_value": True,
@@ -314,6 +342,8 @@ class TestPrimitiveParameters:
                 "affects_outcome_of": expected_affects_outcome_of,
                 "ui_rules": expected_ui_rules,
                 "type": ConfigElementType.BOOLEAN,
+                "auto_hpo_state": expected_auto_hpo_state,
+                "auto_hpo_value": expected_auto_hpo_value
             }
             assert isinstance(boolean_instance, _make._CountingAttr)
             assert boolean_instance._default
@@ -338,6 +368,9 @@ class TestPrimitiveParameters:
         visible_in_ui = False
         affects_outcome_of = ModelLifecycle.TESTING
         ui_rules = self.ui_rules
+        auto_hpo_state = AutoHPOState.POSSIBLE
+        auto_hpo_value = False
+
         actual_boolean = configurable_boolean(
             default_value=default_value,
             header=header,
@@ -347,6 +380,8 @@ class TestPrimitiveParameters:
             visible_in_ui=visible_in_ui,
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
+            auto_hpo_value=auto_hpo_value,
+            auto_hpo_state=auto_hpo_state
         )
         check_configurable_boolean(
             boolean_instance=actual_boolean,  # type: ignore
@@ -356,6 +391,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui=visible_in_ui,
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
+            expected_auto_hpo_value=auto_hpo_value,
+            expected_auto_hpo_state=auto_hpo_state
         )
 
     @pytest.mark.priority_medium
@@ -387,6 +424,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui: bool = True,
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
+            expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+            expected_auto_hpo_value: float = None
         ):
             expected_metadata = {
                 "default_value": 0.1,
@@ -399,6 +438,8 @@ class TestPrimitiveParameters:
                 "ui_rules": expected_ui_rules,
                 "type": ConfigElementType.FLOAT_SELECTABLE,
                 "options": [0.2, 1.4, 2.8],
+                "auto_hpo_state": expected_auto_hpo_state,
+                "auto_hpo_value": expected_auto_hpo_value
             }
             assert isinstance(float_selectable_instance, _make._CountingAttr)
             assert float_selectable_instance._default
@@ -424,6 +465,9 @@ class TestPrimitiveParameters:
         visible_in_ui = False
         affects_outcome_of = ModelLifecycle.TESTING
         ui_rules = self.ui_rules
+        auto_hpo_state = AutoHPOState.POSSIBLE
+        auto_hpo_value = options[-1]
+
         actual_float_selectable = float_selectable(
             default_value=default_value,
             options=options,
@@ -434,6 +478,8 @@ class TestPrimitiveParameters:
             visible_in_ui=visible_in_ui,
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
+            auto_hpo_value=auto_hpo_value,
+            auto_hpo_state=auto_hpo_state
         )
         check_float_selectable(
             float_selectable_instance=actual_float_selectable,  # type: ignore
@@ -443,6 +489,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui=visible_in_ui,
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
+            expected_auto_hpo_value=auto_hpo_value,
+            expected_auto_hpo_state=auto_hpo_state
         )
 
     @pytest.mark.priority_medium
@@ -473,6 +521,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui: bool = True,
             expected_affects_outcome_of: ModelLifecycle = ModelLifecycle.NONE,
             expected_ui_rules: UIRules = NullUIRules(),
+            expected_auto_hpo_state: AutoHPOState = AutoHPOState.NOT_POSSIBLE,
+            expected_auto_hpo_value: SomeEnumSelectable = None
         ):
             expected_metadata = {
                 "default_value": SomeEnumSelectable.OPTION_C,
@@ -491,6 +541,8 @@ class TestPrimitiveParameters:
                     "BOGUS_NAME": "bogus",
                     "OPTION_C": "option_c",
                 },
+                "auto_hpo_state": expected_auto_hpo_state,
+                "auto_hpo_value": expected_auto_hpo_value
             }
             assert isinstance(selectable_instance, _make._CountingAttr)
             assert selectable_instance._default == SomeEnumSelectable.OPTION_C
@@ -514,6 +566,8 @@ class TestPrimitiveParameters:
         visible_in_ui = False
         affects_outcome_of = ModelLifecycle.TESTING
         ui_rules = self.ui_rules
+        auto_hpo_state = AutoHPOState.POSSIBLE
+        auto_hpo_value = SomeEnumSelectable.BOGUS_NAME
 
         actual_selectable = selectable(
             default_value=default_value,
@@ -524,6 +578,8 @@ class TestPrimitiveParameters:
             visible_in_ui=visible_in_ui,
             affects_outcome_of=affects_outcome_of,
             ui_rules=ui_rules,
+            auto_hpo_value=auto_hpo_value,
+            auto_hpo_state=auto_hpo_state
         )
         check_selectable(
             selectable_instance=actual_selectable,  # type: ignore
@@ -533,6 +589,8 @@ class TestPrimitiveParameters:
             expected_visible_in_ui=visible_in_ui,
             expected_affects_outcome_of=affects_outcome_of,
             expected_ui_rules=ui_rules,
+            expected_auto_hpo_state=auto_hpo_state,
+            expected_auto_hpo_value=auto_hpo_value
         )
 
     @pytest.mark.priority_medium

--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
@@ -17,7 +17,7 @@ from ote_sdk.configuration.elements.primitive_parameters import (
     string_attribute,
 )
 from ote_sdk.configuration.elements.utils import attr_strict_int_validator
-from ote_sdk.configuration.enums import ConfigElementType, ModelLifecycle, AutoHPOState
+from ote_sdk.configuration.enums import AutoHPOState, ConfigElementType, ModelLifecycle
 from ote_sdk.configuration.ui_rules import NullUIRules, Rule, UIRules
 from ote_sdk.tests.configuration.dummy_config import SomeEnumSelectable
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent

--- a/ote_sdk/ote_sdk/tests/configuration/test_configurable_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configurable_parameters.py
@@ -1,12 +1,16 @@
 # Copyright (C) 2021-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+import copy
 
 import pytest
 
 from ote_sdk.configuration.configurable_parameters import ConfigurableParameters
+from ote_sdk.configuration.elements import metadata_keys
+from ote_sdk.configuration.enums import AutoHPOState
 from ote_sdk.configuration.enums.config_element_type import ConfigElementType
 from ote_sdk.entities.id import ID
+from ote_sdk.tests.configuration.dummy_config import DatasetManagerConfig
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
 from ote_sdk.tests.constants.requirements import Requirements
 
@@ -70,3 +74,80 @@ class TestConfigurableParameters:
             expected_id=config_id,
             expected_visible_in_ui=visible_in_ui,
         )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_set_metadata(self):
+        """
+        <b>Description:</b>
+        Check "ConfigurableParameters" class parameter metadata setting
+
+        <b>Input data:</b>
+        Dummy configuration -- DatasetManagerConfig
+
+        <b>Expected results:</b>
+        Test passes if:
+            1. Metadata for a given parameter inside the ConfigurableParameters can be
+               set successfully,
+            2. Attempting to set metadata for a non-existing parameter results in
+               failure
+            3. Attempting to set metadata for a non-existing metadata key results in
+               failure
+            4. Attempting to set metadata to a value of a type that does not match the
+               original metadata item type results in failure
+            5. Resetting the metadata back to its original value can be done
+               successfully
+        """
+        # Arrange
+        config = DatasetManagerConfig(
+            description="Configurable parameters for the DatasetManager -- TEST ONLY",
+            header="Dataset Manager configuration -- TEST ONLY",
+        )
+        test_parameter_name = "dummy_float_selectable"
+        metadata_key = metadata_keys.AUTO_HPO_STATE
+        old_value = config.get_metadata(
+            test_parameter_name
+        )[metadata_key]
+        new_value = AutoHPOState.OPTIMIZED
+
+        # Act
+        success = config.set_metadata_value(
+            parameter_name=test_parameter_name,
+            metadata_key=metadata_key,
+            value=new_value
+        )
+        no_success_invalid_param = config.set_metadata_value(
+            parameter_name=test_parameter_name+'_invalid',
+            metadata_key=metadata_key,
+            value=new_value
+        )
+        no_success_invalid_key = config.set_metadata_value(
+            parameter_name=test_parameter_name,
+            metadata_key=metadata_key+'_invalid',
+            value=new_value
+        )
+        no_success_invalid_value_type = config.set_metadata_value(
+            parameter_name=test_parameter_name,
+            metadata_key=metadata_key,
+            value=str(new_value)
+        )
+        config_copy = copy.deepcopy(config)
+        success_revert = config_copy.set_metadata_value(
+            parameter_name=test_parameter_name,
+            metadata_key=metadata_key,
+            value=old_value
+        )
+
+        # Assert
+        assert old_value != new_value
+        assert all([success, success_revert])
+        assert not any(
+            [
+                no_success_invalid_key,
+                no_success_invalid_param,
+                no_success_invalid_value_type
+            ]
+        )
+        assert config.get_metadata(test_parameter_name)[metadata_key] == new_value
+        assert config_copy.get_metadata(test_parameter_name)[metadata_key] == old_value

--- a/ote_sdk/ote_sdk/tests/configuration/test_configurable_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configurable_parameters.py
@@ -106,37 +106,35 @@ class TestConfigurableParameters:
         )
         test_parameter_name = "dummy_float_selectable"
         metadata_key = metadata_keys.AUTO_HPO_STATE
-        old_value = config.get_metadata(
-            test_parameter_name
-        )[metadata_key]
+        old_value = config.get_metadata(test_parameter_name)[metadata_key]
         new_value = AutoHPOState.OPTIMIZED
 
         # Act
         success = config.set_metadata_value(
             parameter_name=test_parameter_name,
             metadata_key=metadata_key,
-            value=new_value
+            value=new_value,
         )
         no_success_invalid_param = config.set_metadata_value(
-            parameter_name=test_parameter_name+'_invalid',
+            parameter_name=test_parameter_name + "_invalid",
             metadata_key=metadata_key,
-            value=new_value
+            value=new_value,
         )
         no_success_invalid_key = config.set_metadata_value(
             parameter_name=test_parameter_name,
-            metadata_key=metadata_key+'_invalid',
-            value=new_value
+            metadata_key=metadata_key + "_invalid",
+            value=new_value,
         )
         no_success_invalid_value_type = config.set_metadata_value(
             parameter_name=test_parameter_name,
             metadata_key=metadata_key,
-            value=str(new_value)
+            value=str(new_value),
         )
         config_copy = copy.deepcopy(config)
         success_revert = config_copy.set_metadata_value(
             parameter_name=test_parameter_name,
             metadata_key=metadata_key,
-            value=old_value
+            value=old_value,
         )
 
         # Assert
@@ -146,7 +144,7 @@ class TestConfigurableParameters:
             [
                 no_success_invalid_key,
                 no_success_invalid_param,
-                no_success_invalid_value_type
+                no_success_invalid_value_type,
             ]
         )
         assert config.get_metadata(test_parameter_name)[metadata_key] == new_value
@@ -188,27 +186,35 @@ class TestConfigurableParameters:
         success_1 = config.set_metadata_value(
             parameter_name=test_parameter_1,
             metadata_key=metadata_keys.AUTO_HPO_VALUE,
-            value=auto_hpo_result_float
+            value=auto_hpo_result_float,
         )
         config.subset_parameters.train_proportion = auto_hpo_result_train_prop
         success_2 = config.subset_parameters.set_metadata_value(
             parameter_name=test_parameter_2,
             metadata_key=metadata_keys.AUTO_HPO_VALUE,
-            value=auto_hpo_result_train_prop
+            value=auto_hpo_result_train_prop,
         )
 
         # Act
         config.update_auto_hpo_states()
-        auto_hpo_state_1 = config.get_metadata(test_parameter_1)[metadata_keys.AUTO_HPO_STATE]
-        auto_hpo_state_2 = config.subset_parameters.get_metadata(test_parameter_2)[metadata_keys.AUTO_HPO_STATE]
+        auto_hpo_state_1 = config.get_metadata(test_parameter_1)[
+            metadata_keys.AUTO_HPO_STATE
+        ]
+        auto_hpo_state_2 = config.subset_parameters.get_metadata(test_parameter_2)[
+            metadata_keys.AUTO_HPO_STATE
+        ]
 
         # Simulate override
         config.dummy_float_selectable = auto_hpo_result_float - 0.001
         config.subset_parameters.train_proportion = auto_hpo_result_train_prop - 0.001
 
         config.update_auto_hpo_states()
-        auto_hpo_state_override_1 = config.get_metadata(test_parameter_1)[metadata_keys.AUTO_HPO_STATE]
-        auto_hpo_state_override_2 = config.subset_parameters.get_metadata(test_parameter_2)[metadata_keys.AUTO_HPO_STATE]
+        auto_hpo_state_override_1 = config.get_metadata(test_parameter_1)[
+            metadata_keys.AUTO_HPO_STATE
+        ]
+        auto_hpo_state_override_2 = config.subset_parameters.get_metadata(
+            test_parameter_2
+        )[metadata_keys.AUTO_HPO_STATE]
 
         # Assert
         assert all([success_1, success_2])

--- a/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
@@ -102,12 +102,12 @@ class TestConfigurationHelper:
         )
         test_parameter_name = 'dummy_float_selectable'
         metadata_key = metadata_keys.AUTO_HPO_STATE
-        old_value = config.get_metadata(test_parameter_name)[metadata_key]
-        new_value = AutoHPOState.OPTIMIZED
+        old_state = config.get_metadata(test_parameter_name)[metadata_key]
+        new_state = AutoHPOState.OPTIMIZED
         set_success = config.set_metadata_value(
             parameter_name=test_parameter_name,
             metadata_key=metadata_key,
-            value=new_value
+            value=new_state
         )
 
         # Act
@@ -120,15 +120,15 @@ class TestConfigurationHelper:
         reconstructed_config_from_yaml = ote_config_helper.create(cfg_yaml)
 
         # Assert
-        assert old_value != new_value
+        assert old_state != new_state
         assert set_success
         # Check that metadata changes are properly converted
         assert reconstructed_config.get_metadata(
             parameter_name=test_parameter_name
-        )[metadata_key] == new_value
+        )[metadata_key] == new_state
         assert reconstructed_config_from_yaml.get_metadata(
             parameter_name=test_parameter_name
-        )[metadata_key] == new_value
+        )[metadata_key] == new_state
         # Compare the config dictionaries
         assert cfg == ote_config_helper.convert(reconstructed_config, dict)
         assert cfg == ote_config_helper.convert(reconstructed_config_from_yaml, dict)

--- a/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
@@ -9,7 +9,7 @@ from omegaconf import OmegaConf
 
 from ote_sdk.configuration import ote_config_helper
 from ote_sdk.configuration.elements import metadata_keys
-from ote_sdk.configuration.enums import ModelLifecycle, AutoHPOState
+from ote_sdk.configuration.enums import AutoHPOState, ModelLifecycle
 from ote_sdk.tests.configuration.dummy_config import (
     DatasetManagerConfig,
     SomeEnumSelectable,

--- a/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
@@ -100,14 +100,14 @@ class TestConfigurationHelper:
             description="Configurable parameters for the DatasetManager -- TEST ONLY",
             header="Dataset Manager configuration -- TEST ONLY",
         )
-        test_parameter_name = 'dummy_float_selectable'
+        test_parameter_name = "dummy_float_selectable"
         metadata_key = metadata_keys.AUTO_HPO_STATE
         old_state = config.get_metadata(test_parameter_name)[metadata_key]
         new_state = AutoHPOState.OPTIMIZED
         set_success = config.set_metadata_value(
             parameter_name=test_parameter_name,
             metadata_key=metadata_key,
-            value=new_state
+            value=new_state,
         )
 
         # Act
@@ -123,12 +123,18 @@ class TestConfigurationHelper:
         assert old_state != new_state
         assert set_success
         # Check that metadata changes are properly converted
-        assert reconstructed_config.get_metadata(
-            parameter_name=test_parameter_name
-        )[metadata_key] == new_state
-        assert reconstructed_config_from_yaml.get_metadata(
-            parameter_name=test_parameter_name
-        )[metadata_key] == new_state
+        assert (
+            reconstructed_config.get_metadata(parameter_name=test_parameter_name)[
+                metadata_key
+            ]
+            == new_state
+        )
+        assert (
+            reconstructed_config_from_yaml.get_metadata(
+                parameter_name=test_parameter_name
+            )[metadata_key]
+            == new_state
+        )
         # Compare the config dictionaries
         assert cfg == ote_config_helper.convert(reconstructed_config, dict)
         assert cfg == ote_config_helper.convert(reconstructed_config_from_yaml, dict)


### PR DESCRIPTION
This PR adds two flags to the primitive configurable parameters for bookkeeping of the auto hyper parameter optimization state and value. It also adds a method to the parameter group class to set these metadata flags for each parameter, which will be used by the auto-hpo operator. 

**Update**
I've run the SC e2e tests for this branch and an updated SC branch to make sure that this PR does not cause any failures in the SC tests. The link to the build is [here](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/24370/), all tests have passed. 

The corresponding SC branch has just been [merged](https://gitlab.devtools.intel.com/vmc-eip/IMPT/impt/-/merge_requests/5339). 

So, this PR can now be reviewed and merged without breaking SC.
