### PR TITLE
[MPA] CVS-89088 declare AL capabilities in mpa tasks

### DIFF
--- a/external/model-preparation-algorithm/configs/classification/efficientnet_b0_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/efficientnet_b0_cls_incr/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../deep-object-reid/configs/ote_custom_classification/efficientnet_b0/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/classification/efficientnet_v2_s_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/efficientnet_v2_s_cls_incr/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_075_cls_incr/template_experiment.yaml
+++ b/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_075_cls_incr/template_experiment.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_075/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../deep-object-reid/configs/ote_custom_classification/mobilenet_v3_large_1/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/classification/mobilenet_v3_small_cls_incr/template_experiment.yaml
+++ b/external/model-preparation-algorithm/configs/classification/mobilenet_v3_small_cls_incr/template_experiment.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../deep-object-reid/configs/ote_custom_classification/mobilenet_v3_small/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/detection/cspdarknet_yolox_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/detection/cspdarknet_yolox_cls_incr/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/custom-object-detection/cspdarknet_YOLOX/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/detection/mobilenetv2_atss_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/detection/mobilenetv2_atss_cls_incr/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/custom-object-detection/gen3_mobilenetV2_ATSS/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/detection/mobilenetv2_ssd_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/detection/mobilenetv2_ssd_cls_incr/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/custom-object-detection/gen3_mobilenetV2_SSD/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/detection/resnet50_vfnet_cls_incr/template_experimental.yaml
+++ b/external/model-preparation-algorithm/configs/detection/resnet50_vfnet_cls_incr/template_experimental.yaml
@@ -16,7 +16,8 @@ entrypoints:
   openvino: detection_tasks.apis.detection.OpenVINODetectionTask
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/custom-counting-instance-seg/efficientnetb2b_maskrcnn/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/custom-counting-instance-seg/resnet50_maskrcnn/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/rotated_detection/efficientnetb2b_maskrcnn/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:

--- a/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/template.yaml
@@ -18,7 +18,8 @@ entrypoints:
 base_model_path: ../../../../mmdetection/configs/rotated_detection/resnet50_maskrcnn/template_experimental.yaml
 
 # Capabilities.
-capabilities: []
+capabilities:
+  - compute_representations
 
 # Hyperparameters.
 hyper_parameters:


### PR DESCRIPTION
## Summary

- add the capability `compute_representations` to MPA model templates. It declares the ability of the task to generate Tensor metadata of type "representation_vector".