### PR TITLE
[OTX] Let AccuracyAwareRunner manage training and evaluation

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/nncf/builder.py
+++ b/otx/algorithms/classification/adapters/mmcls/nncf/builder.py
@@ -146,8 +146,11 @@ def build_nncf_classifier(  # pylint: disable=too-many-locals
             compression_ctrl=compression_ctrl,
         )
     )
+    # TODO: move this to OTX task when MPA is absorbed into OTX
     remove_from_configs_by_type(custom_hooks, "CancelInterfaceHook")
     remove_from_configs_by_type(custom_hooks, "TaskAdaptHook")
+    remove_from_configs_by_type(custom_hooks, "LazyEarlyStoppingHook")
+    remove_from_configs_by_type(custom_hooks, "EarlyStoppingHook")
 
     for hook in get_configs_by_pairs(custom_hooks, dict(type="OTXProgressHook")):
         time_monitor = hook.get("time_monitor", None)

--- a/otx/algorithms/common/adapters/mmcv/nncf/patches.py
+++ b/otx/algorithms/common/adapters/mmcv/nncf/patches.py
@@ -23,6 +23,9 @@ if is_nncf_enabled():
 
 # pylint: disable-next=unused-argument,invalid-name
 def _evaluation_wrapper(self, fn, runner, *args, **kwargs):
+    # TODO: move this patch to upper level (mmcv)
+    # as this is not only nncf required feature.
+    # one example is ReduceLROnPlateauLrUpdaterHook
     out = fn(runner, *args, **kwargs)
     setattr(runner, "all_metrics", deepcopy(runner.log_buffer.output))
     return out

--- a/otx/algorithms/common/adapters/mmcv/nncf/runners.py
+++ b/otx/algorithms/common/adapters/mmcv/nncf/runners.py
@@ -136,7 +136,6 @@ class AccuracyAwareRunner(EpochRunnerWithCancel):  # pylint: disable=too-many-in
         """validation_fn.
 
         Return the target metric value on the validation dataset.
-        Evaluation is assumed to be already done at this point since EvalHook was called.
         This method is used in NNCF-based accuracy-aware training.
         """
 

