### PR TITLE
[OTE][Develop][XAI] Hot-fix for Detection fix two stage err

### DIFF
--- a/third-party-programs.txt
+++ b/third-party-programs.txt
@@ -69,3 +69,78 @@ SOFTWARE.
    author: wondervictor
    mail: tianhengcheng@gmail.com
    copyright@wondervictor
+
+
+-------------------------------------------------------------
+
+5. Python
+Python 3.0a1 License
+A. HISTORY OF THE SOFTWARE
+==========================
+
+Python was created in the early 1990s by Guido van Rossum at Stichting Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands as a successor of a language called ABC. Guido remains Python's principal author, although it includes many contributions from others.
+
+In 1995, Guido continued his work on Python at the Corporation for National Research Initiatives (CNRI, see http://www.cnri.reston.va.us) in Reston, Virginia where he released several versions of the software.
+
+In May 2000, Guido and the Python core development team moved to BeOpen.com to form the BeOpen PythonLabs team. In October of the same year, the PythonLabs team moved to Digital Creations (now Zope Corporation, see http://www.zope.com). In 2001, the Python Software Foundation (PSF, see http://www.python.org/psf/) was formed, a non-profit organization created specifically to own Python-related Intellectual Property. Zope Corporation is a sponsoring member of the PSF.
+
+All Python releases are Open Source (see http://www.opensource.org for the Open Source Definition). Historically, most, but not all, Python releases have also been GPL-compatible; the table below summarizes the various releases.
+
+Release	Derived from  	Year	Owner	GPL-compatible? (1)
+ 
+0.9.0 thru 1.2  	 	1991-1995	CWI	yes
+1.3 thru 1.5.2	1.2	1995-1999	CNRI	yes
+1.6	1.5.2	2000	CNRI	no
+2.0	1.6	2000	BeOpen.com	no
+1.6.1	1.6	2001	CNRI	yes (2)
+2.1	2.0+1.6.1	2001	PSF	no
+2.0.1	2.0+1.6.1	2001	PSF	yes
+2.1.1	2.1+2.0.1	2001	PSF	yes
+2.2	2.1.1	2001	PSF	yes
+2.1.2	2.1.1	2002	PSF	yes
+2.1.3	2.1.2	2002	PSF	yes
+2.2.1	2.2	2002	PSF	yes
+2.2.2	2.2.1	2002	PSF	yes
+2.2.3	2.2.2	2003	PSF	yes
+2.3	2.2.2	2002-2003	PSF	yes
+2.3.1	2.3	2002-2003  	PSF	yes
+2.3.2	2.3.1	2002-2003	PSF	yes
+2.3.3	2.3.2	2002-2003	PSF	yes
+2.3.4	2.3.3	2004	PSF	yes
+2.3.5	2.3.4	2005	PSF	yes
+2.4	2.3	2004	PSF	yes
+2.4.1	2.4	2005	PSF	yes
+2.4.2	2.4.1	2005	PSF	yes
+2.4.3	2.4.2	2006	PSF	yes
+2.4.4	2.4.3	2006	PSF	yes
+2.5	2.4	2006	PSF	yes
+2.5.1	2.5	2007	PSF	yes
+3.0	2.6	2007	PSF	yes
+
+
+Footnotes:
+GPL-compatible doesn't mean that we're distributing Python under the GPL. All Python licenses, unlike the GPL, let you distribute a modified version without making your changes open source. The GPL-compatible licenses make it possible to combine Python with other software that is released under the GPL; the others don't.
+
+According to Richard Stallman, 1.6.1 is not GPL-compatible, because its license has a choice of law clause. According to CNRI, however, Stallman's lawyer has told CNRI's lawyer that 1.6.1 is "not incompatible" with the GPL.
+Thanks to the many outside volunteers who have worked under Guido's direction to make these releases possible.
+
+B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
+===============================================================
+
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+--------------------------------------------
+This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and the Individual or Organization ("Licensee") accessing and otherwise using this software ("Python") in source or binary form and its associated documentation.
+
+Subject to the terms and conditions of this License Agreement, PSF hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use Python alone or in any derivative version, provided, however, that PSF's License Agreement and PSF's notice of copyright, i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007 Python Software Foundation; All Rights Reserved" are retained in Python alone or in any derivative version prepared by Licensee.
+
+In the event Licensee prepares a derivative work that is based on or incorporates Python or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python.
+
+PSF is making Python available to Licensee on an "AS IS" basis. PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+This License Agreement will automatically terminate upon a material breach of its terms and conditions.
+
+Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between PSF and Licensee. This License Agreement does not grant permission to use PSF trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
+
+By copying, installing or otherwise using Python, Licensee agrees to be bound by the terms and conditions of this License Agreement.


### PR DESCRIPTION
Changed from default class-wise `DetSaliencyMapHook` in the `inferrer.py` in the MPA side to select the saliency map hook from the checking instance if it is `TwoStageDetector`.