### PR TITLE
[OTE_SDK_TESTS] Added input parameters validation and tests. Part 1

### DIFF
--- a/ote_sdk/ote_sdk/configuration/helper/create.py
+++ b/ote_sdk/ote_sdk/configuration/helper/create.py
@@ -29,6 +29,7 @@ from ote_sdk.configuration.enums.config_element_type import (
 from ote_sdk.configuration.enums.model_lifecycle import ModelLifecycle
 from ote_sdk.configuration.enums.utils import get_enum_names
 from ote_sdk.configuration.ui_rules.rules import NullUIRules, Rule, UIRules
+from ote_sdk.utils.argument_checks import check_input_config_parameter
 
 from .config_element_mapping import (
     GroupElementMapping,
@@ -361,6 +362,8 @@ def create(input_config: Union[str, DictConfig, dict]) -> ConfigurableParameters
     :param input_config: yaml string, dictionary, DictConfig or filepath describing a configuration.
     :return: ConfigurableParameters object
     """
+    # Input parameter validation
+    check_input_config_parameter(input_config=input_config)
     # Parse input, validate config type and convert to dict if needed
     config_dict = input_to_config_dict(copy.deepcopy(input_config))
     # Create config from the resulting dictionary

--- a/ote_sdk/ote_sdk/entities/annotation.py
+++ b/ote_sdk/ote_sdk/entities/annotation.py
@@ -14,6 +14,10 @@ from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.scored_label import ScoredLabel
 from ote_sdk.entities.shapes.shape import ShapeEntity
+from ote_sdk.utils.argument_checks import (
+    check_nested_elements_type,
+    check_required_and_optional_parameters_type,
+)
 from ote_sdk.utils.time_utils import now
 
 
@@ -26,6 +30,20 @@ class Annotation(metaclass=abc.ABCMeta):
     def __init__(
         self, shape: ShapeEntity, labels: List[ScoredLabel], id: Optional[ID] = None
     ):
+        # Initialization parameters validation
+        check_required_and_optional_parameters_type(
+            required_parameters=[
+                (shape, "shape", ShapeEntity),
+                (labels, "labels", list),
+            ],
+            optional_parameters=[(id, "id", ID)],
+        )
+        # Nested labels validation
+        if labels:
+            check_nested_elements_type(
+                iterable=labels, parameter_name="label", expected_type=ScoredLabel
+            )
+
         self.__id = ID(ObjectId()) if id is None else id
         self.__shape = shape
         self.__labels = labels
@@ -159,6 +177,26 @@ class AnnotationSceneEntity(metaclass=abc.ABCMeta):
         creation_date: Optional[datetime.datetime] = None,
         id: Optional[ID] = None,
     ):
+        # Initialization parameters validation
+        check_required_and_optional_parameters_type(
+            required_parameters=[
+                (annotations, "annotations", list),
+                (kind, "kind", AnnotationSceneKind),
+            ],
+            optional_parameters=[
+                (editor, "editor", str),
+                (creation_date, "creation_date", datetime.datetime),
+                (id, "id", ID),
+            ],
+        )
+        # Nested annotations validation
+        if annotations:
+            check_nested_elements_type(
+                iterable=annotations,
+                parameter_name="annotation",
+                expected_type=Annotation,
+            )
+
         self.__annotations = annotations
         self.__kind = kind
         self.__editor = editor

--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -21,6 +21,10 @@ from ote_sdk.entities.model import ModelEntity
 from ote_sdk.entities.scored_label import ScoredLabel
 from ote_sdk.entities.shapes.rectangle import Rectangle
 from ote_sdk.entities.subset import Subset
+from ote_sdk.utils.argument_checks import (
+    check_nested_elements_type,
+    check_required_and_optional_parameters_type,
+)
 from ote_sdk.utils.shape_factory import ShapeFactory
 
 logger = logging.getLogger(__name__)
@@ -89,6 +93,26 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
         metadata: Optional[Sequence[MetadataItemEntity]] = None,
         subset: Subset = Subset.NONE,
     ):
+        # Initialization parameters validation
+        check_required_and_optional_parameters_type(
+            required_parameters=[
+                (media, "media", IMedia2DEntity),
+                (annotation_scene, "annotation_scene", AnnotationSceneEntity),
+                (subset, "subset", Subset),
+            ],
+            optional_parameters=[
+                (roi, "roi", Annotation),
+                (metadata, "metadata", Sequence),
+            ],
+        )
+        # Nested metadata items validation
+        if metadata:
+            check_nested_elements_type(
+                iterable=metadata,
+                parameter_name="metadata item",
+                expected_type=MetadataItemEntity,
+            )
+
         self.__media: IMedia2DEntity = media
         self.__annotation_scene: AnnotationSceneEntity = annotation_scene
         self.__subset: Subset = subset

--- a/ote_sdk/ote_sdk/entities/datasets.py
+++ b/ote_sdk/ote_sdk/entities/datasets.py
@@ -19,6 +19,10 @@ from ote_sdk.entities.dataset_item import DatasetItemEntity
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.subset import Subset
+from ote_sdk.utils.argument_checks import (
+    check_nested_elements_type,
+    check_optional_parameters_type,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +131,17 @@ class DatasetEntity:
         items: Optional[List[DatasetItemEntity]] = None,
         purpose: DatasetPurpose = DatasetPurpose.INFERENCE,
     ):
+        # Initialization parameters validation
+        check_optional_parameters_type(
+            [(items, "items", list), (purpose, "purpose", DatasetPurpose)]
+        )
+        # Nested dataset items validation
+        if items:
+            check_nested_elements_type(
+                iterable=items,
+                parameter_name="dataset item",
+                expected_type=DatasetItemEntity,
+            )
         self._items = [] if items is None else items
         self._purpose = purpose
 

--- a/ote_sdk/ote_sdk/entities/image.py
+++ b/ote_sdk/ote_sdk/entities/image.py
@@ -13,6 +13,7 @@ import numpy as np
 from ote_sdk.entities.annotation import Annotation
 from ote_sdk.entities.media import IMedia2DEntity
 from ote_sdk.entities.shapes.rectangle import Rectangle
+from ote_sdk.utils.argument_checks import check_file_path, check_parameter_type
 
 
 class Image(IMedia2DEntity):
@@ -36,6 +37,17 @@ class Image(IMedia2DEntity):
             raise ValueError(
                 "Either path to image file or image data should be provided."
             )
+        if data is not None:
+            check_parameter_type(
+                parameter=data, parameter_name="data", expected_type=np.ndarray
+            )
+        if file_path is not None:
+            check_file_path(
+                file_path=file_path,
+                file_path_name="file_path",
+                expected_extensions=["jpg", "png"],
+            )
+
         self.__data: Optional[np.ndarray] = data
         self.__file_path: Optional[str] = file_path
         self.__height: Optional[int] = None

--- a/ote_sdk/ote_sdk/entities/label.py
+++ b/ote_sdk/ote_sdk/entities/label.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from ote_sdk.entities.color import Color
 from ote_sdk.entities.id import ID
+from ote_sdk.utils.argument_checks import check_required_and_optional_parameters_type
 from ote_sdk.utils.time_utils import now
 
 
@@ -87,6 +88,18 @@ class LabelEntity:
         is_empty: bool = False,
         id: Optional[ID] = None,
     ):
+        # Initialization parameters validation
+        check_required_and_optional_parameters_type(
+            required_parameters=[(name, "name", str), (domain, "domain", Domain)],
+            optional_parameters=[
+                (color, "color", Color),
+                (hotkey, "hotkey", str),
+                (creation_date, "creation_date", datetime.datetime),
+                (is_empty, "is_empty", bool),
+                (id, "id", ID),
+            ],
+        )
+
         id = ID() if id is None else id
         color = Color.random() if color is None else color
         creation_date = now() if creation_date is None else creation_date

--- a/ote_sdk/ote_sdk/entities/label_schema.py
+++ b/ote_sdk/ote_sdk/entities/label_schema.py
@@ -14,6 +14,11 @@ from ote_sdk.entities.graph import Graph, MultiDiGraph
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.scored_label import ScoredLabel
+from ote_sdk.utils.argument_checks import (
+    check_nested_elements_type,
+    check_optional_parameters_type,
+    check_parameter_type,
+)
 
 
 class LabelGroupExistsException(ValueError):
@@ -300,6 +305,22 @@ class LabelSchemaEntity:
         label_tree: LabelTree = None,
         label_groups: List[LabelGroup] = None,
     ):
+        # Initialization parameters validation
+        check_optional_parameters_type(
+            [
+                (exclusivity_graph, "exclusivity_graph", LabelGraph),
+                (label_tree, "label_tree", LabelTree),
+                (label_groups, "label_groups", list),
+            ]
+        )
+        # Nested label_groups validation
+        if label_groups:
+            check_nested_elements_type(
+                iterable=label_groups,
+                parameter_name="label_group",
+                expected_type=LabelGroup,
+            )
+
         if exclusivity_graph is None:
             exclusivity_graph = LabelGraph(
                 False
@@ -582,5 +603,14 @@ class LabelSchemaEntity:
         :param labels: list of labels
         :return: LabelSchemaEntity from the given labels
         """
+        check_parameter_type(
+            parameter=labels, parameter_name="labels", expected_type=Sequence
+        )
+        # Nested labels validation
+        if labels:
+            check_nested_elements_type(
+                iterable=labels, parameter_name="label", expected_type=LabelEntity
+            )
+
         label_group = LabelGroup(name="from_label_list", labels=labels)
         return LabelSchemaEntity(label_groups=[label_group])

--- a/ote_sdk/ote_sdk/entities/model.py
+++ b/ote_sdk/ote_sdk/entities/model.py
@@ -19,6 +19,13 @@ from ote_sdk.usecases.adapters.model_adapter import (
     IDataSource,
     ModelAdapter,
 )
+from ote_sdk.utils.argument_checks import (
+    check_is_parameter_like_dataset,
+    check_optional_parameters_type,
+    check_parameter_type,
+    check_several_optional_dictionaries_keys_values_type,
+    check_several_optional_lists_elements_type,
+)
 from ote_sdk.utils.time_utils import now
 
 if TYPE_CHECKING:
@@ -115,6 +122,61 @@ class ModelEntity:
         model_size_reduction: float = 0.0,
         _id: Optional[ID] = None,
     ):
+        # Initialization parameters validation
+        check_is_parameter_like_dataset(
+            parameter=train_dataset, parameter_name="train_dataset"
+        )
+        check_parameter_type(
+            parameter=configuration,
+            parameter_name="configuration",
+            expected_type=ModelConfiguration,
+        )
+        check_optional_parameters_type(
+            [
+                (creation_date, "creation_date", datetime.datetime),
+                (performance, "performance", Performance),
+                (previous_trained_revision, "previous_trained_revision", ModelEntity),
+                (previous_revision, "previous_revision", ModelEntity),
+                (version, "version", int),
+                (tags, "tags", list),
+                (model_format, "model_format", ModelFormat),
+                (training_duration, "training_duration", (int, float)),
+                (model_adapters, "model_adapters", dict),
+                (
+                    exportable_code_adapter,
+                    "exportable_code_adapter",
+                    ExportableCodeAdapter,
+                ),
+                (precision, "precision", list),
+                (latency, "latency", int),
+                (fps_throughput, "fps_throughput", int),
+                (target_device, "target_device", TargetDevice),
+                (target_device_type, "target_device_type", str),
+                (optimization_type, "optimization_type", ModelOptimizationType),
+                (optimization_methods, "optimization_methods", list),
+                (optimization_objectives, "optimization_objectives", dict),
+                (performance_improvement, "performance_improvement", dict),
+                (model_size_reduction, "model_size_reduction", (int, float)),
+                (_id, "_id", ID),
+            ]
+        )
+        # Nested list elements validation
+        check_several_optional_lists_elements_type(
+            [
+                (tags, "tag", str),
+                (precision, "precision", ModelPrecision),
+                (optimization_methods, "optimization method", OptimizationMethod),
+            ]
+        )
+        # Dictionary keys and values validation
+        check_several_optional_dictionaries_keys_values_type(
+            [
+                (model_adapters, "model_adapter", str, ModelAdapter),
+                (optimization_objectives, "optimization_objective", str, str),
+                (performance_improvement, "performance_improvement", str, (int, float)),
+            ]
+        )
+
         _id = ID() if _id is None else _id
         performance = NullPerformance() if performance is None else performance
         creation_date = now() if creation_date is None else creation_date

--- a/ote_sdk/ote_sdk/entities/model_template.py
+++ b/ote_sdk/ote_sdk/entities/model_template.py
@@ -13,6 +13,7 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from ote_sdk.configuration.elements import metadata_keys
 from ote_sdk.entities.label import Domain
+from ote_sdk.utils.argument_checks import check_file_path
 
 
 class TargetDevice(IntEnum):
@@ -475,6 +476,13 @@ def parse_model_template(model_template_path: str) -> ModelTemplate:
 
     :param model_template_path: Path to the model template template.yaml file
     """
+    # Input parameter validation
+    check_file_path(
+        file_path=model_template_path,
+        file_path_name="model_template_path",
+        expected_extensions=["yaml"],
+    )
+
     config = OmegaConf.load(model_template_path)
     if not isinstance(config, DictConfig):
         raise ValueError(

--- a/ote_sdk/ote_sdk/entities/resultset.py
+++ b/ote_sdk/ote_sdk/entities/resultset.py
@@ -14,6 +14,7 @@ from ote_sdk.entities.datasets import DatasetEntity
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.metrics import NullPerformance, Performance
 from ote_sdk.entities.model import ModelEntity
+from ote_sdk.utils.argument_checks import check_required_and_optional_parameters_type
 from ote_sdk.utils.time_utils import now
 
 
@@ -77,6 +78,21 @@ class ResultSetEntity(metaclass=abc.ABCMeta):
         creation_date: Optional[datetime.datetime] = None,
         id: Optional[ID] = None,
     ):
+        # Initialization parameters validation
+        check_required_and_optional_parameters_type(
+            required_parameters=[
+                (model, "model", ModelEntity),
+                (ground_truth_dataset, "ground_truth_dataset", DatasetEntity),
+                (prediction_dataset, "prediction_dataset", DatasetEntity),
+                (purpose, "purpose", ResultsetPurpose),
+            ],
+            optional_parameters=[
+                (performance, "performance", Performance),
+                (creation_date, "creation_date", datetime.datetime),
+                (id, "id", ID),
+            ],
+        )
+
         id = ID() if id is None else id
         performance = NullPerformance() if performance is None else performance
         creation_date = now() if creation_date is None else creation_date

--- a/ote_sdk/ote_sdk/entities/scored_label.py
+++ b/ote_sdk/ote_sdk/entities/scored_label.py
@@ -9,6 +9,7 @@ import datetime
 from ote_sdk.entities.color import Color
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import Domain, LabelEntity
+from ote_sdk.utils.argument_checks import check_required_parameters_type
 
 
 class ScoredLabel:
@@ -20,6 +21,11 @@ class ScoredLabel:
     """
 
     def __init__(self, label: LabelEntity, probability: float = 0.0):
+        # Initialization parameters validation
+        check_required_parameters_type(
+            [(label, "label", LabelEntity), (probability, "probability", (float, int))]
+        )
+
         self.label = label
         self.probability = probability
 

--- a/ote_sdk/ote_sdk/entities/shapes/rectangle.py
+++ b/ote_sdk/ote_sdk/entities/shapes/rectangle.py
@@ -16,6 +16,10 @@ from shapely.geometry import Polygon as shapely_polygon
 
 from ote_sdk.entities.scored_label import ScoredLabel
 from ote_sdk.entities.shapes.shape import Shape, ShapeEntity, ShapeType
+from ote_sdk.utils.argument_checks import (
+    check_nested_elements_type,
+    check_required_and_optional_parameters_type,
+)
 from ote_sdk.utils.time_utils import now
 
 # pylint: disable=invalid-name
@@ -50,6 +54,25 @@ class Rectangle(Shape):
         labels: Optional[List[ScoredLabel]] = None,
         modification_date: Optional[datetime.datetime] = None,
     ):
