### PR TITLE
[ANOMALY] Use is_anomalous attribute instead of string matching

### DIFF
--- a/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py
+++ b/ote_sdk/ote_sdk/tests/usecases/exportable_code/test_prediction_to_annotation_converter.py
@@ -293,7 +293,10 @@ class TestCreateConverter:
                 name="Normal", domain=Domain.ANOMALY_CLASSIFICATION, id=ID("1")
             ),
             LabelEntity(
-                name="Anomalous", domain=Domain.ANOMALY_CLASSIFICATION, id=ID("2")
+                name="Anomalous",
+                domain=Domain.ANOMALY_CLASSIFICATION,
+                id=ID("2"),
+                is_anomalous=True,
             ),
         ]
         label_group = LabelGroup(
@@ -310,7 +313,12 @@ class TestCreateConverter:
         # "ANOMALY_DETECTION" is specified as "converter_type"
         labels = [
             LabelEntity(name="Normal", domain=Domain.ANOMALY_DETECTION, id=ID("1")),
-            LabelEntity(name="Anomalous", domain=Domain.ANOMALY_DETECTION, id=ID("2")),
+            LabelEntity(
+                name="Anomalous",
+                domain=Domain.ANOMALY_DETECTION,
+                id=ID("2"),
+                is_anomalous=True,
+            ),
         ]
         label_group = LabelGroup(name="Anomaly detection labels group", labels=labels)
         label_schema = LabelSchemaEntity(label_groups=[label_group])
@@ -325,7 +333,10 @@ class TestCreateConverter:
         labels = [
             LabelEntity(name="Normal", domain=Domain.ANOMALY_SEGMENTATION, id=ID("1")),
             LabelEntity(
-                name="Anomalous", domain=Domain.ANOMALY_SEGMENTATION, id=ID("2")
+                name="Anomalous",
+                domain=Domain.ANOMALY_SEGMENTATION,
+                id=ID("2"),
+                is_anomalous=True,
             ),
         ]
         label_group = LabelGroup(name="Anomaly detection labels group", labels=labels)
@@ -947,8 +958,18 @@ class TestSegmentationToAnnotation:
             non_empty_labels = [
                 LabelEntity(name="Normal", domain=Domain.CLASSIFICATION, id=ID("1")),
                 LabelEntity(name="Normal", domain=Domain.CLASSIFICATION, id=ID("2")),
-                LabelEntity(name="Anomalous", domain=Domain.CLASSIFICATION, id=ID("1")),
-                LabelEntity(name="Anomalous", domain=Domain.CLASSIFICATION, id=ID("2")),
+                LabelEntity(
+                    name="Anomalous",
+                    domain=Domain.CLASSIFICATION,
+                    id=ID("1"),
+                    is_anomalous=True,
+                ),
+                LabelEntity(
+                    name="Anomalous",
+                    domain=Domain.CLASSIFICATION,
+                    id=ID("2"),
+                    is_anomalous=True,
+                ),
             ]
             label_group = LabelGroup(
                 name="Classification labels group", labels=non_empty_labels
@@ -1030,7 +1051,12 @@ class TestSegmentationToAnnotation:
 
         non_empty_labels = [
             LabelEntity(name="Normal", domain=Domain.CLASSIFICATION, id=ID("1")),
-            LabelEntity(name="Anomalous", domain=Domain.CLASSIFICATION, id=ID("2")),
+            LabelEntity(
+                name="Anomalous",
+                domain=Domain.CLASSIFICATION,
+                id=ID("2"),
+                is_anomalous=True,
+            ),
         ]
         label_group = LabelGroup(
             name="Anomaly classification labels group", labels=non_empty_labels

--- a/ote_sdk/ote_sdk/usecases/exportable_code/prediction_to_annotation_converter.py
+++ b/ote_sdk/ote_sdk/usecases/exportable_code/prediction_to_annotation_converter.py
@@ -259,10 +259,8 @@ class AnomalyClassificationToAnnotationConverter(IPredictionToAnnotationConverte
 
     def __init__(self, label_schema: LabelSchemaEntity):
         labels = label_schema.get_labels(include_empty=False)
-        self.normal_label = [label for label in labels if label.name == "Normal"][0]
-        self.anomalous_label = [label for label in labels if label.name == "Anomalous"][
-            0
-        ]
+        self.normal_label = [label for label in labels if not label.is_anomalous][0]
+        self.anomalous_label = [label for label in labels if label.is_anomalous][0]
 
     def convert_to_annotation(
         self, predictions: np.ndarray, metadata: Dict[str, Any]
@@ -290,10 +288,8 @@ class AnomalySegmentationToAnnotationConverter(IPredictionToAnnotationConverter)
 
     def __init__(self, label_schema: LabelSchemaEntity):
         labels = label_schema.get_labels(include_empty=False)
-        self.normal_label = [label for label in labels if label.name == "Normal"][0]
-        self.anomalous_label = [label for label in labels if label.name == "Anomalous"][
-            0
-        ]
+        self.normal_label = [label for label in labels if not label.is_anomalous][0]
+        self.anomalous_label = [label for label in labels if label.is_anomalous][0]
         self.label_map = {0: self.normal_label, 1: self.anomalous_label}
 
     def convert_to_annotation(
@@ -327,10 +323,8 @@ class AnomalyDetectionToAnnotationConverter(IPredictionToAnnotationConverter):
         :param label_schema: Label Schema containing the label info of the task
         """
         labels = label_schema.get_labels(include_empty=False)
-        self.normal_label = [label for label in labels if label.name == "Normal"][0]
-        self.anomalous_label = [label for label in labels if label.name == "Anomalous"][
-            0
-        ]
+        self.normal_label = [label for label in labels if not label.is_anomalous][0]
+        self.anomalous_label = [label for label in labels if label.is_anomalous][0]
         self.label_map = {0: self.normal_label, 1: self.anomalous_label}
 
     def convert_to_annotation(


### PR DESCRIPTION
The exportable code used string matching to check the normal/anomalous labels based on the label name. This is not safe, because in a future version the label names in anomaly projects may be customizable. This PR replaces the string matching with a check based on the is_anomalous attribute of the label entity.
[Tests](https://ci-ote.iotg.sclab.intel.com/job/ote/job/ote-test/1830/)