### PR TITLE
Bugfix for on_epoch_end function of TrainingProgressCallback.

### DIFF
--- a/external/deep-object-reid/torchreid_tasks/utils.py
+++ b/external/deep-object-reid/torchreid_tasks/utils.py
@@ -411,7 +411,10 @@ class TrainingProgressCallback(TimeMonitorCallback):
             score = logs.get(self.update_progress_callback.metric, None)
         else:
             score = logs
-        if score is not None:
+        if (
+            score is not None
+            and hasattr(self.update_progress_callback, "hp_config")
+        ):
             score = float(score)
             print(f'score = {score} at epoch {self.current_epoch} / {self._num_iters}')
             # as a trick, score (at least if it's accuracy not the loss) and iteration number


### PR DESCRIPTION
This PR fixes a bug which occurs when MPA classification task runs.
The trick code is executed only if HPO callback is used.
Code checks that "hp_config" attribute exists in callback class because HPO callback function is not in HPOpt but in hpo.py.