### PR TITLE
[CVS-83536] updated task configuarions

### DIFF
--- a/external/deep-object-reid/configs/ote_custom_classification/efficientnet_b0/template.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/efficientnet_b0/template.yaml
@@ -29,10 +29,12 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 32
+        auto_hpo_state: POSSIBLE
       max_num_epochs:
         default_value: 200
       learning_rate:
         default_value: 0.007
+        auto_hpo_state: POSSIBLE
       enable_early_stopping:
         default_value: true
     nncf_optimization:

--- a/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template.yaml
@@ -29,10 +29,12 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 32
+        auto_hpo_state: POSSIBLE
       max_num_epochs:
         default_value: 200
       learning_rate:
         default_value: 0.007
+        auto_hpo_state: POSSIBLE
       enable_early_stopping:
         default_value: true
     nncf_optimization:

--- a/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_075/template_experimental.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_075/template_experimental.yaml
@@ -29,10 +29,12 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 32
+        auto_hpo_state: POSSIBLE
       max_num_epochs:
         default_value: 200
       learning_rate:
         default_value: 0.016
+        auto_hpo_state: POSSIBLE
       enable_early_stopping:
         default_value: true
     nncf_optimization:

--- a/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_1/template.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_1/template.yaml
@@ -29,10 +29,12 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 32
+        auto_hpo_state: POSSIBLE
       max_num_epochs:
         default_value: 200
       learning_rate:
         default_value: 0.016
+        auto_hpo_state: POSSIBLE
       enable_early_stopping:
         default_value: true
     nncf_optimization:

--- a/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_small/template_experimental.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/mobilenet_v3_small/template_experimental.yaml
@@ -29,10 +29,12 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 32
+        auto_hpo_state: POSSIBLE
       max_num_epochs:
         default_value: 200
       learning_rate:
         default_value: 0.016
+        auto_hpo_state: POSSIBLE
       enable_early_stopping:
         default_value: true
     nncf_optimization:

--- a/external/deep-object-reid/torchreid_tasks/configuration.yaml
+++ b/external/deep-object-reid/torchreid_tasks/configuration.yaml
@@ -20,7 +20,7 @@ learning_parameters:
     visible_in_ui: true
     warning: Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
-    auto_hpo_state: POSSIBLE
+    auto_hpo_state: NOT_POSSIBLE
   description: Learning Parameters
   header: Learning Parameters
   learning_rate:
@@ -40,7 +40,7 @@ learning_parameters:
       type: UI_RULES
     visible_in_ui: true
     warning: null
-    auto_hpo_state: POSSIBLE
+    auto_hpo_state: NOT_POSSIBLE
   max_num_epochs:
     affects_outcome_of: TRAINING
     default_value: 200