+        # Initialization parameters validation
+        check_required_and_optional_parameters_type(
+            required_parameters=[
+                (x1, "x1", (float, int, np.floating)),
+                (y1, "y1", (float, int, np.floating)),
+                (x2, "x2", (float, int, np.floating)),
+                (y2, "y2", (float, int, np.floating)),
+            ],
+            optional_parameters=[
+                (labels, "labels", list),
+                (modification_date, "modification_date", datetime.datetime),
+            ],
+        )
+        # Nested labels validation
+        if labels:
+            check_nested_elements_type(
+                iterable=labels, parameter_name="label", expected_type=ScoredLabel
+            )
+
         labels = [] if labels is None else labels
         modification_date = now() if modification_date is None else modification_date
         super().__init__(

--- a/ote_sdk/ote_sdk/entities/task_environment.py
+++ b/ote_sdk/ote_sdk/entities/task_environment.py
@@ -11,6 +11,10 @@ from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.label_schema import LabelSchemaEntity
 from ote_sdk.entities.model import ModelConfiguration, ModelEntity
 from ote_sdk.entities.model_template import ModelTemplate
+from ote_sdk.utils.argument_checks import (
+    check_parameter_type,
+    check_required_parameters_type,
+)
 
 TypeVariable = TypeVar("TypeVariable", bound=ConfigurableParameters)
 
@@ -34,6 +38,18 @@ class TaskEnvironment:
         hyper_parameters: ConfigurableParameters,
         label_schema: LabelSchemaEntity,
     ):
