### PR TITLE
fix bug about override_configs in MPA task

### DIFF
--- a/external/model-preparation-algorithm/mpa_tasks/apis/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/task.py
@@ -160,6 +160,10 @@ class BaseTask:
         recipe_hparams = self._init_recipe_hparam()
         if len(recipe_hparams) > 0:
             self._recipe_cfg.merge_from_dict(recipe_hparams)
+        if "custom_hooks" in self.override_configs:
+            override_custom_hooks = self.override_configs.pop("custom_hooks")
+            for override_custom_hook in override_custom_hooks:
+                update_or_add_custom_hook(self._recipe_cfg, ConfigDict(override_custom_hook))
         if len(self.override_configs) > 0:
             logger.info(f"before override configs merging = {self._recipe_cfg}")
             self._recipe_cfg.merge_from_dict(self.override_configs)


### PR DESCRIPTION
This PR fixes bug about override_configs in MPA task.
if custom_hooks is in override_configs, then custom hooks is not appended to existing custom_hooks but override it.
This PR modifies code to make custom_hooks to append to existing custom hooks.