### PR TITLE
[OTX] Bugfix: multi GPU raise error when num_workers isn't set as 0.

### DIFF
--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -169,6 +169,7 @@ class MultiGPUManager:
             output_path (str): output path where task output are saved.
             multi_gpu_port (str): port for communication between multi GPU processes.
         """
+        mp.set_start_method(None, True)  # set multi porcess method as default
         gpus_arg_idx = sys.argv.index("--gpus")
         for _ in range(2):
             sys.argv.pop(gpus_arg_idx)

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -169,7 +169,7 @@ class MultiGPUManager:
             output_path (str): output path where task output are saved.
             multi_gpu_port (str): port for communication between multi GPU processes.
         """
-        mp.set_start_method(None, True)  # set multi porcess method as default
+        mp.set_start_method(method="fork", force=True)  # set multi porcess method as fork
         gpus_arg_idx = sys.argv.index("--gpus")
         for _ in range(2):
             sys.argv.pop(gpus_arg_idx)


### PR DESCRIPTION
### Summary

- fix a bug that error is raised when multi gpu training with none zero num_workers.

### Reason of the bug
When process is spawned, deafult multi porcess method is set as "spawn". It raises error when `dataloader` is used with num_workers > 0.
This is because dataloader has a DatasetItemEntity which has a thread lock attribute and thread lock is unpickleable.
I don't know exact reason, but when forking a new process, unpickleable argument can be passed to new process.