### PR TITLE
[DRAFT] Task implementation for region-based anomaly detection

### DIFF
--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -22,6 +22,8 @@ from anomalib.models import AnomalyModule
 from anomalib.post_processing import anomaly_map_to_color_map
 from pytorch_lightning.callbacks import Callback
 
+from otx.api.entities.shapes.rectangle import Rectangle
+from otx.api.entities.annotation import Annotation
 from otx.algorithms.anomaly.adapters.anomalib.logger import get_logger
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.label import LabelEntity
@@ -54,31 +56,24 @@ class AnomalyInferenceCallback(Callback):
         anomaly_maps = np.vstack([output["anomaly_maps"].cpu() for output in outputs])
         pred_masks = np.vstack([output["pred_masks"].cpu() for output in outputs])
 
-        # Loop over dataset again to assign predictions
-        for dataset_item, pred_score, pred_label, anomaly_map, pred_mask in zip(
-            self.otx_dataset, pred_scores, pred_labels, anomaly_maps, pred_masks
-        ):
-            probability = pred_score if pred_label else 1 - pred_score
-            if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
-                label = self.anomalous_label if pred_label else self.normal_label
-            if self.task_type == TaskType.ANOMALY_DETECTION:
-                annotations = create_detection_annotation_from_anomaly_heatmap(
-                    hard_prediction=pred_mask,
-                    soft_prediction=anomaly_map,
-                    label_map=self.label_map,
-                )
-                dataset_item.append_annotations(annotations)
-                label = self.normal_label if len(annotations) == 0 else self.anomalous_label
-            elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
-                annotations = create_annotation_from_segmentation_map(
-                    hard_prediction=pred_mask.squeeze().astype(np.uint8),
-                    soft_prediction=anomaly_map.squeeze(),
-                    label_map=self.label_map,
-                )
-                dataset_item.append_annotations(annotations)
-                label = self.normal_label if len(annotations) == 0 else self.anomalous_label
+        if self.task_type == TaskType.ACTION_CLASSIFICATION:
+            self._process_classification_predictions(pred_labels, pred_scores)
 
-            dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
+        if self.task_type == TaskType.ANOMALY_DETECTION:
+            pred_boxes = []
+            box_scores = []
+            box_labels = []
+            [pred_boxes.extend(output["pred_boxes"]) for output in outputs]
+            [box_scores.extend(output["box_scores"]) for output in outputs]
+            [box_labels.extend(output["box_labels"]) for output in outputs]
+            
+            self._process_detection_predictions(pred_boxes, box_scores, box_labels, pred_scores, pred_masks.shape[-2:])
+
+        elif self.task_type == TaskType.ANOMALY_SEGMENTATION:
+            self._process_segmentation_predictions(pred_masks, anomaly_maps, pred_scores)
+
+        # add anomaly map as metadata
+        for dataset_item, anomaly_map in zip(self.otx_dataset, anomaly_maps):
             dataset_item.append_metadata_item(
                 ResultMediaEntity(
                     name="Anomaly Map",
@@ -87,11 +82,50 @@ class AnomalyInferenceCallback(Callback):
                     numpy=anomaly_map_to_color_map(anomaly_map.squeeze(), normalize=False),
                 )
             )
