### PR TITLE
[CVS-90400, CVS-91015] NNCF pruning supported tweaks

### DIFF
--- a/external/anomaly/configs/draem/configuration.yaml
+++ b/external/anomaly/configs/draem/configuration.yaml
@@ -182,7 +182,7 @@ nncf_optimization:
     auto_hpo_value: null
     default_value: false
     description: Whether filter pruning is supported
-    editable: true
+    editable: false
     header: Whether filter pruning is supported
     type: BOOLEAN
     ui_rules:
@@ -190,7 +190,8 @@ nncf_optimization:
       operator: AND
       rules: []
       type: UI_RULES
-    visible_in_ui: true
+    value: false
+    visible_in_ui: false
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/anomaly/configs/padim/configuration.yaml
+++ b/external/anomaly/configs/padim/configuration.yaml
@@ -121,7 +121,7 @@ nncf_optimization:
     auto_hpo_value: null
     default_value: false
     description: Whether filter pruning is supported
-    editable: true
+    editable: false
     header: Whether filter pruning is supported
     type: BOOLEAN
     ui_rules:
@@ -130,7 +130,7 @@ nncf_optimization:
       rules: []
       type: UI_RULES
     value: false
-    visible_in_ui: true
+    visible_in_ui: false
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/anomaly/configs/stfpm/configuration.yaml
+++ b/external/anomaly/configs/stfpm/configuration.yaml
@@ -250,7 +250,7 @@ nncf_optimization:
     auto_hpo_value: null
     default_value: false
     description: Whether filter pruning is supported
-    editable: true
+    editable: false
     header: Whether filter pruning is supported
     type: BOOLEAN
     ui_rules:
@@ -259,7 +259,7 @@ nncf_optimization:
       rules: []
       type: UI_RULES
     value: false
-    visible_in_ui: true
+    visible_in_ui: false
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template_experimental.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template_experimental.yaml
@@ -43,7 +43,7 @@ hyper_parameters:
       enable_pruning:
         default_value: false
       pruning_supported:
-        default_value: true
+        default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
 


### PR DESCRIPTION
Tweaked some pruning related parameters:
- CVS-90400 Disabled pruning for EfficientNet-V2-S as it is not working as expected
- CVS-91015 Turned off `pruning_supported` parameter visibility for anomaly models