### PR TITLE
[feature/otx] Changes in available backbone output formats

### DIFF
--- a/otx/cli/builder/builder.py
+++ b/otx/cli/builder/builder.py
@@ -29,7 +29,7 @@ from mmcv.utils import Registry, build_from_cfg
 from mpa.utils.config_utils import MPAConfig
 
 from otx.cli.registry import Registry as OTXRegistry
-from otx.cli.utils.importing import get_backbone_registry
+from otx.cli.utils.importing import get_available_backbone_list, get_backbone_registry
 
 DEFAULT_MODEL_TEMPLATE_ID = {
     "CLASSIFICATION": "Custom_Image_Classification_EfficinetNet-B0",
@@ -61,6 +61,8 @@ def update_backbone_args(backbone_config, registry, skip_missing=False):
     Also, it distinguishes the argment needed for the build to add convenience to the user.
     """
     backbone_function = registry.get(backbone_config["type"])
+    if not backbone_function:
+        raise ValueError(f"{backbone_config['type']} is not supported backbone")
     required_option = {}
     required_args, missing_args = [], []
     args_signature = inspect.signature(backbone_function)
@@ -69,7 +71,6 @@ def update_backbone_args(backbone_config, registry, skip_missing=False):
         if arg_key == "out_indices":
             use_out_indices = True
         if arg_value.default is inspect.Parameter.empty:
-            # TODO: How to get argument type (or hint or format)
             required_args.append(arg_key)
             if hasattr(backbone_function, "arch_settings"):
                 arg_options = [str(option) for option in backbone_function.arch_settings.keys()]
@@ -115,6 +116,27 @@ def update_backbone_args(backbone_config, registry, skip_missing=False):
         )
     backbone_config["use_out_indices"] = use_out_indices
     return missing_args
+
+
+def patch_missing_args(backbone_config, missing_args):
+    """Patch backbone's required arg configuration."""
+    updated_missing_args = []
+    backbone_type = backbone_config["type"]
+    backend, _ = Registry.split_scope_key(backbone_type)
+    backbone_data = get_available_backbone_list(backend)
+    if backbone_type not in backbone_data:
+        return missing_args
+    backbone_data = backbone_data[backbone_type]
+    for arg in missing_args:
+        if "options" in backbone_data and arg in backbone_data["options"]:
+            backbone_config[arg] = backbone_data["options"][arg][0]
+            print(
+                f"[otx build] '{arg}' can choose between: {backbone_data['options'][arg]}"
+                f"\n[otx build] '{arg}' default value: {backbone_config[arg]}"
+            )
+        else:
+            updated_missing_args.append(arg)
+    return updated_missing_args
 
 
 def update_in_channel(model_config, out_channels):
@@ -212,6 +234,7 @@ class Builder:
         backbone_config = {"type": backbone_type}
         otx_registry, _ = get_backbone_registry(backend)
         missing_args = update_backbone_args(backbone_config, otx_registry, skip_missing=True)
+        missing_args = patch_missing_args(backbone_config, missing_args)
         if output_path.endswith((".yml", ".yaml", ".json")):
             mmcv.dump({"backbone": backbone_config}, os.path.abspath(output_path))
             print(f"[otx build] Save backbone configuration: {os.path.abspath(output_path)}")
@@ -257,7 +280,6 @@ class Builder:
         backend, _ = Registry.split_scope_key(backbone_config["type"])
         print(f"\tTarget Backbone: {backbone_config['type']}")
         otx_registry, custom_imports = get_backbone_registry(backend)
-        _ = update_backbone_args(backbone_config, otx_registry)
         if backbone_config["use_out_indices"]:
             backbone_out_indices = backbone_config.get("out_indices", None)
             if (

--- a/otx/cli/builder/builder.py
+++ b/otx/cli/builder/builder.py
@@ -123,10 +123,10 @@ def patch_missing_args(backbone_config, missing_args):
     updated_missing_args = []
     backbone_type = backbone_config["type"]
     backend, _ = Registry.split_scope_key(backbone_type)
-    backbone_data = get_available_backbone_list(backend)
-    if backbone_type not in backbone_data:
+    available_backbones = get_available_backbone_list(backend)
+    if backbone_type not in available_backbones:
         return missing_args
-    backbone_data = backbone_data[backbone_type]
+    backbone_data = available_backbones[backbone_type]
     for arg in missing_args:
         if "options" in backbone_data and arg in backbone_data["options"]:
             backbone_config[arg] = backbone_data["options"][arg][0]

--- a/otx/cli/builder/supported_backbone/mmcls.json
+++ b/otx/cli/builder/supported_backbone/mmcls.json
@@ -1,0 +1,121 @@
+{
+  "backbones": {
+    "mmcls.RegNet": {
+      "required": ["arch"],
+      "options": {
+        "arch": [
+          "regnetx_400mf",
+          "regnetx_800mf",
+          "regnetx_1.6gf",
+          "regnetx_3.2gf",
+          "regnetx_4.0gf",
+          "regnetx_6.4gf",
+          "regnetx_8.0gf",
+          "regnetx_12gf"
+        ]
+      },
+      "available": []
+    },
+    "mmcls.ResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.ResNetV1d": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.ResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.ResNeSt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152, 200, 269]
+      },
+      "available": []
+    },
+    "mmcls.ResNet_CIFAR": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.SEResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.SEResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.VGG": {
+      "required": ["depth"],
+      "options": {
+        "depth": [11, 13, 16, 19]
+      },
+      "available": []
+    },
+    "mmcls.LeNet5": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.AlexNet": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.ShuffleNetV1": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.ShuffleNetV2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.MobileNetV2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.MobileNetV3": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.VisionTransformer": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.SwinTransformer": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.TNT": {
+      "required": [],
+      "options": {},
+      "available": []
+    }
+  }
+}

