### PR TITLE
[OTX][TEST] Disable multi gpu test temporary

### DIFF
--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -246,7 +246,7 @@ class TestToolsMultiClassClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # disable multi GPU test until resolving a bug
+    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -442,7 +442,7 @@ class TestToolsMultilabelClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # disable multi GPU test until resolving a bug
+    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -604,7 +604,7 @@ class TestToolsHierarchicalClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # disable multi GPU test until resolving a bug
+    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -246,6 +246,7 @@ class TestToolsMultiClassClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
+    @pytest.mark.skip  # disable multi GPU test until resolving a bug
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -441,6 +442,7 @@ class TestToolsMultilabelClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
+    @pytest.mark.skip  # disable multi GPU test until resolving a bug
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -602,6 +604,7 @@ class TestToolsHierarchicalClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
+    @pytest.mark.skip  # disable multi GPU test until resolving a bug
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -246,7 +246,7 @@ class TestToolsMultiClassClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
+    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -442,7 +442,7 @@ class TestToolsMultilabelClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
+    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -604,7 +604,7 @@ class TestToolsHierarchicalClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
+    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -238,7 +238,7 @@ class TestToolsMPADetection:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # disable multi GPU test until resolving a bug
+    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -238,6 +238,7 @@ class TestToolsMPADetection:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
+    @pytest.mark.skip  # disable multi GPU test until resolving a bug
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -238,7 +238,7 @@ class TestToolsMPADetection:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
+    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/detection/test_instance_segmentation.py
+++ b/tests/integration/cli/detection/test_instance_segmentation.py
@@ -218,7 +218,7 @@ class TestToolsMPAInstanceSegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # disable multi GPU test until resolving a bug
+    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/detection/test_instance_segmentation.py
+++ b/tests/integration/cli/detection/test_instance_segmentation.py
@@ -218,6 +218,7 @@ class TestToolsMPAInstanceSegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
+    @pytest.mark.skip  # disable multi GPU test until resolving a bug
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/detection/test_instance_segmentation.py
+++ b/tests/integration/cli/detection/test_instance_segmentation.py
@@ -218,7 +218,7 @@ class TestToolsMPAInstanceSegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
+    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/segmentation/test_segmentation.py
+++ b/tests/integration/cli/segmentation/test_segmentation.py
@@ -211,7 +211,7 @@ class TestToolsMPASegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
+    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/segmentation/test_segmentation.py
+++ b/tests/integration/cli/segmentation/test_segmentation.py
@@ -211,7 +211,7 @@ class TestToolsMPASegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip  # disable multi GPU test until resolving a bug
+    @pytest.mark.skip  # TODO: Enable after fix this - https://jira.devtools.intel.com/browse/CVS-101246
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/segmentation/test_segmentation.py
+++ b/tests/integration/cli/segmentation/test_segmentation.py
@@ -211,6 +211,7 @@ class TestToolsMPASegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
+    @pytest.mark.skip  # disable multi GPU test until resolving a bug
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)


### PR DESCRIPTION
### Summary

- Disable multi GPU test case until resolving a bug

### Detail
There is a bug that process is stuck during multi GPU test in CI machine. After resolving the bug, All those tests will be re-enabled again.