### PR TITLE
[OTE_SDK][DETECTION] Updates OTEDet and OTE_SDK to fix pymongo version

### DIFF
--- a/external/anomaly/constraints.txt
+++ b/external/anomaly/constraints.txt
@@ -13,6 +13,6 @@ opencv-python==4.5.3.56
 openvino-dev==2022.1.0.dev20220302
 pillow==9.0.0
 pytorch-lightning==1.5.9
-requests==2.25.1
+requests==2.26.0
 scikit-image==0.17.2
 scikit-learn==0.24.2

--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -3,7 +3,7 @@ scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
 networkx~=2.5
 opencv-python==4.5.3.*
-pymongo>=3.9
+pymongo==3.12.0
 omegaconf==2.1.*
 natsort>=6.0.0
 attrs>=21.2.0


### PR DESCRIPTION
Updates OTEDet:
* Aligns with the latest OTEDet commit
* Replaces `pymongo` version to 3.12.0
* Replaces `requests` version to 2.26.0

Note: [PR#323](https://github.com/openvinotoolkit/mmdetection/pull/323) to mmdet should be merged first.

ote-test: 1390 failed, 1400 🕥