### PR TITLE
[Test] Change ote threshold of openvino test for cls

### DIFF
--- a/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
+++ b/external/model-preparation-algorithm/tests/ote_cli/test_classification.py
@@ -118,7 +118,7 @@ class TestToolsMPAClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ote_eval_openvino(self, template):
-        ote_eval_openvino_testing(template, root, ote_dir, args, threshold=0.0)
+        ote_eval_openvino_testing(template, root, ote_dir, args, threshold=0.2)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")


### PR DESCRIPTION
This PR includes changing threshold for classification openvino export test.
Unlike other methods(det, seg), classification threshold for openvino export test is set as zero.
In this PR, the threshold will be changed to 0.2, same as detection