### PR TITLE
[DEV] Save numpy array as compressed npz in videoframe cache & Exception handling

### DIFF
--- a/external/mmdetection/detection_tasks/extension/utils/pipelines.py
+++ b/external/mmdetection/detection_tasks/extension/utils/pipelines.py
@@ -13,7 +13,7 @@
 # and limitations under the License.
 
 import copy
-
+import tempfile
 from typing import Dict, Any, Optional
 import numpy as np
 
@@ -23,10 +23,10 @@ from ote_sdk.utils.argument_checks import check_input_parameters_type
 from mmdet.datasets.builder import PIPELINES
 
 from ..datasets import get_annotation_mmdet_format
-from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_image
+from mpa_tasks.utils.data_utils import get_image
 
-_CACHE_DIR = "/tmp/det-img-cache"
-clean_up_cache_dir(_CACHE_DIR)  # Clean up cache directory per process launch
+
+_CACHE_DIR = tempfile.TemporaryDirectory(prefix='img-cache-')
 
 @PIPELINES.register_module()
 class LoadImageFromOTEDataset:
@@ -48,7 +48,7 @@ class LoadImageFromOTEDataset:
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):
         # Get image (possibly from cache)
-        img = get_image(results, _CACHE_DIR, to_float32=self.to_float32)
+        img = get_image(results, _CACHE_DIR.name, to_float32=self.to_float32)
         shape = img.shape
 
         assert shape[0] == results["height"], f"{shape[0]} != {results['height']}"

--- a/external/mmdetection/detection_tasks/extension/utils/pipelines.py
+++ b/external/mmdetection/detection_tasks/extension/utils/pipelines.py
@@ -23,7 +23,7 @@ from ote_sdk.utils.argument_checks import check_input_parameters_type
 from mmdet.datasets.builder import PIPELINES
 
 from ..datasets import get_annotation_mmdet_format
-from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_cached_image
+from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_image
 
 _CACHE_DIR = "/tmp/det-img-cache"
 clean_up_cache_dir(_CACHE_DIR)  # Clean up cache directory per process launch
@@ -48,7 +48,7 @@ class LoadImageFromOTEDataset:
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):
         # Get image (possibly from cache)
-        img = get_cached_image(results, _CACHE_DIR, to_float32=self.to_float32)
+        img = get_image(results, _CACHE_DIR, to_float32=self.to_float32)
         shape = img.shape
 
         assert shape[0] == results["height"], f"{shape[0]} != {results['height']}"

--- a/external/mmsegmentation/segmentation_tasks/extension/utils/pipelines.py
+++ b/external/mmsegmentation/segmentation_tasks/extension/utils/pipelines.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import tempfile
 import numpy as np
 from typing import Dict, Any
 
@@ -19,11 +20,10 @@ from ote_sdk.utils.argument_checks import check_input_parameters_type
 
 from mmseg.datasets.builder import PIPELINES
 from ..datasets import get_annotation_mmseg_format
-from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_image
+from mpa_tasks.utils.data_utils import get_image
 
-_CACHE_DIR = "/tmp/seg-img-cache"
-clean_up_cache_dir(_CACHE_DIR)  # Clean up cache directory per process launch
 
+_CACHE_DIR = tempfile.TemporaryDirectory(prefix='img-cache-')
 
 @PIPELINES.register_module()
 class LoadImageFromOTEDataset:
@@ -45,7 +45,7 @@ class LoadImageFromOTEDataset:
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):
         # Get image (possibly from cache)
-        img = get_image(results, _CACHE_DIR, to_float32=self.to_float32)
+        img = get_image(results, _CACHE_DIR.name, to_float32=self.to_float32)
         shape = img.shape
 
         assert img.shape[0] == results['height'], f"{img.shape[0]} != {results['height']}"

--- a/external/mmsegmentation/segmentation_tasks/extension/utils/pipelines.py
+++ b/external/mmsegmentation/segmentation_tasks/extension/utils/pipelines.py
@@ -19,7 +19,7 @@ from ote_sdk.utils.argument_checks import check_input_parameters_type
 
 from mmseg.datasets.builder import PIPELINES
 from ..datasets import get_annotation_mmseg_format
