### PR TITLE
[ANOMALY SEGMENTATION] Remove dashboard metrics for anomaly segmentation

### DIFF
--- a/external/anomaly/ote_anomalib/task.py
+++ b/external/anomaly/ote_anomalib/task.py
@@ -221,13 +221,13 @@ class BaseAnomalyTask(ITrainingTask, IInferenceTask, IEvaluationTask, IExportTas
         self.trainer.predict(model=self.model, datamodule=datamodule)
         return dataset
 
-    def evaluate(self, output_resultset: ResultSetEntity, evaluation_metric: Optional[str] = None) -> None:
+    def evaluate(self, output_resultset: ResultSetEntity, _evaluation_metric: Optional[str] = None) -> None:
         """Evaluate the performance on a result set.
 
         Args:
             output_resultset (ResultSetEntity): Result Set from which the performance is evaluated.
-            evaluation_metric (Optional[str], optional): Evaluation metric. Defaults to None. Instead,
-                f-measure is used by default.
+            _evaluation_metric (Optional[str], optional): Evaluation metric. Defaults to None. Instead,
+                metric is chosen depending on the task type.
         """
         if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
             metric = MetricsHelper.compute_f_measure(output_resultset)
@@ -237,8 +237,9 @@ class BaseAnomalyTask(ITrainingTask, IInferenceTask, IEvaluationTask, IExportTas
             raise ValueError(f"Unknown task type: {self.task_type}")
         output_resultset.performance = metric.get_performance()
 
-        accuracy = MetricsHelper.compute_accuracy(output_resultset).get_performance()
-        output_resultset.performance.dashboard_metrics.extend(accuracy.dashboard_metrics)
+        if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
+            accuracy = MetricsHelper.compute_accuracy(output_resultset).get_performance()
+            output_resultset.performance.dashboard_metrics.extend(accuracy.dashboard_metrics)
 
     def export(self, export_type: ExportType, output_model: ModelEntity) -> None:
         """Export model to OpenVINO IR.

--- a/external/anomaly/ote_anomalib/task.py
+++ b/external/anomaly/ote_anomalib/task.py
@@ -221,12 +221,12 @@ class BaseAnomalyTask(ITrainingTask, IInferenceTask, IEvaluationTask, IExportTas
         self.trainer.predict(model=self.model, datamodule=datamodule)
         return dataset
 
-    def evaluate(self, output_resultset: ResultSetEntity, _evaluation_metric: Optional[str] = None) -> None:
+    def evaluate(self, output_resultset: ResultSetEntity, evaluation_metric: Optional[str] = None) -> None:
         """Evaluate the performance on a result set.
 
         Args:
             output_resultset (ResultSetEntity): Result Set from which the performance is evaluated.
-            _evaluation_metric (Optional[str], optional): Evaluation metric. Defaults to None. Instead,
+            evaluation_metric (Optional[str], optional): Evaluation metric. Defaults to None. Instead,
                 metric is chosen depending on the task type.
         """
         if self.task_type == TaskType.ANOMALY_CLASSIFICATION:


### PR DESCRIPTION
This PR disables the accuracy dashboard metrics for anomaly segmentation, because these dashboard metrics are only relevant for the anomaly classification task.

[BMM](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/26594/)