### PR TITLE
[OTX] Execute cleanup function instead unload

### DIFF
--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -191,10 +191,8 @@ class ClassificationInferenceTask(
 
     def unload(self):
         """Unload function of OTX Classification Task."""
-
         logger.info("called unload()")
-        if self._work_dir_is_temp:
-            self._delete_scratch_space()
+        self.cleanup()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -551,6 +551,11 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
                 f"Done unloading. " f"Torch is still occupying {torch.cuda.memory_allocated()} bytes of GPU memory"
             )
 
+    def cleanup(self):
+        """Clean up work directory if user specified it."""
+        if self._work_dir_is_temp:
+            self._delete_scratch_space()
+
     class OnHookInitialized:
         """OnHookInitialized class."""
 

--- a/otx/algorithms/detection/tasks/inference.py
+++ b/otx/algorithms/detection/tasks/inference.py
@@ -224,8 +224,7 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
 
     def unload(self):
         """Unload the task."""
-        if self._work_dir_is_temp:
-            self._delete_scratch_space()
+        self.cleanup()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -144,8 +144,7 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
 
     def unload(self):
         """Unload the task."""
-        if self._work_dir_is_temp:
-            self._delete_scratch_space()
+        self.cleanup()
 
     @check_input_parameters_type()
     def export(self, export_type: ExportType, output_model: ModelEntity):

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -259,7 +259,7 @@ def main():  # pylint: disable=too-many-branches
         assert resultset.performance is not None
         print(resultset.performance)
 
-    task.unload()
+    task.cleanup()
 
     if args.gpus:
         multigpu_manager.finalize()


### PR DESCRIPTION
### Summary

- execute cleanup function instead unload

### Detail
There is a bug that segmentation fault is thrown while anomaly test cases are running in CI. This is because `unload()` in anomaly task throws segmentation fault on purpose in docker environment. To avoid this, separate code part to remove work directory and use it.