### PR TITLE
[OTX][Hot-fix] Add init_weights call in the custom atss head

### DIFF
--- a/otx/algorithms/detection/adapters/mmdet/utils/builder.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/builder.py
@@ -8,7 +8,11 @@ from typing import Optional, Union
 
 import torch
 from mmcv.runner import load_checkpoint
-from mmcv.utils import Config, ConfigDict
+from mmcv.utils import Config, ConfigDict, get_logger
+
+from otx.mpa.utils.logger import LEVEL
+
+logger = get_logger("mmdet")
 
 
 def build_detector(
@@ -35,7 +39,9 @@ def build_detector(
 
     model_cfg = deepcopy(config.model)
     model = origin_build_detector(model_cfg, train_cfg=train_cfg, test_cfg=test_cfg)
+    logger.setLevel("WARNING")
     model.init_weights()
+    logger.setLevel(LEVEL)
     model = model.to(device)
 
     checkpoint = checkpoint if checkpoint else config.pop("load_from", None)

--- a/otx/algorithms/detection/adapters/mmdet/utils/builder.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/builder.py
@@ -35,6 +35,7 @@ def build_detector(
 
     model_cfg = deepcopy(config.model)
     model = origin_build_detector(model_cfg, train_cfg=train_cfg, test_cfg=test_cfg)
+    model.init_weights()
     model = model.to(device)
 
     checkpoint = checkpoint if checkpoint else config.pop("load_from", None)

--- a/otx/mpa/modules/models/heads/custom_atss_head.py
+++ b/otx/mpa/modules/models/heads/custom_atss_head.py
@@ -36,15 +36,6 @@ class CustomATSSHead(CrossDatasetDetectorHead, ATSSHead):
         self.bg_loss_weight = bg_loss_weight
         self.use_qfl = use_qfl
 
-    def _init_layers(self):
-        """Initialize layers of the ATSS head.
-
-        Current mmdetection requires to call init_weights function to reflect init_cfg
-        """
-
-        super(CustomATSSHead, self)._init_layers()
-        self.init_weights()
-
     @force_fp32(apply_to=("cls_scores", "bbox_preds", "centernesses"))
     def loss(self, cls_scores, bbox_preds, centernesses, gt_bboxes, gt_labels, img_metas, gt_bboxes_ignore=None):
         """Compute losses of the head.

--- a/otx/mpa/modules/models/heads/custom_atss_head.py
+++ b/otx/mpa/modules/models/heads/custom_atss_head.py
@@ -36,6 +36,15 @@ class CustomATSSHead(CrossDatasetDetectorHead, ATSSHead):
         self.bg_loss_weight = bg_loss_weight
         self.use_qfl = use_qfl
 
+    def _init_layers(self):
+        """Initialize layers of the ATSS head.
+
+        Current mmdetection requires to call init_weights function to reflect init_cfg
+        """
+
+        super(CustomATSSHead, self)._init_layers()
+        self.init_weights()
+
     @force_fp32(apply_to=("cls_scores", "bbox_preds", "centernesses"))
     def loss(self, cls_scores, bbox_preds, centernesses, gt_bboxes, gt_labels, img_metas, gt_bboxes_ignore=None):
         """Compute losses of the head.

--- a/otx/mpa/utils/logger.py
+++ b/otx/mpa/utils/logger.py
@@ -18,6 +18,8 @@ _LOG_DIR = None
 _FILE_HANDLER = None
 _CUSTOM_LOG_LEVEL = 31
 
+LEVEL = logging.INFO
+
 logging.addLevelName(_CUSTOM_LOG_LEVEL, "LOG")
 
 
@@ -31,7 +33,7 @@ def _get_logger():
 
     logger.print = print
 
-    logger.setLevel(logging.INFO)
+    logger.setLevel(LEVEL)
     console = logging.StreamHandler(sys.stdout)
     console.setFormatter(logging.Formatter(_LOGGING_FORMAT))
 


### PR DESCRIPTION
After changing mmcv framework, init_weights function call in atss head is disappeared.
That raise large classification loss at the early stage. 
This fix add init_weights call in the init_layer function in atss_head. 

Before
![image](https://user-images.githubusercontent.com/106788349/213598160-bf95afc3-cbac-4a96-a187-006bab2f84be.png)

After
![image](https://user-images.githubusercontent.com/106788349/213598278-d3aeec3f-f5bf-4bd0-9c57-209ba54c3291.png)
