### PR TITLE
[OTE_SDK] Updates Shapely

### DIFF
--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.4
 scikit-learn==0.24.*
-Shapely==1.7.*
+Shapely>=1.7.1
 networkx~=2.5
 opencv-python==4.5.3.*
 pymongo>=3.9


### PR DESCRIPTION
Updates Shapely version in OTE_SDK and OTEDet.

Build on BMM: 25371 🕥
Train on BMM: not started 💤