### PR TITLE
Add active score evaluation to the classification task

### DIFF
--- a/external/model-preparation-algorithm/configs/detection/mobilenetv2_ssd_cls_incr/data_pipeline.py
+++ b/external/model-preparation-algorithm/configs/detection/mobilenetv2_ssd_cls_incr/data_pipeline.py
@@ -37,10 +37,10 @@ data = dict(
     samples_per_gpu=10,
     workers_per_gpu=4,
     train=dict(
-          type=dataset_type,
-          ann_file="data/coco/annotations/instances_train2017.json",
-          img_prefix="data/coco/train2017",
-          pipeline=train_pipeline,
+        type=dataset_type,
+        ann_file="data/coco/annotations/instances_train2017.json",
+        img_prefix="data/coco/train2017",
+        pipeline=train_pipeline,
     ),
     val=dict(
         type=dataset_type,

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -270,8 +270,9 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
             top_idxs = np.argpartition(prediction_item, -2)[-2:]
             top_probs = prediction_item[top_idxs]
             active_score = top_probs[1] - top_probs[0]
-            active_score_media = FloatMetadata(name="active_score", value=active_score,
-                                               float_type=FloatType.ACTIVE_SCORE)
+            active_score_media = FloatMetadata(
+                name="active_score", value=active_score, float_type=FloatType.ACTIVE_SCORE
+            )
             dataset_item.append_metadata_item(active_score_media, model=self._task_environment.model)
 
             if feature_vector is not None:

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -259,6 +259,9 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
 
             dataset_item.append_labels(item_labels)
 
+            probs = TensorEntity(name="probabilities", numpy=prediction_item.reshape(-1))
+            dataset_item.append_metadata_item(probs, model=self._task_environment.model)
+
             top_idxs = np.argpartition(prediction_item, -2)[-2:]
             top_probs = prediction_item[top_idxs]
             active_score = top_probs[1] - top_probs[0]

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -24,6 +24,7 @@ from ote_sdk.entities.inference_parameters import (
     default_progress_callback,
 )
 from ote_sdk.entities.label import Domain
+from ote_sdk.entities.metadata import FloatMetadata, FloatType
 from ote_sdk.entities.metrics import (
     CurveMetric,
     LineChartInfo,
@@ -257,6 +258,13 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
                 item_labels.append(cls_label)
 
             dataset_item.append_labels(item_labels)
+
+            top_idxs = np.argpartition(prediction_item, -2)[-2:]
+            top_probs = prediction_item[top_idxs]
+            active_score = top_probs[1] - top_probs[0]
+            active_score_media = FloatMetadata(name="active_score", value=active_score,
+                                               float_type=FloatType.ACTIVE_SCORE)
+            dataset_item.append_metadata_item(active_score_media, model=self._task_environment.model)
 
             if feature_vector is not None:
                 active_score = TensorEntity(name="representation_vector", numpy=feature_vector.reshape(-1))

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -119,11 +119,16 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
         ) == len(
             task_environment.get_labels(include_empty=False)
         )  # noqa:E127
+        if self._multilabel:
+            logger.info("Classiification mode: multilabel")
 
         self._hierarchical_info = None
         if not self._multilabel and len(task_environment.label_schema.get_groups(False)) > 1:
+            logger.info("Classiification mode: hierarchical")
             self._hierarchical = True
             self._hierarchical_info = get_hierarchical_info(task_environment.label_schema)
+        else:
+            logger.info("Classiification mode: multiclass")
 
     def infer(
         self,

--- a/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
@@ -354,9 +354,7 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
                         pipeline_step.type = "LoadAnnotationFromOTEDataset"
                         pipeline_step.domain = domain
                         pipeline_step.min_size = cfg.pop("min_size", -1)
-                    if (subset == "train" and
-                        pipeline_step.type == "Collect" and
-                        cfg.type not in ["ImageTilingDataset"]):
+                    if subset == "train" and pipeline_step.type == "Collect" and cfg.type not in ["ImageTilingDataset"]:
                         pipeline_step = BaseTask._get_meta_keys(pipeline_step)
                 patch_color_conversion(cfg.pipeline)
 


### PR DESCRIPTION
This functionality is restored from the original d-o-r based task implementation. Basically active score is defined as a difference between top1 and top2 predictions confidence.