### PR TITLE
[Hot-fix][OTX] Exclude background label in OTX dataset in segmentation

### DIFF
--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -243,6 +243,8 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
 
     def _get_polygon_entity(self, annotation: DatumaroAnnotation, width: int, height: int) -> Annotation:
         """Get polygon entity."""
+        if annotation.label == 0:
+            return None
         return Annotation(
             Polygon(
                 points=[

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -40,7 +40,9 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
                             # TODO: consider case -> didn't include the background information
                             datumaro_polygons = MasksToPolygons.convert_mask(ann)
                             for d_polygon in datumaro_polygons:
-                                shapes.append(self._get_polygon_entity(d_polygon, image.width, image.height))
+                                shape = self._get_polygon_entity(d_polygon, image.width, image.height)
+                                if shape is not None:
+                                    shapes.append(self._get_polygon_entity(d_polygon, image.width, image.height))
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -42,7 +42,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
                             for d_polygon in datumaro_polygons:
                                 shape = self._get_polygon_entity(d_polygon, image.width, image.height)
                                 if shape is not None:
-                                    shapes.append(self._get_polygon_entity(d_polygon, image.width, image.height))
+                                    shapes.append(shape)
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)


### PR DESCRIPTION
This PR is to resolve the training performance degradation in segmentation due to inclusion of background label and annotation when converting to OTXdataset.
After excluding the background label in OTX dataset annotation, the training was working properly and val mdice and accuracy is increased as before.
Still the issue about final performance value logging as '-1' is not resolved. So after finding the root cause, that will be dealt in other PR.