### PR TITLE
[OTX] Fix a timing to compare score and add bad_count in ReduceLROnPlateauLrUpdaterHook

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -497,11 +497,11 @@ class ReduceLROnPlateauLrUpdaterHook(LrUpdaterHook):
         return check_time(runner, self.interval) and (self.warmup_iters <= runner.iter)
 
     def after_each_n_epochs(self, runner: BaseRunner, n: int) -> bool:
-        """Check whether current epoch is a next epoch after multiples of n epoch"""
+        """Check whether current epoch is a next epoch after multiples of n epoch."""
         return runner.epoch % n == 0 if n > 0 and runner.epoch != 0 else False
 
     def after_each_n_iters(self, runner: BaseRunner, n: int) -> bool:
-        """Check whether current iter is a next iter after multiples of n iters"""
+        """Check whether current iter is a next iter after multiples of n iters."""
         return runner.iter % n == 0 if n > 0 and runner.iter != 0 else False
 
     @check_input_parameters_type()


### PR DESCRIPTION
### Summary

- modify a timing to compare score after evaluation
- modify an order of print_log to infrom hook status after updating `patience` and `best score`

### Detail
**This PR is for fixing below two bugs.** 
**Bug1 : increase `bad_count` during warmup iteration**
This is due to `_is_check_timing()`. it's fixed to return False during warmup iterations.

**Bug2: compare score and increase `bad_count` right before evaluating model**
This is because `ReduceLROnPlateauLrUpdaterHook` is executed at `before_train_epoch` but eval hook is executed at `after_train_epoch`. To remedy it, the code is fixed to compare score and add `bad_count` at next epoch (or iter) after multiples of interval epoch(iter).