### PR TITLE
[OTX] Add Instance-Segmentation model configs

### DIFF
--- a/otx/algorithms/detection/configs/detection/configuration.yaml
+++ b/otx/algorithms/detection/configs/detection/configuration.yaml
@@ -245,20 +245,20 @@ algo_backend:
   header: Algo backend parameters
   train_type:
     affects_outcome_of: NONE
-    default_value: Incremental
+    default_value: INCREMENTAL
     description: Quantization preset that defines quantization scheme
     editable: false
     enum_name: TrainType
     header: Train type
     options:
-      Incremental: "Incremental"
+      INCREMENTAL: "INCREMENTAL"
     type: SELECTABLE
     ui_rules:
       action: DISABLE_EDITING
       operator: AND
       rules: []
       type: UI_RULES
-    value: Incremental
+    value: INCREMENTAL
     visible_in_ui: True
     warning: null
   type: PARAMETER_GROUP

--- a/otx/algorithms/detection/configs/detection/cspdarknet_yolox/template.yaml
+++ b/otx/algorithms/detection/configs/detection/cspdarknet_yolox/template.yaml
@@ -46,7 +46,7 @@ hyper_parameters:
         default_value: 1.0
     algo_backend:
       train_type:
-        default_value: Incremental
+        default_value: INCREMENTAL
 
 # Training resources.
 max_nodes: 1

--- a/otx/algorithms/detection/configs/detection/mobilenetv2_atss/template.yaml
+++ b/otx/algorithms/detection/configs/detection/mobilenetv2_atss/template.yaml
@@ -15,7 +15,6 @@ entrypoints:
   base: otx.algorithms.detection.tasks.DetectionTrainTask
   openvino: otx.algorithms.detection.tasks.OpenVINODetectionTask
   nncf: otx.algorithms.detection.tasks.DetectionNNCFTask
-base_model_path: ../../../../mmdetection/configs/custom-object-detection/gen3_mobilenetV2_ATSS/template_experimental.yaml
 
 # Capabilities.
 capabilities:

--- a/otx/algorithms/detection/configs/detection/mobilenetv2_atss/template.yaml
+++ b/otx/algorithms/detection/configs/detection/mobilenetv2_atss/template.yaml
@@ -46,7 +46,7 @@ hyper_parameters:
         default_value: 1.0
     algo_backend:
       train_type:
-        default_value: Incremental
+        default_value: INCREMENTAL
 
 # Training resources.
 max_nodes: 1

--- a/otx/algorithms/detection/configs/detection/mobilenetv2_ssd/template.yaml
+++ b/otx/algorithms/detection/configs/detection/mobilenetv2_ssd/template.yaml
@@ -15,7 +15,6 @@ entrypoints:
   base: otx.algorithms.detection.tasks.DetectionTrainTask
   openvino: otx.algorithms.detection.tasks.OpenVINODetectionTask
   nncf: otx.algorithms.detection.tasks.DetectionNNCFTask
-base_model_path: ../../../../mmdetection/configs/custom-object-detection/gen3_mobilenetV2_SSD/template_experimental.yaml
 
 # Capabilities.
 capabilities:

--- a/otx/algorithms/detection/configs/detection/mobilenetv2_ssd/template.yaml
+++ b/otx/algorithms/detection/configs/detection/mobilenetv2_ssd/template.yaml
@@ -46,7 +46,7 @@ hyper_parameters:
         default_value: 1.0
     algo_backend:
       train_type:
-        default_value: Incremental
+        default_value: INCREMENTAL
 
 # Training resources.
 max_nodes: 1

--- a/otx/algorithms/detection/configs/detection/resnet50_vfnet/template_experimental.yaml
+++ b/otx/algorithms/detection/configs/detection/resnet50_vfnet/template_experimental.yaml
@@ -34,7 +34,7 @@ hyper_parameters:
         default_value: 100
     algo_backend:
       train_type:
-        default_value: Incremental
+        default_value: INCREMENTAL
 
 # Training resources.
 max_nodes: 1

--- a/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -1,0 +1,392 @@
+description: Configuration for an instance segmentation task
+header: Configuration for an instance segmentation task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description: ""
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_checkpoints:
+    affects_outcome_of: NONE
+    default_value: 5
+    description: ""
+    editable: true
+    header: Number of checkpoints that is done during the single training round
+    max_value: 100
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 100000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 0
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 10
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 10
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    # value: 0.35
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: NONE
+    default_value: Incremental
+    description: Quantization preset that defines quantization scheme
+    editable: false
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 9223372036854775807
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True

--- a/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -245,20 +245,20 @@ algo_backend:
   header: Algo backend parameters
   train_type:
     affects_outcome_of: NONE
-    default_value: Incremental
+    default_value: INCREMENTAL
     description: Quantization preset that defines quantization scheme
     editable: false
     enum_name: TrainType
     header: Train type
     options:
-      Incremental: "Incremental"
+      INCREMENTAL: "INCREMENTAL"
     type: SELECTABLE
     ui_rules:
       action: DISABLE_EDITING
       operator: AND
       rules: []
       type: UI_RULES