--- a/otx/cli/builder/supported_backbone/mmdet.json
+++ b/otx/cli/builder/supported_backbone/mmdet.json
@@ -1,0 +1,92 @@
+{
+  "backbones": {
+    "mmdet.RegNet": {
+      "required": ["arch"],
+      "options": {
+        "arch": [
+          "regnetx_400mf",
+          "regnetx_800mf",
+          "regnetx_1.6gf",
+          "regnetx_3.2gf",
+          "regnetx_4.0gf",
+          "regnetx_6.4gf",
+          "regnetx_8.0gf",
+          "regnetx_12gf"
+        ]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.ResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.ResNetV1d": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.ResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.SSDVGG": {
+      "required": ["input_size", "depth"],
+      "options": {
+        "input_size": [300],
+        "depth": [11, 16, 19]
+      },
+      "available": ["ATSS", "YOLOX"]
+    },
+    "mmdet.HRNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmdet.Res2Net": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.DetectoRS_ResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.DetectoRS_ResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.Darknet": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmdet.ResNest": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152, 200]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmdet.CSPDarknet": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Mask-RCNN"]
+    }
+  }
+}

--- a/otx/cli/builder/supported_backbone/mmseg.json
+++ b/otx/cli/builder/supported_backbone/mmseg.json
@@ -1,0 +1,114 @@
+{
+  "backbones": {
+    "mmseg.ResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmseg.ResNetV1c": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmseg.ResNetV1d": {
+      "required": ["depth"],
+      "options": {
+        "depth": [18, 34, 50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmseg.ResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmseg.FastSCNN": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Mask-RCNN"]
+    },
+    "mmseg.ResNest": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152, 200]
+      },
+      "available": ["ATSS", "Mask-RCNN"]
+    },
+    "mmseg.MobileNetV2": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "mmseg.CGNet": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmseg.MobileNetV3": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmseg.VisionTransformer": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Mask-RCNN"]
+    },
+    "mmseg.UNet": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Mask-RCNN"]
+    },
+    "mmseg.HRNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.LiteHRNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.DABNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.DDRNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.BiSeNetV2": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.ShelfNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.EfficientNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.CABiNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.STDCNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    }
+  }
+}

