### PR TITLE
Class-wise saliency map generation for the detection task

### DIFF
--- a/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
@@ -473,7 +473,6 @@ class OpenVINODetectionTask(
                     dataset_item.append_metadata_item(saliency_media, model=self.model)
                 elif saliency_map.ndim == 3:
                     # Multiple saliency maps per image (class-wise saliency map)
-                    # TODO: Handle background class for SSD
                     labels = self.task_environment.get_labels(include_empty=True)
                     num_saliency_maps = saliency_map.shape[0]
                     if num_saliency_maps == len(labels) + 1:
@@ -494,18 +493,6 @@ class OpenVINODetectionTask(
                 else:
                     raise RuntimeError(f'Single saliency map has to be 2 or 3-dimensional, '
                                        f'but got {saliency_map.ndim} dims')
-
-                # saliency_map = get_actmap(
-                #     saliency_map, (dataset_item.width, dataset_item.height)
-                # )
-                # saliency_map_media = ResultMediaEntity(
-                #     name="Saliency Map",
-                #     type="saliency_map",
-                #     annotation_scene=dataset_item.annotation_scene,
-                #     numpy=saliency_map,
-                #     roi=dataset_item.roi,
-                # )
-                # dataset_item.append_metadata_item(saliency_map_media, model=self.model)
         logger.info("OpenVINO inference completed")
         return dataset
 

--- a/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
@@ -51,6 +51,7 @@ from ote_sdk.entities.result_media import ResultMediaEntity
 from ote_sdk.entities.resultset import ResultSetEntity
 from ote_sdk.entities.task_environment import TaskEnvironment
 from ote_sdk.entities.tensor import TensorEntity
+from ote_sdk.entities.label import Domain, LabelEntity
 from ote_sdk.serialization.label_mapper import LabelSchemaMapper, label_schema_to_bytes
 from ote_sdk.usecases.evaluation.metrics_helper import MetricsHelper
 from ote_sdk.usecases.exportable_code.inference import BaseInferencer
@@ -164,7 +165,7 @@ class BaseInferencerWithConverter(BaseInferencer):
         else:
             features = [
                 raw_predictions["feature_vector"].reshape(-1),
-                raw_predictions["saliency_map"],
+                raw_predictions["saliency_map"][0],
             ]
         return predictions, features
 
@@ -455,18 +456,56 @@ class OpenVINODetectionTask(
                     representation_vector, model=self.model
                 )
 
+            add_saliency_map = True
             if add_saliency_map and saliency_map is not None:
-                saliency_map = get_actmap(
-                    saliency_map, (dataset_item.width, dataset_item.height)
-                )
-                saliency_map_media = ResultMediaEntity(
-                    name="Saliency Map",
-                    type="saliency_map",
-                    annotation_scene=dataset_item.annotation_scene,
-                    numpy=saliency_map,
-                    roi=dataset_item.roi,
-                )
-                dataset_item.append_metadata_item(saliency_map_media, model=self.model)
+                if saliency_map.ndim == 2:
+                    # Single saliency map per image, support e.g. EigenCAM use case
+                    actmap = get_actmap(
+                        saliency_map, (dataset_item.width, dataset_item.height)
+                    )
+                    saliency_media = ResultMediaEntity(
+                        name="Saliency Map",
+                        type="saliency_map",
+                        annotation_scene=dataset_item.annotation_scene,
+                        numpy=actmap,
+                        roi=dataset_item.roi
+                    )
+                    dataset_item.append_metadata_item(saliency_media, model=self.model)
+                elif saliency_map.ndim == 3:
+                    # Multiple saliency maps per image (class-wise saliency map)
+                    # TODO: Handle background class for SSD
+                    labels = self.task_environment.get_labels(include_empty=True)
+                    num_saliency_maps = saliency_map.shape[0]
+                    if num_saliency_maps == len(labels) + 1:
+                        # include the background as the last label
+                        labels.append(LabelEntity('backgroung', Domain.DETECTION))
+                    for class_id, class_wise_saliency_map in enumerate(saliency_map):
+                        actmap = get_actmap(
+                            class_wise_saliency_map, (dataset_item.width, dataset_item.height)
+                        )
+                        class_name_str = labels[class_id].name
+                        saliency_media = ResultMediaEntity(
+                            name=class_name_str,
+                            type="saliency_map",
+                            annotation_scene=dataset_item.annotation_scene,
+                            numpy=actmap, roi=dataset_item.roi
+                        )
+                        dataset_item.append_metadata_item(saliency_media, model=self.model)
+                else:
+                    raise RuntimeError(f'Single saliency map has to be 2 or 3-dimensional, '
+                                       f'but got {saliency_map.ndim} dims')
+
+                # saliency_map = get_actmap(
+                #     saliency_map, (dataset_item.width, dataset_item.height)
+                # )
+                # saliency_map_media = ResultMediaEntity(
+                #     name="Saliency Map",
+                #     type="saliency_map",
+                #     annotation_scene=dataset_item.annotation_scene,
+                #     numpy=saliency_map,
+                #     roi=dataset_item.roi,
+                # )
+                # dataset_item.append_metadata_item(saliency_map_media, model=self.model)
         logger.info("OpenVINO inference completed")
         return dataset
 

--- a/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
@@ -476,8 +476,8 @@ class OpenVINODetectionTask(
                     labels = self.task_environment.get_labels(include_empty=True)
                     num_saliency_maps = saliency_map.shape[0]
                     if num_saliency_maps == len(labels) + 1:
-                        # include the background as the last label
-                        labels.append(LabelEntity('backgroung', Domain.DETECTION))
+                        # Include the background as the last label
+                        labels.append(LabelEntity('background', Domain.DETECTION))
                     for class_id, class_wise_saliency_map in enumerate(saliency_map):
                         actmap = get_actmap(
                             class_wise_saliency_map, (dataset_item.width, dataset_item.height)

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -283,7 +283,7 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
                         )
                         class_name_str = self._labels[class_id].name
                         saliency_map_media = ResultMediaEntity(
-                            name=f"Saliency Map: {class_name_str}",
+                            name=class_name_str,
                             type="saliency_map",
                             annotation_scene=dataset_item.annotation_scene,
                             numpy=class_wise_saliency_map,

--- a/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
@@ -31,7 +31,7 @@ from ote_sdk.entities.annotation import Annotation
 from ote_sdk.entities.datasets import DatasetEntity
 from ote_sdk.entities.id import ID
 from ote_sdk.entities.inference_parameters import InferenceParameters
-from ote_sdk.entities.label import Domain
+from ote_sdk.entities.label import Domain, LabelEntity
 from ote_sdk.entities.metrics import (
     BarChartInfo,
     BarMetricsGroup,
@@ -307,15 +307,41 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
                 dataset_item.append_metadata_item(active_score, model=self._task_environment.model)
 
             if saliency_map is not None:
-                saliency_map = get_actmap(saliency_map, (dataset_item.width, dataset_item.height))
-                saliency_map_media = ResultMediaEntity(
-                    name="Saliency Map",
-                    type="saliency_map",
-                    annotation_scene=dataset_item.annotation_scene,
-                    numpy=saliency_map,
-                    roi=dataset_item.roi,
-                )
-                dataset_item.append_metadata_item(saliency_map_media, model=self._task_environment.model)
+                if saliency_map.ndim == 2:
+                    # Single saliency map per image, support e.g. EigenCAM use case
+                    actmap = get_actmap(
+                        saliency_map, (dataset_item.width, dataset_item.height)
+                    )
+                    saliency_media = ResultMediaEntity(
+                        name="Saliency Map",
+                        type="saliency_map",
+                        annotation_scene=dataset_item.annotation_scene,
+                        numpy=actmap,
+                        roi=dataset_item.roi
+                    )
+                    dataset_item.append_metadata_item(saliency_media, model=self._task_environment.model)
+                elif saliency_map.ndim == 3:
+                    # Multiple saliency maps per image (class-wise saliency map)
+                    labels = self._labels
+                    num_saliency_maps = saliency_map.shape[0]
+                    if num_saliency_maps == len(labels) + 1:
+                        # Include the background as the last category
+                        labels.append(LabelEntity('background', Domain.DETECTION))
+                    for class_id, class_wise_saliency_map in enumerate(saliency_map):
+                        actmap = get_actmap(
+                            class_wise_saliency_map, (dataset_item.width, dataset_item.height)
+                        )
+                        class_name_str = labels[class_id].name
+                        saliency_media = ResultMediaEntity(
+                            name=class_name_str,
+                            type="saliency_map",
+                            annotation_scene=dataset_item.annotation_scene,
+                            numpy=actmap, roi=dataset_item.roi
+                        )
+                        dataset_item.append_metadata_item(saliency_media, model=self._task_environment.model)
+                else:
+                    raise RuntimeError(f'Single saliency map has to be 2 or 3-dimensional, '
+                                       f'but got {saliency_map.ndim} dims')
 
     def _patch_data_pipeline(self):
         base_dir = os.path.abspath(os.path.dirname(self.template_file_path))

--- a/external/model-preparation-algorithm/tests/test_xai.py
+++ b/external/model-preparation-algorithm/tests/test_xai.py
@@ -6,8 +6,10 @@ import numpy as np
 import torch
 
 from mmcls.models import build_classifier
+from mmdet.models import build_detector
 
-from mpa.modules.hooks.auxiliary_hooks import ReciproCAMHook
+from mpa.modules.hooks.auxiliary_hooks import ReciproCAMHook, SaliencyMapHookDet
+from mpa.det.stage import DetectionStage
 
 
 torch.manual_seed(0)
@@ -15,7 +17,7 @@ torch.manual_seed(0)
 
 class TestExplainMethods:
     @staticmethod
-    def get_model():
+    def get_classification_model():
         model_cfg = dict(
             type="ImageClassifier",
             backbone=dict(type="ResNet", depth=18, num_stages=4, out_indices=(3,), style="pytorch"),
@@ -32,8 +34,40 @@ class TestExplainMethods:
         model = build_classifier(model_cfg)
         return model.eval()
 
+    @staticmethod
+    def get_detection_model():
+        model_cfg = dict(
+            type='CustomSingleStageDetector',
+            backbone=dict(type='mobilenetv2_w1',
+                          out_indices=(4, 5),
+                          frozen_stages=-1,
+                          norm_eval=False,
+                          pretrained=True),
+            bbox_head=dict(
+                type='CustomSSDHead',
+                in_channels=(96, 320),
+                num_classes=20,
+                anchor_generator=dict(
+                    type='SSDAnchorGeneratorClustered',
+                    reclustering_anchors=True,
+                    strides=[16, 32],
+                    widths=[np.array([70.93408016, 132.06659281, 189.56180207, 349.90057837]),
+                            np.array([272.31733885, 448.52200666, 740.63350023, 530.78990182,
+                                      790.99297377])],
+                    heights=[np.array([93.83759764, 235.21261441, 432.6029996, 250.08979657]),
+                             np.array([672.8829653, 474.84783528, 420.18291446, 741.02592293,
+                                       766.45636125])]),
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[.0, .0, .0, .0],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+            )
+        )
+        model = build_detector(model_cfg)
+        return model.eval()
+
     def test_recipro_cam(self):
-        model = self.get_model()
+        model = self.get_classification_model()
         img = torch.rand(2, 3, 224, 224) - 0.5
         data = {"img_metas": {}, "img": img}
 
@@ -66,6 +100,46 @@ class TestExplainMethods:
                 [195, 184, 17, 105, 127, 90, 106],
                 [240, 41, 104, 119, 130, 39, 211],
                 [218, 156, 140, 193, 155, 0, 224],
+            ],
+            dtype=np.uint8,
+        )
+        assert (saliency_maps[0][0] == sal_class0_reference).all()
+        assert (saliency_maps[0][1] == sal_class1_reference).all()
+
+    def test_saliency_map_detection(self):
+        model = self.get_detection_model()
+        img = torch.rand(2, 3, 224, 224) - 0.5
+        data = {"img_metas": [{}], "img": [img]}
+
+        with SaliencyMapHookDet(model) as det_hook:
+            _ = model(return_loss=False, rescale=True, **data)
+        saliency_maps = det_hook.records
+
+        assert len(saliency_maps) == 2
+        assert saliency_maps[0].ndim == 3
+        assert saliency_maps[0].shape == (21, 7, 7)
+
+        sal_class0_reference = np.array(
+            [
+                [189, 224, 89, 115, 133, 135, 176],
+                [54, 134, 148, 82, 135, 177, 154],
+                [0, 103, 39, 66, 156, 206, 73],
+                [82, 126, 142, 123, 210, 147, 167],
+                [115, 129, 108, 128, 174, 185, 121],
+                [90, 131, 118, 113, 89, 150, 105],
+                [106, 189, 148, 180, 206, 255, 145],
+            ],
+            dtype=np.uint8,
+        )
+        sal_class1_reference = np.array(
+            [
+                [230, 138, 133, 92, 127, 101, 77],
+                [100, 129, 141, 156, 0, 87, 136],
+                [99, 51, 147, 218, 123, 50, 75],
+                [111, 98, 70, 142, 172, 110, 73],
+                [124, 69, 34, 97, 157, 78, 171],
+                [214, 153, 56, 93, 128, 139, 148],
+                [189, 255, 208, 224, 169, 167, 202],
             ],
             dtype=np.uint8,
         )

--- a/external/model-preparation-algorithm/tests/test_xai.py
+++ b/external/model-preparation-algorithm/tests/test_xai.py
@@ -8,7 +8,7 @@ import torch
 from mmcls.models import build_classifier
 from mmdet.models import build_detector
 
-from mpa.modules.hooks.auxiliary_hooks import ReciproCAMHook, SaliencyMapHookDet
+from mpa.modules.hooks.auxiliary_hooks import ReciproCAMHook, DetSaliencyMapHook
 from mpa.det.stage import DetectionStage
 
 
@@ -111,7 +111,7 @@ class TestExplainMethods:
         img = torch.rand(2, 3, 224, 224) - 0.5
         data = {"img_metas": [{}], "img": [img]}
 
-        with SaliencyMapHookDet(model) as det_hook:
+        with DetSaliencyMapHook(model) as det_hook:
             _ = model(return_loss=False, rescale=True, **data)
         saliency_maps = det_hook.records
 


### PR DESCRIPTION
Enable class-wise saliency map generation for the detection case.

Tested with all detection models from `external\model-preparation-algorithm\configs\detection\` on PASCAL VOC dataset

related PR:
https://github.com/openvinotoolkit/model_preparation_algorithm/pull/97

Some examples (mobilenetv2_ssd):
![image](https://user-images.githubusercontent.com/17028475/204863408-c57878b3-0fce-43fc-8ff4-3f37873dbf43.png)
