### PR TITLE
[OTX-CI] extend timeout setting

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, linux, x64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Code Quality Checks
@@ -29,10 +29,11 @@ jobs:
   Pre-Merge-Tests:
     runs-on: [self-hosted, linux, x64]
     needs: Code-Quality-Checks
+    timeout-minutes: 600
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Pre-Merge Tests


### PR DESCRIPTION
for the pre-merge testing job to 600 minutes from 360 minutes

Signed-off-by: Lee, Yunchu <yunchu.lee@intel.com>