### PR TITLE
[ANOMALY SEGMENTATION] Use only polygon annotations for evaluation

### DIFF
--- a/external/anomaly/ote_anomalib/callbacks/inference.py
+++ b/external/anomaly/ote_anomalib/callbacks/inference.py
@@ -58,16 +58,13 @@ class AnomalyInferenceCallback(Callback):
             self.ote_dataset, pred_scores, pred_labels, anomaly_maps, pred_masks
         ):
             label = self.anomalous_label if pred_label else self.normal_label
-            if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
-                probability = (1 - pred_score) if pred_score < 0.5 else pred_score
-                dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
-            elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
+            probability = (1 - pred_score) if pred_score < 0.5 else pred_score
+            dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
+            if self.task_type == TaskType.ANOMALY_SEGMENTATION:
                 mask = pred_mask.squeeze().astype(np.uint8)
                 dataset_item.append_annotations(
                     create_annotation_from_segmentation_map(mask, anomaly_map.squeeze(), self.label_map)
                 )
-            else:
-                raise ValueError(f"Unknown task type: {self.task_type}")
 
             dataset_item.append_metadata_item(
                 ResultMediaEntity(

--- a/external/anomaly/ote_anomalib/data/data.py
+++ b/external/anomaly/ote_anomalib/data/data.py
@@ -199,9 +199,13 @@ class OTEAnomalyDataModule(LightningDataModule):
         Validation Dataloader
         """
         global_dataset, local_dataset = split_local_global_dataset(self.val_ote_dataset)
+        logger.info(f"Global annotations: {len(global_dataset)}")
+        logger.info(f"Local annotations: {len(local_dataset)}")
         if contains_anomalous_images(local_dataset):
+            logger.info("Dataset contains polygon annotations. Passing masks to anomalib.")
             dataset = OTEAnomalyDataset(self.config, local_dataset, TaskType.ANOMALY_SEGMENTATION)
         else:
+            logger.info("Dataset does not contain polygon annotations. Not passing masks to anomalib.")
             dataset = OTEAnomalyDataset(self.config, global_dataset, TaskType.ANOMALY_CLASSIFICATION)
         return DataLoader(
             dataset,

--- a/external/anomaly/ote_anomalib/data/data.py
+++ b/external/anomaly/ote_anomalib/data/data.py
@@ -23,9 +23,12 @@ import numpy as np
 from anomalib.pre_processing import PreProcessor
 from omegaconf import DictConfig, ListConfig
 from ote_anomalib.logging import get_logger
+from ote_sdk.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
+from ote_sdk.entities.dataset_item import DatasetItemEntity
 from ote_sdk.entities.datasets import DatasetEntity
 from ote_sdk.entities.model_template import TaskType
 from ote_sdk.entities.shapes.polygon import Polygon
+from ote_sdk.entities.shapes.rectangle import Rectangle
 from ote_sdk.entities.subset import Subset
 from ote_sdk.utils.segmentation_utils import mask_from_dataset_item
 from pytorch_lightning.core.datamodule import LightningDataModule
@@ -149,12 +152,18 @@ class OTEAnomalyDataModule(LightningDataModule):
         if stage == "fit" or stage is None:
             self.train_ote_dataset = self.dataset.get_subset(Subset.TRAINING)
             self.val_ote_dataset = self.dataset.get_subset(Subset.VALIDATION)
+            if self.task_type == TaskType.ANOMALY_SEGMENTATION:
+                self.val_ote_dataset = self.filter_full_annotations(self.val_ote_dataset)
 
         if stage == "validate":
             self.val_ote_dataset = self.dataset.get_subset(Subset.VALIDATION)
+            if self.task_type == TaskType.ANOMALY_SEGMENTATION:
+                self.val_ote_dataset = self.filter_full_annotations(self.val_ote_dataset)
 
         if stage == "test" or stage is None:
             self.test_ote_dataset = self.dataset.get_subset(Subset.TESTING)
+            if self.task_type == TaskType.ANOMALY_SEGMENTATION:
+                self.test_ote_dataset = self.filter_full_annotations(self.test_ote_dataset)
 
         if stage == "predict":
             self.predict_ote_dataset = self.dataset
@@ -195,7 +204,6 @@ class OTEAnomalyDataModule(LightningDataModule):
         """
         Validation Dataloader
         """
-
         dataset = OTEAnomalyDataset(self.config, self.val_ote_dataset, self.task_type)
         return DataLoader(
             dataset,
@@ -227,3 +235,28 @@ class OTEAnomalyDataModule(LightningDataModule):
             batch_size=self.config.dataset.test_batch_size,
             num_workers=self.config.dataset.num_workers,
         )
+
+    @staticmethod
+    def filter_full_annotations(dataset) -> DatasetEntity:
+        """
+        Filter out the fully annotated images in the dataset.
+        """
+        fully_annotated = []
+        for dataset_item in dataset:
+            annotations = dataset_item.get_annotations()
+            local_annotations = [
+                annotation for annotation in annotations if not Rectangle.is_full_box(annotation.shape)
+            ]
+            if not any(label.is_anomalous for label in dataset_item.get_shapes_labels()):
+                fully_annotated.append(dataset_item)
+            if len(local_annotations) > 0:
+                fully_annotated.append(
+                    DatasetItemEntity(
+                        media=dataset_item.media,
+                        annotation_scene=AnnotationSceneEntity(local_annotations, kind=AnnotationSceneKind.ANNOTATION),
+                        metadata=dataset_item.metadata,
+                        subset=dataset_item.subset,
+                        ignored_labels=dataset_item.ignored_labels,
+                    )
+                )
+        return DatasetEntity(fully_annotated, purpose=dataset.purpose)

--- a/external/anomaly/ote_anomalib/data/utils.py
+++ b/external/anomaly/ote_anomalib/data/utils.py
@@ -1,0 +1,147 @@
+"""
+Dataset utils for OTE Anomaly
+"""
+
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from typing import Tuple
+
+from ote_sdk.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
+from ote_sdk.entities.dataset_item import DatasetItemEntity
+from ote_sdk.entities.datasets import DatasetEntity
+from ote_sdk.entities.resultset import ResultSetEntity
+from ote_sdk.entities.shapes.rectangle import Rectangle
+
+
+def filter_full_annotations(dataset) -> DatasetEntity:
+    """
+    Filter out the fully annotated images in the dataset.
+    """
+    fully_annotated = []
+    for dataset_item in dataset:
+        annotations = dataset_item.get_annotations()
+        local_annotations = [annotation for annotation in annotations if not Rectangle.is_full_box(annotation.shape)]
+        if not any(label.is_anomalous for label in dataset_item.get_shapes_labels()):
+            fully_annotated.append(dataset_item)
+        if len(local_annotations) > 0:
+            fully_annotated.append(
+                DatasetItemEntity(
+                    media=dataset_item.media,
+                    annotation_scene=AnnotationSceneEntity(local_annotations, kind=AnnotationSceneKind.ANNOTATION),
+                    metadata=dataset_item.metadata,
+                    subset=dataset_item.subset,
+                    ignored_labels=dataset_item.ignored_labels,
+                )
+            )
+    return DatasetEntity(fully_annotated, purpose=dataset.purpose)
+
+
+def split_local_global_annotations(resultset) -> Tuple[ResultSetEntity, ResultSetEntity]:
+    """Split resultset based on the type of available annotations."""
+    # splits the dataset
+    globally_annotated = []
+    locally_annotated = []
+    globally_predicted = []
+    locally_predicted = []
+    for gt_item, pred_item in zip(resultset.ground_truth_dataset, resultset.prediction_dataset):
+
+        annotations = gt_item.get_annotations()
+        global_annotations = [annotation for annotation in annotations if Rectangle.is_full_box(annotation.shape)]
+        local_annotations = [annotation for annotation in annotations if not Rectangle.is_full_box(annotation.shape)]
+
+        predictions = gt_item.get_annotations()
+        global_predictions = [predictions for predictions in predictions if Rectangle.is_full_box(predictions.shape)]
+        local_predictions = [predictions for predictions in predictions if not Rectangle.is_full_box(predictions.shape)]
+
+        if not any(label.is_anomalous for label in gt_item.get_shapes_labels()):
+            # normal images get added to both datasets
+            globally_annotated.append(gt_item)
+            locally_annotated.append(gt_item)
+            globally_predicted.append(
+                DatasetItemEntity(
+                    media=pred_item.media,
+                    annotation_scene=AnnotationSceneEntity(global_predictions, kind=AnnotationSceneKind.PREDICTION),
+                    metadata=pred_item.metadata,
+                    subset=pred_item.subset,
+                    ignored_labels=pred_item.ignored_labels,
+                )
+            )
+            locally_predicted.append(
+                DatasetItemEntity(
+                    media=pred_item.media,
+                    annotation_scene=AnnotationSceneEntity(local_predictions, kind=AnnotationSceneKind.PREDICTION),
+                    metadata=pred_item.metadata,
+                    subset=pred_item.subset,
+                    ignored_labels=pred_item.ignored_labels,
+                )
+            )
+        else:  # image is abnormal
+            globally_annotated.append(
+                DatasetItemEntity(
+                    media=gt_item.media,
+                    annotation_scene=AnnotationSceneEntity(global_annotations, kind=AnnotationSceneKind.ANNOTATION),
+                    metadata=gt_item.metadata,
+                    subset=gt_item.subset,
+                    ignored_labels=gt_item.ignored_labels,
+                )
+            )
+            globally_predicted.append(
+                DatasetItemEntity(
+                    media=pred_item.media,
+                    annotation_scene=AnnotationSceneEntity(global_predictions, kind=AnnotationSceneKind.PREDICTION),
+                    metadata=pred_item.metadata,
+                    subset=pred_item.subset,
+                    ignored_labels=pred_item.ignored_labels,
+                )
+            )
+            # add locally annotated dataset items
+            if len(local_annotations) > 0:
+                locally_annotated.append(
+                    DatasetItemEntity(
+                        media=gt_item.media,
+                        annotation_scene=AnnotationSceneEntity(local_annotations, kind=AnnotationSceneKind.ANNOTATION),
+                        metadata=gt_item.metadata,
+                        subset=gt_item.subset,
+                        ignored_labels=gt_item.ignored_labels,
+                    )
+                )
+                locally_predicted.append(
+                    DatasetItemEntity(
+                        media=pred_item.media,
+                        annotation_scene=AnnotationSceneEntity(local_predictions, kind=AnnotationSceneKind.PREDICTION),
+                        metadata=pred_item.metadata,
+                        subset=pred_item.subset,
+                        ignored_labels=pred_item.ignored_labels,
+                    )
+                )
+    global_gt_dataset = DatasetEntity(globally_annotated, purpose=resultset.ground_truth_dataset.purpose)
+    local_gt_dataset = DatasetEntity(locally_annotated, purpose=resultset.ground_truth_dataset.purpose)
+    global_pred_dataset = DatasetEntity(globally_predicted, purpose=resultset.prediction_dataset.purpose)
+    local_pred_dataset = DatasetEntity(locally_predicted, purpose=resultset.prediction_dataset.purpose)
+
+    global_resultset = ResultSetEntity(resultset.model, global_gt_dataset, global_pred_dataset, resultset.purpose)
+    local_resultset = ResultSetEntity(resultset.model, local_gt_dataset, local_pred_dataset, resultset.purpose)
+
+    return global_resultset, local_resultset
+
+
+def contains_anomalous_images(resultset: ResultSetEntity) -> bool:
+    """Find the number of local annotations in a resultset."""
+    gt_dataset = resultset.ground_truth_dataset
+    for item in gt_dataset:
+        labels = item.get_shapes_labels()
+        if any(label.is_anomalous for label in labels):
+            return True
+    return False

--- a/external/anomaly/ote_anomalib/data/utils.py
+++ b/external/anomaly/ote_anomalib/data/utils.py
@@ -25,30 +25,47 @@ from ote_sdk.entities.resultset import ResultSetEntity
 from ote_sdk.entities.shapes.rectangle import Rectangle
 
 
-def filter_full_annotations(dataset) -> DatasetEntity:
-    """
-    Filter out the fully annotated images in the dataset.
-    """
-    fully_annotated = []
-    for dataset_item in dataset:
-        annotations = dataset_item.get_annotations()
+def split_local_global_dataset(dataset) -> Tuple[DatasetEntity, DatasetEntity]:
+    """Split a dataset into globally and locally annotated items."""
+    globally_annotated = []
+    locally_annotated = []
+    for gt_item in dataset:
+
+        annotations = gt_item.get_annotations()
+        global_annotations = [annotation for annotation in annotations if Rectangle.is_full_box(annotation.shape)]
         local_annotations = [annotation for annotation in annotations if not Rectangle.is_full_box(annotation.shape)]
-        if not any(label.is_anomalous for label in dataset_item.get_shapes_labels()):
-            fully_annotated.append(dataset_item)
-        if len(local_annotations) > 0:
-            fully_annotated.append(
+
+        if not any(label.is_anomalous for label in gt_item.get_shapes_labels()):
+            # normal images get added to both datasets
+            globally_annotated.append(gt_item)
+            locally_annotated.append(gt_item)
+        else:  # image is abnormal
+            globally_annotated.append(
                 DatasetItemEntity(
-                    media=dataset_item.media,
-                    annotation_scene=AnnotationSceneEntity(local_annotations, kind=AnnotationSceneKind.ANNOTATION),
-                    metadata=dataset_item.metadata,
-                    subset=dataset_item.subset,
-                    ignored_labels=dataset_item.ignored_labels,
+                    media=gt_item.media,
+                    annotation_scene=AnnotationSceneEntity(global_annotations, kind=AnnotationSceneKind.ANNOTATION),
+                    metadata=gt_item.metadata,
+                    subset=gt_item.subset,
+                    ignored_labels=gt_item.ignored_labels,
                 )
             )
-    return DatasetEntity(fully_annotated, purpose=dataset.purpose)
+            # add locally annotated dataset items
+            if len(local_annotations) > 0:
+                locally_annotated.append(
+                    DatasetItemEntity(
+                        media=gt_item.media,
+                        annotation_scene=AnnotationSceneEntity(local_annotations, kind=AnnotationSceneKind.ANNOTATION),
+                        metadata=gt_item.metadata,
+                        subset=gt_item.subset,
+                        ignored_labels=gt_item.ignored_labels,
+                    )
+                )
+    global_gt_dataset = DatasetEntity(globally_annotated, purpose=dataset.purpose)
+    local_gt_dataset = DatasetEntity(locally_annotated, purpose=dataset.purpose)
+    return global_gt_dataset, local_gt_dataset
 
 
-def split_local_global_annotations(resultset) -> Tuple[ResultSetEntity, ResultSetEntity]:
+def split_local_global_resultset(resultset) -> Tuple[ResultSetEntity, ResultSetEntity]:
     """Split resultset based on the type of available annotations."""
     # splits the dataset
     globally_annotated = []
@@ -126,21 +143,26 @@ def split_local_global_annotations(resultset) -> Tuple[ResultSetEntity, ResultSe
                         ignored_labels=pred_item.ignored_labels,
                     )
                 )
-    global_gt_dataset = DatasetEntity(globally_annotated, purpose=resultset.ground_truth_dataset.purpose)
-    local_gt_dataset = DatasetEntity(locally_annotated, purpose=resultset.ground_truth_dataset.purpose)
-    global_pred_dataset = DatasetEntity(globally_predicted, purpose=resultset.prediction_dataset.purpose)
-    local_pred_dataset = DatasetEntity(locally_predicted, purpose=resultset.prediction_dataset.purpose)
 
-    global_resultset = ResultSetEntity(resultset.model, global_gt_dataset, global_pred_dataset, resultset.purpose)
-    local_resultset = ResultSetEntity(resultset.model, local_gt_dataset, local_pred_dataset, resultset.purpose)
+    global_resultset = ResultSetEntity(
+        model=resultset.model,
+        ground_truth_dataset=DatasetEntity(globally_annotated, purpose=resultset.ground_truth_dataset.purpose),
+        prediction_dataset=DatasetEntity(globally_predicted, purpose=resultset.prediction_dataset.purpose),
+        purpose=resultset.purpose,
+    )
+    local_resultset = ResultSetEntity(
+        model=resultset.model,
+        ground_truth_dataset=DatasetEntity(locally_annotated, purpose=resultset.ground_truth_dataset.purpose),
+        prediction_dataset=DatasetEntity(locally_predicted, purpose=resultset.prediction_dataset.purpose),
+        purpose=resultset.purpose,
+    )
 
     return global_resultset, local_resultset
 
 
-def contains_anomalous_images(resultset: ResultSetEntity) -> bool:
+def contains_anomalous_images(dataset: DatasetEntity) -> bool:
     """Find the number of local annotations in a resultset."""
-    gt_dataset = resultset.ground_truth_dataset
-    for item in gt_dataset:
+    for item in dataset:
         labels = item.get_shapes_labels()
         if any(label.is_anomalous for label in labels):
             return True

--- a/external/anomaly/ote_anomalib/openvino.py
+++ b/external/anomaly/ote_anomalib/openvino.py
@@ -220,9 +220,15 @@ class OpenVINOAnomalyTask(IInferenceTask, IEvaluationTask, IOptimizationTask, ID
             metric = MetricsHelper.compute_f_measure(output_resultset)
         elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
             global_resultset, local_resultset = split_local_global_resultset(output_resultset)
+            logger.info(f"Global annotations: {len(global_resultset.ground_truth_dataset)}")
+            logger.info(f"Local annotations: {len(local_resultset.ground_truth_dataset)}")
+            logger.info(f"Global predictions: {len(global_resultset.prediction_dataset)}")
+            logger.info(f"Local predictions: {len(local_resultset.prediction_dataset)}")
             if contains_anomalous_images(local_resultset.ground_truth_dataset):
+                logger.info("Dataset contains polygon annotations. Using pixel-level evaluation metric.")
                 metric = MetricsHelper.compute_dice_averaged_over_pixels(local_resultset, MetricAverageMethod.MICRO)
             else:
+                logger.info("Dataset does not contain polygon annotations. Using image-level evaluation metric.")
                 metric = MetricsHelper.compute_f_measure(global_resultset)
         else:
             raise ValueError(f"Unknown task type: {self.task_type}")

--- a/external/anomaly/ote_anomalib/task.py
+++ b/external/anomaly/ote_anomalib/task.py
@@ -237,9 +237,15 @@ class BaseAnomalyTask(ITrainingTask, IInferenceTask, IEvaluationTask, IExportTas
             metric = MetricsHelper.compute_f_measure(output_resultset)
         elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
             global_resultset, local_resultset = split_local_global_resultset(output_resultset)
+            logger.info(f"Global annotations: {len(global_resultset.ground_truth_dataset)}")
+            logger.info(f"Local annotations: {len(local_resultset.ground_truth_dataset)}")
+            logger.info(f"Global predictions: {len(global_resultset.prediction_dataset)}")
+            logger.info(f"Local predictions: {len(local_resultset.prediction_dataset)}")
             if contains_anomalous_images(local_resultset.ground_truth_dataset):
+                logger.info("Dataset contains polygon annotations. Using pixel-level evaluation metric.")
                 metric = MetricsHelper.compute_dice_averaged_over_pixels(local_resultset, MetricAverageMethod.MICRO)
             else:
+                logger.info("Dataset does not contain polygon annotations. Using image-level evaluation metric.")
                 metric = MetricsHelper.compute_f_measure(global_resultset)
         else:
             raise ValueError(f"Unknown task type: {self.task_type}")

--- a/external/anomaly/ote_anomalib/task.py
+++ b/external/anomaly/ote_anomalib/task.py
@@ -32,7 +32,7 @@ from ote_anomalib.configs import get_anomalib_config
 from ote_anomalib.data import OTEAnomalyDataModule
 from ote_anomalib.data.utils import (
     contains_anomalous_images,
-    split_local_global_annotations,
+    split_local_global_resultset,
 )
 from ote_anomalib.logging import get_logger
 from ote_sdk.entities.datasets import DatasetEntity
@@ -236,8 +236,8 @@ class BaseAnomalyTask(ITrainingTask, IInferenceTask, IEvaluationTask, IExportTas
         if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
             metric = MetricsHelper.compute_f_measure(output_resultset)
         elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
-            global_resultset, local_resultset = split_local_global_annotations(output_resultset)
-            if contains_anomalous_images(local_resultset):
+            global_resultset, local_resultset = split_local_global_resultset(output_resultset)
+            if contains_anomalous_images(local_resultset.ground_truth_dataset):
                 metric = MetricsHelper.compute_dice_averaged_over_pixels(local_resultset, MetricAverageMethod.MICRO)
             else:
                 metric = MetricsHelper.compute_f_measure(global_resultset)

--- a/external/anomaly/ote_anomalib/task.py
+++ b/external/anomaly/ote_anomalib/task.py
@@ -91,13 +91,7 @@ class BaseAnomalyTask(ITrainingTask, IInferenceTask, IEvaluationTask, IExportTas
         config = get_anomalib_config(task_name=self.model_name, ote_config=hyper_parameters)
         config.project.path = self.project_path
 
-        # set task type
-        if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
-            config.dataset.task = "classification"
-        elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
-            config.dataset.task = "segmentation"
-        else:
-            raise ValueError(f"Unknown task type: {self.task_type}")
+        config.dataset.task = "classification"
 
         return config
 

--- a/ote_cli/ote_cli/tools/utils/demo/visualization.py
+++ b/ote_cli/ote_cli/tools/utils/demo/visualization.py
@@ -20,6 +20,7 @@ Visualisation module.
 import cv2
 import numpy as np
 from ote_sdk.entities.model_template import TaskType
+from ote_sdk.entities.shapes.polygon import Polygon
 
 
 def put_text_on_rect_bg(frame, message, position, color=(255, 255, 0)):
@@ -56,6 +57,8 @@ def draw_masks(frame, predictions, put_object_count=False):
     aggregated_mask = np.zeros(frame.shape[:2], dtype=np.uint8)
     aggregated_colored_mask = np.zeros(frame.shape, dtype=np.uint8)
     for prediction in predictions:
+        if not isinstance(prediction.shape, Polygon):
+            continue
         contours = np.array(
             [[(int(p.x * width), int(p.y * height)) for p in prediction.shape.points]]
         )


### PR DESCRIPTION
This PR fixes an issue in anomaly segmentation where the evaluation was done on both global (image-level) and local (polygon) annotations. With these changes, the resultset is now split into a subset that has local annotations available and a subset that has only global annotations available. If the local subset contains anomalous images, it will be used to compute performance. Otherwise the global dataset will be used (in this case the reported performance will be image-level F1). This would allow users to train the task and see the predictions before making any polygon annotations.

Additionally, a similar split is done for the validation set before sending the data to Anomalib. This makes sure that Anomalib does not try to compute segmentation performance without ground truth masks available. If the global dataset is used for validation, Anomalib will use the image-level threshold to generate segmentation predictions.

[BMM](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/27001/)