### PR TITLE
[IAI] CVS-79679 Add unassigned annotation subset to subset enum

### DIFF
--- a/ote_sdk/ote_sdk/entities/subset.py
+++ b/ote_sdk/ote_sdk/entities/subset.py
@@ -18,7 +18,7 @@ class Subset(Enum):
     TESTING = 3
     UNLABELED = 4
     PSEUDOLABELED = 5
-    UNASSIGNED_ANNOTATION = 6
+    UNASSIGNED = 6
 
     def __str__(self):
         return str(self.name)

--- a/ote_sdk/ote_sdk/entities/subset.py
+++ b/ote_sdk/ote_sdk/entities/subset.py
@@ -18,6 +18,7 @@ class Subset(Enum):
     TESTING = 3
     UNLABELED = 4
     PSEUDOLABELED = 5
+    UNASSIGNED_ANNOTATION = 6
 
     def __str__(self):
         return str(self.name)


### PR DESCRIPTION
The dataset manager in the backend needs to use the 'unassigned annotation' subset to recognize unassigned annotations.