### PR TITLE
[ANOMALY DETECTION] pass correct task type when creating local dataset

### DIFF
--- a/external/anomaly/ote_anomalib/data/data.py
+++ b/external/anomaly/ote_anomalib/data/data.py
@@ -206,7 +206,7 @@ class OTEAnomalyDataModule(LightningDataModule):
         logger.info(f"Local annotations: {len(local_dataset)}")
         if contains_anomalous_images(local_dataset):
             logger.info("Dataset contains polygon annotations. Passing masks to anomalib.")
-            dataset = OTEAnomalyDataset(self.config, local_dataset, TaskType.ANOMALY_SEGMENTATION)
+            dataset = OTEAnomalyDataset(self.config, local_dataset, self.task_type)
         else:
             logger.info("Dataset does not contain polygon annotations. Not passing masks to anomalib.")
             dataset = OTEAnomalyDataset(self.config, global_dataset, TaskType.ANOMALY_CLASSIFICATION)


### PR DESCRIPTION
This PR fixes a bug that caused the anomaly detection performance to always be 0. This was caused by passing an incorrect task type to the dataset class, which resulted in empty GT masks being added to anomalous items. This in turn inflated the pixel threshold value up to the point where no pixels were marked anomalous during inference.

[BMM](https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/29274/)