### PR TITLE
[CVS-89912] Fixed config path computation

### DIFF
--- a/external/anomaly/tasks/nncf.py
+++ b/external/anomaly/tasks/nncf.py
@@ -109,8 +109,9 @@ class NNCFTask(InferenceTask, IOptimizationTask):
                 classification or segmentation model with/without weights.
         """
         # replaces the templates dir with configs and removes task type
+        anomaly_dir = self.base_dir.partition("/templates/")[0]
         nncf_config_path = os.path.join(
-            self.base_dir.partition("templates")[0], "configs", self.base_dir.split("/")[-1], "compression_config.json"
+            anomaly_dir, "configs", self.base_dir.split("/")[-1], "compression_config.json"
         )
 
         with open(nncf_config_path, encoding="utf8") as nncf_config_file:


### PR DESCRIPTION
**Description** 
Fixed how a path to NNCF config file is computed so that optimization of anomaly classification task would start.

Ticket: https://jira.devtools.intel.com/browse/CVS-89912
BMM: https://10.211.120.60/