### PR TITLE
[OTX] support openvino OTX explanation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.sh
 __pycache__
 .idea/
 .vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ If you want to add training code of your model to this repository, make sure:
    1. [IInferenceTask](https://github.com/openvinotoolkit/training_extensions/blob/develop/ote_sdk/ote_sdk/usecases/tasks/interfaces/inference_interface.py) - your model must be inferable on some datasets.
    1. [IEvaluationTask](https://github.com/openvinotoolkit/training_extensions/blob/develop/ote_sdk/ote_sdk/usecases/tasks/interfaces/evaluate_interface.py) - it must be possible to evaluate some quality metric of you model.
    1. [IExportTask](https://github.com/openvinotoolkit/training_extensions/blob/develop/ote_sdk/ote_sdk/usecases/tasks/interfaces/export_interface.py) - your model must be exportable to the OpenVINO format.
+   1. [IExplainTask](https://github.com/openvinotoolkit/training_extensions/blob/develop/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py) - your model must be explainable on some datasets.
 4. You provide a model `template.yaml` file, that describes your model and its configurable parameters. See an example [here](external/anomaly/configs/anomaly_classification/padim/template.yaml).
 5. You create a PR to the `develop` branch.
 6. You provide `requirements.txt` file and a bash `init_venv.sh` script for creating virtual environment.

--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -446,6 +446,7 @@ optional arguments:
   --save-model-to SAVE_MODEL_TO
                         Location where openvino.zip will be stored.
 ```
+
 ### ote explain
 
 `ote explain` runs explanation of a trained model on a particular dataset.
@@ -472,8 +473,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -i INPUT, --input INPUT
-                        Source of input data: images folder, image, webcam and
-                        video.
+                        Source of input data: images folder or single image
   -o OUTPUT, --output OUTPUT
                         Root path for image dump. Will save saliency map
                         or overlay images to this folder
@@ -481,6 +481,7 @@ optional arguments:
   --xai-model XAI_MODEL_NAME
                         xai model name. Currently only support EigenCAM
 ```
+
 ---
 
 \* Other names and brands may be claimed as the property of others.

--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -446,7 +446,41 @@ optional arguments:
   --save-model-to SAVE_MODEL_TO
                         Location where openvino.zip will be stored.
 ```
+### ote explain
 
+`ote explain` runs explanation of a trained model on a particular dataset.
+
+With the `--help` command, you can list additional information, such as its parameters common to all model templates:
+command example:
+
+```
+ote explain ./external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml --help
+```
+
+output example:
+
+```
+usage: ote explain [-h] TEMPLATE
+                --input INPUT_IMAGE_ROOTS --output OUTPUT_FOLDER_ROOT
+                --load-weights WEIGHT_PATHS --xai-model XAI_MODEL_NAME
+
+positional arguments:
+  template
+  {params}              sub-command help
+    params              Hyper parameters defined in template file.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INPUT, --input INPUT
+                        Source of input data: images folder, image, webcam and
+                        video.
+  -o OUTPUT, --output OUTPUT
+                        Root path for image dump. Will save saliency map
+                        or overlay images to this folder
+  --load-weights WEIGHT_PATHS
+  --xai-model XAI_MODEL_NAME
+                        xai model name. Currently only support EigenCAM
+```
 ---
 
 \* Other names and brands may be claimed as the property of others.

--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -472,14 +472,14 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i INPUT, --input INPUT
-                        Source of input data: images folder or single image
-  -o OUTPUT, --output OUTPUT
+  --explain-data-root EXPLAIN_DATA_ROOT
+                        paths to explain data roots
+  --save-explanation-to SAVE_EXPLANATION_TO
                         Root path for image dump. Will save saliency map
-                        or overlay images to this folder
+                        and overlay images to this folder
   --load-weights WEIGHT_PATHS
-  --xai-model XAI_MODEL_NAME
-                        xai model name. Currently only support EigenCAM
+  --explain-algorithm EXPLAIN_ALGORITHM
+                        explain algirhtm name. Currently only support EigenCAM and CAM
 ```
 
 ---

--- a/external/deep-object-reid/torchreid_tasks/model_wrappers/classification.py
+++ b/external/deep-object-reid/torchreid_tasks/model_wrappers/classification.py
@@ -95,7 +95,7 @@ class OteClassification(Classification):
         self,
         predictions: Dict[str, np.ndarray],
         metadata: Dict[str, Any],
-        explainer: str = None,
+        explainer: str,
     ):
         actmap = get_actmap(
             predictions['saliency_map'][0],
@@ -116,21 +116,20 @@ class OteClassification(Classification):
 @check_input_parameters_type()
 def get_actmap(features: Union[np.ndarray, Iterable, int, float],
                output_res: Union[tuple, list],
-               explainer: str = None):
-    if explainer is None:
+               explainer: str):
+    if not explainer:
         am = features
     else:
-        am = torch.Tensor(am)
-        am = am.unsqueeze(0).unsqueeze(0).unsqueeze(0)
+        am = torch.Tensor(features)
+        am = am.unsqueeze(0).unsqueeze(0)
         if explainer.lower() == 'eigencam':
-            am = eigen_cam(features)
+            am = eigen_cam(am)
         elif explainer.lower() == 'cam':
-            am = cam(features)
+            am = cam(am)
         else:
             raise NotImplementedError(f"explain algorithm {explainer} not supported!")
         am = am.squeeze(0).squeeze(0)
         am = am.numpy().astype(np.uint8)
-
     am = cv2.resize(am, output_res)
     am = cv2.applyColorMap(am, cv2.COLORMAP_JET)
     am = cv2.cvtColor(am, cv2.COLOR_BGR2RGB)

--- a/external/deep-object-reid/torchreid_tasks/openvino_task.py
+++ b/external/deep-object-reid/torchreid_tasks/openvino_task.py
@@ -203,10 +203,10 @@ class OpenVINOClassificationTask(IDeploymentTask, IInferenceTask, IEvaluationTas
 
     @check_input_parameters_type({"dataset": DatasetParamTypeCheck})
     def explain(self, dataset: DatasetEntity,
-              inference_parameters: Optional[InferenceParameters] = None) -> DatasetEntity:
+              explain_parameters: Optional[InferenceParameters] = None) -> DatasetEntity:
         update_progress_callback = default_progress_callback
-        if inference_parameters is not None:
-            update_progress_callback = inference_parameters.update_progress
+        if explain_parameters is not None:
+            update_progress_callback = explain_parameters.update_progress
         dataset_size = len(dataset)
         for i, dataset_item in enumerate(dataset, 1):
             predicted_scene, actmap, repr_vector, act_score = self.inferencer.predict(dataset_item.numpy)

--- a/external/deep-object-reid/torchreid_tasks/openvino_task.py
+++ b/external/deep-object-reid/torchreid_tasks/openvino_task.py
@@ -48,6 +48,7 @@ from ote_sdk.usecases.evaluation.metrics_helper import MetricsHelper
 from ote_sdk.usecases.tasks.interfaces.deployment_interface import IDeploymentTask
 from ote_sdk.usecases.tasks.interfaces.evaluate_interface import IEvaluationTask
 from ote_sdk.usecases.tasks.interfaces.inference_interface import IInferenceTask
+from ote_sdk.usecases.tasks.interfaces.explain_interface import IExplainTask
 from ote_sdk.usecases.tasks.interfaces.optimization_interface import (
     IOptimizationTask,
     OptimizationType,
@@ -158,7 +159,7 @@ class OTEOpenVinoDataLoader(DataLoader):
         return len(self.dataset)
 
 
-class OpenVINOClassificationTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IOptimizationTask):
+class OpenVINOClassificationTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IExplainTask, IOptimizationTask):
     @check_input_parameters_type()
     def __init__(self, task_environment: TaskEnvironment):
         self.task_environment = task_environment
@@ -196,6 +197,28 @@ class OpenVINOClassificationTask(IDeploymentTask, IInferenceTask, IEvaluationTas
                                                    numpy=actmap, roi=dataset_item.roi,
                                                    label=predicted_scene.annotations[0].get_labels()[0].label)
                 dataset_item.append_metadata_item(saliency_media, model=self.model)
+
+            update_progress_callback(int(i / dataset_size * 100))
+        return dataset
+
+    @check_input_parameters_type({"dataset": DatasetParamTypeCheck})
+    def explain(self, dataset: DatasetEntity,
+              inference_parameters: Optional[InferenceParameters] = None) -> DatasetEntity:
+        update_progress_callback = default_progress_callback
+        if inference_parameters is not None:
+            update_progress_callback = inference_parameters.update_progress
+        dataset_size = len(dataset)
+        for i, dataset_item in enumerate(dataset, 1):
+            predicted_scene, actmap, repr_vector, act_score = self.inferencer.predict(dataset_item.numpy)
+            dataset_item.append_labels(predicted_scene.annotations[0].get_labels())
+            active_score_media = FloatMetadata(name="active_score", value=act_score,
+                                               float_type=FloatType.ACTIVE_SCORE)
+            dataset_item.append_metadata_item(active_score_media, model=self.model)
+            saliency_media = ResultMediaEntity(name="Saliency Map", type="saliency_map",
+                                                annotation_scene=dataset_item.annotation_scene,
+                                                numpy=actmap, roi=dataset_item.roi,
+                                                label=predicted_scene.annotations[0].get_labels()[0].label)
+            dataset_item.append_metadata_item(saliency_media, model=self.model)
 
             update_progress_callback(int(i / dataset_size * 100))
         return dataset

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -56,6 +56,7 @@ from ote_sdk.usecases.reporting.time_monitor_callback import TimeMonitorCallback
 from ote_sdk.usecases.tasks.interfaces.evaluate_interface import IEvaluationTask
 from ote_sdk.usecases.tasks.interfaces.export_interface import ExportType, IExportTask
 from ote_sdk.usecases.tasks.interfaces.inference_interface import IInferenceTask
+from ote_sdk.usecases.tasks.interfaces.explain_interface import IExplainTask
 from ote_sdk.usecases.tasks.interfaces.unload_interface import IUnload
 from ote_sdk.utils.argument_checks import check_input_parameters_type
 from ote_sdk.utils.labels_utils import get_empty_label
@@ -100,7 +101,7 @@ class TrainingProgressCallback(TimeMonitorCallback):
         self.update_progress_callback(self.get_progress(), score=score)
 
 
-class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationTask, IUnload):
+class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationTask, IExplainTask, IUnload):
     def __init__(self, task_environment: TaskEnvironment):
         self._should_stop = False
         super().__init__(TASK_CONFIG, task_environment)

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -169,7 +169,12 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
         self._data_cfg = self._init_test_data_cfg(dataset)
         dataset = dataset.with_empty_annotations()
 