-    value: Incremental
+    value: INCREMENTAL
     visible_in_ui: True
     warning: null
   type: PARAMETER_GROUP

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/__init__.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/__init__.py
@@ -1,0 +1,15 @@
+"""Initialization of EfficientNetB2B-MaskRCNN model for Instance-Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/compression_config.json
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/compression_config.json
@@ -1,0 +1,41 @@
+{
+  "base": {
+    "find_unused_parameters": true,
+    "nncf_config": {
+      "target_metric_name": "mAP",
+      "input_info": {
+        "sample_size": [1, 3, 1024, 1024]
+      },
+      "compression": [],
+      "log_dir": "."
+    }
+  },
+  "nncf_quantization": {
+    "optimizer": {
+      "lr": 0.0005
+    },
+    "nncf_config": {
+      "compression": [
+        {
+          "algorithm": "quantization",
+          "initializer": {
+            "range": {
+              "num_init_samples": 1000
+            },
+            "batchnorm_adaptation": {
+              "num_bn_adaptation_samples": 1000
+            }
+          }
+        }
+      ],
+      "accuracy_aware_training": {
+        "mode": "early_exit",
+        "params": {
+          "maximal_absolute_accuracy_degradation": 0.01,
+          "maximal_total_epochs": 20
+        }
+      }
+    }
+  },
+  "order_of_parts": ["nncf_quantization"]
+}

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/data_pipeline.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/data_pipeline.py
@@ -19,6 +19,7 @@
 dataset_type = "CocoDataset"
 img_size = (1024, 1024)
 
+# TODO: A comparison experiment is needed to determine which value is appropriate for to_rgb.
 img_norm_cfg = dict(mean=(103.53, 116.28, 123.675), std=(1.0, 1.0, 1.0), to_rgb=False)
 
 train_pipeline = [

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/data_pipeline.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/data_pipeline.py
@@ -1,0 +1,80 @@
+"""Data Pipeline of EfficientNetB2B model for Instance-Seg Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+dataset_type = "CocoDataset"
+img_size = (1024, 1024)
+
+img_norm_cfg = dict(mean=(103.53, 116.28, 123.675), std=(1.0, 1.0, 1.0), to_rgb=False)
+
+train_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(type="LoadAnnotations", with_bbox=True, with_mask=True, poly2mask=False),
+    dict(type="Resize", img_scale=img_size, keep_ratio=False),
+    dict(type="RandomFlip", flip_ratio=0.5),
+    dict(type="Normalize", **img_norm_cfg),
+    dict(type="Pad", size_divisor=32),
+    dict(type="DefaultFormatBundle"),
+    dict(type="Collect", keys=["img", "gt_bboxes", "gt_labels", "gt_masks"]),
+]
+
+test_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=img_size,
+        flip=False,
+        transforms=[
+            dict(type="Resize", keep_ratio=False),
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **img_norm_cfg),
+            dict(type="Pad", size_divisor=32),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+
+__dataset_type = "CocoDataset"
+__data_root = "data/coco/"
+
+__samples_per_gpu = 4
+
+data = dict(
+    samples_per_gpu=__samples_per_gpu,
+    workers_per_gpu=2,
+    train=dict(
+        type=__dataset_type,
+        ann_file=__data_root + "annotations/instances_train2017.json",
+        img_prefix=__data_root + "train2017/",
+        pipeline=train_pipeline,
+    ),
+    val=dict(
+        type=__dataset_type,
+        ann_file=__data_root + "annotations/instances_val2017.json",
+        img_prefix=__data_root + "val2017/",
+        test_mode=True,
+        pipeline=test_pipeline,
+    ),
+    test=dict(
+        type=__dataset_type,
+        ann_file=__data_root + "annotations/instances_val2017.json",
+        img_prefix=__data_root + "val2017/",
+        test_mode=True,
+        pipeline=test_pipeline,
+    ),
+)

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/hpo_config.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/hpo_config.yaml
@@ -1,0 +1,16 @@
+metric: mAP
+search_algorithm: asha
+early_stop: None
+hp_space:
+  learning_parameters.learning_rate:
+    param_type: qloguniform
+    range:
+      - 0.003
+      - 0.075
+      - 0.001
+  learning_parameters.batch_size:
+    param_type: qloguniform
+    range:
+      - 2
+      - 6
+      - 2

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/model.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/model.py
@@ -1,0 +1,119 @@
+"""Model configuration of EfficientNetB2B-MaskRCNN model for Instance-Seg Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+_base_ = [
+    "../../../../common/adapters/mmcv/configs/backbones/efficientnet_b2b.yaml",
+    "../../base/models/detector.py",
+]
+
+task = "instance-segmentation"
+
+model = dict(
+    type="CustomMaskRCNN",  # Use CustomMaskRCNN for Incremental Learning
+    neck=dict(type="FPN", in_channels=[24, 48, 120, 352], out_channels=80, num_outs=5),
+    rpn_head=dict(
+        type="RPNHead",
+        in_channels=80,
+        feat_channels=80,
+        anchor_generator=dict(type="AnchorGenerator", scales=[8], ratios=[0.5, 1.0, 2.0], strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(type="CrossEntropyLoss", use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+    ),
+    roi_head=dict(
+        type="CustomRoIHead",  # Use CustomROIHead for Ignore mode
+        bbox_roi_extractor=dict(
+            type="SingleRoIExtractor",
+            roi_layer=dict(type="RoIAlign", output_size=7, sampling_ratio=0),
+            out_channels=80,
+            featmap_strides=[4, 8, 16, 32],
+        ),
+        bbox_head=dict(
+            type="Shared2FCBBoxHead",
+            in_channels=80,
+            fc_out_channels=1024,
+            roi_feat_size=7,
+            num_classes=80,
+            bbox_coder=dict(
+                type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[0.1, 0.1, 0.2, 0.2]
+            ),
+            reg_class_agnostic=False,
+            loss_cls=dict(type="CrossEntropyLoss", use_sigmoid=False, loss_weight=1.0),
+            loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+        ),
+        mask_roi_extractor=dict(
+            type="SingleRoIExtractor",
+            roi_layer=dict(type="RoIAlign", output_size=14, sampling_ratio=0),
+            out_channels=80,
+            featmap_strides=[4, 8, 16, 32],
+        ),
+        mask_head=dict(
+            type="FCNMaskHead",
+            num_convs=4,
+            in_channels=80,
+            conv_out_channels=80,
+            num_classes=80,
+            loss_mask=dict(type="CrossEntropyLoss", use_mask=True, loss_weight=1.0),
+        ),
+    ),
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type="MaxIoUAssigner",
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1,
+                gpu_assign_thr=300,
+            ),
+            sampler=dict(type="RandomSampler", num=256, pos_fraction=0.5, neg_pos_ub=-1, add_gt_as_proposals=False),
+            allowed_border=-1,
+            pos_weight=-1,
+            debug=False,
+        ),
+        rpn_proposal=dict(
+            nms_across_levels=False, nms_pre=2000, nms_post=1000, max_num=1000, nms_thr=0.8, min_bbox_size=0
+        ),
+        rcnn=dict(
+            assigner=dict(
+                type="MaxIoUAssigner",
+                pos_iou_thr=0.5,
+                neg_iou_thr=0.5,
+                min_pos_iou=0.5,
+                match_low_quality=True,
+                ignore_iof_thr=-1,
+                gpu_assign_thr=300,
+            ),
+            sampler=dict(type="RandomSampler", num=256, pos_fraction=0.25, neg_pos_ub=-1, add_gt_as_proposals=True),
+            mask_size=28,
+            pos_weight=-1,
+            debug=False,
+        ),
+    ),
+    test_cfg=dict(
+        rpn=dict(nms_across_levels=False, nms_pre=800, nms_post=500, max_num=500, nms_thr=0.8, min_bbox_size=0),
+        rcnn=dict(score_thr=0.05, nms=dict(type="nms", iou_threshold=0.7), max_per_img=500, mask_thr_binary=0.5),
+    ),
+)
+load_from = "https://storage.openvinotoolkit.org/repositories/\
+openvino_training_extensions/models/instance_segmentation/\
+v2/efficientnet_b2b-mask_rcnn-576x576.pth"
+
+fp16 = dict(loss_scale=512.0)
+ignore = True

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Object_Detection_YOLOX
-name: YOLOX
-task_type: DETECTION
+model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_EfficientNetB2B
+name: MaskRCNN-EfficientNetB2B
+task_type: INSTANCE_SEGMENTATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Object Detection for YOLOX
+summary: Class-Incremental Instance Segmentation for MaskRCNN-EfficientNetB2B
 application: ~
 
 # Algo backend.
@@ -26,15 +26,18 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 8
+        default_value: 4
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.0002
+        default_value: 0.015
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
-        default_value: 200
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true
@@ -55,10 +58,5 @@ training_targets:
   - CPU
 
 # Stats.
-gigaflops: 6.5
-size: 20.4
-# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
-# inference_targets:
-#   - CPU
-#   - GPU
-#   - VPU
+gigaflops: 68.48
+size: 13.27

--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -49,7 +49,7 @@ hyper_parameters:
         default_value: 1.0
     algo_backend:
       train_type:
-        default_value: Incremental
+        default_value: INCREMENTAL
 
 # Training resources.
 max_nodes: 1

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/__init__.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/__init__.py
@@ -1,0 +1,15 @@
+"""Initialization of Resnet50-MaskRCNN model for Instance-Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/compression_config.json
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/compression_config.json
@@ -1,0 +1,41 @@
+{
+  "base": {
+    "find_unused_parameters": true,
+    "nncf_config": {
+      "target_metric_name": "mAP",
+      "input_info": {
+        "sample_size": [1, 3, 1344, 800]
+      },
+      "compression": [],
+      "log_dir": "."
+    }
+  },
+  "nncf_quantization": {
+    "optimizer": {
+      "lr": 0.0005
+    },
+    "nncf_config": {
+      "compression": [
+        {
+          "algorithm": "quantization",
+          "initializer": {
+            "range": {
+              "num_init_samples": 1000
+            },
+            "batchnorm_adaptation": {
+              "num_bn_adaptation_samples": 1000
+            }
+          }
+        }
+      ],
+      "accuracy_aware_training": {
+        "mode": "early_exit",
+        "params": {
+          "maximal_absolute_accuracy_degradation": 0.01,
+          "maximal_total_epochs": 20
+        }
+      }
+    }
+  },
+  "order_of_parts": ["nncf_quantization"]
+}

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/data_pipeline.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/data_pipeline.py
@@ -19,6 +19,7 @@
 dataset_type = "CocoDataset"
 img_size = (1344, 800)
 