+        # Initialization parameters validation
+        check_required_parameters_type(
+            [
+                (model_template, "model_template", ModelTemplate),
+                (hyper_parameters, "hyper_parameters", ConfigurableParameters),
+                (label_schema, "label_schema", LabelSchemaEntity),
+            ]
+        )
+        if model:
+            check_parameter_type(
+                parameter=model, parameter_name="model", expected_type=ModelEntity
+            )
 
         self.model_template = model_template
         self.model = model

--- a/ote_sdk/ote_sdk/tests/entities/test_datasets.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_datasets.py
@@ -548,8 +548,6 @@ class TestDatasetEntity:
         <b>Steps</b>
         1. Check "items" attribute of DatasetEntity object after adding new DatasetEntity object
         2. Check "items" attribute of DatasetEntity object after adding existing DatasetEntity object
-        3. Check that ValueError exception is raised when appending DatasetEntity with "media" attribute is equal to
-        "None"
         """
         dataset = self.dataset()
         expected_items = list(dataset._items)
@@ -562,10 +560,6 @@ class TestDatasetEntity:
         dataset.append(item_to_add)
         expected_items.append(item_to_add)
         assert dataset._items == expected_items
-        # Checking that ValueError exception is raised when appending DatasetEntity with "media" is "None" attribute
-        no_media_item = DatasetItemEntity(None, self.annotations_entity())
-        with pytest.raises(ValueError):
-            dataset.append(no_media_item)
 
     @pytest.mark.priority_medium
     @pytest.mark.component

--- a/ote_sdk/ote_sdk/tests/entities/test_label_schema.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_label_schema.py
@@ -2146,11 +2146,16 @@ class TestLabelSchemaEntity:
         Check LabelSchemaEntity class from_labels method
 
         <b>Input data:</b>
-        LabelSchemaEntity objects with specified exclusivity_graph, label_tree and label_groups parameters
+        LabelSchemaEntity class, "labels" list
 
         <b>Expected results:</b>
         Test passes if LabelSchemaEntity object returned by from_labels method is equal expected
+
+        1. Check that LabelSchemaEntity object returned by from_labels is equal to expected
+        2. Check that ValueError exception is raised when unexpected type object is specified as "label_groups"
+        initialization parameter of LabelSchemaEntity object
         """
