### PR TITLE
[OTE SDK] Prevent deepcopy of AnnotationScene instance inside DatasetItem to avoid ID sharing

### DIFF
--- a/external/mmdetection/detection_tasks/extension/datasets/mmdataset.py
+++ b/external/mmdetection/detection_tasks/extension/datasets/mmdataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+from copy import copy
 from typing import Any, Dict, List, Sequence
 
 import numpy as np
@@ -192,7 +193,7 @@ class OTEDataset(CustomDataset):
         :param idx: int, Index of data.
         :return dict: Training data and annotation after pipeline with new keys introduced by pipeline.
         """
-        item = self.data_infos[idx]
+        item = copy(self.data_infos[idx])  # Copying dict(), not contents
         self.pre_pipeline(item)
         return self.pipeline(item)
 
@@ -203,7 +204,7 @@ class OTEDataset(CustomDataset):
         :param idx: int, Index of data.
         :return dict: Testing data after pipeline with new keys introduced by pipeline.
         """
-        item = self.data_infos[idx]
+        item = copy(self.data_infos[idx])  # Copying dict(), not contents
         self.pre_pipeline(item)
         return self.pipeline(item)
 

--- a/external/mmdetection/detection_tasks/extension/datasets/mmdataset.py
+++ b/external/mmdetection/detection_tasks/extension/datasets/mmdataset.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from copy import deepcopy
 from typing import Any, Dict, List, Sequence
 
 import numpy as np
@@ -193,7 +192,7 @@ class OTEDataset(CustomDataset):
         :param idx: int, Index of data.
         :return dict: Training data and annotation after pipeline with new keys introduced by pipeline.
         """
-        item = deepcopy(self.data_infos[idx])
+        item = self.data_infos[idx]
         self.pre_pipeline(item)
         return self.pipeline(item)
 
@@ -204,8 +203,6 @@ class OTEDataset(CustomDataset):
         :param idx: int, Index of data.
         :return dict: Testing data after pipeline with new keys introduced by pipeline.
         """
-        # FIXME.
-        # item = deepcopy(self.data_infos[idx])
         item = self.data_infos[idx]
         self.pre_pipeline(item)
         return self.pipeline(item)

--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -447,7 +447,7 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
             if "__roi_lock" in name:
                 setattr(clone, name, Lock())
             elif "__annotation_scene" in name:
-                setattr(clone, name, copy.copy(value))
+                pass  # Keep the same instance
             else:
                 setattr(clone, name, copy.deepcopy(value, memo))
         return clone

--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -433,23 +433,6 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
             )
         return False
 
-    def __deepcopy__(self, memo):
-        """
-        When we deepcopy this object, be sure not to deep copy the lock, as this is not possible,
-        make a new lock instead.
-        """
-        # Call ROI getter to ensure original object has an ROI.
-        _ = self.roi
-
-        clone = copy.copy(self)
-
-        for name, value in vars(self).items():
-            if "__roi_lock" in name:
-                setattr(clone, name, Lock())
-            else:
-                setattr(clone, name, copy.deepcopy(value, memo))
-        return clone
-
     def append_metadata_item(
         self, data: IMetadata, model: Optional[ModelEntity] = None
     ):

--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -436,7 +436,9 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
     def __deepcopy__(self, memo):
         """
         When we deepcopy this object, be sure not to deep copy the lock, as this is not possible,
-        make a new lock instead.
+        make a new lock instead. In addition, we prevent deepcopy of AnnotationSceneEntity member
+        variable to avoid unintentional ID sharing among instances. Same instance reference is
+        copied to the output instead.
         """
         # Call ROI getter to ensure original object has an ROI.
         _ = self.roi

--- a/ote_sdk/ote_sdk/entities/dataset_item.py
+++ b/ote_sdk/ote_sdk/entities/dataset_item.py
@@ -433,6 +433,25 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
             )
         return False
 
+    def __deepcopy__(self, memo):
+        """
+        When we deepcopy this object, be sure not to deep copy the lock, as this is not possible,
+        make a new lock instead.
+        """
+        # Call ROI getter to ensure original object has an ROI.
+        _ = self.roi
+
+        clone = copy.copy(self)
+
+        for name, value in vars(self).items():
+            if "__roi_lock" in name:
+                setattr(clone, name, Lock())
+            elif "__annotation_scene" in name:
+                setattr(clone, name, copy.copy(value))
+            else:
+                setattr(clone, name, copy.deepcopy(value, memo))
+        return clone
+
     def append_metadata_item(
         self, data: IMetadata, model: Optional[ModelEntity] = None
     ):

--- a/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import datetime
-from copy import deepcopy
+from copy import copy
 from typing import List
 
 import numpy as np
@@ -566,7 +566,7 @@ class TestDatasetItemEntity:
         self.compare_denormalized_annotations(result_annotations, expected_annotations)
 
         # Check that get_annotations only returns the annotations whose center falls within the ROI
-        partial_box_dataset_item = deepcopy(full_box_roi_dataset_item)
+        partial_box_dataset_item = copy(full_box_roi_dataset_item)
         partial_box_dataset_item.roi = Annotation(
             shape=Rectangle(x1=0.0, y1=0.0, x2=0.4, y2=0.5), labels=[]
         )
