### PR TITLE
[feature/otx] Disable pre-merge test on CI with Draft PR + Add concurrency for workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,13 @@
 # See help here: https://github.com/marketplace/actions/labeler
 
 dependencies:
-  - "**/*requirements*.*"
-  - "**/setup.py"
+  - "requirements/*"
+  - "setup.py"
 CLI:
-  - "ote_cli/**/*"
+  - "otx/cli/**/*"
 SDK:
-  - "ote_sdk/**/*"
+  - "otx/sdk/**/*"
 tests:
   - "tests/**/*"
 tasks:
-  - "external/**/*"
+  - "otx/algorithms/**/*"

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -11,6 +11,7 @@ on:
       - synchronize
       - ready_for_review
 
+# This is what will cancel the workflow concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -11,6 +11,10 @@ on:
       - synchronize
       - ready_for_review
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Code-Quality-Checks:
     runs-on: [self-hosted, linux, x64]

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -19,7 +19,7 @@ jobs:
   Pre-Merge-Tests:
     runs-on: [self-hosted, linux, x64]
     needs: Code-Quality-Checks
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - feature/otx
     workflow_dispatch: # run on request (no need for PR)
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   Code-Quality-Checks:

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -19,6 +19,7 @@ jobs:
   Pre-Merge-Tests:
     runs-on: [self-hosted, linux, x64]
     needs: Code-Quality-Checks
+    if: ! github.event.pull_request.draft
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
Currently, quite a lot of tests are running even though it is a draft. This may affect other PRs that need testing.
I suggest the following method for github action CI.
In the case of Draft PR, only Code-Quality-Checks (takes about 7 minutes) are checked, and the Pre-Merge test is modified so that it does not work.
**If you have any concern or new ideas, please feel free to comment.**

- Status: Draft
    - Pull Request Labeler / triage (pull_request_target)
    - Pre-Merge Checks / Code-Quality-Checks (pull_request)
![image](https://user-images.githubusercontent.com/38045080/208564320-f17332e9-3c84-423f-9d06-fec4f1206e48.png)
- Status: Ready for review
    - Pre-Merge Checks / Code-Quality-Checks (pull_request)
    - Pre-Merge Checks / Pre-Merge-Tests (pull_request)
 

### + Add Concurrency Group for workflow
If there is a new push from the same PR, it will cancel the old queue.
ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
![image](https://user-images.githubusercontent.com/38045080/208624285-d4c47271-a19a-42e7-9434-b6fe16627da0.png)
