### PR TITLE
[Release branch] Disable NNCF optimization for FP16 models 

### DIFF
--- a/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -40,8 +40,9 @@ hyper_parameters:
       stat_requests_number:
         default_value: 2
     nncf_optimization:
+      visible_in_ui: false
       enable_quantization:
-        default_value: true
+        default_value: false
       enable_pruning:
         default_value: false
       pruning_supported:

--- a/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -14,7 +14,6 @@ framework: OTEDetection v2.9.1
 entrypoints:
   base: mpa_tasks.apis.detection.DetectionTrainTask
   openvino: detection_tasks.apis.detection.OpenVINODetectionTask
-  nncf: mpa_tasks.apis.detection.DetectionNNCFTask
 base_model_path: ../../../../mmdetection/configs/custom-counting-instance-seg/efficientnetb2b_maskrcnn/template_experimental.yaml
 
 # Capabilities.
@@ -40,7 +39,6 @@ hyper_parameters:
       stat_requests_number:
         default_value: 2
     nncf_optimization:
-      visible_in_ui: false
       enable_quantization:
         default_value: false
       enable_pruning:

--- a/external/model-preparation-algorithm/configs/segmentation/ocr-lite-hrnet-x-mod3/template.yaml
+++ b/external/model-preparation-algorithm/configs/segmentation/ocr-lite-hrnet-x-mod3/template.yaml
@@ -14,7 +14,6 @@ framework: OTESegmentation v0.14.0
 entrypoints:
   base: mpa_tasks.apis.segmentation.SegmentationTrainTask
   openvino: segmentation_tasks.apis.segmentation.OpenVINOSegmentationTask
-  nncf: mpa_tasks.apis.segmentation.SegmentationNNCFTask
 base_model_path: ../../../../mmsegmentation/configs/custom-sematic-segmentation/ocr-lite-hrnet-x-mod3/template_experimental.yaml
 
 # Capabilities.
@@ -39,7 +38,6 @@ hyper_parameters:
       num_iters:
         default_value: 300
     nncf_optimization:
-      visible_in_ui: false
       enable_quantization:
         default_value: false
       enable_pruning:

--- a/external/model-preparation-algorithm/configs/segmentation/ocr-lite-hrnet-x-mod3/template.yaml
+++ b/external/model-preparation-algorithm/configs/segmentation/ocr-lite-hrnet-x-mod3/template.yaml
@@ -39,8 +39,9 @@ hyper_parameters:
       num_iters:
         default_value: 300
     nncf_optimization:
+      visible_in_ui: false
       enable_quantization:
-        default_value: true
+        default_value: false
       enable_pruning:
         default_value: false
       pruning_supported:


### PR DESCRIPTION
FP16 model optimization by NNCF will be supported only in OTX2.0. Until then NNCF optimization for that models should be disabled.