### PR TITLE
[OTX][HOT-FIX] Keep pre-installed torch

### DIFF
--- a/otx/algorithms/init_venv.sh
+++ b/otx/algorithms/init_venv.sh
@@ -104,7 +104,7 @@ pip install torch=="${TORCH_VERSION}" torchvision=="${TORCHVISION_VERSION}" -f h
 #   - numpy: mmpycocotool uses source distribution, setup.py imports numpy
 #   - torch: mmdet/seg are installed via source, setup.py imports torch
 # shellcheck disable=SC2102
-pip install -e ../../[full] || exit 1
+pip install -e ../../[full] -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html || exit 1
 
 deactivate
 


### PR DESCRIPTION
New resolver introduced in https://github.com/openvinotoolkit/training_extensions/pull/1448 related issue.

If `file-links` are not specified explicitly, pip gets info from pypi only and reinstall torch, etc. with version from pypi.

