### PR TITLE
[OTX][HOT-FIX] Revert otx cli tools with data.yaml check

### DIFF
--- a/otx/cli/tools/eval.py
+++ b/otx/cli/tools/eval.py
@@ -56,12 +56,9 @@ def parse_args():
     parser = argparse.ArgumentParser()
     if not os.path.exists("./template.yaml"):
         parser.add_argument("template")
-    parser.add_argument("--data", required=False)
+    parser.add_argument("--data", required=False, default="./data.yaml")
     parsed, _ = parser.parse_known_args()
-    required = True
-    if parsed.data is not None:
-        assert os.path.exists(parsed.data)
-        required = False
+    required = not os.path.exists(parsed.data)
 
     parser.add_argument(
         "--test-ann-files",

--- a/otx/cli/tools/optimize.py
+++ b/otx/cli/tools/optimize.py
@@ -61,12 +61,9 @@ def parse_args():
     parser = argparse.ArgumentParser()
     if not os.path.exists("./template.yaml"):
         parser.add_argument("template")
-    parser.add_argument("--data", required=False)
+    parser.add_argument("--data", required=False, default="./data.yaml")
     parsed, _ = parser.parse_known_args()
-    required = True
-    if parsed.data is not None:
-        assert os.path.exists(parsed.data)
-        required = False
+    required = not os.path.exists(parsed.data)
 
     parser.add_argument(
         "--train-ann-files",

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -69,12 +69,9 @@ def parse_args():
     parser = argparse.ArgumentParser()
     if not os.path.exists("./template.yaml"):
         parser.add_argument("template")
-    parser.add_argument("--data", required=False)
+    parser.add_argument("--data", required=False, default="./data.yaml")
     parsed, _ = parser.parse_known_args()
-    required = True
-    if parsed.data is not None:
-        assert os.path.exists(parsed.data)
-        required = False
+    required = not os.path.exists(parsed.data)
 
     parser.add_argument(
         "--train-ann-files",


### PR DESCRIPTION
## Summary
Due to the effect of that https://github.com/openvinotoolkit/training_extensions/pull/1497, data.yaml of otx-workspace becomes unusable, so I revert this.