### PR TITLE
[Develop CI-Fix] Add xfail mark for deprecated model template

### DIFF
--- a/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/efficientnetb2b_maskrcnn/model.py
@@ -2,5 +2,5 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/efficientnet_b2b.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/efficientnetb2b_maskrcnn.custom.py",
 ]
-evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])
+evaluation = dict(interval=1, metric="mAP", save_best="mAP", iou_thr=[0.5])
 fp16 = dict(loss_scale=512.0)

--- a/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/instance-segmentation/resnet50_maskrcnn/model.py
@@ -2,4 +2,4 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/resnet50.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/resnet50_maskrcnn.custom.py",
 ]
-evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])
+evaluation = dict(interval=1, metric="mAP", save_best="mAP", iou_thr=[0.5])

--- a/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/rotated-detection/efficientnetb2b_maskrcnn/model.py
@@ -2,5 +2,5 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/efficientnet_b2b.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/efficientnetb2b_maskrcnn.custom.py",
 ]
-evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])
+evaluation = dict(interval=1, metric="mAP", save_best="mAP", iou_thr=[0.5])
 fp16 = dict(loss_scale=512.0)

--- a/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/model.py
+++ b/external/model-preparation-algorithm/configs/rotated-detection/resnet50_maskrcnn/model.py
@@ -2,4 +2,4 @@ _base_ = [
     "../../../submodule/samples/cfgs/models/backbones/resnet50.yaml",
     "../../../submodule/recipes/stages/_base_/models/detectors/resnet50_maskrcnn.custom.py",
 ]
-evaluation = dict(interval=1, metric='mAP', save_best='mAP', iou_thr=[0.5])
+evaluation = dict(interval=1, metric="mAP", save_best="mAP", iou_thr=[0.5])

--- a/external/model-preparation-algorithm/tests/ote_cli/test_segmentation.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_segmentation.py
@@ -149,6 +149,8 @@ class TestToolsMPASegmentation:
     def test_nncf_optimize(self, template):
         if template.entrypoints.nncf is None:
             pytest.skip("nncf entrypoint is none")
+        if template.model_template_id == "Custom_Semantic_Segmentation_Lite-HRNet-18_OCR":
+            pytest.skip("[CVS-91469] This is a deprecated model template.")
 
         nncf_optimize_testing(template, root, ote_dir, args)
 
@@ -158,6 +160,8 @@ class TestToolsMPASegmentation:
     def test_nncf_export(self, template):
         if template.entrypoints.nncf is None:
             pytest.skip("nncf entrypoint is none")
+        if template.model_template_id == "Custom_Semantic_Segmentation_Lite-HRNet-18_OCR":
+            pytest.skip("[CVS-91469] This is a deprecated model template.")
 
         nncf_export_testing(template, root)
 
@@ -167,6 +171,8 @@ class TestToolsMPASegmentation:
     def test_nncf_eval(self, template):
         if template.entrypoints.nncf is None:
             pytest.skip("nncf entrypoint is none")
+        if template.model_template_id == "Custom_Semantic_Segmentation_Lite-HRNet-18_OCR":
+            pytest.skip("[CVS-91469] This is a deprecated model template.")
 
         nncf_eval_testing(template, root, ote_dir, args, threshold=0.001)
 
@@ -176,6 +182,8 @@ class TestToolsMPASegmentation:
     def test_nncf_eval_openvino(self, template):
         if template.entrypoints.nncf is None:
             pytest.skip("nncf entrypoint is none")
+        if template.model_template_id == "Custom_Semantic_Segmentation_Lite-HRNet-18_OCR":
+            pytest.skip("[CVS-91469] This is a deprecated model template.")
 
         nncf_eval_openvino_testing(template, root, ote_dir, args)
 


### PR DESCRIPTION
## Summary
Add xfail mark for deprecated model template & Enable black format to model.py

## Resolves
- https://jira.devtools.intel.com/browse/CVS-96084