### PR TITLE
CVS-86379 Enhance numerical stability for numpy_softmax() in classification task

### DIFF
--- a/external/deep-object-reid/torchreid_tasks/utils.py
+++ b/external/deep-object-reid/torchreid_tasks/utils.py
@@ -496,7 +496,7 @@ def sigmoid_numpy(x: np.ndarray):
 
 @check_input_parameters_type()
 def softmax_numpy(x: np.ndarray):
-    x = np.exp(x)
+    x = np.exp(x - np.max(x))
     x /= np.sum(x)
     return x
 


### PR DESCRIPTION
Change:
softmax(x) = exp(x)/sum(exp(x)) -> exp(x-max(x))/sum(exp(x-max(x)))

Test result:
https://ci-ote.iotg.sclab.intel.com/job/ote/job/pr-ote-test/386/
http://validationreports.sclab.intel.com:8006/reports/build_number_report?test_session_build_number=pr-ote-test-386&environment=iotg-dev-workstation-18