### PR TITLE
[OTX][Hotfix] Remove base_path in semisl hparam.yaml

### DIFF
--- a/otx/algorithms/classification/configs/efficientnet_b0_cls_incr/semisl/hparam.yaml
+++ b/otx/algorithms/classification/configs/efficientnet_b0_cls_incr/semisl/hparam.yaml
@@ -1,6 +1,5 @@
 # Hyperparameters.
 hyper_parameters:
-  base_path: ../../configuration.yaml
   parameter_overrides:
     learning_parameters:
       batch_size:

--- a/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/semisl/hparam.yaml
+++ b/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/semisl/hparam.yaml
@@ -1,6 +1,5 @@
 # Hyperparameters.
 hyper_parameters:
-  base_path: ../../configuration.yaml
   parameter_overrides:
     learning_parameters:
       batch_size:

--- a/otx/algorithms/classification/configs/mobilenet_v3_large_1_cls_incr/semisl/hparam.yaml
+++ b/otx/algorithms/classification/configs/mobilenet_v3_large_1_cls_incr/semisl/hparam.yaml
@@ -1,6 +1,5 @@
 # Hyperparameters.
 hyper_parameters:
-  base_path: ../../configuration.yaml
   parameter_overrides:
     learning_parameters:
       batch_size:


### PR DESCRIPTION
To support otx build -> otx train in semi-sl, base_path should not be included in hparam.yaml.