+        # Checking that LabelSchemaEntity returned by "from_labels" is equal to expected
         expected_labels = [
             labels.label_0,
             labels.label_0_1,
@@ -2165,3 +2170,9 @@ class TestLabelSchemaEntity:
         assert len(labels_schema_entity_groups) == 1
         assert labels_schema_entity_groups[0].name == "from_label_list"
         assert labels_schema_entity_groups[0].labels == expected_labels
+        # Checking that ValueError exception is raised by "from_labels" when incorrect type object is specified as
+        # "labels"
+        unexpected_type_value = 1
+        for value in [unexpected_type_value, (labels.label_0, unexpected_type_value)]:
+            with pytest.raises(ValueError):
+                LabelSchemaEntity.from_labels(labels=value)

--- a/ote_sdk/ote_sdk/tests/entities/test_metadata.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_metadata.py
@@ -19,13 +19,16 @@ import re
 
 import pytest
 
+from ote_sdk.configuration import ConfigurableParameters
+from ote_sdk.entities.datasets import DatasetEntity
+from ote_sdk.entities.label_schema import LabelSchemaEntity
 from ote_sdk.entities.metadata import (
     FloatMetadata,
     FloatType,
     IMetadata,
     MetadataItemEntity,
 )
-from ote_sdk.entities.model import ModelEntity
+from ote_sdk.entities.model import ModelConfiguration, ModelEntity
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
 from ote_sdk.tests.constants.requirements import Requirements
 
@@ -172,8 +175,12 @@ class TestMetadataItemEntity:
         test_data0 = test_data1 = i_metadata.name
         i_metadata.name = "i_metadata"
         test_data2 = i_metadata.name
+        configuration = ModelConfiguration(
+            configurable_parameters=ConfigurableParameters(header="test header"),
+            label_schema=LabelSchemaEntity(),
+        )
         test_model0 = test_model1 = ModelEntity(
-            train_dataset="default_dataset", configuration="default_config"
+            train_dataset=DatasetEntity(), configuration=configuration
         )
         test_instance0 = MetadataItemEntity(test_data0, test_model0)
         test_instance1 = MetadataItemEntity(test_data1, test_model1)

--- a/ote_sdk/ote_sdk/tests/entities/test_model_template.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_model_template.py
@@ -1116,6 +1116,8 @@ class TestParseModelTemplate:
         parse_model_template function for template file with specified model_template_id parameter
         3. Check ValueError exception raised if path to list-type template file is specified as input parameter in
         parse_model_template function
+        4. Check that ValueError exception raised if unexpected type object is specified as "model_template_path"
+        parameter
         """
         # Check for template file with not specified model_template_id
         model_template_path = TestHyperParameterData().model_template_path()
@@ -1148,6 +1150,21 @@ class TestParseModelTemplate:
         with pytest.raises(ValueError):
             parse_model_template(incorrect_model_template_path)
         remove(incorrect_model_template_path)
+        # Checking that ValueError exception raised if unexpected type object is specified as "model_template_path"
+        for incorrect_parameter in [
+            # Unexpected integer is specified as "model_template_path" parameter
+            1,
+            # Empty string is specified as "model_template_path" parameter
+            "",
+            # Path to non-yaml file is specified as "model_template_path" parameter
+            TestHyperParameterData.get_path_to_file(r"./incorrect_model_template.jpg"),
+            # Path to non-existing file is specified as "model_template_path" parameter
+            TestHyperParameterData.get_path_to_file(r"./non_existing_file.yaml"),
+            # Path with null character is specified as "file_path" parameter
+            TestHyperParameterData.get_path_to_file(r"./null\0char.yaml"),
+        ]:
+            with pytest.raises(ValueError):
+                parse_model_template(incorrect_parameter)
 
     @pytest.mark.priority_medium
     @pytest.mark.component

--- a/ote_sdk/ote_sdk/tests/entities/test_resultset.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_resultset.py
@@ -16,8 +16,12 @@ import datetime
 
 import pytest
 
+from ote_sdk.configuration import ConfigurableParameters
+from ote_sdk.entities.datasets import DatasetEntity
 from ote_sdk.entities.id import ID
-from ote_sdk.entities.metrics import NullPerformance
+from ote_sdk.entities.label_schema import LabelSchemaEntity
+from ote_sdk.entities.metrics import NullPerformance, Performance, ScoreMetric
+from ote_sdk.entities.model import ModelConfiguration, ModelEntity
 from ote_sdk.entities.resultset import ResultSetEntity, ResultsetPurpose
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
 from ote_sdk.tests.constants.requirements import Requirements
@@ -73,12 +77,21 @@ class TestResultset:
         2. Check the processing of default values
         3. Check the processing of changed values
         """
+        dataset_entity = DatasetEntity()
+        model_configuration = ModelConfiguration(
+            configurable_parameters=ConfigurableParameters(
+                header="model configurable parameters"
+            ),
+            label_schema=LabelSchemaEntity(),
+        )
+        model = ModelEntity(
+            train_dataset=dataset_entity, configuration=model_configuration
+        )
 
         test_data = {
-            "model": None,
-            "ground_truth_dataset": None,
-            "prediction_dataset": None,
-            "purpose": None,
+            "model": model,
+            "ground_truth_dataset": dataset_entity,
+            "prediction_dataset": dataset_entity,
             "performance": None,
             "creation_date": None,
             "id": None,
@@ -92,18 +105,19 @@ class TestResultset:
                 "model",
                 "ground_truth_dataset",
                 "prediction_dataset",
-                "purpose",
             ]:
                 assert getattr(result_set, name) == value
                 setattr(result_set, name, set_attr_name)
                 assert getattr(result_set, name) == set_attr_name
 
+        assert result_set.purpose == ResultsetPurpose.EVALUATION
         assert result_set.performance == NullPerformance()
         assert type(result_set.creation_date) == datetime.datetime
         assert result_set.id == ID()
-
         assert result_set.has_score_metric() is False
-        result_set.performance = "test_performance"
+        result_set.performance = Performance(
+            score=ScoreMetric(name="test score_metric", value=0.6)
+        )
         assert result_set.performance != NullPerformance()
         assert result_set.has_score_metric() is True
 
@@ -111,7 +125,7 @@ class TestResultset:
         result_set.creation_date = creation_date
         assert result_set.creation_date == creation_date
 
-        set_attr_id = ID(123456789)
+        set_attr_id = ID("123456789")
         result_set.id = set_attr_id
         assert result_set.id == set_attr_id
 

--- a/ote_sdk/ote_sdk/tests/parameters_validation/test_input_parameters_validation.py
+++ b/ote_sdk/ote_sdk/tests/parameters_validation/test_input_parameters_validation.py
@@ -1,0 +1,692 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ote_sdk.configuration import ConfigurableParameters
+from ote_sdk.configuration.helper.create import create
+from ote_sdk.entities.annotation import (
+    Annotation,
+    AnnotationSceneEntity,
+    AnnotationSceneKind,
+)
+from ote_sdk.entities.dataset_item import DatasetItemEntity
+from ote_sdk.entities.datasets import DatasetEntity
+from ote_sdk.entities.id import ID
+from ote_sdk.entities.image import Image
+from ote_sdk.entities.label import Domain, LabelEntity
+from ote_sdk.entities.label_schema import (
+    LabelGraph,
+    LabelGroup,
+    LabelSchemaEntity,
+    LabelTree,
+)
+from ote_sdk.entities.metadata import MetadataItemEntity
+from ote_sdk.entities.model import (
+    ModelAdapter,
+    ModelConfiguration,
+    ModelEntity,
+    ModelPrecision,
+    OptimizationMethod,
+)
+from ote_sdk.entities.model_template import parse_model_template
+from ote_sdk.entities.resultset import ResultSetEntity
+from ote_sdk.entities.scored_label import ScoredLabel
+from ote_sdk.entities.shapes.rectangle import Rectangle
+from ote_sdk.entities.subset import Subset
+from ote_sdk.entities.task_environment import TaskEnvironment
+from ote_sdk.entities.tensor import TensorEntity
+from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
+from ote_sdk.tests.constants.requirements import Requirements
+
+
+@pytest.mark.components(OteSdkComponent.OTE_SDK)
+class TestParamsValidation:
+    @staticmethod
+    def random_image() -> Image:
+        return Image(data=np.random.randint(low=0, high=255, size=(10, 16, 3)))
+
+    @staticmethod
+    def scored_labels() -> list:
+        detection_label = LabelEntity(name="detection label", domain=Domain.DETECTION)
+        segmentation_label = LabelEntity(
+            name="segmentation label", domain=Domain.SEGMENTATION
+        )
+        return [
+            ScoredLabel(label=detection_label),
+            ScoredLabel(label=segmentation_label),
+        ]
+
+    @staticmethod
+    def annotations() -> list:
+        full_box_rectangle = Rectangle.generate_full_box()
+        annotation = Annotation(shape=full_box_rectangle, labels=[])
+        other_annotation = Annotation(shape=full_box_rectangle, labels=[])
+        return [annotation, other_annotation]
+
+    def annotation_scene(self) -> AnnotationSceneEntity:
+        return AnnotationSceneEntity(
+            annotations=self.annotations(), kind=AnnotationSceneKind.ANNOTATION
+        )
+
+    @staticmethod
+    def metadata() -> list:
+        numpy = np.random.uniform(low=0.0, high=255.0, size=(10, 15, 3))
+        metadata_item = TensorEntity(name="test_metadata", numpy=numpy)
+        other_metadata_item = TensorEntity(name="other_metadata", numpy=numpy)
+        return [
+            MetadataItemEntity(data=metadata_item),
+            MetadataItemEntity(data=other_metadata_item),
+        ]
+
+    def dataset_items(self) -> list:
+        random_image = self.random_image()
+        annotation_scene = self.annotation_scene()
+        default_values_dataset_item = DatasetItemEntity(random_image, annotation_scene)
+        dataset_item = DatasetItemEntity(
+            media=random_image,
+            annotation_scene=annotation_scene,
+            roi=Annotation(
+                shape=Rectangle.generate_full_box(), labels=self.scored_labels()
+            ),
+            metadata=self.metadata(),
+            subset=Subset.TESTING,
+        )
+        return [default_values_dataset_item, dataset_item]
+
+    @staticmethod
+    def exclusivity_groups() -> list:
+        label_0_1 = LabelEntity(name="Label 0_1", domain=Domain.DETECTION)
+        label_0_2 = LabelEntity(name="Label 0_2", domain=Domain.SEGMENTATION)
+        label_0_2_4 = LabelEntity(name="Label_0_2_4", domain=Domain.SEGMENTATION)
+        label_0_2_5 = LabelEntity(name="Label_0_2_5", domain=Domain.SEGMENTATION)
+        exclusivity_0_1_and_0_2 = LabelGroup(
+            name="Exclusivity edges 0_1 and 0_2",
+            labels=[label_0_1, label_0_2],
+            id=ID("ex_01_02"),
+        )
+        exclusivity_2_4_and_2_5 = LabelGroup(
+            name="Exclusivity edges 0_2_4 and 0_2_5", labels=[label_0_2_4, label_0_2_5]
+        )
+        return [exclusivity_0_1_and_0_2, exclusivity_2_4_and_2_5]
+
+    @staticmethod
+    def check_value_error_exception_raised(
+        correct_parameters: dict, unexpected_values: list, class_or_function
+    ) -> None:
+        for key, value in unexpected_values:
+            incorrect_parameters_dict = dict(correct_parameters)
+            incorrect_parameters_dict[key] = value
+            with pytest.raises(ValueError):
+                class_or_function(**incorrect_parameters_dict)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_annotation_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check Annotation object initialization parameters validation
+
+        <b>Input data:</b>
+        Annotation object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as Annotation
+        initialization parameter
+        """
+        labels = self.scored_labels()
+        correct_values_dict = {"shape": Rectangle.generate_full_box(), "labels": labels}
+        unexpected_type_value = "unexpected str"
+        unexpected_values = [
+            # Unexpected string is specified as "shape" parameter
+            ("shape", unexpected_type_value),
+            # Unexpected string is specified as "labels" parameter
+            ("labels", unexpected_type_value),
+            # Unexpected string is specified as nested "label"
+            ("labels", labels + [unexpected_type_value]),  # type: ignore
+            # Unexpected string is specified as "id" parameter
+            ("id", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=Annotation,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_annotation_scene_entity_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check AnnotationSceneEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        AnnotationSceneEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as AnnotationSceneEntity
+        initialization parameter
+        """
+        annotations = self.annotations()
+        correct_values_dict = {
+            "annotations": annotations,
+            "kind": AnnotationSceneKind.ANNOTATION,
+        }
+        unexpected_type_value = "unexpected str"
+        unexpected_values = [
+            # Unexpected string is specified as "annotations" parameter
+            ("annotations", unexpected_type_value),
+            # Unexpected string is specified nested annotation
+            ("annotations", [annotations[0], unexpected_type_value]),
+            # Unexpected string is specified as "kind" parameter
+            ("kind", unexpected_type_value),
+            # Unexpected integer is specified as "editor" parameter
+            ("editor", 1),
+            # Unexpected string is specified as "creation_date" parameter
+            ("creation_date", unexpected_type_value),
+            # Unexpected string is specified as "id" parameter
+            ("id", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=AnnotationSceneEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_dataset_item_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check DatasetItemEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        DatasetItemEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as DatasetItemEntity
+        initialization parameter
+        """
+        unexpected_type_value = 1
+        correct_values_dict = {
+            "media": self.random_image(),
+            "annotation_scene": self.annotation_scene(),
+        }
+        unexpected_values = [
+            # Unexpected integer is specified as "media" parameter
+            ("media", unexpected_type_value),
+            # Unexpected integer is specified as "annotation_scene" parameter
+            ("annotation_scene", unexpected_type_value),
+            # Unexpected integer is specified as "roi" parameter
+            ("roi", unexpected_type_value),
+            # Unexpected integer is specified as "metadata" parameter
+            ("metadata", unexpected_type_value),
+            # Unexpected integer is specified as nested "metadata" item
+            ("metadata", self.metadata() + [unexpected_type_value]),  # type: ignore
+            # Unexpected integer is specified as "subset" parameter
+            ("subset", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=DatasetItemEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_dataset_entity_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check DatasetEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        DatasetEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as DatasetEntity
+        initialization parameter
+        """
+        items = self.dataset_items()
+        unexpected_type_value = {"unexpected_key": False}
+        correct_values_dict = {"items": items}
+        unexpected_values = [
+            # Unexpected dictionary is specified as "items" parameter
+            ("items", unexpected_type_value),
+            # Unexpected boolean is specified as nested "dataset item" parameter
+            ("items", items + [False]),  # type: ignore
+            # Unexpected dictionary is specified as "purpose" parameter
+            ("purpose", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=DatasetEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_label_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check LabelEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        LabelEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when incorrect type object is specified as LabelEntity
+        initialization parameter
+        """
+        correct_values_dict = {"name": "label name", "domain": Domain.SEGMENTATION}
+        unexpected_type_value = 1
+        unexpected_values = [
+            # Unexpected integer is specified as "name" parameter
+            ("name", unexpected_type_value),
+            # Unexpected integer is specified as "domain" parameter
+            ("domain", unexpected_type_value),
+            # Unexpected integer is specified as "color" parameter
+            ("color", unexpected_type_value),
+            # Unexpected integer is specified as "hotkey" parameter
+            ("hotkey", unexpected_type_value),
+            # Unexpected integer is specified as "creation_date" parameter
+            ("creation_date", unexpected_type_value),
+            # Unexpected integer is specified as "is_empty" parameter
+            ("is_empty", unexpected_type_value),
+            # Unexpected string is specified as "id" parameter
+            ("id", "unexpected str"),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=LabelEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_label_schema_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check LabelSchemaEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        LabelSchemaEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as LabelSchemaEntity
+        initialization parameter
+        """
+        correct_values_dict = {
+            "exclusivity_graph": LabelGraph(directed=True),
+            "label_tree": LabelTree(),
+        }
+        unexpected_type_value = "unexpected str"
+        unexpected_values = [
+            # Unexpected string is specified as "exclusivity_graph" parameter
+            ("exclusivity_graph", unexpected_type_value),
+            # Unexpected string is specified as "label_tree" parameter
+            ("label_tree", unexpected_type_value),
+            # Unexpected string is specified as "label_groups" parameter
+            ("label_groups", unexpected_type_value),
+            # Unexpected string is specified as nested "label_group"
+            ("label_groups", self.exclusivity_groups() + [unexpected_type_value]),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=LabelSchemaEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_model_entity_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check ModelEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        ModelEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as ModelEntity
+        initialization parameter
+        """
+        dataset = DatasetEntity()
+        configuration = ModelConfiguration(
+            configurable_parameters=ConfigurableParameters(header="Test header"),
+            label_schema=LabelSchemaEntity(),
+        )
+        unexpected_str = "unexpected str"
+        unexpected_int = 1
+        unexpected_float = 1.1
+        model_adapter = ModelAdapter(b"{0: binaryrepo://localhost/repo/data_source/0}")
+        correct_values_dict = {
+            "train_dataset": dataset,
+            "configuration": configuration,
+        }
+        unexpected_values = [
+            # Unexpected string is specified as "train_dataset" parameter
+            ("train_dataset", unexpected_str),
+            # Unexpected string is specified as "configuration" parameter
+            ("configuration", unexpected_str),
+            # Unexpected string is specified as "creation_date" parameter
+            ("creation_date", unexpected_str),
+            # Unexpected string is specified as "performance" parameter
+            ("performance", unexpected_str),
+            # Unexpected string is specified as "previous_trained_revision" parameter
+            ("previous_trained_revision", unexpected_str),
+            # Unexpected string is specified as "previous_revision" parameter
+            ("previous_revision", unexpected_str),
+            # Unexpected string is specified as "version" parameter
+            ("version", unexpected_str),
+            # Unexpected string is specified as "tags" parameter
+            ("tags", unexpected_str),
+            # Unexpected integer is specified as nested "tag"
+            ("tags", ["tag_1", unexpected_int]),
+            # Unexpected string is specified as "model_format" parameter
+            ("model_format", unexpected_str),
+            # Unexpected string is specified as "training_duration" parameter
+            ("training_duration", unexpected_str),
+            # Unexpected string is specified as "model_adapters" parameter
+            ("model_adapters", unexpected_str),
+            # Unexpected integer is specified as "model_adapter" key
+            (
+                "model_adapters",
+                {"model_adapter_1": model_adapter, unexpected_int: model_adapter},
+            ),
+            # Unexpected string is specified as "model_adapter" value
+            (
+                "model_adapters",
+                {"model_adapter_1": model_adapter, "model_adapter_2": unexpected_str},
+            ),
+            # Unexpected string is specified as "exportable_code_adapter" parameter
+            ("exportable_code_adapter", unexpected_str),
+            # Unexpected string is specified as "precision" parameter
+            ("precision", unexpected_str),
+            # Unexpected integer is specified as nested "precision"
+            ("precision", [ModelPrecision.INT8, unexpected_int]),
+            # Unexpected float is specified as "latency" parameter
+            ("latency", unexpected_float),
+            # Unexpected float is specified as "fps_throughput" parameter
+            ("fps_throughput", unexpected_float),
+            # Unexpected string is specified as "target_device" parameter
+            ("target_device", unexpected_str),
+            # Unexpected integer is specified as nested "target_device"
+            ("target_device_type", unexpected_int),
+            # Unexpected string is specified as "optimization_type" parameter
+            ("optimization_type", unexpected_str),  # str-type "optimization_type"
+            # Unexpected string is specified as "optimization_methods" parameter
+            ("optimization_methods", unexpected_str),
+            # Unexpected string is specified as nested "optimization_method"
+            ("optimization_methods", [OptimizationMethod.QUANTIZATION, unexpected_str]),
+            # Unexpected string is specified as "optimization_objectives" parameter
+            ("optimization_objectives", unexpected_str),
+            # Unexpected integer key is specified in nested "optimization_objective"
+            (
+                "optimization_objectives",
+                {"objective_1": "optimization_1", unexpected_int: "optimization_2"},
+            ),
+            # Unexpected integer value is specified in nested "optimization_objective"
+            (
+                "optimization_objectives",
+                {"objective_1": "optimization_1", "objective_2": unexpected_int},
+            ),
+            # Unexpected string is specified as "performance_improvement" parameter
+            ("performance_improvement", unexpected_str),
+            # Unexpected integer key is specified in nested "performance_improvement"
+            ("performance_improvement", {"improvement_1": 1.1, unexpected_int: 1.2}),
+            # Unexpected string value is specified in nested "performance_improvement"
+            (
+                "performance_improvement",
+                {"improvement_1": 1.1, "improvement_2": unexpected_str},
+            ),
+            # Unexpected string is specified as "model_size_reduction" parameter
+            ("model_size_reduction", unexpected_str),
+            # Unexpected string is specified as "_id" parameter
+            ("_id", unexpected_int),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=ModelEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_rectangle_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check Rectangle object initialization parameters validation
+
+        <b>Input data:</b>
+        Rectangle object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as Rectangle
+        initialization parameter
+        """
+        rectangle_label = ScoredLabel(
+            label=LabelEntity(name="Rectangle label", domain=Domain.DETECTION)
+        )
+        unexpected_type_value = "unexpected str"
+        correct_values_dict = {"x1": 0.1, "y1": 0.1, "x2": 0.8, "y2": 0.6}
+        unexpected_values = [
+            # Unexpected string is specified as "x1" parameter
+            ("x1", unexpected_type_value),
+            # Unexpected string is specified as "y1" parameter
+            ("y1", unexpected_type_value),
+            # Unexpected string is specified as "x2" parameter
+            ("x2", unexpected_type_value),
+            # Unexpected string is specified as "y2" parameter
+            ("y2", unexpected_type_value),
+            # Unexpected string is specified as "labels" parameter
+            ("labels", unexpected_type_value),  # str-type "labels"
+            # Unexpected string is specified as nested "label"
+            ("labels", [rectangle_label, unexpected_type_value]),
+            # Unexpected string is specified as "modification_date" parameter
+            ("modification_date", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=Rectangle,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_result_set_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check ResultSetEntity object initialization parameters validation
+
+        <b>Input data:</b>
+        ResultSetEntity object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as ResultSetEntity
+        initialization parameter
+        """
+        dataset_entity = DatasetEntity()
+        model_configuration = ModelConfiguration(
+            configurable_parameters=ConfigurableParameters(
+                header="model configurable parameters"
+            ),
+            label_schema=LabelSchemaEntity(),
+        )
+        correct_values_dict = {
+            "model": ModelEntity(
+                train_dataset=dataset_entity, configuration=model_configuration
+            ),
+            "ground_truth_dataset": dataset_entity,
+            "prediction_dataset": dataset_entity,
+        }
+        unexpected_type_value = 1
+        unexpected_values = [
+            # Unexpected integer is specified as "model" parameter
+            ("model", unexpected_type_value),
+            # Unexpected integer is specified as "ground_truth_dataset" parameter
+            ("ground_truth_dataset", unexpected_type_value),
+            # Unexpected integer is specified as "prediction_dataset" parameter
+            ("prediction_dataset", unexpected_type_value),
+            # Unexpected integer is specified as "purpose" parameter
+            ("purpose", unexpected_type_value),
+            # Unexpected integer is specified as "performance" parameter
+            ("performance", unexpected_type_value),
+            # Unexpected integer is specified as "creation_date" parameter
+            ("creation_date", unexpected_type_value),
+            # Unexpected integer is specified as "id" parameter
+            ("id", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=ResultSetEntity,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_scored_label_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check ScoredLabel object initialization parameters validation
+
+        <b>Input data:</b>
+        ScoredLabel object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as
+        ScoredLabel object initialization parameter
+        """
+        label = LabelEntity(name="test scored label", domain=Domain.SEGMENTATION)
+        correct_values_dict = {"label": label, "probability": 0.1}
+        unexpected_type_value = "unexpected_str"
+        unexpected_values = [
+            # Unexpected string is specified as "label" parameter
+            ("label", unexpected_type_value),
+            # Unexpected string is specified as "probability" parameter
+            ("probability", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=ScoredLabel,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_task_environment_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check TaskEnvironment object initialization parameters validation
+
+        <b>Input data:</b>
+        TaskEnvironment object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as
+        TaskEnvironment initialization parameter
+        """
+        dummy_template = str(
+            Path(__file__).parent / Path("../entities/dummy_template.yaml")
+        )
+        correct_values_dict = {
+            "model_template": parse_model_template(dummy_template),
+            "model": None,
+            "hyper_parameters": ConfigurableParameters(
+                header="hyper configurable parameters"
+            ),
+            "label_schema": LabelSchemaEntity(),
+        }
+        unexpected_type_value = "unexpected str"
+        unexpected_values = [
+            # Unexpected string is specified as "model_template" parameter
+            ("model_template", unexpected_type_value),
+            # Unexpected string is specified as "model" parameter
+            ("model", unexpected_type_value),
+            # Unexpected string is specified as "hyper_parameters" parameter
+            ("hyper_parameters", unexpected_type_value),
+            # Unexpected string is specified as "label_schema" parameter
+            ("label_schema", unexpected_type_value),
+        ]
+        self.check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=TaskEnvironment,
+        )
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_create_input_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check "create" function input parameters validation
+
+        <b>Input data:</b>
+        "input_config" parameter
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as "input_config"
+        parameter
+        """
+        for incorrect_parameter in [
+            # Unexpected integer is specified as "input_config" parameter
+            1,
+            # Empty string is specified as "input_config" parameter
+            "",
+            # Empty dictionary is specified as "input_config" parameter
+            {},
+            # Path to non-existing file is specified as "input_config" parameter
+            str(Path(__file__).parent / Path("./non_existing.yaml")),
+            # Path to non-yaml file is specified as "input_config" parameter
+            str(Path(__file__).parent / Path("./unexpected_type.jpg")),
+            # Path with null character is specified as "input_config" parameter
+            str(Path(__file__).parent / Path("./null\0char.yaml")),
+        ]:
+            with pytest.raises(ValueError):
+                create(incorrect_parameter)
+
+    @pytest.mark.priority_medium
+    @pytest.mark.component
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_image_initialization_parameters_validation(self):
+        """
+        <b>Description:</b>
+        Check Image object initialization parameters validation
+
+        <b>Input data:</b>
+        Image object initialization parameters
+
+        <b>Expected results:</b>
+        Test passes if ValueError exception is raised when unexpected type object is specified as Image initialization
+        parameter
+        """
+        for key, value in [
+            # Unexpected integer is specified as "data" parameter
+            ("data", 1),
+            # Unexpected integer is specified as "file_path" parameter
+            ("file_path", 1),
+            # Empty string is specified as "file_path" parameter
+            ("file_path", ""),
+            # Path to file with unexpected extension is specified as "file_path" parameter
+            (
+                "file_path",
+                str(Path(__file__).parent / Path("./unexpected_extension.yaml")),
+            ),
+            # Path to non-existing file is specified as "file_path" parameter
+            ("file_path", str(Path(__file__).parent / Path("./non_existing.jpg"))),
+            # Path with null character is specified as "file_path" parameter
+            ("file_path", str(Path(__file__).parent / Path("./null\0char.jpg"))),
+        ]:
+            with pytest.raises(ValueError):
+                Image(**{key: value})

--- a/ote_sdk/ote_sdk/tests/usecases/adapters/test_model_adapter.py
+++ b/ote_sdk/ote_sdk/tests/usecases/adapters/test_model_adapter.py
@@ -33,7 +33,7 @@ class TestIDataSource:
             IDataSource().data()
 
 
-class TestDataSource(IDataSource):
+class DataSource(IDataSource):
     def __init__(self, data: str):
         self._data = data
 
@@ -66,7 +66,7 @@ class TestModelAdapter:
         """
         # Checking properties of "ModelAdapter" initialized with IDataSource "data_source"
         data = "some data"
-        data_source = TestDataSource(data=data)
+        data_source = DataSource(data=data)
         model_adapter = ModelAdapter(data_source=data_source)
         assert model_adapter.data_source == data_source
         assert model_adapter.from_file_storage
@@ -104,10 +104,10 @@ class TestModelAdapter:
         3. Check properties of ModelAdapter object after manual setting "data_source" property to other bytes object
         4. Check properties of ModelAdapter object after manual setting "data_source" property to IDataSource object
         """
-        model_adapter = ModelAdapter(data_source=TestDataSource(data="some data"))
+        model_adapter = ModelAdapter(data_source=DataSource(data="some data"))
         # Checking properties of ModelAdapter after manual setting "data_source" to other IDataSource
         other_data = "other data"
-        other_data_source = TestDataSource(data=other_data)
+        other_data_source = DataSource(data=other_data)
         model_adapter.data_source = other_data_source
         assert model_adapter.data_source == other_data_source
         assert model_adapter.data == other_data
@@ -155,7 +155,7 @@ class TestExportableCodeAdapter:
         """
         # Checking properties of "ExportableCodeAdapter" initialized with IDataSource "data_source"
         data = "some_data"
-        data_source = TestDataSource(data=data)
+        data_source = DataSource(data=data)
         exportable_code_adapter = ExportableCodeAdapter(data_source=data_source)
         assert exportable_code_adapter.data_source == data_source
         assert exportable_code_adapter.from_file_storage

--- a/ote_sdk/ote_sdk/tests/utils/test_segmentation_utils.py
+++ b/ote_sdk/ote_sdk/tests/utils/test_segmentation_utils.py
@@ -383,7 +383,7 @@ class TestSegmentationUtils:
         def check_annotation(
             annotation: Annotation,
             expected_points: list,
-            expected_label: str,
+            expected_label: LabelEntity,
             expected_probability: float,
         ):
             assert isinstance(annotation.shape, Polygon)
@@ -412,11 +412,10 @@ class TestSegmentationUtils:
                 (False, False, False, False, False),
             ]
         )
-        labels = {
-            False: "false_label",
-            True: "true_label",
-            2: "label_2",
-        }
+        false_label = LabelEntity(name="false_label", domain=Domain.DETECTION)
+        true_label = LabelEntity(name="true_label", domain=Domain.DETECTION)
+        non_included_label = LabelEntity("label_2", domain=Domain.DETECTION)
+        labels = {False: false_label, True: true_label, 2: non_included_label}
         annotations = create_annotation_from_segmentation_map(
             hard_prediction=hard_prediction,
             soft_prediction=soft_prediction,
@@ -435,7 +434,7 @@ class TestSegmentationUtils:
                 Point(0.6, 0.4),
                 Point(0.6, 0.2),
             ],
-            expected_label="true_label",
+            expected_label=true_label,
             expected_probability=0.7375,
         )
         # Checking list returned by "create_annotation_from_segmentation_map" for 3-dimensional arrays
@@ -450,7 +449,10 @@ class TestSegmentationUtils:
         hard_prediction = np.array(
             [(0, 0, 2, 2), (1, 1, 2, 2), (1, 1, 2, 2), (1, 1, 2, 2)]
         )
-        labels = {0: "false_label", 1: "class_1", 2: "class_2"}
+        class_1_label = LabelEntity(name="class_1_label", domain=Domain.SEGMENTATION)
+        class_2_label = LabelEntity(name="class_2_label", domain=Domain.SEGMENTATION)
+
+        labels = {0: false_label, 1: class_1_label, 2: class_2_label}
         annotations = create_annotation_from_segmentation_map(
             hard_prediction=hard_prediction,
             soft_prediction=soft_prediction,
@@ -467,7 +469,7 @@ class TestSegmentationUtils:
                 Point(0.25, 0.5),
                 Point(0.25, 0.25),
             ],
-            expected_label="class_1",
+            expected_label=class_1_label,
             expected_probability=0.83333,
         )
         check_annotation(
@@ -482,7 +484,7 @@ class TestSegmentationUtils:
                 Point(0.75, 0.25),
                 Point(0.75, 0.0),
             ],
-            expected_label="class_2",
+            expected_label=class_2_label,
             expected_probability=0.8125,
         )
         # Checking list returned by "create_annotation_from_segmentation_map" for prediction arrays with hole in
@@ -512,9 +514,9 @@ class TestSegmentationUtils:
             ]
         )
         labels = {
-            False: "false_label",
-            True: "true_label",
-            2: "label_2",
+            False: false_label,
+            True: true_label,
+            2: non_included_label,
         }
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "The geometry of the segmentation map")
@@ -540,7 +542,7 @@ class TestSegmentationUtils:
                 Point(0.5, 0.25),
                 Point(0.375, 0.25),
             ],
-            expected_label="true_label",
+            expected_label=true_label,
             expected_probability=0.90833,
         )
         check_annotation(
@@ -575,6 +577,6 @@ class TestSegmentationUtils:
                 Point(0.25, 0.0),
                 Point(0.125, 0.0),
             ],
-            expected_label="true_label",
+            expected_label=true_label,
             expected_probability=0.91071,
         )

--- a/ote_sdk/ote_sdk/utils/argument_checks.py
+++ b/ote_sdk/ote_sdk/utils/argument_checks.py
@@ -1,0 +1,210 @@
+"""
+Utils for checking functions and methods arguments
+"""
+
+from os.path import exists
+
+from omegaconf import DictConfig
+from yaml import safe_load
+
+
+def check_parameter_type(parameter, parameter_name, expected_type):
+    """Function raises ValueError exception if parameter has unexpected type"""
+    if not isinstance(parameter, expected_type):
+        parameter_type = type(parameter)
+        raise ValueError(
+            f"Unexpected type of '{parameter_name}' parameter, expected: {expected_type}, actual: {parameter_type}"
+        )
+
+
+def check_required_parameters_type(parameter_name_expected_type: list):
+    """
+    Function raises ValueError exception if required parameters have unexpected type
+    :param parameter_name_expected_type: list with tuples that contain parameter, name for exception message and
+    expected type
+    """
+    for parameter, name, expected_type in parameter_name_expected_type:
+        check_parameter_type(
+            parameter=parameter, parameter_name=name, expected_type=expected_type
+        )
+
+
+def check_optional_parameters_type(parameter_name_expected_type: list):
+    """
+    Function checks if optional parameters exist and raises ValueError exception if one of them has unexpected type
+    :param parameter_name_expected_type: list with tuples that contain optional parameter, name for exception message
+    and expected type
+    """
+    for parameter, name, expected_type in parameter_name_expected_type:
+        if parameter is not None:
+            check_parameter_type(
+                parameter=parameter, parameter_name=name, expected_type=expected_type
+            )
+
+
+def check_required_and_optional_parameters_type(
+    required_parameters: list, optional_parameters: list
+):
+    """Function raises ValueError exception if required or optional parameter has unexpected type"""
+    check_required_parameters_type(required_parameters)
+    check_optional_parameters_type(optional_parameters)
+
+
+def check_nested_elements_type(iterable, parameter_name, expected_type):
+    """Function raises ValueError exception if one of elements in collection has unexpected type"""
+    for element in iterable:
+        check_parameter_type(
+            parameter=element,
+            parameter_name=f"nested {parameter_name}",
+            expected_type=expected_type,
+        )
+
+
+def check_several_optional_lists_elements_type(parameter_name_expected_type: list):
+    """
+    Function checks if parameters lists exist and raises ValueError exception if lists elements have unexpected type
+    :param parameter_name_expected_type: list with tuples that contain parameter with nested elements, name for
+    exception message and expected type
+    """
+    for parameter, name, expected_type in parameter_name_expected_type:
+        if parameter is not None:
+            check_nested_elements_type(
+                iterable=parameter, parameter_name=name, expected_type=expected_type
+            )
+
+
+def check_dictionary_keys_values_type(
+    parameter, parameter_name, expected_key_class, expected_value_class
+):
+    """Function raises ValueError exception if dictionary keys or values have unexpected type"""
+    for key, value in parameter.items():
+        parameter_type = type(key)
+        if not isinstance(key, expected_key_class):
+            raise ValueError(
+                f"Unexpected type of nested '{parameter_name}' dictionary key, expected: {expected_key_class}, "
+                f"actual: {parameter_type}"
+            )
+        parameter_type = type(value)
+        if not isinstance(value, expected_value_class):
+            raise ValueError(
+                f"Unexpected type of nested '{parameter_name}' dictionary value, expected: {expected_value_class}, "
+                f"actual: {parameter_type}"
+            )
+
+
+def check_several_optional_dictionaries_keys_values_type(
+    parameter_name_expected_type: list,
+):
+    """
+    Function checks if parameters dictionaries exist and raises ValueError exception if their key or value have
+    unexpected type
+    :param parameter_name_expected_type: list with tuples that contain dictionary parameter, name for exception message
+    and expected type
+    """
+    for (
+        parameter,
+        name,
+        expected_key_class,
+        expected_value_class,
+    ) in parameter_name_expected_type:
+        if parameter is not None:
+            check_dictionary_keys_values_type(
+                parameter=parameter,
+                parameter_name=name,
+                expected_key_class=expected_key_class,
+                expected_value_class=expected_value_class,
+            )
+
+
+def check_that_string_not_empty(string: str, parameter_name: str):
+    """Function raises ValueError exception if string parameter is empty"""
+    if string == "":
+        raise ValueError(f"Empty string is specified as {parameter_name} parameter")
+
+
+def check_file_extension(
+    file_path: str, file_path_name: str, expected_extensions: list
+):
+    """Function raises ValueError exception if file has unexpected extension"""
+    file_extension = file_path.split(".")[-1].lower()
+    if file_extension not in expected_extensions:
+        raise ValueError(
+            f"Unexpected extension of {file_path_name} file. expected: {expected_extensions} actual: {file_extension}"
+        )
+
+
+def check_that_null_character_absents_in_string(parameter: str, parameter_name: str):
+    """Function raises ValueError exception if null character: '\0' is specified in string"""
+    if "\0" in parameter:
+        raise ValueError(f"\0 is specified in {parameter_name}: {parameter}")
+
+
+def check_that_file_exists(file_path: str, file_path_name: str):
+    """Function raises ValueError exception if file not exists"""
+    if not exists(file_path):
+        raise ValueError(
+            f"File {file_path} specified in '{file_path_name}' parameter not exists"
+        )
+
+
+def check_file_path(file_path: str, file_path_name: str, expected_extensions: list):
+    """
+    Function raises ValueError exception if non-string object is specified as file path, if file has unexpected
+    extension or if file not exists
+    """
+    check_parameter_type(
+        parameter=file_path, parameter_name=file_path_name, expected_type=str
+    )
+    check_that_string_not_empty(string=file_path, parameter_name=file_path_name)
+    check_file_extension(
+        file_path=file_path,
+        file_path_name=file_path_name,
+        expected_extensions=expected_extensions,
+    )
+    check_that_null_character_absents_in_string(
+        parameter=file_path, parameter_name=file_path_name
+    )
+    check_that_file_exists(file_path=file_path, file_path_name=file_path_name)
+
+
+def check_input_config_parameter(input_config):
+    """
+    Function raises ValueError exception if "input_config" parameter is not equal to expected
+    """
+    parameter_name = "input_config"
+    check_parameter_type(
+        parameter=input_config,
+        parameter_name=parameter_name,
+        expected_type=(str, DictConfig, dict),
+    )
+    if isinstance(input_config, str):
+        check_that_string_not_empty(string=input_config, parameter_name=parameter_name)
+        check_that_null_character_absents_in_string(
+            parameter=input_config, parameter_name=parameter_name
+        )
+        if isinstance(safe_load(input_config), str):
+            check_file_extension(
+                file_path=input_config,
+                file_path_name=parameter_name,
+                expected_extensions=["yaml"],
+            )
+            check_that_file_exists(
+                file_path=input_config, file_path_name=parameter_name
+            )
+    if isinstance(input_config, dict):
+        if input_config == {}:
+            raise ValueError(
+                "Empty dictionary is specified as 'input_config' parameter"
+            )
+
+
+def check_is_parameter_like_dataset(parameter, parameter_name):
+    """Function raises ValueError exception if parameter does not have __len__, __getitem__ and get_subset attributes of
+    DataSet-type object"""
+    for expected_attribute in ("__len__", "__getitem__", "get_subset"):
+        if not hasattr(parameter, expected_attribute):
+            parameter_type = type(parameter)
+            raise ValueError(
+                f"parameter {parameter_name} has type {parameter_type} which does not have expected "
+                f"'{expected_attribute}' dataset attribute"
+            )


### PR DESCRIPTION
Added input parameters validations for OTE_SDK modules:
• configuration/helper/create.py: “create” function
• entities/annotation.py: initialization methods of Annotation and AnnotationSceneEntity classes
• entities/dataset_item.py: initialization method of DatasetItemEntity class
• entities/datasets.py: initialization method of DatasetEntity class
• entities/image.py: initialization method of Image class
• entities/label.py: initialization method of LabelEntity class
• entities/label_schema.py: initialization and “from_labels” methods of LabelSchemaEntity class
• entities/model.py: initialization method of ModelEntity class
• entities/model_template.py: “parse_model_template” function
• entities/resultset.py: initialization method of ResultSetEntity class
• entities/scored_label.py: initialization method of ScoredLabel class
• entities/shapes/rectangle.py: initialization method of Rectangle class
• entities/task_environment.py: initialization method of TaskEnvironment class
Changed OTE SDK tests according to changes:
• tests/entities/test_datasets.py: test_dataset_entity_append: removed scenario when appending DatasetItemEntity object with None-type “media” attribute
• tests/entities/test_label_schema.py: test_label_schema_from_labels: added check that ValueError exception is raised when unexpected type object is specified as “label_groups” parameter for “from_labels” method
• tests/entities/test_model_template.py: test_parse_model_template: added check that ValueError exception is raised when unexpected object is specified as “model_template_path” parameter for “parse_model_template” function
• tests/entities/test_resultset.py: test_resultset_entity: changed input dataset and expected results
Added tests:
• ote_sdk/ote_sdk/tests/parameters_validation/test_input_parameters_validation.py

Task: CVS-76584