### PR TITLE
[NNCF] Early GPU model move

### DIFF
--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/nncf_task.py
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/nncf_task.py
@@ -149,6 +149,9 @@ class OTESegmentationNNCFTask(OTESegmentationInferenceTask, IOptimizationTask):
             raise ValueError(f"No trained model in project. NNCF require pretrained weights to compress the model")
 
         self._compression_ctrl = compression_ctrl
+
+        if torch.cuda.is_available():
+            model.cuda()
         return model
 
 


### PR DESCRIPTION
Fix to enable FP16 NNCF training.
Motivation is to move the model to GPU before ` register_default_init_args` call. If this function is called with a model on CPU, NNCF uses CPU for initialization stage. When model use half precision it leads to runtime error.