### PR TITLE
[feature/otx] Changed activation naming for proper checkpoint handling, fixed unexpected accuracy range

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/data/datasets.py
+++ b/otx/algorithms/classification/adapters/mmcls/data/datasets.py
@@ -151,7 +151,6 @@ class MPAClsDataset(BaseDataset):
         eval_results = super().evaluate(results, metrics, metric_options, logger=logger)
         for k in metric_options["topk"]:
             eval_results[f"accuracy_top-{k}"] /= 100
-            assert 0 <= eval_results[f"accuracy_top-{k}"] <= 1
 
         # Add Evaluation Accuracy score per Class - it can be used only for multi-class dataset.
         if self.class_acc:

--- a/otx/algorithms/classification/adapters/mmcls/data/datasets.py
+++ b/otx/algorithms/classification/adapters/mmcls/data/datasets.py
@@ -149,6 +149,9 @@ class MPAClsDataset(BaseDataset):
             self.class_acc = True
 
         eval_results = super().evaluate(results, metrics, metric_options, logger=logger)
+        for k in metric_options["topk"]:
+            eval_results[f"accuracy_top-{k}"] /= 100
+            assert 0 <= eval_results[f"accuracy_top-{k}"] <= 1
 
         # Add Evaluation Accuracy score per Class - it can be used only for multi-class dataset.
         if self.class_acc:

--- a/otx/mpa/modules/datasets/cls_dir_dataset.py
+++ b/otx/mpa/modules/datasets/cls_dir_dataset.py
@@ -33,15 +33,7 @@ class ClsDirDataset(BaseDataset):
         use_labels (bool): dataset with labels or unlabels
     """
 
-    def __init__(
-        self,
-        data_dir,
-        pipeline=[],
-        classes=[],
-        new_classes=[],
-        use_labels=True,
-        **kwargs,
-    ):
+    def __init__(self, data_dir, pipeline=[], classes=[], new_classes=[], use_labels=True, **kwargs):
         self.data_dir = data_dir
         self._samples_per_gpu = kwargs.pop("samples_per_gpu", 1)
         self._workers_per_gpu = kwargs.pop("workers_per_gpu", 1)
@@ -124,11 +116,7 @@ class ClsDirDataset(BaseDataset):
                 gt_label = np.array(self.class_to_idx[img_cls])
             else:
                 gt_label = np.array([-1])
-            info = {
-                "img_prefix": img_prefix,
-                "img_info": {"filename": img_path},
-                "gt_label": gt_label,
-            }
+            info = {"img_prefix": img_prefix, "img_info": {"filename": img_path}, "gt_label": gt_label}
             data_infos.append(info)
             if img_cls in self.new_classes:
                 self.img_indices["new"].append(i)

--- a/otx/mpa/modules/datasets/cls_dir_dataset.py
+++ b/otx/mpa/modules/datasets/cls_dir_dataset.py
@@ -186,6 +186,9 @@ class ClsDirDataset(BaseDataset):
             self.class_acc = True
 
         eval_results = super().evaluate(results, metrics, metric_options, logger)
+        for k in metric_options["topk"]:
+            eval_results[f"accuracy_top-{k}"] /= 100
+            assert 0 <= eval_results[f"accuracy_top-{k}"] <= 1
 
         # Add Evaluation Accuracy score per Class
         if self.class_acc:

--- a/otx/mpa/modules/datasets/cls_dir_dataset.py
+++ b/otx/mpa/modules/datasets/cls_dir_dataset.py
@@ -33,7 +33,15 @@ class ClsDirDataset(BaseDataset):
         use_labels (bool): dataset with labels or unlabels
     """
 
-    def __init__(self, data_dir, pipeline=[], classes=[], new_classes=[], use_labels=True, **kwargs):
+    def __init__(
+        self,
+        data_dir,
+        pipeline=[],
+        classes=[],
+        new_classes=[],
+        use_labels=True,
+        **kwargs,
+    ):
         self.data_dir = data_dir
         self._samples_per_gpu = kwargs.pop("samples_per_gpu", 1)
         self._workers_per_gpu = kwargs.pop("workers_per_gpu", 1)
@@ -111,12 +119,18 @@ class ClsDirDataset(BaseDataset):
     def load_annotations(self):
         img_path_list, img_class_list, img_prefix_list = self._read_dir()
         data_infos = []
