### PR TITLE
add is_anomalous flag to OTE label

### DIFF
--- a/ote_sdk/ote_sdk/entities/label.py
+++ b/ote_sdk/ote_sdk/entities/label.py
@@ -78,7 +78,7 @@ class LabelEntity:
         will be assigned upon saving. If the argument is None, it will be set to ID()
     """
 
-    # pylint: disable=redefined-builtin, too-many-arguments; Requires refactor
+    # pylint: disable=redefined-builtin, too-many-instance-attributes, too-many-arguments; Requires refactor
     def __init__(
         self,
         name: str,

--- a/ote_sdk/ote_sdk/entities/label.py
+++ b/ote_sdk/ote_sdk/entities/label.py
@@ -88,6 +88,7 @@ class LabelEntity:
         creation_date: Optional[datetime.datetime] = None,
         is_empty: bool = False,
         id: Optional[ID] = None,
+        is_anomalous: bool = False,
     ):
         id = ID() if id is None else id
         color = Color.random() if color is None else color
@@ -100,6 +101,7 @@ class LabelEntity:
         self._is_empty = is_empty
         self._creation_date = creation_date
         self._id = id
+        self.is_anomalous = is_anomalous
 
     @property
     def name(self):
@@ -184,6 +186,7 @@ class LabelEntity:
                 and self.color == other.color
                 and self.hotkey == other.hotkey
                 and self.domain == other.domain
+                and self.is_anomalous == other.is_anomalous
             )
         return False
 

--- a/ote_sdk/ote_sdk/entities/label.py
+++ b/ote_sdk/ote_sdk/entities/label.py
@@ -76,6 +76,8 @@ class LabelEntity:
     :param is_empty: set to True if the label is an empty label.
     :param id: the ID of the label. Set to ID() so that a new unique ID
         will be assigned upon saving. If the argument is None, it will be set to ID()
+    :param is_anomalous: boolean that indicates whether the label is the Anomalous label. Always set to False for non-
+        anomaly projects.
     """
 
     # pylint: disable=redefined-builtin, too-many-instance-attributes, too-many-arguments; Requires refactor


### PR DESCRIPTION
As discussed a few weeks ago, we will replace checking the name of the label with checking for a flag is_anomalous. We need to do it in multiple steps to avoid causing regression between merges:

1. OTE: Add is_anomalous attribute to LabelEntity

2. Backend: Add is_anomalous in SC and add it as a non-required field in the project creation contract. Automatically set it from the “name” field on project creation. Replace all checks for the label name with checks for is_anomalous.

3. OTE: Replace all checks for the label name with checks for the value of is_anomalous.

4. Backend: Use the is_anomalous field in the API to set the value of the attribute during project creation instead of determining it based on the label name. Remove checks that block the API from changing normal and anomalous label names.