### PR TITLE
[OTE_SDK] Fix calculation of auto hpo support in ModelTemplate

### DIFF
--- a/ote_sdk/ote_sdk/entities/model_template.py
+++ b/ote_sdk/ote_sdk/entities/model_template.py
@@ -553,7 +553,7 @@ class ModelTemplate:
             self.hyper_parameters.data, key_to_search=metadata_keys.AUTO_HPO_STATE
         )
         for result in auto_hpo_state_results:
-            if result[0] == AutoHPOState.POSSIBLE:
+            if result[0].lower() == str(AutoHPOState.POSSIBLE):
                 return True
         return False
 

--- a/ote_sdk/ote_sdk/entities/model_template.py
+++ b/ote_sdk/ote_sdk/entities/model_template.py
@@ -553,7 +553,7 @@ class ModelTemplate:
             self.hyper_parameters.data, key_to_search=metadata_keys.AUTO_HPO_STATE
         )
         for result in auto_hpo_state_results:
-            if result[0].lower() == str(AutoHPOState.POSSIBLE):
+            if str(result[0]).lower() == str(AutoHPOState.POSSIBLE):
                 return True
         return False
 


### PR DESCRIPTION
This PR fixes a mistake in the calculation of the `supports_auto_hpo` function in the ModelTemplate. It now correctly returns True for algorithms that support auto HPO.