### PR TITLE
[CVS-91906] [POT] High RAM footprint fix

### DIFF
--- a/external/mmdetection/configs/custom-counting-instance-seg/efficientnetb2b_maskrcnn/template_experimental.yaml
+++ b/external/mmdetection/configs/custom-counting-instance-seg/efficientnetb2b_maskrcnn/template_experimental.yaml
@@ -35,6 +35,9 @@ hyper_parameters:
         default_value: 200
       num_iters:
         default_value: 300
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/mmdetection/configs/custom-counting-instance-seg/resnet50_maskrcnn/template_experimental.yaml
+++ b/external/mmdetection/configs/custom-counting-instance-seg/resnet50_maskrcnn/template_experimental.yaml
@@ -35,6 +35,9 @@ hyper_parameters:
         default_value: 200
       num_iters:
         default_value: 300
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/mmdetection/configs/rotated_detection/efficientnetb2b_maskrcnn/template_experimental.yaml
+++ b/external/mmdetection/configs/rotated_detection/efficientnetb2b_maskrcnn/template_experimental.yaml
@@ -35,6 +35,9 @@ hyper_parameters:
         default_value: 200
       num_iters:
         default_value: 300
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/mmdetection/configs/rotated_detection/resnet50_maskrcnn/template_experimental.yaml
+++ b/external/mmdetection/configs/rotated_detection/resnet50_maskrcnn/template_experimental.yaml
@@ -35,6 +35,9 @@ hyper_parameters:
         default_value: 200
       num_iters:
         default_value: 300
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/mmdetection/detection_tasks/apis/detection/configuration.py
+++ b/external/mmdetection/detection_tasks/apis/detection/configuration.py
@@ -163,6 +163,14 @@ class OTEDetectionConfig(ConfigurableParameters):
             max_value=maxsize
         )
 
+        stat_requests_number = configurable_integer(
+            header="Number of requests",
+            description="Number of requests during statistics collection",
+            default_value=0,
+            min_value=0,
+            max_value=maxsize
+        )
+
         preset = selectable(default_value=POTQuantizationPreset.PERFORMANCE, header="Preset",
                             description="Quantization preset that defines quantization scheme",
                             editable=True, visible_in_ui=True)

--- a/external/mmdetection/detection_tasks/apis/detection/configuration.yaml
+++ b/external/mmdetection/detection_tasks/apis/detection/configuration.yaml
@@ -184,6 +184,23 @@ pot_parameters:
     value: 300
     visible_in_ui: true
     warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: false
 nncf_optimization:

--- a/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
@@ -16,6 +16,7 @@ import attr
 import copy
 import io
 import json
+import multiprocessing
 import numpy as np
 import os
 import ote_sdk.usecases.exportable_code.demo as demo
@@ -374,7 +375,8 @@ class OpenVINODetectionTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IO
             optimization_parameters.update_progress(10)
 
         engine_config = ADDict({
-            'device': 'CPU'
+            'device': 'CPU',
+            'stat_requests_number': min(self.hparams.pot_parameters.stat_requests_number, multiprocessing.cpu_count()),
         })
 
         stat_subset_size = self.hparams.pot_parameters.stat_subset_size

--- a/external/model-preparation-algorithm/configs/detection/configuration.yaml
+++ b/external/model-preparation-algorithm/configs/detection/configuration.yaml
@@ -225,6 +225,23 @@ pot_parameters:
     value: 300
     visible_in_ui: True
     warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 nncf_optimization:

--- a/external/model-preparation-algorithm/configs/instance-segmentation/configuration.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/configuration.yaml
@@ -225,6 +225,23 @@ pot_parameters:
     value: 300
     visible_in_ui: True
     warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 nncf_optimization:

--- a/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -36,6 +36,9 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/template.yaml
@@ -36,6 +36,9 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/model-preparation-algorithm/configs/rotated-detection/configuration.yaml
+++ b/external/model-preparation-algorithm/configs/rotated-detection/configuration.yaml
@@ -225,6 +225,23 @@ pot_parameters:
     value: 300
     visible_in_ui: True
     warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 nncf_optimization:

--- a/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/template.yaml
@@ -36,6 +36,9 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/template.yaml
@@ -36,6 +36,9 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true

--- a/external/model-preparation-algorithm/mpa_tasks/apis/config.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/config.py
@@ -157,6 +157,14 @@ class BaseConfig(ConfigurableParameters):
             max_value=maxsize
         )
 
+        stat_requests_number = configurable_integer(
+            header="Number of requests",
+            description="Number of requests during statistics collection",
+            default_value=0,
+            min_value=0,
+            max_value=maxsize
+        )
+
     @attrs
     class BaseAlgoBackendParameters(ParameterGroup):
         train_type = selectable(default_value=TrainType.Incremental,


### PR DESCRIPTION
POT was noticed to have high RAM consumption for MaskRCNN models [CVS-91906](https://jira.devtools.intel.com/browse/CVS-91906). This is due to high number of requests during statistics collection. By default `stat_requests_number` is 0 which means that the number of requests equals the number of CPU cores. For example, this results in 40+ GB RAM footprint when run on an 18 core machine.

Added a custom value for `stat_requests_number` parameter for EfficientNet and ResNet based MaskRCNN models.