### PR TITLE
[CVS-94911] Fix difference between train and validation normalization pipeline

### DIFF
--- a/external/model-preparation-algorithm/configs/detection/mobilenetv2_ssd_cls_incr/data_pipeline.py
+++ b/external/model-preparation-algorithm/configs/detection/mobilenetv2_ssd_cls_incr/data_pipeline.py
@@ -37,15 +37,10 @@ data = dict(
     samples_per_gpu=10,
     workers_per_gpu=4,
     train=dict(
-        type="RepeatDataset",
-        times=1,
-        adaptive_repeat_times=True,
-        dataset=dict(
-            type=dataset_type,
-            ann_file="data/coco/annotations/instances_train2017.json",
-            img_prefix="data/coco/train2017",
-            pipeline=train_pipeline,
-        ),
+          type=dataset_type,
+          ann_file="data/coco/annotations/instances_train2017.json",
+          img_prefix="data/coco/train2017",
+          pipeline=train_pipeline,
     ),
     val=dict(
         type=dataset_type,

--- a/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
@@ -354,7 +354,9 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
                         pipeline_step.type = "LoadAnnotationFromOTEDataset"
                         pipeline_step.domain = domain
                         pipeline_step.min_size = cfg.pop("min_size", -1)
-                    if subset == "train" and pipeline_step.type == "Collect":
+                    if (subset == "train" and
+                        pipeline_step.type == "Collect" and
+                        cfg.type not in ["ImageTilingDataset"]):
                         pipeline_step = BaseTask._get_meta_keys(pipeline_step)
                 patch_color_conversion(cfg.pipeline)
 

--- a/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
@@ -344,6 +344,21 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
                 elif pipeline_step.type == "MultiScaleFlipAug":
                     patch_color_conversion(pipeline_step.transforms)
 
+        def patch_data_pipeline(cfg):
+            pipeline = cfg.get("pipeline", None)
+            if pipeline is not None:
+                for pipeline_step in pipeline:
+                    if pipeline_step.type == "LoadImageFromFile":
+                        pipeline_step.type = "LoadImageFromOTEDataset"
+                    if pipeline_step.type == "LoadAnnotations":
+                        pipeline_step.type = "LoadAnnotationFromOTEDataset"
+                        pipeline_step.domain = domain
+                        pipeline_step.min_size = cfg.pop("min_size", -1)
+                    if subset == "train" and pipeline_step.type == "Collect":
+                        pipeline_step = BaseTask._get_meta_keys(pipeline_step)
+                patch_color_conversion(cfg.pipeline)
+
+        # FIXME This code assume that max of wrapped data depth is 2
         # remove redundant parameters introduced in self._recipe_cfg.merge_from_dict
         remove_from_config(config, "ann_file")
         remove_from_config(config, "img_prefix")
@@ -355,8 +370,10 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
             # remove redundant parameters introduced in self._recipe_cfg.merge_from_dict
             remove_from_config(cfg, "ann_file")
             remove_from_config(cfg, "img_prefix")
+            patch_data_pipeline(cfg)
             if cfg.type in ["RepeatDataset", "MultiImageMixDataset", "ImageTilingDataset"]:
                 cfg = cfg.dataset
+                patch_data_pipeline(cfg)
             cfg.type = "MPADetDataset"
             cfg.domain = domain
             cfg.ote_dataset = None
@@ -364,16 +381,6 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
             remove_from_config(cfg, "ann_file")
             remove_from_config(cfg, "img_prefix")
             remove_from_config(cfg, "classes")  # Get from DatasetEntity
-            for pipeline_step in cfg.pipeline:
-                if pipeline_step.type == "LoadImageFromFile":
-                    pipeline_step.type = "LoadImageFromOTEDataset"
-                if pipeline_step.type == "LoadAnnotations":
-                    pipeline_step.type = "LoadAnnotationFromOTEDataset"
-                    pipeline_step.domain = domain
-                    pipeline_step.min_size = cfg.pop("min_size", -1)
-                if subset == "train" and pipeline_step.type == "Collect":
-                    pipeline_step = BaseTask._get_meta_keys(pipeline_step)
-            patch_color_conversion(cfg.pipeline)
 
     @staticmethod
     def _patch_evaluation(config: MPAConfig):


### PR DESCRIPTION
This PR includes solve issue CVS-94911.
Previous implementation only look into pipeline of the most inside dataset
I change the code to also look into outside dataset
I think we should refactor this function recursive way to handle various dataset settings.