### PR TITLE
Remove `git checkout` from quick start guide

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -11,7 +11,6 @@
     ```
     git clone https://github.com/openvinotoolkit/training_extensions.git
     cd training_extensions
-    git checkout -b develop origin/develop
     git submodule update --init --recursive
     ```
 


### PR DESCRIPTION
Prevent error:

```
~/code/training_extensions$ git checkout -b develop origin/develop
fatal: A branch named 'develop' already exists.
```

The develop branch is the default branch, so it is not necessary anymore to checkout a specific branch.