### PR TITLE
[OTX][Hot-fix] Fix instance segmentation error

### DIFF
--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -250,5 +250,5 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
                     for i in range(0, len(annotation.points), 2)
                 ]
             ),
-            labels=[ScoredLabel(label=self.label_entities[annotation.label - 1])],
+            labels=[ScoredLabel(label=self.label_entities[annotation.label])],
         )

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -252,3 +252,18 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             ),
             labels=[ScoredLabel(label=self.label_entities[annotation.label])],
         )
+
+    def remove_unused_label_entities(self, used_labels: List):
+        """Remove unused label from label entities.
+        
+        Because label entities will be used to make Label Schema,
+        If there is unused label in Label Schema, it will hurts the model performance.
+        So, remove the unused label from label entities.
+
+        Args:
+            used_labels (List): list for index of used label
+        """
+        clean_label_entities = []
+        for used_label in used_labels:
+            clean_label_entities.append(self.label_entities[used_label])
+        self.label_entities = clean_label_entities

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -255,7 +255,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
 
     def remove_unused_label_entities(self, used_labels: List):
         """Remove unused label from label entities.
-        
+
         Because label entities will be used to make Label Schema,
         If there is unused label in Label Schema, it will hurts the model performance.
         So, remove the unused label from label entities.

--- a/otx/core/data/adapter/detection_dataset_adapter.py
+++ b/otx/core/data/adapter/detection_dataset_adapter.py
@@ -6,12 +6,13 @@
 
 # pylint: disable=invalid-name, too-many-locals, no-member
 from typing import List
+
 from datumaro.components.annotation import AnnotationType
 
-from otx.api.entities.model_template import TaskType
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.image import Image
+from otx.api.entities.model_template import TaskType
 from otx.core.data.adapter.base_dataset_adapter import BaseDatasetAdapter
 
 
@@ -44,7 +45,7 @@ class DetectionDatasetAdapter(BaseDatasetAdapter):
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)
-        
+
         # Remove unused labels from label entities
         self.remove_unused_label_entities(used_labels)
         return DatasetEntity(items=dataset_items)

--- a/otx/core/data/adapter/detection_dataset_adapter.py
+++ b/otx/core/data/adapter/detection_dataset_adapter.py
@@ -5,8 +5,10 @@
 #
 
 # pylint: disable=invalid-name, too-many-locals, no-member
+from typing import List
 from datumaro.components.annotation import AnnotationType
 
+from otx.api.entities.model_template import TaskType
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.image import Image
@@ -25,19 +27,24 @@ class DetectionDatasetAdapter(BaseDatasetAdapter):
         label_information = self._prepare_label_information(self.dataset)
         self.label_entities = label_information["label_entities"]
 
-        dataset_items = []
+        dataset_items: List[DatasetItemEntity] = []
+        used_labels: List[int] = []
         for subset, subset_data in self.dataset.items():
             for _, datumaro_items in subset_data.subsets().items():
                 for datumaro_item in datumaro_items:
                     image = Image(file_path=datumaro_item.media.path)
                     shapes = []
                     for ann in datumaro_item.annotations:
-                        if ann.type == AnnotationType.polygon:
+                        if self.task_type is TaskType.DETECTION and ann.type == AnnotationType.polygon:
                             shapes.append(self._get_polygon_entity(ann, image.width, image.height))
-                        if ann.type == AnnotationType.bbox:
+                            used_labels.append(ann.label)
+                        if self.task_type is TaskType.INSTANCE_SEGMENTATION and ann.type == AnnotationType.bbox:
                             shapes.append(self._get_normalized_bbox_entity(ann, image.width, image.height))
+                            used_labels.append(ann.label)
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)
-
+        
+        # Remove unused labels from label entities
+        self.remove_unused_label_entities(used_labels)
         return DatasetEntity(items=dataset_items)

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -48,7 +48,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)
-        
+
         # Remove unused labels from label entities
         self.remove_unused_label_entities(used_labels)
         return DatasetEntity(items=dataset_items)

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -41,6 +41,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
                             datumaro_polygons = MasksToPolygons.convert_mask(ann)
                             for d_polygon in datumaro_polygons:
                                 if d_polygon.label != 0:
+                                    d_polygon.label -= 1
                                     shapes.append(self._get_polygon_entity(d_polygon, image.width, image.height))
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -30,6 +30,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
         self.label_entities = label_information["label_entities"]
 
         dataset_items: List[DatasetItemEntity] = []
+        used_labels: List[int] = []
         for subset, subset_data in self.dataset.items():
             for _, datumaro_items in subset_data.subsets().items():
                 for datumaro_item in datumaro_items:
@@ -43,8 +44,11 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
                                 if d_polygon.label != 0:
                                     d_polygon.label -= 1
                                     shapes.append(self._get_polygon_entity(d_polygon, image.width, image.height))
+                                    used_labels.append(d_polygon.label)
 
                     dataset_item = DatasetItemEntity(image, self._get_ann_scene_entity(shapes), subset=subset)
                     dataset_items.append(dataset_item)
-
+        
+        # Remove unused labels from label entities
+        self.remove_unused_label_entities(used_labels)
         return DatasetEntity(items=dataset_items)


### PR DESCRIPTION
# Changes
* Fix mis-input labels for instance segmentation.
* Add a function that removes unused label entities to make the correct `Label Schema`.
* Add `task check` logic for the detection adapter: To handle instance segmentation, detection, both.

# Details
* To consider the semantic segmentation, Datumaro shouldn't include the `background` for labels 
and the label file has `{1: 'person'}` format. In this case `labels` like as below:
```python3
self.label_entities = [LabelEntity(1, 'person', ...)]
```

So, we need to subtract 1 from the polygon's label to match the polygon's label with `label.entities`. 
```python3
d_polygon.label -= 1
```

* For instance segmentation, we don't need to consider the background label. So, it must be implemented like as below:
```python3
labels=[ScoredLabel(label=self.label_entities[annotation.label])],
```