### PR TITLE
[ANOMALY TASKS] Fix IndexError in adaptive threshold computation

### DIFF
--- a/external/anomaly/requirements.txt
+++ b/external/anomaly/requirements.txt
@@ -1,4 +1,4 @@
-anomalib @ git+https://github.com/openvinotoolkit/anomalib.git@cd20c548fc5b510dd53fb63fa28f16835e715bcd
+anomalib @ git+https://github.com/openvinotoolkit/anomalib.git@5f3ee2725d97af8a0a7865b2fcac7280140bfc08
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2021/SCMVP#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 openvino==2022.1.0.dev20220302
 openvino-dev==2022.1.0.dev20220302


### PR DESCRIPTION
This PR fixes an issue that was sometimes encountered in anomaly tasks, where the adaptive threshold computation would raise an IndexError. A fix was recently merged in anomalib. This PR upgrades the anomaly tasks to the latest anomalib version so that the fix will be included in the OTE tasks.

For more details about the bugfix, see the description in the [anomalib PR](https://github.com/openvinotoolkit/anomalib/pull/146).

[BMM](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/26635/)