### PR TITLE
[OTE SDK] Fix dataset_item.get_annotations label check

### DIFF
--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -279,19 +279,22 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
 
                 shape_labels = annotation.get_labels(include_empty)
 
+                check_labels = False
                 if not include_ignored:
                     shape_labels = [
                         label
                         for label in shape_labels
                         if label.label not in self.ignored_labels
                     ]
+                    check_labels = True
 
                 if labels is not None:
                     shape_labels = [
                         label for label in shape_labels if label.name in labels_set
                     ]
+                    check_labels = True
 
-                if len(shape_labels) == 0:
+                if check_labels and len(shape_labels) == 0:
                     continue
 
                 if not is_full_box:


### PR DESCRIPTION
This PR fixes the `DatasetItem.get_annotations` method. The method was checking annotation labels, even in cases where this was not appropriate.