### PR TITLE
Add label source to scored label

### DIFF
--- a/ote_sdk/ote_sdk/entities/scored_label.py
+++ b/ote_sdk/ote_sdk/entities/scored_label.py
@@ -6,10 +6,31 @@
 
 import datetime
 import math
+from dataclasses import dataclass
+from typing import Optional
 
 from ote_sdk.entities.color import Color
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import Domain, LabelEntity
+
+
+@dataclass
+class LabelSource:
+    """
+    This dataclass contains information about the source of a scored label.
+
+    For annotations, the id of the user who created the label and for predictions, the
+    id and model storage id of the model that created the prediction. When a user has
+    accepted a predictions as is, both the user id of the user who accepted and the
+    model/model storage id of the model that predicted should be filled in.
+
+    Note that usually the LabelSource is created with default values and the source is
+    set at a later stage.
+    """
+
+    user_id: str = ""
+    model_id: ID = ID()
+    model_storage_id: ID = ID()
 
 
 class ScoredLabel:
@@ -18,13 +39,22 @@ class ScoredLabel:
 
     :param label: a label. See :class:`Label`
     :param probability: a float denoting the probability of the shape belonging to the label.
+    :param label_source: a LabelSource dataclass containing the id of the user who created
+        or the model that predicted this label.
     """
 
-    def __init__(self, label: LabelEntity, probability: float = 0.0):
+    def __init__(
+        self,
+        label: LabelEntity,
+        probability: float = 0.0,
+        label_source: Optional[LabelSource] = None,
+    ):
         if math.isnan(probability) or (not 0 <= probability <= 1.0) :
             raise ValueError(f"Probability should be in range [0, 1], {probability} is given")
+
         self.label = label
         self.probability = probability
+        self.label_source = label_source if label_source is not None else LabelSource()
 
     @property
     def name(self) -> str:
@@ -89,7 +119,8 @@ class ScoredLabel:
     def __repr__(self):
         return (
             f"ScoredLabel({self.id_}, name={self.name}, probability={self.probability}, "
-            f"domain={self.domain}, color={self.color}, hotkey={self.hotkey})"
+            f"domain={self.domain}, color={self.color}, hotkey={self.hotkey}, "
+            f"label_source={self.label_source})"
         )
 
     def __eq__(self, other):
@@ -101,6 +132,7 @@ class ScoredLabel:
                 and self.hotkey == other.hotkey
                 and self.probability == other.probability
                 and self.domain == other.domain
+                and self.label_source == other.label_source
             )
         return False
 

--- a/ote_sdk/ote_sdk/entities/scored_label.py
+++ b/ote_sdk/ote_sdk/entities/scored_label.py
@@ -23,9 +23,6 @@ class LabelSource:
     id and model storage id of the model that created the prediction. When a user has
     accepted a predictions as is, both the user id of the user who accepted and the
     model/model storage id of the model that predicted should be filled in.
-
-    Note that usually the LabelSource is created with default values and the source is
-    set at a later stage.
     """
 
     user_id: str = ""
@@ -49,8 +46,10 @@ class ScoredLabel:
         probability: float = 0.0,
         label_source: Optional[LabelSource] = None,
     ):
-        if math.isnan(probability) or (not 0 <= probability <= 1.0) :
-            raise ValueError(f"Probability should be in range [0, 1], {probability} is given")
+        if math.isnan(probability) or (not 0 <= probability <= 1.0):
+            raise ValueError(
+                f"Probability should be in range [0, 1], {probability} is given"
+            )
 
         self.label = label
         self.probability = probability

--- a/ote_sdk/ote_sdk/tests/entities/test_annotation.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_annotation.py
@@ -175,8 +175,12 @@ class TestAnnotation:
             "[ScoredLabel(987654321, name=person, probability=0.0, domain=DETECTION,"
             in str(annotation.get_labels())
         )
-        assert "color=Color(red=11, green=18, blue=38, alpha=200), hotkey=)]" in str(
+        assert "color=Color(red=11, green=18, blue=38, alpha=200), hotkey=" in str(
             annotation.get_labels()
+        )
+        assert (
+            ", label_source=LabelSource(user_id='', model_id=ID(), model_storage_id=ID()))]"
+            in str(annotation.get_labels())
         )
 
         assert "[ScoredLabel(123456789, name=car" in str(
@@ -188,8 +192,12 @@ class TestAnnotation:
         assert "color=Color(red=16, green=15," in str(
             annotation.get_labels(include_empty=True)
         )
-        assert "blue=56, alpha=255), hotkey=)," in str(
+        assert "blue=56, alpha=255), hotkey=," in str(
             annotation.get_labels(include_empty=True)
+        )
+        assert (
+            "label_source=LabelSource(user_id='', model_id=ID(), model_storage_id=ID())),"
+            in str(annotation.get_labels(include_empty=True))
         )
 
     @pytest.mark.priority_medium

--- a/ote_sdk/ote_sdk/tests/entities/test_scored_label.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_scored_label.py
@@ -17,7 +17,7 @@ import pytest
 from ote_sdk.entities.color import Color
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.label import Domain, LabelEntity
-from ote_sdk.entities.scored_label import ScoredLabel
+from ote_sdk.entities.scored_label import LabelSource, ScoredLabel
 from ote_sdk.tests.constants.ote_sdk_components import OteSdkComponent
 from ote_sdk.tests.constants.requirements import Requirements
 
@@ -63,11 +63,17 @@ class TestScoredLabel:
         car_label.probability += delta_probability
         assert car_label.probability == probability
 
+        label_source = LabelSource()
+        assert car_label.label_source == label_source
+        user_name = "User Name"
+        car_label.label_source.user_id = user_name
+        label_source_with_user = LabelSource(user_id=user_name)
+        assert car_label.label_source == label_source_with_user
+
         car.color = Color(red=16, green=15, blue=56, alpha=255)
-        assert (
+        assert repr(car_label) == (
             "ScoredLabel(123456789, name=car, probability=0.4, domain=DETECTION, color="
-            in repr(car_label)
-        )
-        assert "Color(red=16, green=15, blue=56, alpha=255), hotkey=)" in repr(
-            car_label
+            "Color(red=16, green=15, blue=56, alpha=255), hotkey=ctrl+0, "
+            "label_source=LabelSource(user_id='User Name', model_id=ID(), "
+            "model_storage_id=ID()))"
         )

--- a/ote_sdk/ote_sdk/tests/entities/test_scored_label.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_scored_label.py
@@ -73,7 +73,7 @@ class TestScoredLabel:
         car.color = Color(red=16, green=15, blue=56, alpha=255)
         assert repr(car_label) == (
             "ScoredLabel(123456789, name=car, probability=0.4, domain=DETECTION, color="
-            "Color(red=16, green=15, blue=56, alpha=255), hotkey=ctrl+0, "
+            "Color(red=16, green=15, blue=56, alpha=255), hotkey=, "
             "label_source=LabelSource(user_id='User Name', model_id=ID(), "
             "model_storage_id=ID()))"
         )


### PR DESCRIPTION
Add label source to scored label and update tests. The label source indicates either who made the annotation/label, or which model created the prediction/label.