--- a/external/deep-object-reid/torchreid_tasks/parameters.py
+++ b/external/deep-object-reid/torchreid_tasks/parameters.py
@@ -50,7 +50,7 @@ class OTEClassificationParameters(ConfigurableParameters):
             warning="Increasing this value may cause the system to use more memory than available, "
             "potentially causing out of memory errors, please update with caution.",
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.NOT_POSSIBLE
         )
 
         max_num_epochs = configurable_integer(
@@ -71,7 +71,7 @@ class OTEClassificationParameters(ConfigurableParameters):
             description="Increasing this value will speed up training \
                          convergence but might make it unstable.",
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.NOT_POSSIBLE
         )
 
         enable_lr_finder = configurable_boolean(

--- a/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml
+++ b/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_ATSS/template.yaml
@@ -29,8 +29,10 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 8
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.008
+        auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 200
       num_iters:

--- a/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_SSD/template.yaml
+++ b/external/mmdetection/configs/custom-object-detection/gen3_mobilenetV2_SSD/template.yaml
@@ -29,8 +29,10 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 10
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.01
+        auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 200
       num_iters:

--- a/external/mmdetection/detection_tasks/apis/detection/configuration.py
+++ b/external/mmdetection/detection_tasks/apis/detection/configuration.py
@@ -50,7 +50,7 @@ class OTEDetectionConfig(ConfigurableParameters):
             warning="Increasing this value may cause the system to use more memory than available, "
             "potentially causing out of memory errors, please update with caution.",
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.NOT_POSSIBLE
         )
 
         num_iters = configurable_integer(
@@ -69,7 +69,7 @@ class OTEDetectionConfig(ConfigurableParameters):
             header="Learning rate",
             description="Increasing this value will speed up training convergence but might make it unstable.",
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.NOT_POSSIBLE
         )
 
         learning_rate_warmup_iters = configurable_integer(

--- a/external/mmdetection/detection_tasks/apis/detection/configuration.yaml
+++ b/external/mmdetection/detection_tasks/apis/detection/configuration.yaml
@@ -23,7 +23,7 @@ learning_parameters:
     warning:
       Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
-    auto_hpo_state: POSSIBLE
+    auto_hpo_state: NOT_POSSIBLE
   description: Learning Parameters
   header: Learning Parameters
   learning_rate:
@@ -45,7 +45,7 @@ learning_parameters:
     value: 0.01
     visible_in_ui: true
     warning: null
-    auto_hpo_state: POSSIBLE
+    auto_hpo_state: NOT_POSSIBLE
   learning_rate_warmup_iters:
     affects_outcome_of: TRAINING
     default_value: 100

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18-mod2/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18-mod2/template.yaml
@@ -27,8 +27,10 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 8
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.001
+        auto_hpo_state: POSSIBLE
       learning_rate_fixed_iters:
         default_value: 0
       learning_rate_warmup_iters:

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-18/template.yaml
@@ -27,8 +27,10 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 8
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.001
+        auto_hpo_state: POSSIBLE
       learning_rate_fixed_iters:
         default_value: 0
       learning_rate_warmup_iters:

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-s-mod2/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-s-mod2/template.yaml
@@ -27,8 +27,10 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 8
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.001
+        auto_hpo_state: POSSIBLE
       learning_rate_fixed_iters:
         default_value: 0
       learning_rate_warmup_iters:

--- a/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-x-mod3/template.yaml
+++ b/external/mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-x-mod3/template.yaml
@@ -27,8 +27,10 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 5
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.001
+        auto_hpo_state: POSSIBLE
       learning_rate_fixed_iters:
         default_value: 0
       learning_rate_warmup_iters:

--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.py
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.py
@@ -50,7 +50,7 @@ class OTESegmentationConfig(ConfigurableParameters):
             warning="Increasing this value may cause the system to use more memory than available, "
             "potentially causing out of memory errors, please update with caution.",
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.NOT_POSSIBLE
         )
 
         num_iters = configurable_integer(
@@ -69,7 +69,7 @@ class OTESegmentationConfig(ConfigurableParameters):
             header="Learning rate",
             description="Increasing this value will speed up training convergence but might make it unstable.",
             affects_outcome_of=ModelLifecycle.TRAINING,
-            auto_hpo_state=AutoHPOState.POSSIBLE
+            auto_hpo_state=AutoHPOState.NOT_POSSIBLE
         )
 
         learning_rate_fixed_iters = configurable_integer(

--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.yaml
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/configuration.yaml
@@ -4,7 +4,7 @@ id: ""
 learning_parameters:
   batch_size:
     affects_outcome_of: TRAINING
-    auto_hpo_state: POSSIBLE
+    auto_hpo_state: NOT_POSSIBLE
     auto_hpo_value: null
     default_value: 8
     description:
@@ -30,7 +30,7 @@ learning_parameters:
   header: Learning Parameters
   learning_rate:
     affects_outcome_of: TRAINING
-    auto_hpo_state: POSSIBLE
+    auto_hpo_state: NOT_POSSIBLE
     auto_hpo_value: null
     default_value: 0.001
     description:


### PR DESCRIPTION
to disable auto-hpo as default configurations for each tasks
and selectively enable auto-hpo which are tested.
for templates below will be enabled auto-hpo at this point.
* custom classifications
* custom object detections (bounding box)
* semantic segmentations
JIRA ticket: [CVS-83536](https://jira.devtools.intel.com/browse/CVS-83536)