### PR TITLE
[Hot-fix][OTX] Polygon label exclusion for semantic segmentation - workaround for instance-segmentation

### DIFF
--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -243,8 +243,6 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
 
     def _get_polygon_entity(self, annotation: DatumaroAnnotation, width: int, height: int) -> Annotation:
         """Get polygon entity."""
-        if annotation.label == 0:
-            return None
         return Annotation(
             Polygon(
                 points=[

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -40,9 +40,8 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
                             # TODO: consider case -> didn't include the background information
                             datumaro_polygons = MasksToPolygons.convert_mask(ann)
                             for d_polygon in datumaro_polygons:
-                                shape = self._get_polygon_entity(d_polygon, image.width, image.height)
-                                if shape is not None:
-                                    shapes.append(shape)
+                                if d_polygon.label != 0:
+                                    shapes.append(self._get_polygon_entity(d_polygon, image.width, image.height))
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)


### PR DESCRIPTION
This PR is for resolving the background label in segmentation in the previous PR. Polygon may be affect to instance-segmentation so excluding background label would be done in seg dataset adapter.