### PR TITLE
[OTE SDK] CVS-78677 Replace ModelConfiguration.label_schema with get method

### DIFF
--- a/ote_sdk/ote_sdk/entities/model.py
+++ b/ote_sdk/ote_sdk/entities/model.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from ote_sdk.configuration import ConfigurableParameters
 from ote_sdk.entities.id import ID
-from ote_sdk.entities.label import LabelEntity
 from ote_sdk.entities.label_schema import LabelSchemaEntity
 from ote_sdk.entities.metrics import NullPerformance, Performance
 from ote_sdk.entities.model_template import TargetDevice
@@ -46,8 +45,6 @@ class ModelConfiguration:
     """
 
     configurable_parameters: ConfigurableParameters
-    labels: List[LabelEntity]
-    label_schema: LabelSchemaEntity
 
     def __init__(
         self,
@@ -55,7 +52,11 @@ class ModelConfiguration:
         label_schema: LabelSchemaEntity,
     ):
         self.configurable_parameters = configurable_parameters
-        self.label_schema = label_schema
+        self.__label_schema = label_schema
+
+    def get_label_schema(self) -> LabelSchemaEntity:
+        """Get the LabelSchema"""
+        return self.__label_schema
 
 
 class ModelFormat(IntEnum):

--- a/ote_sdk/ote_sdk/tests/entities/test_model.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_model.py
@@ -154,7 +154,7 @@ class TestModelConfiguration:
             configurable_parameters=parameters, label_schema=label_schema
         )
         assert model_configuration.configurable_parameters == parameters
-        assert model_configuration.label_schema == label_schema
+        assert model_configuration.get_label_schema() == label_schema
 
 
 @pytest.mark.components(OteSdkComponent.OTE_SDK)

--- a/ote_sdk/ote_sdk/tests/usecases/evaluation/test_f_measure.py
+++ b/ote_sdk/ote_sdk/tests/usecases/evaluation/test_f_measure.py
@@ -1636,8 +1636,10 @@ class TestFMeasure:
             labels[1]: ScoreMetric(name="class_2", value=0.6666666666666665),
             labels[2]: ScoreMetric(name="class_3", value=0.6666666666666665),
         }
-        label_schema_labels = result_set.model.configuration.label_schema.get_labels(
-            include_empty=False
+        label_schema_labels = (
+            result_set.model.configuration.get_label_schema().get_labels(
+                include_empty=False
+            )
         )
         classes = [label.name for label in label_schema_labels]
         boxes_pair = _FMeasureCalculator(

--- a/ote_sdk/ote_sdk/usecases/evaluation/accuracy.py
+++ b/ote_sdk/ote_sdk/usecases/evaluation/accuracy.py
@@ -229,7 +229,7 @@ def __get_gt_and_predicted_label_indices_from_resultset(
     pred_dataset.sort_items()
 
     # Iterate over each dataset item, and collect the labels for this item (pred and gt)
-    task_labels = resultset.model.configuration.label_schema.get_labels(
+    task_labels = resultset.model.configuration.get_label_schema().get_labels(
         include_empty=True
     )
     for gt_item, pred_item in zip(gt_dataset, pred_dataset):
@@ -364,12 +364,12 @@ def compute_unnormalized_confusion_matrices_from_resultset(
         true_label_idx,
         predicted_label_idx,
     ) = __get_gt_and_predicted_label_indices_from_resultset(resultset)
-    task_labels = resultset.model.configuration.label_schema.get_labels(
+    task_labels = resultset.model.configuration.get_label_schema().get_labels(
         include_empty=False
     )
 
     # Confusion matrix computation
-    for label_group in resultset.model.configuration.label_schema.get_groups():
+    for label_group in resultset.model.configuration.get_label_schema().get_groups():
         matrix = __compute_unnormalized_confusion_matrices_for_label_group(
             true_label_idx, predicted_label_idx, label_group, task_labels
         )

--- a/ote_sdk/ote_sdk/usecases/evaluation/dice.py
+++ b/ote_sdk/ote_sdk/usecases/evaluation/dice.py
@@ -113,7 +113,9 @@ class DiceAverage(IPerformanceProvider):
             + resultset.ground_truth_dataset.get_labels()
         )
         model_labels = set(
-            resultset.model.configuration.label_schema.get_labels(include_empty=False)
+            resultset.model.configuration.get_label_schema().get_labels(
+                include_empty=False
+            )
         )
         labels = sorted(resultset_labels.intersection(model_labels))
         hard_predictions = []

--- a/ote_sdk/ote_sdk/usecases/evaluation/f_measure.py
+++ b/ote_sdk/ote_sdk/usecases/evaluation/f_measure.py
@@ -649,7 +649,7 @@ class FMeasure(IPerformanceProvider):
         ground_truth_dataset.sort_items()
         prediction_dataset.sort_items()
 
-        labels = resultset.model.configuration.label_schema.get_labels(
+        labels = resultset.model.configuration.get_label_schema().get_labels(
             include_empty=False
         )
         classes = [label.name for label in labels]


### PR DESCRIPTION
To implement an adapter for ModelConfiguration.label_schema, we need to change it to a function. In the OTE repo this is a non-functional change.