### PR TITLE
[OTX][CVS-96667] Fix issue of test_nncf_eval_openvino for multilabel classification in OTX CLI test

### DIFF
--- a/otx/algorithms/classification/tasks/openvino.py
+++ b/otx/algorithms/classification/tasks/openvino.py
@@ -233,7 +233,6 @@ class ClassificationOpenVINOTask(IDeploymentTask, IInferenceTask, IEvaluationTas
                     annotation_scene=dataset_item.annotation_scene,
                     numpy=actmap,
                     roi=dataset_item.roi,
-                    label=predicted_scene.annotations[0].get_labels()[0].label,
                 )
                 dataset_item.append_metadata_item(saliency_media, model=self.model)
 


### PR DESCRIPTION
**This PR includes**
-  Fix an error of test_nncf_eval_openvino for multilabel classification in CLI test

This occurred because it tries to get labels of predicted data item but with empty labels since it returns empty list, it cannot get the index of 0. Checked that labels argument is optional for ResultMediaEntity and it was unnecessarily specified only in classification task, thus omitted the line causing error.

https://jira.devtools.intel.com/browse/CVS-96667