### PR TITLE
[OTX] remove temporary work directory after training

### DIFF
--- a/otx/algorithms/action/tasks/inference.py
+++ b/otx/algorithms/action/tasks/inference.py
@@ -304,7 +304,8 @@ class ActionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationTask
 
     def unload(self):
         """Unload the task."""
-        self.finalize()
+        if self._work_dir_is_temp:
+            self._delete_scratch_space()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -187,7 +187,8 @@ class ClassificationInferenceTask(
         """Unload function of OTX Classification Task."""
 
         logger.info("called unload()")
-        self.finalize()
+        if self._work_dir_is_temp:
+            self._delete_scratch_space()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/algorithms/detection/tasks/inference.py
+++ b/otx/algorithms/detection/tasks/inference.py
@@ -223,7 +223,8 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
 
     def unload(self):
         """Unload the task."""
-        self._delete_scratch_space()
+        if self._work_dir_is_temp:
+            self._delete_scratch_space()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -144,7 +144,8 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
 
     def unload(self):
         """Unload the task."""
-        self._delete_scratch_space()
+        if self._work_dir_is_temp:
+            self._delete_scratch_space()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -259,6 +259,8 @@ def main():  # pylint: disable=too-many-branches
         assert resultset.performance is not None
         print(resultset.performance)
 
+    task.unload()
+
     if args.gpus:
         multigpu_manager.finalize()
 


### PR DESCRIPTION
### Summary

- This PR makes temporary work directory removed after training
- Also fix a bug that CI is stuck while HPO tests is running after error occurs

### Detail
Current OTX deletes a work directory when garbage collector decides to delete a train task. So, it's uncertain when and whether the directory is deleted. After merging this PR, work directory always deleted at the last part of train.py of CLI if `work-dir` is not specified by user. If user specifies `work-dir`, then OTX assumes that user needs `work-dir` and not delete it.

### Reason of the bug that CI is stuck while HPO test case is running
While a trial of HPO is running, garbage collector deletes train task, which result in executing `__del__()`  in the class.
Then, work directory is deleted, and logger hook raises error that logger text file is missing.
I don't know exact reason why garbage collector deletes the task, but I checked that this PR fixes this bug.