### PR TITLE
[DEV] Fix 'Invalid version: `ote-alpha`' issue regarding PEP440 in anomaly_task

### DIFF
--- a/external/anomaly/setup.py
+++ b/external/anomaly/setup.py
@@ -34,7 +34,6 @@ def get_requirements() -> List[str]:
 
 setup(
     name="anomaly tasks",
-    version="ote-alpha",
     packages=find_packages(
         include=[
             "adapters",


### PR DESCRIPTION
There might be a version update in CI server that suddenly raises errors for invalid version spec.
![image](https://user-images.githubusercontent.com/4629606/212663451-d65bfcd9-c25c-4e76-b66d-05304a1f84ea.png)

Build: https://ci-ote.iotg.sclab.intel.com/job/ote/job/pr-ote-test/880