### PR TITLE
Update evaluation iou_thr values

### DIFF
--- a/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/model.py
@@ -2,4 +2,5 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/efficientnet_b2b.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/efficientnetb2b_maskrcnn.custom.py",
 ]
+evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])
 fp16 = dict(loss_scale=512.0)

--- a/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/model.py
@@ -2,3 +2,4 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/resnet50.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/resnet50_maskrcnn.custom.py",
 ]
+evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])

--- a/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/model.py
@@ -2,3 +2,5 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/efficientnet_b2b.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/efficientnetb2b_maskrcnn.custom.py",
 ]
+evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])
+fp16 = dict(loss_scale=512.0)

--- a/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/model.py
@@ -2,3 +2,4 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/resnet50.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/resnet50_maskrcnn.custom.py",
 ]
+evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])


### PR DESCRIPTION
## Summary
Validation time is too long due to the issue of selecting too many iou_thr values ​​as a table during validation on a relatively large size dataset. Fix this to iou_thr = [0.5]
only instance-segmentation & rotated-detection

### This PR includes :
- Update iou_thr = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9] -> [0.5]