### PR TITLE
Fix hierarchical exportable code

### DIFF
--- a/external/deep-object-reid/torchreid_tasks/utils.py
+++ b/external/deep-object-reid/torchreid_tasks/utils.py
@@ -495,7 +495,7 @@ def get_hierarchical_predictions(logits: np.ndarray, labels: List[LabelEntity],
                                  pos_thr: float = 0.5, activate: bool = True) -> List[ScoredLabel]:
     predicted_labels = []
     for i in range(multihead_class_info['num_multiclass_heads']):
-        logits_begin, logits_end = multihead_class_info['head_idx_to_logits_range'][i]
+        logits_begin, logits_end = multihead_class_info['head_idx_to_logits_range'][str(i)]
         head_logits = logits[logits_begin : logits_end]
         if activate:
             head_logits = softmax_numpy(head_logits)


### PR DESCRIPTION
cast int to str type as `multihead_class_info['head_idx_to_logits_range']` is a dict with str keys