### PR TITLE
CVS-84033 [OTE] Set wrong learning rate when resuming training

### DIFF
--- a/external/mmdetection/detection_tasks/extension/utils/hooks.py
+++ b/external/mmdetection/detection_tasks/extension/utils/hooks.py
@@ -486,7 +486,7 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         for group in runner.optimizer.param_groups:
             group.setdefault('initial_lr', group['lr'])
         self.base_lr = [
-            group['lr'] for group in runner.optimizer.param_groups
+            group['initial_lr'] for group in runner.optimizer.param_groups
         ]
         self.bad_count = 0
         self.last_iter = 0


### PR DESCRIPTION
Bug fix for ReduceLROnPlateauLrUpdaterHook class.
When resuming training, current code sets learning rate at stopped iteration as base learning rate.
This PR modified code to set real base learning rate of resumed training as base learning rate.