### PR TITLE
Fix QUICK_START_GUIDE.md

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -36,6 +36,7 @@
    ```
    ./external/mmdetection/init_venv.sh det_venv
    source det_venv/bin/activate
+   pip3 install -e ote_sdk/
    pip3 install -e ote_cli/
    ```
 


### PR DESCRIPTION
It is necessary to install ote_sdk to run OTE CLI. I'm not sure that the fix is correct, but it works.
