### PR TITLE
[OTX] Learning rate bugfix on ReduceLROnPlateau

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -491,13 +491,10 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         self.key_indicator = key_indicator
         self.compare_func = self.rule_map[self.rule]
 
-    def _is_check_timing(self, runner):
-        """Called _is_check_timing in ReduceLROnPlateauLrUpdaterHook."""
+    def _is_check_timing(self, runner) -> bool:
+        """Check whether current epoch or iter is multiple of self.interval."""
         check_time = self.every_n_epochs if self.by_epoch else self.every_n_iters
-        if not check_time(runner, self.interval):
-            # No evaluation during the interval.
-            return False
-        return True
+        return check_time(runner, self.interval)
 
     @check_input_parameters_type()
     def get_lr(self, runner: BaseRunner, base_lr: float):

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -491,7 +491,7 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         self.key_indicator = key_indicator
         self.compare_func = self.rule_map[self.rule]
 
-    def _is_check_timing(self, runner) -> bool:
+    def _is_check_timing(self, runner: BaseRunner) -> bool:
         """Check whether current epoch or iter is multiple of self.interval."""
         check_time = self.every_n_epochs if self.by_epoch else self.every_n_iters
         return check_time(runner, self.interval)

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -491,7 +491,7 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         self.key_indicator = key_indicator
         self.compare_func = self.rule_map[self.rule]
 
-    def _should_check_stopping(self, runner):
+    def _is_check_timing(self, runner):
         """Called _should_check_stopping in ReduceLROnPlateauLrUpdaterHook."""
         check_time = self.every_n_epochs if self.by_epoch else self.every_n_iters
         if not check_time(runner, self.interval):
@@ -502,11 +502,11 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
     @check_input_parameters_type()
     def get_lr(self, runner: BaseRunner, base_lr: float):
         """Called get_lr in ReduceLROnPlateauLrUpdaterHook."""
-        if not self._should_check_stopping(runner) or self.warmup_iters > runner.iter:
-            return base_lr
-
         if self.current_lr < 0:
             self.current_lr = base_lr
+
+        if not self._is_check_timing(runner) or self.warmup_iters > runner.iter:
+            return self.current_lr
 
         if hasattr(runner, self.metric):
             score = getattr(runner, self.metric, 0.0)

--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -492,7 +492,7 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         self.compare_func = self.rule_map[self.rule]
 
     def _is_check_timing(self, runner):
-        """Called _should_check_stopping in ReduceLROnPlateauLrUpdaterHook."""
+        """Called _is_check_timing in ReduceLROnPlateauLrUpdaterHook."""
         check_time = self.every_n_epochs if self.by_epoch else self.every_n_iters
         if not check_time(runner, self.interval):
             # No evaluation during the interval.


### PR DESCRIPTION
## This PR includes:
- Fix learning rate reverting bug after dropping LR in ROP which was found in detection task.

### What was the root cause?
- ROP didn't consider **adaptive interval**. 
- If current epoch is not multiple of `self.interval` in ROP, `_should_check_stopping` returns `False`.
- Then, by `if` statement at line 505, ROP returns `base_lr` instead of reduced `self.current_lr`.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/72460430/212132565-28a2d4b7-b58e-46eb-9de3-9f2ee30c7ba9.png">

### How I fixed
- Define `self.currnt_lr` in initial epoch and return `self.current_lr` instead of `base_lr` when runner is not in check timing (every interval or epoch).

### Verify ROP
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/72460430/212132233-1272fa70-a82c-40a9-abb3-083d5ce92487.png">
- By non-deterministic training, learning rate can differ but note that ROP works well on both tasks by this PR.

