### PR TITLE
[ANOMALY] Fix local anomaly segmentation performance bug

### DIFF
--- a/ote_sdk/ote_sdk/utils/dataset_utils.py
+++ b/ote_sdk/ote_sdk/utils/dataset_utils.py
@@ -152,8 +152,9 @@ def split_local_global_resultset(
     :param resultset: Input result set
     :return: Globally annotated result set, locally annotated result set
     """
-    global_gt_dataset, local_gt_dataset = split_local_global_dataset(
-        resultset.ground_truth_dataset
+    global_gt_dataset = get_global_subset(resultset.ground_truth_dataset)
+    local_gt_dataset = get_local_subset(
+        resultset.ground_truth_dataset, include_normal=False
     )
     local_idx = get_fully_annotated_idx(resultset.ground_truth_dataset)
     global_pred_dataset = get_global_subset(resultset.prediction_dataset)


### PR DESCRIPTION
This PR fixes a bug in the anomaly segmentation performance computation. The full-image bounding boxes for the normal images of the ground truth dataset were included in the Dice score computation, but not the normal predictions of the prediction dataset. This resulted in underestimation of the performance. 

Fixed by excluding the normal annotations from the computation.