### PR TITLE
[OTE_SDK] Excludes invalid Shapely versions

### DIFF
--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.4
 scikit-learn==0.24.*
-Shapely>=1.7.1
+Shapely>=1.7.1,<=1.8.0
 networkx~=2.5
 opencv-python==4.5.3.*
 pymongo>=3.9


### PR DESCRIPTION
Restricts the Shapely version (>=1.7.1,<=1.8.0) to exclude the recent broken builds.

ote-test/1030 ✔️ (excluding NNCF tests)