--- a/otx/algorithms/common/adapters/mmcv/nncf/runners.py
+++ b/otx/algorithms/common/adapters/mmcv/nncf/runners.py
@@ -139,11 +139,14 @@ class AccuracyAwareRunner(EpochRunnerWithCancel):  # pylint: disable=too-many-in
         Evaluation is assumed to be already done at this point since EvalHook was called.
         This method is used in NNCF-based accuracy-aware training.
         """
+
+        # make sure evaluation hook is in a 'should_evaluate' state
+        interval_bak = self._eval_hook.interval
+        self._eval_hook.interval = 1
+        self._eval_hook._do_evaluate(self)  # pylint: disable=protected-access
+        self._eval_hook.interval = interval_bak
         # Get metric from runner's attributes that set in EvalHook.evaluate() function
         all_metrics = getattr(self, "all_metrics", {})
-        if len(all_metrics) == 0:
-            self._eval_hook._do_evaluate(self)  # pylint: disable=protected-access
-            all_metrics = getattr(self, "all_metrics", {})
         metric = all_metrics.get(self._target_metric_name, None)
         if metric is None:
             raise RuntimeError(f"Could not find the {self._target_metric_name} key")

--- a/otx/algorithms/common/adapters/nncf/patchers/patcher.py
+++ b/otx/algorithms/common/adapters/nncf/patchers/patcher.py
@@ -14,6 +14,7 @@ from typing import Callable
 
 class Patcher:
     """Simple monkey patch helper."""
+
     # TODO: move this class to OTX level
 
     def __init__(self):

--- a/otx/algorithms/common/adapters/nncf/patchers/patcher.py
+++ b/otx/algorithms/common/adapters/nncf/patchers/patcher.py
@@ -14,6 +14,7 @@ from typing import Callable
 
 class Patcher:
     """Simple monkey patch helper."""
+    # TODO: move this class to OTX level
 
     def __init__(self):
         self._patched = OrderedDict()

--- a/otx/algorithms/common/tasks/nncf_base.py
+++ b/otx/algorithms/common/tasks/nncf_base.py
@@ -29,6 +29,7 @@ import otx.algorithms.common.adapters.mmcv.nncf.patches  # noqa: F401  # pylint:
 from otx.algorithms.common.adapters.mmcv.utils import (
     get_configs_by_keys,
     remove_from_config,
+    remove_from_configs_by_type,
 )
 from otx.algorithms.common.adapters.nncf import (
     check_nncf_is_enabled,
@@ -211,12 +212,14 @@ class NNCFBaseTask(BaseTask, IOptimizationTask):  # pylint: disable=too-many-ins
                 "nncf_config": nncf_config,
             }
 
-            # AccuracyAwareRunner actively evaluates model
+            # AccuracyAwareRunner needs to evaluate a model when it needs
             # unlike other runners counting on periodically evaluated score by 'EvalHook'.
             # To configure 'interval' to 'max_epoch' makes sure 'EvalHook' not to evaluate
             # during training.
             max_epoch = nncf_config.accuracy_aware_training.params.maximal_total_epochs
             self._recipe_cfg.evaluation.interval = max_epoch
+            # Disable 'AdaptiveTrainSchedulingHook' as training is managed by AccuracyAwareRunner
+            remove_from_configs_by_type(self._recipe_cfg.custom_hooks, "AdaptiveTrainSchedulingHook")
 
     @staticmethod
     def model_builder(

--- a/otx/algorithms/common/tasks/nncf_base.py
+++ b/otx/algorithms/common/tasks/nncf_base.py
@@ -211,6 +211,13 @@ class NNCFBaseTask(BaseTask, IOptimizationTask):  # pylint: disable=too-many-ins
                 "nncf_config": nncf_config,
             }
 
+            # AccuracyAwareRunner actively evaluates model
+            # unlike other runners counting on periodically evaluated score by 'EvalHook'.
+            # To configure 'interval' to 'max_epoch' makes sure 'EvalHook' not to evaluate
+            # during training.
+            max_epoch = nncf_config.accuracy_aware_training.params.maximal_total_epochs
+            self._recipe_cfg.evaluation.interval = max_epoch
+
     @staticmethod
     def model_builder(
         config,

--- a/otx/algorithms/detection/adapters/mmdet/nncf/builder.py
+++ b/otx/algorithms/detection/adapters/mmdet/nncf/builder.py
@@ -199,8 +199,11 @@ def build_nncf_detector(  # pylint: disable=too-many-locals,too-many-statements
             compression_ctrl=compression_ctrl,
         )
     )
+    # TODO: move this to OTX task when MPA is absorbed into OTX
     remove_from_configs_by_type(custom_hooks, "CancelInterfaceHook")
     remove_from_configs_by_type(custom_hooks, "TaskAdaptHook")
+    remove_from_configs_by_type(custom_hooks, "LazyEarlyStoppingHook")
+    remove_from_configs_by_type(custom_hooks, "EarlyStoppingHook")
     remove_from_configs_by_type(custom_hooks, "EMAHook")
     remove_from_configs_by_type(custom_hooks, "CustomModelEMAHook")
 

--- a/otx/algorithms/segmentation/adapters/mmseg/nncf/builder.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/nncf/builder.py
@@ -160,8 +160,11 @@ def build_nncf_segmentor(  # noqa: C901  # pylint: disable=too-many-locals
             compression_ctrl=compression_ctrl,
         )
     )
+    # TODO: move this to OTX task when MPA is absorbed into OTX
     remove_from_configs_by_type(custom_hooks, "CancelInterfaceHook")
     remove_from_configs_by_type(custom_hooks, "TaskAdaptHook")
+    remove_from_configs_by_type(custom_hooks, "LazyEarlyStoppingHook")
+    remove_from_configs_by_type(custom_hooks, "EarlyStoppingHook")
 
     for hook in get_configs_by_pairs(custom_hooks, dict(type="OTXProgressHook")):
         time_monitor = hook.get("time_monitor", None)


### PR DESCRIPTION
### Summary
`AccuracyAwareRunner` used for nncf optimization evaluates a model as it needs actively unlike other runners counting on `EvalHook` which periodically evaluate a model while training.


### Change
- Do not evaluate a model periodically by forcing `interval` of `EvalHook` to `max_epoch` while training but evaluate a model whenever `AccuracyAwareRunner` needs to do so.
- Remove `EarlyStoppingHook`, `AdaptiveTrainingHook` as they will be handled by `AccuracyAwareRunner`.
- Add some TODOs.


### Jira Ticket
CVS-101789