### PR TITLE
Speedup  reading images meta

### DIFF
--- a/ote_sdk/ote_sdk/entities/image.py
+++ b/ote_sdk/ote_sdk/entities/image.py
@@ -59,8 +59,8 @@ class Image(IMedia2DEntity):
             return self.__data.shape[0], self.__data.shape[1]
         try:
             width, height = imagesize.get(self.__file_path)
-            if width <= 0 or height <=0:
-                raise ValueError('Invalide image size')
+            if width <= 0 or height <= 0:
+                raise ValueError("Invalide image size")
         except ValueError:
             image = cv2.imread(self.__file_path)
             height, width = image.shape[:2]

--- a/ote_sdk/ote_sdk/entities/image.py
+++ b/ote_sdk/ote_sdk/entities/image.py
@@ -8,6 +8,7 @@
 from typing import Optional, Tuple
 
 import cv2
+import imagesize
 import numpy as np
 
 from ote_sdk.entities.annotation import Annotation
@@ -56,9 +57,14 @@ class Image(IMedia2DEntity):
         """
         if self.__data is not None:
             return self.__data.shape[0], self.__data.shape[1]
-        # TODO(pdruzhkov). Get image size w/o reading & decoding its data.
-        image = cv2.imread(self.__file_path)
-        return image.shape[:2]
+        try:
+            width, height = imagesize.get(self.__file_path)
+            if width <= 0 or height <=0:
+                raise ValueError('Invalide image size')
+        except ValueError:
+            image = cv2.imread(self.__file_path)
+            height, width = image.shape[:2]
+        return height, width
 
     @property
     def numpy(self) -> np.ndarray:

--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -7,3 +7,4 @@ pymongo==3.12.0
 omegaconf==2.1.*
 natsort>=6.0.0
 attrs>=21.2.0
+imagesize==1.4.1

--- a/otx/api/entities/image.py
+++ b/otx/api/entities/image.py
@@ -8,6 +8,7 @@
 from typing import Optional, Tuple
 
 import cv2
+import imagesize
 import numpy as np
 
 from otx.api.entities.annotation import Annotation
@@ -55,9 +56,14 @@ class Image(IMedia2DEntity):
         """
         if self.__data is not None:
             return self.__data.shape[0], self.__data.shape[1]
-        # TODO(pdruzhkov). Get image size w/o reading & decoding its data.
-        image = cv2.imread(self.__file_path)
-        return image.shape[:2]
+        try:
+            width, height = imagesize.get(self.__file_path)
+            if width <= 0 or height <=0:
+                raise ValueError('Invalide image size')
+        except ValueError:
+            image = cv2.imread(self.__file_path)
+            height, width = image.shape[:2]
+        return height, width
 
     @property
     def numpy(self) -> np.ndarray:

--- a/otx/api/entities/image.py
+++ b/otx/api/entities/image.py
@@ -58,8 +58,8 @@ class Image(IMedia2DEntity):
             return self.__data.shape[0], self.__data.shape[1]
         try:
             width, height = imagesize.get(self.__file_path)
-            if width <= 0 or height <=0:
-                raise ValueError('Invalide image size')
+            if width <= 0 or height <= 0:
+                raise ValueError("Invalide image size")
         except ValueError:
             image = cv2.imread(self.__file_path)
             height, width = image.shape[:2]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,3 +17,4 @@ torchvision>=0.9.1, <=0.10.1
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
 hpopt@git+https://github.com/openvinotoolkit/hyper_parameter_optimization@develop
+imagesize==1.4.1


### PR DESCRIPTION
Speedup datasets loading process in OTE CLI scenario: instead of a full image, now only header is read on ote_sdk dataset preparation step.
On VOC start of a multilabel training takes now ~14s vs 50s.