### PR TITLE
CVS-86379 Fix NaN inference output from classification task

### DIFF
--- a/external/deep-object-reid/torchreid_tasks/inference_task.py
+++ b/external/deep-object-reid/torchreid_tasks/inference_task.py
@@ -245,7 +245,7 @@ class OTEClassificationInferenceTask(IInferenceTask, IEvaluationTask, IExportTas
                 scores[i] = softmax_numpy(scores[i])
                 item_labels = get_multiclass_predictions(scores[i], self._labels, activate=False)
 
-            if (self._multilabel or self._hierarchical) and not item_labels:
+            if not item_labels:
                 item_labels = [ScoredLabel(self._empty_label, probability=1.)]
 
             dataset_item.append_labels(item_labels)

--- a/external/deep-object-reid/torchreid_tasks/utils.py
+++ b/external/deep-object-reid/torchreid_tasks/utils.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from enum import Enum, auto
 import importlib
 import json
+import math
 import os
 import shutil
 import tempfile
@@ -474,6 +475,8 @@ def get_multiclass_predictions(logits: np.ndarray, labels: List[LabelEntity],
     i = np.argmax(logits)
     if activate:
         logits = softmax_numpy(logits)
+    if math.isnan(float(logits[i])):
+        return []
     return [ScoredLabel(labels[i], probability=float(logits[i]))]
 
 

--- a/external/deep-object-reid/torchreid_tasks/utils.py
+++ b/external/deep-object-reid/torchreid_tasks/utils.py
@@ -465,7 +465,7 @@ def sigmoid_numpy(x: np.ndarray):
 
 
 def softmax_numpy(x: np.ndarray):
-    x = np.exp(x)
+    x = np.exp(x - np.max(x))
     x /= np.sum(x)
     return x
 

--- a/external/mmdetection/detection_tasks/apis/detection/inference_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/inference_task.py
@@ -14,6 +14,7 @@
 
 import copy
 import io
+import math
 import os
 import shutil
 import tempfile
@@ -211,13 +212,13 @@ class OTEDetectionInferenceTask(IInferenceTask, IExportTask, IEvaluationTask, IU
                     for mask, probability in zip(masks, boxes[:, 4]):
                         mask = mask.astype(np.uint8)
                         probability = float(probability)
+                        if math.isnan(probability) or probability < confidence_threshold:
+                            continue
                         contours, hierarchies = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
                         if hierarchies is None:
                             continue
                         for contour, hierarchy in zip(contours, hierarchies[0]):
-                            if hierarchy[3] != -1:
-                                continue
-                            if len(contour) <= 2 or probability < confidence_threshold:
+                            if hierarchy[3] != -1 or len(contour) <= 2:
                                 continue
                             if self._task_type == TaskType.INSTANCE_SEGMENTATION:
                                 points = [Point(x=point[0][0] / width, y=point[0][1] / height) for point in contour]

--- a/ote_sdk/ote_sdk/entities/scored_label.py
+++ b/ote_sdk/ote_sdk/entities/scored_label.py
@@ -5,6 +5,7 @@
 """This module define the scored label entity."""
 
 import datetime
+import math
 
 from ote_sdk.entities.color import Color
 from ote_sdk.entities.id import ID
@@ -20,6 +21,8 @@ class ScoredLabel:
     """
 
     def __init__(self, label: LabelEntity, probability: float = 0.0):
+        if math.isnan(probability) or (not 0 <= probability <= 1.0) :
+            raise ValueError(f"Probability should be in range [0, 1], {probability} is given")
         self.label = label
         self.probability = probability
 


### PR DESCRIPTION
* Prevent NaN output from inference
* Raise exception for NaN input to ScoredLabel class in OTE_SDK
* Enhance stability in numpy_softmax()

Build: https://ci-ote.iotg.sclab.intel.com/job/ote/job/pr-ote-test/387/
Test report: http://validationreports.sclab.intel.com:8006/reports/build_number_report?test_session_build_number=pr-ote-test-387&environment=iotg-dev-workstation-18