### PR TITLE
[OTE_SDK] Add attribute ignored_labels to DatasetItemEntity

### DIFF
--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -9,7 +9,7 @@ import copy
 import itertools
 import logging
 from threading import Lock
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 
@@ -31,13 +31,14 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
     DatasetItemEntity represents an item in the DatasetEntity. It holds a media item, annotation and an ROI.
     The ROI determines the region of interest for the dataset item, and is described by a shape entity.
 
-    Dataset items hold five fundamental properties:
+    The fundamental properties of a dataset item are:
 
     - A 2d media entity (e.g. Image)
     - A 2d annotation entity for the full resolution media entity
     - An ROI, describing the region of interest.
     - The subset it belongs to
     - Metadata for the media entity (e.g. saliency map or active score)
+    - A list of labels to ignore
 
     .. rubric:: Getting data from dataset item
 
@@ -78,6 +79,9 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
     :param roi: Region Of Interest
     :param metadata: Metadata attached to dataset item
     :param subset: `Subset` for item. E.g. `Subset.VALIDATION`
+    :param ignored_labels: Collection of labels that should be ignored in this dataset item.
+        For instance, in a training scenario, this parameter is used to ignore certain labels within the
+        existing annotations because their status becomes uncertain following a label schema change.
     """
 
     # pylint: disable=too-many-arguments
@@ -88,6 +92,9 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
         roi: Optional[Annotation] = None,
         metadata: Optional[Sequence[MetadataItemEntity]] = None,
         subset: Subset = Subset.NONE,
+        ignored_labels: Optional[
+            Union[List[LabelEntity], Tuple[LabelEntity, ...], Set[LabelEntity]]
+        ] = None,
     ):
         self.__media: IMedia2DEntity = media
         self.__annotation_scene: AnnotationSceneEntity = annotation_scene
@@ -107,10 +114,27 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
         if metadata is not None:
             self.__metadata = list(metadata)
 
+        self.__ignored_labels: Set[LabelEntity] = (
+            set() if ignored_labels is None else set(ignored_labels)
+        )
+
     @property
     def metadata(self) -> Sequence[MetadataItemEntity]:
         """Provides access to metadata."""
         return self.__metadata
+
+    @property
+    def ignored_labels(self) -> Set[LabelEntity]:
+        """
+        Get the IDs of the labels to ignore in this dataset item
+        """
+        return self.__ignored_labels
+
+    @ignored_labels.setter
+    def ignored_labels(
+        self, value: Union[List[LabelEntity], Tuple[LabelEntity, ...], Set[LabelEntity]]
+    ):
+        self.__ignored_labels = set(value)
 
     def __repr__(self):
         return (
@@ -372,6 +396,7 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
                 and self.annotation_scene == other.annotation_scene
                 and self.roi == other.roi
                 and self.subset == other.subset
+                and self.ignored_labels == other.ignored_labels
             )
         return False
 

--- a/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
@@ -145,6 +145,7 @@ class DatasetItemParameters:
             roi=self.roi(),
             metadata=self.metadata(),
             subset=Subset.TESTING,
+            ignored_labels={self.labels()[1]},
         )
 
 
@@ -255,18 +256,21 @@ class TestDatasetItemEntity:
         assert default_values_dataset_item.annotation_scene == annotations_scene
         assert not default_values_dataset_item.metadata
         assert default_values_dataset_item.subset == Subset.NONE
+        assert default_values_dataset_item.ignored_labels == set()
         # Checking attributes of DatasetItemEntity object initialized with specified optional parameters
         roi = DatasetItemParameters().roi()
         metadata = DatasetItemParameters.metadata()
         subset = Subset.TESTING
+        ignored_labels = DatasetItemParameters().labels()
         specified_values_dataset_item = DatasetItemEntity(
-            media, annotations_scene, roi, metadata, subset
+            media, annotations_scene, roi, metadata, subset, ignored_labels
         )
         assert specified_values_dataset_item.media == media
         assert specified_values_dataset_item.annotation_scene == annotations_scene
         assert specified_values_dataset_item.roi == roi
         assert specified_values_dataset_item.metadata == metadata
         assert specified_values_dataset_item.subset == subset
+        assert specified_values_dataset_item.ignored_labels == ignored_labels
 
     @pytest.mark.priority_medium
     @pytest.mark.unit
@@ -796,8 +800,8 @@ class TestDatasetItemEntity:
         Check DatasetItemEntity class __eq__ method
 
         <b>Input data:</b>
-        DatasetItemEntity class objects with specified "media", "annotation_scene", "roi", "metadata" and "subset"
-        parameters
+        DatasetItemEntity class objects with specified "media", "annotation_scene", "roi", "metadata", "subset"
+        and "ignored_labels" parameters
 
         <b>Expected results:</b>
         Test passes if value returned by __eq__ method is equal to expected
@@ -805,7 +809,7 @@ class TestDatasetItemEntity:
         <b>Steps</b>
         1. Check value returned by __eq__ method for equal DatasetItemEntity objects
         2. Check value returned by __eq__ method for DatasetItemEntity objects with unequal "media", "annotation_scene",
-        "roi" or "subset"  parameters
+        "roi", "subset" or "ignored_labels" parameters
         3. Check value returned by __eq__ method for DatasetItemEntity objects with unequal "metadata" parameters
         4. Check value returned by __eq__ method for DatasetItemEntity object compared to different type object
         """
@@ -813,12 +817,14 @@ class TestDatasetItemEntity:
         annotation_scene = DatasetItemParameters().annotations_entity()
         roi = DatasetItemParameters().roi()
         metadata = DatasetItemParameters.metadata()
+        ignored_labels = DatasetItemParameters.labels()[:1]
         dataset_parameters = {
             "media": media,
             "annotation_scene": annotation_scene,
             "roi": roi,
             "metadata": metadata,
             "subset": Subset.TESTING,
+            "ignored_labels": ignored_labels,
         }
         dataset_item = DatasetItemEntity(**dataset_parameters)
         # Checking value returned by __eq__ method for equal DatasetItemEntity objects
@@ -827,11 +833,13 @@ class TestDatasetItemEntity:
         # Checking inequality of DatasetItemEntity objects with unequal initialization parameters
         unequal_annotation_scene = DatasetItemParameters().annotations_entity()
         unequal_annotation_scene.annotations.pop(0)
+        unequal_ignored_labels = DatasetItemParameters.labels()[1:]
         unequal_values = [
             ("media", DatasetItemParameters.generate_random_image()),
             ("annotation_scene", unequal_annotation_scene),
             ("roi", None),
             ("subset", Subset.VALIDATION),
+            ("ignored_labels", unequal_ignored_labels),
         ]
         for key, value in unequal_values:
             unequal_parameters = dict(dataset_parameters)

--- a/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
@@ -261,7 +261,7 @@ class TestDatasetItemEntity:
         roi = DatasetItemParameters().roi()
         metadata = DatasetItemParameters.metadata()
         subset = Subset.TESTING
-        ignored_labels = DatasetItemParameters().labels()
+        ignored_labels = set(DatasetItemParameters().labels())
         specified_values_dataset_item = DatasetItemEntity(
             media, annotations_scene, roi, metadata, subset, ignored_labels
         )


### PR DESCRIPTION
It is needed to implement 'dynamic labels'-aware training routines.