### PR TITLE
[OTX][TEST] Switch `test_threaded_streamer` TC to xfail

### DIFF
--- a/tests/unit/api/usecases/exportable_code/test_streamer.py
+++ b/tests/unit/api/usecases/exportable_code/test_streamer.py
@@ -290,6 +290,7 @@ class TestStreamer:
     @pytest.mark.unit
     @pytest.mark.reqids(Requirements.REQ_1)
     @pytest.mark.timeout(10)
+    @pytest.mark.xfail(reason="CVS-102619")
     def test_threaded_streamer(self):
         """
         <b>Description:</b>


### PR DESCRIPTION
## Summary
Currently `tests/unit/api/usecases/exportable_code/test_streamer.py::TestStreamer::test_threaded_streamer` test is failing due to timeout.
Created a [jira ticket](https://jira.devtools.intel.com/browse/CVS-102619) for this, and temporarily fixed it to xfail.