### PR TITLE
[Develop] Applying new Hpopt

### DIFF
--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/progress.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/progress.py
@@ -83,13 +83,8 @@ class ProgressCallback(TQDMProgressBar):
         if self.progress_and_hpo_callback is not None:
             score = None
             metric = getattr(self.progress_and_hpo_callback, "metric", None)
-            print(f"[DEBUG-HPO] logged_metrics = {trainer.logged_metrics}")
             if metric in trainer.logged_metrics:
                 score = float(trainer.logged_metrics[metric])
-                if score < 1.0:
-                    score = score + int(trainer.global_step)
-                else:
-                    score = -(score + int(trainer.global_step))
 
             # Always assumes that hpo validation step is called during training.
             self.progress_and_hpo_callback(int(self._get_progress("train")), score)  # pylint: disable=not-callable

--- a/otx/algorithms/common/utils/callback.py
+++ b/otx/algorithms/common/utils/callback.py
@@ -40,6 +40,7 @@ class TrainingProgressCallback(TimeMonitorCallback):
             score = logs.get(self.update_progress_callback.metric, None)
         self.update_progress_callback(progress, score=score)
 
+
 class InferenceProgressCallback(TimeMonitorCallback):
     """InferenceProgressCallback class for time monitoring."""
 

--- a/otx/algorithms/common/utils/callback.py
+++ b/otx/algorithms/common/utils/callback.py
@@ -33,23 +33,12 @@ class TrainingProgressCallback(TimeMonitorCallback):
     def on_epoch_end(self, epoch, logs=None):
         """Callback function on epoch ended."""
         self.past_epoch_duration.append(time.time() - self.start_epoch_time)
+        progress = ((epoch + 1) / self.total_epochs) * 100
         self._calculate_average_epoch()
         score = None
         if hasattr(self.update_progress_callback, "metric") and isinstance(logs, dict):
             score = logs.get(self.update_progress_callback.metric, None)
-            score = float(score) if score is not None else None
-            if score is not None:
-                iter_num = logs.get("current_iters", None)
-                if iter_num is not None:
-                    print(f"score = {score} at epoch {epoch} / {int(iter_num)}")
-                    # as a trick, score (at least if it's accuracy not the loss) and iteration number
-                    # could be assembled just using summation and then disassembeled.
-                    if score < 1.0:
-                        score = score + int(iter_num)
-                    else:
-                        score = -(score + int(iter_num))
-        self.update_progress_callback(self.get_progress(), score=score)
-
+        self.update_progress_callback(progress, score=score)
 
 class InferenceProgressCallback(TimeMonitorCallback):
     """InferenceProgressCallback class for time monitoring."""

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -218,7 +218,7 @@ def main():  # pylint: disable=too-many-branches
         )
 
     if args.enable_hpo:
-        task = run_hpo(args, environment, dataset, template.task_type)
+        task = run_hpo(args, environment, dataset, data_roots)
         if task is None:
             print("cannot run HPO for this task. will train a model without HPO.")
             task = task_class(task_environment=environment, output_path=args.work_dir)

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -218,7 +218,7 @@ def main():  # pylint: disable=too-many-branches
         )
 
     if args.enable_hpo:
-        run_hpo(args, environment, dataset, data_roots)
+        environment = run_hpo(args, environment, dataset, data_roots)
 
     task = task_class(task_environment=environment, output_path=args.work_dir)
 

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -218,12 +218,9 @@ def main():  # pylint: disable=too-many-branches
         )
 
     if args.enable_hpo:
-        task = run_hpo(args, environment, dataset, data_roots)
-        if task is None:
-            print("cannot run HPO for this task. will train a model without HPO.")
-            task = task_class(task_environment=environment, output_path=args.work_dir)
-    else:
-        task = task_class(task_environment=environment, output_path=args.work_dir)
+        run_hpo(args, environment, dataset, data_roots)
+
+    task = task_class(task_environment=environment, output_path=args.work_dir)
 
     if args.gpus:
         multigpu_manager = MultiGPUManager(main, args.gpus, args.rdzv_endpoint, args.base_rank, args.world_size)

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -172,7 +172,7 @@ class TaskManager:
                 if not (osp.islink(weight_candidate) or osp.exists(osp.join(det, osp.basename(weight_candidate)))):
                     shutil.copy(weight_candidate, det)
         else:
-            raise NotImplementedError
+            return  # TODO need to implement after anomaly task supports resume 
 
     def get_latest_weight(self, workdir: str) -> Optional[str]:
         """Get latest model weight from all weights.
@@ -197,7 +197,7 @@ class TaskManager:
                         current_latest_epoch = epoch
                         latest_weight = weight_name
         else:
-            raise NotImplementedError
+            return None  # TODO need to implement after anomaly task supports resume
 
         return latest_weight
 

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -44,11 +44,6 @@ except ImportError:
     hpopt = None
 
 
-logger.setLevel(logging.DEBUG)
-hpopt_logger = logging.getLogger("hpopt")
-hpopt_logger.setLevel(logging.DEBUG)
-
-
 def _check_hpo_enabled_task(task_type):
     return task_type in [
         TaskType.CLASSIFICATION,

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -167,8 +167,7 @@ class TaskManager:
             for weight_candidate in src.rglob("*epoch*.pth"):
                 if not (weight_candidate.is_symlink() or (det / weight_candidate.name).exists()):
                     shutil.copy(weight_candidate, det)
-        else:
-            return  # TODO need to implement after anomaly task supports resume
+        # TODO need to implement after anomaly task supports resume
 
     def get_latest_weight(self, workdir: Union[str, Path]) -> Optional[str]:
         """Get latest model weight from all weights.
@@ -193,8 +192,7 @@ class TaskManager:
                     if current_latest_epoch < epoch:
                         current_latest_epoch = epoch
                         latest_weight = str(weight_name)
-        else:
-            return None  # TODO need to implement after anomaly task supports resume
+        # TODO need to implement after anomaly task supports resume
 
         return latest_weight
 
@@ -424,7 +422,7 @@ class HpoRunner:
 
     def _set_hpo_config(self):
         hpo_config_path = Path(self._environment.get_model_template_path()).parent / "hpo_config.yaml"
-        with open(hpo_config_path, "r", encoding="utf-8") as f:
+        with hpo_config_path.open("r") as f:
             hpopt_cfg = yaml.safe_load(f)
 
         return hpopt_cfg
@@ -741,10 +739,6 @@ class Trainer:
         if initial_weight_path.exists():
             return initial_weight_path
         return None
-
-    def _prepare_task(self, environment):
-        task_class = get_impl_class(environment.model_template.entrypoints.base)
-        return task_class(task_environment=environment)
 
     def _add_initial_weight_saving_hook(self, task):
         initial_weight_path = self._get_initial_weight_path()

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -316,7 +316,9 @@ class TaskEnvironmentManager:
                 task = self.get_train_task()
                 model = self.get_new_model_entity()
                 task.save_model(model)
-                save_model_data(model, save_path)
+                dir_path = osp.dirname(save_path)
+                save_model_data(model, dir_path)
+                os.rename(osp.join(dir_path, "weights.pth"), save_path)
                 return True
         else:
             save_model_data(self._environment.model, save_path)

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -125,7 +125,7 @@ class TaskManager:
         ]
 
     def get_batch_size_name(self) -> str:
-        """Give an proper batch size name depending on frameowrk.
+        """Give an proper batch size name depending on framework.
 
         Returns:
             str: batch size name
@@ -140,7 +140,7 @@ class TaskManager:
         return batch_size_name
 
     def get_epoch_name(self) -> str:
-        """Give an proper epoch name depending on frameowrk.
+        """Give an proper epoch name depending on framework.
 
         Returns:
             str: epoch name

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -16,6 +16,7 @@ from inspect import isclass
 from math import floor
 from os import path as osp
 from typing import Any, Callable, Dict, List, Optional, Union
+from copy import deepcopy
 
 import torch
 import yaml
@@ -821,6 +822,12 @@ class HpoCallback(UpdateProgressCallback):
             logger.debug(f"In hpo callback : {score} / {progress} / {epoch}")
             if self._report_func(score=score, progress=epoch) == TrialStatus.STOP:
                 self._task.cancel_training()
+
+    def __deepcopy__(self, memo):
+        """Prevent repot_func from deepcopied."""
+        args = [self.metric, self._max_epoch, self._task]
+        copied_args = deepcopy(args, memo)
+        return self.__class__(self._report_func, *copied_args)
 
 
 class HpoDataset:

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -1,63 +1,51 @@
-"""Utils for HPO with hpopt."""
+"""
+Utils for HPO with hpopt
+"""
 
 # Copyright (C) 2021-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 
-import builtins
-import collections
-import importlib
-import multiprocessing
+import glob
 import os
-import pickle  # nosec
+import re
 import shutil
-import subprocess  # nosec
-import sys
 import time
-
-# pylint: disable=too-many-locals, too-many-instance-attributes, too-many-branches, too-many-statements
-# disbled some pylint refactor related categories
-# TODO: refactor code to resolve these things
-from argparse import Namespace
 from enum import Enum
+from functools import partial
 from inspect import isclass
-from math import ceil
+from math import floor
 from os import path as osp
-from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 import yaml
-
-from otx.api.configuration.configurable_parameters import ConfigurableParameters
 from otx.api.configuration.helper import create
-from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.model import ModelEntity
 from otx.api.entities.model_template import TaskType
 from otx.api.entities.subset import Subset
-from otx.api.entities.task_environment import TaskEnvironment, TypeVariable
+from otx.api.entities.task_environment import TaskEnvironment
 from otx.api.entities.train_parameters import TrainParameters, UpdateProgressCallback
+
+from otx.cli.datasets import get_dataset_class
 from otx.cli.utils.importing import get_impl_class
 from otx.cli.utils.io import read_model, save_model_data
 from otx.core.data.adapter import get_dataset_adapter
 
 try:
     import hpopt
+    from hpopt.hpo_runner import run_hpo_loop
+    from hpopt.hyperband import HyperBand
+    from hpopt.hpo_base import TrialStatus
 except ImportError:
     print("cannot import hpopt module")
     hpopt = None
 
+import logging
+hpopt_logger = logging.getLogger("hpopt")
+hpopt_logger.setLevel(logging.DEBUG)
 
-def check_hpopt_available() -> bool:
-    """Check whether hpopt is avaiable."""
-
-    if hpopt is None:
-        return False
-    return True
-
-
-def _check_hpo_enabled_task(task_type: TaskType):
-    """Check whether HPO available task."""
+def _check_hpo_enabled_task(task_type):
     return task_type in [
         TaskType.CLASSIFICATION,
         TaskType.DETECTION,
@@ -69,45 +57,317 @@ def _check_hpo_enabled_task(task_type: TaskType):
         TaskType.ANOMALY_SEGMENTATION,
     ]
 
+def check_hpopt_available():
+    """Check whether hpopt is avaiable"""
 
-def _is_mpa_framework_task(task_type: TaskType):
-    """Check whether mpa framework task."""
-    return _is_cls_framework_task(task_type) or _is_det_framework_task(task_type) or _is_seg_framework_task(task_type)
+    if hpopt is None:
+        return False
+    return True
 
+class TaskManager:
+    def __init__(self, task_type: TaskType):
+        self._task_type = task_type
 
-def _is_cls_framework_task(task_type: TaskType):
-    """Check whether classification framework task."""
-    return task_type == TaskType.CLASSIFICATION
+    @property
+    def task_type(self):
+        return self._task_type
 
+    def is_mpa_framework_task(self):
+        return (
+            self.is_cls_framework_task()
+            or self.is_det_framework_task()
+            or self.is_seg_framework_task()
+        )
 
-def _is_det_framework_task(task_type: TaskType):
-    """Check whether detection framework task."""
-    return task_type in [
-        TaskType.DETECTION,
-        TaskType.INSTANCE_SEGMENTATION,
-        TaskType.ROTATED_DETECTION,
-    ]
+    def is_cls_framework_task(self):
+        return self._task_type == TaskType.CLASSIFICATION
 
+    def is_det_framework_task(self):
+        return self._task_type in [
+            TaskType.DETECTION,
+            TaskType.INSTANCE_SEGMENTATION,
+            TaskType.ROTATED_DETECTION,
+        ]
 
-def _is_seg_framework_task(task_type: TaskType):
-    """Check whether segmentation framework task."""
-    return task_type == TaskType.SEGMENTATION
+    def is_seg_framework_task(self):
+        return self._task_type == TaskType.SEGMENTATION
 
+    def is_anomaly_framework_task(self):
+        return self._task_type in [
+            TaskType.ANOMALY_CLASSIFICATION,
+            TaskType.ANOMALY_DETECTION,
+            TaskType.ANOMALY_SEGMENTATION,
+        ]
 
-def _is_anomaly_framework_task(task_type: TaskType):
-    """Check whether anomaly framework task."""
-    return task_type in [
-        TaskType.ANOMALY_CLASSIFICATION,
-        TaskType.ANOMALY_DETECTION,
-        TaskType.ANOMALY_SEGMENTATION,
-    ]
+    def get_batch_size_name(self):
+        batch_size_name = None
+        if self.is_mpa_framework_task():
+            batch_size_name = "learning_parameters.batch_size"
+        elif self.is_anomaly_framework_task():
+            batch_size_name = "learning_parameters.train_batch_size"
 
+        return batch_size_name
+        
+    def get_epoch_name(self):
+        epoch_name = None
+        if self.is_mpa_framework_task():
+            epoch_name = "num_iters"
+        elif self.is_anomaly_framework_task():
+            epoch_name = "max_epochs"
 