-from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_cached_image
+from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_image
 
 _CACHE_DIR = "/tmp/seg-img-cache"
 clean_up_cache_dir(_CACHE_DIR)  # Clean up cache directory per process launch
@@ -45,7 +45,7 @@ class LoadImageFromOTEDataset:
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):
         # Get image (possibly from cache)
-        img = get_cached_image(results, _CACHE_DIR, to_float32=self.to_float32)
+        img = get_image(results, _CACHE_DIR, to_float32=self.to_float32)
         shape = img.shape
 
         assert img.shape[0] == results['height'], f"{img.shape[0]} != {results['height']}"

--- a/external/model-preparation-algorithm/mpa_tasks/extensions/datasets/pipelines/mpa_cls_pipeline.py
+++ b/external/model-preparation-algorithm/mpa_tasks/extensions/datasets/pipelines/mpa_cls_pipeline.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import numpy as np
 from mmcls.datasets import PIPELINES
-from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_cached_image
+from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_image
 from ote_sdk.utils.argument_checks import check_input_parameters_type
 
 _CACHE_DIR = "/tmp/cls-img-cache"
@@ -35,7 +35,7 @@ class LoadImageFromOTEDataset:
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):
         # Get image (possibly from cache)
-        img = get_cached_image(results, _CACHE_DIR, to_float32=self.to_float32)
+        img = get_image(results, _CACHE_DIR, to_float32=self.to_float32)
         shape = img.shape
 
         assert img.shape[0] == results["height"], f"{img.shape[0]} != {results['height']}"

--- a/external/model-preparation-algorithm/mpa_tasks/extensions/datasets/pipelines/mpa_cls_pipeline.py
+++ b/external/model-preparation-algorithm/mpa_tasks/extensions/datasets/pipelines/mpa_cls_pipeline.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
-
+import tempfile
 from typing import Any, Dict
 
 import numpy as np
 from mmcls.datasets import PIPELINES
-from mpa_tasks.utils.data_utils import clean_up_cache_dir, get_image
+from mpa_tasks.utils.data_utils import get_image
 from ote_sdk.utils.argument_checks import check_input_parameters_type
 
-_CACHE_DIR = "/tmp/cls-img-cache"
-clean_up_cache_dir(_CACHE_DIR)  # Clean up cache directory per process launch
 
+_CACHE_DIR = tempfile.TemporaryDirectory(prefix='img-cache-')
 
 # Temporary copy from detection_tasks
 # TODO: refactoring to common modules
@@ -35,7 +34,7 @@ class LoadImageFromOTEDataset:
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):
         # Get image (possibly from cache)
-        img = get_image(results, _CACHE_DIR, to_float32=self.to_float32)
+        img = get_image(results, _CACHE_DIR.name, to_float32=self.to_float32)
         shape = img.shape
 
         assert img.shape[0] == results["height"], f"{img.shape[0]} != {results['height']}"

--- a/external/model-preparation-algorithm/mpa_tasks/utils/data_utils.py
+++ b/external/model-preparation-algorithm/mpa_tasks/utils/data_utils.py
@@ -4,7 +4,6 @@
 
 import fcntl
 import os
-import shutil
 from typing import Any, Dict
 
 import numpy as np
@@ -36,13 +35,12 @@ def get_old_new_img_indices(labels, new_classes, dataset):
     return {"old": ids_old, "new": ids_new}
 
 
-def clean_up_cache_dir(cache_dir: str):
-    shutil.rmtree(cache_dir, ignore_errors=True)
-    os.makedirs(cache_dir)
-
 def get_image(results: Dict[str, Any], cache_dir: str, to_float32=False):
     def is_video_frame(media):
         return "VideoFrame" in repr(media)
+
+    def is_training_subset(subset):
+        return subset.name in ["TRAINING", "VALIDATION"]
 
     def load_image_from_cache(filename: str):
         with open(filename, "rb") as f:
