### PR TITLE
[OTE_SDK] Updates Shapely version

### DIFF
--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.4
 scikit-learn==0.24.*
-Shapely==1.7.*
+Shapely==1.8.*
 networkx~=2.5
 opencv-python==4.5.3.*
 pymongo>=3.9


### PR DESCRIPTION
Updates Shapely version in OTEDet and OTE_SDK

Build on BMM: 25312 🕥
Train on BMM: not started 💤