-        results = self._run_task(stage_module, mode="train", dataset=dataset)
+        results = self._run_task(
+            stage_module,
+            mode="train",
+            dataset=dataset,
+            explainer=explain_parameters.explainer,
+        )
         logger.debug(f"result of run_task {stage_module} module = {results}")
         activations = results["outputs"]
         activation_results = zip(

--- a/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
@@ -118,6 +118,12 @@ class TestToolsMPAClassification:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_ote_eval(self, template):
+        ote_explain_testing(template, root, ote_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ote_eval_openvino(self, template):
         ote_eval_openvino_testing(template, root, ote_dir, args, threshold=0.0)
 
@@ -273,6 +279,12 @@ class TestToolsMPAMultilabelClassification:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_ote_eval(self, template):
+        ote_explain_testing(template, root, ote_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ote_eval_openvino(self, template):
         ote_eval_openvino_testing(template, root, ote_dir, args_m, threshold=0.0)
 
@@ -409,6 +421,12 @@ class TestToolsMPAHierarchicalClassification:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ote_eval(self, template):
         ote_eval_testing(template, root, ote_dir, args_h)
+    
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_ote_eval(self, template):
+        ote_explain_testing(template, root, ote_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")

--- a/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
@@ -118,7 +118,7 @@ class TestToolsMPAClassification:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
-    def test_ote_eval(self, template):
+    def test_ote_explain(self, template):
         ote_explain_testing(template, root, ote_dir, args)
 
     @e2e_pytest_component
@@ -279,7 +279,7 @@ class TestToolsMPAMultilabelClassification:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
-    def test_ote_eval(self, template):
+    def test_ote_explain(self, template):
         ote_explain_testing(template, root, ote_dir, args)
 
     @e2e_pytest_component
@@ -425,7 +425,7 @@ class TestToolsMPAHierarchicalClassification:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
-    def test_ote_eval(self, template):
+    def test_ote_explain(self, template):
         ote_explain_testing(template, root, ote_dir, args)
 
     @e2e_pytest_component

--- a/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
@@ -280,7 +280,7 @@ class TestToolsMPAMultilabelClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ote_explain(self, template):
-        ote_explain_testing(template, root, ote_dir, args)
+        ote_explain_testing(template, root, ote_dir, args_m)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
@@ -426,7 +426,7 @@ class TestToolsMPAHierarchicalClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ote_explain(self, template):
-        ote_explain_testing(template, root, ote_dir, args)
+        ote_explain_testing(template, root, ote_dir, args_h)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")

--- a/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
@@ -23,6 +23,7 @@ from ote_cli.utils.tests import (
     ote_hpo_testing,
     ote_train_testing,
     ote_export_testing,
+    ote_explain_testing,
     pot_optimize_testing,
     pot_eval_testing,
     nncf_optimize_testing,

--- a/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
@@ -24,6 +24,7 @@ from ote_cli.utils.tests import (
     ote_train_testing,
     ote_export_testing,
     ote_explain_testing,
+    ote_explain_openvino_testing,
     pot_optimize_testing,
     pot_eval_testing,
     nncf_optimize_testing,

--- a/ote_cli/README.md
+++ b/ote_cli/README.md
@@ -13,6 +13,7 @@
 - `ote export` - export trained model to the OpenVINO format in order to efficiently run it on Intel hardware.
 - `ote demo` - run model inference on images, videos, webcam in order to see how it works on user's data.
 - `ote deploy` - create openvino.zip with self-contained python package, demo application and exported model.
+- `ote explain` - run model's explanation and save saliency map for feature vector to the dump path.
 
 ### Jupyter notebooks
 

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -17,9 +17,9 @@ Model inference demonstration tool.
 # and limitations under the License.
 
 import argparse
+import os
 import time
 from collections import deque
-import os
 
 import cv2
 import numpy as np
@@ -34,14 +34,15 @@ from ote_cli.registry import find_and_parse_model_template
 from ote_cli.tools.utils.demo.images_capture import open_images_capture
 from ote_cli.utils.config import override_parameters
 from ote_cli.utils.importing import get_impl_class
-from ote_cli.utils.io import read_label_schema, read_model, get_image_files
+from ote_cli.utils.io import get_image_files, read_label_schema, read_model
 from ote_cli.utils.parser import (
     add_hyper_parameters_sub_parser,
     gen_params_dict_from_args,
 )
 
 ESC_BUTTON = 27
-SUPPORTED_XAI_MODELS = ['EigenCAM']
+SUPPORTED_XAI_MODELS = ["CAM", "EigenCAM"]
+
 
 def parse_args():
     """
@@ -68,7 +69,7 @@ def parse_args():
     parser.add_argument(
         "-o",
         "--output",
-        default='saliency_dump',
+        default="saliency_dump",
         help="Output path for explanation images.",
     )
     parser.add_argument(
@@ -79,7 +80,7 @@ def parse_args():
     parser.add_argument(
         "--explain-model",
         default="EigenCAM",
-        help=f"XAI model name, currently support {SUPPORTED_XAI_MODELS}"
+        help=f"XAI model name, currently support {SUPPORTED_XAI_MODELS}",
     )
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
 
@@ -154,18 +155,22 @@ def main():
 
     elapsed_times = deque(maxlen=10)
 
-    for (root_dir, filename) in imgs:
+    for i, (root_dir, filename) in enumerate(imgs):
         frame = cv2.imread(os.path.join(root_dir, filename))
         saliency_map, elapsed_time = get_explain_map(task, frame)
         elapsed_times.append(elapsed_time)
         elapsed_time = np.mean(elapsed_times)
 
         overlay = cv2.addWeighted(frame, 0.7, saliency_map.numpy, 0.3, 0)
-        filename = filename.split('.')[0]
-        cv2.imwrite(f'{os.path.join(args.output, filename)}_saliency_map.png', saliency_map.numpy)
-        cv2.imwrite(f'{os.path.join(args.output, filename)}_overlay_img.png', overlay)
-    
-    print(f'saliency maps saved to {args.output}...')
+        filename = filename.split(".")[0]
+        cv2.imwrite(
+            f"{os.path.join(args.output, filename)}_saliency_map.png",
+            saliency_map.numpy,
+        )
+        cv2.imwrite(f"{os.path.join(args.output, filename)}_overlay_img.png", overlay)
+
+    print(f"saliency maps saved to {args.output}...")
+
 
 if __name__ == "__main__":
     main()

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -73,6 +73,12 @@ def parse_args():
         help="Output path for explanation images.",
     )
     parser.add_argument(
+        "-w",
+        "--weight",
+        default=0.5,
+        help="weight of the saliency map when overlaying the saliency map",
+    )
+    parser.add_argument(
         "--load-weights",
         required=True,
         help="Load only weights from previously saved checkpoint",
@@ -159,7 +165,8 @@ def main():
         img = cv2.imread(os.path.join(root_dir, fname))
         saliency_map, elapsed_time = get_explain_map(task, img)
         elapsed_times.append(elapsed_time)
-        save_saliency_output(img, saliency_map.numpy, args.output, os.path.splitext(fname)[0])
+        save_saliency_output(img, saliency_map.numpy, args.output, \
+            os.path.splitext(fname)[0], weight=args.weight)
 
     print(f"saliency maps saved to {args.output}...")
 

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -155,11 +155,11 @@ def main():
 
     elapsed_times = deque(maxlen=10)
 
-    for _, (root_dir, filename) in enumerate(imgs):
-        img = cv2.imread(os.path.join(root_dir, filename))
+    for _, (root_dir, fname) in enumerate(imgs):
+        img = cv2.imread(os.path.join(root_dir, fname))
         saliency_map, elapsed_time = get_explain_map(task, img)
         elapsed_times.append(elapsed_time)
-        save_saliency_output(img, saliency_map.numpy, root_dir, filename.split[0])
+        save_saliency_output(img, saliency_map.numpy, args.output, os.path.splitext(fname)[0])
 
     print(f"saliency maps saved to {args.output}...")
 

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -129,16 +129,12 @@ def main():
     )
 
     task = task_class(task_environment=environment)
-    image_files = get_image_files(args.explain_data_root)
 
     if args.explain_algorithm not in SUPPORTED_EXPLAIN_ALGORITHMS:
         raise NotImplementedError(
             f"{args.explain_algorithm} currently not supported. \
             Currently only supporting {SUPPORTED_EXPLAIN_ALGORITHMS}"
         )
-
-    if image_files is None:
-        raise ValueError(f"No image found in {args.explain_data_root}!")
 
     dataset_class = get_dataset_class(template.task_type)
     dataset = dataset_class(test_subset={"data_root": args.explain_data_root})
@@ -157,19 +153,18 @@ def main():
     )
     elapsed_time = time.perf_counter() - start_time
 
-    for img, saliency_map, (_, fname) in zip(
-        explain_dataset, saliency_maps, image_files
-    ):
+    for img, saliency_map in zip(explain_dataset, saliency_maps):
+        file_path = img.media.filepath
         save_saliency_output(
             img.numpy,
             saliency_map.numpy,
             args.save_explanation_to,
-            os.path.splitext(fname)[0],
+            os.path.splitext(file_path)[0],
             weight=args.weight,
         )
 
     print(f"saliency maps saved to {args.save_explanation_to}...")
-    print(f"total elapsed_time: {elapsed_time:.3f} for {len(image_files)} images")
+    print(f"total elapsed_time: {elapsed_time:.3f} for {len(explain_dataset)} images")
 
 
 if __name__ == "__main__":

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -91,16 +91,6 @@ def parse_args():
     return parser.parse_args(), template, hyper_parameters
 
 
-def get_explain_map(task, explain_dataset, explain_algorithm):
-    start_time = time.perf_counter()
-    saliency_maps = task.explain(
-        explain_dataset,
-        InferenceParameters(is_evaluation=True),
-    )
-    elapsed_time = time.perf_counter() - start_time
-    return saliency_maps, elapsed_time
-
-
 def main():
     """
     Main function that is used for model demonstration.
@@ -147,8 +137,14 @@ def main():
 
     if not os.path.exists(args.output):
         os.makedirs(args.output)
-
-    saliency_maps, elapsed_time = get_explain_map(task, explain_dataset, args.explain_algorithm)
+    
+    start_time = time.perf_counter()
+    saliency_maps = task.explain(
+        explain_dataset.with_empty_annotations(),
+        InferenceParameters(is_evaluation=True),
+    )
+    elapsed_time = time.perf_counter() - start_time
+    
     for img, saliency_map, (_, fname) in zip(explain_dataset, saliency_maps, image_files):
         save_saliency_output(img.numpy, saliency_map.numpy, args.output, \
             os.path.splitext(fname)[0], weight=args.weight)

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -59,14 +59,12 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("template")
     parser.add_argument(
-        "-i",
-        "--input",
+        "--explain-data-root",
         required=True,
         help="Source of input data: images folder, image, webcam and video.",
     )
     parser.add_argument(
-        "-o",
-        "--output",
+        "--save-explanation-to",
         default="saliency_dump",
         help="Output path for explanation images.",
     )
@@ -125,21 +123,21 @@ def main():
     )
 
     task = task_class(task_environment=environment)
-    image_files = get_image_files(args.input)
+    image_files = get_image_files(args.explain_data_root)
 
     if args.explain_algorithm not in SUPPORTED_EXPLAIN_ALGORITHMS:
         raise NotImplementedError(f"{args.explain_algorithm} currently not supported. \
             Currently only supporting {SUPPORTED_EXPLAIN_ALGORITHMS}")
 
     if image_files is None:
-        raise ValueError(f"No image found in {args.input}!")
+        raise ValueError(f"No image found in {args.explain_data_root}!")
 
     dataset_class = get_dataset_class(template.task_type)
-    dataset = dataset_class(test_subset={"data_root": args.input})
+    dataset = dataset_class(test_subset={"data_root": args.explain_data_root})
     explain_dataset = dataset.get_subset(Subset.TESTING)
 
-    if not os.path.exists(args.output):
-        os.makedirs(args.output)
+    if not os.path.exists(args.save_explanation_to):
+        os.makedirs(args.save_explanation_to)
     
     start_time = time.perf_counter()
     saliency_maps = task.explain(
@@ -149,10 +147,10 @@ def main():
     elapsed_time = time.perf_counter() - start_time
     
     for img, saliency_map, (_, fname) in zip(explain_dataset, saliency_maps, image_files):
-        save_saliency_output(img.numpy, saliency_map.numpy, args.output, \
+        save_saliency_output(img.numpy, saliency_map.numpy, args.save_explanation_to, \
             os.path.splitext(fname)[0], weight=args.weight)
 
-    print(f"saliency maps saved to {args.output}...")
+    print(f"saliency maps saved to {args.save_explanation_to}...")
     print(f"total elapsed_time: {elapsed_time:.3f} for {len(image_files)} images")
 
 

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -19,10 +19,7 @@ Model inference demonstration tool.
 import argparse
 import os
 import time
-from collections import deque
 
-import cv2
-import numpy as np
 from ote_sdk.configuration.helper import create
 from ote_sdk.entities.subset import Subset
 from ote_sdk.entities.inference_parameters import InferenceParameters
@@ -142,7 +139,10 @@ def main():
     start_time = time.perf_counter()
     saliency_maps = task.explain(
         explain_dataset.with_empty_annotations(),
-        InferenceParameters(is_evaluation=True),
+        InferenceParameters(
+            is_evaluation=True,
+            explainer=args.explain_algorithm,
+        ),
     )
     elapsed_time = time.perf_counter() - start_time
     

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -101,9 +101,7 @@ def main():
     hyper_parameters = create(hyper_parameters)
 
     # Get classes for Task, ConfigurableParameters and Dataset.
-    if any(args.load_weights.endswith(x) for x in (".bin", ".xml", ".zip")):
-        task_class = get_impl_class(template.entrypoints.openvino)
-    elif args.load_weights.endswith(".pth"):
+    if args.load_weights.endswith(".pth"):
         task_class = get_impl_class(template.entrypoints.base)
     else:
         raise ValueError(f"Unsupported file: {args.load_weights}")

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -20,9 +20,14 @@ import argparse
 import os
 import time
 
+import cv2
+import numpy as np
 from ote_sdk.configuration.helper import create
-from ote_sdk.entities.inference_parameters import InferenceParameters
+from ote_sdk.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
+from ote_sdk.entities.datasets import DatasetEntity, DatasetItemEntity
+from ote_sdk.entities.image import Image
 from ote_sdk.entities.subset import Subset
+from ote_sdk.entities.inference_parameters import InferenceParameters
 from ote_sdk.entities.task_environment import TaskEnvironment
 
 from ote_cli.datasets import get_dataset_class
@@ -62,20 +67,14 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("template")
     parser.add_argument(
-        "--explain-data-root",
+        "--explain-data-roots",
         required=True,
-        help="Source of input data: images folder, image, webcam and video.",
+        help="Comma-separated paths to explain data folders.",
     )
     parser.add_argument(
         "--save-explanation-to",
         default="saliency_dump",
         help="Output path for explanation images.",
-    )
-    parser.add_argument(
-        "-w",
-        "--weight",
-        default=0.5,
-        help="weight of the saliency map when overlaying the saliency map",
     )
     parser.add_argument(
         "--load-weights",
@@ -86,6 +85,12 @@ def parse_args():
         "--explain-algorithm",
         default="EigenCAM",
         help=f"Explain algorithm name, currently support {SUPPORTED_EXPLAIN_ALGORITHMS}",
+    )
+    parser.add_argument(
+        "-w",
+        "--weight",
+        default=0.5,
+        help="weight of the saliency map when overlaying the saliency map",
     )
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
 
@@ -107,9 +112,7 @@ def main():
     hyper_parameters = create(hyper_parameters)
 
     # Get classes for Task, ConfigurableParameters and Dataset.
-    if any(args.load_weights.endswith(x) for x in (".bin", ".xml", ".zip")):
-        task_class = get_impl_class(template.entrypoints.openvino)
-    elif args.load_weights.endswith(".pth"):
+    if args.load_weights.endswith(".pth"):
         if is_checkpoint_nncf(args.load_weights):
             task_class = get_impl_class(template.entrypoints.nncf)
         else:
@@ -136,9 +139,20 @@ def main():
             Currently only supporting {SUPPORTED_EXPLAIN_ALGORITHMS}"
         )
 
-    dataset_class = get_dataset_class(template.task_type)
-    dataset = dataset_class(test_subset={"data_root": args.explain_data_root})
-    explain_dataset = dataset.get_subset(Subset.TESTING)
+    empty_annotation = AnnotationSceneEntity(
+        annotations=[], kind=AnnotationSceneKind.PREDICTION
+    )
+    
+    image_files = get_image_files(args.explain_data_roots)
+    items = []
+    for root_dir, filename in image_files:
+        frame = cv2.imread(os.path.join(root_dir, filename))
+        item = DatasetItemEntity(
+            media=Image(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)),
+            annotation_scene=empty_annotation,
+        )
+        items.append(item)
+    explain_dataset = DatasetEntity(items=items)
 
     if not os.path.exists(args.save_explanation_to):
         os.makedirs(args.save_explanation_to)
@@ -153,13 +167,13 @@ def main():
     )
     elapsed_time = time.perf_counter() - start_time
 
-    for img, saliency_map in zip(explain_dataset, saliency_maps):
-        file_path = img.media.filepath
+    for img, saliency_map, (_, fname) in zip(explain_dataset, saliency_maps, image_files):
+        # file_path = img.media.filepath
         save_saliency_output(
             img.numpy,
             saliency_map.numpy,
             args.save_explanation_to,
-            os.path.splitext(file_path)[0],
+            os.path.splitext(fname)[0],
             weight=args.weight,
         )
 

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -1,0 +1,171 @@
+"""
+Model inference demonstration tool.
+"""
+
+# Copyright (C) 2021 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import argparse
+import time
+from collections import deque
+import os
+
+import cv2
+import numpy as np
+from ote_sdk.configuration.helper import create
+from ote_sdk.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
+from ote_sdk.entities.datasets import DatasetEntity, DatasetItemEntity
+from ote_sdk.entities.image import Image
+from ote_sdk.entities.inference_parameters import InferenceParameters
+from ote_sdk.entities.task_environment import TaskEnvironment
+
+from ote_cli.registry import find_and_parse_model_template
+from ote_cli.tools.utils.demo.images_capture import open_images_capture
+from ote_cli.utils.config import override_parameters
+from ote_cli.utils.importing import get_impl_class
+from ote_cli.utils.io import read_label_schema, read_model, get_image_files
+from ote_cli.utils.parser import (
+    add_hyper_parameters_sub_parser,
+    gen_params_dict_from_args,
+)
+
+ESC_BUTTON = 27
+SUPPORTED_XAI_MODELS = ['EigenCAM']
+
+def parse_args():
+    """
+    Parses command line arguments.
+    """
+
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument("template")
+    parsed, _ = pre_parser.parse_known_args()
+    # Load template.yaml file.
+    template = find_and_parse_model_template(parsed.template)
+    # Get hyper parameters schema.
+    hyper_parameters = template.hyper_parameters.data
+    assert hyper_parameters
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("template")
+    parser.add_argument(
+        "-i",
+        "--input",
+        required=True,
+        help="Source of input data: images folder, image, webcam and video.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default='saliency_dump',
+        help="Output path for explanation images.",
+    )
+    parser.add_argument(
+        "--load-weights",
+        required=True,
+        help="Load only weights from previously saved checkpoint",
+    )
+    parser.add_argument(
+        "--explain-model",
+        default="EigenCAM",
+        help=f"XAI model name, currently support {SUPPORTED_XAI_MODELS}"
+    )
+    add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
+
+    return parser.parse_args(), template, hyper_parameters
+
+
+def get_explain_map(task, frame):
+    """
+    Returns list of explanations made by task on frame and time spent on doing explanation.
+    """
+
+    empty_annotation = AnnotationSceneEntity(
+        annotations=[], kind=AnnotationSceneKind.PREDICTION
+    )
+
+    item = DatasetItemEntity(
+        media=Image(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)),
+        annotation_scene=empty_annotation,
+    )
+
+    dataset = DatasetEntity(items=[item])
+
+    start_time = time.perf_counter()
+    explain_map = task.explain(
+        dataset,
+        InferenceParameters(is_evaluation=True),
+    )
+    elapsed_time = time.perf_counter() - start_time
+    saliency_map = explain_map[0]
+    return saliency_map, elapsed_time
+
+
+def main():
+    """
+    Main function that is used for model demonstration.
+    """
+
+    # Dynamically create an argument parser based on override parameters.
+    args, template, hyper_parameters = parse_args()
+    # Get new values from user's input.
+    updated_hyper_parameters = gen_params_dict_from_args(args)
+    # Override overridden parameters by user's values.
+    override_parameters(updated_hyper_parameters, hyper_parameters)
+
+    hyper_parameters = create(hyper_parameters)
+
+    # Get classes for Task, ConfigurableParameters and Dataset.
+    if args.load_weights.endswith(".pth"):
+        task_class = get_impl_class(template.entrypoints.base)
+    else:
+        raise ValueError(f"Unsupported file: {args.load_weights}.")
+
+    environment = TaskEnvironment(
+        model=None,
+        hyper_parameters=hyper_parameters,
+        label_schema=read_label_schema(args.load_weights),
+        model_template=template,
+    )
+
+    environment.model = read_model(
+        environment.get_model_configuration(), args.load_weights, None
+    )
+
+    task = task_class(task_environment=environment)
+
+    imgs = get_image_files(args.input)
+    if imgs is None:
+        raise ValueError(f"No images found in {args.input}")
+
+    if not os.path.exists(args.output):
+        os.makedirs(args.output)
+
+    elapsed_times = deque(maxlen=10)
+
+    for (root_dir, filename) in imgs:
+        frame = cv2.imread(os.path.join(root_dir, filename))
+        saliency_map, elapsed_time = get_explain_map(task, frame)
+        elapsed_times.append(elapsed_time)
+        elapsed_time = np.mean(elapsed_times)
+
+        overlay = cv2.addWeighted(frame, 0.7, saliency_map.numpy, 0.3, 0)
+        filename = filename.split('.')[0]
+        cv2.imwrite(f'{os.path.join(args.output, filename)}_saliency_map.png', saliency_map.numpy)
+        cv2.imwrite(f'{os.path.join(args.output, filename)}_overlay_img.png', overlay)
+    
+    print(f'saliency maps saved to {args.output}...')
+
+if __name__ == "__main__":
+    main()

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -41,7 +41,7 @@ from ote_cli.utils.parser import (
 )
 
 ESC_BUTTON = 27
-SUPPORTED_XAI_MODELS = ["CAM", "EigenCAM"]
+SUPPORTED_EXPLAIN_ALGORITHMS = ["CAM", "EigenCAM"]
 
 
 def parse_args():
@@ -80,7 +80,7 @@ def parse_args():
     parser.add_argument(
         "--explain-model",
         default="EigenCAM",
-        help=f"XAI model name, currently support {SUPPORTED_XAI_MODELS}",
+        help=f"XAI model name, currently support {SUPPORTED_EXPLAIN_ALGORITHMS}",
     )
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
 

--- a/ote_cli/ote_cli/tools/explain.py
+++ b/ote_cli/ote_cli/tools/explain.py
@@ -142,7 +142,10 @@ def main():
     start_time = time.perf_counter()
     saliency_maps = task.explain(
         explain_dataset.with_empty_annotations(),
-        InferenceParameters(is_evaluation=True),
+        InferenceParameters(
+            is_evaluation=True,
+            explainer=args.explain_algorithm,
+        ),
     )
     elapsed_time = time.perf_counter() - start_time
     
@@ -152,7 +155,7 @@ def main():
 
     print(f"saliency maps saved to {args.save_explanation_to}...")
     print(f"total elapsed_time: {elapsed_time:.3f} for {len(image_files)} images")
-
+    
 
 if __name__ == "__main__":
     main()

--- a/ote_cli/ote_cli/tools/ote.py
+++ b/ote_cli/ote_cli/tools/ote.py
@@ -22,11 +22,11 @@ import sys
 from .demo import main as ote_demo
 from .deploy import main as ote_deploy
 from .eval import main as ote_eval
+from .explain import main as ote_explain
 from .export import main as ote_export
 from .find import main as ote_find
 from .optimize import main as ote_optimize
 from .train import main as ote_train
-from .explain import main as ote_explain
 
 __all__ = [
     "ote_demo",
@@ -36,7 +36,7 @@ __all__ = [
     "ote_find",
     "ote_train",
     "ote_optimize",
-    "ote_explain"
+    "ote_explain",
 ]
 
 

--- a/ote_cli/ote_cli/tools/ote.py
+++ b/ote_cli/ote_cli/tools/ote.py
@@ -26,6 +26,7 @@ from .export import main as ote_export
 from .find import main as ote_find
 from .optimize import main as ote_optimize
 from .train import main as ote_train
+from .explain import main as ote_explain
 
 __all__ = [
     "ote_demo",

--- a/ote_cli/ote_cli/tools/ote.py
+++ b/ote_cli/ote_cli/tools/ote.py
@@ -35,6 +35,7 @@ __all__ = [
     "ote_find",
     "ote_train",
     "ote_optimize",
+    "ote_explain"
 ]
 
 
@@ -59,6 +60,7 @@ def main():
       - find
       - train
       - optimize
+      - explain
     """
 
     name = parse_args().operation

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -22,6 +22,7 @@ import re
 import struct
 import tempfile
 from zipfile import ZipFile
+from pathlib import Path
 
 from ote_sdk.entities.label import Domain, LabelEntity
 from ote_sdk.entities.label_schema import LabelGroup, LabelGroupType, LabelSchemaEntity

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -236,3 +236,12 @@ def generate_label_schema(dataset, task_type):
         return label_schema
 
     return LabelSchemaEntity.from_labels(dataset.get_labels())
+
+def get_image_files(root_dir):
+    # recursively get all image file paths from given root_dir
+    img_data_formats = ['.jpg', '.jpeg', '.JPEG', '.gif', '.bmp', '.tif', '.tiff', '.png']
+    img_files = []
+    for root, _, _ in os.walk(root_dir):
+        for format in img_data_formats:
+            img_files.extend([(root, file.name) for file in Path(root).glob(f'*{format}')])
+    return img_files if img_files else None

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -21,11 +21,11 @@ import os
 import re
 import struct
 import tempfile
-import cv2
-import numpy as np
 from pathlib import Path
 from zipfile import ZipFile
 
+import cv2
+import numpy as np
 from ote_sdk.entities.label import Domain, LabelEntity
 from ote_sdk.entities.label_schema import LabelGroup, LabelGroupType, LabelSchemaEntity
 from ote_sdk.entities.model import ModelEntity, ModelOptimizationType
@@ -267,12 +267,18 @@ def get_image_files(root_dir):
             )
     return img_files if img_files else None
 
-def save_saliency_output(img: np.array, saliency_map: np.array, save_dir: str,
-                         fname: str, weight: float = 0.5) -> None:
-    
+
+def save_saliency_output(
+    img: np.array,
+    saliency_map: np.array,
+    save_dir: str,
+    fname: str,
+    weight: float = 0.5,
+) -> None:
+
     # GRAY to RGB
     heatmap = cv2.applyColorMap(np.uint8(saliency_map), cv2.COLORMAP_JET)
-    overlay = (1-weight) * img + weight * heatmap
+    overlay = (1 - weight) * img + weight * heatmap
     overlay /= np.max(overlay)
     overlay = np.uint8(255 * overlay)
     cv2.imwrite(f"{os.path.join(save_dir, fname)}_saliency_map.png", heatmap)

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -267,7 +267,13 @@ def get_image_files(root_dir):
             )
     return img_files if img_files else None
 
-def save_saliency_output(img: np.array, saliency_map: np.array, root: str, fname: str) -> None:
-    overlay = cv2.addWeighted(img, 0.7, saliency_map, 0.3, 0)
-    cv2.imwrite(f"{os.path.join(root, fname)}_saliency_map.png", saliency_map)
-    cv2.imwrite(f"{os.path.join(root, fname)}_overlay_img.png", overlay)
+def save_saliency_output(img: np.array, saliency_map: np.array, save_dir: str,
+                         fname: str, weight: float = 0.5) -> None:
+    
+    # GRAY to RGB
+    heatmap = cv2.applyColorMap(np.uint8(saliency_map), cv2.COLORMAP_JET)
+    overlay = (1-weight) * img + weight * heatmap
+    overlay /= np.max(overlay)
+    overlay = np.uint8(255 * overlay)
+    cv2.imwrite(f"{os.path.join(save_dir, fname)}_saliency_map.png", heatmap)
+    cv2.imwrite(f"{os.path.join(save_dir, fname)}_overlay_img.png", overlay)

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -252,6 +252,7 @@ def get_image_files(root_dir):
         ".tif",
         ".tiff",
         ".png",
+        ".PNG",
     ]
 
     for format_ in img_data_formats:

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -22,6 +22,7 @@ import re
 import struct
 import tempfile
 import cv2
+import numpy as np
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -261,6 +262,6 @@ def get_image_files(root_dir):
     return img_files if img_files else None
 
 def save_saliency_output(img: np.array, saliency_map: np.array, root: str, fname: str) -> None:
-    overlay = cv2.addWeighted(frame, 0.7, saliency_map, 0.3, 0)
-    cv2.imwrite(f"{os.path.join(args.output, filename)}_saliency_map.png", saliency_map)
-    cv2.imwrite(f"{os.path.join(args.output, filename)}_overlay_img.png", overlay)
+    overlay = cv2.addWeighted(img, 0.7, saliency_map, 0.3, 0)
+    cv2.imwrite(f"{os.path.join(root, fname)}_saliency_map.png", saliency_map)
+    cv2.imwrite(f"{os.path.join(root, fname)}_overlay_img.png", overlay)

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -21,8 +21,8 @@ import os
 import re
 import struct
 import tempfile
-from zipfile import ZipFile
 from pathlib import Path
+from zipfile import ZipFile
 
 from ote_sdk.entities.label import Domain, LabelEntity
 from ote_sdk.entities.label_schema import LabelGroup, LabelGroupType, LabelSchemaEntity
@@ -238,11 +238,23 @@ def generate_label_schema(dataset, task_type):
 
     return LabelSchemaEntity.from_labels(dataset.get_labels())
 
+
 def get_image_files(root_dir):
     # recursively get all image file paths from given root_dir
-    img_data_formats = ['.jpg', '.jpeg', '.JPEG', '.gif', '.bmp', '.tif', '.tiff', '.png']
+    img_data_formats = [
+        ".jpg",
+        ".jpeg",
+        ".JPEG",
+        ".gif",
+        ".bmp",
+        ".tif",
+        ".tiff",
+        ".png",
+    ]
     img_files = []
     for root, _, _ in os.walk(root_dir):
-        for format in img_data_formats:
-            img_files.extend([(root, file.name) for file in Path(root).glob(f'*{format}')])
+        for format_ in img_data_formats:
+            img_files.extend(
+                [(root, file.name) for file in Path(root).glob(f"*{format_}")]
+            )
     return img_files if img_files else None

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -21,6 +21,7 @@ import os
 import re
 import struct
 import tempfile
+import cv2
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -258,3 +259,8 @@ def get_image_files(root_dir):
                 [(root, file.name) for file in Path(root).glob(f"*{format_}")]
             )
     return img_files if img_files else None
+
+def save_saliency_output(img: np.array, saliency_map: np.array, root: str, fname: str) -> None:
+    overlay = cv2.addWeighted(frame, 0.7, saliency_map, 0.3, 0)
+    cv2.imwrite(f"{os.path.join(args.output, filename)}_saliency_map.png", saliency_map)
+    cv2.imwrite(f"{os.path.join(args.output, filename)}_overlay_img.png", overlay)

--- a/ote_cli/ote_cli/utils/io.py
+++ b/ote_cli/ote_cli/utils/io.py
@@ -253,6 +253,12 @@ def get_image_files(root_dir):
         ".tiff",
         ".png",
     ]
+
+    for format_ in img_data_formats:
+        # single image path
+        if root_dir.endswith(format_):
+            return [os.path.dirname(root_dir), os.path.basename(root_dir)]
+
     img_files = []
     for root, _, _ in os.walk(root_dir):
         for format_ in img_data_formats:

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -568,7 +568,7 @@ def xfail_templates(templates, xfail_template_ids_reasons):
     return xfailed_templates
 
 
-def ote_torch_explain_testing(template, root, ote_dir, args):
+def ote_explain_testing(template, root, ote_dir, args):
     work_dir, template_work_dir, _ = get_some_vars(template, root)
     command_line = [
         "ote",

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -570,6 +570,7 @@ def xfail_templates(templates, xfail_template_ids_reasons):
 
 def ote_explain_testing(template, root, ote_dir, args):
     work_dir, template_work_dir, _ = get_some_vars(template, root)
+    output_dir = f"{template_work_dir}/explain_{template.model_template_id}_output/"
     command_line = [
         "ote",
         "explain",
@@ -579,9 +580,8 @@ def ote_explain_testing(template, root, ote_dir, args):
         "--explain-data-root",
         os.path.join(ote_dir, args["--input"]),
         "--save-explanation-to",
-        f"{template_work_dir}/explain_{template.model_template_id}_output/",
+        output_dir,
     ]
-    output_dir = f"{template_work_dir}/explain_{template.model_template_id}_output/"
     assert run(command_line, env=collect_env_vars(work_dir)).returncode == 0
     assert os.path.exists(output_dir)
     assert len(os.listdir(output_dir)) > 0

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -568,7 +568,7 @@ def xfail_templates(templates, xfail_template_ids_reasons):
     return xfailed_templates
 
 
-def ote_explain_testing(template, root, ote_dir, args):
+def ote_torch_explain_testing(template, root, ote_dir, args):
     work_dir, template_work_dir, _ = get_some_vars(template, root)
     command_line = [
         "ote",
@@ -576,9 +576,11 @@ def ote_explain_testing(template, root, ote_dir, args):
         template.model_template_path,
         "--load-weights",
         f"{template_work_dir}/trained_{template.model_template_id}/weights.pth",
-        "--input",
+        "--explain-data-root",
         os.path.join(ote_dir, args["--input"]),
-        "--output",
-        "./explain_example",
+        "--save-explanation-to",
+        f"{template_work_dir}/explain_{template.model_template_id}_output/",
     ]
     assert run(command_line, env=collect_env_vars(work_dir)).returncode == 0
+    assert os.path.exists(f"{template_work_dir}/explain_{template.model_template_id}_output/")
+    assert len(os.listdir(f"{template_work_dir}/explain_{template.model_template_id}_output/")) > 0

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -566,3 +566,19 @@ def xfail_templates(templates, xfail_template_ids_reasons):
                 "More than one reason for template. If you have more than one Jira tickets, list them in one reason."
             )
     return xfailed_templates
+
+
+def ote_explain_testing(template, root, ote_dir, args):
+    work_dir, template_work_dir, _ = get_some_vars(template, root)
+    command_line = [
+        "ote",
+        "explain",
+        template.model_template_path,
+        "--load-weights",
+        f"{template_work_dir}/trained_{template.model_template_id}/weights.pth",
+        "--input",
+        os.path.join(ote_dir, args["--input"]),
+        "--output",
+        "./explain_example",
+    ]
+    assert run(command_line, env=collect_env_vars(work_dir)).returncode == 0

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -581,8 +581,7 @@ def ote_explain_testing(template, root, ote_dir, args):
         "--save-explanation-to",
         f"{template_work_dir}/explain_{template.model_template_id}_output/",
     ]
+    output_dir = f"{template_work_dir}/explain_{template.model_template_id}_output/"
     assert run(command_line, env=collect_env_vars(work_dir)).returncode == 0
-    assert os.path.exists(
-        f"{template_work_dir}/explain_{template.model_template_id}_output/"
-    )
-    assert len(os.listdir(f"{template_work_dir}/explain_{template.model_template_id}_output/")) > 0
+    assert os.path.exists(output_dir)
+    assert len(os.listdir(output_dir)) > 0

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -582,5 +582,7 @@ def ote_explain_testing(template, root, ote_dir, args):
         f"{template_work_dir}/explain_{template.model_template_id}_output/",
     ]
     assert run(command_line, env=collect_env_vars(work_dir)).returncode == 0
-    assert os.path.exists(f"{template_work_dir}/explain_{template.model_template_id}_output/")
+    assert os.path.exists(
+        f"{template_work_dir}/explain_{template.model_template_id}_output/"
+    )
     assert len(os.listdir(f"{template_work_dir}/explain_{template.model_template_id}_output/")) > 0

--- a/ote_sdk/ote_sdk/entities/image.py
+++ b/ote_sdk/ote_sdk/entities/image.py
@@ -118,3 +118,10 @@ class Image(IMedia2DEntity):
         if self.__width is None:
             self.__height, self.__width = self.__get_size()
         return self.__width
+
+    @property
+    def filepath(self) -> str:
+        """
+        Returns the filepath of the image.
+        """
+        return self.__file_path

--- a/ote_sdk/ote_sdk/entities/inference_parameters.py
+++ b/ote_sdk/ote_sdk/entities/inference_parameters.py
@@ -28,3 +28,4 @@ class InferenceParameters:
 
     is_evaluation: bool = False
     update_progress: Callable[[int], None] = default_progress_callback
+    explainer: str = None

--- a/ote_sdk/ote_sdk/entities/inference_parameters.py
+++ b/ote_sdk/ote_sdk/entities/inference_parameters.py
@@ -28,4 +28,4 @@ class InferenceParameters:
 
     is_evaluation: bool = False
     update_progress: Callable[[int], None] = default_progress_callback
-    explainer: str = None
+    explainer: str = ''

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/deployment_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/deployment_interface.py
@@ -21,4 +21,5 @@ class IDeploymentTask(metaclass=abc.ABCMeta):
 
         :param output_model: Output model
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/deployment_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/deployment_interface.py
@@ -21,5 +21,5 @@ class IDeploymentTask(metaclass=abc.ABCMeta):
 
         :param output_model: Output model
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/evaluate_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/evaluate_interface.py
@@ -27,6 +27,8 @@ class IEvaluationTask(metaclass=abc.ABCMeta):
         The performance will be stored directly to output_resultset.performance
 
         :param output_resultset: The set of results which must be evaluated.
-        :param evaluation_metric: the evaluation metric used to compute the performance
+        :param evaluatio
+        n_metric: the evaluation metric used to compute the performance
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/evaluate_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/evaluate_interface.py
@@ -30,5 +30,5 @@ class IEvaluationTask(metaclass=abc.ABCMeta):
         :param evaluatio
         n_metric: the evaluation metric used to compute the performance
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py
@@ -29,4 +29,5 @@ class IExplainTask(metaclass=abc.ABCMeta):
         :param explain_parameters: The parameters to use for the explain.
         :return: The results of the explain, such as saliency_map or feature_map
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py
@@ -1,0 +1,32 @@
+"""This module contains the interface class for tasks. """
+
+
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import abc
+
+from ote_sdk.entities.datasets import DatasetEntity
+from ote_sdk.entities.inference_parameters import InferenceParameters
+
+
+class IExplainTask(metaclass=abc.ABCMeta):
+    """
+    A base interface for explain task.
+    """
+
+    @abc.abstractmethod
+    def explain(
+        self,
+        dataset: DatasetEntity,
+        explain_parameters: InferenceParameters,
+    ) -> DatasetEntity:
+        """
+        This is the method that is called upon explanation.
+
+        :param dataset: The input dataset to perform the explain on.
+        :param explain_parameters: The parameters to use for the explain.
+        :return: The results of the explain, such as saliency_map or feature_map
+        """
+        raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/explain_interface.py
@@ -29,5 +29,5 @@ class IExplainTask(metaclass=abc.ABCMeta):
         :param explain_parameters: The parameters to use for the explain.
         :return: The results of the explain, such as saliency_map or feature_map
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/export_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/export_interface.py
@@ -31,5 +31,5 @@ class IExportTask(metaclass=abc.ABCMeta):
         :param export_type: The type of optimization
         :param output_model: Output model
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/export_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/export_interface.py
@@ -31,4 +31,5 @@ class IExportTask(metaclass=abc.ABCMeta):
         :param export_type: The type of optimization
         :param output_model: Output model
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/inference_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/inference_interface.py
@@ -56,4 +56,5 @@ class IRawInference(metaclass=abc.ABCMeta):
         :param input_tensors: Dictionary containing the input tensors.
         :param output_tensors: Dictionary to be filled by the task with the output tensors.
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/inference_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/inference_interface.py
@@ -56,5 +56,5 @@ class IRawInference(metaclass=abc.ABCMeta):
         :param input_tensors: Dictionary containing the input tensors.
         :param output_tensors: Dictionary to be filled by the task with the output tensors.
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/optimization_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/optimization_interface.py
@@ -44,5 +44,5 @@ class IOptimizationTask(metaclass=abc.ABCMeta):
         :param output_model: Output model
         :param optimization_parameters: Additional optimization parameters
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/optimization_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/optimization_interface.py
@@ -44,4 +44,5 @@ class IOptimizationTask(metaclass=abc.ABCMeta):
         :param output_model: Output model
         :param optimization_parameters: Additional optimization parameters
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/training_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/training_interface.py
@@ -27,6 +27,7 @@ class ITrainingTask(metaclass=abc.ABCMeta):
 
         :param output_model: Output model where the weights should be stored
         """
+
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -51,6 +52,7 @@ class ITrainingTask(metaclass=abc.ABCMeta):
         :param output_model: Output model where the weights should be stored
         :param train_parameters: Training parameters
         """
+
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -59,4 +61,5 @@ class ITrainingTask(metaclass=abc.ABCMeta):
         Cancels the currently running training process.
         If training is not running, do nothing.
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/training_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/training_interface.py
@@ -61,5 +61,5 @@ class ITrainingTask(metaclass=abc.ABCMeta):
         Cancels the currently running training process.
         If training is not running, do nothing.
         """
-        
+
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/unload_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/unload_interface.py
@@ -24,4 +24,5 @@ class IUnload(metaclass=abc.ABCMeta):
 
         It is acceptable to restart the server as a last resort strategy if unloading the resources is too difficult.
         """
+        
         raise NotImplementedError

--- a/ote_sdk/ote_sdk/usecases/tasks/interfaces/unload_interface.py
+++ b/ote_sdk/ote_sdk/usecases/tasks/interfaces/unload_interface.py
@@ -24,5 +24,5 @@ class IUnload(metaclass=abc.ABCMeta):
 
         It is acceptable to restart the server as a last resort strategy if unloading the resources is too difficult.
         """
-        
+
         raise NotImplementedError


### PR DESCRIPTION
**Summary**
Support OV explanation in OTX
This should be merged after #1311([OTX] support torch OTX explanation mode)

**This PR includes**
Add OV input type in explain mode
Add explainer parameter, to accept various explainer algorithm
Add `eigen_cam` and `cam` in `external/deep-object-reid/torchreid_tasks/model_wrappers/classification.py`, to post-process the activation map and feature vector.

**Test Codes**
- train model
```
CUDA_VISIBLE_DEVICES=3 ote train \
./external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml \
--train-data-roots ./data/classification/train \
--val-data-roots ./data/classification/train \
--save-model-to ./ote_cls \
--train-ann-file ./data/classification/annotation.txt \
--val-ann-file ./data/classification/annotation.txt \
```

- export ov model
```
CUDA_VISIBLE_DEVICES=3 ote export \
./external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml \
--load-weights ./ote_cls/weights.pth \
--save-model-to ./ote_cls_export \
```

- explain with ov model
```
CUDA_VISIBLE_DEVICES=3 ote explain \
./external/model-preparation-algorithm/configs/classification/mobilenet_v3_large_1_cls_incr/template.yaml \
--explain-data-root ./data/classification/train \
--save-explanation-to ./saliency_dump \
--load-weights ./ote_cls_export/openvino.xml \
--explain-algorithm EigenCAM \
```