-        for i, (img_path, img_cls, img_prefix) in enumerate(zip(img_path_list, img_class_list, img_prefix_list)):
+        for i, (img_path, img_cls, img_prefix) in enumerate(
+            zip(img_path_list, img_class_list, img_prefix_list)
+        ):
             if self.use_labels:
                 gt_label = np.array(self.class_to_idx[img_cls])
             else:
                 gt_label = np.array([-1])
-            info = {"img_prefix": img_prefix, "img_info": {"filename": img_path}, "gt_label": gt_label}
+            info = {
+                "img_prefix": img_prefix,
+                "img_info": {"filename": img_path},
+                "gt_label": gt_label,
+            }
             data_infos.append(info)
             if img_cls in self.new_classes:
                 self.img_indices["new"].append(i)
@@ -147,7 +161,9 @@ class ClsDirDataset(BaseDataset):
         if self.pipeline is None:
             return self.data_infos[idx]
 
-        data_infos = [copy.deepcopy(self.data_infos[idx]) for _ in range(self.num_pipes)]
+        data_infos = [
+            copy.deepcopy(self.data_infos[idx]) for _ in range(self.num_pipes)
+        ]
         if isinstance(self.pipeline, dict):
             results = {}
             for i, (k, v) in enumerate(self.pipeline.items()):
@@ -195,7 +211,9 @@ class ClsDirDataset(BaseDataset):
             results = np.vstack(results)
             gt_labels = self.get_gt_labels()
             accuracies = self.class_accuracy(results, gt_labels)
-            eval_results.update({f"{c} accuracy": a for c, a in zip(self.CLASSES, accuracies)})
+            eval_results.update(
+                {f"{c} accuracy": a for c, a in zip(self.CLASSES, accuracies)}
+            )
             eval_results.update({"mean accuracy": np.mean(accuracies)})
 
         return eval_results

--- a/otx/mpa/modules/datasets/cls_dir_dataset.py
+++ b/otx/mpa/modules/datasets/cls_dir_dataset.py
@@ -198,9 +198,6 @@ class ClsDirDataset(BaseDataset):
             self.class_acc = True
 
         eval_results = super().evaluate(results, metrics, metric_options, logger)
-        for k in metric_options["topk"]:
-            eval_results[f"accuracy_top-{k}"] /= 100
-            assert 0 <= eval_results[f"accuracy_top-{k}"] <= 1
 
         # Add Evaluation Accuracy score per Class
         if self.class_acc:

--- a/otx/mpa/modules/datasets/cls_dir_dataset.py
+++ b/otx/mpa/modules/datasets/cls_dir_dataset.py
@@ -119,9 +119,7 @@ class ClsDirDataset(BaseDataset):
     def load_annotations(self):
         img_path_list, img_class_list, img_prefix_list = self._read_dir()
         data_infos = []
-        for i, (img_path, img_cls, img_prefix) in enumerate(
-            zip(img_path_list, img_class_list, img_prefix_list)
-        ):
+        for i, (img_path, img_cls, img_prefix) in enumerate(zip(img_path_list, img_class_list, img_prefix_list)):
             if self.use_labels:
                 gt_label = np.array(self.class_to_idx[img_cls])
             else:
@@ -161,9 +159,7 @@ class ClsDirDataset(BaseDataset):
         if self.pipeline is None:
             return self.data_infos[idx]
 
-        data_infos = [
-            copy.deepcopy(self.data_infos[idx]) for _ in range(self.num_pipes)
-        ]
+        data_infos = [copy.deepcopy(self.data_infos[idx]) for _ in range(self.num_pipes)]
         if isinstance(self.pipeline, dict):
             results = {}
             for i, (k, v) in enumerate(self.pipeline.items()):
@@ -211,9 +207,7 @@ class ClsDirDataset(BaseDataset):
             results = np.vstack(results)
             gt_labels = self.get_gt_labels()
             accuracies = self.class_accuracy(results, gt_labels)
-            eval_results.update(
-                {f"{c} accuracy": a for c, a in zip(self.CLASSES, accuracies)}
-            )
+            eval_results.update({f"{c} accuracy": a for c, a in zip(self.CLASSES, accuracies)})
             eval_results.update({"mean accuracy": np.mean(accuracies)})
 
         return eval_results

--- a/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
+++ b/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
@@ -31,7 +31,9 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         hid_channels=1280,
         act_cfg=dict(type="ReLU"),
         scale=1.0,
