### PR TITLE
[OTX][HOT-FIX] Learning rate bugfix on ReduceLROnPlateau

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -492,9 +492,9 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         self.compare_func = self.rule_map[self.rule]
 
     def _is_check_timing(self, runner: BaseRunner) -> bool:
-        """Check whether current epoch or iter is multiple of self.interval."""
+        """Check whether current epoch or iter is multiple of self.interval, skip during warmup interations."""
         check_time = self.every_n_epochs if self.by_epoch else self.every_n_iters
-        return check_time(runner, self.interval)
+        return check_time(runner, self.interval) or (self.warmup_iters > runner.iter)
 
     @check_input_parameters_type()
     def get_lr(self, runner: BaseRunner, base_lr: float):
@@ -502,7 +502,7 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         if self.current_lr < 0:
             self.current_lr = base_lr
 
-        if not self._is_check_timing(runner) or self.warmup_iters > runner.iter:
+        if not self._is_check_timing(runner):
             return self.current_lr
 
         if hasattr(runner, "all_metrics"):


### PR DESCRIPTION
## This PR includes:
- Fix learning rate reverting bug after dropping LR in ROP which was found in detection task.

### What was the root cause?
- ROP didn't consider **adaptive interval**. 
- If current epoch is not multiple of `self.interval` in ROP, `_should_check_stopping` returns `False`.
- Then, by `if` statement at line 505, ROP returns `base_lr` instead of reduced `self.current_lr`.
<img width="820" alt="image" src="https://user-images.githubusercontent.com/72460430/212132565-28a2d4b7-b58e-46eb-9de3-9f2ee30c7ba9.png">

### How I fixed
- Define `self.currnt_lr` in initial epoch and return `self.current_lr` instead of `base_lr` when runner is not in check timing (every interval or epoch).

### Verify ROP
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/72460430/212132233-1272fa70-a82c-40a9-abb3-083d5ce92487.png">
- By non-deterministic training, learning rate can differ but note that ROP works well on both tasks by this PR.
