### PR TITLE
specified ruby version to pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 default_language_version:
   python: python3.8
   node: 16.15.0
+  ruby: 2.7.2
 
 repos:
   - repo: https://github.com/PyCQA/isort


### PR DESCRIPTION
to resolve issue that cannot find some binary (gem) in the system for running pre-commit hook.

https://github.com/pre-commit/pre-commit/issues/1930

Signed-off-by: Lee, Yunchu <yunchu.lee@intel.com>