### PR TITLE
[OTX] bugfix: HPO trial raises error when evaluating after training

### DIFF
--- a/otx/mpa/modules/hooks/cancel_interface_hook.py
+++ b/otx/mpa/modules/hooks/cancel_interface_hook.py
@@ -35,3 +35,6 @@ class CancelInterfaceHook(Hook):
     def before_run(self, runner):
         self.runner = runner
         self.on_init_callback(self)
+
+    def after_run(self, runner):
+        self.runner = None


### PR DESCRIPTION
### Summray

- Fix a bug that HPO trial raises error when evaluating after training

### Detail
The error is raised when executing `self._infer_detector()` in `DetectionTrainTask.train()`. `self._infer_detector()` executes `self._run_task()` and self._recipe_cfg is deepcopied when building `workflow`. At that time, the error is raised because self._recipe_cfg has a tensor of model.
The reason for this is that HPO trial adds HpoCallback which executes `task.cancel_training()` if needed. `task.cancel_training()` uses `CancelInterfaceHook` which saves runner as an attribute when `before_run`.
Therefore, it results in the error when _recipe_cfg is deepcopied after training because runner has a model as an attribute.
To prevent this, set runner as None in `CancelInterfaceHook`.