### PR TITLE
[CVS-82892] Removed xfail test decorator

### DIFF
--- a/external/deep-object-reid/tests/ote_cli/test_classification.py
+++ b/external/deep-object-reid/tests/ote_cli/test_classification.py
@@ -141,7 +141,6 @@ class TestToolsClassification:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
-    @pytest.mark.xfail(reason="CVS-82892")
     def test_nncf_eval(self, template):
         if template.entrypoints.nncf is None:
             pytest.skip("nncf entrypoint is none")


### PR DESCRIPTION
CVS-82892 is not reproducible. Removed xfail decorator.