### PR TITLE
Num_workers=0 for classification tasks

### DIFF
--- a/external/model-preparation-algorithm/configs/classification/configuration.yaml
+++ b/external/model-preparation-algorithm/configs/classification/configuration.yaml
@@ -60,7 +60,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    visible_in_ui: true
+    visible_in_ui: false
     warning: null
   num_iters:
     affects_outcome_of: TRAINING

--- a/external/model-preparation-algorithm/configs/classification/efficientnet_b0_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/efficientnet_b0_cls_incr/template.yaml
@@ -30,12 +30,12 @@ hyper_parameters:
         default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
-        default_value: 4
+        default_value: 0
       learning_rate:
-        default_value: 0.007
+        default_value: 0.025
         auto_hpo_state: POSSIBLE
       num_iters:
-        default_value: 20
+        default_value: 90
     algo_backend:
       train_type:
         default_value: Incremental

--- a/external/model-preparation-algorithm/configs/classification/efficientnet_b0_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/efficientnet_b0_cls_incr/template.yaml
@@ -32,10 +32,10 @@ hyper_parameters:
       num_workers:
         default_value: 0
       learning_rate:
-        default_value: 0.025
+        default_value: 0.007
         auto_hpo_state: POSSIBLE
       num_iters:
-        default_value: 90
+        default_value: 20
     algo_backend:
       train_type:
         default_value: Incremental

--- a/external/model-preparation-algorithm/configs/classification/efficientnet_v2_s_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/efficientnet_v2_s_cls_incr/template.yaml
@@ -30,12 +30,12 @@ hyper_parameters:
         default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
-        default_value: 4
+        default_value: 0
       learning_rate:
-        default_value: 0.007
+        default_value: 0.025
         auto_hpo_state: POSSIBLE
       num_iters:
-        default_value: 20
+        default_value: 90
     algo_backend:
       train_type:
         default_value: Incremental

--- a/external/model-preparation-algorithm/configs/classification/efficientnet_v2_s_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/efficientnet_v2_s_cls_incr/template.yaml
@@ -32,10 +32,10 @@ hyper_parameters:
       num_workers:
         default_value: 0
       learning_rate:
-        default_value: 0.025
+        default_value: 0.007
         auto_hpo_state: POSSIBLE
       num_iters:
-        default_value: 90
+        default_value: 20
     algo_backend:
       train_type:
         default_value: Incremental

--- a/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -30,14 +30,14 @@ hyper_parameters:
         default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
-        default_value: 4
+        default_value: 0
       learning_rate:
         default_value: 0.016
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 0
       num_iters:
-        default_value: 20
+        default_value: 90
     algo_backend:
       train_type:
         default_value: Incremental

--- a/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -35,7 +35,7 @@ hyper_parameters:
         default_value: 0.016
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 0
+        default_value: 100
       num_iters:
         default_value: 20
     algo_backend:

--- a/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -37,7 +37,7 @@ hyper_parameters:
       learning_rate_warmup_iters:
         default_value: 0
       num_iters:
-        default_value: 90
+        default_value: 20
     algo_backend:
       train_type:
         default_value: Incremental


### PR DESCRIPTION
## This PR includes:
### Summary:
- Disabled max_num_epochs on UI (we are only using num_iters)
- Changed to num_workers=0 for classification tasks
- Update MPA commit to disable persistent_workers (only operates with num_workers > 0)