### PR TITLE
Revert num_workers on classification task.

### DIFF
--- a/external/model-preparation-algorithm/configs/classification/configuration.yaml
+++ b/external/model-preparation-algorithm/configs/classification/configuration.yaml
@@ -83,7 +83,7 @@ learning_parameters:
     warning: null
   num_workers:
     affects_outcome_of: NONE
-    default_value: 2
+    default_value: 0
     description:
       Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading


### PR DESCRIPTION
To prevent unexpected dataloader issue, revert num_workers on classification task as (2->0).
