### PR TITLE
[Anomaly Task] 🚨 Fix nncf keys

### DIFF
--- a/external/anomaly/tasks/nncf.py
+++ b/external/anomaly/tasks/nncf.py
@@ -132,9 +132,9 @@ class NNCFTask(InferenceTask, IOptimizationTask):
             for key in model_data["model"].keys():
                 if key.startswith("model."):
                     new_key = key.replace("model.", "")
-                    res = re.search(r"nncf_module\.(\w+)_backbone\.(.*)", new_key)
+                    res = re.search(r"nncf_module\.(\w+)_feature_extractor\.(.*)", new_key)
                     if res:
-                        new_key = f"nncf_module.{res.group(1)}_model.backbone.{res.group(2)}"
+                        new_key = f"nncf_module.{res.group(1)}_model.feature_extractor.{res.group(2)}"
                     nncf_modules[new_key] = model_data["model"][key]
                 else:
                     pl_modules[key] = model_data["model"][key]


### PR DESCRIPTION
# Description

- NNCF export refers to `model.backbone` which has been replaced by `model.feature_extractor`. This PR updates the references