-            log_string = (
-                f"\n\tThreshold: {pl_module.image_threshold.value.item():.3f},"
-                f" Assigned Label '{label.name}', {pred_score:.3f}"
+
+    def _process_classification_predictions(self, pred_labels, pred_scores):
+        for dataset_item, pred_label, pred_score in zip(self.otx_dataset, pred_labels, pred_scores):
+            # get label
+            label = self.anomalous_label if pred_label else self.normal_label
+            probability = pred_score if pred_label else 1 - pred_score
+            # update dataset item
+            dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
+
+    def _process_detection_predictions(self, pred_boxes, box_scores, box_labels, pred_scores, image_size):
+
+        height, width = image_size
+        for dataset_item, im_boxes, im_box_scores, im_box_labels, pred_score in zip(self.otx_dataset, pred_boxes, box_scores, box_labels, pred_scores):
+            # generate annotations
+            annotations: List[Annotation] = []
+            for box, score, label in zip(im_boxes, im_box_scores, im_box_labels):
+                shape = Rectangle(
+                    x1=box[0].item() / width,
+                    y1=box[1].item() / height,
+                    x2=box[2].item() / width,
+                    y2=box[3].item() / height,
+                )
+                label = self.label_map[label.item()]
+                probability = score.item()
+                annotations.append(Annotation(shape=shape, labels=[ScoredLabel(label=label, probability=probability)]))
+            # get label
+            label = self.normal_label if len(annotations) == 0 else self.anomalous_label
+            probability = pred_score if label.is_anomalous else 1 - pred_score
+            # update dataset item
+            dataset_item.append_annotations(annotations)
+            dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
+
+    def _process_segmentation_predictions(self, pred_masks, anomaly_maps, pred_scores):
+
+        for dataset_item, pred_mask, anomaly_map, pred_score in zip(self.otx_dataset, pred_masks, anomaly_maps, pred_scores):
+            # generate polygon annotations
+            annotations = create_annotation_from_segmentation_map(
+                hard_prediction=pred_mask.squeeze().astype(np.uint8),
+                soft_prediction=anomaly_map.squeeze(),
+                label_map=self.label_map,
             )
-            if hasattr(pl_module, "normalization_metrics"):
-                for key, value in pl_module.normalization_metrics.state_dict().items():
-                    log_string += f" {key}: {value}"
-            logger.info(log_string)
+            # get label
+            label = self.normal_label if len(annotations) == 0 else self.anomalous_label
+            probability = pred_score if label.is_anomalous else 1 - pred_score
+            # update dataset item
+            dataset_item.append_annotations(annotations)
+            dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])

--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -88,7 +88,12 @@ class AnomalyInferenceCallback(Callback):
             )
 
     def _process_classification_predictions(self, pred_labels: Tensor, pred_scores: Tensor):
+        """Add classification predictions to the dataset items.
 
+        Args:
+            pred_labels (Tensor): Predicted image labels.
+            pred_scores (Tensor): Predicted image-level anomaly scores.
+        """
         for dataset_item, pred_label, pred_score in zip(self.otx_dataset, pred_labels, pred_scores):
             # get label
             label = self.anomalous_label if pred_label else self.normal_label
@@ -104,6 +109,15 @@ class AnomalyInferenceCallback(Callback):
         pred_scores: Tensor,
         image_size: torch.Size,
     ):
