### PR TITLE
Fix keys for checkpoint loading in mmdetection

### DIFF
--- a/external/mmdetection/detection_tasks/apis/detection/nncf_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/nncf_task.py
@@ -143,7 +143,13 @@ class OTEDetectionNNCFTask(OTEDetectionInferenceTask, IOptimizationTask):
                     logger.info("Loaded model weights from Task Environment and wrapped by NNCF")
                 else:
                     try:
-                        model.load_state_dict(model_data['model'])
+                        if 'state_dict' in model_data:
+                            state_dict = model_data['state_dict']
+                        elif 'model' in model_data:
+                            state_dict = model_data['model']
+                        else:
+                            state_dict = model_data
+                        model.load_state_dict(state_dict)
                         logger.info(f"Loaded model weights from Task Environment")
                         logger.info(f"Model architecture: {self._model_name}")
                     except BaseException as ex:


### PR DESCRIPTION
### Changes

Weights loading is modified in nncf task

### Reason

Attempt to load weights to `ote optimize` mmdetection task just after `ote train` leads to following error:

```
Traceback (most recent call last):
  File "/home/dlyakhov/training_extensions/external/mmdetection/detection_tasks/apis/detection/nncf_task.py", line 147, in _load_model
    model.load_state_dict(model_data['model'])
KeyError: 'model'
```

I aligned mmdetection nncf task with dor nncf task: https://github.com/openvinotoolkit/deep-object-reid/blob/d7f473ab659b3dd394bc36574dcf010882b26cf6/torchreid/utils/torchtools.py#L341-L348

### Tests

TODO:

- [ ] Check changes by a tests
