### PR TITLE
[CVS-84981] openvino.model_zoo.model_api.models.model.WrapperError: There is no model with name "blur_segmentation" in list

### DIFF
--- a/ote_sdk/ote_sdk/usecases/exportable_code/prediction_to_annotation_converter.py
+++ b/ote_sdk/ote_sdk/usecases/exportable_code/prediction_to_annotation_converter.py
@@ -238,7 +238,7 @@ class ClassificationToAnnotationConverter(IPredictionToAnnotationConverter):
         self, predictions: List[Tuple[int, float]], metadata: Optional[Dict] = None
     ) -> AnnotationSceneEntity:
         labels = []
-        for index, score in predictions:
+        for index, (score, featuremap, vector) in enumerate(predictions):
             labels.append(ScoredLabel(self.labels[index], float(score)))
         if self.hierarchical:
             labels = self.label_schema.resolve_labels_probabilistic(labels)


### PR DESCRIPTION
## This PR includes:
### Summary
- Resolve CVS-84981 for classification, which expect three output when export.