--- a/otx/cli/builder/supported_backbone/torchvision.json
+++ b/otx/cli/builder/supported_backbone/torchvision.json
@@ -1,0 +1,179 @@
+{
+  "backbones": {
+    "torchvision.alexnet": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnet18": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnet34": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnet50": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnet101": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnet152": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnext50_32x4d": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.resnext101_32x8d": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.wide_resnet50_2": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.wide_resnet101_2": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "YOLOX", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg11": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg11_bn": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg13": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg13_bn": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg16": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg16_bn": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg19": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.vgg19_bn": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.squeezenet1_0": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.squeezenet1_1": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet121": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet161": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet169": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet201": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mobilenet_v2": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mobilenet_v3_large": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mobilenet_v3_small": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet0_5": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet0_75": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet1_0": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet1_3": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x0_5": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x1_0": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x1_5": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x2_0": {
+      "required": [],
+      "options": {},
+      "available": ["ATSS", "Segmentation", "Mask-RCNN"]
+    }
+  }
+}

--- a/otx/cli/registry/registry.py
+++ b/otx/cli/registry/registry.py
@@ -21,7 +21,7 @@ import os
 import yaml
 
 from otx.api.entities.model_template import parse_model_template
-from otx.cli.utils.importing import get_backbone_list
+from otx.cli.utils.importing import get_available_backbone_list
 
 
 class Registry:
@@ -80,7 +80,7 @@ class Registry:
         """Returns list of backbones for a given template."""
         backbone_lst = {}
         for backend in backend_filter:
-            backbone_lst[backend] = get_backbone_list(backend)
+            backbone_lst[backend] = get_available_backbone_list(backend)
         return backbone_lst
 
     def __str__(self):

--- a/otx/cli/tools/find.py
+++ b/otx/cli/tools/find.py
@@ -79,6 +79,7 @@ def main():
             )
         print(template_table)
 
+    # TODO: Get params from cli args & Flow arrangement (for all tasks backbone usable)
     if args.backbone:
         all_backbones = otx_registry.get_backbones(args.backbone)
         backbone_table = PrettyTable(["Index", "Backbone Type", "Required Args", "Confirmed model"])

--- a/otx/cli/utils/tests.py
+++ b/otx/cli/utils/tests.py
@@ -522,7 +522,7 @@ def otx_explain_testing(template, root, otx_dir, args):
                 assert diff == 0, f"saliency map output is not same as the sample one, with {diff}!"
 
 
-def otx_find_testing(otx_dir):
+def otx_find_testing():
     # Find all model template
     command_line = ["otx", "find", "--template"]
     assert run(command_line).returncode == 0
@@ -543,7 +543,7 @@ def otx_find_testing(otx_dir):
         assert run(command_line).returncode == 0
 
 
-def otx_build_testing(root, otx_dir, args):
+def otx_build_testing(root, args):
     # Build otx-workspace per tasks check - Default Model Template only
     for task in build_supported_tasks:
         command_line = [

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -30,8 +30,8 @@ def tmp_dir_path():
 class TestToolsOTXCLI:
     @e2e_pytest_component
     def test_otx_find(self):
-        otx_find_testing(otx_dir)
+        otx_find_testing()
 
     @e2e_pytest_component
     def test_otx_build(self, tmp_dir_path):
-        otx_build_testing(tmp_dir_path, otx_dir, build_backbone_args)
+        otx_build_testing(tmp_dir_path, build_backbone_args)

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -18,6 +18,7 @@ otx_dir = os.getcwd()
 build_backbone_args = {
     "DETECTION": "torchvision.mobilenet_v3_large",
     "INSTANCE_SEGMENTATION": "torchvision.mobilenet_v3_large",
+    "SEGMENTATION": "torchvision.mobilenet_v3_large",
 }
 
 


### PR DESCRIPTION
## Summary
Change auto collection of backbone list to json format list of available backbones.

## This PR includes
- Create `otx/cli/builder/supported_backbone` folder that include available backbone list (json file)
![image](https://user-images.githubusercontent.com/38045080/206396506-b99673a0-aaa8-4465-80fe-bcb974ca214f.png)
- If there is a related json file, use that data for `otx find & build`
- Updated required args to show available options in `otx find` as well
![image](https://user-images.githubusercontent.com/38045080/206397272-51751ee9-eeaa-4b69-8b01-dd50e74e8476.png)
- Modified to build backbone configuration using the first value as default when selectable options are provided among required args
- Add raise error statement for exceptions