### PR TITLE
[NNCF] Remove ability to enable model pruning in UI

### DIFF
--- a/external/deep-object-reid/configs/ote_custom_classification/efficientnet_b0/template.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/efficientnet_b0/template.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_075/template_experimental.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_075/template_experimental.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_1/template.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_1/template.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_small/template_experimental.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_small/template_experimental.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/deep-object-reid/torchreid_tasks/configuration.yaml
+++ b/external/deep-object-reid/torchreid_tasks/configuration.yaml
@@ -160,6 +160,21 @@ nncf_optimization:
     value: false
     visible_in_ui: true
     warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
   maximal_accuracy_degradation:
     affects_outcome_of: TRAINING
     default_value: 1.0

--- a/external/deep-object-reid/torchreid_tasks/parameters.py
+++ b/external/deep-object-reid/torchreid_tasks/parameters.py
@@ -105,6 +105,13 @@ class OTEClassificationParameters(ConfigurableParameters):
             affects_outcome_of=ModelLifecycle.TRAINING
         )
 
+        pruning_supported = configurable_boolean(
+            default_value=False,
+            header="Whether filter pruning is supported",
+            description="Whether filter pruning is supported",
+            affects_outcome_of=ModelLifecycle.TRAINING
+        )
+
         maximal_accuracy_degradation = configurable_float(
             default_value=1.0,
             min_value=0.0,

--- a/external/mmdetection/configs/custom-counting-instance-seg/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/mmdetection/configs/custom-counting-instance-seg/efficientnetb2b_maskrcnn/template.yaml
@@ -38,6 +38,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/custom-counting-instance-seg/resnet50_maskrcnn/template.yaml
+++ b/external/mmdetection/configs/custom-counting-instance-seg/resnet50_maskrcnn/template.yaml
@@ -38,6 +38,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/custom-object-detection/cspdarknet_YOLOX/template.yaml
+++ b/external/mmdetection/configs/custom-object-detection/cspdarknet_YOLOX/template.yaml
@@ -41,6 +41,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml
+++ b/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_SSD/template.yaml
+++ b/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_SSD/template.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/custom-object-detection/gen3_resnet50_VFNet/template_experimental.yaml
+++ b/external/mmdetection/configs/custom-object-detection/gen3_resnet50_VFNet/template_experimental.yaml
@@ -40,6 +40,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/face-detection/face-detection-0200/template_experimental.yaml
+++ b/external/mmdetection/configs/face-detection/face-detection-0200/template_experimental.yaml
@@ -39,6 +39,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 0.01
 

--- a/external/mmdetection/configs/face-detection/face-detection-0202/template_experimental.yaml
+++ b/external/mmdetection/configs/face-detection/face-detection-0202/template_experimental.yaml
@@ -39,6 +39,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 0.01
 

--- a/external/mmdetection/configs/face-detection/face-detection-0204/template_experimental.yaml
+++ b/external/mmdetection/configs/face-detection/face-detection-0204/template_experimental.yaml
@@ -39,6 +39,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 0.01
 

--- a/external/mmdetection/configs/face-detection/face-detection-0205/template_experimental.yaml
+++ b/external/mmdetection/configs/face-detection/face-detection-0205/template_experimental.yaml
@@ -39,6 +39,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 0.01
 

--- a/external/mmdetection/configs/face-detection/face-detection-0206/template_experimental.yaml
+++ b/external/mmdetection/configs/face-detection/face-detection-0206/template_experimental.yaml
@@ -39,6 +39,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 0.01
 

--- a/external/mmdetection/configs/face-detection/face-detection-0207/template_experimental.yaml
+++ b/external/mmdetection/configs/face-detection/face-detection-0207/template_experimental.yaml
@@ -38,6 +38,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 0.01
 

--- a/external/mmdetection/configs/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/mmdetection/configs/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
@@ -38,6 +38,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/configs/rotated_detection/resnet50_maskrcnn/template.yaml
+++ b/external/mmdetection/configs/rotated_detection/resnet50_maskrcnn/template.yaml
@@ -38,6 +38,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmdetection/detection_tasks/apis/detection/configuration.py
+++ b/external/mmdetection/detection_tasks/apis/detection/configuration.py
@@ -129,6 +129,13 @@ class OTEDetectionConfig(ConfigurableParameters):
             affects_outcome_of=ModelLifecycle.TRAINING
         )
 
+        pruning_supported = configurable_boolean(
+            default_value=False,
+            header="Whether filter pruning is supported",
+            description="Whether filter pruning is supported",
+            affects_outcome_of=ModelLifecycle.TRAINING
+        )
+
         maximal_accuracy_degradation = configurable_float(
             default_value=1.0,
             min_value=0.0,

--- a/external/mmdetection/detection_tasks/apis/detection/configuration.yaml
+++ b/external/mmdetection/detection_tasks/apis/detection/configuration.yaml
@@ -217,6 +217,21 @@ nncf_optimization:
     value: false
     visible_in_ui: true
     warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
   maximal_accuracy_degradation:
     affects_outcome_of: TRAINING
     default_value: 1.0

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18-mod2/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18-mod2/template.yaml
@@ -45,6 +45,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18/template.yaml
@@ -45,6 +45,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-x-mod3/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-x-mod3/template.yaml
@@ -45,6 +45,8 @@ hyper_parameters:
         default_value: true
       enable_pruning:
         default_value: false
+      pruning_supported:
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 

--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.py
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.py
@@ -173,6 +173,13 @@ class OTESegmentationConfig(ConfigurableParameters):
             affects_outcome_of=ModelLifecycle.TRAINING
         )
 
+        pruning_supported = configurable_boolean(
+            default_value=False,
+            header="Whether filter pruning is supported",
+            description="Whether filter pruning is supported",
+            affects_outcome_of=ModelLifecycle.TRAINING
+        )
+
         maximal_accuracy_degradation = configurable_float(
             default_value=1.0,
             min_value=0.0,

--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.yaml
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.yaml
@@ -275,6 +275,21 @@ nncf_optimization:
     value: false
     visible_in_ui: true
     warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
   maximal_accuracy_degradation:
     affects_outcome_of: TRAINING
     default_value: 1.0


### PR DESCRIPTION
Disabled ability to turn on filter pruning for a model if it is not supported for this model. Added `pruning_supported` boolean parameter that is false by default and is true for couple of models that currently support filter pruning. #ref 80370