+# TODO: A comparison experiment is needed to determine which value is appropriate for to_rgb.
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/data_pipeline.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/data_pipeline.py
@@ -1,0 +1,73 @@
+"""Data Pipeline of Resnet model for Instance-Seg Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+dataset_type = "CocoDataset"
+img_size = (1344, 800)
+
+img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+
+train_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(type="LoadAnnotations", with_bbox=True, with_mask=True, poly2mask=False),
+    dict(type="Resize", img_scale=img_size, keep_ratio=False),
+    dict(type="RandomFlip", flip_ratio=0.5),
+    dict(type="Normalize", **img_norm_cfg),
+    dict(type="DefaultFormatBundle"),
+    dict(type="Collect", keys=["img", "gt_bboxes", "gt_labels", "gt_masks"]),
+]
+
+test_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=img_size,
+        flip=False,
+        transforms=[
+            dict(type="Resize", keep_ratio=False),
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+
+data = dict(
+    samples_per_gpu=4,
+    workers_per_gpu=2,
+    train=dict(
+        type=dataset_type,
+        ann_file="data/coco/annotations/instances_train2017.json",
+        img_prefix="data/coco/train2017",
+        pipeline=train_pipeline,
+    ),
+    val=dict(
+        type=dataset_type,
+        test_mode=True,
+        ann_file="data/coco/annotations/instances_val2017.json",
+        img_prefix="data/coco/val2017",
+        pipeline=test_pipeline,
+    ),
+    test=dict(
+        type=dataset_type,
+        test_mode=True,
+        ann_file="data/coco/annotations/instances_val2017.json",
+        img_prefix="data/coco/val2017",
+        pipeline=test_pipeline,
+    ),
+)

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/hpo_config.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/hpo_config.yaml
@@ -1,0 +1,16 @@
+metric: mAP
+search_algorithm: asha
+early_stop: None
+hp_space:
+  learning_parameters.learning_rate:
+    param_type: qloguniform
+    range:
+      - 0.0001
+      - 0.01
+      - 0.001
+  learning_parameters.batch_size:
+    param_type: qloguniform
+    range:
+      - 2
+      - 6
+      - 2

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/model.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/model.py
@@ -1,0 +1,125 @@
+"""Model configuration of Resnet50-MaskRCNN model for Instance-Seg Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+_base_ = ["../../../../common/adapters/mmcv/configs/backbones/resnet50.yaml", "../../base/models/detector.py"]
+
+task = "instance-segmentation"
+
+model = dict(
+    type="CustomMaskRCNN",  # Use CustomMaskRCNN for Incremental Learning
+    neck=dict(type="FPN", in_channels=[256, 512, 1024, 2048], out_channels=256, num_outs=5),
+    rpn_head=dict(
+        type="RPNHead",
+        in_channels=256,
+        feat_channels=256,
+        anchor_generator=dict(type="AnchorGenerator", scales=[8], ratios=[0.5, 1.0, 2.0], strides=[4, 8, 16, 32, 64]),
+        bbox_coder=dict(type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[1.0, 1.0, 1.0, 1.0]),
+        loss_cls=dict(type="CrossEntropyLoss", use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+    ),
+    roi_head=dict(
+        type="CustomRoIHead",  # Use CustomROIHead for Ignore mode
+        bbox_roi_extractor=dict(
+            type="SingleRoIExtractor",
+            roi_layer=dict(type="RoIAlign", output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32],
+        ),
+        bbox_head=dict(
+            type="Shared2FCBBoxHead",
+            in_channels=256,
+            fc_out_channels=1024,
+            roi_feat_size=7,
+            num_classes=80,
+            bbox_coder=dict(
+                type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[0.1, 0.1, 0.2, 0.2]
+            ),
+            reg_class_agnostic=False,
+            loss_cls=dict(type="CrossEntropyLoss", use_sigmoid=False, loss_weight=1.0),
+            loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+        ),
+        mask_roi_extractor=dict(
+            type="SingleRoIExtractor",
+            roi_layer=dict(type="RoIAlign", output_size=14, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32],
+        ),
+        mask_head=dict(
+            type="FCNMaskHead",
+            num_convs=4,
+            in_channels=256,
+            conv_out_channels=256,
+            num_classes=80,
+            loss_mask=dict(type="CrossEntropyLoss", use_mask=True, loss_weight=1.0),
+        ),
+    ),
+    train_cfg=dict(
+        rpn=dict(
+            assigner=dict(
+                type="MaxIoUAssigner",
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.3,
+                match_low_quality=True,
+                ignore_iof_thr=-1,
+                gpu_assign_thr=300,
+            ),
+            sampler=dict(type="RandomSampler", num=256, pos_fraction=0.5, neg_pos_ub=-1, add_gt_as_proposals=False),
+            allowed_border=-1,
+            pos_weight=-1,
+            debug=False,
+        ),
+        rpn_proposal=dict(
+            nms_across_levels=False, nms_pre=2000, nms_post=1000, max_num=1000, nms_thr=0.7, min_bbox_size=0
+        ),
+        rcnn=dict(
+            assigner=dict(
+                type="MaxIoUAssigner",
+                pos_iou_thr=0.5,
+                neg_iou_thr=0.5,
+                min_pos_iou=0.5,
+                match_low_quality=True,
+                ignore_iof_thr=-1,
+                gpu_assign_thr=300,
+            ),
+            sampler=dict(type="RandomSampler", num=512, pos_fraction=0.25, neg_pos_ub=-1, add_gt_as_proposals=True),
+            mask_size=28,
+            pos_weight=-1,
+            debug=False,
+        ),
+    ),
+    test_cfg=dict(
+        rpn=dict(
+            nms_across_levels=False,
+            nms_pre=1000,
+            nms_post=1000,
+            max_num=1000,
+            nms_thr=0.7,
+            max_per_img=1000,
+            min_bbox_size=0,
+        ),
+        rcnn=dict(
+            score_thr=0.05, nms=dict(type="nms", iou_threshold=0.5, max_num=100), max_per_img=100, mask_thr_binary=0.5
+        ),
+    ),
+)
+load_from = "https://download.openmmlab.com/mmdetection/\
+v2.0/mask_rcnn/mask_rcnn_r50_fpn_mstrain-poly_3x_coco/\
+mask_rcnn_r50_fpn_mstrain-poly_3x_coco_20210524_201154-21b550bb.pth"
+
+ignore = True

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/template.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/template.yaml
@@ -49,7 +49,7 @@ hyper_parameters:
         default_value: 1.0
     algo_backend:
       train_type:
-        default_value: Incremental
+        default_value: INCREMENTAL
 
 # Training resources.
 max_nodes: 1

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/template.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Object_Detection_YOLOX
-name: YOLOX
-task_type: DETECTION
+model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_ResNet50
+name: MaskRCNN-ResNet50
+task_type: INSTANCE_SEGMENTATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Object Detection for YOLOX
+summary: Class-Incremental Instance Segmentation for MaskRCNN-ResNet50
 application: ~
 
 # Algo backend.
@@ -26,15 +26,18 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 8
+        default_value: 4
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.0002
+        default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
-        default_value: 200
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 2
     nncf_optimization:
       enable_quantization:
         default_value: true
@@ -55,10 +58,5 @@ training_targets:
   - CPU
 
 # Stats.
-gigaflops: 6.5
-size: 20.4
-# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
-# inference_targets:
-#   - CPU
-#   - GPU
-#   - VPU
+gigaflops: 533.8
+size: 177.9

--- a/otx/algorithms/detection/tools/instance_segmentation_sample.py
+++ b/otx/algorithms/detection/tools/instance_segmentation_sample.py
@@ -1,0 +1,393 @@
+"""Sample Code of otx training for instance segmentation."""
+
+# Copyright (C) 2021-2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import argparse
+import sys
+
+import cv2
+import numpy as np
+from mmcv.utils import get_logger
+
+from otx.algorithms.detection.utils import get_task_class
+from otx.api.configuration.helper import create
+from otx.api.entities.annotation import (
+    Annotation,
+    AnnotationSceneEntity,
+    AnnotationSceneKind,
+)
+from otx.api.entities.dataset_item import DatasetItemEntity
+from otx.api.entities.datasets import DatasetEntity
+from otx.api.entities.image import Image
+from otx.api.entities.inference_parameters import InferenceParameters
+from otx.api.entities.label import Domain, LabelEntity
+from otx.api.entities.label_schema import LabelSchemaEntity
+from otx.api.entities.model import ModelEntity
+from otx.api.entities.model_template import parse_model_template
+from otx.api.entities.optimization_parameters import OptimizationParameters
+from otx.api.entities.resultset import ResultSetEntity
+from otx.api.entities.scored_label import ScoredLabel
+from otx.api.entities.shapes.polygon import Point, Polygon
+from otx.api.entities.subset import Subset
+from otx.api.entities.task_environment import TaskEnvironment
+from otx.api.usecases.tasks.interfaces.export_interface import ExportType
+from otx.api.usecases.tasks.interfaces.optimization_interface import OptimizationType
+
+logger = get_logger(name="sample")
+
+# pylint: disable=too-many-locals, too-many-statements
+
+
+def parse_args():
+    """Parse function for getting model template & check export."""
+    parser = argparse.ArgumentParser(description="Sample showcasing the new API")
+    parser.add_argument("template_file_path", help="path to template file")
+    parser.add_argument("--export", action="store_true")
+    return parser.parse_args()
+
+
+colors = dict(red=(255, 0, 0), green=(0, 255, 0))
+
+
+def load_test_dataset(data_type, task_type=Domain.INSTANCE_SEGMENTATION):
+    """Load Sample dataset for Instance_segmentation."""
+
+    def gen_circle_image(resolution):
+        width, height = resolution
+        image = np.full([height, width, 3], fill_value=255, dtype=np.uint8)
+        gt_label = np.full([height, width, 1], fill_value=0, dtype=np.uint8)
+        cv2.circle(image, (int(height / 2), int(width / 2)), 90, (0, 0, 255), -1)
+        cv2.circle(gt_label, (int(height / 2), int(width / 2)), 90, 1, -1)
+        return (image, gt_label)
+
+    def gen_rect_image(resolution):
+        width, height = resolution
+        image = np.full([height, width, 3], fill_value=255, dtype=np.uint8)
+        gt_label = np.full([height, width, 1], fill_value=0, dtype=np.uint8)
+        cv2.rectangle(image, (int(height * 0.1), int(width * 0.1)), (int(height / 2), int(width / 2)), (0, 255, 0), -1)
+        cv2.rectangle(gt_label, (int(height * 0.1), int(width * 0.1)), (int(height / 2), int(width / 2)), 2, -1)
+        return (image, gt_label)
+
+    labels = [
+        LabelEntity(name="circle", domain=task_type, id=1),  # OLD class
+        LabelEntity(name="rect", domain=task_type, id=2),
+    ]
+
+    def get_image(split_type, subset, label_id):
+        ignored_labels = []
+        height, width = 1280, 720
+        if label_id == 1:
+            image, gt_label = gen_circle_image((height, width))
+            if split_type == "new" and subset == Subset.TRAINING:
+                ignored_labels = [LabelEntity(name="rect", domain=Domain.INSTANCE_SEGMENTATION, id=2)]
+        else:
+            image, gt_label = gen_rect_image((height, width))
+
+        height, width = gt_label.shape[:2]
+        label_mask = gt_label == label_id
+        label_index_map = label_mask.astype(np.uint8)
+        contours, hierarchies = cv2.findContours(label_index_map, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
+
+        for contour, hierarchy in zip(contours, hierarchies[0]):
+            if hierarchy[3] != -1:
+                continue
+
+            contour = list(contour)
+            if len(contour) <= 2:
+                continue
+
+            points = [Point(x=point[0][0] / width, y=point[0][1] / height) for point in contour]
+
+        return DatasetItemEntity(
+            media=Image(data=image),
+            annotation_scene=AnnotationSceneEntity(
+                annotations=[Annotation(Polygon(points=points), labels=[ScoredLabel(label=labels[label_id - 1])])],
+                kind=AnnotationSceneKind.ANNOTATION,
+            ),
+            subset=subset,
+            ignored_labels=ignored_labels,
+        )
+
+    old_train = [
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+        get_image("old", Subset.TRAINING, 1),
+    ]
+
+    old_val = [
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+        get_image("old", Subset.VALIDATION, 1),
+    ]
+
+    new_train = [
+        get_image("new", Subset.TRAINING, 1),
+        get_image("new", Subset.TRAINING, 1),
+        get_image("new", Subset.TRAINING, 1),
+        get_image("new", Subset.TRAINING, 1),
+        get_image("new", Subset.TRAINING, 2),
+        get_image("new", Subset.TRAINING, 2),
+        get_image("new", Subset.TRAINING, 2),
+        get_image("new", Subset.TRAINING, 2),
+    ]
+
+    new_val = [
+        get_image("new", Subset.VALIDATION, 1),
+        get_image("new", Subset.VALIDATION, 1),
+        get_image("new", Subset.VALIDATION, 1),
+        get_image("new", Subset.VALIDATION, 1),
+        get_image("new", Subset.VALIDATION, 2),
+        get_image("new", Subset.VALIDATION, 2),
+        get_image("new", Subset.VALIDATION, 2),
+        get_image("new", Subset.VALIDATION, 2),
+    ]
+
+    new_test = [
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("old", Subset.TESTING, 1),
+        get_image("new", Subset.TESTING, 1),
+        get_image("new", Subset.TESTING, 1),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+        get_image("new", Subset.TESTING, 2),
+    ]
+
+    old = old_train + old_val
+    new = new_train + new_val
+    if data_type == "old":
+        return DatasetEntity(old * 5), [labels[0]]
+    if data_type == "test":
+        return DatasetEntity(new_test * 5), labels
+    return DatasetEntity((old * 5 + new * 3)), labels
+
+
+def main(args):
+    """Main function of Detection Sample."""
+    logger.info("[SL] Train initial model with OLD dataset")
+    model_template = parse_model_template(args.template_file_path)
+    task_type = model_template.task_type.domain
+
+    logger.info("Train initial model with OLD dataset")
+    dataset, labels_list = load_test_dataset("old", task_type)
+    labels_schema = LabelSchemaEntity.from_labels(labels_list)
+
+    logger.info(f"Train dataset: {len(dataset.get_subset(Subset.TRAINING))} items")
+    logger.info(f"Validation dataset: {len(dataset.get_subset(Subset.VALIDATION))} items")
+
+    logger.info("Set hyperparameters")
+    params = create(model_template.hyper_parameters.data)
+    params.learning_parameters.num_iters = 5
+    params.learning_parameters.learning_rate = 0.01
+    params.learning_parameters.learning_rate_warmup_iters = 1
+    params.learning_parameters.batch_size = 4
+
+    logger.info("Setup environment")
+    environment = TaskEnvironment(
+        model=None, hyper_parameters=params, label_schema=labels_schema, model_template=model_template
+    )
+
+    logger.info("Create base Task")
+    task_impl_path = model_template.entrypoints.base
+    task_cls = get_task_class(task_impl_path)
+    task = task_cls(task_environment=environment)
+
+    logger.info("Train model")
+    initial_model = ModelEntity(
+        dataset,
+        environment.get_model_configuration(),
+    )
+    task.train(dataset, initial_model)
+
+    logger.info("Class-incremental learning with OLD + NEW dataset")
+    dataset, labels_list = load_test_dataset("new", task_type)
+    labels_schema = LabelSchemaEntity.from_labels(labels_list)
+
+    logger.info(f"Train dataset: {len(dataset.get_subset(Subset.TRAINING))} items")
+    logger.info(f"Validation dataset: {len(dataset.get_subset(Subset.VALIDATION))} items")
+
+    logger.info("Load model template")
+    model_template = parse_model_template(args.template_file_path)
+
+    logger.info("Set hyperparameters")
+    params = create(model_template.hyper_parameters.data)
+    params.learning_parameters.num_iters = 5
+    params.learning_parameters.learning_rate = 0.015
+    params.learning_parameters.learning_rate_warmup_iters = 1
+    params.learning_parameters.batch_size = 4
+
+    logger.info("Setup environment")
+    environment = TaskEnvironment(
+        model=initial_model, hyper_parameters=params, label_schema=labels_schema, model_template=model_template
+    )
+
+    logger.info("Create base Task")
+    task_impl_path = model_template.entrypoints.base
+    task_cls = get_task_class(task_impl_path)
+    task = task_cls(task_environment=environment)
+
+    logger.info("Train model")
+    output_model = ModelEntity(
+        dataset,
+        environment.get_model_configuration(),
+    )
+    task.train(dataset, output_model)
+
+    logger.info("Get predictions on the test set")
+    testset, _ = load_test_dataset("test", task_type)
+    validation_dataset = testset.get_subset(Subset.TESTING)
+    predicted_validation_dataset = task.infer(
+        validation_dataset.with_empty_annotations(), InferenceParameters(is_evaluation=True)
+    )
+    resultset = ResultSetEntity(
+        model=output_model,
+        ground_truth_dataset=validation_dataset,
+        prediction_dataset=predicted_validation_dataset,
+    )
+    logger.info("Estimate quality on validation set")
+    task.evaluate(resultset)
+    logger.info(str(resultset.performance))
+
+    if args.export:
+        logger.info("Export model")
+        exported_model = ModelEntity(
+            dataset,
+            environment.get_model_configuration(),
+        )
+        task.export(ExportType.OPENVINO, exported_model)
+
+        logger.info("Create OpenVINO Task")
+        environment.model = exported_model
+        openvino_task_impl_path = model_template.entrypoints.openvino
+        openvino_task_cls = get_task_class(openvino_task_impl_path)
+        openvino_task = openvino_task_cls(environment)
+
+        logger.info("Get predictions on the validation set")
+        predicted_validation_dataset = openvino_task.infer(
+            validation_dataset.with_empty_annotations(), InferenceParameters(is_evaluation=True)
+        )
+
+        resultset = ResultSetEntity(
+            model=output_model,
+            ground_truth_dataset=validation_dataset,
+            prediction_dataset=predicted_validation_dataset,
+        )
+        logger.info("Estimate quality on validation set")
+        openvino_task.evaluate(resultset)
+        logger.info(str(resultset.performance))
+
+        logger.info("Run POT optimization")
+        optimized_model = ModelEntity(
+            dataset,
+            environment.get_model_configuration(),
+        )
+        openvino_task.optimize(
+            OptimizationType.POT, dataset.get_subset(Subset.TRAINING), optimized_model, OptimizationParameters()
+        )
+
+        logger.info("Get predictions on the validation set")
+        predicted_validation_dataset = openvino_task.infer(
+            validation_dataset.with_empty_annotations(), InferenceParameters(is_evaluation=True)
+        )
+        resultset = ResultSetEntity(
+            model=optimized_model,
+            ground_truth_dataset=validation_dataset,
+            prediction_dataset=predicted_validation_dataset,
+        )
+        logger.info("Performance of optimized model:")
+        openvino_task.evaluate(resultset)
+        logger.info(str(resultset.performance))
+
+        logger.info("Running the NNCF optimization")
+        environment.model = output_model
+        nncf_task_impl_path = model_template.entrypoints.nncf
+        nncf_task_cls = get_task_class(nncf_task_impl_path)
+        nncf_task = nncf_task_cls(environment)
+
+        optimized_model = ModelEntity(
+            dataset,
+            configuration=environment.get_model_configuration(),
+        )
+        nncf_task.optimize(OptimizationType.NNCF, dataset, optimized_model)
+
+        logger.info("Inferring the optimised model on the validation set.")
+        predicted_validation_dataset = nncf_task.infer(
+            validation_dataset.with_empty_annotations(),
+            InferenceParameters(is_evaluation=True),
+        )
+        resultset = ResultSetEntity(
+            model=optimized_model,
+            ground_truth_dataset=validation_dataset,
+            prediction_dataset=predicted_validation_dataset,
+        )
+
+        logger.info("Evaluating the optimized model on the validation set.")
+        nncf_task.evaluate(resultset)
+        logger.info(str(resultset.performance))
+
+        logger.info("Exporting the model.")
+        exported_model = ModelEntity(
+            train_dataset=dataset,
+            configuration=environment.get_model_configuration(),
+        )
+        nncf_task.export(ExportType.OPENVINO, exported_model)
+        environment.model = exported_model
+
+        logger.info("Creating the OpenVINO Task.")
+        environment.model = exported_model
+        openvino_task_impl_path = model_template.entrypoints.openvino
+        nncf_openvino_task_cls = get_task_class(openvino_task_impl_path)
+        nncf_openvino_task = nncf_openvino_task_cls(environment)
+
+        logger.info("Inferring the exported model on the validation set.")
+        predicted_validation_dataset = nncf_openvino_task.infer(
+            validation_dataset.with_empty_annotations(),
+            InferenceParameters(is_evaluation=True),
+        )
+
+        logger.info("Evaluating the exported model on the validation set.")
+        resultset = ResultSetEntity(
+            model=exported_model,
+            ground_truth_dataset=validation_dataset,
+            prediction_dataset=predicted_validation_dataset,
+        )
+        nncf_openvino_task.evaluate(resultset)
+        logger.info(str(resultset.performance))
+
+
+if __name__ == "__main__":
+    sys.exit(main(parse_args()) or 0)

--- a/tests/integration/cli/detection/test_instance_segmentation.py
+++ b/tests/integration/cli/detection/test_instance_segmentation.py
@@ -1,0 +1,193 @@
+"""Tests for MPA Class-Incremental Learning for object detection with OTX CLI"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from otx.api.entities.model_template import parse_model_template
+from otx.cli.registry import Registry
+from otx.cli.utils.tests import (
+    get_template_dir,
+    nncf_eval_openvino_testing,
+    nncf_eval_testing,
+    nncf_export_testing,
+    nncf_optimize_testing,
+    otx_demo_deployment_testing,
+    otx_demo_openvino_testing,
+    otx_demo_testing,
+    otx_deploy_openvino_testing,
+    otx_eval_deployment_testing,
+    otx_eval_openvino_testing,
+    otx_eval_testing,
+    otx_export_testing,
+    otx_hpo_testing,
+    otx_train_testing,
+    pot_eval_testing,
+    pot_optimize_testing,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_component
+
+# Pre-train w/ 'car & tree' class
+args0 = {
+    "--train-ann-file": "data/car_tree_bug/annotations/instances_car_tree.json",
+    "--train-data-roots": "data/car_tree_bug/images",
+    "--val-ann-file": "data/car_tree_bug/annotations/instances_car_tree.json",
+    "--val-data-roots": "data/car_tree_bug/images",
+    "--test-ann-files": "data/car_tree_bug/annotations/instances_car_tree.json",
+    "--test-data-roots": "data/car_tree_bug/images",
+    "--input": "data/car_tree_bug/images",
+    "train_params": ["params", "--learning_parameters.num_iters", "4", "--learning_parameters.batch_size", "2"],
+}
+
+# Class-Incremental learning w/ 'car', 'tree', 'bug' classes
+args = {
+    "--train-ann-file": "data/car_tree_bug/annotations/instances_default.json",
+    "--train-data-roots": "data/car_tree_bug/images",
+    "--val-ann-file": "data/car_tree_bug/annotations/instances_default.json",
+    "--val-data-roots": "data/car_tree_bug/images",
+    "--test-ann-files": "data/car_tree_bug/annotations/instances_default.json",
+    "--test-data-roots": "data/car_tree_bug/images",
+    "--input": "data/car_tree_bug/images",
+    "train_params": ["params", "--learning_parameters.num_iters", "4", "--learning_parameters.batch_size", "2"],
+}
+
+otx_dir = os.getcwd()
+
+TT_STABILITY_TESTS = os.environ.get("TT_STABILITY_TESTS", False)
+if TT_STABILITY_TESTS:
+    default_template = parse_model_template(
+        os.path.join("otx/algorithms/detection/configs", "instance_segmentation", "resnet50_maskrcnn", "template.yaml")
+    )
+    templates = [default_template] * 100
+    templates_ids = [template.model_template_id + f"-{i+1}" for i, template in enumerate(templates)]
+else:
+    templates = Registry("otx/algorithms/detection").filter(task_type="INSTANCE_SEGMENTATION").templates
+    templates_ids = [template.model_template_id for template in templates]
+
+
+@pytest.fixture(scope="session")
+def tmp_dir_path():
+    with TemporaryDirectory() as tmp_dir:
+        yield Path(tmp_dir)
+
+
+class TestToolsMPAInstanceSegmentation:
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_train(self, template, tmp_dir_path):
+        otx_train_testing(template, tmp_dir_path, otx_dir, args0)
+        template_work_dir = get_template_dir(template, tmp_dir_path)
+        args1 = args.copy()
+        args1["--load-weights"] = f"{template_work_dir}/trained_{template.model_template_id}/weights.pth"
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_eval(self, template, tmp_dir_path):
+        otx_eval_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_eval_openvino(self, template, tmp_dir_path):
+        otx_eval_openvino_testing(template, tmp_dir_path, otx_dir, args, threshold=0.2)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_demo(self, template, tmp_dir_path):
+        otx_demo_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_demo_openvino(self, template, tmp_dir_path):
+        otx_demo_openvino_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_deploy_openvino(self, template, tmp_dir_path):
+        otx_deploy_openvino_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_eval_deployment(self, template, tmp_dir_path):
+        otx_eval_deployment_testing(template, tmp_dir_path, otx_dir, args, threshold=0.0)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_demo_deployment(self, template, tmp_dir_path):
+        otx_demo_deployment_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_hpo(self, template, tmp_dir_path):
+        otx_hpo_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    @pytest.mark.skip(reason="CVS-94790")
+    def test_nncf_optimize(self, template, tmp_dir_path):
+        if template.entrypoints.nncf is None:
+            pytest.skip("nncf entrypoint is none")
+
+        nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    @pytest.mark.skip(reason="CVS-94790")
+    def test_nncf_export(self, template, tmp_dir_path):
+        if template.entrypoints.nncf is None:
+            pytest.skip("nncf entrypoint is none")
+
+        nncf_export_testing(template, tmp_dir_path)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    @pytest.mark.skip(reason="CVS-94790")
+    def test_nncf_eval(self, template, tmp_dir_path):
+        if template.entrypoints.nncf is None:
+            pytest.skip("nncf entrypoint is none")
+
+        nncf_eval_testing(template, tmp_dir_path, otx_dir, args, threshold=0.001)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    @pytest.mark.skip(reason="CVS-94790")
+    def test_nncf_eval_openvino(self, template, tmp_dir_path):
+        if template.entrypoints.nncf is None:
+            pytest.skip("nncf entrypoint is none")
+
+        nncf_eval_openvino_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_pot_optimize(self, template, tmp_dir_path):
+        pot_optimize_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_pot_eval(self, template, tmp_dir_path):
+        pot_eval_testing(template, tmp_dir_path, otx_dir, args)


### PR DESCRIPTION
## Summary
Add Instance-segmentation model template & sample & test codes

### This PR includes :
- Add Instance-Segmentation model templates (Resnet50-MaskRCNN, EfficientNetB2B-MaskRCNN)
- Add Instance-Segmentation Sample code
- Add Instance-Segmentation test code (Integration) - CLI
- Fix some wrong value in detection

### Test Codes
```
# I-Seg Sample Code
bash otx/algorithms/detection/init_venv.sh ./venv python3.8
source venv/bin/activate
python -m otx.algorithms.detection.tools.instance_segmentation_sample otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/template.yaml --export

# CLI Tests
pytest -s -v tests/integration/cli/detection/test_instance_segmentation.py
```