### PR TITLE
[SEGMENTATION] Updates OTESeg to extend OTE templates

### DIFF
--- a/external/README.md
+++ b/external/README.md
@@ -42,3 +42,5 @@ Custom_Rotated_Detection_via_Instance_Segmentation_MaskRCNN_ResNet50 | MaskRCNN-
 ID | Name | Complexity (GFlops) | Model size (MB) | Path
 ------- | ------- | ------- | ------- | -------
 Custom_Semantic_Segmentation_Lite-HRNet-18_OCR | Lite-HRNet-18 OCR | 3.45 | 4.5 | mmsegmentation/configs/ote/custom-sematic-segmentation/ocr-lite-hrnet-18/template.yaml
+Custom_Semantic_Segmentation_Lite-HRNet-18-mod2_OCR | Lite-HRNet-18-mod2 OCR | 3.63 | 4.8 | mmsegmentation/configs/ote/custom-sematic-segmentation/ocr-lite-hrnet-18-mod2/template.yaml
+Custom_Semantic_Segmentation_Lite-HRNet-x-mod3_OCR | Lite-HRNet-x-mod3 OCR | 13.97 | 6.4 | mmsegmentation/configs/ote/custom-sematic-segmentation/ocr-lite-hrnet-x-mod3/template.yaml


### PR DESCRIPTION
* Enables new templates:
   * Lite-HRNet-18-mod2 (middle)
   * Lite-HRNet-x-mod3 (heavy)
 
Note: Should be merged after [PR#73](https://github.com/openvinotoolkit/mmsegmentation/pull/73) and [PR#80](https://github.com/openvinotoolkit/mmsegmentation/pull/80).

Build on BMM: 25979 ✔️ - deprecated
Train on BMM: finished ✔️ - deprecated
OTE-test: 1334 🕥