### PR TITLE
[OTE SDK] Added supports_auto_hpo flag to ModelTemplate

### DIFF
--- a/ote_sdk/ote_sdk/entities/model_template.py
+++ b/ote_sdk/ote_sdk/entities/model_template.py
@@ -12,6 +12,8 @@ from typing import Dict, List, Optional, Sequence, Union, cast
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from ote_sdk.configuration.elements import metadata_keys
+from ote_sdk.configuration.enums import AutoHPOState
+from ote_sdk.configuration.helper.utils import search_in_config_dict
 from ote_sdk.entities.label import Domain
 
 
@@ -423,6 +425,21 @@ class ModelTemplate:
         Returns ``True`` if the task is global task i.e. if task produces global labels
         """
         return self.task_type in [TaskType.CLASSIFICATION]
+
+    def supports_auto_hpo(self) -> bool:
+        """
+        Returns `True` if the algorithm supports automatic hyper parameter
+        optimization, False otherwise
+        """
+        if not self.hyper_parameters.has_valid_configurable_parameters:
+            return False
+        auto_hpo_state_results = search_in_config_dict(
+            self.hyper_parameters.data, key_to_search=metadata_keys.AUTO_HPO_STATE
+        )
+        for result in auto_hpo_state_results:
+            if result[0] == AutoHPOState.POSSIBLE:
+                return True
+        return False
 
 
 class NullModelTemplate(ModelTemplate):

--- a/ote_sdk/ote_sdk/entities/model_template.py
+++ b/ote_sdk/ote_sdk/entities/model_template.py
@@ -429,7 +429,7 @@ class ModelTemplate:
     def supports_auto_hpo(self) -> bool:
         """
         Returns `True` if the algorithm supports automatic hyper parameter
-        optimization, False otherwise
+        optimization, `False` otherwise
         """
         if not self.hyper_parameters.has_valid_configurable_parameters:
             return False


### PR DESCRIPTION
This PR adds a convenience method to ModelTemplate, to quickly deduce if a model template supports automatic hyper parameter optimization.

It relies on the 'auto_hpo_state' attribute in the hyper parameter metadata. This still needs to be updated for those model templates that support auto hpo, as per [this ticket](https://jira.devtools.intel.com/browse/CVS-79795). 