### PR TITLE
[OTE][Develop] Align saliency map media creation over tasks

### DIFF
--- a/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
+++ b/external/mmdetection/detection_tasks/apis/detection/openvino_task.py
@@ -473,28 +473,32 @@ class OpenVINODetectionTask(
                     dataset_item.append_metadata_item(saliency_media, model=self.model)
                 elif saliency_map.ndim == 3:
                     # Multiple saliency maps per image (class-wise saliency map)
-                    predicted_class_set = set()
+                    predicted_labels = set()
                     for bbox in predicted_scene.annotations:
-                        predicted_class_set.add(bbox.get_labels()[0].name)
+                        scored_label = bbox.get_labels()[0]
+                        predicted_labels.add(scored_label.label)
 
                     labels = self.task_environment.get_labels()
                     num_saliency_maps = saliency_map.shape[0]
                     if num_saliency_maps == len(labels) + 1:
                         # Include the background as the last category
                         labels.append(LabelEntity('background', Domain.DETECTION))
+
                     for class_id, class_wise_saliency_map in enumerate(saliency_map):
-                        class_name_str = labels[class_id].name
-                        if class_name_str in predicted_class_set:
+                        label = labels[class_id]
+                        if label in predicted_labels:
                             # TODO (negvet): Support more advanced use case,
                             #  when all/configurable set of saliency maps is returned
                             actmap = get_actmap(
                                 class_wise_saliency_map, (dataset_item.width, dataset_item.height)
                             )
                             saliency_media = ResultMediaEntity(
-                                name=class_name_str,
+                                name=label.name,
                                 type="saliency_map",
                                 annotation_scene=dataset_item.annotation_scene,
-                                numpy=actmap, roi=dataset_item.roi
+                                numpy=actmap,
+                                roi=dataset_item.roi,
+                                label=label
                             )
                             dataset_item.append_metadata_item(saliency_media, model=self.model)
                 else:

--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/inference_task.py
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/inference_task.py
@@ -229,7 +229,7 @@ class OTESegmentationInferenceTask(IInferenceTask, IExportTask, IEvaluationTask,
                     current_label_soft_prediction = soft_prediction[:, :, label_index]
 
                     class_act_map = get_activation_map(current_label_soft_prediction)
-                    result_media = ResultMediaEntity(name='Soft Prediction',
+                    result_media = ResultMediaEntity(name=label.name,
                                                      type='soft_prediction',
                                                      label=label,
                                                      annotation_scene=dataset_item.annotation_scene,

--- a/external/mmsegmentation/segmentation_tasks/apis/segmentation/openvino_task.py
+++ b/external/mmsegmentation/segmentation_tasks/apis/segmentation/openvino_task.py
@@ -185,7 +185,7 @@ class OpenVINOSegmentationTask(IDeploymentTask, IInferenceTask, IEvaluationTask,
                         continue
                     current_label_soft_prediction = soft_prediction[:, :, label_index]
                     class_act_map = get_activation_map(current_label_soft_prediction)
-                    result_media = ResultMediaEntity(name='Soft Prediction',
+                    result_media = ResultMediaEntity(name=label.name,
                                                      type='soft_prediction',
                                                      label=label,
                                                      annotation_scene=dataset_item.annotation_scene,

--- a/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/classification/task.py
@@ -289,7 +289,6 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
                         annotation_scene=dataset_item.annotation_scene,
                         numpy=saliency_map,
                         roi=dataset_item.roi,
-                        label=item_labels[0].label,
                     )
                     dataset_item.append_metadata_item(saliency_map_media, model=self._task_environment.model)
                 elif saliency_map.ndim == 3:
@@ -298,14 +297,14 @@ class ClassificationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvalua
                         class_wise_saliency_map = get_actmap(
                             class_wise_saliency_map, (dataset_item.width, dataset_item.height)
                         )
-                        class_name_str = self._labels[class_id].name
+                        label = self._labels[class_id]
                         saliency_map_media = ResultMediaEntity(
-                            name=class_name_str,
+                            name=label.name,
                             type="saliency_map",
                             annotation_scene=dataset_item.annotation_scene,
                             numpy=class_wise_saliency_map,
                             roi=dataset_item.roi,
-                            label=item_labels[0].label,
+                            label=label,
                         )
                         dataset_item.append_metadata_item(saliency_map_media, model=self._task_environment.model)
                 else:

--- a/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/detection/task.py
@@ -327,13 +327,14 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
                         labels.append(LabelEntity("background", Domain.DETECTION))
                     for class_id, class_wise_saliency_map in enumerate(saliency_map):
                         actmap = get_actmap(class_wise_saliency_map, (dataset_item.width, dataset_item.height))
-                        class_name_str = labels[class_id].name
+                        label = labels[class_id]
                         saliency_media = ResultMediaEntity(
-                            name=class_name_str,
+                            name=label.name,
                             type="saliency_map",
                             annotation_scene=dataset_item.annotation_scene,
                             numpy=actmap,
                             roi=dataset_item.roi,
+                            label=label,
                         )
                         dataset_item.append_metadata_item(saliency_media, model=self._task_environment.model)
                 else:


### PR DESCRIPTION
Not sure if it is still possible to merge it to be used by Geti1.1, but this PR would make the life of the Geti UI team much easier.

Changes are approved by the Geti UI team.

Update relates to the `ResultMediaEntity` instance creation.

Single saliency map per image case
- hardcode `name` attribute
- remove the `label`. It makes no sense to use label because saliency map created per image, not per label or per class

Multiple saliency maps per image case
- use `label.name` as `name`
- provide corresponding `LabelEntity` instance as `label`

The same logic aligned among cls, det, anomaly, seg.