-        loss=dict(type="CrossEntropyLoss", use_sigmoid=True, reduction="mean", loss_weight=1.0),
+        loss=dict(
+            type="CrossEntropyLoss", use_sigmoid=True, reduction="mean", loss_weight=1.0
+        ),
         dropout=False,
         normalized=False,
     ):
@@ -51,9 +53,11 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         self._init_layers(act_cfg)
 
     def _init_layers(self, act_cfg):
-        modules = [nn.Linear(self.in_channels, self.hid_channels),
-                   nn.BatchNorm1d(self.hid_channels),
-                   build_activation_layer(act_cfg)]
+        modules = [
+            nn.Linear(self.in_channels, self.hid_channels),
+            nn.BatchNorm1d(self.hid_channels),
+            build_activation_layer(act_cfg),
+        ]
         if self.dropout:
             modules.append(nn.Dropout(p=0.2))
         if self.normalized:
@@ -78,9 +82,12 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         # map difficult examples to positive ones
         _gt_label = torch.abs(gt_label)
         # compute loss
-        loss = self.compute_loss(cls_score, _gt_label,
-                                 valid_label_mask=valid_label_mask,
-                                 avg_factor=num_samples)
+        loss = self.compute_loss(
+            cls_score,
+            _gt_label,
+            valid_label_mask=valid_label_mask,
+            avg_factor=num_samples,
+        )
         losses["loss"] = loss / self.scale
         return losses
 

--- a/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
+++ b/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
@@ -31,9 +31,7 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         hid_channels=1280,
         act_cfg=dict(type="ReLU"),
         scale=1.0,
-        loss=dict(
-            type="CrossEntropyLoss", use_sigmoid=True, reduction="mean", loss_weight=1.0
-        ),
+        loss=dict(type="CrossEntropyLoss", use_sigmoid=True, reduction="mean", loss_weight=1.0),
         dropout=False,
         normalized=False,
     ):

--- a/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
+++ b/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
@@ -41,7 +41,6 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         self.in_channels = in_channels
         self.num_classes = num_classes
         self.hid_channels = hid_channels
-        self.act = build_activation_layer(act_cfg)
         self.dropout = dropout
         self.normalized = normalized
         self.scale = scale
@@ -49,10 +48,10 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         if self.num_classes <= 0:
             raise ValueError(f"num_classes={num_classes} must be a positive integer")
 
-        self._init_layers()
+        self._init_layers(act_cfg)
 
-    def _init_layers(self):
-        modules = [nn.Linear(self.in_channels, self.hid_channels), nn.BatchNorm1d(self.hid_channels), self.act]
+    def _init_layers(self, act_cfg):
+        modules = [nn.Linear(self.in_channels, self.hid_channels), nn.BatchNorm1d(self.hid_channels), build_activation_layer(act_cfg)]
         if self.dropout:
             modules.append(nn.Dropout(p=0.2))
         if self.normalized:

--- a/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
+++ b/otx/mpa/modules/models/heads/custom_multi_label_non_linear_cls_head.py
@@ -51,7 +51,9 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         self._init_layers(act_cfg)
 
     def _init_layers(self, act_cfg):
-        modules = [nn.Linear(self.in_channels, self.hid_channels), nn.BatchNorm1d(self.hid_channels), build_activation_layer(act_cfg)]
+        modules = [nn.Linear(self.in_channels, self.hid_channels),
+                   nn.BatchNorm1d(self.hid_channels),
+                   build_activation_layer(act_cfg)]
         if self.dropout:
             modules.append(nn.Dropout(p=0.2))
         if self.normalized:
@@ -76,7 +78,9 @@ class CustomMultiLabelNonLinearClsHead(MultiLabelClsHead):
         # map difficult examples to positive ones
         _gt_label = torch.abs(gt_label)
         # compute loss
-        loss = self.compute_loss(cls_score, _gt_label, valid_label_mask=valid_label_mask, avg_factor=num_samples)
+        loss = self.compute_loss(cls_score, _gt_label,
+                                 valid_label_mask=valid_label_mask,
+                                 avg_factor=num_samples)
         losses["loss"] = loss / self.scale
         return losses
 


### PR DESCRIPTION
Problem:
1) The checkpoint in OTX eval loaded incorrectly due to the `load_state_dict_pre_hook` function that changes keys in state_dict.
2) The accuracy range is expected to be in [0,1] range. mmcls computes in different range. This is actually just a copy-paste from develop branch