### PR TITLE
[CI] Enable coverage report with Codecov

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,20 @@
+name: Daily-Regression Test
+
+on:
+  workflow_dispatch: # run on request (no need for PR)
+  schedule:
+    # every 4AM from Tue to Sat
+    - cron: "0 4 * * 2-6"
+
+jobs:
+  Regression-Tests:
+    runs-on: [self-hosted, linux, x64, dev]
+    timeout-minutes: 600
+    if: github.ref == 'ref/heads/develop'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Pre-Merge Tests
+        run: tox -e pre-merge -- tests/regression

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -30,19 +30,19 @@ jobs:
         run: python -m pip install tox
       - name: Code Quality Checks
         run: tox -e pre-commit
-  Pre-Merge-Tests:
+  Pre-Merge-Unit-Test:
     runs-on: [self-hosted, linux, x64, dev]
     needs: Code-Quality-Checks
-    timeout-minutes: 360
+    timeout-minutes: 120
     if: github.event.pull_request.draft == false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
-      - name: Pre-Merge Tests
-        run: tox -e pre-merge
-      - name: Upload coverage report
+      - name: Unit-testing
+        run: tox -e pre-merge -- tests/unit
+      - name: Upload coverage reports to Codecov
         run: |
           # If the workflow is triggered from PR then it gets the commit id from the PR.
           # else it uses the commit id of the latest commit. This is because the commit
@@ -55,5 +55,19 @@ jobs:
           else
             COMMIT_ID=${{ github.sha }}
           fi
-          pip install codacy-coverage
-          python-codacy-coverage -r .tox/coverage.xml -c $COMMIT_ID
+          # current version of codecov-action does not support uploading reports through the proxy
+          # so we use the latest version of codecov uploader binary
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov --sha $COMMIT_ID -Z true -U $HTTP_PROXY -f .tox/coverage.xml
+  Pre-Merge-Integration-Test:
+    runs-on: [self-hosted, linux, x64, dev]
+    needs: Pre-Merge-Unit-Test
+    timeout-minutes: 360
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Integration-testing
+        run: tox -e pre-merge -- tests/integration

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Integration-testing
-        run: tox -e pre-merge -- tests/integration
+        run: tox -e pre-merge -- tests/integration/cli

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -1,15 +1,16 @@
 name: Pre-Merge Checks
 
 on:
-  pull_request:
+  push:
     branches:
       - develop
-    workflow_dispatch: # run on request (no need for PR)
+  pull_request:
     types:
       - opened
       - reopened
       - synchronize
       - ready_for_review
+  workflow_dispatch: # run on request (no need for PR)
 
 # This is what will cancel the workflow concurrency
 concurrency:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,15 +1,15 @@
-name: Daily Test
+name: Weekly Test
 
 on:
   workflow_dispatch: # run on request (no need for PR)
   schedule:
-    # every 4AM from Tue to Sat
-    - cron: "0 4 * * 2-6"
+    # every 4AM on Sunday
+    - cron: "0 4 * * 0"
 
 jobs:
   Daily-Tests:
     runs-on: [self-hosted, linux, x64, dev]
-    timeout-minutes: 600
+    timeout-minutes: 1440
     if: github.ref == 'ref/heads/develop'
     steps:
       - name: Checkout repository
@@ -17,4 +17,4 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox
       - name: Pre-Merge Tests
-        run: tox -e pre-merge -- tests/e2e
+        run: tox -e pre-merge -- tests/regression

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 [![openvino](https://img.shields.io/badge/openvino-2021.4-purple)]()
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/31d17b3adb0a46d888078c543e4ec4c5?branch=feature%2Fotx)](https://www.codacy.com/gh/openvinotoolkit/training_extensions/dashboard?utm_source=github.com&utm_medium=referral&utm_content=openvinotoolkit/training_extensions&utm_campaign=Badge_Grade)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/31d17b3adb0a46d888078c543e4ec4c5?branch=feature%2Fotx)](https://www.codacy.com/gh/openvinotoolkit/training_extensions/dashboard?utm_source=github.com&utm_medium=referral&utm_content=openvinotoolkit/training_extensions&utm_campaign=Badge_Coverage)
+[![codecov](https://codecov.io/gh/openvinotoolkit/training_extensions/branch/develop/graph/badge.svg?token=9HVFNMPFGD)](https://codecov.io/gh/openvinotoolkit/training_extensions)
 [![Build Docs](https://github.com/openvinotoolkit/training_extensions/actions/workflows/docs.yml/badge.svg)](https://github.com/openvinotoolkit/training_extensions/actions/workflows/docs.yml)
 
 ---

--- a/otx/__init__.py
+++ b/otx/__init__.py
@@ -3,4 +3,4 @@
 # Copyright (C) 2021-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.0.0dev0"
+__version__ = "1.0.0.dev0"

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
     pip install -e .[mpa]
     # pre-merge teset
     coverage erase
-    coverage run --include=otx/* -m pytest -ra --showlocals tests/unit tests/integration/cli
+    coverage run --include=otx/* -m pytest -ra --showlocals {posargs}
     coverage report -m --fail-under=0
     coverage xml -o {toxworkdir}/coverage.xml
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,10 +52,9 @@ commands =
     pip install -e .[mpa]
     # pre-merge teset
     coverage erase
-    coverage run --include=otx/* -m pytest -ra --showlocals {posargs}
+    coverage run --include=otx/* -m pytest -ra --showlocals {posargs:tests/unit tests/integration}
     coverage report -m --fail-under=0
     coverage xml -o {toxworkdir}/coverage.xml
-
 
 ; all env below need to be verified
 [testenv:anomaly]


### PR DESCRIPTION
Replaced coverage report from Codacy to Codecov

Note that some tox usage is updated for the "pre-merge" env.
to run testing on your local machine, you need to set the testing target folder to the tox command like below.
(the default value is "tests/unit tests/integration")
```
tox -e pre-merge -- <testing-target-path>
```