@@ -65,53 +63,18 @@ def get_image(results: Dict[str, Any], cache_dir: str, to_float32=False):
             finally:
                 fcntl.flock(f, fcntl.LOCK_UN)
 
-    if is_video_frame(results["dataset_item"].media):
-        subset = results["dataset_item"].subset
+    subset = results["dataset_item"].subset
+    if is_training_subset(subset) and is_video_frame(results["dataset_item"].media):
         index = results["index"]
         filename = os.path.join(cache_dir, f"{subset}-{index:06d}.npz")
         if os.path.exists(filename):
             return load_image_from_cache(filename)
-        
+
     img = results["dataset_item"].numpy  # this takes long for VideoFrame
     if to_float32:
         img = img.astype(np.float32)
 
-    if is_video_frame(results["dataset_item"].media) and not os.path.exists(filename):
+    if is_training_subset(subset) and is_video_frame(results["dataset_item"].media) and not os.path.exists(filename):
         save_image_to_cache(img, filename)
 
-    return img
-
-def get_cached_image(results: Dict[str, Any], cache_dir: str, to_float32=False):
-    def is_video_frame(media):
-        return "VideoFrame" in repr(media)
-
-    if is_video_frame(results["dataset_item"].media):
-        subset = results["dataset_item"].subset
-        index = results["index"]
-        filename = os.path.join(cache_dir, f"{subset}-{index:06d}.npz")
-        if os.path.exists(filename):
-            # Might be slower than dict key checking, but persitent
-            with open(filename, "rb") as f:
-                fcntl.flock(f, fcntl.LOCK_SH)
-                try:
-                    cached_img = np.load(f)
-                    return cached_img['img']
-                except Exception as e:
-                    logger.warning(f"Skip loading cached {filename} \nError msg: {e}")
-                finally:
-                    fcntl.flock(f, fcntl.LOCK_UN)
-
-    img = results["dataset_item"].numpy  # this takes long for VideoFrame
-    if to_float32:
-        img = img.astype(np.float32)
-
-    if is_video_frame(results["dataset_item"].media) and not os.path.exists(filename):
-        with open(filename, "wb") as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
-            try:
-                np.savez_compressed(f, img=img)
-            except Exception as e:
-                logger.warning(f"Skip caching for {filename} \nError msg: {e}")
-            finally:
-                fcntl.flock(f, fcntl.LOCK_UN)
     return img

--- a/external/model-preparation-algorithm/mpa_tasks/utils/data_utils.py
+++ b/external/model-preparation-algorithm/mpa_tasks/utils/data_utils.py
@@ -48,14 +48,14 @@ def get_cached_image(results: Dict[str, Any], cache_dir: str, to_float32=False):
     if is_video_frame(results["dataset_item"].media):
         subset = results["dataset_item"].subset
         index = results["index"]
-        filename = os.path.join(cache_dir, f"{subset}-{index:06d}.npy")
+        filename = os.path.join(cache_dir, f"{subset}-{index:06d}.npz")
         if os.path.exists(filename):
             # Might be slower than dict key checking, but persitent
             with open(filename, "rb") as f:
                 fcntl.flock(f, fcntl.LOCK_SH)
                 cached_img = np.load(f)
                 fcntl.flock(f, fcntl.LOCK_UN)
-                return cached_img
+                return cached_img['img']
 
     img = results["dataset_item"].numpy  # this takes long for VideoFrame
     if to_float32:
@@ -64,6 +64,6 @@ def get_cached_image(results: Dict[str, Any], cache_dir: str, to_float32=False):
     if is_video_frame(results["dataset_item"].media) and not os.path.exists(filename):
         with open(filename, "wb") as f:
             fcntl.flock(f, fcntl.LOCK_EX)
-            np.save(f, img)
+            np.savez_compressed(f, img=img)
             fcntl.flock(f, fcntl.LOCK_UN)
     return img


### PR DESCRIPTION
To reduce space complexity, changed to use compressed npz when save numpy array.
+) Add exception handling for file lock
+) Use tempfile.TemporaryDirectory (cached file automatically will be removed after training)
+) Prevent caching in evaluation phase