### PR TITLE
[OTX][Hot-Fix] Fix self-sl seg issue

### DIFF
--- a/otx/mpa/det/trainer.py
+++ b/otx/mpa/det/trainer.py
@@ -59,12 +59,6 @@ class DetectionTrainer(DetectionStage):
         if 'val' in cfg.data:
             cfg.data.val_dataloader.samples_per_gpu = 1
 
-        # FIXME: scale_factors is fixed at 1 even batch_size > 1 in simple_test_mask
-        # Need to investigate, possibly due to OpenVINO
-        if "roi_head" in model_cfg.model:
-            if "mask_head" in model_cfg.model.roi_head:
-                cfg.data.val_dataloader.samples_per_gpu = 1
-
         if hasattr(cfg, "hparams"):
             if cfg.hparams.get("adaptive_anchor", False):
                 num_ratios = cfg.hparams.get("num_anchor_ratios", 5)

--- a/otx/mpa/det/trainer.py
+++ b/otx/mpa/det/trainer.py
@@ -56,7 +56,8 @@ class DetectionTrainer(DetectionStage):
         datasets = [build_dataset(cfg.data.train)]
 
         # FIXME: Currently detection do not support multi batch evaluation. This will be fixed
-        cfg.data.val_dataloader.samples_per_gpu = 1
+        if 'val' in cfg.data:
+            cfg.data.val_dataloader.samples_per_gpu = 1
 
         # FIXME: scale_factors is fixed at 1 even batch_size > 1 in simple_test_mask
         # Need to investigate, possibly due to OpenVINO

--- a/otx/mpa/seg/trainer.py
+++ b/otx/mpa/seg/trainer.py
@@ -57,7 +57,9 @@ class SegTrainer(SegStage):
         datasets = [build_dataset(cfg.data.train)]
 
         # FIXME: Currently segmentor does not support multi batch evaluation.
-        cfg.data.val_dataloader.samples_per_gpu = 1
+        # For the Self-SL case, there is no val data. So, need to check the 
+        if 'val' in cfg.data:
+            cfg.data.val_dataloader.samples_per_gpu = 1
 
         # Dataset for HPO
         hp_config = kwargs.get("hp_config", None)


### PR DESCRIPTION
# Summary
For self-supervised learning, there is no argument `--val-data-roots`.
In this case, `seg/trainer.py` need to check the whether `val` data is included in data configuration to avoid making `val_dataloader`

Here is the local test result for Self-SL segmentation
![image](https://user-images.githubusercontent.com/80735344/213118185-ce81b9a3-f569-42c1-87ea-202896a660e7.png)
