### PR TITLE
[OTX] Add SupCon for semantic segmentation

### DIFF
--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -328,7 +328,7 @@ class ClassificationInferenceTask(
                 ConfigDict(warmup_iters=warmup_iters) if warmup_iters > 0 else ConfigDict(warmup_iters=0, warmup=None)
             )
 
-        if params.enable_early_stopping and self._recipe_cfg.get("evaluation", None):  # type: ignore
+        if params.enable_early_stopping is not None and self._recipe_cfg.get("evaluation", None) is not None:
             early_stop = ConfigDict(
                 start=int(params.early_stop_start),
                 patience=int(params.early_stop_patience),

--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -328,7 +328,7 @@ class ClassificationInferenceTask(
                 ConfigDict(warmup_iters=warmup_iters) if warmup_iters > 0 else ConfigDict(warmup_iters=0, warmup=None)
             )
 
-        if params.enable_early_stopping:
+        if params.enable_early_stopping and self._recipe_cfg.get("evaluation", None):  # type: ignore
             early_stop = ConfigDict(
                 start=int(params.early_stop_start),
                 patience=int(params.early_stop_patience),

--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -330,7 +330,7 @@ class ClassificationInferenceTask(
 
         early_stop = False
         if self._recipe_cfg is not None:
-            if params.enable_early_stopping is not None and self._recipe_cfg.get("evaluation", None) is not None:
+            if params.enable_early_stopping and self._recipe_cfg.get("evaluation", None):
                 early_stop = ConfigDict(
                     start=int(params.early_stop_start),
                     patience=int(params.early_stop_patience),

--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -328,14 +328,14 @@ class ClassificationInferenceTask(
                 ConfigDict(warmup_iters=warmup_iters) if warmup_iters > 0 else ConfigDict(warmup_iters=0, warmup=None)
             )
 
-        if params.enable_early_stopping is not None and self._recipe_cfg.get("evaluation", None) is not None:
-            early_stop = ConfigDict(
-                start=int(params.early_stop_start),
-                patience=int(params.early_stop_patience),
-                iteration_patience=int(params.early_stop_iteration_patience),
-            )
-        else:
-            early_stop = False
+        early_stop = False
+        if self._recipe_cfg is not None:
+            if params.enable_early_stopping is not None and self._recipe_cfg.get("evaluation", None) is not None:
+                early_stop = ConfigDict(
+                    start=int(params.early_stop_start),
+                    patience=int(params.early_stop_patience),
+                    iteration_patience=int(params.early_stop_iteration_patience),
+                )
 
         if self._recipe_cfg.runner.get("type").startswith("IterBasedRunner"):  # type: ignore
             runner = ConfigDict(max_iters=int(params.num_iters))

--- a/otx/algorithms/common/adapters/mmcv/__init__.py
+++ b/otx/algorithms/common/adapters/mmcv/__init__.py
@@ -23,7 +23,7 @@ from .hooks import (
     OTXProgressHook,
     ReduceLROnPlateauLrUpdaterHook,
     StopLossNanTrainingHook,
-    SwitchPipelineHook,
+    TwoCropTransformHook,
 )
 from .nncf.hooks import CompressionHook
 from .nncf.runners import AccuracyAwareRunner
@@ -42,5 +42,5 @@ __all__ = [
     "EMAMomentumUpdateHook",
     "CompressionHook",
     "AccuracyAwareRunner",
-    "SwitchPipelineHook",
+    "TwoCropTransformHook",
 ]

--- a/otx/algorithms/common/adapters/mmcv/__init__.py
+++ b/otx/algorithms/common/adapters/mmcv/__init__.py
@@ -23,6 +23,7 @@ from .hooks import (
     OTXProgressHook,
     ReduceLROnPlateauLrUpdaterHook,
     StopLossNanTrainingHook,
+    SwitchPipelineHook,
 )
 from .nncf.hooks import CompressionHook
 from .nncf.runners import AccuracyAwareRunner
@@ -41,4 +42,5 @@ __all__ = [
     "EMAMomentumUpdateHook",
     "CompressionHook",
     "AccuracyAwareRunner",
+    "SwitchPipelineHook",
 ]

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -707,11 +707,19 @@ class SwitchPipelineHook(Hook):
 
     @check_input_parameters_type()
     def before_train_epoch(self, runner: BaseRunner):
+        if self.interval == 1:
+            # Always keep `TwoCropTransform` enabled.
+            return
+            
         dataset = self.get_dataset(runner)
         self.decide_pipeline(dataset.pipeline.transforms)
 
     @check_input_parameters_type()
     def after_train_iter(self, runner: BaseRunner):
+        if self.interval == 1:
+            # Always keep `TwoCropTransform` enabled.
+            return
+            
         if self.cnt < self.interval-1:
             # Instead of using `runner.every_n_iters` or `runner.every_n_inner_iters`,
             # this condition is used to compare `self.cnt` with `self.interval` throughout the entire epochs.
@@ -722,9 +730,9 @@ class SwitchPipelineHook(Hook):
             for transform in dataset.pipeline.transforms:
                 if transform.__class__.__name__ == "TwoCropTransform":
                     if not transform.is_both:
-                        # if self.cnt == self.interval-1, there are two cases,
-                        # 1. self.cnt was updated in L696, so is_both must be on.
-                        # 2. if iter was already conducted, is_both must be off.
+                        # If `self.cnt` == `self.interval`-1, there are two cases,
+                        # 1. `self.cnt` was updated in L704, so `is_both` must be on for the next iter.
+                        # 2. if the current iter was already conducted, `is_both` must be off.
                         transform.is_both = True
                     else:
                         transform.is_both = False

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -675,10 +675,11 @@ class TwoCropTransformHook(Hook):
     This hook decides whether using single pipeline or two pipelines
     implemented in `TwoCropTransform` for the current iteration.
 
-    :param interval: If `interval` == 1, both pipelines is used.
-        If `interval` > 1, the first pipeline is used and then
-        both pipelines are used every `interval`, defaults to 1.
-    :param by_epoch: (TODO) Use `interval` by epoch, defaults to False.
+    Args:
+        interval (int): If `interval` == 1, both pipelines is used.
+            If `interval` > 1, the first pipeline is used and then
+            both pipelines are used every `interval`. Defaults to 1.
+        by_epoch (bool): (TODO) Use `interval` by epoch. Defaults to False.
     """
 
     @check_input_parameters_type()

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -701,7 +701,7 @@ class TwoCropTransformHook(Hook):
         return dataset
 
     @check_input_parameters_type()
-    def _find_two_crop_transform(self, transforms: List[Any]):
+    def _find_two_crop_transform(self, transforms):
         for transform in transforms:
             if transform.__class__.__name__ == "TwoCropTransform":
                 return transform

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -704,7 +704,7 @@ class TwoCropTransformHook(Hook):
 
     # pylint: disable=inconsistent-return-statements
     @check_input_parameters_type()
-    def _find_two_crop_transform(self, transforms: List):
+    def _find_two_crop_transform(self, transforms: List[object]):
         """Find TwoCropTransform among transforms."""
         for transform in transforms:
             if transform.__class__.__name__ == "TwoCropTransform":

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -703,7 +703,7 @@ class TwoCropTransformHook(Hook):
 
     # pylint: disable=inconsistent-return-statements
     @check_input_parameters_type()
-    def _find_two_crop_transform(self, transforms):
+    def _find_two_crop_transform(self, transforms: List):
         """Find TwoCropTransform among transforms."""
         for transform in transforms:
             if transform.__class__.__name__ == "TwoCropTransform":

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -666,3 +666,67 @@ class ForceTrainModeHook(Hook):
     def before_train_epoch(self, runner):
         """Make sure to put a model in a training mode before train epoch."""
         runner.model.train()
+
+
+class SwitchPipelineHook(Hook):
+    """Switch pipeline with every specific interval.
+
+    This hook enables to apply the second pipeline every specific interval.
+    This hook is related to `TwoCropTransform`.
+
+    :param interval: If `interval` == 1, both pipelines is used.
+        If `interval` > 1, the first pipeline is used and then
+        both pipelines are used every `interval`, defaults to 1.
+    """
+
+    @check_input_parameters_type()
+    def __init__(self, interval: int = 1):
+        assert interval > 0
+        self.interval = interval
+        self.cnt = 0
+
+    @check_input_parameters_type()
+    def get_dataset(self, runner: BaseRunner):
+        if hasattr(runner.data_loader.dataset, 'dataset'):
+            # for RepeatDataset
+            dataset = runner.data_loader.dataset.dataset
+        else:
+            dataset = runner.data_loader.dataset
+
+        return dataset
+
+    @check_input_parameters_type()
+    def decide_pipeline(self, transforms):
+        for transform in transforms:
+            if transform.__class__.__name__ == "TwoCropTransform":
+                if self.cnt == self.interval-1:
+                    # start using both pipelines
+                    transform.is_both = True
+                else:
+                    transform.is_both = False
+
+    @check_input_parameters_type()
+    def before_train_epoch(self, runner: BaseRunner):
+        dataset = self.get_dataset(runner)
+        self.decide_pipeline(dataset.pipeline.transforms)
+
+    @check_input_parameters_type()
+    def before_train_iter(self, runner: BaseRunner):
+        dataset = self.get_dataset(runner)
+        self.decide_pipeline(dataset.pipeline.transforms)
+
+    @check_input_parameters_type()
+    def after_train_iter(self, runner: BaseRunner):
+        if self.cnt < self.interval-1:
+            # Instead of using `runner.every_n_iters` or `runner.every_n_inner_iters`,
+            # this condition is used to compare `self.cnt` with `self.interval` throughout the entire epochs.
+            self.cnt += 1
+
+        elif self.cnt == self.interval-1:
+            # end using both pipelines
+            dataset = self.get_dataset(runner)
+            for transform in dataset.pipeline.transforms:
+                if transform.__class__.__name__ == "TwoCropTransform" and self.cnt == self.interval-1:
+                    transform.is_both = False
+
+            self.cnt = 0

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -368,7 +368,7 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
             else ConfigDict(warmup_iters=warmup_iters, warmup=None)
         )
 
-        if params.enable_early_stopping:
+        if params.enable_early_stopping and self._recipe_cfg.get("evaluation", None):
             early_stop = ConfigDict(
                 start=int(params.early_stop_start),
                 patience=int(params.early_stop_patience),

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -284,10 +284,7 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
         else:
             self._recipe_cfg.pop("adaptive_validation_interval", None)
 
-        # TODO (sungchul): it will be removed after an update that applies hparam.yaml
-        if self._hyperparams.algo_backend.train_type != TrainType.SELFSUPERVISED:
-            # to disenable early stopping during self-sl
-            self.set_early_stopping_hook()
+        self.set_early_stopping_hook()
 
         # add Cancel tranining hook
         update_or_add_custom_hook(

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -58,7 +58,7 @@ from otx.mpa.utils.logger import get_logger
 
 logger = get_logger()
 TRAIN_TYPE_DIR_PATH = {
-    TrainType.INCREMENTAL.name: ".",
+    TrainType.INCREMENTAL.name: "",
     TrainType.SELFSUPERVISED.name: "selfsl",
     TrainType.SEMISUPERVISED.name: "semisl",
 }

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -58,7 +58,7 @@ from otx.mpa.utils.logger import get_logger
 
 logger = get_logger()
 TRAIN_TYPE_DIR_PATH = {
-    TrainType.INCREMENTAL.name: "",
+    TrainType.INCREMENTAL.name: ".",
     TrainType.SELFSUPERVISED.name: "selfsl",
     TrainType.SEMISUPERVISED.name: "semisl",
 }

--- a/otx/algorithms/segmentation/adapters/mmseg/__init__.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .data import MPASegDataset
-from .models import DetConB, DetConLoss, SelfSLMLP
+from .models import DetConB, DetConLoss, SelfSLMLP, SupConDetConB
 
 # fmt: off
 # isort: off
@@ -16,4 +16,4 @@ get_root_logger().propagate = False
 # fmt: off
 # isort: on
 
-__all__ = ["MPASegDataset", "DetConLoss", "SelfSLMLP", "DetConB"]
+__all__ = ["MPASegDataset", "DetConLoss", "SelfSLMLP", "DetConB", "SupConDetConB"]

--- a/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
@@ -124,14 +124,8 @@ class TwoCropTransform:
         results2 = self.view1(deepcopy(results))
 
         results = deepcopy(results1)
-        results["img"] = to_tensor(
-            np.ascontiguousarray(np.stack((results1["img"], results2["img"]), axis=0).transpose(0, 3, 1, 2))
-        )
-        results["gt_semantic_seg"] = to_tensor(
-            np.ascontiguousarray(
-                np.stack((results1["gt_semantic_seg"], results2["gt_semantic_seg"]), axis=0).transpose(0, 1, 2)
-            )
-        )
+        results["img"] = np.stack((results1["img"], results2["img"]), axis=0)
+        results["gt_semantic_seg"] = np.stack((results1["gt_semantic_seg"], results2["gt_semantic_seg"]), axis=0)
         results["flip"] = [results1["flip"], results2["flip"]]
 
         return results

--- a/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
@@ -106,7 +106,7 @@ class LoadAnnotationFromOTXDataset:
 class TwoCropTransform:
     """TwoCropTransform to combine two pipelines.
 
-    Through `SwitchPipelineHook`, how frequently both pipelines (view0 + view1) is applied can be set.
+    Through `TwoCropTransformHook`, how frequently both pipelines (view0 + view1) is applied can be set.
 
     :param view0: Pipeline for online network.
     :param view1: Pipeline for target network.

--- a/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List
 import numpy as np
 from mmcv.utils import build_from_cfg
 from mmseg.datasets.builder import PIPELINES
-from mmseg.datasets.pipelines import Compose, to_tensor
+from mmseg.datasets.pipelines import Compose
 from PIL import Image
 from torchvision import transforms as T
 from torchvision.transforms import functional as F
@@ -131,11 +131,11 @@ class TwoCropTransform:
             results["img"] = np.stack((results1["img"], results2["img"]), axis=0)
             results["gt_semantic_seg"] = np.stack((results1["gt_semantic_seg"], results2["gt_semantic_seg"]), axis=0)
             results["flip"] = [results1["flip"], results2["flip"]]
-        
+
         else:
             results = self.view0(results)
 
-        results['is_both'] = self.is_both
+        results["is_both"] = self.is_both
 
         return results
 

--- a/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
@@ -108,8 +108,9 @@ class TwoCropTransform:
 
     Through `TwoCropTransformHook`, how frequently both pipelines (view0 + view1) is applied can be set.
 
-    :param view0: Pipeline for online network.
-    :param view1: Pipeline for target network.
+    Args:
+        view0 (list): Pipeline for online network.
+        view1 (list): Pipeline for target network.
     """
 
     def __init__(self, view0: List, view1: List):
@@ -121,7 +122,12 @@ class TwoCropTransform:
     def __call__(self, results: Dict[str, Any]):
         """Callback function of TwoCropTransform.
 
-        :param results: Inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes stuffs for training.
+                  They have different shape or attribute depending on `self.is_both`.
         """
         if self.is_both:
             results1 = self.view0(deepcopy(results))
@@ -151,7 +157,11 @@ class RandomResizedCrop(T.RandomResizedCrop):
     def __call__(self, results: Dict[str, Any]):
         """Callback function of RandomResizedCrop.
 
-        :param results: Inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img and related information.
         """
         img = results["img"]
         i, j, height, width = self.get_params(img, self.scale, self.ratio)
@@ -178,7 +188,8 @@ class RandomColorJitter(T.ColorJitter):
     Since this transformation is applied to PIL Image,
     `NDArrayToPILImage` must be applied first before this is applied.
 
-    :param p: Probability for transformation.
+    Args:
+        p (float): Probability for transformation. Defaults to 0.8.
     """
 
     def __init__(self, p: float = 0.8, **kwargs):
@@ -189,7 +200,11 @@ class RandomColorJitter(T.ColorJitter):
     def __call__(self, results: Dict[str, Any]):
         """Callback function of ColorJitter.
 
-        :param results: Inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img.
         """
         if np.random.random() < self.p:
             results["img"] = self.forward(results["img"])
@@ -207,7 +222,11 @@ class RandomGrayscale(T.RandomGrayscale):
     def __call__(self, results: Dict[str, Any]):
         """Callback function of RandomGrayscale.
 
-        :param results: Inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img.
         """
         results["img"] = self.forward(results["img"])
         return results
@@ -220,7 +239,8 @@ class RandomGaussianBlur(T.GaussianBlur):
     Since this transformation is applied to PIL Image,
     `NDArrayToPILImage` must be applied first before this is applied.
 
-    :param p: Probability for transformation.
+    Args:
+        p (float): Probability for transformation. Defaults to 0.1.
     """
 
     def __init__(self, p: float = 0.1, **kwargs):
@@ -231,7 +251,11 @@ class RandomGaussianBlur(T.GaussianBlur):
     def __call__(self, results: Dict[str, Any]):
         """Callback function of GaussianBlur.
 
-        :param results: Inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img.
         """
         if np.random.random() < self.p:
             results["img"] = self.forward(results["img"])
@@ -242,8 +266,9 @@ class RandomGaussianBlur(T.GaussianBlur):
 class RandomSolarization:
     """Random Solarization augmentation.
 
-    :param threshold: Threshold for solarization, defaults to 128.
-    :param p: Probability for transformation.
+    Args:
+        threshold (int): Threshold for solarization. Defaults to 128.
+        p (float): Probability for transformation. Defaults to 0.2.
     """
 
     def __init__(self, threshold: int = 128, p: float = 0.2):
@@ -254,7 +279,11 @@ class RandomSolarization:
     def __call__(self, results: Dict[str, Any]):
         """Callback function of Solarization.
 
-        :param results: inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img.
         """
         if np.random.random() < self.p:
             img = results["img"]
@@ -272,7 +301,8 @@ class RandomSolarization:
 class NDArrayToPILImage:
     """Convert image from numpy to PIL.
 
-    :param keys: Keys to be transformed.
+    Args:
+        keys (list): Keys to be transformed.
     """
 
     def __init__(self, keys: List[str]):
@@ -281,7 +311,11 @@ class NDArrayToPILImage:
     def __call__(self, results: Dict[str, Any]):
         """Callback function of NDArrayToPILImage.
 
-        :param results: inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img.
         """
         for key in self.keys:
             img = results[key]
@@ -299,7 +333,8 @@ class NDArrayToPILImage:
 class PILImageToNDArray:
     """Convert image from PIL to numpy.
 
-    :param keys: Keys to be transformed.
+    Args:
+        keys (list): Keys to be transformed.
     """
 
     def __init__(self, keys: List[str]):
@@ -308,7 +343,11 @@ class PILImageToNDArray:
     def __call__(self, results: Dict[str, Any]):
         """Callback function of PILImageToNDArray.
 
-        :param results: inputs to be transformed.
+        Args:
+            results (dict): Inputs to be transformed.
+
+        Returns:
+            dict: Dictionary that includes transformed img.
         """
         for key in self.keys:
             img = results[key]

--- a/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py
@@ -115,7 +115,7 @@ class TwoCropTransform:
     def __init__(self, view0: List, view1: List):
         self.view0 = Compose([build_from_cfg(p, PIPELINES) for p in view0])
         self.view1 = Compose([build_from_cfg(p, PIPELINES) for p in view1])
-        self.is_both = False
+        self.is_both = True
 
     @check_input_parameters_type()
     def __call__(self, results: Dict[str, Any]):

--- a/otx/algorithms/segmentation/adapters/mmseg/models/__init__.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/__init__.py
@@ -17,6 +17,6 @@
 
 from .losses import DetConLoss
 from .necks import SelfSLMLP
-from .segmentors import DetConB
+from .segmentors import DetConB, SupConDetConB
 
-__all__ = ["DetConLoss", "SelfSLMLP", "DetConB"]
+__all__ = ["DetConLoss", "SelfSLMLP", "DetConB", "SupConDetConB"]

--- a/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
@@ -20,7 +20,9 @@ from mmseg.models.builder import (  # pylint: disable=no-name-in-module
     build_backbone,
     build_loss,
     build_neck,
+    build_head,
 )
+from mmseg.models import EncoderDecoder
 from mmseg.ops import resize
 from torch import nn
 
@@ -266,9 +268,9 @@ class DetConB(nn.Module):
             img (Tensor): Input image.
 
         Return:
-            Tensor: Features from the backbone.
+            Tensor: Features from the online_backbone.
         """
-        x = self.backbone(img)
+        x = self.online_backbone(img)
         return x
 
     def sample_masked_feats(self, feats: Union[torch.Tensor, List, Tuple], masks: torch.Tensor, projector: nn.Module):
@@ -297,7 +299,7 @@ class DetConB(nn.Module):
         return proj, sampled_mask_ids
 
     # pylint: disable=too-many-locals
-    def forward(self, img: torch.Tensor, img_metas: List[Dict], gt_semantic_seg: torch.Tensor):
+    def forward_train(self, img: torch.Tensor, img_metas: List[Dict], gt_semantic_seg: torch.Tensor, return_embedding: bool = False):
         """Forward function for training.
 
         Args:
@@ -305,15 +307,18 @@ class DetConB(nn.Module):
             img_metas (list[dict]): Input information.
             gt_semantic_seg (Tensor): Pseudo masks.
                 It is used to organize features among the same classes.
+            return_embedding (bool): Whether returning embeddings from the online backbone.
+                It can be used for SupCon. Default: False.
 
         Returns:
             dict[str, Tensor]: A dictionary of loss components.
         """
-        assert img.ndim == 5 and gt_semantic_seg.ndim == 4
+        assert img.ndim == 5 and gt_semantic_seg.ndim == 5
         img1, img2 = img[:, 0], img[:, 1]
-        mask1, mask2 = gt_semantic_seg[:, 0], gt_semantic_seg[:, 1]
+        mask1, mask2 = gt_semantic_seg[:, :, 0], gt_semantic_seg[:, :, 1]
 
-        proj1, id1 = self.sample_masked_feats(self.online_backbone(img1), mask1, self.online_projector)
+        embd1 = self.online_backbone(img1)
+        proj1, id1 = self.sample_masked_feats(embd1, mask1, self.online_projector)
         proj2, id2 = self.sample_masked_feats(self.online_backbone(img2), mask2, self.online_projector)
 
         with torch.no_grad():
@@ -341,7 +346,25 @@ class DetConB(nn.Module):
             tind2=id2_tgt,
         )
 
-        return loss
+        if return_embedding:
+            return loss, embd1
+        else:
+            return loss
+
+    def forward(self, img, img_metas, return_loss=True, **kwargs):
+        """Calls either :func:`forward_train` or :func:`forward_test` depending
+        on whether ``return_loss`` is ``True``.
+
+        Note this setting will change the expected inputs. When
+        ``return_loss=True``, img and img_meta are single-nested (i.e. Tensor
+        and List[dict]), and when ``resturn_loss=False``, img and img_meta
+        should be double nested (i.e.  List[Tensor], List[List[dict]]), with
+        the outer list indicating test time augmentations.
+        """
+        if return_loss:
+            return self.forward_train(img, img_metas, **kwargs)
+        else:
+            raise AttributeError("Self-SL doesn't support `forward_test` for evaluation.")
 
     def train_step(self, data_batch: Dict[str, Any], optimizer: Union[torch.optim.Optimizer, Dict], **kwargs):
         """The iteration step during training.
@@ -433,3 +456,102 @@ class DetConB(nn.Module):
                 k = k.replace("online_backbone.", "backbone.")
                 output[k] = v
         return output
+
+
+@SEGMENTORS.register_module()
+class SupConDetConB(EncoderDecoder):
+    """Apply DetConB as a contrastive part of `Supervised Contrastive Learning` (https://arxiv.org/abs/2004.11362)
+
+    SupCon with DetConB uses ground truth masks instead of pseudo masks to organize features among the same classes.
+    
+    Args:
+        decode_head (dict, optional): Config dict for module of decode head. Default: None.
+        train_cfg (dict, optional): Config dict for training. Default: None.
+    """
+    def __init__(
+        self,
+        backbone: Dict[str, Any],
+        decode_head: Optional[Dict[str, Any]] = None,
+        neck: Optional[Dict[str, Any]] = None,
+        head: Optional[Dict[str, Any]] = None,
+        pretrained: Optional[str] = None,
+        base_momentum: float = 0.996,
+        num_classes: int = 256,
+        num_samples: int = 16,
+        downsample: int = 32,
+        input_transform: str = "resize_concat",
+        in_index: List[int] = [0],
+        align_corners: bool = False,
+        loss_cfg: Optional[Dict[str, Any]] = None,
+        train_cfg: Optional[Dict[str, Any]] = None,
+        test_cfg: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            backbone=backbone,
+            decode_head=decode_head,
+            train_cfg=train_cfg,
+            test_cfg=test_cfg,
+        )
+
+        self.detconb = DetConB(
+            backbone=backbone,
+            neck=neck,
+            head=head,
+            pretrained=pretrained,
+            base_momentum=base_momentum,
+            num_classes=num_classes,
+            num_samples=num_samples,
+            downsample=downsample,
+            input_transform=input_transform,
+            in_index=in_index,
+            align_corners=align_corners,
+            loss_cfg=loss_cfg,
+            **kwargs,
+        )
+        self.backbone = self.detconb.online_backbone
+        # TODO (sungchul): Is state_dict_hook needed to save segmentor only?
+        # 1. use state_dict_hook : we can save memory as only saving backbone + decode_head.
+        # 2. save all : we can use additional training with the whole weights (backbone + decode_head + detcon).
+
+    def forward_train(
+        self,
+        img: torch.Tensor,
+        img_metas: List[Dict],
+        gt_semantic_seg: torch.Tensor,
+        pixel_weights: Optional[torch.Tensor] = None,
+        **kwargs
+    ):
+        """Forward function for training.
+
+        Args:
+            img (Tensor): Input images.
+            img_metas (list[dict]): Input information.
+            gt_semantic_seg (Tensor): Ground truth masks.
+                It is used to organize features among the same classes.
+            pixel_weights (Tensor): Pixels weights.
+
+        Returns:
+            dict[str, Tensor]: A dictionary of loss components.
+        """
+        losses = dict()
+        if img.ndim == 4:
+            # supervised learning with interval
+            embd = self.detconb.online_backbone(img)
+        else:
+            # supcon training
+            mask = gt_semantic_seg[:, :, 0]
+            loss_detcon, embd = self.detconb.forward_train(
+                img=img,
+                img_metas=img_metas,
+                gt_semantic_seg=gt_semantic_seg,
+                return_embedding=True
+            )
+            losses.update(dict(loss_detcon=loss_detcon["loss"]))
+
+        # decode head
+        loss_decode, _ = self._decode_head_forward_train(
+            embd, img_metas, gt_semantic_seg=mask, pixel_weights=pixel_weights)
+        losses.update(loss_decode)
+
+        return losses

--- a/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
@@ -538,6 +538,7 @@ class SupConDetConB(EncoderDecoder):
         if img.ndim == 4:
             # supervised learning with interval
             embd = self.detconb.online_backbone(img)
+            mask = gt_semantic_seg
         else:
             # supcon training
             mask = gt_semantic_seg[:, :, 0]

--- a/otx/algorithms/segmentation/configs/base/data/selfsl/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/base/data/selfsl/data_pipeline.py
@@ -19,7 +19,7 @@
 __resize_target_size = (224, 224)
 __img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
-train_pipeline = [
+__train_pipeline = [
     dict(type="LoadImageFromFile"),
     dict(type="LoadAnnotations"),
     dict(
@@ -50,4 +50,4 @@ train_pipeline = [
     dict(type="Collect", keys=["img", "gt_semantic_seg"]),
 ]
 
-data = dict(train=dict(type="MPASegDataset", pipeline=train_pipeline))
+data = dict(train=dict(type="MPASegDataset", pipeline=__train_pipeline))

--- a/otx/algorithms/segmentation/configs/base/data/selfsl/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/base/data/selfsl/data_pipeline.py
@@ -16,7 +16,7 @@
 
 # pylint: disable=invalid-name
 
-__resize_target_size = 224
+__resize_target_size = (224, 224)
 __img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [

--- a/otx/algorithms/segmentation/configs/base/data/selfsl/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/base/data/selfsl/data_pipeline.py
@@ -19,7 +19,7 @@
 __resize_target_size = 224
 __img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
-__train_pipeline = [
+train_pipeline = [
     dict(type="LoadImageFromFile"),
     dict(type="LoadAnnotations"),
     dict(
@@ -46,7 +46,8 @@ __train_pipeline = [
             dict(type="Normalize", **__img_norm_cfg),
         ],
     ),
+    dict(type="DefaultFormatBundle"),
     dict(type="Collect", keys=["img", "gt_semantic_seg"]),
 ]
 
-data = dict(train=dict(type="MPASegDataset", pipeline=__train_pipeline))
+data = dict(train=dict(type="MPASegDataset", pipeline=train_pipeline))

--- a/otx/algorithms/segmentation/configs/base/data/supcon/__init__.py
+++ b/otx/algorithms/segmentation/configs/base/data/supcon/__init__.py
@@ -1,5 +1,4 @@
-"""OTX Algorithms - Segmentation Segmentors."""
-
+"""SupCon data pipeline configurations folder."""
 # Copyright (C) 2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions
 # and limitations under the License.
-
-from .detcon import DetConB, SupConDetConB
-
-__all__ = ["DetConB", "SupConDetConB"]

--- a/otx/algorithms/segmentation/configs/base/data/supcon/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/base/data/supcon/data_pipeline.py
@@ -1,0 +1,48 @@
+"""Data Pipeline for SupCon model of Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+_base_ = ["../selfsl/data_pipeline.py",]
+
+__img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+__img_scale = (544, 544)
+
+test_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_scale,
+        flip=False,
+        transforms=[
+            dict(type="Resize", keep_ratio=False),
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+
+# TODO (Sungchul, Soobee) : Remove Repeatdataset in data config
+# when otx/algorithms/segmentation/configs/base/data/data_pipeline.py is updated.
+data = dict(
+    train=dict(
+        _delete_=True,
+        dataset=dict(pipeline={{_base_.train_pipeline}})),
+    val=dict(pipeline=test_pipeline),
+    test=dict(pipeline=test_pipeline),
+)

--- a/otx/algorithms/segmentation/configs/base/data/supcon/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/base/data/supcon/data_pipeline.py
@@ -16,12 +16,42 @@
 
 # pylint: disable=invalid-name
 
-_base_ = ["../selfsl/data_pipeline.py",]
-
 __img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 __img_scale = (544, 544)
+__resize_target_size = (512, 512)
 
-test_pipeline = [
+__train_pipeline = [
+    dict(type="LoadImageFromFile"),
+    dict(type="LoadAnnotations"),
+    dict(
+        type="TwoCropTransform",
+        view0=[
+            dict(type="NDArrayToPILImage", keys=["img"]),
+            dict(type="RandomResizedCrop", size=__resize_target_size),
+            dict(type="RandomColorJitter", brightness=0.4, contrast=0.4, saturation=0.2, hue=0.1, p=0.8),
+            dict(type="RandomGrayscale", p=0.2),
+            dict(type="RandomGaussianBlur", kernel_size=23, p=1.0),
+            dict(type="PILImageToNDArray", keys=["img"]),
+            dict(type="RandomFlip", prob=0.5, direction="horizontal"),
+            dict(type="Normalize", **__img_norm_cfg),
+        ],
+        view1=[
+            dict(type="NDArrayToPILImage", keys=["img"]),
+            dict(type="RandomResizedCrop", size=__resize_target_size),
+            dict(type="RandomColorJitter", brightness=0.4, contrast=0.4, saturation=0.2, hue=0.1, p=0.8),
+            dict(type="RandomGrayscale", p=0.2),
+            dict(type="RandomGaussianBlur", kernel_size=23, p=0.1),
+            dict(type="PILImageToNDArray", keys=["img"]),
+            dict(type="RandomSolarization", threshold=128, p=0.2),
+            dict(type="RandomFlip", prob=0.5, direction="horizontal"),
+            dict(type="Normalize", **__img_norm_cfg),
+        ],
+    ),
+    dict(type="DefaultFormatBundle"),
+    dict(type="Collect", keys=["img", "gt_semantic_seg"]),
+]
+
+__test_pipeline = [
     dict(type="LoadImageFromFile"),
     dict(
         type="MultiScaleFlipAug",
@@ -40,9 +70,7 @@ test_pipeline = [
 # TODO (Sungchul, Soobee) : Remove Repeatdataset in data config
 # when otx/algorithms/segmentation/configs/base/data/data_pipeline.py is updated.
 data = dict(
-    train=dict(
-        _delete_=True,
-        dataset=dict(pipeline={{_base_.train_pipeline}})),
-    val=dict(pipeline=test_pipeline),
-    test=dict(pipeline=test_pipeline),
+    train=dict(dataset=dict(pipeline=__train_pipeline)),
+    val=dict(pipeline=__test_pipeline),
+    test=dict(pipeline=__test_pipeline),
 )

--- a/otx/algorithms/segmentation/configs/configuration.yaml
+++ b/otx/algorithms/segmentation/configs/configuration.yaml
@@ -212,6 +212,22 @@ learning_parameters:
     value: 0
     visible_in_ui: true
     warning: This is applied exclusively when early stopping is enabled.
+  enable_supcon:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description:
+      Enable an auxiliar supervised contrastive loss, which might increase robustness
+      and accuracy for small datasets.
+    editable: true
+    header: Enable Supervised Contrastive helper loss
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 postprocessing:

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/__init__.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/__init__.py
@@ -1,4 +1,4 @@
-"""OTX Algorithms - Segmentation Segmentors."""
+"""Initialization of OCR-Lite-HRnet-18-mod2 model for SupCon Segmentation Task."""
 
 # Copyright (C) 2022 Intel Corporation
 #
@@ -13,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions
 # and limitations under the License.
-
-from .detcon import DetConB, SupConDetConB
-
-__all__ = ["DetConB", "SupConDetConB"]

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/data_pipeline.py
@@ -1,0 +1,18 @@
+"""Data Pipeline of HR-Net model for Segmentation Task."""
+
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+_base_ = ["../../base/data/supcon/data_pipeline.py"]

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/model.py
@@ -1,0 +1,27 @@
+"""Model configuration of OCR-Lite-HRnet-18-mod2 model for Self-SL Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+_base_ = ["../selfsl/model.py",]
+
+model = dict(type="SupConDetConB")
+
+load_from = None
+
+resume_from = None
+
+fp16 = dict(_delete_=True, loss_scale=512.0)

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/supcon/model.py
@@ -16,7 +16,9 @@
 
 # pylint: disable=invalid-name
 
-_base_ = ["../selfsl/model.py",]
+_base_ = [
+    "../selfsl/model.py",
+]
 
 model = dict(type="SupConDetConB")
 

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/__init__.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/__init__.py
@@ -1,4 +1,4 @@
-"""OTX Algorithms - Segmentation Segmentors."""
+"""Initialization of OCR-Lite-HRnet-s-mod2 model for SupCon Segmentation Task."""
 
 # Copyright (C) 2022 Intel Corporation
 #
@@ -13,7 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions
 # and limitations under the License.
-
-from .detcon import DetConB, SupConDetConB
-
-__all__ = ["DetConB", "SupConDetConB"]

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/data_pipeline.py
@@ -1,0 +1,18 @@
+"""Data Pipeline of HR-Net model for Segmentation Task."""
+
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+_base_ = ["../../base/data/supcon/data_pipeline.py"]

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/model.py
@@ -16,7 +16,9 @@
 
 # pylint: disable=invalid-name
 
-_base_ = ["../selfsl/model.py",]
+_base_ = [
+    "../selfsl/model.py",
+]
 
 model = dict(type="SupConDetConB")
 

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/model.py
@@ -1,4 +1,4 @@
-"""Model configuration of OCR-Lite-HRnet-s-mod2 model for Self-SL Segmentation Task."""
+"""Model configuration of OCR-Lite-HRnet-s-mod2 model for SupCon Segmentation Task."""
 
 # Copyright (C) 2022 Intel Corporation
 #

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/supcon/model.py
@@ -1,0 +1,27 @@
+"""Model configuration of OCR-Lite-HRnet-s-mod2 model for Self-SL Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+_base_ = ["../selfsl/model.py",]
+
+model = dict(type="SupConDetConB")
+
+load_from = None
+
+resume_from = None
+
+fp16 = dict(_delete_=True, loss_scale=512.0)

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/__init__.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/__init__.py
@@ -1,0 +1,15 @@
+"""Initialization of OCR-Lite-HRnet-x-mod3 model for SupCon Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/data_pipeline.py
@@ -1,0 +1,18 @@
+"""Data Pipeline of HR-Net model for Segmentation Task."""
+
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+_base_ = ["../../base/data/supcon/data_pipeline.py"]

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/model.py
@@ -16,7 +16,9 @@
 
 # pylint: disable=invalid-name
 
-_base_ = ["../selfsl/model.py",]
+_base_ = [
+    "../selfsl/model.py",
+]
 
 model = dict(type="SupConDetConB")
 

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/supcon/model.py
@@ -1,4 +1,4 @@
-"""Model configuration of OCR-Lite-HRnet-18-mod2 model for SupCon Segmentation Task."""
+"""Model configuration of OCR-Lite-HRnet-x-mod3 model for SupCon Segmentation Task."""
 
 # Copyright (C) 2022 Intel Corporation
 #

--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -207,6 +207,9 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
         if self._recipe_cfg.get("evaluation", None):
             self.metric = self._recipe_cfg.evaluation.metric
 
+        if self._recipe_cfg.get("override_configs", None):
+            self.override_configs.update(self._recipe_cfg.override_configs)
+
         if not self.freeze:
             remove_from_configs_by_type(self._recipe_cfg.custom_hooks, "FreezeLayers")
         logger.info(f"initialized recipe = {recipe}")

--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -189,7 +189,8 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
         if self._train_type in RECIPE_TRAIN_TYPE:
             if self._train_type == TrainType.INCREMENTAL and self._hyperparams.learning_parameters.enable_supcon:
                 recipe = os.path.join(recipe_root, "supcon.py")
-                self._model_dir = os.path.join(self._model_dir, "supcon")
+                if "supcon" not in self._model_dir:
+                    self._model_dir = os.path.join(self._model_dir, "supcon")
             else:
                 recipe = os.path.join(recipe_root, RECIPE_TRAIN_TYPE[self._train_type])
         else:

--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -187,7 +187,11 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
         logger.info(f"train type = {self._train_type}")
 
         if self._train_type in RECIPE_TRAIN_TYPE:
-            recipe = os.path.join(recipe_root, RECIPE_TRAIN_TYPE[self._train_type])
+            if self._train_type == TrainType.INCREMENTAL and self._hyperparams.learning_parameters.enable_supcon:
+                recipe = os.path.join(recipe_root, "supcon.py")
+                self._model_dir = os.path.join(self._model_dir, "supcon")
+            else:
+                recipe = os.path.join(recipe_root, RECIPE_TRAIN_TYPE[self._train_type])
         else:
             raise NotImplementedError(f"Train type {self._train_type} is not implemented yet.")
 

--- a/otx/mpa/modules/datasets/pipelines/transforms/seg_custom_pipelines.py
+++ b/otx/mpa/modules/datasets/pipelines/transforms/seg_custom_pipelines.py
@@ -80,7 +80,14 @@ class DefaultFormatBundle(object):
             img = results[target]
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
-            img = np.ascontiguousarray(img.transpose(2, 0, 1)).astype(np.float32)
+                
+            if len(img.shape) == 3:
+                img = np.ascontiguousarray(img.transpose(2, 0, 1)).astype(np.float32)
+            elif len(img.shape) == 4:
+                # for selfsl or supcon
+                img = np.ascontiguousarray(img.transpose(0, 3, 1, 2)).astype(np.float32)
+            else:
+                raise ValueError(f"img.shape={img.shape} is not supported.")
 
             results[target] = DC(to_tensor(img), stack=True)
 

--- a/otx/mpa/modules/datasets/pipelines/transforms/seg_custom_pipelines.py
+++ b/otx/mpa/modules/datasets/pipelines/transforms/seg_custom_pipelines.py
@@ -80,7 +80,7 @@ class DefaultFormatBundle(object):
             img = results[target]
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
-                
+
             if len(img.shape) == 3:
                 img = np.ascontiguousarray(img.transpose(2, 0, 1)).astype(np.float32)
             elif len(img.shape) == 4:

--- a/otx/mpa/seg/stage.py
+++ b/otx/mpa/seg/stage.py
@@ -121,6 +121,10 @@ class SegStage(Stage):
                 for head in decode_head:
                     head.num_classes = len(model_classes)
 
+            # For SupConDetCon
+            if "SupConDetCon" in cfg.model.type:
+                cfg.model.num_classes = len(model_classes)
+
         # Task classes
         self.org_model_classes = org_model_classes
         self.model_classes = model_classes

--- a/otx/recipes/stages/segmentation/supcon.py
+++ b/otx/recipes/stages/segmentation/supcon.py
@@ -1,5 +1,3 @@
 _base_ = ["./incremental.py"]
 
-override_configs = dict(
-    custom_hooks=[dict(type="TwoCropTransformHook", interval=5)]
-)
+override_configs = dict(custom_hooks=[dict(type="TwoCropTransformHook", interval=5)])

--- a/otx/recipes/stages/segmentation/supcon.py
+++ b/otx/recipes/stages/segmentation/supcon.py
@@ -1,5 +1,5 @@
 _base_ = ["./incremental.py"]
 
 override_configs = dict(
-    custom_hooks=[dict(type='SwitchPipelineHook', interval=1)]
+    custom_hooks=[dict(type="TwoCropTransformHook", interval=5)]
 )

--- a/otx/recipes/stages/segmentation/supcon.py
+++ b/otx/recipes/stages/segmentation/supcon.py
@@ -1,0 +1,5 @@
+_base_ = ["./incremental.py"]
+
+override_configs = dict(
+    custom_hooks=[dict(type='SwitchPipelineHook', interval=1)]
+)

--- a/tests/integration/cli/segmentation/test_segmentation.py
+++ b/tests/integration/cli/segmentation/test_segmentation.py
@@ -93,6 +93,13 @@ templates_ids = [default_template.model_template_id]
 class TestSegmentationCLI:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_train_supcon(self, template, tmp_dir_path):
+        args1 = copy.deepcopy(args)
+        args1["train_params"].extend(["--learning_parameters.enable_supcon", "True"])
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
         otx_train_testing(template, tmp_dir_path, otx_dir, args)
 


### PR DESCRIPTION
# This PR includes 
- Add supcon for semantic segmentation modules, configs
- Enable detcon when training w/ fp16
- Update selfsl & supcon data_pipeline to use `DefaultFormatBundle`

## TODOs

- [x] experiments for reproducibility and improvement
- [x] change target branch from `feature/selfsl/cls` to `feature/otx` after merging https://github.com/openvinotoolkit/training_extensions/pull/1406
- [ ] ~unit test~ 
→ It will be implemented in other PR because this PR is so huge and it's unit test depends on self-sl for semantic segmentation.
- [x] integration test
`tests/integration/cli/segmentation/test_segmentation.py::TestSegmentationCLI::test_otx_train_supcon`

## To be considered in the future
- If with incremental setting, `model.num_classes` is automatically set from `256` to `len(model_classes)`. if not, `model.num_classes` remains `256`. https://github.com/openvinotoolkit/training_extensions/blob/cc643d3dd4ab9f8811d1a8e9a77959b05725b318/otx/mpa/seg/stage.py#L136-L138