-def run_hpo(args: Namespace, environment: TaskEnvironment, dataset: DatasetEntity, task_type: TaskType):
-    """Update the environment with better hyper-parameters found by HPO."""
+        return epoch_name
+
+    def copy_weight(self, src: str, det: str):
+        if self.is_mpa_framework_task():
+            for weight_candidate in glob.iglob(osp.join(src, "**/epoch_*.pth"), recursive=True):
+                if not (osp.islink(weight_candidate) or osp.exists(osp.join(det, osp.basename(weight_candidate)))):
+                    shutil.copy(weight_candidate, det)
+
+    def get_latest_weight(self, workdir: str):
+        latest_weight = None
+        if self.is_mpa_framework_task():
+            pattern = re.compile(r"(\d+)\.pth")
+            current_latest_epoch = -1
+            latest_weight = None
+
+            for weight_name in  glob.iglob(osp.join(workdir, "**/epoch_*.pth"), recursive=True):
+                ret = pattern.search(weight_name)
+                epoch = int(ret.group(1))
+                if current_latest_epoch < epoch:
+                    current_latest_epoch = epoch
+                    latest_weight = weight_name
+
+        return latest_weight
+
+class TaskEnvironmentManager:
+    def __init__(self, environment: TaskEnvironment):
+        self._environment = environment
+        self.task = TaskManager(environment.model_template.task_type)
+
+    def get_task(self):
+        return self._environment.model_template.task_type
+
+    def get_model_template(self):
+        return self._environment.model_template
+
+    def get_model_template_path(self):
+        return self._environment.model_template.model_template_path
+
+    def set_hyper_parameter_from_flatten_format_dict(self, hyper_parameter: Dict):
+        env_hp = self._environment.get_hyper_parameters()
+
+        for param_key, param_val in hyper_parameter.items():
+            param_key = param_key.split(".")
+
+            target = env_hp
+            for val in param_key[:-1]:
+                target = getattr(target, val)
+            setattr(target, param_key[-1], param_val)
+
+    def get_dict_type_hyper_parameter(self):
+        learning_parameters = self._environment.get_hyper_parameters().learning_parameters
+        learning_parameters = self._convert_parameter_group_to_dict(learning_parameters)
+        hyper_parameter = {f"learning_parameters.{key}" : val for key, val in learning_parameters.items()}
+        return hyper_parameter
+
+    @staticmethod
+    def _convert_parameter_group_to_dict(parameter_group):
+        groups = getattr(parameter_group, "groups", None)
+        parameters = getattr(parameter_group, "parameters", None)
+
+        total_arr = []
+        for val in [groups, parameters]:
+            if val is not None:
+                total_arr.extend(val)
+        if not total_arr:
+            return parameter_group
+
+        ret = {}
+        for key in total_arr:
+            val = TaskEnvironmentManager._convert_parameter_group_to_dict(getattr(parameter_group, key))
+            if not (isclass(val) or isinstance(val, Enum)):
+                ret[key] = val
+
+        return ret
+
+    def get_max_epoch(self):
+        return getattr(self._environment.get_hyper_parameters().learning_parameters, self.task.get_epoch_name())
+
+    def save_initial_weight(self, save_path: str):
+        if self._environment.model is None:
+            if self.task.is_anomaly_framework_task():
+                # if task isn't anomaly, then save model weight during first trial
+                task = self.get_train_task(self._environment)
+                model = self.get_output_model()
+                task.save_model(model)
+                save_model_data(model, save_path)
+                return True
+        else:
+            save_model_data(self._environment.model, self.save_path)
+            return True
+        return False
+
+    def get_train_task(self):
+        impl_class = get_impl_class(self._environment.model_template.entrypoints.base)
+        return impl_class(task_environment=self._environment)
+
+    def get_batch_size_name(self):
+        return self.task.get_batch_size_name()
+
+    def load_model_weight(self, model_weight_path: str):
+        self._environment.model = read_model(self._environment.get_model_configuration(), model_weight_path, None)
+
+    def resume_model_weight(self, model_weight_path: str):
+        self.load_model_weight(model_weight_path)
+        self._environment.model.model_adapters["resume"] = True
+
+    def get_output_model(self, dataset = None):
+        return ModelEntity(
+            dataset,
+            self._environment.get_model_configuration(),
+        )
+
+    def set_epoch(self, epoch: int):
+        hp = {f"learning_parameters.{self.task.get_epoch_name()}" : epoch}
+        self.set_hyper_parameter_from_flatten_format_dict(hp)
+
+class HpoRunner:
+    def __init__(
+        self,
+        environment: TaskEnvironment,
+        train_dataset_size: int,
+        val_dataset_size: int,
+        hpo_workdir: str,
+        hpo_time_ratio: int = 4,
+    ):
+        self._environment = TaskEnvironmentManager(environment)
+        self._hpo_workdir = hpo_workdir
+        self._hpo_time_ratio = hpo_time_ratio
+        self._hpo_config: Dict = self._set_hpo_config()
+        self._train_dataset_size = train_dataset_size
+        self._val_dataset_size = val_dataset_size
+        self._fixed_hp = {}
+        self._initial_weight_name = "initial_weight.pth"
+
+        self._align_batch_size_search_space_to_dataset_size()
+
+    def _set_hpo_config(self):
+        hpo_config_path = osp.join(
+            osp.dirname(self._environment.get_model_template_path()),
+            "hpo_config.yaml",
+        )
+        with open(hpo_config_path, "r", encoding="utf-8") as f:
+            hpopt_cfg = yaml.safe_load(f)
+
+        return hpopt_cfg
+
+    def _align_batch_size_search_space_to_dataset_size(self):
+        batch_size_name = self._environment.get_batch_size_name()
+
+        if batch_size_name in self._hpo_config["hp_space"]:
+            if "range" in self._hpo_config["hp_space"][batch_size_name]:
+                max_val = self._hpo_config["hp_space"][batch_size_name]["range"][1]
+                min_val = self._hpo_config["hp_space"][batch_size_name]["range"][0]
+                if max_val > self._train_dataset_size:
+                    max_val = self._train_dataset_size
+                    self._hpo_config["hp_space"][batch_size_name]["range"][1] = max_val
+
+                # If trainset size is lower than min batch size range,
+                # fix batch size to trainset size
+                if min_val >= max_val:
+                    print(
+                        "Train set size is equal or lower than batch size range."
+                        "Batch size is fixed to train set size."
+                    )
+                    del self._hpo_config["hp_space"][batch_size_name]
+                    self._fixed_hp[batch_size_name] = self._train_dataset_size
+                    self._environment.set_hyper_parameter_from_flatten_format_dict(self._fixed_hp)
+            else:
+                raise NotImplementedError
+
+    def run_hpo(self, train_func: Callable, data_roots: Dict[str, str]):
+        self._environment.save_initial_weight(self._get_initial_model_weight_path())
+        hpo_algo = self._get_hpo_algo()
+        resource_type = "gpu" if torch.cuda.is_available() else "cpu"
+        best_config = run_hpo_loop(
+            hpo_algo,
+            partial(
+                train_func,
+                model_template=self._environment.get_model_template(),
+                data_roots=data_roots,
+                task_type=self._environment.get_task(),
+                hpo_workdir=self._hpo_workdir,
+                initial_weight_name=self._initial_weight_name,
+                metric=self._hpo_config["metric"]
+            ),
+            resource_type,
+        )
+        self._restore_fixed_hp(best_config)
+        hpo_algo.print_result()
+
+        return best_config
+
+    def _restore_fixed_hp(self, hyper_parameter: Dict[str, Any]):
+        for key, val in self._fixed_hp.items():
+            hyper_parameter[key] = val
+
+    def _get_hpo_algo(self):
+        hpo_algo_type = self._hpo_config.get("search_algorithm", "asha")
+
+        if hpo_algo_type == "asha":
+            hpo_algo = self._prepare_asha()
+        elif hpo_algo_type == "smbo":
+            hpo_algo = self._prepare_smbo()
+        else:
+            raise ValueError(f"Supported HPO algorithms are asha and smbo. your value is {hpo_algo_type}.")
+
+        return hpo_algo
+
+    def _prepare_asha(self):
+        args = {
+            "search_space" : self._hpo_config["hp_space"],
+            "save_path" : self._hpo_workdir,
+            "mode" : self._hpo_config.get("mode", "max"),
+            "num_workers" : 1,
+            "num_full_iterations" : self._environment.get_max_epoch(),
+            "full_dataset_size" : self._train_dataset_size,
+            "non_pure_train_ratio" : self._val_dataset_size / (self._train_dataset_size + self._val_dataset_size),
+            "metric" : self._hpo_config.get("metric", "mAP"),
+            "expected_time_ratio" : self._hpo_time_ratio,
+            "prior_hyper_parameters" : self._get_default_hyper_parameters(),
+            "asynchronous_bracket" : True,
+            "asynchronous_sha" : False if torch.cuda.device_count() == 1 else True
+        }
+
+        print(f"[OTE_CLI] [DEBUG-HPO] ASHA args for create hpopt = {args}")
+
+        return HyperBand(**args)
+
+    def _prepare_smbo(self):
+        raise NotImplementedError
+
+    def _get_default_hyper_parameters(self):
+        default_hyper_parameters = {}
+        hp_from_env = self._environment.get_dict_type_hyper_parameter()
+
+        for key, val in hp_from_env.items():
+            if key in self._hpo_config["hp_space"]:
+                default_hyper_parameters[key] = val
+
+        if not default_hyper_parameters:
+            return None
+        return default_hyper_parameters
+
+    def _get_initial_model_weight_path(self):
+        return osp.join(self._hpo_workdir, self._initial_weight_name)
+
+def run_hpo(args, environment, dataset, data_roots: Dict[str, str]):
+    """Update the environment with better hyper-parameters found by HPO"""
     if not check_hpopt_available():
+        print("hpopt isn't available. hpo is skipped.")
         return None
 
