### PR TITLE
Remove timeit decorator

### DIFF
--- a/ote_sdk/ote_sdk/utils/segmentation_utils.py
+++ b/ote_sdk/ote_sdk/utils/segmentation_utils.py
@@ -21,7 +21,6 @@ from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.scored_label import ScoredLabel
 from ote_sdk.entities.shapes.polygon import Point, Polygon
 from ote_sdk.utils.shape_factory import ShapeFactory
-from ote_sdk.utils.time_utils import timeit
 
 
 def mask_from_dataset_item(
@@ -178,7 +177,6 @@ def get_subcontours(contour: Contour) -> List[Contour]:
     return subcontours
 
 
-@timeit
 def create_annotation_from_segmentation_map(
     hard_prediction: np.ndarray, soft_prediction: np.ndarray, label_map: dict
 ) -> List[Annotation]:


### PR DESCRIPTION
Looks like used for debugging, no need to be in develop branch

```
function [create_annotation_from_segmentation_map] finished in 5.825996398925781 ms
function [create_annotation_from_segmentation_map] finished in 8.982658386230469 ms
function [create_annotation_from_segmentation_map] finished in 6.443023681640625 ms
...
```