### PR TITLE
[OTX] consider multi GPU when setting drop last

### DIFF
--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -455,10 +455,10 @@ class ClassificationInferenceTask(
             # In train dataset, when sample size is smaller than batch size
             if subset == "train" and self._data_cfg:
                 train_data_cfg = Stage.get_data_cfg(self._data_cfg, "train")
-                num_gpus = dist.get_world_size() if dist.is_initialized() else 1
+                num_worlds = dist.get_world_size() if dist.is_initialized() else 1
                 if (
                     len(train_data_cfg.get("otx_dataset", []))
-                    < self._recipe_cfg.data.get("samples_per_gpu", 2) * num_gpus
+                    < self._recipe_cfg.data.get("samples_per_gpu", 2) * num_worlds
                 ):
                     cfg.drop_last = False
 

--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -455,7 +455,7 @@ class ClassificationInferenceTask(
             # In train dataset, when sample size is smaller than batch size
             if subset == "train" and self._data_cfg:
                 train_data_cfg = Stage.get_data_cfg(self._data_cfg, "train")
-                num_gpus = dist.get_world_size() if self.distributed else 1
+                num_gpus = dist.get_world_size() if dist.is_initialized() else 1
                 if (
                     len(train_data_cfg.get("otx_dataset", []))
                     < self._recipe_cfg.data.get("samples_per_gpu", 2) * num_gpus

--- a/otx/mpa/cls/trainer.py
+++ b/otx/mpa/cls/trainer.py
@@ -106,10 +106,10 @@ class ClsTrainer(ClsStage):
         drop_last = False
         dataset_len = len(otx_dataset) if otx_dataset else 0
         # if task == h-label & dataset size is bigger than batch size
-        num_gpus = dist.get_world_size() if self.distributed else 1
+        num_worlds = dist.get_world_size() if self.distributed else 1
         if (
             train_data_cfg.get("hierarchical_info", None)
-            and dataset_len > cfg.data.get("samples_per_gpu", 2) * num_gpus
+            and dataset_len > cfg.data.get("samples_per_gpu", 2) * num_worlds
         ):
             drop_last = True
         # updated to adapt list of dataset for the 'train'

--- a/otx/mpa/cls/trainer.py
+++ b/otx/mpa/cls/trainer.py
@@ -8,6 +8,7 @@ import time
 import warnings
 
 import mmcv
+import torch.distributed as dist
 from mmcls import __version__
 from mmcls.core import DistOptimizerHook
 from mmcls.datasets import build_dataloader, build_dataset
@@ -105,7 +106,11 @@ class ClsTrainer(ClsStage):
         drop_last = False
         dataset_len = len(otx_dataset) if otx_dataset else 0
         # if task == h-label & dataset size is bigger than batch size
-        if train_data_cfg.get("hierarchical_info", None) and dataset_len > cfg.data.get("samples_per_gpu", 2):
+        num_gpus = dist.get_world_size() if self.distributed else 1
+        if (
+            train_data_cfg.get("hierarchical_info", None)
+            and dataset_len > cfg.data.get("samples_per_gpu", 2) * num_gpus
+        ):
             drop_last = True
         # updated to adapt list of dataset for the 'train'
         data_loaders = [

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -464,7 +464,7 @@ args_h = {
         "--learning_parameters.num_iters",
         "2",
         "--learning_parameters.batch_size",
-        "2",
+        "4",
     ],
 }
 


### PR DESCRIPTION
### Summray

- setting drop_laste considering multi GPU

### Detail
Although samplers_per_gpu * num_gpus is bigger than number of images, drop_last is set as 0, then max_iter is calculated as 0, which makes a bug.