### PR TITLE
Revert "[CVS-90400, CVS-91015] NNCF pruning supported tweaks"

### DIFF
--- a/external/anomaly/configs/draem/configuration.yaml
+++ b/external/anomaly/configs/draem/configuration.yaml
@@ -182,7 +182,7 @@ nncf_optimization:
     auto_hpo_value: null
     default_value: false
     description: Whether filter pruning is supported
-    editable: false
+    editable: true
     header: Whether filter pruning is supported
     type: BOOLEAN
     ui_rules:
@@ -190,8 +190,7 @@ nncf_optimization:
       operator: AND
       rules: []
       type: UI_RULES
-    value: false
-    visible_in_ui: false
+    visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/anomaly/configs/padim/configuration.yaml
+++ b/external/anomaly/configs/padim/configuration.yaml
@@ -121,7 +121,7 @@ nncf_optimization:
     auto_hpo_value: null
     default_value: false
     description: Whether filter pruning is supported
-    editable: false
+    editable: true
     header: Whether filter pruning is supported
     type: BOOLEAN
     ui_rules:
@@ -130,7 +130,7 @@ nncf_optimization:
       rules: []
       type: UI_RULES
     value: false
-    visible_in_ui: false
+    visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/anomaly/configs/stfpm/configuration.yaml
+++ b/external/anomaly/configs/stfpm/configuration.yaml
@@ -250,7 +250,7 @@ nncf_optimization:
     auto_hpo_value: null
     default_value: false
     description: Whether filter pruning is supported
-    editable: false
+    editable: true
     header: Whether filter pruning is supported
     type: BOOLEAN
     ui_rules:
@@ -259,7 +259,7 @@ nncf_optimization:
       rules: []
       type: UI_RULES
     value: false
-    visible_in_ui: false
+    visible_in_ui: true
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template_experimental.yaml
+++ b/external/deep-object-reid/configs/ote_custom_classification/efficientnet_v2_s/template_experimental.yaml
@@ -43,7 +43,7 @@ hyper_parameters:
       enable_pruning:
         default_value: false
       pruning_supported:
-        default_value: false
+        default_value: true
       maximal_accuracy_degradation:
         default_value: 1.0
 


### PR DESCRIPTION
Reverting since a near-duplicate [PR](https://github.com/openvinotoolkit/training_extensions/pull/1256) was merged to release branch.