+    task_type = environment.model_template.task_type
     if not _check_hpo_enabled_task(task_type):
         print(
             "Currently supported task types are classification, detection, segmentation and anomaly"
@@ -115,822 +375,262 @@ def run_hpo(args: Namespace, environment: TaskEnvironment, dataset: DatasetEntit
         )
         return None
 
-    dataset_paths = {
-        "train_data_root": args.train_data_roots,
-        "val_data_root": args.val_data_roots,
-    }
-
     hpo_save_path = os.path.abspath(os.path.join(os.path.dirname(args.save_model_to), "hpo"))
-    hpo = HpoManager(environment, dataset, dataset_paths, args.hpo_time_ratio, hpo_save_path)
-    print(f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} [HPO] started hyper-parameter optimization")
-    hyper_parameters, hpo_weight_path = hpo.run()
-    print(f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} [HPO] completed hyper-parameter optimization")
-
-    environment.set_hyper_parameters(hyper_parameters)
-
-    assert (
-        environment.model_template.entrypoints is not None and environment.model_template.entrypoints.base is not None
-    )
-    task_class = get_impl_class(environment.model_template.entrypoints.base)
-    task_class = get_train_wrapper_task(task_class, task_type)
-
-    task = task_class(task_environment=environment, output_path=args.work_dir)
-
-    hpopt_cfg = _load_hpopt_config(
-        osp.join(
-            osp.dirname(environment.model_template.model_template_path),
-            "hpo_config.yaml",
-        )
+    hpo_runner = HpoRunner(
+        environment,
+        len(dataset.get_subset(Subset.TRAINING)),
+        len(dataset.get_subset(Subset.VALIDATION)),
+        hpo_save_path,
+        args.hpo_time_ratio
     )
 
-    if hpopt_cfg.get("resume", False):
-        task.set_resume_path_to_config(hpo_weight_path)  # prepare finetune stage to resume
+    print(
+        f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} [HPO] started hyper-parameter optimization"
+    )
+    best_config = hpo_runner.run_hpo(run_trial, data_roots)
+    print(
+        f"{time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())} [HPO] completed hyper-parameter optimization"
+    )
 
-    if args.load_weights:
-        assert environment.model is not None
-        environment.model.configuration.configurable_parameters = hyper_parameters
+    TaskEnvironmentManager(environment).set_hyper_parameter_from_flatten_format_dict(best_config)
 
-    return task
+class Trainer:
+    def __init__(
+        self,
+        hp_config: Dict[str, Any],
+        report_func: Callable,
+        model_template,
+        data_roots: Dict[str, str],
+        task_type: TaskType,
+        hpo_workdir: str,
+        initial_weight_name: str,
+        metric: str
+    ):
+        self._hp_config = hp_config
+        self._report_func = report_func
+        self._model_template = model_template
+        self._data_roots = data_roots
+        self._task = TaskManager(task_type)
+        self._hpo_workdir = hpo_workdir
+        self._initial_weight_name = initial_weight_name
+        self._metric = metric
+        self._epoch = floor(self._hp_config["configuration"]["iterations"])
+        del self._hp_config["configuration"]["iterations"]
 
+    def run(self):
+        """Run each training of each trial with given hyper parameters"""
+        hyper_parameters = self._prepare_hyper_parameter()
+        dataset = self._prepare_dataset()
 
-def get_cuda_device_list():
-    """Returns the list of avaiable cuda devices."""
-    if torch.cuda.is_available():
-        hpo_env = os.environ.copy()
-        cuda_visible_devices = hpo_env.get("CUDA_VISIBLE_DEVICES", None)
+        environment = self._prepare_environment(hyper_parameters, dataset)
+        self._set_hyper_parameter(environment)
 
-        if cuda_visible_devices is None:
-            return list(range(0, torch.cuda.device_count()))
-
-        return [int(i) for i in cuda_visible_devices.split(",")]
-    return None
-
-
-def run_hpo_trainer(
-    hp_config,
-    hyper_parameters,
-    model_template,
-    dataset_paths: Dict[str, str],
-    task_type: TaskType,
-):
-    """Run each training of each trial with given hyper parameters."""
-    if dataset_paths is None:
-        raise ValueError("Dataset is not defined.")
-
-    # User argument Parameters are applied to HPO trial
-    default_hp = create(model_template.hyper_parameters.data)
-    _set_dict_to_parameter_group(default_hp, hyper_parameters)
-    hyper_parameters = default_hp
-
-    # set epoch and warm-up stage depending on given epoch
-    if _is_cls_framework_task(task_type):
-        hyper_parameters.learning_parameters.num_iters = hp_config["iterations"]
-    elif _is_det_framework_task(task_type):
-        if "bracket" not in hp_config:
-            hyper_parameters.learning_parameters.learning_rate_warmup_iters = int(
-                hyper_parameters.learning_parameters.learning_rate_warmup_iters
-                * hp_config["iterations"]
-                / hyper_parameters.learning_parameters.num_iters
-            )
-        hyper_parameters.learning_parameters.num_iters = hp_config["iterations"]
-    elif _is_seg_framework_task(task_type):
-        if "bracket" not in hp_config:
-            eph_comp = [
-                hyper_parameters.learning_parameters.learning_rate_fixed_iters,
-                hyper_parameters.learning_parameters.learning_rate_warmup_iters,
-                hyper_parameters.learning_parameters.num_iters,
-            ]
-
-            eph_comp = list(map(lambda x: x * hp_config["iterations"] / sum(eph_comp), eph_comp))
-
-            for val in sorted(
-                list(range(len(eph_comp))),
-                key=lambda k: eph_comp[k] - int(eph_comp[k]),
-                reverse=True,
-            )[: hp_config["iterations"] - sum(map(int, eph_comp))]:
-                eph_comp[val] += 1
-
-            hyper_parameters.learning_parameters.learning_rate_fixed_iters = int(eph_comp[0])
-            hyper_parameters.learning_parameters.learning_rate_warmup_iters = int(eph_comp[1])
-            hyper_parameters.learning_parameters.num_iters = int(eph_comp[2])
+        need_to_save_initial_weight = False
+        resume_weight_path = self._get_resume_weight_path()
+        if resume_weight_path is not None:
+            environment.resume_model_weight(resume_weight_path)
         else:
-            hyper_parameters.learning_parameters.num_iters = hp_config["iterations"]
+            initial_weight = self._load_fixed_initial_weight()
+            if initial_weight is not None:
+                environment.load_model_weight(initial_weight)
+            else:
+                need_to_save_initial_weight = True
 
-    # current HPO requires batch_size information.
-    # so if batch_size is not in the HPO's target hyper parameters,
-    # need to set batch_size config from the instance of ConfigurableParameters
-    if hp_config["batch_size_param_name"] not in hp_config["params"].keys():
-        attr = hyper_parameters
-        for val in hp_config["batch_size_param_name"].split("."):
-            # TODO explicitly check for typing
-            attr = getattr(attr, val)  # type: ignore[call-overload]
-        hp_config["batch_size"] = attr
+        task = environment.get_train_task()
+        if need_to_save_initial_weight:
+            self._add_initial_weight_saving_hook(task)
 
-    # set hyper-parameters and print them
-    HpoManager.set_hyperparameter(hyper_parameters, hp_config["params"])
-    print(f"hyper parameter of current trial : {hp_config['params']}")
+        output_model = environment.get_output_model(dataset)
+        score_report_callback = self._prepare_score_report_callback(task)
+        task.train(dataset=dataset, output_model=output_model, train_parameters=score_report_callback)
+        self._finalize_trial(task)
 
-    # TODO remove None from dataset_paths
-    data_roots = dict(
-        train_subset={  # type: ignore
-            "data_root": dataset_paths.get("train_data_root", None),
-        },
-        val_subset={  # type: ignore
-            "data_root": dataset_paths.get("val_data_root", None),
-        },
-    )
+    def _prepare_hyper_parameter(self):
+        return create(self._model_template.hyper_parameters.data)
 
-    # Datumaro
-    dataset_adapter = get_dataset_adapter(
-        task_type,
-        train_data_roots=data_roots["train_subset"]["data_root"],
-        val_data_roots=data_roots["val_subset"]["data_root"],
-    )
-    dataset = dataset_adapter.get_otx_dataset()
-    label_schema = dataset_adapter.get_label_schema()
+    def _prepare_dataset(self):
+        dataset_class = get_dataset_class(self._task.task_type)
+        dataset = dataset_class(**self._data_roots)
+        dataset = HpoDataset(dataset, self._hp_config)
 
-    train_env = TaskEnvironment(
-        model=None,
-        hyper_parameters=hyper_parameters,
-        label_schema=label_schema,
-        model_template=model_template,
-    )
+        return dataset
 
-    # load fixed initial weight
-    save_initial_weight_flag = False
-    initial_weight_path = osp.join(_get_hpo_dir(hp_config), "weights.pth")
-    if osp.exists(initial_weight_path):
-        train_env.model = read_model(
-            train_env.get_model_configuration(),
-            osp.join(osp.dirname(hp_config["file_path"]), "weights.pth"),
-            # TODO replace None in read_model.
-            None,  # type: ignore[arg-type]
+    def _set_hyper_parameter(self, environment: TaskEnvironmentManager):
+        environment.set_hyper_parameter_from_flatten_format_dict(self._hp_config["configuration"])
+        environment.set_epoch(self._epoch)
+
+    def _prepare_environment(self, hyper_parameters, dataset):
+        enviroment = TaskEnvironment(
+            model=None,
+            hyper_parameters=hyper_parameters,
+            label_schema=generate_label_schema(dataset, self._task.task_type),
+            model_template=self._model_template
         )
-    else:
-        save_initial_weight_flag = True
 
-    train_env.model_template.hpo = {
-        "hp_config": hp_config,
-        "metric": hp_config["metric"],
-    }
+        return TaskEnvironmentManager(enviroment)
 
-    assert train_env.model_template.entrypoints is not None and train_env.model_template.entrypoints.base is not None
-    task_class = get_impl_class(train_env.model_template.entrypoints.base)
-    hpo_impl_class = get_train_wrapper_task(task_class, task_type)
-    task = hpo_impl_class(task_environment=train_env)
-    task.prepare_hpo(hp_config)
-    if save_initial_weight_flag:
-        task.prepare_saving_initial_weight(_get_hpo_dir(hp_config))
+    def _get_resume_weight_path(self):
+        trial_work_dir = self._get_weight_dir_path()
+        if not osp.exists(trial_work_dir):
+            return None
+        return self._task.get_latest_weight(trial_work_dir)
 
-    dataset = HpoDataset(dataset, hp_config)
+    def _load_fixed_initial_weight(self):
+        initial_weight_path = self._get_initial_weight_path()
+        if osp.exists(initial_weight_path):
+            return initial_weight_path
+        return None
 
-    output_model = ModelEntity(
-        dataset,
-        train_env.get_model_configuration(),
-    )
+    def _prepare_task(self, environment: TaskEnvironment):
+        task_class = get_impl_class(environment.model_template.entrypoints.base)
+        return task_class(task_environment=environment)
 
-    # make callback to report score to hpopt every epoch
-    train_param = TrainParameters(False, HpoCallback(hp_config, hp_config["metric"], task))
+    def _add_initial_weight_saving_hook(self, task):
+        initial_weight_path = self._get_initial_weight_path()
+        task.update_override_configurations(
+            {
+                "custom_hooks": [
+                    dict(
+                        type="SaveInitialWeightHook",
+                        save_path=osp.dirname(initial_weight_path),
+                        file_name=osp.basename(initial_weight_path),
+                        after_save_func=self._change_model_weight_to_otx_format
+                    )
+                ]
+            }
+        )
 
-    task.train(dataset=dataset, output_model=output_model, train_parameters=train_param)
-
-    hpopt.finalize_trial(hp_config)
-
-    # align MPA checkpoint file to OTX weight file format
-    if save_initial_weight_flag:
+    def _change_model_weight_to_otx_format(self):
+        initial_weight_path = self._get_initial_weight_path()
         initial_weight = torch.load(initial_weight_path, map_location="cpu")
         initial_weight["model"] = initial_weight["state_dict"]
         torch.save(initial_weight, initial_weight_path)
 
-    # remove model weight except best model weight
-    best_model_weight = _get_best_model_weight_path(_get_hpo_dir(hp_config), str(hp_config["trial_id"]), task_type)
-    if best_model_weight is not None:
-        best_model_weight = osp.realpath(best_model_weight)
-        for dirpath, _, filenames in os.walk(_get_hpo_trial_workdir(hp_config)):
-            for filename in filenames:
-                full_name = osp.join(dirpath, filename)
-                if (not osp.islink(full_name)) and full_name != best_model_weight:
-                    os.remove(full_name)
+    def _prepare_score_report_callback(self, task):
+        return TrainParameters(False, HpoCallback(self._report_func, self._metric, self._epoch, task))
 
+    def _get_initial_weight_path(self):
+        return osp.join(self._hpo_workdir, self._initial_weight_name)
 
-def exec_hpo_trainer(arg_file_name, alloc_gpus):
-    """Execute new process to train model for ASHA's trial."""
+    def _finalize_trial(self, task):
+        weight_dir_path = self._get_weight_dir_path()
+        os.makedirs(weight_dir_path, exist_ok=True)
+        self._task.copy_weight(task.project_path, weight_dir_path)
+        self._report_func(0, 0, done=True)
 
-    gpu_ids = ",".join(str(val) for val in alloc_gpus)
-    trainer_file_name = osp.abspath(__file__)
-    hpo_env = os.environ.copy()
-    if torch.cuda.device_count() > 0:
-        hpo_env["CUDA_VISIBLE_DEVICES"] = gpu_ids
-    hpo_env["PYTHONPATH"] = f"{osp.dirname(__file__)}/../../:" + hpo_env.get("PYTHONPATH", "")
+    def _get_weight_dir_path(self):
+        return osp.join(self._hpo_workdir, "weight", self._hp_config["id"])
 
-    subprocess.run(
-        ["python3", trainer_file_name, arg_file_name],
-        shell=False,
-        env=hpo_env,
-        check=False,
+def run_trial(
+    hp_config:  Dict,
+    report_func: Callable,
+    model_template,
+    data_roots: Dict[str, str],
+    task_type: TaskType,
+    hpo_workdir: str,
+    initial_weight_name: str,
+    metric: str
+):
+    trainer = Trainer(
+        hp_config,
+        report_func,
+        model_template,
+        data_roots,
+        task_type,
+        hpo_workdir,
+        initial_weight_name,
+        metric
     )
-    time.sleep(10)
+    trainer.run()
 
+def mocking_run_trial(
+    hp_config:  Dict,
+    report_func: Callable,
+    model_template,
+    dataset_paths: Dict[str, str],
+    task_type: TaskType,
+    hpo_workdir: str,
+    initial_weight_name: str,
+    metric: str,
+):
+    print("mocking_run_trial start!")
 
-def get_train_wrapper_task(impl_class, task_type):
-    """Get task wrapper for the HPO with given task type."""
+    import logging
+    hpopt_logger = logging.getLogger("hpopt")
+    hpopt_logger.setLevel(logging.DEBUG)
 
-    # pylint: disable=attribute-defined-outside-init
-    class HpoTrainTask(impl_class):
-        """wrapper class for the HPO."""
+    lr = hp_config["configuration"]["learning_parameters.learning_rate"]
+    bs = hp_config["configuration"]["learning_parameters.batch_size"]
+    obj_func = 100 - (0.001 - lr) ** 2 - ((16 - bs) ** 2) / 100
+    iteration = floor(hp_config["configuration"]["iterations"])
+    validation_interval = 2
+    print(f"iteratoin : {iteration}")
+    if iteration > 50:
+        iteration = 50
+        print("iteration is modified to 50.")
 
-        def __init__(self, task_environment, **kwargs):
-            super().__init__(task_environment, **kwargs)
-            self._task_type = task_type
+    for i in range(validation_interval, iteration+1, validation_interval):
+        score = obj_func + i / 100
+        progress = i
+        stop_train = report_func(score, progress)
+        if stop_train == TrialStatus.STOP:
+            break
 
-        # TODO: need to check things below whether works on MPA tasks
-        def set_resume_path_to_config(self, resume_path):
-            """Set path for the resume to the config of the each task framework."""
-            if _is_cls_framework_task(self._task_type):
-                self._cfg.model.resume = resume_path
-                self._cfg.test.save_initial_metric = True
-            elif _is_det_framework_task(self._task_type):
-                self._config.resume_from = resume_path
-            elif _is_seg_framework_task(self._task_type):
-                self._config.resume_from = resume_path
-
-        def prepare_hpo(self, hp_config):
-            """Update config of the each task framework for the HPO."""
-            if _is_mpa_framework_task(self._task_type):
-                cfg = dict(checkpoint_config=dict(max_keep_ckpts=(hp_config["iterations"] + 10), interval=1))
-                self.update_override_configurations(cfg)
-                self._output_path = _get_hpo_trial_workdir(hp_config)  # pylint: disable=attribute-defined-outside-init
-
-        def prepare_saving_initial_weight(self, save_path):
-            """Add a hook which saves initial model weight before training."""
-            if _is_mpa_framework_task(task_type):
-                cfg = {"custom_hooks": [dict(type="SaveInitialWeightHook", save_path=save_path)]}
-                self.update_override_configurations(cfg)
-            else:
-                raise RuntimeError(
-                    "If task is not classification, detection or segmentation,"
-                    "initial weight should be saved before HPO."
-                )
-
-    return HpoTrainTask
-
-
-def _convert_parameter_group_to_dict(parameter_group: TypeVariable):
-    groups = getattr(parameter_group, "groups", None)
-    parameters = getattr(parameter_group, "parameters", None)
-
-    total_arr = []
-    for val in [groups, parameters]:
-        if val is not None:
-            total_arr.extend(val)
-    if not total_arr:
-        return parameter_group
-
-    ret = {}
-    for key in total_arr:
-        val = _convert_parameter_group_to_dict(getattr(parameter_group, key))
-        if not (isclass(val) or isinstance(val, Enum)):
-            ret[key] = val
-
-    return ret
-
-
-def _set_dict_to_parameter_group(origin_hp: ConfigurableParameters, hp_config: Dict):
-    """Set given hyper parameter to hyper parameter in environment aligning with "ConfigurableParameters"."""
-    for key, val in hp_config.items():
-        if not isinstance(val, dict):
-            setattr(origin_hp, key, val)
-        else:
-            _set_dict_to_parameter_group(getattr(origin_hp, key), val)
-
-
-def _load_hpopt_config(file_path: str):
-    """Load HPOpt config file."""
-    try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            hpopt_cfg = yaml.safe_load(f)
-    except FileNotFoundError as err:
-        print("hpo_config.yaml file should be in directory where template.yaml is.")
-        raise err
-
-    return hpopt_cfg
-
-
-def _get_best_model_weight_path(hpo_dir: str, trial_num: str, task_type: TaskType):
-    """Return best model weight from HPO trial directory."""
-    best_weight_path = None
-    if _is_mpa_framework_task(task_type):
-        best_arr = Path(osp.join(hpo_dir, str(trial_num))).glob("**/best*.pth")
-        for best_name_file in best_arr:
-            if not osp.islink(best_name_file):
-                best_weight_path = best_name_file
-                break
-    elif _is_anomaly_framework_task(task_type):
-        # TODO need to implement later
-        pass
-
-    return best_weight_path
-
-
-def _get_hpo_dir(hp_config):
-    """Return HPO work directory path from hp_config."""
-    return osp.dirname(hp_config["file_path"])
-
-
-def _get_hpo_trial_workdir(hp_config):
-    """Return HPO trial work directory path from hp_config."""
-    return osp.join(_get_hpo_dir(hp_config), str(hp_config["trial_id"]))
-
+    report_func(0, 0, done=True)
 
 class HpoCallback(UpdateProgressCallback):
-    """Callback class to report score to hpopt."""
+    """Callback class to report score to hpopt"""
 
-    def __init__(self, hp_config, metric, hpo_task):
+    def __init__(self, report_func: Callable, metric: str, max_epoch: int, task):
         super().__init__()
-        self.hp_config = hp_config
+        self._report_func = report_func
         self.metric = metric
-        self.hpo_task = hpo_task
+        self._max_epoch = max_epoch
+        self._task = task
 
-    def __call__(self, progress: float, score: Optional[float] = None):
-        """Reports score to hpopt when called.
-
-        Args:
-            progress (float): (Unused) This is an artifact of using ProgressCallback for HPOCallback.
-            score (Optional[float], optional): Score to report. Defaults to None.
-        """
+    def __call__(self, progress: Union[int, float], score: Optional[float] = None):
         if score is not None:
-            current_iters = -1
-            if score > 1.0:
-                current_iters = int(score)
-                score = float(score - current_iters)
-            elif score < 0.0:
-                current_iters = int(-1.0 * score - 1.0)
-                score = 1.0
-            print(f"score = {score} at iteration {current_iters}")
-            # pylint: disable=unexpected-keyword-arg
-            if hpopt.report(config=self.hp_config, score=score, current_iters=current_iters) == hpopt.Status.STOP:
-                self.hpo_task.cancel_training()
-
-
-class HpoManager:
-    """Manage overall HPO process."""
-
-    def __init__(self, environment, dataset, dataset_paths, expected_time_ratio, hpo_save_path):
-        self.environment = environment
-        self.dataset_paths = dataset_paths
-        self.work_dir = hpo_save_path
-        # If hyper parameter candidates should be fixed,
-        # they're excluded from hp search space.
-        # But they are used in hpo and included to final hyper parameters as fixed.
-        self.fixed_hp = {}
-
-        task_type = self.environment.model_template.task_type
-        if environment.model is None:
-            #  Fixed initial weight is saved during first trial,
-            #  if task is the one ofcalssification, detection and segmentation.
-            if _is_anomaly_framework_task(task_type):
-                impl_class = get_impl_class(environment.model_template.entrypoints.base)
-                task = impl_class(task_environment=environment)
-                torch.save(task.model_info(), osp.join(self.work_dir, "weights.pth"))
-        else:
-            save_model_data(environment.model, self.work_dir)
-
-        hpopt_cfg = _load_hpopt_config(
-            osp.join(
-                osp.dirname(self.environment.model_template.model_template_path),
-                "hpo_config.yaml",
-            )
-        )
-
-        self.algo = hpopt_cfg.get("search_algorithm", "smbo")
-        self.metric = hpopt_cfg.get("metric", "mAP")
-
-        num_available_gpus = torch.cuda.device_count()
-
-        self.num_gpus_per_trial = 1
-
-        train_dataset_size = len(dataset.get_subset(Subset.TRAINING))
-        val_dataset_size = len(dataset.get_subset(Subset.VALIDATION))
-
-        # make batch size range lower than train set size
-        env_hp = self.environment.get_hyper_parameters()
-        if _is_mpa_framework_task(task_type):
-            batch_size_name = "learning_parameters.batch_size"
-        elif _is_anomaly_framework_task(task_type):
-            batch_size_name = "learning_parameters.train_batch_size"
-        if batch_size_name in hpopt_cfg["hp_space"]:
-            batch_range = hpopt_cfg["hp_space"][batch_size_name]["range"]
-            if batch_range[1] > train_dataset_size:
-                batch_range[1] = train_dataset_size
-
-            # If trainset size is lower than min batch size range,
-            # fix batch size to trainset size
-            if batch_range[0] > batch_range[1]:
-                print("Train set size is lower than batch size range. Batch size is fixed to train set size.")
-                del hpopt_cfg["hp_space"][batch_size_name]
-                self.fixed_hp[batch_size_name] = train_dataset_size
-
-        # prepare default hyper parameters
-        default_hyper_parameters = {}
-        for key in hpopt_cfg["hp_space"].keys():
-            splited_key = key.split(".")
-            target = env_hp
-            for val in splited_key:
-                target = getattr(target, val, None)
-                if target is None:
-                    break
-            if target is not None:
-                default_hyper_parameters[key] = target
-
-        hpopt_arguments = dict(
-            search_alg="bayes_opt" if self.algo == "smbo" else self.algo,
-            search_space=HpoManager.generate_hpo_search_space(hpopt_cfg["hp_space"]),
-            early_stop=hpopt_cfg.get("early_stop", None),
-            resume=self.check_resumable(),
-            save_path=self.work_dir,
-            max_iterations=hpopt_cfg.get("max_iterations"),
-            subset_ratio=hpopt_cfg.get("subset_ratio"),
-            num_full_iterations=HpoManager.get_num_full_iterations(self.environment),
-            full_dataset_size=train_dataset_size,
-            expected_time_ratio=expected_time_ratio,
-            non_pure_train_ratio=val_dataset_size / (train_dataset_size + val_dataset_size),
-            batch_size_name=batch_size_name,
-            default_hyper_parameters=default_hyper_parameters,
-            metric=self.metric,
-            mode=hpopt_cfg.get("mode", "max"),
-        )
-
-        if self.algo == "smbo":
-            hpopt_arguments["num_init_trials"] = hpopt_cfg.get("num_init_trials")
-            hpopt_arguments["num_trials"] = hpopt_cfg.get("num_trials")
-        elif self.algo == "asha":
-            hpopt_arguments["num_brackets"] = hpopt_cfg.get("num_brackets")
-            hpopt_arguments["reduction_factor"] = hpopt_cfg.get("reduction_factor")
-            hpopt_arguments["min_iterations"] = hpopt_cfg.get("min_iterations")
-            hpopt_arguments["num_trials"] = hpopt_cfg.get("num_trials")
-            hpopt_arguments["num_workers"] = num_available_gpus // self.num_gpus_per_trial
-
-            # Prevent each trials from being stopped during warmup stage
-            batch_size = default_hyper_parameters.get(batch_size_name)
-            if "min_iterations" not in hpopt_cfg and batch_size is not None:
-                if _is_mpa_framework_task(task_type):
-                    hpopt_arguments["min_iterations"] = ceil(
-                        env_hp.learning_parameters.learning_rate_warmup_iters / ceil(train_dataset_size / batch_size)
-                    )
-
-        HpoManager.remove_empty_keys(hpopt_arguments)
-
-        print(f"[otx.cli] [DEBUG-HPO] hpopt args for create hpopt = {hpopt_arguments}")
-
-        # pylint: disable=unexpected-keyword-arg
-        self.hpo = hpopt.create(**hpopt_arguments)
-
-    def check_resumable(self):
-        """Check if HPO could be resumed from the previous result.
-
-        If previous results are found, ask the user if resume or start from scratch.
-        """
-        resume_flag = False
-
-        hpo_previous_status = hpopt.get_previous_status(self.work_dir)
-
-        if hpo_previous_status in [
-            hpopt.Status.PARTIALRESULT,
-            hpopt.Status.COMPLETERESULT,
-        ]:
-            print(f"Previous HPO results are found in {self.work_dir}.")
-            retry_count = 0
-
-            while True:
-                if hpo_previous_status == hpopt.Status.PARTIALRESULT:
-                    user_input = input("Do you want to resume HPO? [\033[1mY\033[0m/n]: ")
-                else:
-                    user_input = input("Do you want to reuse previously found hyper-parameters? [\033[1mY\033[0m/n]: ")
-
-                input_len = len(user_input)
-
-                if input_len < 1:
-                    # It means that an user accepted the default choice.
-                    resume_flag = True
-                    break
-
-                if input_len == 1:
-                    user_input = user_input.lower()
-                    if user_input in ["y", "n"]:
-                        if user_input == "y":
-                            resume_flag = True
-                        else:
-                            shutil.rmtree(self.work_dir, ignore_errors=True)
-                        break
-
-                retry_count += 1
-                if retry_count >= 5:
-                    print("Your inputs are invalid. The whole program is terminating...")
-                    sys.exit()
-
-                print("You should type 'y' or 'n'. Nothing means 'y'.")
-        return resume_flag
-
-    def run(self):
-        """Execute HPO according to configuration."""
-        task_type = self.environment.model_template.task_type
-        proc_list = []
-        gpu_alloc_list = []
-        num_workers = 1
-        if self.algo == "asha":
-            num_workers = torch.cuda.device_count() // self.num_gpus_per_trial
-
-        while True:
-            num_active_workers = 0
-            for proc, gpu in zip(reversed(proc_list), reversed(gpu_alloc_list)):
-                if proc.is_alive():
-                    num_active_workers += 1
-                else:
-                    proc.close()
-                    proc_list.remove(proc)
-                    gpu_alloc_list.remove(gpu)
-
-            if num_active_workers == num_workers:
-                time.sleep(10)
-
-            while num_active_workers < num_workers:
-                hp_config = self.hpo.get_next_sample()
-
-                if hp_config is None:
-                    # Wait for unfinished trials
-                    for proc in proc_list:
-                        if proc.is_alive():
-                            proc.join()
-                    break
-
-                for key, val in self.fixed_hp.items():
-                    hp_config["params"][key] = val
-
-                hp_config["metric"] = self.metric
-
-                hpo_work_dir = osp.abspath(_get_hpo_trial_workdir(hp_config))
-
-                # Clear hpo_work_dir
-                if osp.exists(hpo_work_dir):
-                    shutil.rmtree(hpo_work_dir)
-                Path(hpo_work_dir).mkdir(parents=True)
-
-                _kwargs = {
-                    "hp_config": hp_config,
-                    "hyper_parameters": _convert_parameter_group_to_dict(self.environment.get_hyper_parameters()),
-                    "model_template": self.environment.model_template,
-                    "dataset_paths": self.dataset_paths,
-                    "task_type": task_type,
-                }
-
-                pickle_path = HpoManager.safe_pickle_dump(hpo_work_dir, f"hpo_trial_{hp_config['trial_id']}", _kwargs)
-
-                alloc_gpus = self.__alloc_gpus(gpu_alloc_list)
-
-                p = multiprocessing.Process(
-                    target=exec_hpo_trainer,
-                    args=(
-                        pickle_path,
-                        alloc_gpus,
-                    ),
-                )
-                proc_list.append(p)
-                gpu_alloc_list.append(alloc_gpus)
-                p.start()
-                num_active_workers += 1
-
-            # All trials are done.
-            if num_active_workers == 0:
-                break
-
-        best_config = self.hpo.get_best_config()
-        for key, val in self.fixed_hp.items():
-            best_config[key] = val
-
-        hyper_parameters = self.environment.get_hyper_parameters()
-        HpoManager.set_hyperparameter(hyper_parameters, best_config)
-
-        self.hpo.print_results()
-
-        print("Best Hyper-parameters")
-        print(best_config)
-
-        # get weight to pass for resume
-        hpo_weight_path = _get_best_model_weight_path(
-            self.hpo.save_path, str(self.hpo.hpo_status["best_config_id"]), task_type
-        )
-
-        return hyper_parameters, hpo_weight_path
-
-    def __alloc_gpus(self, gpu_alloc_list):
-        gpu_list = get_cuda_device_list()
-        # CPU-mode
-        if torch.cuda.device_count() == 0:
-            gpu_list = [0]
-
-        alloc_gpus = []
-        flat_gpu_alloc_list = sum(gpu_alloc_list, [])
-        for idx in gpu_list:
-            if idx not in flat_gpu_alloc_list:
-                alloc_gpus.append(idx)
-                if len(alloc_gpus) == self.num_gpus_per_trial:
-                    break
-
-        if len(alloc_gpus) < self.num_gpus_per_trial:
-            raise ValueError("No available GPU!!")
-
-        return alloc_gpus
-
-    @staticmethod
-    def generate_hpo_search_space(hp_space_dict):
-        """Generate search space from user's input."""
-        search_space = {}
-        for key, val in hp_space_dict.items():
-            # pylint: disable=no-member
-            search_space[key] = hpopt.SearchSpace(val["param_type"], val["range"])
-        return search_space
-
-    @staticmethod
-    def remove_empty_keys(arg_dict):
-        """Remove keys with null values in the arg_dict dictionary."""
-        del_candidate = []
-        for key, val in arg_dict.items():
-            if val is None:
-                del_candidate.append(key)
-        for val in del_candidate:
-            arg_dict.pop(val)
-        return del_candidate
-
-    @staticmethod
-    def get_num_full_iterations(environment):
-        """Get the number of full iterations for the specified environment."""
-        num_full_iterations = 0
-
-        task_type = environment.model_template.task_type
-        params = environment.get_hyper_parameters()
-        if _is_mpa_framework_task(task_type):
-            learning_parameters = params.learning_parameters
-            num_full_iterations = learning_parameters.num_iters
-        elif _is_anomaly_framework_task(task_type):
-            learning_parameters = params.learning_parameters
-            num_full_iterations = learning_parameters.max_epochs
-
-        return num_full_iterations
-
-    @staticmethod
-    def safe_pickle_dump(dir_path, file_name, data):
-        """Dump a pickle file with minimal file permission."""
-        pickle_path = osp.join(dir_path, f"{file_name}.pickle")
-
-        oldmask = os.umask(0o077)
-        with open(pickle_path, "wb") as pfile:
-            pickle.dump(data, pfile)
-        os.umask(oldmask)
-
-        return pickle_path
-
-    @staticmethod
-    def set_hyperparameter(origin_hp, hp_config):
-        """Set given hyper parameter to hyper parameter in environment aligning with "ConfigurableParameters"."""
-
-        for param_key, param_val in hp_config.items():
-            param_key = param_key.split(".")
-
-            target = origin_hp
-            for val in param_key[:-1]:
-                target = getattr(target, val)
-            setattr(target, param_key[-1], param_val)
-
+            epoch = round(self._max_epoch * progress / 100)
+            print("*"*100, f"In hpo callback : {score} / {progress} / {epoch}")
+            if self._report_func(score=score, progress=epoch) == TrialStatus.STOP:
+                self._task.cancel_training()
 
 class HpoDataset:
-    """Wrapper class for DatasetEntity of dataset.
-
+    """
+    Wrapper class for DatasetEntity of dataset.
     It's used to make subset during HPO.
     """
 
-    def __init__(self, fullset: DatasetEntity, config=None, indices=None):
+    def __init__(self, fullset, config=None, indices=None):
         self.fullset = fullset
         self.indices = indices
-        self.subset_ratio = 1 if config is None else config["subset_ratio"]
+        subset_ratio = config["train_environment"]["subset_ratio"]
+        self.subset_ratio = 1 if subset_ratio is None else subset_ratio
 
     def __len__(self) -> int:
-        """Gets size of dataset."""
         return len(self.indices)
 
     def __getitem__(self, indx) -> dict:
-        """Get item from dataset."""
         return self.fullset[self.indices[indx]]
 
     def __getattr__(self, name):
-        """Get attribute from fullset."""
         if name == "__setstate__":
             raise AttributeError(name)
         return getattr(self.fullset, name)
 
     def get_subset(self, subset: Subset):
-        """Get subset according to subset_ratio if training dataset is requested."""
+        """
+        Get subset according to subset_ratio if trainin dataset is requeseted.
+        """
 
         dataset = self.fullset.get_subset(subset)
         if subset != Subset.TRAINING or self.subset_ratio > 0.99:
             return dataset
 
-        indices = torch.randperm(len(dataset), generator=torch.Generator().manual_seed(42))
+        indices = torch.randperm(
+            len(dataset), generator=torch.Generator().manual_seed(42)
+        )
         indices = indices.tolist()  # type: ignore
         indices = indices[: int(len(dataset) * self.subset_ratio)]
 
         return HpoDataset(dataset, config=None, indices=indices)
-
-
-class HpoUnpickler(pickle.Unpickler):
-    """Safe unpickler for HPO."""
-
-    __safe_builtins = {
-        "range",
-        "complex",
-        "set",
-        "frozenset",
-        "slice",
-        "dict",
-    }
-
-    __safe_collections = {"OrderedDict", "defaultdict"}
-
-    __allowed_classes = {
-        "datetime": {
-            "datetime",
-            "timezone",
-            "timedelta",
-        },
-        "networkx.classes.graph": {
-            "Graph",
-        },
-        "networkx.classes.multidigraph": {
-            "MultiDiGraph",
-        },
-        "otx.api.configuration.enums.config_element_type": {
-            "ConfigElementType",
-        },
-        "otx.api.entities.label_schema": {
-            "LabelTree",
-            "LabelGroup",
-            "LabelGroupType",
-            "LabelSchemaEntity",
-            "LabelGraph",
-        },
-        "otx.api.entities.id": {
-            "ID",
-        },
-        "otx.api.entities.label": {
-            "Domain",
-            "LabelEntity",
-        },
-        "otx.api.entities.color": {
-            "Color",
-        },
-        "otx.api.entities.model_template": {
-            "ModelTemplate",
-            "TaskFamily",
-            "TaskType",
-            "InstantiationType",
-            "TargetDevice",
-            "DatasetRequirements",
-            "HyperParameterData",
-            "EntryPoints",
-            "ExportableCodePaths",
-        },
-    }
-
-    def find_class(self, module_name, class_name):
-        """Find class in module_name."""
-        # Only allow safe classes from builtins.
-        if module_name in ["builtins", "__builtin__"] and class_name in self.__safe_builtins:
-            return getattr(builtins, class_name)
-        if module_name == "collections" and class_name in self.__safe_collections:
-            return getattr(collections, class_name)
-        for allowed_module_name, val in self.__allowed_classes.items():
-            if module_name == allowed_module_name and class_name in val:
-                module = importlib.import_module(module_name)
-                return getattr(module, class_name)
-
-        # Forbid everything else.
-        raise pickle.UnpicklingError(f"global '{module_name}.{class_name}' is forbidden")
-
-
-def main():
-    """Run run_hpo_trainer with a pickle file."""
-    hp_config = None
-    sys.path[0] = ""  # to prevent importing nncf from this directory
-
-    try:
-        with open(sys.argv[1], "rb") as pfile:
-            kwargs = HpoUnpickler(pfile).load()
-            hp_config = kwargs["hp_config"]
-
-            run_hpo_trainer(**kwargs)
-    except RuntimeError as err:
-        if str(err).startswith("CUDA out of memory"):
-            hpopt.reportOOM(hp_config)
-
-
-if __name__ == "__main__":
-    main()

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -436,19 +436,24 @@ class HpoRunner:
                 if max_val > self._train_dataset_size:
                     max_val = self._train_dataset_size
                     self._hpo_config["hp_space"][batch_size_name]["range"][1] = max_val
-
-                # If trainset size is lower than min batch size range,
-                # fix batch size to trainset size
-                if min_val >= max_val:
-                    logger.info(
-                        "Train set size is equal or lower than batch size range."
-                        "Batch size is fixed to train set size."
-                    )
-                    del self._hpo_config["hp_space"][batch_size_name]
-                    self._fixed_hp[batch_size_name] = self._train_dataset_size
-                    self._environment.set_hyper_parameter_using_str_key(self._fixed_hp)
             else:
-                raise NotImplementedError
+                max_val = self._hpo_config["hp_space"][batch_size_name]["max"]
+                min_val = self._hpo_config["hp_space"][batch_size_name]["min"]
+
+                if max_val > self._train_dataset_size:
+                    max_val = self._train_dataset_size
+                    self._hpo_config["hp_space"][batch_size_name]["max"] = max_val
+
+            # If trainset size is lower than min batch size range,
+            # fix batch size to trainset size
+            if min_val >= max_val:
+                logger.info(
+                    "Train set size is equal or lower than batch size range."
+                    "Batch size is fixed to train set size."
+                )
+                del self._hpo_config["hp_space"][batch_size_name]
+                self._fixed_hp[batch_size_name] = self._train_dataset_size
+                self._environment.set_hyper_parameter_using_str_key(self._fixed_hp)
 
     def run_hpo(self, train_func: Callable, data_roots: Dict[str, str]) -> Dict[str, Any]:
         """Run HPO and provides optimized hyper parameters.

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -849,7 +849,7 @@ class HpoDataset:
     Args:
         fullset: full dataset
         config (Optional[Dict[str, Any]], optional): hyper parameter trial config
-        indices (Optional[List[int]]): datatset index. Defaults to None.
+        indices (Optional[List[int]]): dataset index. Defaults to None.
     """
 
     def __init__(self, fullset, config: Optional[Dict[str, Any]] = None, indices: Optional[List[int]] = None):
@@ -878,7 +878,7 @@ class HpoDataset:
         return getattr(self.fullset, name)
 
     def get_subset(self, subset: Subset):
-        """Get subset according to subset_ratio if trainin dataset is requeseted.
+        """Get subset according to subset_ratio if training dataset is requested.
 
         Args:
             subset (Subset): which subset to get

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -686,7 +686,7 @@ class Trainer:
         else:
             initial_weight = self._load_fixed_initial_weight()
             if initial_weight is not None:
-                environment.load_model_weight(initial_weight, dataset)
+                environment.load_model_weight(str(initial_weight), dataset)
             else:
                 need_to_save_initial_weight = True
 

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -853,13 +853,13 @@ class HpoDataset:
     def __len__(self) -> int:
         """Get length of subset."""
         if self.indices is None:
-            raise RuntimeError("This function shouldn't be called before get_subset() is called.")
+            return len(self.fullset)
         return len(self.indices)
 
     def __getitem__(self, indx) -> dict:
         """Get dataset at index."""
         if self.indices is None:
-            raise RuntimeError("This function shouldn't be called before get_subset() is called.")
+            return self.fullset[indx]
         return self.fullset[self.indices[indx]]
 
     def __getattr__(self, name):

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -8,13 +8,13 @@ import json
 import logging
 import re
 import shutil
+from copy import deepcopy
 from enum import Enum
 from functools import partial
 from inspect import isclass
 from math import floor
-from typing import Any, Callable, Dict, List, Optional, Union
-from copy import deepcopy
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 import yaml

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -449,7 +449,7 @@ class HpoRunner:
             # fix batch size to trainset size
             if min_val >= max_val:
                 logger.info(
-                    "Train set size is equal or lower than batch size range." "Batch size is fixed to train set size."
+                    "Train set size is equal or lower than batch size range. Batch size is fixed to train set size."
                 )
                 del self._hpo_config["hp_space"][batch_size_name]
                 self._fixed_hp[batch_size_name] = self._train_dataset_size
@@ -578,7 +578,6 @@ def run_hpo(args, environment: TaskEnvironment, dataset: DatasetEntity, data_roo
     best_config = hpo_runner.run_hpo(run_trial, data_roots)
     logger.info("completed hyper-parameter optimization")
 
-    breakpoint()
     env_manager = TaskEnvironmentManager(environment)
     env_manager.set_hyper_parameter_using_str_key(best_config["config"])
     best_hpo_weight = get_best_hpo_weight(hpo_save_path, best_config["id"])

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -79,11 +79,11 @@ class TaskManager:
         """Task_type property."""
         return self._task_type
 
-    def is_mpa_framework_task(self) -> bool:
-        """Check task is run on MPA.
+    def is_mmcv_framework_task(self) -> bool:
+        """Check task is run on mmcv.
 
         Returns:
-            bool: whether task is run on MPA
+            bool: whether task is run on mmcv
         """
         return self.is_cls_framework_task() or self.is_det_framework_task() or self.is_seg_framework_task()
 
@@ -133,7 +133,7 @@ class TaskManager:
         Returns:
             str: batch size name
         """
-        if self.is_mpa_framework_task():
+        if self.is_mmcv_framework_task():
             batch_size_name = "learning_parameters.batch_size"
         elif self.is_anomaly_framework_task():
             batch_size_name = "learning_parameters.train_batch_size"
@@ -148,7 +148,7 @@ class TaskManager:
         Returns:
             str: epoch name
         """
-        if self.is_mpa_framework_task():
+        if self.is_mmcv_framework_task():
             epoch_name = "num_iters"
         elif self.is_anomaly_framework_task():
             epoch_name = "max_epochs"
@@ -166,7 +166,7 @@ class TaskManager:
         """
         src = Path(src)
         det = Path(det)
-        if self.is_mpa_framework_task():
+        if self.is_mmcv_framework_task():
             for weight_candidate in src.glob("**/*epoch*.pth"):
                 if not (weight_candidate.is_symlink() or (det / weight_candidate.name).exists()):
                     shutil.copy(weight_candidate, det)
@@ -184,7 +184,7 @@ class TaskManager:
         """
         latest_weight = None
         workdir = Path(workdir)
-        if self.is_mpa_framework_task():
+        if self.is_mmcv_framework_task():
             pattern = re.compile(r"(\d+)\.pth")
             current_latest_epoch = -1
             latest_weight = None

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -172,7 +172,7 @@ class TaskManager:
                 if not (osp.islink(weight_candidate) or osp.exists(osp.join(det, osp.basename(weight_candidate)))):
                     shutil.copy(weight_candidate, det)
         else:
-            return  # TODO need to implement after anomaly task supports resume 
+            return  # TODO need to implement after anomaly task supports resume
 
     def get_latest_weight(self, workdir: str) -> Optional[str]:
         """Get latest model weight from all weights.
@@ -449,8 +449,7 @@ class HpoRunner:
             # fix batch size to trainset size
             if min_val >= max_val:
                 logger.info(
-                    "Train set size is equal or lower than batch size range."
-                    "Batch size is fixed to train set size."
+                    "Train set size is equal or lower than batch size range." "Batch size is fixed to train set size."
                 )
                 del self._hpo_config["hp_space"][batch_size_name]
                 self._fixed_hp[batch_size_name] = self._train_dataset_size
@@ -579,6 +578,7 @@ def run_hpo(args, environment: TaskEnvironment, dataset: DatasetEntity, data_roo
     best_config = hpo_runner.run_hpo(run_trial, data_roots)
     logger.info("completed hyper-parameter optimization")
 
+    breakpoint()
     env_manager = TaskEnvironmentManager(environment)
     env_manager.set_hyper_parameter_using_str_key(best_config["config"])
     best_hpo_weight = get_best_hpo_weight(hpo_save_path, best_config["id"])
@@ -617,11 +617,11 @@ def get_best_hpo_weight(hpo_dir: str, trial_id: str) -> Optional[str]:
             best_score = score
             best_epochs = [eph]
         elif best_score == score:
-            best_epochs.append(score)
+            best_epochs.append(eph)
 
     best_weight = None
     for best_epoch in best_epochs:
-        best_weight_path = glob.glob(f"{hpo_dir}/weight/**/best*epoch*{best_epoch}*")
+        best_weight_path = glob.glob(f"{hpo_dir}/weight/**/*epoch*{best_epoch}*")
         if best_weight_path:
             best_weight = best_weight_path[0]
 
@@ -706,10 +706,10 @@ class Trainer:
         dataset_adapter = get_dataset_adapter(
             self._task.task_type,
             train_data_roots=self._data_roots["train_subset"]["data_root"],
-            val_data_roots=self._data_roots["val_subset"]["data_root"]
-            if "val_subset" in self._data_roots else None,
+            val_data_roots=self._data_roots["val_subset"]["data_root"] if "val_subset" in self._data_roots else None,
             unlabeled_data_roots=self._data_roots["unlabeled_subset"]["data_root"]
-            if "unlabeled_subset" in self._data_roots else None,
+            if "unlabeled_subset" in self._data_roots
+            else None,
         )
 
         return dataset_adapter

--- a/otx/cli/utils/tests.py
+++ b/otx/cli/utils/tests.py
@@ -17,8 +17,8 @@ import json
 import os
 import shutil
 import sys
-from typing import Dict
 from pathlib import Path
+from typing import Dict
 
 import pytest
 import yaml
@@ -185,13 +185,15 @@ def otx_hpo_testing(template, root, otx_dir, args):
 
     command_line.extend(args["train_params"])
     check_run(command_line)
-    trials_json = list(Path(f"{template_work_dir}/hpo/").rglob("*.json"))
+    trials_json = list(
+        filter(lambda x: x.name.split(".")[0].isnumeric(), Path(f"{template_work_dir}/hpo/").rglob("*.json"))
+    )
     assert trials_json
     for trial_json in trials_json:
         with trial_json.open("r") as f:
             trial_result = json.load(f)
         assert trial_result.get("score")
-        
+
     assert os.path.exists(f"{template_work_dir}/hpo_trained_{template.model_template_id}/weights.pth")
     assert os.path.exists(f"{template_work_dir}/hpo_trained_{template.model_template_id}/label_schema.json")
 

--- a/otx/cli/utils/tests.py
+++ b/otx/cli/utils/tests.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sys
 from typing import Dict
+from pathlib import Path
 
 import pytest
 import yaml
@@ -184,9 +185,13 @@ def otx_hpo_testing(template, root, otx_dir, args):
 
     command_line.extend(args["train_params"])
     check_run(command_line)
-    assert os.path.exists(f"{template_work_dir}/hpo/hpopt_status.json")
-    with open(f"{template_work_dir}/hpo/hpopt_status.json", "r") as f:
-        assert json.load(f).get("best_config_id", None) is not None
+    trials_json = list(Path(f"{template_work_dir}/hpo/").rglob("*.json"))
+    assert trials_json
+    for trial_json in trials_json:
+        with trial_json.open("r") as f:
+            trial_result = json.load(f)
+        assert trial_result.get("score")
+        
     assert os.path.exists(f"{template_work_dir}/hpo_trained_{template.model_template_id}/weights.pth")
     assert os.path.exists(f"{template_work_dir}/hpo_trained_{template.model_template_id}/label_schema.json")
 

--- a/otx/mpa/modules/hooks/adaptive_training_hooks.py
+++ b/otx/mpa/modules/hooks/adaptive_training_hooks.py
@@ -74,6 +74,7 @@ class AdaptiveTrainSchedulingHook(Hook):
             self._original_interval = None
 
         if self.enable_adaptive_interval_hook and not self._initialized:
+            self.max_interval = min(self.max_interval, runner.max_epochs - runner.epoch)
             iter_per_epoch = len(runner.data_loader)
             adaptive_interval = self.get_adaptive_interval(iter_per_epoch)
             for hook in runner.hooks:

--- a/otx/mpa/modules/hooks/checkpoint_hook.py
+++ b/otx/mpa/modules/hooks/checkpoint_hook.py
@@ -81,9 +81,7 @@ class CheckpointHookWithValResults(Hook):
             weight_name = f"best_epoch_{runner.epoch + 1}.pth"
         else:
             weight_name = f"best_iter_{runner.iter + 1}.pth"
-        runner.save_checkpoint(
-            self.out_dir, filename_tmpl=weight_name, save_optimizer=self.save_optimizer, **self.args
-        )
+        runner.save_checkpoint(self.out_dir, filename_tmpl=weight_name, save_optimizer=self.save_optimizer, **self.args)
 
         self._best_model_weight = Path(weight_name)
         if runner.meta is not None:
@@ -101,8 +99,10 @@ class CheckpointHookWithValResults(Hook):
             cur_step = runner.iter + 1
 
         runner.save_checkpoint(
-            self.out_dir, filename_tmpl=weight_name_format.format(cur_step),
-            save_optimizer=self.save_optimizer, **self.args
+            self.out_dir,
+            filename_tmpl=weight_name_format.format(cur_step),
+            save_optimizer=self.save_optimizer,
+            **self.args,
         )
 
         # remove other checkpoints

--- a/otx/mpa/modules/hooks/checkpoint_hook.py
+++ b/otx/mpa/modules/hooks/checkpoint_hook.py
@@ -32,16 +32,14 @@ class CheckpointHookWithValResults(Hook):
             gpus. Default: False.
     """
 
-    def __init__(
-        self,
-        interval=-1,
-        by_epoch=True,
-        save_optimizer=True,
-        out_dir=None,
-        max_keep_ckpts=-1,
-        sync_buffer=False,
-        **kwargs,
-    ):
+    def __init__(self,
+                 interval=-1,
+                 by_epoch=True,
+                 save_optimizer=True,
+                 out_dir=None,
+                 max_keep_ckpts=-1,
+                 sync_buffer=False,
+                 **kwargs):
         self.interval = interval
         self.by_epoch = by_epoch
         self.save_optimizer = save_optimizer
@@ -50,42 +48,74 @@ class CheckpointHookWithValResults(Hook):
         self.args = kwargs
         self.sync_buffer = sync_buffer
 
+    def before_run(self, runner):
+        if not self.out_dir:
+            self.out_dir = runner.work_dir
+
     def after_train_epoch(self, runner):
         if not self.by_epoch or not self.every_n_epochs(runner, self.interval):
             return
-        if hasattr(runner, "save_ckpt") and runner.save_ckpt:
-            if hasattr(runner, "save_ema_model") and runner.save_ema_model:
-                backup_model = runner.model
-                runner.model = runner.ema_model
-            runner.logger.info(f"Saving checkpoint at {runner.epoch + 1} epochs")
-            if self.sync_buffer:
-                allreduce_params(runner.model.buffers())
+
+        if self.sync_buffer:
+            allreduce_params(runner.model.buffers())
+        if getattr(runner, "save_ckpt", False):
+            runner.logger.info(f'Saving best checkpoint at {runner.epoch + 1} epochs')
             self._save_checkpoint(runner)
-            if hasattr(runner, "save_ema_model") and runner.save_ema_model:
-                runner.model = backup_model
-                runner.save_ema_model = False
             runner.save_ckpt = False
+        self._save_last_epoch(runner)
 
     @master_only
     def _save_checkpoint(self, runner):
         """Save the current checkpoint and delete unwanted checkpoint."""
-        if not self.out_dir:
-            self.out_dir = runner.work_dir
+        cur_ckpt_filename = f'best_epoch_{runner.epoch + 1}.pth'
         runner.save_checkpoint(
-            self.out_dir, filename_tmpl="best_model.pth", save_optimizer=self.save_optimizer, **self.args
-        )
+            self.out_dir, filename_tmpl=cur_ckpt_filename, save_optimizer=self.save_optimizer, **self.args)
         if runner.meta is not None:
-            cur_ckpt_filename = "best_model.pth"
-            runner.meta.setdefault("hook_msgs", dict())
-            runner.meta["hook_msgs"]["last_ckpt"] = os.path.join(self.out_dir, cur_ckpt_filename)
+            runner.meta.setdefault('hook_msgs', dict())
+            runner.meta['hook_msgs']['best_ckpt'] = os.path.join(
+                self.out_dir, cur_ckpt_filename)
+
+    @master_only
+    def _save_last_epoch(self, runner):
+        """Save the current checkpoint and delete unwanted checkpoint."""
+        runner.save_checkpoint(
+            self.out_dir, save_optimizer=self.save_optimizer, **self.args)
+        if runner.meta is not None:
+            if self.by_epoch:
+                cur_ckpt_filename = self.args.get('filename_tmpl', f'epoch_{runner.epoch + 1}.pth')
+            else:
+                cur_ckpt_filename = self.args.get('filename_tmpl', f'iter_{runner.iter + 1}.pth')
+            runner.meta.setdefault('hook_msgs', dict())
+            runner.meta['hook_msgs']['last_ckpt'] = os.path.join(
+                self.out_dir, cur_ckpt_filename)
+        # remove other checkpoints
+        if self.max_keep_ckpts > 0:
+            if self.by_epoch:
+                name = 'epoch_{}.pth'
+                current_ckpt = runner.epoch + 1
+            else:
+                name = 'iter_{}.pth'
+                current_ckpt = runner.iter + 1
+            redundant_ckpts = range(
+                current_ckpt - self.max_keep_ckpts * self.interval, 0,
+                -self.interval)
+            filename_tmpl = self.args.get('filename_tmpl', name)
+            for _step in redundant_ckpts:
+                ckpt_path = os.path.join(self.out_dir,
+                                         filename_tmpl.format(_step))
+                if os.path.exists(ckpt_path):
+                    os.remove(ckpt_path)
+                else:
+                    break
 
     def after_train_iter(self, runner):
         if self.by_epoch or not self.every_n_iters(runner, self.interval):
             return
 
-        if hasattr(runner, "save_ckpt"):
+        if hasattr(runner, 'save_ckpt'):
             if runner.save_ckpt:
-                runner.logger.info(f"Saving checkpoint at {runner.iter + 1} iterations")
+                runner.logger.info(
+                    f'Saving checkpoint at {runner.iter + 1} iterations')
                 if self.sync_buffer:
                     allreduce_params(runner.model.buffers())
                 self._save_checkpoint(runner)

--- a/otx/mpa/modules/hooks/checkpoint_hook.py
+++ b/otx/mpa/modules/hooks/checkpoint_hook.py
@@ -32,14 +32,16 @@ class CheckpointHookWithValResults(Hook):
             gpus. Default: False.
     """
 
-    def __init__(self,
-                 interval=-1,
-                 by_epoch=True,
-                 save_optimizer=True,
-                 out_dir=None,
-                 max_keep_ckpts=-1,
-                 sync_buffer=False,
-                 **kwargs):
+    def __init__(
+        self,
+        interval=-1,
+        by_epoch=True,
+        save_optimizer=True,
+        out_dir=None,
+        max_keep_ckpts=-1,
+        sync_buffer=False,
+        **kwargs,
+    ):
         self.interval = interval
         self.by_epoch = by_epoch
         self.save_optimizer = save_optimizer
@@ -59,7 +61,7 @@ class CheckpointHookWithValResults(Hook):
         if self.sync_buffer:
             allreduce_params(runner.model.buffers())
         if getattr(runner, "save_ckpt", False):
-            runner.logger.info(f'Saving best checkpoint at {runner.epoch + 1} epochs')
+            runner.logger.info(f"Saving best checkpoint at {runner.epoch + 1} epochs")
             self._save_checkpoint(runner)
             runner.save_ckpt = False
         self._save_last_epoch(runner)
@@ -67,42 +69,37 @@ class CheckpointHookWithValResults(Hook):
     @master_only
     def _save_checkpoint(self, runner):
         """Save the current checkpoint and delete unwanted checkpoint."""
-        cur_ckpt_filename = f'best_epoch_{runner.epoch + 1}.pth'
+        cur_ckpt_filename = f"best_epoch_{runner.epoch + 1}.pth"
         runner.save_checkpoint(
-            self.out_dir, filename_tmpl=cur_ckpt_filename, save_optimizer=self.save_optimizer, **self.args)
+            self.out_dir, filename_tmpl=cur_ckpt_filename, save_optimizer=self.save_optimizer, **self.args
+        )
         if runner.meta is not None:
-            runner.meta.setdefault('hook_msgs', dict())
-            runner.meta['hook_msgs']['best_ckpt'] = os.path.join(
-                self.out_dir, cur_ckpt_filename)
+            runner.meta.setdefault("hook_msgs", dict())
+            runner.meta["hook_msgs"]["best_ckpt"] = os.path.join(self.out_dir, cur_ckpt_filename)
 
     @master_only
     def _save_last_epoch(self, runner):
         """Save the current checkpoint and delete unwanted checkpoint."""
-        runner.save_checkpoint(
-            self.out_dir, save_optimizer=self.save_optimizer, **self.args)
+        runner.save_checkpoint(self.out_dir, save_optimizer=self.save_optimizer, **self.args)
         if runner.meta is not None:
             if self.by_epoch:
-                cur_ckpt_filename = self.args.get('filename_tmpl', f'epoch_{runner.epoch + 1}.pth')
+                cur_ckpt_filename = self.args.get("filename_tmpl", f"epoch_{runner.epoch + 1}.pth")
             else:
-                cur_ckpt_filename = self.args.get('filename_tmpl', f'iter_{runner.iter + 1}.pth')
-            runner.meta.setdefault('hook_msgs', dict())
-            runner.meta['hook_msgs']['last_ckpt'] = os.path.join(
-                self.out_dir, cur_ckpt_filename)
+                cur_ckpt_filename = self.args.get("filename_tmpl", f"iter_{runner.iter + 1}.pth")
+            runner.meta.setdefault("hook_msgs", dict())
+            runner.meta["hook_msgs"]["last_ckpt"] = os.path.join(self.out_dir, cur_ckpt_filename)
         # remove other checkpoints
         if self.max_keep_ckpts > 0:
             if self.by_epoch:
-                name = 'epoch_{}.pth'
+                name = "epoch_{}.pth"
                 current_ckpt = runner.epoch + 1
             else:
-                name = 'iter_{}.pth'
+                name = "iter_{}.pth"
                 current_ckpt = runner.iter + 1
-            redundant_ckpts = range(
-                current_ckpt - self.max_keep_ckpts * self.interval, 0,
-                -self.interval)
-            filename_tmpl = self.args.get('filename_tmpl', name)
+            redundant_ckpts = range(current_ckpt - self.max_keep_ckpts * self.interval, 0, -self.interval)
+            filename_tmpl = self.args.get("filename_tmpl", name)
             for _step in redundant_ckpts:
-                ckpt_path = os.path.join(self.out_dir,
-                                         filename_tmpl.format(_step))
+                ckpt_path = os.path.join(self.out_dir, filename_tmpl.format(_step))
                 if os.path.exists(ckpt_path):
                     os.remove(ckpt_path)
                 else:
@@ -112,10 +109,9 @@ class CheckpointHookWithValResults(Hook):
         if self.by_epoch or not self.every_n_iters(runner, self.interval):
             return
 
-        if hasattr(runner, 'save_ckpt'):
+        if hasattr(runner, "save_ckpt"):
             if runner.save_ckpt:
-                runner.logger.info(
-                    f'Saving checkpoint at {runner.iter + 1} iterations')
+                runner.logger.info(f"Saving checkpoint at {runner.iter + 1} iterations")
                 if self.sync_buffer:
                     allreduce_params(runner.model.buffers())
                 self._save_checkpoint(runner)

--- a/otx/mpa/modules/hooks/save_initial_weight_hook.py
+++ b/otx/mpa/modules/hooks/save_initial_weight_hook.py
@@ -2,17 +2,28 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from typing import Optional, Callable
+
 from mmcv.runner import HOOKS, Hook
 
 
 @HOOKS.register_module()
 class SaveInitialWeightHook(Hook):
-    def __init__(self, save_path, **kwargs):
-        self.save_path = save_path
-        self.args = kwargs
+    def __init__(self, save_path, file_name: str = "weights.pth", after_save_func: Optional[Callable] = None, **kwargs):
+        self._save_path = save_path
+        self._file_name = file_name
+        self._after_save_func = after_save_func
+        self._args = kwargs
 
     def before_run(self, runner):
-        runner.logger.info("Saving weight before training")
+        runner.logger.info('Saving weight before training')
         runner.save_checkpoint(
-            self.save_path, filename_tmpl="weights.pth", save_optimizer=False, create_symlink=False, **self.args
+            self._save_path,
+            filename_tmpl=self._file_name,
+            save_optimizer=False,
+            create_symlink=False,
+            **self._args
         )
+
+        if self._after_save_func is not None:
+            self._after_save_func()

--- a/otx/mpa/modules/hooks/save_initial_weight_hook.py
+++ b/otx/mpa/modules/hooks/save_initial_weight_hook.py
@@ -2,17 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from typing import Optional, Callable
-
 from mmcv.runner import HOOKS, Hook
 
 
 @HOOKS.register_module()
 class SaveInitialWeightHook(Hook):
-    def __init__(self, save_path, file_name: str = "weights.pth", after_save_func: Optional[Callable] = None, **kwargs):
+    def __init__(self, save_path, file_name: str = "weights.pth", **kwargs):
         self._save_path = save_path
         self._file_name = file_name
-        self._after_save_func = after_save_func
         self._args = kwargs
 
     def before_run(self, runner):
@@ -24,6 +21,3 @@ class SaveInitialWeightHook(Hook):
             create_symlink=False,
             **self._args
         )
-
-        if self._after_save_func is not None:
-            self._after_save_func()

--- a/otx/mpa/modules/hooks/save_initial_weight_hook.py
+++ b/otx/mpa/modules/hooks/save_initial_weight_hook.py
@@ -13,11 +13,7 @@ class SaveInitialWeightHook(Hook):
         self._args = kwargs
 
     def before_run(self, runner):
-        runner.logger.info('Saving weight before training')
+        runner.logger.info("Saving weight before training")
         runner.save_checkpoint(
-            self._save_path,
-            filename_tmpl=self._file_name,
-            save_optimizer=False,
-            create_symlink=False,
-            **self._args
+            self._save_path, filename_tmpl=self._file_name, save_optimizer=False, create_symlink=False, **self._args
         )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ torch>=1.8.2  # To be removed (as prerequisite)
 torchvision>=0.9.2  # To be removed (as prerequisite)
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
-hpopt @ git+https://github.com/openvinotoolkit/hyper_parameter_optimization@new_asha_with_refactored_hpopt
+hpopt @ git+https://github.com/openvinotoolkit/hyper_parameter_optimization@new_hpo
 imagesize==1.4.1
 datumaro==0.4.0.1
 psutil

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ torch>=1.8.2  # To be removed (as prerequisite)
 torchvision>=0.9.2  # To be removed (as prerequisite)
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
-hpopt==0.3.0
+hpopt @ git+https://github.com/openvinotoolkit/hyper_parameter_optimization@new_asha_with_refactored_hpopt
 imagesize==1.4.1
 datumaro==0.4.0.1
 psutil

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -155,8 +155,8 @@ class TestTaskManager:
             assert task_manager.get_latest_weight(work_dir) == str(latest_model_weight)
 
 
-def get_template_path(task_name: str) -> Path:
-    task_config_dir = OTX_ROOT_PATH / "algorithms" / task_name / "configs"
+def get_template_path(template_dir: str) -> Path:
+    task_config_dir = OTX_ROOT_PATH / "algorithms" / template_dir
     return list(task_config_dir.glob("**/template.yaml"))[0]
 
 
@@ -167,22 +167,22 @@ def make_task_env(template_path: str) -> TaskEnvironment:
 
 @pytest.fixture(scope="module")
 def cls_template_path() -> str:
-    return str(get_template_path("classification"))
+    return str(get_template_path("classification/configs"))
 
 
 @pytest.fixture(scope="module")
 def det_template_path() -> str:
-    return str(get_template_path("detection"))
+    return str(get_template_path("detection/configs/detection"))
 
 
 @pytest.fixture(scope="module")
 def seg_template_path() -> str:
-    return str(get_template_path("segmentation"))
+    return str(get_template_path("segmentation/configs"))
 
 
 @pytest.fixture(scope="module")
 def anomaly_template_path() -> str:
-    return str(get_template_path("anomaly"))
+    return str(get_template_path("anomaly/configs"))
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -22,11 +22,12 @@ from otx.cli.utils.hpo import (
     TaskEnvironmentManager,
     TaskManager,
     Trainer,
-    check_hpopt_available,
     get_best_hpo_weight,
+    is_hpopt_available,
     run_hpo,
     run_trial,
 )
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 CLASSIFCATION_TASK = {TaskType.CLASSIFICATION}
 DETECTION_TASK = {TaskType.DETECTION, TaskType.INSTANCE_SEGMENTATION, TaskType.ROTATED_DETECTION}
@@ -38,66 +39,79 @@ OTX_ROOT_PATH = Path(otx.__file__).parent
 
 
 class TestTaskManager:
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", MMCV_TASK)
     def test_is_mmcv_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.is_mmcv_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ANOMALY_TASK)
     def test_is_not_mmcv_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert not task_manager.is_mmcv_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", CLASSIFCATION_TASK)
     def test_is_cls_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.is_cls_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ALL_TASK - CLASSIFCATION_TASK)
     def test_is_not_cls_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert not task_manager.is_cls_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", DETECTION_TASK)
     def test_is_det_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.is_det_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ALL_TASK - DETECTION_TASK)
     def test_is_not_det_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert not task_manager.is_det_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", SEGMENTATION_TASK)
     def test_is_seg_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.is_seg_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ALL_TASK - SEGMENTATION_TASK)
     def test_is_not_seg_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert not task_manager.is_seg_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ANOMALY_TASK)
     def test_is_anomaly_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.is_anomaly_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ALL_TASK - ANOMALY_TASK)
     def test_is_not_anomaly_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
         assert not task_manager.is_anomaly_framework_task()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", MMCV_TASK)
     def test_get_mmcv_batch_size_name(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.get_batch_size_name() == "learning_parameters.batch_size"
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ANOMALY_TASK)
     def test_get_anomaly_batch_size_name(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.get_batch_size_name() == "learning_parameters.train_batch_size"
 
+    @e2e_pytest_unit
     def test_get_unknown_task_batch_size_name(self, mocker):
         mock_func1 = mocker.patch.object(TaskManager, "is_mmcv_framework_task")
         mock_func1.return_value = False
@@ -109,16 +123,19 @@ class TestTaskManager:
         with pytest.raises(RuntimeError):
             task_manager.get_batch_size_name()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", MMCV_TASK)
     def test_get_mmcv_epoch_name(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.get_epoch_name() == "num_iters"
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ANOMALY_TASK)
     def test_get_anomaly_epoch_name(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.get_epoch_name() == "max_epochs"
 
+    @e2e_pytest_unit
     def test_get_unknown_task_epoch_name(self, mocker):
         mock_func1 = mocker.patch.object(TaskManager, "is_mmcv_framework_task")
         mock_func1.return_value = False
@@ -130,6 +147,7 @@ class TestTaskManager:
         with pytest.raises(RuntimeError):
             task_manager.get_epoch_name()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", MMCV_TASK)
     def test_copy_weight(self, task: TaskType):
         task_manager = TaskManager(task)
@@ -142,6 +160,7 @@ class TestTaskManager:
 
             assert weight_in_det.exists()
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", MMCV_TASK)
     def test_get_latest_weight(self, task: TaskType):
         task_manager = TaskManager(task)
@@ -236,10 +255,12 @@ class TestTaskEnvironmentManager:
     def _make_mock_task_env(self, mock_environment):
         self._mock_environment = mock_environment
 
+    @e2e_pytest_unit
     def test_init(self, all_task_env):
         for task_env in all_task_env:
             TaskEnvironmentManager(task_env)
 
+    @e2e_pytest_unit
     def test_get_task(self, cls_task_env, det_task_env, seg_task_env):
         task_env = TaskEnvironmentManager(cls_task_env)
         assert task_env.get_task() == TaskType.CLASSIFICATION
@@ -250,6 +271,7 @@ class TestTaskEnvironmentManager:
         task_env = TaskEnvironmentManager(seg_task_env)
         assert task_env.get_task() == TaskType.SEGMENTATION
 
+    @e2e_pytest_unit
     def test_get_model_template(
         self, cls_task_env, det_task_env, seg_task_env, cls_template_path, det_template_path, seg_template_path
     ):
@@ -262,6 +284,7 @@ class TestTaskEnvironmentManager:
         task_env = TaskEnvironmentManager(seg_task_env)
         assert task_env.get_model_template() == find_and_parse_model_template(seg_template_path)
 
+    @e2e_pytest_unit
     def test_get_model_template_path(
         self, cls_task_env, det_task_env, seg_task_env, cls_template_path, det_template_path, seg_template_path
     ):
@@ -274,6 +297,7 @@ class TestTaskEnvironmentManager:
         task_env = TaskEnvironmentManager(seg_task_env)
         assert task_env.get_model_template_path() == seg_template_path
 
+    @e2e_pytest_unit
     def test_set_hyper_parameter_using_str_key(self):
         task_env = TaskEnvironmentManager(self._mock_environment)
         hyper_parameter = {"a.b.c.d": 1, "e.f.g.h": 2}
@@ -285,6 +309,7 @@ class TestTaskEnvironmentManager:
         assert env_hp.a.b.c.d == hyper_parameter["a.b.c.d"]
         assert env_hp.e.f.g.h == hyper_parameter["e.f.g.h"]
 
+    @e2e_pytest_unit
     def test_get_dict_type_hyper_parameter(self):
         learning_parameters = self._mock_environment.get_hyper_parameters().learning_parameters
         learning_parameters.parameters = ["a", "b"]
@@ -297,6 +322,7 @@ class TestTaskEnvironmentManager:
         assert dict_hp["learning_parameters.a"] == 1
         assert dict_hp["learning_parameters.b"] == 2
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("task", ALL_TASK)
     def test_get_max_epoch(self, task):
         max_epoch = 10
@@ -308,12 +334,14 @@ class TestTaskEnvironmentManager:
 
         assert task_env.get_max_epoch() == max_epoch
 
+    @e2e_pytest_unit
     def test_save_mmcv_initial_weight(self, mmcv_task_env):
         for task_env in mmcv_task_env:
             task_env.model = None
             task_env = TaskEnvironmentManager(task_env)
             assert not task_env.save_initial_weight("fake_path")
 
+    @e2e_pytest_unit
     def test_save_anomaly_initial_weight(self, mocker, anomaly_task_env):
         def mock_save_model_data(model, save_path: str):
             (Path(save_path) / "weights.pth").write_text("fake")
@@ -327,6 +355,7 @@ class TestTaskEnvironmentManager:
             assert task_env.save_initial_weight(str(save_path))
             assert save_path.exists()
 
+    @e2e_pytest_unit
     def test_loaded_inital_weight(self, mocker, all_task_env):
         def mock_save_model_data(model, save_path: str):
             (Path(save_path) / "weights.pth").write_text("fake")
@@ -341,6 +370,7 @@ class TestTaskEnvironmentManager:
                 assert task_env.save_initial_weight(str(save_path))
                 assert save_path.exists()
 
+    @e2e_pytest_unit
     def test_get_train_task(self, mocker, all_task_env):
         mock_func = mocker.patch("otx.cli.utils.hpo.get_impl_class")
 
@@ -352,15 +382,18 @@ class TestTaskEnvironmentManager:
 
             mock_class.assert_not_called()
 
+    @e2e_pytest_unit
     def test_get_mmcv_batch_size_name(self, mmcv_task_env):
         for task_env in mmcv_task_env:
             task_env = TaskEnvironmentManager(task_env)
             assert task_env.get_batch_size_name() == "learning_parameters.batch_size"
 
+    @e2e_pytest_unit
     def test_get_anomaly_batch_size_name(self, anomaly_task_env):
         task_env = TaskEnvironmentManager(anomaly_task_env)
         assert task_env.get_batch_size_name() == "learning_parameters.train_batch_size"
 
+    @e2e_pytest_unit
     def test_load_model_weight(self, mocker, all_task_env):
         mock_func = mocker.patch("otx.cli.utils.hpo.read_model")
 
@@ -371,6 +404,7 @@ class TestTaskEnvironmentManager:
             task_manager.load_model_weight("fake", mocker.MagicMock())
             assert task_env.model == mock_class
 
+    @e2e_pytest_unit
     def test_resume_model_weight(self, mocker, all_task_env):
         mock_func = mocker.patch("otx.cli.utils.hpo.read_model")
 
@@ -382,12 +416,14 @@ class TestTaskEnvironmentManager:
             assert task_env.model == mock_class
             assert mock_class.model_adapters["resume"]
 
+    @e2e_pytest_unit
     def test_get_new_model_entity(self, all_task_env):
         for task_env in all_task_env:
             task_manager = TaskEnvironmentManager(task_env)
             model_entity = task_manager.get_new_model_entity()
             assert isinstance(model_entity, ModelEntity)
 
+    @e2e_pytest_unit
     def test_set_epoch(self, all_task_env):
         epoch = 123
         for task_env in all_task_env:
@@ -397,20 +433,24 @@ class TestTaskEnvironmentManager:
 
 
 class TestHpoRunner:
+    @e2e_pytest_unit
     def test_init(self, all_task_env):
         for task_env in all_task_env:
             HpoRunner(task_env, 100, 10, "fake_path")
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("train_dataset_size,val_dataset_size", [(0, 10), (10, 0), (-1, -1)])
     def test_init_wrong_dataset_size(self, cls_task_env, train_dataset_size, val_dataset_size):
         with pytest.raises(ValueError):
             HpoRunner(cls_task_env, train_dataset_size, val_dataset_size, "fake_path", 4)
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("hpo_time_ratio", [-3, 0])
     def test_init_wrong_hpo_time_ratio(self, cls_task_env, hpo_time_ratio):
         with pytest.raises(ValueError):
             HpoRunner(cls_task_env, 100, 10, "fake_path", hpo_time_ratio)
 
+    @e2e_pytest_unit
     def test_run_hpo(self, mocker, cls_task_env):
         cls_task_env.model = None
         hpo_runner = HpoRunner(cls_task_env, 100, 10, "fake_path")
@@ -422,6 +462,7 @@ class TestHpoRunner:
         mock_run_hpo_loop.assert_called()  # call hpo_loop to run HPO
         mock_hb.assert_called()  # make hyperband
 
+    @e2e_pytest_unit
     def test_run_hpo_w_dataset_smaller_than_batch(self, mocker, cls_task_env):
         cls_task_env.model = None
         hpo_runner = HpoRunner(cls_task_env, 2, 10, "fake_path")
@@ -435,6 +476,7 @@ class TestHpoRunner:
 
 
 class TestTrainer:
+    @e2e_pytest_unit
     def test_init(self, mocker, cls_template_path):
         Trainer(
             hp_config={"configuration": {"iterations": 10}},
@@ -447,6 +489,7 @@ class TestTrainer:
             metric="fake",
         )
 
+    @e2e_pytest_unit
     def test_run(self, mocker, cls_template_path):
         with TemporaryDirectory() as tmp_dir:
             # prepare
@@ -491,14 +534,17 @@ class TestTrainer:
 
 
 class TestHpoCallback:
+    @e2e_pytest_unit
     def test_init(self, mocker):
         HpoCallback(mocker.MagicMock(), "fake", 3, mocker.MagicMock())
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("max_epoch", [-3, 0])
     def test_init_wrong_max_epoch(self, mocker, max_epoch):
         with pytest.raises(ValueError):
             HpoCallback(mocker.MagicMock(), "fake", max_epoch, mocker.MagicMock())
 
+    @e2e_pytest_unit
     def test_call(self, mocker):
         mock_report_func = mocker.MagicMock()
 
@@ -507,6 +553,7 @@ class TestHpoCallback:
 
         mock_report_func.assert_called_once_with(progress=10, score=100)
 
+    @e2e_pytest_unit
     def test_call_and_get_stop_flag(self, mocker):
         mock_report_func = mocker.MagicMock()
         mock_report_func.return_value = TrialStatus.STOP
@@ -517,6 +564,7 @@ class TestHpoCallback:
 
         mock_task.cancel_training.assert_called_once_with()
 
+    @e2e_pytest_unit
     def test_not_copy_report_func(self, mocker):
         mock_report_func = mocker.MagicMock()
 
@@ -528,10 +576,12 @@ class TestHpoCallback:
 
 
 class TestHpoDataset:
+    @e2e_pytest_unit
     def test_init(self, mocker):
         hpo_dataset = HpoDataset(fullset=mocker.MagicMock(), config={"train_environment": {"subset_ratio": 0.5}})
         assert hpo_dataset.subset_ratio == 0.5
 
+    @e2e_pytest_unit
     @pytest.mark.parametrize("subset_ratio", [0.1, 0.5, 1])
     def test_get_subset(self, mocker, subset_ratio):
         mock_fullset = mocker.MagicMock()
@@ -547,10 +597,12 @@ class TestHpoDataset:
         for i in range(num_hpo_sub_dataset):
             hpo_sub_dataset[i]
 
+    @e2e_pytest_unit
     def test_len_before_get_subset(self):
         hpo_dataset = HpoDataset(fullset=range(10), config={"train_environment": {"subset_ratio": 0.5}})
         assert len(hpo_dataset) == 10
 
+    @e2e_pytest_unit
     def test_getitem_before_get_subset(self):
         hpo_dataset = HpoDataset(fullset=range(10), config={"train_environment": {"subset_ratio": 0.5}})
 
@@ -558,16 +610,19 @@ class TestHpoDataset:
             pass
 
 
-def test_check_hpopt_available(mocker):
+@e2e_pytest_unit
+def test_is_hpopt_available(mocker):
     mocker.patch("otx.cli.utils.hpo.hpopt")
-    assert check_hpopt_available()
+    assert is_hpopt_available()
 
 
+@e2e_pytest_unit
 def test_check_hpopt_unavailable(mocker):
     mocker.patch("otx.cli.utils.hpo.hpopt", None)
-    assert not check_hpopt_available()
+    assert not is_hpopt_available()
 
 
+@e2e_pytest_unit
 def test_run_hpo(mocker, mock_environment):
     with TemporaryDirectory() as tmp_dir:
         # prepare
@@ -606,6 +661,7 @@ def test_run_hpo(mocker, mock_environment):
         assert mock_environment.model == "mock_best_weight_path"  # check that best model weight is used
 
 
+@e2e_pytest_unit
 def test_run_hpo_hpopt_unavailable(mocker):
     mock_hpo_runner_instance = mocker.MagicMock()
     mock_hpo_runner_class = mocker.patch("otx.cli.utils.hpo.HpoRunner")
@@ -617,6 +673,7 @@ def test_run_hpo_hpopt_unavailable(mocker):
     mock_hpo_runner_instance.run_hpo.assert_not_called()
 
 
+@e2e_pytest_unit
 def test_run_hpo_not_supported_task(mocker, action_task_env):
     mock_hpo_runner_instance = mocker.MagicMock()
     mock_hpo_runner_class = mocker.patch("otx.cli.utils.hpo.HpoRunner")
@@ -626,6 +683,7 @@ def test_run_hpo_not_supported_task(mocker, action_task_env):
     mock_hpo_runner_instance.run_hpo.assert_not_called()
 
 
+@e2e_pytest_unit
 def test_get_best_hpo_weight():
     with TemporaryDirectory() as tmp_dir:
         # prepare
@@ -647,6 +705,7 @@ def test_get_best_hpo_weight():
         assert get_best_hpo_weight(hpo_dir, "1") == str(weight_path / "1" / "epoch_10.pth")
 
 
+@e2e_pytest_unit
 def test_get_best_hpo_weight_not_exist():
     with TemporaryDirectory() as tmp_dir:
         # prepare
@@ -668,6 +727,7 @@ def test_get_best_hpo_weight_not_exist():
         assert get_best_hpo_weight(hpo_dir, "1") is None
 
 
+@e2e_pytest_unit
 def test_run_trial(mocker):
     mock_run = mocker.patch.object(Trainer, "run")
     run_trial(

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -201,7 +201,7 @@ def seg_template_path() -> str:
 
 @pytest.fixture(scope="module")
 def anomaly_template_path() -> str:
-    return str(get_template_path("anomaly/configs"))
+    return str(OTX_ROOT_PATH / "algorithms/anomaly/configs/classification/stfpm/template.yaml")
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -1,0 +1,376 @@
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List
+
+import pytest
+
+import otx
+from otx.api.configuration.helper import create as create_conf_hp
+from otx.api.entities.task_environment import TaskEnvironment
+from otx.api.entities.model_template import TaskType
+from otx.api.entities.model import ModelEntity
+from otx.cli.registry import find_and_parse_model_template
+from otx.cli.utils.hpo import (
+    TaskManager,
+    TaskEnvironmentManager,
+    check_hpopt_available
+)
+
+from tempfile import TemporaryDirectory
+
+CLASSIFCATION_TASK = {TaskType.CLASSIFICATION}
+DETECTION_TASK = {TaskType.DETECTION, TaskType.INSTANCE_SEGMENTATION, TaskType.ROTATED_DETECTION}
+SEGMENTATION_TASK = {TaskType.SEGMENTATION}
+ANOMALY_TASK = {TaskType.ANOMALY_CLASSIFICATION, TaskType.ANOMALY_DETECTION, TaskType.ANOMALY_SEGMENTATION}
+MPA_TASK = CLASSIFCATION_TASK | DETECTION_TASK | SEGMENTATION_TASK
+ALL_TASK = MPA_TASK | ANOMALY_TASK
+OTX_ROOT_PATH = Path(otx.__file__).parent
+
+
+class TestTaskManager:
+    @pytest.mark.parametrize("task", MPA_TASK)
+    def test_is_mpa_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.is_mpa_framework_task()
+
+    @pytest.mark.parametrize("task", ANOMALY_TASK)
+    def test_is_not_mpa_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert not task_manager.is_mpa_framework_task()
+
+    @pytest.mark.parametrize("task", CLASSIFCATION_TASK)
+    def test_is_cls_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.is_cls_framework_task()
+
+    @pytest.mark.parametrize("task", ALL_TASK - CLASSIFCATION_TASK)
+    def test_is_not_cls_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert not task_manager.is_cls_framework_task()
+
+    @pytest.mark.parametrize("task", DETECTION_TASK)
+    def test_is_det_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.is_det_framework_task()
+
+    @pytest.mark.parametrize("task", ALL_TASK - DETECTION_TASK)
+    def test_is_det_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert not task_manager.is_det_framework_task()
+
+    @pytest.mark.parametrize("task", SEGMENTATION_TASK)
+    def test_is_seg_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.is_seg_framework_task()
+
+    @pytest.mark.parametrize("task", ALL_TASK - SEGMENTATION_TASK)
+    def test_is_seg_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert not task_manager.is_seg_framework_task()
+
+    @pytest.mark.parametrize("task", ANOMALY_TASK)
+    def test_is_anomaly_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.is_anomaly_framework_task()
+
+    @pytest.mark.parametrize("task", ALL_TASK - ANOMALY_TASK)
+    def test_is_anomaly_framework_task(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert not task_manager.is_anomaly_framework_task()
+
+    @pytest.mark.parametrize("task", MPA_TASK)
+    def test_get_mpa_batch_size_name(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.get_batch_size_name() == "learning_parameters.batch_size"
+
+    @pytest.mark.parametrize("task", ANOMALY_TASK)
+    def test_get_anomaly_batch_size_name(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.get_batch_size_name() == "learning_parameters.train_batch_size"
+
+    @pytest.mark.parametrize("task", MPA_TASK)
+    def test_get_mpa_epoch_name(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.get_epoch_name() == "num_iters"
+
+    @pytest.mark.parametrize("task", ANOMALY_TASK)
+    def test_get_anomaly_epoch_name(self, task: TaskType):
+        task_manager = TaskManager(task)
+        assert task_manager.get_epoch_name() == "max_epochs"
+
+    @pytest.mark.parametrize("task", MPA_TASK)
+    def test_copy_weight(self, task: TaskType):
+        task_manager = TaskManager(task)
+        fake_model_weight = Path("temp_epoch_3.pth")
+        with TemporaryDirectory() as src_dir, TemporaryDirectory() as det_dir:
+            weight_in_src = src_dir / fake_model_weight
+            weight_in_det = det_dir / fake_model_weight
+            weight_in_src.write_text("fake")
+            task_manager.copy_weight(src_dir, det_dir)
+
+            assert weight_in_det.exists()
+
+    @pytest.mark.parametrize("task", MPA_TASK)
+    def test_get_latest_weight(self, task: TaskType):
+        task_manager = TaskManager(task)
+
+        with TemporaryDirectory() as src_dir, TemporaryDirectory() as det_dir:
+            for i in range(1, 10):
+                (src_dir / Path(f"epoch_{i}.pth")).write_text("fake")
+
+            latest_model_weight = Path("epoch_10.pth")
+            weight_in_src = src_dir / latest_model_weight
+            weight_in_det = det_dir / latest_model_weight
+            weight_in_src.write_text("fake")
+            task_manager.copy_weight(src_dir, det_dir)
+
+            assert weight_in_det.exists()
+
+def get_template_path(task_name: str) -> Path:
+    task_config_dir = OTX_ROOT_PATH / "algorithms" / task_name / "configs"
+    return list(task_config_dir.glob("**/template.yaml"))[0]
+
+def make_task_env(template_path: str) -> TaskEnvironment:
+    template = find_and_parse_model_template(template_path)
+    return TaskEnvironment(template, None, create_conf_hp(template.hyper_parameters.data), MagicMock())
+
+@pytest.fixture(scope="module")
+def cls_template_path() -> str:
+    return str(get_template_path("classification"))
+
+@pytest.fixture(scope="module")
+def det_template_path() -> str:
+    return str(get_template_path("detection"))
+
+@pytest.fixture(scope="module")
+def seg_template_path() -> str:
+    return str(get_template_path("segmentation"))
+
+@pytest.fixture(scope="module")
+def anomaly_template_path() -> str:
+    return str(get_template_path("anomaly"))
+
+@pytest.fixture(scope="module")
+def cls_task_env(cls_template_path):
+    return make_task_env(cls_template_path)
+
+@pytest.fixture(scope="module")
+def det_task_env(det_template_path) -> TaskEnvironment:
+    return make_task_env(det_template_path)
+
+@pytest.fixture(scope="module")
+def seg_task_env(seg_template_path) -> TaskEnvironment:
+    return make_task_env(seg_template_path)
+
+@pytest.fixture(scope="module")
+def anomaly_task_env(anomaly_template_path) -> TaskEnvironment:
+    return make_task_env(anomaly_template_path)
+
+@pytest.fixture
+def mpa_task_env(cls_task_env, det_task_env, seg_task_env) -> List[TaskEnvironment]:
+    return [cls_task_env, det_task_env, seg_task_env]
+
+@pytest.fixture
+def all_task_env(cls_task_env, det_task_env, seg_task_env, anomaly_task_env) -> List[TaskEnvironment]:
+    return [cls_task_env, det_task_env, seg_task_env, anomaly_task_env]
+
+@pytest.fixture
+def mock_environment():
+    MockTaskEnv = MagicMock(spec=TaskEnvironment)
+    return MockTaskEnv()
+
+
+class TestTaskEnvironmentManager:
+    @pytest.fixture(autouse=True)
+    def _make_mock_task_env(self, mock_environment):
+        self._mock_environment = mock_environment
+
+    def test_init(self, all_task_env):
+        for task_env in all_task_env:
+            TaskEnvironmentManager(task_env)
+
+    def test_get_task(self, cls_task_env, det_task_env, seg_task_env):
+        task_env = TaskEnvironmentManager(cls_task_env)
+        assert task_env.get_task() == TaskType.CLASSIFICATION
+
+        task_env = TaskEnvironmentManager(det_task_env)
+        assert task_env.get_task() == TaskType.DETECTION
+
+        task_env = TaskEnvironmentManager(seg_task_env)
+        assert task_env.get_task() == TaskType.SEGMENTATION
+
+    def test_get_model_template(
+            self, cls_task_env, det_task_env, seg_task_env,
+            cls_template_path, det_template_path, seg_template_path
+        ):
+        task_env = TaskEnvironmentManager(cls_task_env)
+        assert task_env.get_model_template() == find_and_parse_model_template(cls_template_path)
+
+        task_env = TaskEnvironmentManager(det_task_env)
+        assert task_env.get_model_template() == find_and_parse_model_template(det_template_path)
+
+        task_env = TaskEnvironmentManager(seg_task_env)
+        assert task_env.get_model_template() == find_and_parse_model_template(seg_template_path)
+
+    def test_get_model_template_path(
+            self, cls_task_env, det_task_env, seg_task_env,
+            cls_template_path, det_template_path, seg_template_path
+        ):
+        task_env = TaskEnvironmentManager(cls_task_env)
+        assert task_env.get_model_template_path() == cls_template_path
+
+        task_env = TaskEnvironmentManager(det_task_env)
+        assert task_env.get_model_template_path() == det_template_path
+
+        task_env = TaskEnvironmentManager(seg_task_env)
+        assert task_env.get_model_template_path() == seg_template_path
+
+    def test_set_hyper_parameter_using_str_key(self):
+        task_env = TaskEnvironmentManager(self._mock_environment)
+        hyper_parameter = {"a.b.c.d" : 1, "e.f.g.h" : 2}
+
+        task_env.set_hyper_parameter_using_str_key(hyper_parameter)
+
+        env_hp = self._mock_environment.get_hyper_parameters()
+
+        assert env_hp.a.b.c.d == hyper_parameter["a.b.c.d"]
+        assert env_hp.e.f.g.h == hyper_parameter["e.f.g.h"]
+
+    def test_get_dict_type_hyper_parameter(self):
+        learning_parameters = self._mock_environment.get_hyper_parameters().learning_parameters
+        learning_parameters.parameters = ["a", "b"]
+        learning_parameters.a = 1
+        learning_parameters.b = 2
+
+        task_env = TaskEnvironmentManager(self._mock_environment)
+        dict_hp = task_env.get_dict_type_hyper_parameter()
+
+        assert dict_hp["learning_parameters.a"] == 1
+        assert dict_hp["learning_parameters.b"] == 2
+        
+    @pytest.mark.parametrize("task", ALL_TASK)
+    def test_get_max_epoch(self, task):
+        max_epoch = 10
+        self._mock_environment.model_template.task_type = task
+        learning_parameters = self._mock_environment.get_hyper_parameters().learning_parameters
+        setattr(learning_parameters, TaskManager(task).get_epoch_name(), max_epoch)
+
+        task_env = TaskEnvironmentManager(self._mock_environment)
+
+        assert task_env.get_max_epoch() == max_epoch
+
+    def test_save_mpa_initial_weight(self, mpa_task_env):
+        for task_env in mpa_task_env:
+            task_env.model = None
+            task_env = TaskEnvironmentManager(task_env)
+            assert not task_env.save_initial_weight("fake_path")
+
+    def test_save_anomaly_initial_weight(self, anomaly_task_env):
+        def mock_save_model_data(model, save_path: str):
+            (Path(save_path) / "weights.pth").write_text('fake')
+        
+        with patch.object(TaskEnvironmentManager, "get_train_task"), \
+            patch("otx.cli.utils.hpo.save_model_data", mock_save_model_data), \
+            TemporaryDirectory() as tmp_dir:
+        
+            anomaly_task_env.model = None
+            task_env = TaskEnvironmentManager(anomaly_task_env)
+            save_path = Path(tmp_dir) / "init.pth"
+            assert task_env.save_initial_weight(str(save_path))
+            assert save_path.exists()
+
+    def test_loaded_inital_weight(self, all_task_env):
+        def mock_save_model_data(model, save_path: str):
+            (Path(save_path) / "weights.pth").write_text('fake')
+        
+        with patch.object(TaskEnvironmentManager, "get_train_task"), \
+            patch("otx.cli.utils.hpo.save_model_data", mock_save_model_data), \
+            TemporaryDirectory() as tmp_dir:
+            for task_env in all_task_env:
+                task_env.model = MagicMock()
+                task_env = TaskEnvironmentManager(task_env)
+                save_path = Path(tmp_dir) / "init.pth"
+                assert task_env.save_initial_weight(str(save_path))
+                assert save_path.exists()
+
+    def test_get_train_task(self, all_task_env):
+        for task_env in all_task_env:
+            mock_class = MagicMock()
+            with patch("otx.cli.utils.hpo.get_impl_class") as mock_func:
+                mock_func.return_vlaue = mock_class
+                task_env = TaskEnvironmentManager(task_env)
+                task_env.get_train_task()
+
+                mock_class.assert_not_called()
+
+    def test_get_mpa_batch_size_name(self, mpa_task_env):
+        for task_env in mpa_task_env:
+            task_env = TaskEnvironmentManager(task_env)
+            assert task_env.get_batch_size_name() == "learning_parameters.batch_size"
+
+    def test_get_anomaly_batch_size_name(self, anomaly_task_env):
+        task_env = TaskEnvironmentManager(anomaly_task_env)
+        assert task_env.get_batch_size_name() == "learning_parameters.train_batch_size"
+
+    def test_load_model_weight(self, all_task_env):
+        for task_env in all_task_env:
+            with patch("otx.cli.utils.hpo.read_model") as mock_func:
+                mock_class = MagicMock()
+                mock_func.return_value = mock_class
+                task_manager = TaskEnvironmentManager(task_env)
+                task_manager.load_model_weight("fake", MagicMock())
+                assert task_env.model == mock_class
+
+    def test_resume_model_weight(self, all_task_env):
+        for task_env in all_task_env:
+            with patch("otx.cli.utils.hpo.read_model") as mock_func:
+                mock_class = MagicMock()
+                mock_func.return_value = mock_class
+                task_manager = TaskEnvironmentManager(task_env)
+                task_manager.load_model_weight("fake", MagicMock())
+                assert task_env.model == mock_class
+                assert mock_class.model_adapters["resume"]
+
+    def test_get_new_model_entity(self, all_task_env):
+        for task_env in all_task_env:
+            task_manager = TaskEnvironmentManager(task_env)
+            model_entity = task_manager.get_new_model_entity()
+            assert isinstance(model_entity, ModelEntity)
+
+    def test_set_epoch(self, all_task_env):
+        epoch = 123
+        for task_env in all_task_env:
+            task_manager = TaskEnvironmentManager(task_env)
+            task_manager.set_epoch(epoch)
+            assert task_manager.get_max_epoch() == epoch
+
+
+class TestHpoRunner:
+    pass
+
+class TestTrainer:
+    pass
+
+class HpoCallback:
+    pass
+
+class HpoDataset:
+    pass
+
+def test_check_hpopt_available():
+    with patch("otx.cli.utils.hpo.hpopt"):
+        assert check_hpopt_available()
+
+def test_check_hpopt_unavailable():
+    with patch("otx.cli.utils.hpo.hpopt", None):
+        assert not check_hpopt_available()
+
+def test_run_hpo():
+    pass
+
+def test_get_best_hpo_weight():
+    pass
+
+def test_run_trial():
+    pass

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -651,14 +651,14 @@ def test_run_hpo(mocker, mock_environment):
         mock_environment.model_template.task_type = TaskType.CLASSIFICATION
 
         # run
-        run_hpo(mock_args, mock_environment, mocker.MagicMock(), mocker.MagicMock())
+        environment = run_hpo(mock_args, mock_environment, mocker.MagicMock(), mocker.MagicMock())
 
         # check
         mock_hpo_runner_instance.run_hpo.assert_called()  # Check that HpoRunner.run_hpo is called
-        env_hp = mock_environment.get_hyper_parameters()  # Check that best HP is applied well.
+        env_hp = environment.get_hyper_parameters()  # Check that best HP is applied well.
         assert env_hp.a.b == 1
         assert env_hp.c.d == 2
-        assert mock_environment.model == "mock_best_weight_path"  # check that best model weight is used
+        assert environment.model == "mock_best_weight_path"  # check that best model weight is used
 
 
 @e2e_pytest_unit

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -23,21 +23,21 @@ CLASSIFCATION_TASK = {TaskType.CLASSIFICATION}
 DETECTION_TASK = {TaskType.DETECTION, TaskType.INSTANCE_SEGMENTATION, TaskType.ROTATED_DETECTION}
 SEGMENTATION_TASK = {TaskType.SEGMENTATION}
 ANOMALY_TASK = {TaskType.ANOMALY_CLASSIFICATION, TaskType.ANOMALY_DETECTION, TaskType.ANOMALY_SEGMENTATION}
-MPA_TASK = CLASSIFCATION_TASK | DETECTION_TASK | SEGMENTATION_TASK
-ALL_TASK = MPA_TASK | ANOMALY_TASK
+MMCV_TASK = CLASSIFCATION_TASK | DETECTION_TASK | SEGMENTATION_TASK
+ALL_TASK = MMCV_TASK | ANOMALY_TASK
 OTX_ROOT_PATH = Path(otx.__file__).parent
 
 
 class TestTaskManager:
-    @pytest.mark.parametrize("task", MPA_TASK)
-    def test_is_mpa_framework_task(self, task: TaskType):
+    @pytest.mark.parametrize("task", MMCV_TASK)
+    def test_is_mmcv_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
-        assert task_manager.is_mpa_framework_task()
+        assert task_manager.is_mmcv_framework_task()
 
     @pytest.mark.parametrize("task", ANOMALY_TASK)
-    def test_is_not_mpa_framework_task(self, task: TaskType):
+    def test_is_not_mmcv_framework_task(self, task: TaskType):
         task_manager = TaskManager(task)
-        assert not task_manager.is_mpa_framework_task()
+        assert not task_manager.is_mmcv_framework_task()
 
     @pytest.mark.parametrize("task", CLASSIFCATION_TASK)
     def test_is_cls_framework_task(self, task: TaskType):
@@ -79,8 +79,8 @@ class TestTaskManager:
         task_manager = TaskManager(task)
         assert not task_manager.is_anomaly_framework_task()
 
-    @pytest.mark.parametrize("task", MPA_TASK)
-    def test_get_mpa_batch_size_name(self, task: TaskType):
+    @pytest.mark.parametrize("task", MMCV_TASK)
+    def test_get_mmcv_batch_size_name(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.get_batch_size_name() == "learning_parameters.batch_size"
 
@@ -89,8 +89,8 @@ class TestTaskManager:
         task_manager = TaskManager(task)
         assert task_manager.get_batch_size_name() == "learning_parameters.train_batch_size"
 
-    @pytest.mark.parametrize("task", MPA_TASK)
-    def test_get_mpa_epoch_name(self, task: TaskType):
+    @pytest.mark.parametrize("task", MMCV_TASK)
+    def test_get_mmcv_epoch_name(self, task: TaskType):
         task_manager = TaskManager(task)
         assert task_manager.get_epoch_name() == "num_iters"
 
@@ -99,7 +99,7 @@ class TestTaskManager:
         task_manager = TaskManager(task)
         assert task_manager.get_epoch_name() == "max_epochs"
 
-    @pytest.mark.parametrize("task", MPA_TASK)
+    @pytest.mark.parametrize("task", MMCV_TASK)
     def test_copy_weight(self, task: TaskType):
         task_manager = TaskManager(task)
         fake_model_weight = Path("temp_epoch_3.pth")
@@ -111,7 +111,7 @@ class TestTaskManager:
 
             assert weight_in_det.exists()
 
-    @pytest.mark.parametrize("task", MPA_TASK)
+    @pytest.mark.parametrize("task", MMCV_TASK)
     def test_get_latest_weight(self, task: TaskType):
         task_manager = TaskManager(task)
 
@@ -168,7 +168,7 @@ def anomaly_task_env(anomaly_template_path) -> TaskEnvironment:
     return make_task_env(anomaly_template_path)
 
 @pytest.fixture
-def mpa_task_env(cls_task_env, det_task_env, seg_task_env) -> List[TaskEnvironment]:
+def mmcv_task_env(cls_task_env, det_task_env, seg_task_env) -> List[TaskEnvironment]:
     return [cls_task_env, det_task_env, seg_task_env]
 
 @pytest.fixture
@@ -260,8 +260,8 @@ class TestTaskEnvironmentManager:
 
         assert task_env.get_max_epoch() == max_epoch
 
-    def test_save_mpa_initial_weight(self, mpa_task_env):
-        for task_env in mpa_task_env:
+    def test_save_mmcv_initial_weight(self, mmcv_task_env):
+        for task_env in mmcv_task_env:
             task_env.model = None
             task_env = TaskEnvironmentManager(task_env)
             assert not task_env.save_initial_weight("fake_path")
@@ -304,8 +304,8 @@ class TestTaskEnvironmentManager:
 
             mock_class.assert_not_called()
 
-    def test_get_mpa_batch_size_name(self, mpa_task_env):
-        for task_env in mpa_task_env:
+    def test_get_mmcv_batch_size_name(self, mmcv_task_env):
+        for task_env in mmcv_task_env:
             task_env = TaskEnvironmentManager(task_env)
             assert task_env.get_batch_size_name() == "learning_parameters.batch_size"
 

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -547,15 +547,15 @@ class TestHpoDataset:
         for i in range(num_hpo_sub_dataset):
             hpo_sub_dataset[i]
 
-    def test_len_before_get_subset(self, mocker):
-        hpo_dataset = HpoDataset(fullset=mocker.MagicMock(), config={"train_environment": {"subset_ratio": 0.5}})
-        with pytest.raises(RuntimeError):
-            len(hpo_dataset)
+    def test_len_before_get_subset(self):
+        hpo_dataset = HpoDataset(fullset=range(10), config={"train_environment": {"subset_ratio": 0.5}})
+        assert len(hpo_dataset) == 10
 
-    def test_getitem_before_get_subset(self, mocker):
-        hpo_dataset = HpoDataset(fullset=mocker.MagicMock(), config={"train_environment": {"subset_ratio": 0.5}})
-        with pytest.raises(RuntimeError):
-            hpo_dataset[0]
+    def test_getitem_before_get_subset(self):
+        hpo_dataset = HpoDataset(fullset=range(10), config={"train_environment": {"subset_ratio": 0.5}})
+
+        for _ in hpo_dataset:
+            pass
 
 
 def test_check_hpopt_available(mocker):

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     coverage[toml]
     pytest
     pytest-timeout
+    pytest-mock
     flaky
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu111/torch1.8.0/mmcv_full-1.6.1-cp38-cp38-manylinux1_x86_64.whl
     coverage
     pytest-timeout
+    pytest-mock
     -r{toxinidir}/requirements/base.txt
     -r{toxinidir}/requirements/anomaly.txt
     -r{toxinidir}/requirements/openvino.txt


### PR DESCRIPTION
### Summary

- This PR applies new Hpopt.
- SMBO isn't supported yet.
- This PR also includes unit test of `hpo.py`.

### Detail
I reimplemented hpopt to execute ASHA as explained in original paper and also refactor codes.
To apply this "new hpopt", OTX part also needs to be modified and this is for that.
I also added a feature that best hpo weight is now re-used when training a model after HPO.

### Purpose of code modification
**-> otx/algorithms/anomaly/adapters/anomalib/callbacks/progress.py**
Current HPO gets progress iteration information from score, but new HPO gets that from progress argument. So unnecessary code is removed.

**-> otx/algorithms/common/utils/callback.py**
For same reason as above, unnecessary code is removed.

**-> otx/cli/tools/train.py**
This is for code refactoring. Now HPO changes hyper parameters by optimized ones in `environment` variable.

**-> otx/cli/utils/tests.py**
Modify test code to align with new Hpopt.

**-> otx/cli/utils/hpo.py**
Code is modified to align with new hpopt. Because all code is changes, so recommend not to compare it with previous code when code review.

**-> otx/mpa/modules/hooks/adaptive_training_hooks.py**
A model is evaluated at least once before training is done.

**-> otx/mpa/modules/hooks/checkpoint_hook.py**
This file is in charge of saving a classification model weight. Current classification task saves a best model weight named "best.pth". But HPO needs both latest model weight and best model weight, so code is modified to save both.

**-> otx/mpa/modules/hooks/save_initial_weight_hook.py**
Code refactoring.

**-> requirements/base.txt**
Use "new_hpo" branch in hpopt repository. hpopt will be consolidated into OTX, so it's used for a while.

**-> tests/unit/cli/utils/test_hpo.py**
Unit test of "hpo.py"