### PR TITLE
[OTE_SDK] Improve configurable parameter on-setattr validation

### DIFF
--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -136,14 +136,14 @@ def configurable_integer(
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
+    value_validator = construct_attr_value_validator(min_value, max_value)
+    type_validator = attr_strict_int_validator
 
     return attr.ib(
         default=default_value,
         type=int,
-        validator=[
-            attr_strict_int_validator,
-            construct_attr_value_validator(min_value, max_value),
-        ],
+        validator=[value_validator, type_validator],
+        on_setattr=attr.setters.validate,
         metadata=metadata,
     )
 
@@ -205,13 +205,15 @@ def configurable_float(
     )
 
     metadata.update({MIN_VALUE: min_value, MAX_VALUE: max_value})
+    value_validator = construct_attr_value_validator(min_value, max_value)
+    type_validator = attr_strict_float_on_setattr
 
     return attr.ib(
         default=default_value,
         type=float,
-        validator=construct_attr_value_validator(min_value, max_value),
+        validator=[value_validator, type_validator],
         converter=attr_strict_float_converter,
-        on_setattr=attr_strict_float_on_setattr,
+        on_setattr=[attr.setters.convert, attr.setters.validate],
         metadata=metadata,
     )
 
@@ -268,12 +270,14 @@ def configurable_boolean(
         auto_hpo_state=auto_hpo_state,
         auto_hpo_value=auto_hpo_value,
     )
+    type_validator = attr.validators.instance_of(bool)
 
     return attr.ib(
         default=default_value,
         metadata=metadata,
         type=bool,
-        validator=attr.validators.instance_of(bool),
+        validator=type_validator,
+        on_setattr=attr.setters.validate,
     )
 
 
@@ -332,13 +336,15 @@ def float_selectable(
     )
 
     metadata.update({OPTIONS: options})
+    value_validator = construct_attr_selectable_validator(options)
+    type_validator = attr_strict_float_on_setattr
 
     return attr.ib(
         default=default_value,
         type=float,
-        validator=construct_attr_selectable_validator(options),
+        validator=[value_validator, type_validator],
         converter=attr_strict_float_converter,
-        on_setattr=attr_strict_float_on_setattr,
+        on_setattr=[attr.setters.convert, attr.setters.validate],
         metadata=metadata,
     )
 
@@ -399,15 +405,18 @@ def selectable(
 
     metadata.update(default_value.get_class_info())
 
+    type_validator = attr.validators.instance_of(ConfigurableEnum)
+    value_validator = construct_attr_enum_selectable_onsetattr(default_value)
+
     # The Attribute returned by attr.ib is not compatible with the return typevar TConfigurableEnum. However, as the
     # class containing the Attribute is instantiated the selectable type will correspond to the TConfigurableEnum, so
     # mypy can ignore the error.
     return attr.ib(
         default=default_value,
         type=ConfigurableEnum,
-        validator=attr.validators.instance_of(ConfigurableEnum),
+        validator=[type_validator, value_validator],
         converter=construct_attr_enum_selectable_converter(default_value),
-        on_setattr=construct_attr_enum_selectable_onsetattr(default_value),
+        on_setattr=[attr.setters.convert, value_validator],
         metadata=metadata,
     )  # type: ignore
 

--- a/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
+++ b/ote_sdk/ote_sdk/configuration/elements/primitive_parameters.py
@@ -414,7 +414,7 @@ def selectable(
     return attr.ib(
         default=default_value,
         type=ConfigurableEnum,
-        validator=[type_validator, value_validator],
+        validator=[type_validator, value_validator],  # type: ignore
         converter=construct_attr_enum_selectable_converter(default_value),
         on_setattr=[attr.setters.convert, value_validator],
         metadata=metadata,

--- a/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/elements/test_primitive_parameters.py
@@ -141,13 +141,6 @@ class TestPrimitiveParameters:
             assert integer_instance._default == 100
             assert integer_instance.type == int
             assert len(integer_instance._validator._validators) == 2
-            assert (
-                integer_instance._validator._validators[0] == attr_strict_int_validator
-            )
-            assert (
-                integer_instance._validator._validators[1].__name__
-                == "attr_validate_value"
-            )
             assert integer_instance.metadata == expected_metadata
 
         # Checking _CountingAttr object returned by "configurable_integer" for default values of optional parameters
@@ -251,7 +244,6 @@ class TestPrimitiveParameters:
             assert isinstance(float_instance, _make._CountingAttr)
             assert float_instance._default == 100.1
             assert float_instance.type == float
-            assert float_instance._validator.__name__ == "attr_validate_value"
             assert float_instance.metadata == expected_metadata
 
         # Checking _CountingAttr object returned by "configurable_float" for default values of optional parameters
@@ -444,10 +436,6 @@ class TestPrimitiveParameters:
             assert isinstance(float_selectable_instance, _make._CountingAttr)
             assert float_selectable_instance._default
             assert float_selectable_instance.type == float
-            assert (
-                float_selectable_instance._validator.__name__
-                == "attr_validate_selectable"
-            )
             assert float_selectable_instance.metadata == expected_metadata
 
         # Checking _CountingAttr object returned by "float_selectable" for default values of optional parameters
@@ -547,10 +535,6 @@ class TestPrimitiveParameters:
             assert isinstance(selectable_instance, _make._CountingAttr)
             assert selectable_instance._default == SomeEnumSelectable.OPTION_C
             assert selectable_instance.type == ConfigurableEnum
-            assert isinstance(
-                selectable_instance._validator, validators._InstanceOfValidator  # type: ignore
-            )
-            assert selectable_instance._validator.type == ConfigurableEnum
             assert selectable_instance.metadata == expected_metadata
 
         # Checking _CountingAttr object returned by "selectable" for default values of optional parameters

--- a/ote_sdk/ote_sdk/tests/configuration/test_configurable_parameters.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configurable_parameters.py
@@ -205,7 +205,7 @@ class TestConfigurableParameters:
         ]
 
         # Simulate override
-        config.dummy_float_selectable = auto_hpo_result_float - 0.001
+        config.dummy_float_selectable = auto_hpo_result_float - 1
         config.subset_parameters.train_proportion = auto_hpo_result_train_prop - 0.001
 
         config.update_auto_hpo_states()

--- a/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
+++ b/ote_sdk/ote_sdk/tests/configuration/test_configuration_helper.py
@@ -216,9 +216,8 @@ class TestConfigurationHelper:
         # Loading a config that has an invalid value (-5 for epochs) should raise a ValueError due to runtime
         # input validation upon config creation.
         broken_config_path = self.__get_path_to_file("dummy_broken_config.yaml")
-        config = ote_config_helper.create(broken_config_path)
         with pytest.raises(ValueError) as error:
-            ote_config_helper.validate(config)
+            config = ote_config_helper.create(broken_config_path)
 
         assert "Invalid value set for epochs: -5 is out of bounds." == str(error.value)
 
@@ -266,9 +265,8 @@ class TestConfigurationHelper:
         assert ote_config_helper.validate(config)
 
         # Set invalid test_proportion, and assert that this raises an error upon validation
-        config.subset_parameters.test_proportion = 1.1
         with pytest.raises(ValueError):
-            ote_config_helper.validate(config)
+            config.subset_parameters.test_proportion = 1.1
 
         # Assert that validation passes again after restoring a value that is within the bounds
         config.subset_parameters.test_proportion = 0.25
@@ -277,7 +275,6 @@ class TestConfigurationHelper:
         # Set value that is not one of the options for dummy_selectable, assert that this raises a ValueError
         with pytest.raises(ValueError):
             config.dummy_selectable = "invalid_value"
-            ote_config_helper.validate(config)
 
         # Assert that validation passes again after restoring to a value that is in the options list
         config.dummy_selectable = "option_c"


### PR DESCRIPTION
This PR fixes the data validation for configurable parameters, by making sure that the correct validators and/or converters are run when trying to set a new value for one of the primitive parameters.

The PR also makes minor modifications to the tests for the configurable parameters to account for the changes.

The PR addresses this bug ticket on the platform side: [CVS-71717](https://jira.devtools.intel.com/browse/CVS-71717)