### PR TITLE
Fix CI dependency issues regarding numpy/networkx version

### DIFF
--- a/external/deep-object-reid/constraints.txt
+++ b/external/deep-object-reid/constraints.txt
@@ -1,0 +1,1 @@
+opencv-python==4.5.5.64  # remedy for fixed opencv-python-headless version in e2e-test-framework:w

--- a/external/deep-object-reid/requirements.txt
+++ b/external/deep-object-reid/requirements.txt
@@ -2,4 +2,4 @@ openvino==2022.1.0
 openvino-dev==2022.1.0
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 nncf@ git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf
-networkx==2.6.3
+networkx<=2.8.0

--- a/external/mmdetection/requirements.txt
+++ b/external/mmdetection/requirements.txt
@@ -2,5 +2,5 @@ openvino==2022.1.0
 openvino-dev==2022.1.0
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 nncf@ git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf
-networkx<=2.8.1
+networkx<=2.8.0
 protobuf<3.21.0

--- a/external/mmsegmentation/requirements.txt
+++ b/external/mmsegmentation/requirements.txt
@@ -2,5 +2,5 @@ openvino==2022.1.0
 openvino-dev==2022.1.0
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 nncf@ git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf
-networkx<=2.8.1
+networkx<=2.8.0
 protobuf<3.21.0

--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.16.4
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
 networkx>=2.5,<2.8.1rc1
-opencv-python==4.5.3.*
+opencv-python==4.5.5.*
 pymongo==3.12.0
 omegaconf==2.1.*
 natsort>=6.0.0


### PR DESCRIPTION
Need CI change: https://github.com/intel-innersource/frameworks.ai.interactive-ai-workflow.ote/pull/13
Build: https://ci-ote.iotg.sclab.intel.com/job/ote/job/pr-ote-test/417/
Test: http://validationreports.sclab.intel.com:8006/reports/build_number_report?test_session_build_number=pr-ote-test-417&environment=iotg-dev-workstation-08