### PR TITLE
Fix OTEDetectionInferenceTask._load_model()

### DIFF
--- a/external/mmdetection/detection_tasks/apis/detection/inference_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/inference_task.py
@@ -128,6 +128,10 @@ class OTEDetectionInferenceTask(IInferenceTask, IExportTask, IEvaluationTask, IU
 
             try:
                 load_state_dict(model, model_data['model'])
+
+                if "load_from" in self._config:
+                    self._config.load_from = None
+
                 logger.info(f"Loaded model weights from Task Environment")
                 logger.info(f"Model architecture: {self._model_name}")
             except BaseException as ex:


### PR DESCRIPTION
## Bug description

1. Run `ote train ./external/mmdetection/configs/ote/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml --load-weights $SOME_PATH`
2. Expect OTE to start training from the model weights of `--load-weights $SOME_PATH`.
3. However, OTE actually starts training from the model weights of `load_from = 'https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/object_detection/v2/mobilenet_v2-atss.pth'`

## Changes

 - Remove `self._config.load_from` if exist to prevent `mmdet.apis.train.train_detector()` from reloading weights from `load_from`.

Signed-off-by: Kim, Vinnam <vinnam.kim@intel.com>