### PR TITLE
[OTX] Update OTX detection requirements

### DIFF
--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -174,7 +174,7 @@ def main():  # pylint: disable=too-many-branches
             "ann_file": data_config["data"]["val"]["ann-files"],
             "data_root": data_config["data"]["val"]["data-roots"],
         }
-    if data_config["data"]["unlabeled"]["data-roots"]:
+    if "unlabeled" in data_config["data"] and data_config["data"]["unlabeled"]["data-roots"]:
         data_roots["unlabeled_subset"] = {
             "data_root": data_config["data"]["unlabeled"]["data-roots"],
             "file_list": data_config["data"]["unlabeled"]["file-list"],

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -186,7 +186,7 @@ def main():  # pylint: disable=too-many-branches
         train_data_roots=data_roots["train_subset"]["data_root"],
         val_data_roots=data_roots["val_subset"]["data_root"] if data_config["data"]["val"]["data-roots"] else None,
         unlabeled_data_roots=data_roots["unlabeled_subset"]["data_root"]
-        if "unlabeled" in data_config and data_config["data"]["unlabeled"]["data-roots"]
+        if "unlabeled" in data_config["data"] and data_config["data"]["unlabeled"]["data-roots"]
         else None,
     )
     dataset = dataset_adapter.get_otx_dataset()

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -186,7 +186,7 @@ def main():  # pylint: disable=too-many-branches
         train_data_roots=data_roots["train_subset"]["data_root"],
         val_data_roots=data_roots["val_subset"]["data_root"] if data_config["data"]["val"]["data-roots"] else None,
         unlabeled_data_roots=data_roots["unlabeled_subset"]["data_root"]
-        if data_config["data"]["unlabeled"]["data-roots"]
+        if "unlabeled" in data_config and data_config["data"]["unlabeled"]["data-roots"]
         else None,
     )
     dataset = dataset_adapter.get_otx_dataset()

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -1,5 +1,5 @@
 mmcv-full==1.6.1
 mmdet==2.25.1
 pytorchcv
-mmcls==0.24
+mmcls==0.24.0
 timm

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -1,5 +1,5 @@
 mmcv-full==1.6.1
 mmdet==2.25.1
 pytorchcv
-mmcls==0.24.0
+mmcls==0.23.2
 timm

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -1,3 +1,5 @@
 mmcv-full==1.6.1
 mmdet==2.25.1
 pytorchcv
+mmcls==0.24
+timm

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -2,4 +2,4 @@ mmcv-full==1.6.1
 mmdet==2.25.1
 pytorchcv
 mmcls==0.23.2
-timm
+timm==0.6.12


### PR DESCRIPTION
This PR contains a few code fixes, discovered during [documentation writing](https://github.com/openvinotoolkit/training_extensions/pull/1469). 

- [x] Added missing mmcls and timm packages to the detection requirements
- [x] Make it possible to pass annotation paths via `--data data.yaml` parameter even if it doesn't have `unlabeled` annotation 