@@ -882,49 +882,6 @@ class TestDatasetItemEntity:
         assert dataset_item == unequal_metadata_dataset_item
         # Checking value returned by __eq__ method for DatasetItemEntity object compared to different type object
         assert not dataset_item == str
-
-    @pytest.mark.priority_medium
-    @pytest.mark.unit
-    @pytest.mark.reqids(Requirements.REQ_1)
-    def test_dataset_item_deepcopy(self):
-        """
-        <b>Description:</b>
-        Check DatasetItemEntity class __deepcopy__ method
-
-        <b>Input data:</b>
-        DatasetItemEntity class objects with specified "media", "annotation_scene", "roi", "metadata" and "subset"
-        parameters
-
-        <b>Expected results:</b>
-        Test passes if DatasetItemEntity object created by __deepcopy__ method is equal to expected
-        """
-        dataset_item = DatasetItemParameters().dataset_item()
-        copy_dataset = deepcopy(dataset_item)
-        assert (
-            dataset_item._DatasetItemEntity__roi_lock
-            != copy_dataset._DatasetItemEntity__roi_lock
-        )
-        assert np.array_equal(dataset_item.media.numpy, copy_dataset.media.numpy)
-        assert (
-            dataset_item.annotation_scene.annotations
-            == copy_dataset.annotation_scene.annotations
-        )
-        assert (
-            dataset_item.annotation_scene.creation_date
-            == copy_dataset.annotation_scene.creation_date
-        )
-        assert (
-            dataset_item.annotation_scene.editor_name
-            == copy_dataset.annotation_scene.editor_name
-        )
-        assert dataset_item.annotation_scene.id_ == copy_dataset.annotation_scene.id_
-        assert dataset_item.annotation_scene.kind == copy_dataset.annotation_scene.kind
-        assert (
-            dataset_item.annotation_scene.shapes == copy_dataset.annotation_scene.shapes
-        )
-        assert dataset_item.roi == copy_dataset.roi
-        assert dataset_item.get_metadata() == copy_dataset.get_metadata()
-        assert dataset_item.subset == copy_dataset.subset
 
     @pytest.mark.priority_medium
     @pytest.mark.unit

--- a/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
+++ b/ote_sdk/ote_sdk/tests/entities/test_dataset_item.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import datetime
-from copy import copy
+from copy import deepcopy
 from typing import List
 
 import numpy as np
@@ -566,7 +566,7 @@ class TestDatasetItemEntity:
         self.compare_denormalized_annotations(result_annotations, expected_annotations)
 
         # Check that get_annotations only returns the annotations whose center falls within the ROI
-        partial_box_dataset_item = copy(full_box_roi_dataset_item)
+        partial_box_dataset_item = deepcopy(full_box_roi_dataset_item)
         partial_box_dataset_item.roi = Annotation(
             shape=Rectangle(x1=0.0, y1=0.0, x2=0.4, y2=0.5), labels=[]
         )
@@ -882,6 +882,49 @@ class TestDatasetItemEntity:
         assert dataset_item == unequal_metadata_dataset_item
         # Checking value returned by __eq__ method for DatasetItemEntity object compared to different type object
         assert not dataset_item == str
+
+    @pytest.mark.priority_medium
+    @pytest.mark.unit
+    @pytest.mark.reqids(Requirements.REQ_1)
+    def test_dataset_item_deepcopy(self):
+        """
+        <b>Description:</b>
+        Check DatasetItemEntity class __deepcopy__ method
+
+        <b>Input data:</b>
+        DatasetItemEntity class objects with specified "media", "annotation_scene", "roi", "metadata" and "subset"
+        parameters
+
+        <b>Expected results:</b>
+        Test passes if DatasetItemEntity object created by __deepcopy__ method is equal to expected
+        """
+        dataset_item = DatasetItemParameters().dataset_item()
+        copy_dataset = deepcopy(dataset_item)
+        assert (
+            dataset_item._DatasetItemEntity__roi_lock
+            != copy_dataset._DatasetItemEntity__roi_lock
+        )
+        assert np.array_equal(dataset_item.media.numpy, copy_dataset.media.numpy)
+        assert (
+            dataset_item.annotation_scene.annotations
+            == copy_dataset.annotation_scene.annotations
+        )
+        assert (
+            dataset_item.annotation_scene.creation_date
+            == copy_dataset.annotation_scene.creation_date
+        )
+        assert (
+            dataset_item.annotation_scene.editor_name
+            == copy_dataset.annotation_scene.editor_name
+        )
+        assert dataset_item.annotation_scene.id_ == copy_dataset.annotation_scene.id_
+        assert dataset_item.annotation_scene.kind == copy_dataset.annotation_scene.kind
+        assert (
+            dataset_item.annotation_scene.shapes == copy_dataset.annotation_scene.shapes
+        )
+        assert dataset_item.roi == copy_dataset.roi
+        assert dataset_item.get_metadata() == copy_dataset.get_metadata()
+        assert dataset_item.subset == copy_dataset.subset
 
     @pytest.mark.priority_medium
     @pytest.mark.unit


### PR DESCRIPTION
* Remove unnecessary deepcopy calls
* Force deepcopy -> copy for DatasetItem.__annotations_scene

Test build: https://ci-ote.iotg.sclab.intel.com/job/ote/job/pr-ote-test/475/