### PR TITLE
sstrehlk/Extended conftest configuration for anomaly backend.

### DIFF
--- a/external/anomaly/tests/config.py
+++ b/external/anomaly/tests/config.py
@@ -1,7 +1,0 @@
-try:
-    import os
-    from e2e import config as config_e2e
-
-    config_e2e.repository_name = os.environ.get("TT_REPOSITORY_NAME", "ote/training_extensions/")
-except ImportError:
-    pass

--- a/external/anomaly/tests/config.py
+++ b/external/anomaly/tests/config.py
@@ -1,0 +1,7 @@
+try:
+    import os
+    from e2e import config as config_e2e
+
+    config_e2e.repository_name = os.environ.get("TT_REPOSITORY_NAME", "ote/training_extensions/")
+except ImportError:
+    pass

--- a/external/anomaly/tests/conftest.py
+++ b/external/anomaly/tests/conftest.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+try:
+    import e2e.fixtures
+
+    from e2e.conftest_utils import * # noqa
+    from e2e.conftest_utils import pytest_addoption as _e2e_pytest_addoption # noqa
+    from e2e import config # noqa
+    from e2e.utils import get_plugins_from_packages
+    pytest_plugins = get_plugins_from_packages([e2e])
+except ImportError:
+    _e2e_pytest_addoption = None
+    pass
+import config
 import pytest
 from ote_sdk.test_suite.pytest_insertions import (
     get_pytest_plugins_from_ote,

--- a/external/anomaly/tests/conftest.py
+++ b/external/anomaly/tests/conftest.py
@@ -23,7 +23,6 @@ try:
 except ImportError:
     _e2e_pytest_addoption = None
     pass
-# import config
 import pytest
 from ote_sdk.test_suite.pytest_insertions import (
     get_pytest_plugins_from_ote,

--- a/external/anomaly/tests/conftest.py
+++ b/external/anomaly/tests/conftest.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     _e2e_pytest_addoption = None
     pass
-import config
+# import config
 import pytest
 from ote_sdk.test_suite.pytest_insertions import (
     get_pytest_plugins_from_ote,


### PR DESCRIPTION
Extended conftest configuration for anomaly backend to use conftest_utils from e2e. 
Build with properly logged test results:
https://ci-ote.iotg.sclab.intel.com/job/ote/job/ote-test/1773/ 