### PR TITLE
[DEV] Fix deprecated np.bool issue from numpy==1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Neural Network Compression Framework (NNCF)
+
   - Fix CUDA OOM for NNCF optimization model MaskRCNN-EfficientNetB2B (<https://github.com/openvinotoolkit/training_extensions/pull/1319>)
 
 - Model Preparation Algorithm (MPA)

--- a/external/anomaly/requirements.txt
+++ b/external/anomaly/requirements.txt
@@ -5,3 +5,4 @@ openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@r
 openvino==2022.1.0
 openvino-dev==2022.1.0
 pytorch-lightning>=1.6.0,<1.7.0
+numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/external/deep-object-reid/requirements.txt
+++ b/external/deep-object-reid/requirements.txt
@@ -3,3 +3,4 @@ openvino-dev==2022.1.0
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 nncf@ git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf
 networkx<=2.8.0
+numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/external/mmsegmentation/requirements.txt
+++ b/external/mmsegmentation/requirements.txt
@@ -4,3 +4,4 @@ openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@r
 nncf@ git+https://github.com/openvinotoolkit/nncf@e85a695da95b202b4579ea11f880f1b14bfcda2e#egg=nncf
 networkx<=2.8.0
 protobuf<3.21.0
+numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/external/model-preparation-algorithm/constraints.txt
+++ b/external/model-preparation-algorithm/constraints.txt
@@ -1,1 +1,2 @@
 optuna==2.10.1 # remedy for fixed optuna version incompatible in OTE CI
+numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -36,13 +36,8 @@ def get_some_vars(template, root):
 def create_venv(algo_backend_dir, work_dir):
     venv_dir = f"{work_dir}/venv"
     if not os.path.exists(venv_dir):
-        assert run([f"./{algo_backend_dir}/init_venv.sh", venv_dir]).returncode == 0
-        assert (
-            run(
-                [f"{work_dir}/venv/bin/python", "-m", "pip", "install", "-e", "ote_cli"]
-            ).returncode
-            == 0
-        )
+        check_run([f"./{algo_backend_dir}/init_venv.sh", venv_dir])
+        check_run([f"{work_dir}/venv/bin/python", "-m", "pip", "install", "-e", "ote_cli"])
 
 
 def extract_export_vars(path):

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -74,8 +74,9 @@ def collect_env_vars(work_dir):
 
 
 def check_run(cmd, **kwargs):
-    result = run(cmd, capture_output=True, **kwargs)
-    assert result.returncode == 0, result.stderr.decode("utf=8")
+    #result = run(cmd, capture_output=True, **kwargs)
+    #assert result.returncode == 0, result.stderr.decode("utf=8")
+    run(cmd, check=True, **kwargs)
 
 
 def ote_train_testing(template, root, ote_dir, args):

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -15,7 +15,7 @@
 import json
 import os
 import shutil
-from subprocess import run  # nosec
+import subprocess  # nosec
 
 import pytest
 
@@ -74,9 +74,8 @@ def collect_env_vars(work_dir):
 
 
 def check_run(cmd, **kwargs):
-    #result = run(cmd, capture_output=True, **kwargs)
-    #assert result.returncode == 0, result.stderr.decode("utf=8")
-    run(cmd, check=True, **kwargs)
+    result = subprocess.run(cmd, stderr=subprocess.PIPE, **kwargs)
+    assert result.returncode == 0, result.stderr.decode("utf=8")
 
 
 def ote_train_testing(template, root, ote_dir, args):

--- a/ote_cli/ote_cli/utils/tests.py
+++ b/ote_cli/ote_cli/utils/tests.py
@@ -37,7 +37,9 @@ def create_venv(algo_backend_dir, work_dir):
     venv_dir = f"{work_dir}/venv"
     if not os.path.exists(venv_dir):
         check_run([f"./{algo_backend_dir}/init_venv.sh", venv_dir])
-        check_run([f"{work_dir}/venv/bin/python", "-m", "pip", "install", "-e", "ote_cli"])
+        check_run(
+            [f"{work_dir}/venv/bin/python", "-m", "pip", "install", "-e", "ote_cli"]
+        )
 
 
 def extract_export_vars(path):

--- a/ote_cli/requirements.txt
+++ b/ote_cli/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 opencv-python
-numpy
+numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime
 nbmake
 pytest
 pytest-ordering

--- a/ote_sdk/ote_sdk/usecases/exportable_code/demo/requirements.txt
+++ b/ote_sdk/ote_sdk/usecases/exportable_code/demo/requirements.txt
@@ -1,4 +1,4 @@
 openvino==2022.1.0
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
-ote-sdk @ git+https://github.com/openvinotoolkit/training_extensions/@c29f1b385d5eabcf07bc9a6e9c340fd0dbf67c8d#egg=ote-sdk&subdirectory=ote_sdk
+ote-sdk @ git+https://github.com/openvinotoolkit/training_extensions/@565fbf682cc8a182ce67a69688f0e7b48a991696#egg=ote-sdk&subdirectory=ote_sdk
 numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/ote_sdk/ote_sdk/usecases/exportable_code/demo/requirements.txt
+++ b/ote_sdk/ote_sdk/usecases/exportable_code/demo/requirements.txt
@@ -1,3 +1,4 @@
 openvino==2022.1.0
 openmodelzoo-modelapi @ git+https://github.com/openvinotoolkit/open_model_zoo/@releases/2022/SCv1.1#egg=openmodelzoo-modelapi&subdirectory=demos/common/python
 ote-sdk @ git+https://github.com/openvinotoolkit/training_extensions/@c29f1b385d5eabcf07bc9a6e9c340fd0dbf67c8d#egg=ote-sdk&subdirectory=ote_sdk
+numpy<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/ote_sdk/requirements.txt
+++ b/ote_sdk/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.4
+numpy>=1.16.4,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
 networkx>=2.6,<2.8.1rc1

--- a/tests/ote_cli/misc/test_code_checks.py
+++ b/tests/ote_cli/misc/test_code_checks.py
@@ -13,12 +13,12 @@
 # and limitations under the License.
 
 import os
-from subprocess import run
 
 from ote_sdk.test_suite.e2e_test_system import e2e_pytest_component
+from ote_cli.utils.tests import check_run
 
 class TestCodeChecks:
     @e2e_pytest_component
     def test_code_checks(self):
         wd = os.path.join(os.path.dirname(__file__), "..", "..", "..")
-        assert run(["./tests/run_code_checks.sh"], cwd=wd, check=True).returncode == 0
+        check_run(["./tests/run_code_checks.sh"], cwd=wd)

--- a/tests/run_model_templates_tests.py
+++ b/tests/run_model_templates_tests.py
@@ -2,9 +2,8 @@
 
 import os
 import sys
-from subprocess import run
 
-from ote_cli.utils.tests import collect_env_vars
+from ote_cli.utils.tests import collect_env_vars, check_run
 
 ALGO_ROOT_DIR = "external"
 ALGO_DIRS = [
@@ -59,7 +58,8 @@ def test(run_algo_tests):
     success = True
     command = ["pytest", os.path.join("tests", "ote_cli", "misc"), "-v"]
     try:
-        res = run(command, env=collect_env_vars(wd), check=True).returncode == 0
+        check_run(command, env=collect_env_vars(wd))
+        res = True
     except:
         res = False
     passed["misc"] = res
@@ -68,7 +68,8 @@ def test(run_algo_tests):
         if run_algo_tests[algo_dir]:
             command = ["pytest", os.path.join(algo_dir, "tests", "ote_cli"), "-v", "-rxXs", "--durations=10"]
             try:
-                res = run(command, env=collect_env_vars(wd), check=True).returncode == 0
+                check_run(command, env=collect_env_vars(wd))
+                res = True
             except:
                 res = False
             passed[algo_dir] = res


### PR DESCRIPTION
- Restrict numpy<=1.23.5 which allows np.bool (OpenVINO runtime is using it)
- Enhance CLI test run for better error message
  - Now we can see stack trace from CLI test failure.
![image](https://user-images.githubusercontent.com/4629606/208596661-89088138-d1bd-4ada-957b-5a824a1aba6b.png)