+        """Add detection predictions to the dataset items.
+
+        Args:
+            pred_boxes (List[Tensor]): Predicted bounding box locations.
+            box_scores (List[Tensor]): Predicted anomaly scores for the bounding boxes.
+            box_labels (List[Tensor]): Predicted labels for the bounding boxes.
+            pred_scores (Tensor): Predicted image-level anomaly scores.
+            image_size: (torch.Size): Image size of the original images.
+        """
         height, width = image_size
         for dataset_item, im_boxes, im_box_scores, im_box_labels, pred_score in zip(
             self.otx_dataset, pred_boxes, box_scores, box_labels, pred_scores
@@ -130,7 +144,13 @@ class AnomalyInferenceCallback(Callback):
             dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
 
     def _process_segmentation_predictions(self, pred_masks: Tensor, anomaly_maps: Tensor, pred_scores: Tensor):
+        """Add segmentation predictions to the dataset items.
 
+        Args:
+            pred_masks (Tensor): Predicted anomaly masks.
+            anomaly_maps (Tensor): Predicted pixel-level anomaly scores.
+            pred_scores (Tensor): Predicted image-level anomaly scores.
+        """
         for dataset_item, pred_mask, anomaly_map, pred_score in zip(
             self.otx_dataset, pred_masks, anomaly_maps, pred_scores
         ):

--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -98,6 +98,8 @@ class AnomalyInferenceCallback(Callback):
             # generate annotations
             annotations: List[Annotation] = []
             for box, score, label in zip(im_boxes, im_box_scores, im_box_labels):
+                if box[0] >= box[2] or box[1] >= box[3]:  # discard 1-pixel boxes
+                    continue
                 shape = Rectangle(
                     x1=box[0].item() / width,
                     y1=box[1].item() / height,

--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -17,22 +17,21 @@
 from typing import Any, List
 
 import numpy as np
-import torch
 import pytorch_lightning as pl
+import torch
 from anomalib.models import AnomalyModule
 from anomalib.post_processing import anomaly_map_to_color_map
 from pytorch_lightning.callbacks import Callback
 from torch import Tensor
 
-from otx.api.entities.shapes.rectangle import Rectangle
-from otx.api.entities.annotation import Annotation
 from otx.algorithms.anomaly.adapters.anomalib.logger import get_logger
+from otx.api.entities.annotation import Annotation
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.label import LabelEntity
 from otx.api.entities.model_template import TaskType
 from otx.api.entities.result_media import ResultMediaEntity
 from otx.api.entities.scored_label import ScoredLabel
-from otx.api.utils.anomaly_utils import create_detection_annotation_from_anomaly_heatmap
+from otx.api.entities.shapes.rectangle import Rectangle
 from otx.api.utils.segmentation_utils import create_annotation_from_segmentation_map
 
 logger = get_logger(__name__)
@@ -118,6 +117,8 @@ class AnomalyInferenceCallback(Callback):
             pred_scores (Tensor): Predicted image-level anomaly scores.
             image_size: (torch.Size): Image size of the original images.
         """
+        # TODO; refactor Ignore too many locals
+        # pylint: disable=too-many-locals
         height, width = image_size
         for dataset_item, im_boxes, im_box_scores, im_box_labels, pred_score in zip(
             self.otx_dataset, pred_boxes, box_scores, box_labels, pred_scores

--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -60,7 +60,7 @@ class AnomalyInferenceCallback(Callback):
         pred_masks = torch.vstack([output["pred_masks"].cpu() for output in outputs])
 
         # add the predictions to the dataset item depending on the task type
-        if self.task_type == TaskType.ACTION_CLASSIFICATION:
+        if self.task_type == TaskType.ANOMALY_CLASSIFICATION:
             self._process_classification_predictions(pred_labels, pred_scores)
         elif self.task_type == TaskType.ANOMALY_DETECTION:
             # collect detection predictions

--- a/otx/algorithms/anomaly/adapters/anomalib/data/data.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/data/data.py
@@ -218,7 +218,7 @@ class OTXAnomalyDataModule(LightningDataModule):
         return DataLoader(
             dataset,
             shuffle=False,
-            batch_size=self.config.dataset.test_batch_size,
+            batch_size=self.config.dataset.eval_batch_size,
             num_workers=self.config.dataset.num_workers,
         )
 
@@ -246,6 +246,6 @@ class OTXAnomalyDataModule(LightningDataModule):
         return DataLoader(
             dataset,
             shuffle=False,
-            batch_size=self.config.dataset.test_batch_size,
+            batch_size=self.config.dataset.eval_batch_size,
             num_workers=self.config.dataset.num_workers,
         )

--- a/otx/algorithms/anomaly/adapters/anomalib/data/data.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/data/data.py
@@ -16,8 +16,8 @@
 
 from typing import Dict, List, Optional, Union
 
-import torch
 import numpy as np
+import torch
 from anomalib.data.base.datamodule import collate_fn
 from anomalib.data.utils.transform import get_transforms
 from omegaconf import DictConfig, ListConfig
@@ -25,11 +25,11 @@ from pytorch_lightning.core.datamodule import LightningDataModule
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
-from otx.api.entities.shapes.rectangle import Rectangle
 from otx.algorithms.anomaly.adapters.anomalib.logger import get_logger
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.model_template import TaskType
 from otx.api.entities.shapes.polygon import Polygon
+from otx.api.entities.shapes.rectangle import Rectangle
 from otx.api.entities.subset import Subset
 from otx.api.utils.dataset_utils import (
     contains_anomalous_images,
@@ -68,10 +68,8 @@ class OTXAnomalyDataset(Dataset):
 
         # TODO: distinguish between train and val config here
         self.transform = get_transforms(
-            config=config.dataset.transform_config.train,
-            image_size=tuple(config.dataset.image_size),
-            to_tensor=True
-            )
+            config=config.dataset.transform_config.train, image_size=tuple(config.dataset.image_size), to_tensor=True
+        )
 
     def __len__(self) -> int:
         """Get size of the dataset.
@@ -108,12 +106,14 @@ class OTXAnomalyDataset(Dataset):
             for annotation in dataset_item.get_annotations():
                 if not Rectangle.is_full_box(annotation.shape):  # ignore full image labels
                     boxes.append(
-                        Tensor([
-                            annotation.shape.x1 * width,
-                            annotation.shape.y1 * height,
-                            annotation.shape.x2 * width,
-                            annotation.shape.y2 * height,
-                        ])
+                        Tensor(
+                            [
+                                annotation.shape.x1 * width,
+                                annotation.shape.y1 * height,
+                                annotation.shape.x2 * width,
+                                annotation.shape.y2 * height,
+                            ]
+                        )
                     )
                 if len(boxes) > 0:
                     item["boxes"] = torch.stack(boxes)

--- a/otx/algorithms/anomaly/configs/detection/rkde/__init__.py
+++ b/otx/algorithms/anomaly/configs/detection/rkde/__init__.py
@@ -1,4 +1,4 @@
-"""Base configurable parameter for anomaly tasks."""
+"""Initialization of Configurable Parameters for PADIM Anomaly Detection Task."""
 
 # Copyright (C) 2022 Intel Corporation
 #
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from .configuration import BaseAnomalyConfig
-from .draem import DraemAnomalyBaseConfig
-from .padim import PadimAnomalyBaseConfig
-from .stfpm import STFPMAnomalyBaseConfig
+from .configuration import RKDEAnomalyDetectionConfig
 
-__all__ = ["PadimAnomalyBaseConfig", "STFPMAnomalyBaseConfig", "DraemAnomalyBaseConfig", "BaseAnomalyConfig"]
+__all__ = ["RKDEAnomalyDetectionConfig"]

--- a/otx/algorithms/anomaly/configs/detection/rkde/compression_config.json
+++ b/otx/algorithms/anomaly/configs/detection/rkde/compression_config.json
@@ -1,0 +1,40 @@
+{
+  "base": {
+    "find_unused_parameters": true,
+    "target_metric_name": "image_F1Score",
+    "nncf_config": {
+      "input_info": {
+        "sample_size": [1, 3, 256, 256]
+      },
+      "compression": [],
+      "log_dir": "/tmp"
+    }
+  },
+  "nncf_quantization": {
+    "nncf_config": {
+      "compression": [
+        {
+          "algorithm": "quantization",
+          "preset": "mixed",
+          "initializer": {
+            "range": {
+              "num_init_samples": 250
+            },
+            "batchnorm_adaptation": {
+              "num_bn_adaptation_samples": 250
+            }
+          },
+          "ignored_scopes": [
+            "PadimModel/sqrt_0",
+            "PadimModel/interpolate_2",
+            "PadimModel/__truediv___0",
+            "PadimModel/__truediv___1",
+            "PadimModel/matmul_1",
+            "PadimModel/conv2d_0"
+          ]
+        }
+      ]
+    }
+  },
+  "order_of_parts": ["nncf_quantization"]
+}

--- a/otx/algorithms/anomaly/configs/detection/rkde/configuration.py
+++ b/otx/algorithms/anomaly/configs/detection/rkde/configuration.py
@@ -1,6 +1,6 @@
-"""Base configurable parameter for anomaly tasks."""
+"""Configurable parameters for Padim anomaly Detection task."""
 
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2021 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from .configuration import BaseAnomalyConfig
-from .draem import DraemAnomalyBaseConfig
-from .padim import PadimAnomalyBaseConfig
-from .stfpm import STFPMAnomalyBaseConfig
+from attr import attrs
 
-__all__ = ["PadimAnomalyBaseConfig", "STFPMAnomalyBaseConfig", "DraemAnomalyBaseConfig", "BaseAnomalyConfig"]
+from otx.algorithms.anomaly.configs.base import BaseAnomalyConfig
+
+
+@attrs
+class RKDEAnomalyDetectionConfig(BaseAnomalyConfig):
+    """Configurable parameters for RKDE anomaly Detection task."""

--- a/otx/algorithms/anomaly/configs/detection/rkde/configuration.yaml
+++ b/otx/algorithms/anomaly/configs/detection/rkde/configuration.yaml
@@ -6,7 +6,8 @@ dataset:
     auto_hpo_state: not_possible
     auto_hpo_value: null
     default_value: 8
-    description: Increasing this value might improve training speed however it might
+    description:
+      Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading
       will happen in the main training thread.
     editable: true
@@ -33,7 +34,8 @@ learning_parameters:
     auto_hpo_state: not_possible
     auto_hpo_value: null
     default_value: 32
-    description: The number of training samples seen in each iteration of training.
+    description:
+      The number of training samples seen in each iteration of training.
       Increasing this value improves training time and may make the training more
       stable. A larger batch size has higher memory requirements.
     editable: true
@@ -47,7 +49,8 @@ learning_parameters:
       rules: []
       type: UI_RULES
     visible_in_ui: true
-    warning: Increasing this value may cause the system to use more memory than available,
+    warning:
+      Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/otx/algorithms/anomaly/configs/detection/rkde/configuration.yaml
+++ b/otx/algorithms/anomaly/configs/detection/rkde/configuration.yaml
@@ -1,0 +1,151 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description: Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for an anomaly classification task
+header: Configuration for an anomaly classification task
+learning_parameters:
+  description: Learning Parameters
+  header: Learning Parameters
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description: The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: true
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 9223372036854775807
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/otx/algorithms/anomaly/configs/detection/rkde/pot_optimization_config.json
+++ b/otx/algorithms/anomaly/configs/detection/rkde/pot_optimization_config.json
@@ -1,0 +1,18 @@
+{
+  "algorithms": [
+    {
+      "name": "DefaultQuantization",
+      "params": {
+        "preset": "mixed",
+        "target_device": "ANY",
+        "range_estimator": {
+          "preset": "quantile"
+        },
+        "ignored": {
+          "scope": ["210", "224"]
+        },
+        "shuffle_data": true
+      }
+    }
+  ]
+}

--- a/otx/algorithms/anomaly/configs/detection/rkde/template.yaml
+++ b/otx/algorithms/anomaly/configs/detection/rkde/template.yaml
@@ -1,0 +1,31 @@
+# Description.
+model_template_id: ote_anomaly_detection_rkde
+name: RKDE
+task_type: ANOMALY_DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: This model is very fast, but only capable of detection.
+application: ~
+
+# Algo backend.
+framework: OTEAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 3.9
+size: 168.4

--- a/otx/algorithms/anomaly/tasks/inference.py
+++ b/otx/algorithms/anomaly/tasks/inference.py
@@ -25,12 +25,12 @@ from typing import Dict, List, Optional, Union
 
 import torch
 from anomalib.models import AnomalyModule, get_model
+from anomalib.post_processing import NormalizationMethod, ThresholdMethod
 from anomalib.utils.callbacks import (
     MetricsConfigurationCallback,
     MinMaxNormalizationCallback,
     PostProcessingConfigurationCallback,
 )
-from anomalib.post_processing import NormalizationMethod, ThresholdMethod
 from omegaconf import DictConfig, ListConfig
 from pytorch_lightning import Trainer
 

--- a/otx/algorithms/anomaly/tasks/inference.py
+++ b/otx/algorithms/anomaly/tasks/inference.py
@@ -192,7 +192,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
         metrics_configuration = MetricsConfigurationCallback(
             task=config.dataset.task,
             image_metrics=config.metrics.image,
-            pixel_metrics=config.metrics.pixel,
+            pixel_metrics=config.metrics.get("pixel"),
         )
         post_processing_configuration = PostProcessingConfigurationCallback(
             normalization_method=NormalizationMethod.MIN_MAX,

--- a/otx/algorithms/anomaly/tasks/train.py
+++ b/otx/algorithms/anomaly/tasks/train.py
@@ -77,7 +77,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
             MetricsConfigurationCallback(
                 task=config.dataset.task,
                 image_metrics=config.metrics.image,
-                pixel_metrics=config.metrics.pixel,
+                pixel_metrics=config.metrics.get("pixel"),
             ),
             PostProcessingConfigurationCallback(
                 normalization_method=NormalizationMethod.MIN_MAX,

--- a/otx/algorithms/anomaly/tasks/train.py
+++ b/otx/algorithms/anomaly/tasks/train.py
@@ -22,7 +22,9 @@ from anomalib.models import AnomalyModule, get_model
 from anomalib.utils.callbacks import (
     MetricsConfigurationCallback,
     MinMaxNormalizationCallback,
+    PostProcessingConfigurationCallback,
 )
+from anomalib.post_processing import NormalizationMethod, ThresholdMethod
 from pytorch_lightning import Trainer, seed_everything
 
 from otx.algorithms.anomaly.adapters.anomalib.callbacks import ProgressCallback
@@ -73,12 +75,16 @@ class TrainingTask(InferenceTask, ITrainingTask):
             ProgressCallback(parameters=train_parameters),
             MinMaxNormalizationCallback(),
             MetricsConfigurationCallback(
-                adaptive_threshold=config.metrics.threshold.adaptive,
-                default_image_threshold=config.metrics.threshold.image_default,
-                default_pixel_threshold=config.metrics.threshold.pixel_default,
-                image_metric_names=config.metrics.image,
-                pixel_metric_names=config.metrics.pixel,
+                task=config.dataset.task,
+                image_metrics=config.metrics.image,
+                pixel_metrics=config.metrics.pixel,
             ),
+            PostProcessingConfigurationCallback(
+                normalization_method=NormalizationMethod.MIN_MAX,
+                threshold_method=ThresholdMethod.ADAPTIVE,
+                manual_image_threshold=config.metrics.threshold.manual_image,
+                manual_pixel_threshold=config.metrics.threshold.manual_pixel,
+            )
         ]
 
         self.trainer = Trainer(**config.trainer, logger=False, callbacks=callbacks)

--- a/otx/algorithms/anomaly/tasks/train.py
+++ b/otx/algorithms/anomaly/tasks/train.py
@@ -19,12 +19,12 @@ from typing import Optional
 
 import torch
 from anomalib.models import AnomalyModule, get_model
+from anomalib.post_processing import NormalizationMethod, ThresholdMethod
 from anomalib.utils.callbacks import (
     MetricsConfigurationCallback,
     MinMaxNormalizationCallback,
     PostProcessingConfigurationCallback,
 )
-from anomalib.post_processing import NormalizationMethod, ThresholdMethod
 from pytorch_lightning import Trainer, seed_everything
 
 from otx.algorithms.anomaly.adapters.anomalib.callbacks import ProgressCallback
@@ -84,7 +84,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
                 threshold_method=ThresholdMethod.ADAPTIVE,
                 manual_image_threshold=config.metrics.threshold.manual_image,
                 manual_pixel_threshold=config.metrics.threshold.manual_pixel,
-            )
+            ),
         ]
 
         self.trainer = Trainer(**config.trainer, logger=False, callbacks=callbacks)

--- a/requirements/anomaly.txt
+++ b/requirements/anomaly.txt
@@ -1,4 +1,4 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Anomaly Requirements.                                                       #
-anomalib==0.3.6
+git+https://github.com/openvinotoolkit/anomalib/tree/feature/rbad
 pytorch-lightning>=1.6.0,<1.7.0


### PR DESCRIPTION
This PR adds the task implementation for region-based anomaly detection (or RKDE: Region-based Kernel Density Estimation).

- Adds the config files and `template.yaml` for the new task.
- The task was updated to accommodate the most recent changes on the anomalib side (mainly related to callbacks and some variable/parameter names)
- Some changes were needed to the data and inference functionality of the anomaly task to accommodate this new model:
    - In the `OTXAnomalibDataset` class, we now pass the raw box annotations to anomalib as GT (Previously we converted to mask first).
    - In the inference callback, we now process the box predictions from the anomalib and convert those into box annotations (previously this was done by converting masks to boxes).