### PR TITLE
[CI] Update deprecated commands in Build-Docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           python -m pip install -r requirements/base.txt
@@ -25,9 +25,9 @@ jobs:
           make html
       - name: Create gh-pages branch
         run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
+          echo SOURCE_BRANCH=${GITHUB_REF#refs/heads/} >> $GITHUB_OUTPUT
+          echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
 
           existed_in_remote=$(git ls-remote --heads origin gh-pages)
 


### PR DESCRIPTION
During running Build-Docs, some warnings appear [(link)](https://github.com/openvinotoolkit/training_extensions/actions/runs/3959626527/jobs/6782693832#step:5:25):


![image](https://user-images.githubusercontent.com/33455576/213568367-5e5a1816-4d15-4036-8acf-b38e4f019282.png)

This PR resolves:
- [set-ouput usage ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) -> GITHUB_OUTPUT usage
- transfer to Node.js 16, using actions/checkout@v3 instead of actions/checkout@v2 (similar to [other PR](https://github.com/openvinotoolkit/training_extensions/pull/1513))