### PR TITLE
[OTX][Unit Test] Self-supervised learning for classification and semantic segmentation

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/data/datasets.py
+++ b/otx/algorithms/classification/adapters/mmcls/data/datasets.py
@@ -421,7 +421,9 @@ class SelfSLDataset(Dataset):
     CLASSES = None
 
     @check_input_parameters_type({"otx_dataset": DatasetParamTypeCheck})
-    def __init__(self, otx_dataset: DatasetEntity = None, pipeline: Dict[str, Any] = None, **kwargs):  # pylint: disable=unused-argument
+    def __init__(
+        self, otx_dataset: DatasetEntity, pipeline: Dict[str, Any], **kwargs
+    ):  # pylint: disable=unused-argument
         super().__init__()
         self.otx_dataset = otx_dataset
 

--- a/otx/algorithms/classification/adapters/mmcls/data/datasets.py
+++ b/otx/algorithms/classification/adapters/mmcls/data/datasets.py
@@ -6,7 +6,7 @@
 
 # pylint: disable=invalid-name, too-many-locals, no-member
 
-from typing import List
+from typing import Any, Dict, List
 
 import numpy as np
 from mmcls.core import average_performance, mAP
@@ -420,7 +420,8 @@ class SelfSLDataset(Dataset):
 
     CLASSES = None
 
-    def __init__(self, otx_dataset=None, pipeline=None, **kwargs):  # pylint: disable=unused-argument
+    @check_input_parameters_type({"otx_dataset": DatasetParamTypeCheck})
+    def __init__(self, otx_dataset: DatasetEntity = None, pipeline: Dict[str, Any] = None, **kwargs):  # pylint: disable=unused-argument
         super().__init__()
         self.otx_dataset = otx_dataset
 

--- a/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
@@ -255,6 +255,8 @@ class DetConB(nn.Module):
         elif self.input_transform == "multiple_select":
             inputs = [inputs[i] for i in self.in_index]
         else:
+            if isinstance(self.in_index, (list, tuple)):
+                self.in_index = self.in_index[0]
             inputs = inputs[self.in_index]  # type: ignore
 
         return inputs
@@ -285,6 +287,7 @@ class DetConB(nn.Module):
         if isinstance(feats, (list, tuple)) and len(feats) > 1:
             feats = self.transform_inputs(feats)
 
+        # TODO (sungchul): consider self.input_transform == "multiple_select"
         sampled_masks, sampled_mask_ids = self.mask_pool(masks)
 
         b, c, h, w = feats.shape  # type: ignore

--- a/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
@@ -154,7 +154,7 @@ class DetConB(nn.Module):
         num_samples: int = 16,
         downsample: int = 32,
         input_transform: str = "resize_concat",
-        in_index: List[int] = [0],
+        in_index: Union[List[int], int] = [0],
         align_corners: bool = False,
         loss_cfg: Optional[Dict[str, Any]] = None,
         **kwargs,
@@ -245,14 +245,14 @@ class DetConB(nn.Module):
             Tensor: The transformed inputs.
         """
         # TODO (sungchul): consider tensor component, too
-        if self.input_transform == "resize_concat":
+        if self.input_transform == "resize_concat" and isinstance(self.in_index, (list, tuple)):
             inputs = [inputs[i] for i in self.in_index]
             upsampled_inputs = [
                 resize(input=x, size=inputs[0].shape[2:], mode="bilinear", align_corners=self.align_corners)
                 for x in inputs
             ]
             inputs = torch.cat(upsampled_inputs, dim=1)
-        elif self.input_transform == "multiple_select":
+        elif self.input_transform == "multiple_select" and isinstance(self.in_index, (list, tuple)):
             inputs = [inputs[i] for i in self.in_index]
         else:
             if isinstance(self.in_index, (list, tuple)):

--- a/tests/unit/algorithms/classification/__init__.py
+++ b/tests/unit/algorithms/classification/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/tests/unit/algorithms/classification/adapters/__init__.py
+++ b/tests/unit/algorithms/classification/adapters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/tests/unit/algorithms/classification/adapters/mmcls/__init__.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.classification.adapters.mmcls"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/__init__.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.classification.adapters.mmcls.data"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+from otx.algorithms.classification.adapters.mmcls.data.datasets import SelfSLDataset
+from otx.api.entities.annotation import (
+    Annotation,
+    AnnotationSceneEntity,
+    AnnotationSceneKind,
+)
+from otx.api.entities.dataset_item import DatasetItemEntity
+from otx.api.entities.datasets import DatasetEntity
+from otx.api.entities.image import Image
+from otx.api.entities.label import Domain, LabelEntity
+from otx.api.entities.scored_label import ScoredLabel
+from otx.api.entities.shapes.rectangle import Rectangle
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from tests.unit.api.parameters_validation.validation_helper import (
+    check_value_error_exception_raised,
+)
+
+
+class TestSelfSLDataset:
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        image = Image(data=np.random.randint(low=0, high=255, size=(8, 8, 3)))
+        annotation = Annotation(
+            shape=Rectangle.generate_full_box(),
+            labels=[ScoredLabel(LabelEntity(name="test_selfsl_dataset", domain=Domain.CLASSIFICATION))]
+        )
+        annotation_scene = AnnotationSceneEntity(annotations=[annotation], kind=AnnotationSceneKind.ANNOTATION)
+        dataset_item = DatasetItemEntity(media=image, annotation_scene=annotation_scene)
+
+        self.otx_dataset = DatasetEntity(items=[dataset_item])
+        self.pipeline = {
+            "view0": [dict(type="ImageToTensor", keys=["img"])],
+            "view1": [dict(type="ImageToTensor", keys=["img"])]
+        }
+
+    @e2e_pytest_unit
+    def test_self_sl_dataset_init_params_validation(self):
+        """Test SelfSLDataset initialization parameters validation."""
+        correct_values_dict = {
+            "otx_dataset": self.otx_dataset,
+            "pipeline": self.pipeline,
+        }
+        unexpected_str = "unexpected string"
+        unexpected_values = [
+            # Unexpected string is specified as "otx_dataset" parameter
+            ("otx_dataset", unexpected_str),
+            # Unexpected string is specified as "pipeline" parameter
+            ("pipeline", unexpected_str),
+        ]
+
+        check_value_error_exception_raised(
+            correct_parameters=correct_values_dict,
+            unexpected_values=unexpected_values,
+            class_or_function=SelfSLDataset,
+        )
+
+    @e2e_pytest_unit
+    def test_getitem(self):
+        """Test __getitem__ method."""
+        dataset = SelfSLDataset(otx_dataset=self.otx_dataset, pipeline=self.pipeline)
+
+        data_item = dataset[0]
+        for i in range(1, 3):
+            assert f"dataset_item{i}" in data_item
+            assert f"width{i}" in data_item
+            assert f"height{i}" in data_item
+            assert f"index{i}" in data_item
+            assert f"filename{i}" in data_item
+            assert f"ori_filename{i}" in data_item
+            assert f"img{i}" in data_item
+            assert f"img_shape{i}" in data_item
+            assert f"ori_shape{i}" in data_item
+            assert f"pad_shape{i}" in data_item
+            assert f"img_norm_cfg{i}" in data_item
+            assert f"img_fields{i}" in data_item

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
@@ -19,19 +19,24 @@ from tests.unit.api.parameters_validation.validation_helper import (
 )
 
 
+def create_cls_dataset():
+    image = Image(data=np.random.randint(low=0, high=255, size=(8, 8, 3)))
+    annotation = Annotation(
+        shape=Rectangle.generate_full_box(),
+        labels=[ScoredLabel(LabelEntity(name="test_selfsl_dataset", domain=Domain.CLASSIFICATION))]
+    )
+    annotation_scene = AnnotationSceneEntity(annotations=[annotation], kind=AnnotationSceneKind.ANNOTATION)
+    dataset_item = DatasetItemEntity(media=image, annotation_scene=annotation_scene)
+    
+    dataset = DatasetEntity(items=[dataset_item])
+    return dataset, dataset.get_labels()
+
+
 class TestSelfSLDataset:
 
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
-        image = Image(data=np.random.randint(low=0, high=255, size=(8, 8, 3)))
-        annotation = Annotation(
-            shape=Rectangle.generate_full_box(),
-            labels=[ScoredLabel(LabelEntity(name="test_selfsl_dataset", domain=Domain.CLASSIFICATION))]
-        )
-        annotation_scene = AnnotationSceneEntity(annotations=[annotation], kind=AnnotationSceneKind.ANNOTATION)
-        dataset_item = DatasetItemEntity(media=image, annotation_scene=annotation_scene)
-
-        self.otx_dataset = DatasetEntity(items=[dataset_item])
+        self.otx_dataset, _ = create_cls_dataset()
         self.pipeline = {
             "view0": [dict(type="ImageToTensor", keys=["img"])],
             "view1": [dict(type="ImageToTensor", keys=["img"])]

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
@@ -23,23 +23,22 @@ def create_cls_dataset():
     image = Image(data=np.random.randint(low=0, high=255, size=(8, 8, 3)))
     annotation = Annotation(
         shape=Rectangle.generate_full_box(),
-        labels=[ScoredLabel(LabelEntity(name="test_selfsl_dataset", domain=Domain.CLASSIFICATION))]
+        labels=[ScoredLabel(LabelEntity(name="test_selfsl_dataset", domain=Domain.CLASSIFICATION))],
     )
     annotation_scene = AnnotationSceneEntity(annotations=[annotation], kind=AnnotationSceneKind.ANNOTATION)
     dataset_item = DatasetItemEntity(media=image, annotation_scene=annotation_scene)
-    
+
     dataset = DatasetEntity(items=[dataset_item])
     return dataset, dataset.get_labels()
 
 
 class TestSelfSLDataset:
-
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
         self.otx_dataset, _ = create_cls_dataset()
         self.pipeline = {
             "view0": [dict(type="ImageToTensor", keys=["img"])],
-            "view1": [dict(type="ImageToTensor", keys=["img"])]
+            "view1": [dict(type="ImageToTensor", keys=["img"])],
         }
 
     @e2e_pytest_unit

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_pipelines.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_pipelines.py
@@ -1,0 +1,124 @@
+import numpy as np
+import pytest
+from PIL import Image
+
+from otx.algorithms.classification.adapters.mmcls.data.pipelines import (
+    GaussianBlur,
+    LoadImageFromOTXDataset,
+    OTXColorJitter,
+    PILImageToNDArray,
+    PostAug,
+    RandomAppliedTrans,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from .test_datasets import create_cls_dataset
+
+
+@pytest.fixture(scope="module")
+def inputs_np():
+    return {
+        "img": np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8),
+        "img_fields": ["img"]
+    }
+
+
+@pytest.fixture(scope="module")
+def inputs_PIL():
+    return {
+        "img": Image.fromarray(np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8)),
+    }
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize("to_float32", [False, True])
+def test_load_image_from_otx_dataset_call(to_float32):
+    """Test LoadImageFromOTXDataset."""
+    otx_dataset, labels = create_cls_dataset()
+    load_image_from_otx_dataset = LoadImageFromOTXDataset(to_float32)
+    results = dict(
+        dataset_item=otx_dataset[0],
+        width=otx_dataset[0].width,
+        height=otx_dataset[0].height,
+        index=0,
+        ann_info=dict(label_list=labels),
+    )
+
+    results = load_image_from_otx_dataset(results)
+    
+    assert "filename" in results
+    assert "ori_filename" in results
+    assert "img" in results
+    assert "img_shape" in results
+    assert "ori_shape" in results
+    assert "pad_shape" in results
+    assert "img_norm_cfg" in results
+    assert "img_fields" in results
+    assert isinstance(results["img"], np.ndarray)
+
+
+@e2e_pytest_unit
+def test_random_applied_transforms(mocker, inputs_np):
+    """Test RandomAppliedTrans."""
+    mocker.patch(
+        "otx.algorithms.classification.adapters.mmcls.data.pipelines.build_from_cfg",
+        return_value=lambda x: x)
+
+    random_applied_transforms = RandomAppliedTrans(transforms=[dict()])
+
+    results = random_applied_transforms(inputs_np)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+    assert repr(random_applied_transforms) == "RandomAppliedTrans"
+
+
+@e2e_pytest_unit
+def test_otx_color_jitter(inputs_np):
+    """Test OTXColorJitter."""
+    otx_color_jitter = OTXColorJitter()
+
+    results = otx_color_jitter(inputs_np)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+
+
+@e2e_pytest_unit
+def test_gaussian_blur(inputs_np):
+    """Test GaussianBlur."""
+    gaussian_blur = GaussianBlur(sigma_min=0.1, sigma_max=0.2)
+
+    results = gaussian_blur(inputs_np)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+    assert repr(gaussian_blur) == "GaussianBlur"
+
+
+@e2e_pytest_unit
+def test_pil_image_to_nd_array(inputs_PIL) -> None:
+    """Test PILImageToNDArray."""
+    pil_image_to_nd_array = PILImageToNDArray(keys=["img"])
+
+    results = pil_image_to_nd_array(inputs_PIL)
+
+    assert "img" in results
+    assert isinstance(results["img"], np.ndarray)
+    assert repr(pil_image_to_nd_array) == "PILImageToNDArray"
+
+
+@e2e_pytest_unit
+def test_post_aug(mocker, inputs_np):
+    """Test PostAug."""
+    mocker.patch(
+        "otx.algorithms.classification.adapters.mmcls.data.pipelines.Compose",
+        return_value=lambda x: x)
+
+    post_aug = PostAug(keys=dict(orig=lambda x: x))
+
+    results = post_aug(inputs_np)
+
+    assert isinstance(results, dict)
+    assert "img" in results and "img" in results["img_fields"]
+    assert "orig" in results and "orig" in results["img_fields"]
+    assert repr(post_aug) == "PostAug"

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_pipelines.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_pipelines.py
@@ -11,15 +11,13 @@ from otx.algorithms.classification.adapters.mmcls.data.pipelines import (
     RandomAppliedTrans,
 )
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
 from .test_datasets import create_cls_dataset
 
 
 @pytest.fixture(scope="module")
 def inputs_np():
-    return {
-        "img": np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8),
-        "img_fields": ["img"]
-    }
+    return {"img": np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8), "img_fields": ["img"]}
 
 
 @pytest.fixture(scope="module")
@@ -44,7 +42,7 @@ def test_load_image_from_otx_dataset_call(to_float32):
     )
 
     results = load_image_from_otx_dataset(results)
-    
+
     assert "filename" in results
     assert "ori_filename" in results
     assert "img" in results
@@ -59,9 +57,7 @@ def test_load_image_from_otx_dataset_call(to_float32):
 @e2e_pytest_unit
 def test_random_applied_transforms(mocker, inputs_np):
     """Test RandomAppliedTrans."""
-    mocker.patch(
-        "otx.algorithms.classification.adapters.mmcls.data.pipelines.build_from_cfg",
-        return_value=lambda x: x)
+    mocker.patch("otx.algorithms.classification.adapters.mmcls.data.pipelines.build_from_cfg", return_value=lambda x: x)
 
     random_applied_transforms = RandomAppliedTrans(transforms=[dict()])
 
@@ -110,9 +106,7 @@ def test_pil_image_to_nd_array(inputs_PIL) -> None:
 @e2e_pytest_unit
 def test_post_aug(mocker, inputs_np):
     """Test PostAug."""
-    mocker.patch(
-        "otx.algorithms.classification.adapters.mmcls.data.pipelines.Compose",
-        return_value=lambda x: x)
+    mocker.patch("otx.algorithms.classification.adapters.mmcls.data.pipelines.Compose", return_value=lambda x: x)
 
     post_aug = PostAug(keys=dict(orig=lambda x: x))
 

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/classifiers/__init__.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/classifiers/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.classification.adapters.mmcls.models.classifiers"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/classifiers/test_byol.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/classifiers/test_byol.py
@@ -1,0 +1,133 @@
+from copy import deepcopy
+from typing import Dict, Any
+
+import pytest
+import torch
+import torch.nn as nn
+
+from otx.algorithms.classification.adapters.mmcls import BYOL
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+@e2e_pytest_unit
+class TestBYOL:
+    """Test BYOL."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch, mocker) -> None:
+        class MockBackbone(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pipeline = nn.Sequential(
+                    nn.Conv2d(3, 1, (1, 1), bias=False),
+                    nn.Conv2d(1, 1, (1, 1), bias=False))
+
+            def init_weights(self, pretrained=None):
+                pass
+            
+            def forward(self, x):
+                return self.pipeline(x)
+
+        class MockNeck(nn.Sequential):
+            def __init__(self):
+                super().__init__(
+                    nn.Linear(2, 2, bias=False),
+                    nn.Linear(2, 2, bias=False)
+                )
+
+            def init_weights(self, init_linear=None):
+                pass
+
+        class MockHead(nn.Sequential):
+            def __init__(self):
+                super().__init__(nn.Linear(2, 2, bias=False))
+
+            def init_weights(self, init_linear=None):
+                pass
+
+            def forward(self, *args, **kwargs):
+                return {"loss": torch.Tensor(1)}
+
+        def build_mock_backbone(*args, **kwargs):
+            return MockBackbone()
+
+        def build_mock_neck(*args, **kwargs):
+            return MockNeck()
+
+        def build_mock_head(*args, **kwargs):
+            return MockHead()
+
+        monkeypatch.setattr(
+            "otx.algorithms.classification.adapters.mmcls.models.classifiers.byol.build_backbone",
+            build_mock_backbone
+        )
+        monkeypatch.setattr(
+            "otx.algorithms.classification.adapters.mmcls.models.classifiers.byol.build_neck",
+            build_mock_neck
+        )
+        monkeypatch.setattr(
+            "otx.algorithms.classification.adapters.mmcls.models.classifiers.byol.build_head",
+            build_mock_head)
+
+        self.byol = BYOL(backbone={}, neck={}, head={})
+
+    @e2e_pytest_unit
+    def test_init_weights(self) -> None:
+        """Test init_weights function."""
+        for param_ol, param_tgt in zip(self.byol.online_backbone.parameters(), self.byol.target_backbone.parameters()):
+            assert torch.all(param_ol == param_tgt)
+            assert param_ol.requires_grad == True
+            assert param_tgt.requires_grad == False
+
+        for param_ol, param_tgt in zip(self.byol.online_projector.parameters(), self.byol.target_projector.parameters()):
+            assert torch.all(param_ol == param_tgt)
+            assert param_ol.requires_grad == True
+            assert param_tgt.requires_grad == False
+
+    @e2e_pytest_unit
+    def test_momentum_update(self) -> None:
+        """Test _momentum_update function."""
+        original_params = {"backbone": [], "projector": []}
+        for param_tgt in self.byol.target_backbone.parameters():
+            param_tgt.data *= 2.
+            original_params["backbone"].append(deepcopy(param_tgt))
+
+        for param_tgt in self.byol.target_projector.parameters():
+            param_tgt.data *= 2.
+            original_params["projector"].append(deepcopy(param_tgt))
+
+        self.byol.momentum_update()
+
+        for param_ol, param_tgt, orig_tgt in zip(self.byol.online_backbone.parameters(), self.byol.target_backbone.parameters(), original_params["backbone"]):
+            assert torch.all(param_tgt.data == orig_tgt * self.byol.momentum + param_ol.data * (1.0 - self.byol.momentum))
+
+        for param_ol, param_tgt, orig_tgt in zip(self.byol.online_projector.parameters(), self.byol.target_projector.parameters(), original_params["projector"]):
+            assert torch.all(param_tgt.data == orig_tgt * self.byol.momentum + param_ol.data * (1.0 - self.byol.momentum))
+
+    @e2e_pytest_unit
+    def test_train_step(self) -> None:
+        """Test train_step function wraps forward and _parse_losses."""
+        img1 = torch.randn((1, 3, 2, 2))
+        img2 = torch.randn((1, 3, 2, 2))
+
+        outputs = self.byol.train_step(data=dict(img1=img1, img2=img2), optimizer=None)
+
+        assert "loss" in outputs
+        assert "log_vars" in outputs
+        assert "num_samples" in outputs
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize(
+        "orig_state_dict,prefix,expected",
+        [
+            ({"online_backbone.layer": 1}, "", {"layer": 1}),
+            ({"backbone.layer": 1}, "", {"backbone.layer": 1}),
+            ({"backbone.layer": 1}, "backbone.", {"backbone.layer": 1})
+        ]
+    )
+    def test_state_dict_hook(self, orig_state_dict: Dict[str, Any], prefix: str, expected: Dict[str, Any]) -> None:
+        """Test state_dict_hook function."""
+        new_state_dict = BYOL.state_dict_hook(
+            module=self.byol, state_dict=orig_state_dict, prefix=prefix)
+        
+        assert new_state_dict == expected

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/heads/__init__.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/heads/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.classification.adapters.mmcls.models.heads"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_contrastive_head.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_contrastive_head.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from otx.algorithms.classification.adapters.mmcls import ConstrastiveHead
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestConstrastiveHead:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch) -> None:
+        class MockNeck(nn.Sequential):
+            def __init__(self):
+                super().__init__(nn.Linear(2, 2, bias=False))
+
+            def init_weights(self, init_linear=None):
+                for module in self.modules():
+                    if hasattr(module, 'weight') and module.weight is not None:
+                        nn.init.constant_(module.weight, 1)
+
+        def build_mock_neck(*args, **kwargs):
+            return MockNeck()
+
+        monkeypatch.setattr(
+            "otx.algorithms.classification.adapters.mmcls.models.heads.contrastive_head.build_neck",
+            build_mock_neck
+        )
+
+        self.inputs = torch.Tensor([[1.0, 2.0], [3.0, 4.0]])
+        self.targets = torch.Tensor([[2.0, 3.0], [4.0, 5.0]])
+
+    @e2e_pytest_unit
+    def test_forward(self) -> None:
+        """Test forward function."""
+        contrastive_head = ConstrastiveHead(predictor={})
+        contrastive_head.init_weights()
+
+        result = contrastive_head(self.inputs, self.targets)
+        expected_result = {'loss': torch.tensor(0.0255)}
+
+        assert torch.allclose(result['loss'], expected_result['loss'], rtol=1e-4, atol=1e-4)
+
+    @e2e_pytest_unit
+    def test_forward_no_size_average(self) -> None:
+        """Test forward function without size averaging."""
+        contrastive_head = ConstrastiveHead(predictor={}, size_average=False)
+        contrastive_head.init_weights()
+
+        result = contrastive_head(self.inputs, self.targets)
+        expected_result = {'loss': torch.tensor(0.0511)}
+
+        assert torch.allclose(result['loss'], expected_result['loss'], rtol=1e-4, atol=1e-4)

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_contrastive_head.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_contrastive_head.py
@@ -7,7 +7,6 @@ from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
 class TestConstrastiveHead:
-
     @pytest.fixture(autouse=True)
     def setup(self, monkeypatch) -> None:
         class MockNeck(nn.Sequential):
@@ -16,15 +15,14 @@ class TestConstrastiveHead:
 
             def init_weights(self, init_linear=None):
                 for module in self.modules():
-                    if hasattr(module, 'weight') and module.weight is not None:
+                    if hasattr(module, "weight") and module.weight is not None:
                         nn.init.constant_(module.weight, 1)
 
         def build_mock_neck(*args, **kwargs):
             return MockNeck()
 
         monkeypatch.setattr(
-            "otx.algorithms.classification.adapters.mmcls.models.heads.contrastive_head.build_neck",
-            build_mock_neck
+            "otx.algorithms.classification.adapters.mmcls.models.heads.contrastive_head.build_neck", build_mock_neck
         )
 
         self.inputs = torch.Tensor([[1.0, 2.0], [3.0, 4.0]])
@@ -37,9 +35,9 @@ class TestConstrastiveHead:
         contrastive_head.init_weights()
 
         result = contrastive_head(self.inputs, self.targets)
-        expected_result = {'loss': torch.tensor(0.0255)}
+        expected_result = {"loss": torch.tensor(0.0255)}
 
-        assert torch.allclose(result['loss'], expected_result['loss'], rtol=1e-4, atol=1e-4)
+        assert torch.allclose(result["loss"], expected_result["loss"], rtol=1e-4, atol=1e-4)
 
     @e2e_pytest_unit
     def test_forward_no_size_average(self) -> None:
@@ -48,6 +46,6 @@ class TestConstrastiveHead:
         contrastive_head.init_weights()
 
         result = contrastive_head(self.inputs, self.targets)
-        expected_result = {'loss': torch.tensor(0.0511)}
+        expected_result = {"loss": torch.tensor(0.0511)}
 
-        assert torch.allclose(result['loss'], expected_result['loss'], rtol=1e-4, atol=1e-4)
+        assert torch.allclose(result["loss"], expected_result["loss"], rtol=1e-4, atol=1e-4)

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/necks/__init__.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/necks/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.classification.adapters.mmcls.models.necks"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/necks/test_selfsl_mlp.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/necks/test_selfsl_mlp.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+import torch
+import torch.nn as nn
+from typing import Dict
+
+from otx.algorithms.classification.adapters.mmcls import SelfSLMLP
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestSelfSLMLP:
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("use_conv", [True, False])
+    @pytest.mark.parametrize("with_avg_pool", [True, False])
+    def test_init(self, use_conv: bool, with_avg_pool: bool):
+        """Test __init__ function."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            use_conv=use_conv,
+            with_avg_pool=with_avg_pool
+        )
+
+        if with_avg_pool:
+            assert isinstance(selfslmlp.avgpool, nn.AdaptiveAvgPool2d)
+
+        if use_conv:
+            assert isinstance(selfslmlp.mlp[0], nn.Conv2d)
+            assert isinstance(selfslmlp.mlp[3], nn.Conv2d)
+        else:
+            assert isinstance(selfslmlp.mlp[0], nn.Linear)
+            assert isinstance(selfslmlp.mlp[3], nn.Linear)
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("init_linear", ["normal", "kaiming"])
+    @pytest.mark.parametrize("std", [0.01, 1., 10.])
+    @pytest.mark.parametrize("bias", [0.1, 0., 1.])
+    def test_init_weights(self, init_linear: str, std: float, bias: float):
+        """Test init_weights function.
+        
+        Check if weights of nn.Linear was changed except for biases.
+        BatchNorm weights are already set to 1, so it isn't required to be checked.
+        """
+        def gather_weight_mean_std(modules):
+            mean = []
+            std = []
+            for module in modules:
+                if isinstance(module, nn.Linear):
+                    mean.append(module.weight.mean())
+                    std.append(module.weight.std())
+            return mean, std
+
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            use_conv=False,
+            with_avg_pool=True
+        )
+
+        orig_mean, orig_std = gather_weight_mean_std(selfslmlp.modules())
+        
+        selfslmlp.init_weights(init_linear, std, bias)
+
+        updated_mean, updated_std = gather_weight_mean_std(selfslmlp.modules())
+
+        for origs, updateds in zip([orig_mean, orig_std], [updated_mean, updated_std]):
+            for orig, updated in zip(origs, updateds):
+                assert orig != updated
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("init_linear", ["undefined"])
+    def test_init_weights_undefined_initialization(self, init_linear: str):
+        """Test init_weights function when undefined initialization is given."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            use_conv=False,
+            with_avg_pool=True
+        )
+
+        with pytest.raises(ValueError):
+            selfslmlp.init_weights(init_linear)
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+        [
+            (torch.rand((2, 2)), dict(type='BN1d'), False, False, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type='BN1d'), False, True, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
+        ]
+    )
+    def test_forward_tensor(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+        """Test forward function for tensor."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            norm_cfg=norm_cfg,
+            use_conv=use_conv,
+            with_avg_pool=with_avg_pool
+        )
+
+        results = selfslmlp(inputs)
+        
+        assert results.shape == expected
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+        [
+            ([torch.rand((2, 2)), torch.rand((2, 2))], dict(type='BN1d'), False, False, torch.Size([2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN1d'), False, True, torch.Size([2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
+        ]
+    )
+    def test_forward_list_tuple(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+        """Test forward function for list or tuple."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            norm_cfg=norm_cfg,
+            use_conv=use_conv,
+            with_avg_pool=with_avg_pool
+        )
+
+        results = selfslmlp(inputs)
+        
+        assert results.shape == expected
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("inputs", ["unsupported", 1])
+    def test_forward_unsupported_format(self, inputs: str):
+        """Test forward function for unsupported format."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+        )
+
+        with pytest.raises(TypeError):
+            selfslmlp(inputs)

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/necks/test_selfsl_mlp.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/necks/test_selfsl_mlp.py
@@ -2,28 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from typing import Dict
+
 import pytest
 import torch
 import torch.nn as nn
-from typing import Dict
 
 from otx.algorithms.classification.adapters.mmcls import SelfSLMLP
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
 class TestSelfSLMLP:
-
     @e2e_pytest_unit
     @pytest.mark.parametrize("use_conv", [True, False])
     @pytest.mark.parametrize("with_avg_pool", [True, False])
-    def test_init(self, use_conv: bool, with_avg_pool: bool):
+    def test_init(self, use_conv: bool, with_avg_pool: bool) -> None:
         """Test __init__ function."""
         selfslmlp = SelfSLMLP(
-            in_channels=2,
-            hid_channels=2,
-            out_channels=2,
-            use_conv=use_conv,
-            with_avg_pool=with_avg_pool
+            in_channels=2, hid_channels=2, out_channels=2, use_conv=use_conv, with_avg_pool=with_avg_pool
         )
 
         if with_avg_pool:
@@ -38,14 +34,15 @@ class TestSelfSLMLP:
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("init_linear", ["normal", "kaiming"])
-    @pytest.mark.parametrize("std", [0.01, 1., 10.])
-    @pytest.mark.parametrize("bias", [0.1, 0., 1.])
-    def test_init_weights(self, init_linear: str, std: float, bias: float):
+    @pytest.mark.parametrize("std", [0.01, 1.0, 10.0])
+    @pytest.mark.parametrize("bias", [0.1, 0.0, 1.0])
+    def test_init_weights(self, init_linear: str, std: float, bias: float) -> None:
         """Test init_weights function.
-        
+
         Check if weights of nn.Linear was changed except for biases.
         BatchNorm weights are already set to 1, so it isn't required to be checked.
         """
+
         def gather_weight_mean_std(modules):
             mean = []
             std = []
@@ -55,16 +52,10 @@ class TestSelfSLMLP:
                     std.append(module.weight.std())
             return mean, std
 
-        selfslmlp = SelfSLMLP(
-            in_channels=2,
-            hid_channels=2,
-            out_channels=2,
-            use_conv=False,
-            with_avg_pool=True
-        )
+        selfslmlp = SelfSLMLP(in_channels=2, hid_channels=2, out_channels=2, use_conv=False, with_avg_pool=True)
 
         orig_mean, orig_std = gather_weight_mean_std(selfslmlp.modules())
-        
+
         selfslmlp.init_weights(init_linear, std, bias)
 
         updated_mean, updated_std = gather_weight_mean_std(selfslmlp.modules())
@@ -75,29 +66,26 @@ class TestSelfSLMLP:
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("init_linear", ["undefined"])
-    def test_init_weights_undefined_initialization(self, init_linear: str):
+    def test_init_weights_undefined_initialization(self, init_linear: str) -> None:
         """Test init_weights function when undefined initialization is given."""
-        selfslmlp = SelfSLMLP(
-            in_channels=2,
-            hid_channels=2,
-            out_channels=2,
-            use_conv=False,
-            with_avg_pool=True
-        )
+        selfslmlp = SelfSLMLP(in_channels=2, hid_channels=2, out_channels=2, use_conv=False, with_avg_pool=True)
 
         with pytest.raises(ValueError):
             selfslmlp.init_weights(init_linear)
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+    @pytest.mark.parametrize(
+        "inputs,norm_cfg,use_conv,with_avg_pool,expected",
         [
-            (torch.rand((2, 2)), dict(type='BN1d'), False, False, torch.Size([2, 2])),
-            (torch.rand((2, 2, 2, 2)), dict(type='BN1d'), False, True, torch.Size([2, 2])),
-            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
-            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
-        ]
+            (torch.rand((2, 2)), dict(type="BN1d"), False, False, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type="BN1d"), False, True, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type="BN2d"), True, False, torch.Size([2, 2, 2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type="BN2d"), True, True, torch.Size([2, 2, 1, 1])),
+        ],
     )
-    def test_forward_tensor(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+    def test_forward_tensor(
+        self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size
+    ) -> None:
         """Test forward function for tensor."""
         selfslmlp = SelfSLMLP(
             in_channels=2,
@@ -105,23 +93,38 @@ class TestSelfSLMLP:
             out_channels=2,
             norm_cfg=norm_cfg,
             use_conv=use_conv,
-            with_avg_pool=with_avg_pool
+            with_avg_pool=with_avg_pool,
         )
 
         results = selfslmlp(inputs)
-        
+
         assert results.shape == expected
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+    @pytest.mark.parametrize(
+        "inputs,norm_cfg,use_conv,with_avg_pool,expected",
         [
-            ([torch.rand((2, 2)), torch.rand((2, 2))], dict(type='BN1d'), False, False, torch.Size([2, 2])),
-            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN1d'), False, True, torch.Size([2, 2])),
-            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
-            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
-        ]
+            ([torch.rand((2, 2)), torch.rand((2, 2))], dict(type="BN1d"), False, False, torch.Size([2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type="BN1d"), False, True, torch.Size([2, 2])),
+            (
+                [torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))],
+                dict(type="BN2d"),
+                True,
+                False,
+                torch.Size([2, 2, 2, 2]),
+            ),
+            (
+                [torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))],
+                dict(type="BN2d"),
+                True,
+                True,
+                torch.Size([2, 2, 1, 1]),
+            ),
+        ],
     )
-    def test_forward_list_tuple(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+    def test_forward_list_tuple(
+        self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size
+    ) -> None:
         """Test forward function for list or tuple."""
         selfslmlp = SelfSLMLP(
             in_channels=2,
@@ -129,16 +132,16 @@ class TestSelfSLMLP:
             out_channels=2,
             norm_cfg=norm_cfg,
             use_conv=use_conv,
-            with_avg_pool=with_avg_pool
+            with_avg_pool=with_avg_pool,
         )
 
         results = selfslmlp(inputs)
-        
+
         assert results.shape == expected
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("inputs", ["unsupported", 1])
-    def test_forward_unsupported_format(self, inputs: str):
+    def test_forward_unsupported_format(self, inputs: str) -> None:
         """Test forward function for unsupported format."""
         selfslmlp = SelfSLMLP(
             in_channels=2,

--- a/tests/unit/algorithms/segmentation/adapters/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.segmentation.adapters.mmseg"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/data/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/data/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.segmentation.adapters.mmseg.data"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
@@ -20,7 +20,7 @@ def inputs_np():
     return {
         "img": np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8),
         "gt_semantic_seg": np.random.rand(16, 16),
-        "flip": True
+        "flip": True,
     }
 
 
@@ -30,16 +30,14 @@ def inputs_PIL():
         "img": Image.fromarray(np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8)),
         "gt_semantic_seg": np.random.randint(0, 5, (16, 16), dtype=np.uint8),
         "seg_fields": ["gt_semantic_seg"],
-        "ori_shape": (16, 16, 3)
+        "ori_shape": (16, 16, 3),
     }
 
 
 @e2e_pytest_unit
 def test_two_crop_transform(mocker, inputs_np) -> None:
     """Test TwoCropTransform."""
-    mocker.patch(
-        "otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg",
-        return_value=lambda x: x)
+    mocker.patch("otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg", return_value=lambda x: x)
 
     two_crop_transform = TwoCropTransform(view0=[], view1=[])
 
@@ -69,7 +67,7 @@ def test_random_resized_crop(inputs_PIL) -> None:
 @e2e_pytest_unit
 def test_random_color_jitter(inputs_PIL) -> None:
     """Test RandomColorJitter."""
-    random_color_jitter = RandomColorJitter(p=1.)
+    random_color_jitter = RandomColorJitter(p=1.0)
 
     results = random_color_jitter(inputs_PIL)
 
@@ -91,7 +89,7 @@ def test_random_grayscale(inputs_PIL) -> None:
 @e2e_pytest_unit
 def test_random_gaussian_blur(inputs_PIL) -> None:
     """Test RandomGaussianBlur."""
-    random_gaussian_blur = RandomGaussianBlur(p=1., kernel_size=3)
+    random_gaussian_blur = RandomGaussianBlur(p=1.0, kernel_size=3)
 
     results = random_gaussian_blur(inputs_PIL)
 
@@ -102,7 +100,7 @@ def test_random_gaussian_blur(inputs_PIL) -> None:
 @e2e_pytest_unit
 def test_random_solarization(inputs_np) -> None:
     """Test RandomSolarization."""
-    random_solarization = RandomSolarization(p=1.)
+    random_solarization = RandomSolarization(p=1.0)
 
     results = random_solarization(inputs_np)
 
@@ -115,7 +113,7 @@ def test_random_solarization(inputs_np) -> None:
 def test_nd_array_to_pil_image(inputs_np) -> None:
     """Test NDArrayToPILImage."""
     nd_array_to_pil_image = NDArrayToPILImage(keys=["img"])
-    
+
     results = nd_array_to_pil_image(inputs_np)
 
     assert "img" in results

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
@@ -1,0 +1,135 @@
+import numpy as np
+import pytest
+from PIL import Image
+
+from otx.algorithms.segmentation.adapters.mmseg.data.pipelines import (
+    NDArrayToPILImage,
+    PILImageToNDArray,
+    RandomColorJitter,
+    RandomGaussianBlur,
+    RandomGrayscale,
+    RandomResizedCrop,
+    RandomSolarization,
+    TwoCropTransform,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+@pytest.fixture(scope="module")
+def inputs_np():
+    return {
+        "img": np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8),
+        "gt_semantic_seg": np.random.rand(16, 16),
+        "flip": True
+    }
+
+
+@pytest.fixture(scope="module")
+def inputs_PIL():
+    return {
+        "img": Image.fromarray(np.random.randint(0, 10, (16, 16, 3), dtype=np.uint8)),
+        "gt_semantic_seg": np.random.randint(0, 5, (16, 16), dtype=np.uint8),
+        "seg_fields": ["gt_semantic_seg"],
+        "ori_shape": (16, 16, 3)
+    }
+
+
+@e2e_pytest_unit
+def test_two_crop_transform(mocker, inputs_np) -> None:
+    """Test TwoCropTransform."""
+    mocker.patch(
+        "otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg",
+        return_value=lambda x: x)
+
+    two_crop_transform = TwoCropTransform(view0=[], view1=[])
+
+    results = two_crop_transform(inputs_np)
+
+    assert isinstance(results, dict)
+    assert "img" in results and results["img"].ndim == 4
+    assert "gt_semantic_seg" in results and results["gt_semantic_seg"].ndim == 3
+    assert "flip" in results and isinstance(results["flip"], list)
+
+
+@e2e_pytest_unit
+def test_random_resized_crop(inputs_PIL) -> None:
+    """Test RandomResizedCrop."""
+    random_resized_crop = RandomResizedCrop(size=(8, 8))
+
+    results = random_resized_crop(inputs_PIL)
+
+    assert isinstance(results, dict)
+    assert "img" in results and results["img"].size == (8, 8)
+    assert "gt_semantic_seg" in results and results["gt_semantic_seg"].shape == (8, 8)
+    assert "img_shape" in results
+    assert "ori_shape" in results
+    assert "scale_factor" in results
+
+
+@e2e_pytest_unit
+def test_random_color_jitter(inputs_PIL) -> None:
+    """Test RandomColorJitter."""
+    random_color_jitter = RandomColorJitter(p=1.)
+
+    results = random_color_jitter(inputs_PIL)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+
+
+@e2e_pytest_unit
+def test_random_grayscale(inputs_PIL) -> None:
+    """Test RandomGrayscale."""
+    random_grayscale = RandomGrayscale()
+
+    results = random_grayscale(inputs_PIL)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+
+
+@e2e_pytest_unit
+def test_random_gaussian_blur(inputs_PIL) -> None:
+    """Test RandomGaussianBlur."""
+    random_gaussian_blur = RandomGaussianBlur(p=1., kernel_size=3)
+
+    results = random_gaussian_blur(inputs_PIL)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+
+
+@e2e_pytest_unit
+def test_random_solarization(inputs_np) -> None:
+    """Test RandomSolarization."""
+    random_solarization = RandomSolarization(p=1.)
+
+    results = random_solarization(inputs_np)
+
+    assert isinstance(results, dict)
+    assert "img" in results
+    assert repr(random_solarization) == "RandomSolarization"
+
+
+@e2e_pytest_unit
+def test_nd_array_to_pil_image(inputs_np) -> None:
+    """Test NDArrayToPILImage."""
+    nd_array_to_pil_image = NDArrayToPILImage(keys=["img"])
+    
+    results = nd_array_to_pil_image(inputs_np)
+
+    assert "img" in results
+    assert isinstance(results["img"], Image.Image)
+    assert repr(nd_array_to_pil_image) == "NDArrayToPILImage"
+
+
+@e2e_pytest_unit
+def test_pil_image_to_nd_array(inputs_PIL) -> None:
+    """Test PILImageToNDArray."""
+    pil_image_to_nd_array = PILImageToNDArray(keys=["img"])
+
+    results = pil_image_to_nd_array(inputs_PIL)
+
+    assert "img" in results
+    assert isinstance(results["img"], np.ndarray)
+    assert repr(pil_image_to_nd_array) == "PILImageToNDArray"

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.segmentation.adapters.mmseg.models"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.segmentation.adapters.mmseg.models.losses"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/test_detcon_loss.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/test_detcon_loss.py
@@ -10,20 +10,24 @@ from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 @e2e_pytest_unit
 @pytest.mark.parametrize(
-    "logits,labels,weight,expected", [
+    "logits,labels,weight,expected",
+    [
         (
-            torch.Tensor([[[-1.2786, 2.1673, -1.0000e+09, 6.2263], [-6.7169, -7.1416, 7.3364, -1.0000e+09]]]),
-            torch.Tensor([[[1., 0., 0., 0.], [0., 1., 0., 0.]]]),
-            torch.Tensor([[1., 1.]]),
-            torch.tensor(11.0003)
+            torch.Tensor([[[-1.2786, 2.1673, -1.0000e09, 6.2263], [-6.7169, -7.1416, 7.3364, -1.0000e09]]]),
+            torch.Tensor([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]]),
+            torch.Tensor([[1.0, 1.0]]),
+            torch.tensor(11.0003),
         ),
         (
-            torch.Tensor([[[4.3260e-01, 1.6511e+00, -1.0000e+09, -7.9047e-01], [9.4888e-01, 2.6476e+00, -3.7093e-01, -1.0000e+09]]]),
-            torch.Tensor([[[1., 0., 0., 0.], [0., 1., 0., 0.]]]),
-            torch.Tensor([[1., 1.]]),
-            torch.tensor(0.8755)
-        )
-    ])
+            torch.Tensor(
+                [[[4.3260e-01, 1.6511e00, -1.0000e09, -7.9047e-01], [9.4888e-01, 2.6476e00, -3.7093e-01, -1.0000e09]]]
+            ),
+            torch.Tensor([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]]),
+            torch.Tensor([[1.0, 1.0]]),
+            torch.tensor(0.8755),
+        ),
+    ],
+)
 def test_manual_cross_entropy(logits, labels, weight, expected):
     results = manual_cross_entropy(logits, labels, weight)
 
@@ -31,23 +35,29 @@ def test_manual_cross_entropy(logits, labels, weight, expected):
 
 
 @e2e_pytest_unit
-@pytest.mark.parametrize("inputs,expected", [
-    ({
-        "pred1": torch.Tensor([[[-0.0461, 0.1686, -0.1898, -0.1727], [-0.0609, -0.0948, -0.0463, -0.1461]]]),
-        "pred2": torch.Tensor([[[-0.0811, -0.0115, -0.1901, -0.0227], [-0.0230, 0.0898, -0.1495, -0.0360]]]),
-        "target1": torch.Tensor([[[-0.7734, 0.1523, 0.4729, -2.2324], [-0.3711, 0.2083, 0.0198, -1.9111]]]),
-        "target2": torch.Tensor([[[-1.0625, 1.4160, 0.7988, 1.3291], [-0.2479, 0.9683, 0.0859, 0.4832]]]),
-        "pind1": torch.Tensor([[1, 0]]),
-        "pind2": torch.Tensor([[1, 0]]),
-        "tind1": torch.Tensor([[1, 0]]),
-        "tind2": torch.Tensor([[1, 0]]),
-    }, torch.tensor(11.8758))
-])
+@pytest.mark.parametrize(
+    "inputs,expected",
+    [
+        (
+            {
+                "pred1": torch.Tensor([[[-0.0461, 0.1686, -0.1898, -0.1727], [-0.0609, -0.0948, -0.0463, -0.1461]]]),
+                "pred2": torch.Tensor([[[-0.0811, -0.0115, -0.1901, -0.0227], [-0.0230, 0.0898, -0.1495, -0.0360]]]),
+                "target1": torch.Tensor([[[-0.7734, 0.1523, 0.4729, -2.2324], [-0.3711, 0.2083, 0.0198, -1.9111]]]),
+                "target2": torch.Tensor([[[-1.0625, 1.4160, 0.7988, 1.3291], [-0.2479, 0.9683, 0.0859, 0.4832]]]),
+                "pind1": torch.Tensor([[1, 0]]),
+                "pind2": torch.Tensor([[1, 0]]),
+                "tind1": torch.Tensor([[1, 0]]),
+                "tind2": torch.Tensor([[1, 0]]),
+            },
+            torch.tensor(11.8758),
+        )
+    ],
+)
 def test_detcon_loss(mocker, inputs, expected):
     mocker.patch("torch.cuda.device_count", return_value=0)
     detcon_loss = DetConLoss()
 
     results = detcon_loss(**inputs)
-    
+
     assert "loss" in results
     assert torch.allclose(results["loss"], expected)

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/test_detcon_loss.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/test_detcon_loss.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from otx.algorithms.segmentation.adapters.mmseg.models.losses.detcon_loss import (
+    DetConLoss,
+    manual_cross_entropy,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize(
+    "logits,labels,weight,expected", [
+        (
+            torch.Tensor([[[-1.2786, 2.1673, -1.0000e+09, 6.2263], [-6.7169, -7.1416, 7.3364, -1.0000e+09]]]),
+            torch.Tensor([[[1., 0., 0., 0.], [0., 1., 0., 0.]]]),
+            torch.Tensor([[1., 1.]]),
+            torch.tensor(11.0003)
+        ),
+        (
+            torch.Tensor([[[4.3260e-01, 1.6511e+00, -1.0000e+09, -7.9047e-01], [9.4888e-01, 2.6476e+00, -3.7093e-01, -1.0000e+09]]]),
+            torch.Tensor([[[1., 0., 0., 0.], [0., 1., 0., 0.]]]),
+            torch.Tensor([[1., 1.]]),
+            torch.tensor(0.8755)
+        )
+    ])
+def test_manual_cross_entropy(logits, labels, weight, expected):
+    results = manual_cross_entropy(logits, labels, weight)
+
+    assert torch.allclose(results, expected)
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize("inputs,expected", [
+    ({
+        "pred1": torch.Tensor([[[-0.0461, 0.1686, -0.1898, -0.1727], [-0.0609, -0.0948, -0.0463, -0.1461]]]),
+        "pred2": torch.Tensor([[[-0.0811, -0.0115, -0.1901, -0.0227], [-0.0230, 0.0898, -0.1495, -0.0360]]]),
+        "target1": torch.Tensor([[[-0.7734, 0.1523, 0.4729, -2.2324], [-0.3711, 0.2083, 0.0198, -1.9111]]]),
+        "target2": torch.Tensor([[[-1.0625, 1.4160, 0.7988, 1.3291], [-0.2479, 0.9683, 0.0859, 0.4832]]]),
+        "pind1": torch.Tensor([[1, 0]]),
+        "pind2": torch.Tensor([[1, 0]]),
+        "tind1": torch.Tensor([[1, 0]]),
+        "tind2": torch.Tensor([[1, 0]]),
+    }, torch.tensor(11.8758))
+])
+def test_detcon_loss(mocker, inputs, expected):
+    mocker.patch("torch.cuda.device_count", return_value=0)
+    detcon_loss = DetConLoss()
+
+    results = detcon_loss(**inputs)
+    
+    assert "loss" in results
+    assert torch.allclose(results["loss"], expected)

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/necks/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/necks/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.segmentation.adapters.mmseg.models.necks"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/necks/test_selfsl_mlp.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/necks/test_selfsl_mlp.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+import torch
+import torch.nn as nn
+from typing import Dict
+
+from otx.algorithms.segmentation.adapters.mmseg import SelfSLMLP
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestSelfSLMLP:
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("use_conv", [True, False])
+    @pytest.mark.parametrize("with_avg_pool", [True, False])
+    def test_init(self, use_conv: bool, with_avg_pool: bool):
+        """Test __init__ function."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            use_conv=use_conv,
+            with_avg_pool=with_avg_pool
+        )
+
+        if with_avg_pool:
+            assert isinstance(selfslmlp.avgpool, nn.AdaptiveAvgPool2d)
+
+        if use_conv:
+            assert isinstance(selfslmlp.mlp[0], nn.Conv2d)
+            assert isinstance(selfslmlp.mlp[3], nn.Conv2d)
+        else:
+            assert isinstance(selfslmlp.mlp[0], nn.Linear)
+            assert isinstance(selfslmlp.mlp[3], nn.Linear)
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("init_linear", ["normal", "kaiming"])
+    @pytest.mark.parametrize("std", [0.01, 1., 10.])
+    @pytest.mark.parametrize("bias", [0.1, 0., 1.])
+    def test_init_weights(self, init_linear: str, std: float, bias: float):
+        """Test init_weights function.
+        
+        Check if weights of nn.Linear was changed except for biases.
+        BatchNorm weights are already set to 1, so it isn't required to be checked.
+        """
+        def gather_weight_mean_std(modules):
+            mean = []
+            std = []
+            for module in modules:
+                if isinstance(module, nn.Linear):
+                    mean.append(module.weight.mean())
+                    std.append(module.weight.std())
+            return mean, std
+
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            use_conv=False,
+            with_avg_pool=True
+        )
+
+        orig_mean, orig_std = gather_weight_mean_std(selfslmlp.modules())
+        
+        selfslmlp.init_weights(init_linear, std, bias)
+
+        updated_mean, updated_std = gather_weight_mean_std(selfslmlp.modules())
+
+        for origs, updateds in zip([orig_mean, orig_std], [updated_mean, updated_std]):
+            for orig, updated in zip(origs, updateds):
+                assert orig != updated
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("init_linear", ["undefined"])
+    def test_init_weights_undefined_initialization(self, init_linear: str):
+        """Test init_weights function when undefined initialization is given."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            use_conv=False,
+            with_avg_pool=True
+        )
+
+        with pytest.raises(ValueError):
+            selfslmlp.init_weights(init_linear)
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+        [
+            (torch.rand((2, 2)), dict(type='BN1d'), False, False, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type='BN1d'), False, True, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
+        ]
+    )
+    def test_forward_tensor(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+        """Test forward function for tensor."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            norm_cfg=norm_cfg,
+            use_conv=use_conv,
+            with_avg_pool=with_avg_pool
+        )
+
+        results = selfslmlp(inputs)
+        
+        assert results.shape == expected
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+        [
+            ([torch.rand((2, 2)), torch.rand((2, 2))], dict(type='BN1d'), False, False, torch.Size([2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN1d'), False, True, torch.Size([2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
+        ]
+    )
+    def test_forward_list_tuple(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+        """Test forward function for list or tuple."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+            norm_cfg=norm_cfg,
+            use_conv=use_conv,
+            with_avg_pool=with_avg_pool
+        )
+
+        results = selfslmlp(inputs)
+        
+        assert results.shape == expected
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("inputs", ["unsupported", 1])
+    def test_forward_unsupported_format(self, inputs: str):
+        """Test forward function for unsupported format."""
+        selfslmlp = SelfSLMLP(
+            in_channels=2,
+            hid_channels=2,
+            out_channels=2,
+        )
+
+        with pytest.raises(TypeError):
+            selfslmlp(inputs)

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/necks/test_selfsl_mlp.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/necks/test_selfsl_mlp.py
@@ -2,28 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from typing import Dict
+
 import pytest
 import torch
 import torch.nn as nn
-from typing import Dict
 
 from otx.algorithms.segmentation.adapters.mmseg import SelfSLMLP
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
 class TestSelfSLMLP:
-
     @e2e_pytest_unit
     @pytest.mark.parametrize("use_conv", [True, False])
     @pytest.mark.parametrize("with_avg_pool", [True, False])
     def test_init(self, use_conv: bool, with_avg_pool: bool):
         """Test __init__ function."""
         selfslmlp = SelfSLMLP(
-            in_channels=2,
-            hid_channels=2,
-            out_channels=2,
-            use_conv=use_conv,
-            with_avg_pool=with_avg_pool
+            in_channels=2, hid_channels=2, out_channels=2, use_conv=use_conv, with_avg_pool=with_avg_pool
         )
 
         if with_avg_pool:
@@ -38,14 +34,15 @@ class TestSelfSLMLP:
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("init_linear", ["normal", "kaiming"])
-    @pytest.mark.parametrize("std", [0.01, 1., 10.])
-    @pytest.mark.parametrize("bias", [0.1, 0., 1.])
+    @pytest.mark.parametrize("std", [0.01, 1.0, 10.0])
+    @pytest.mark.parametrize("bias", [0.1, 0.0, 1.0])
     def test_init_weights(self, init_linear: str, std: float, bias: float):
         """Test init_weights function.
-        
+
         Check if weights of nn.Linear was changed except for biases.
         BatchNorm weights are already set to 1, so it isn't required to be checked.
         """
+
         def gather_weight_mean_std(modules):
             mean = []
             std = []
@@ -55,16 +52,10 @@ class TestSelfSLMLP:
                     std.append(module.weight.std())
             return mean, std
 
-        selfslmlp = SelfSLMLP(
-            in_channels=2,
-            hid_channels=2,
-            out_channels=2,
-            use_conv=False,
-            with_avg_pool=True
-        )
+        selfslmlp = SelfSLMLP(in_channels=2, hid_channels=2, out_channels=2, use_conv=False, with_avg_pool=True)
 
         orig_mean, orig_std = gather_weight_mean_std(selfslmlp.modules())
-        
+
         selfslmlp.init_weights(init_linear, std, bias)
 
         updated_mean, updated_std = gather_weight_mean_std(selfslmlp.modules())
@@ -77,27 +68,24 @@ class TestSelfSLMLP:
     @pytest.mark.parametrize("init_linear", ["undefined"])
     def test_init_weights_undefined_initialization(self, init_linear: str):
         """Test init_weights function when undefined initialization is given."""
-        selfslmlp = SelfSLMLP(
-            in_channels=2,
-            hid_channels=2,
-            out_channels=2,
-            use_conv=False,
-            with_avg_pool=True
-        )
+        selfslmlp = SelfSLMLP(in_channels=2, hid_channels=2, out_channels=2, use_conv=False, with_avg_pool=True)
 
         with pytest.raises(ValueError):
             selfslmlp.init_weights(init_linear)
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+    @pytest.mark.parametrize(
+        "inputs,norm_cfg,use_conv,with_avg_pool,expected",
         [
-            (torch.rand((2, 2)), dict(type='BN1d'), False, False, torch.Size([2, 2])),
-            (torch.rand((2, 2, 2, 2)), dict(type='BN1d'), False, True, torch.Size([2, 2])),
-            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
-            (torch.rand((2, 2, 2, 2)), dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
-        ]
+            (torch.rand((2, 2)), dict(type="BN1d"), False, False, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type="BN1d"), False, True, torch.Size([2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type="BN2d"), True, False, torch.Size([2, 2, 2, 2])),
+            (torch.rand((2, 2, 2, 2)), dict(type="BN2d"), True, True, torch.Size([2, 2, 1, 1])),
+        ],
     )
-    def test_forward_tensor(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+    def test_forward_tensor(
+        self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size
+    ):
         """Test forward function for tensor."""
         selfslmlp = SelfSLMLP(
             in_channels=2,
@@ -105,23 +93,38 @@ class TestSelfSLMLP:
             out_channels=2,
             norm_cfg=norm_cfg,
             use_conv=use_conv,
-            with_avg_pool=with_avg_pool
+            with_avg_pool=with_avg_pool,
         )
 
         results = selfslmlp(inputs)
-        
+
         assert results.shape == expected
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("inputs,norm_cfg,use_conv,with_avg_pool,expected", 
+    @pytest.mark.parametrize(
+        "inputs,norm_cfg,use_conv,with_avg_pool,expected",
         [
-            ([torch.rand((2, 2)), torch.rand((2, 2))], dict(type='BN1d'), False, False, torch.Size([2, 2])),
-            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN1d'), False, True, torch.Size([2, 2])),
-            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, False, torch.Size([2, 2, 2, 2])),
-            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type='BN2d'), True, True, torch.Size([2, 2, 1, 1])),
-        ]
+            ([torch.rand((2, 2)), torch.rand((2, 2))], dict(type="BN1d"), False, False, torch.Size([2, 2])),
+            ([torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))], dict(type="BN1d"), False, True, torch.Size([2, 2])),
+            (
+                [torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))],
+                dict(type="BN2d"),
+                True,
+                False,
+                torch.Size([2, 2, 2, 2]),
+            ),
+            (
+                [torch.rand((2, 2, 2, 2)), torch.rand((2, 2, 2, 2))],
+                dict(type="BN2d"),
+                True,
+                True,
+                torch.Size([2, 2, 1, 1]),
+            ),
+        ],
     )
-    def test_forward_list_tuple(self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size):
+    def test_forward_list_tuple(
+        self, inputs: torch.Tensor, norm_cfg: Dict, use_conv: bool, with_avg_pool: bool, expected: torch.Size
+    ):
         """Test forward function for list or tuple."""
         selfslmlp = SelfSLMLP(
             in_channels=2,
@@ -129,11 +132,11 @@ class TestSelfSLMLP:
             out_channels=2,
             norm_cfg=norm_cfg,
             use_conv=use_conv,
-            with_avg_pool=with_avg_pool
+            with_avg_pool=with_avg_pool,
         )
 
         results = selfslmlp(inputs)
-        
+
         assert results.shape == expected
 
     @e2e_pytest_unit

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/__init__.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.segmentation.adapters.mmseg.models.segmentors"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
@@ -1,0 +1,189 @@
+# Copyright (C) 2021-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+from copy import deepcopy
+from typing import List, Union
+from functools import reduce
+
+import pytest
+import torch
+import torch.nn as nn
+
+from otx.algorithms.segmentation.adapters.mmseg import DetConB
+from otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon import (
+    MaskPooling,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestMaskPooling:
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("masks", [torch.Tensor([[[[0, 1], [1, 2]]]]).to(torch.int64),
+                                       torch.Tensor([[[0, 1], [1, 2]]]).to(torch.int64)])
+    @pytest.mark.parametrize("num_classes", [256, 3])
+    def test_pool_masks(self, masks, num_classes):
+        """Test pool_masks function."""
+        mask_pooling = MaskPooling(num_classes=num_classes, downsample=1)
+
+        binary_masks = mask_pooling.pool_masks(masks)
+
+        assert binary_masks.shape[1] == num_classes
+
+    @e2e_pytest_unit
+    def test_sample_masks(self):
+        """Test sample_masks function."""
+        num_classes = 3
+        masks = torch.Tensor([[[[0, 1], [1, 2]]]]).to(torch.int64)
+        mask_pooling = MaskPooling(num_classes=num_classes, downsample=1)
+
+        binary_masks = mask_pooling.pool_masks(masks)
+        _, sampled_mask_ids = mask_pooling.sample_masks(binary_masks)
+
+        assert len(torch.unique(sampled_mask_ids)) > 1
+        assert len(torch.unique(sampled_mask_ids)) <= num_classes
+
+    @e2e_pytest_unit
+    def test_forward(self):
+        """Test forward function."""
+        num_classes = 3
+        masks = torch.Tensor([[[[0, 1], [1, 2]]]]).to(torch.int64)
+        mask_pooling = MaskPooling(num_classes=num_classes, downsample=1)
+
+        sampled_masks, _ = mask_pooling(masks)
+
+        assert torch.all(sampled_masks.sum(dim=-1) == 1)
+
+
+class TestDetConB:
+    """Test DetConB"""
+    
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch, mocker) -> None:
+        class MockBackbone(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pipeline1 = nn.Sequential(
+                    nn.Conv2d(3, 1, (1, 1), bias=False),
+                    nn.Conv2d(1, 1, (1, 1), bias=False))
+                self.pipeline2 = nn.Sequential(
+                    nn.Conv2d(3, 1, (1, 1), stride=2, bias=False),
+                    nn.Conv2d(1, 1, (1, 1), bias=False))
+
+            def init_weights(self, init_linear=None):
+                pass
+            
+            def forward(self, x):
+                return [self.pipeline1(x), self.pipeline2(x)]
+
+        class MockNeck(nn.Sequential):
+            def __init__(self):
+                super().__init__(
+                    nn.Linear(2, 2, bias=False),
+                    nn.Linear(2, 2, bias=False)
+                )
+
+            def init_weights(self, init_linear=None):
+                pass
+
+        def build_mock_backbone(*args, **kwargs):
+            return MockBackbone()
+
+        def build_mock_neck(*args, **kwargs):
+            return MockNeck()
+
+        monkeypatch.setattr(
+            "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_backbone",
+            build_mock_backbone
+        )
+        monkeypatch.setattr(
+            "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_neck",
+            build_mock_neck
+        )
+        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_loss", return_value=lambda *args, **kwargs: dict(loss=1.))
+        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB._register_state_dict_hook")
+        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB.state_dict_hook")
+        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.load_checkpoint")
+
+        self.detconb = DetConB(backbone={}, neck={}, head={}, downsample=1, loss_cfg=dict(type="DetConLoss"))
+    
+    @e2e_pytest_unit
+    def test_init_weights(self) -> None:
+        """Test init_weights function."""
+        for param_ol, param_tgt in zip(self.detconb.online_backbone.parameters(), self.detconb.target_backbone.parameters()):
+            assert torch.all(param_ol == param_tgt)
+            assert param_ol.requires_grad == True
+            assert param_tgt.requires_grad == False
+
+        for param_ol, param_tgt in zip(self.detconb.online_projector.parameters(), self.detconb.target_projector.parameters()):
+            assert torch.all(param_ol == param_tgt)
+            assert param_ol.requires_grad == True
+            assert param_tgt.requires_grad == False
+
+    @e2e_pytest_unit
+    def test_momentum_update(self) -> None:
+        """Test _momentum_update function."""
+        original_params = {"backbone": [], "projector": []}
+        for param_tgt in self.detconb.target_backbone.parameters():
+            param_tgt.data *= 2.
+            original_params["backbone"].append(deepcopy(param_tgt))
+
+        for param_tgt in self.detconb.target_projector.parameters():
+            param_tgt.data *= 2.
+            original_params["projector"].append(deepcopy(param_tgt))
+
+        self.detconb._momentum_update()
+
+        for param_ol, param_tgt, orig_tgt in zip(self.detconb.online_backbone.parameters(), self.detconb.target_backbone.parameters(), original_params["backbone"]):
+            assert torch.all(param_tgt.data == orig_tgt * self.detconb.momentum + param_ol.data * (1.0 - self.detconb.momentum))
+
+        for param_ol, param_tgt, orig_tgt in zip(self.detconb.online_projector.parameters(), self.detconb.target_projector.parameters(), original_params["projector"]):
+            assert torch.all(param_tgt.data == orig_tgt * self.detconb.momentum + param_ol.data * (1.0 - self.detconb.momentum))
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("input_transform", ["resize_concat", "multiple_select", "etc"])
+    @pytest.mark.parametrize("inputs,in_index", [([torch.ones(1, 1, 4, 4), torch.ones(1, 1, 2, 2)], [0, 1]), ([torch.ones(1, 1, 4, 4), torch.ones(1, 1, 2, 2)], [0]), ([torch.ones(1, 1, 4, 4)], [0])])
+    def test_transform_inputs(self, inputs: List, in_index: Union[List, int], input_transform: str) -> None:
+        """Test transform_inputs function."""
+        setattr(self.detconb, "in_index", in_index)
+        setattr(self.detconb, "input_transform", input_transform)
+
+        transformed_inputs = self.detconb.transform_inputs(inputs)
+
+        if input_transform == "resize_concat":
+            assert transformed_inputs.shape[1] == len(in_index)
+        elif input_transform == "multiple_select":
+            assert len(transformed_inputs) == len(in_index)
+        else:
+            assert len(transformed_inputs) == 1
+
+    @e2e_pytest_unit
+    def test_sample_masked_feats(self) -> None:
+        """Test sample_masked_feats function."""
+        setattr(self.detconb, "in_index", [0, 1])
+        setattr(self.detconb, "input_transform", "resize_concat")
+        feats = [torch.randn((1, 1, 4, 4)), torch.randn((1, 1, 2, 2))]
+        masks = torch.randint(0, 3, (1, 1, 4, 4), dtype=torch.int64)
+
+        proj, sampled_mask_ids = self.detconb.sample_masked_feats(feats, masks, self.detconb.online_projector)
+
+        assert proj.ndim == 2
+        assert proj.shape[0] == reduce(lambda x, y: x * y, feats[0].shape[2:])
+        assert proj.shape[1] == sum([feat.shape[1] for feat in feats])
+        assert proj.shape[0] == sampled_mask_ids.shape[1]
+
+    @e2e_pytest_unit
+    def test_detconb_train_step(self) -> None:
+        """Test train_step function wraps forward and _parse_losses."""
+        setattr(self.detconb, "in_index", [0, 1])
+        setattr(self.detconb, "input_transform", "resize_concat")
+        img = torch.randn((1, 2, 3, 4, 4))
+        gt_semantic_seg = torch.randint(0, 3, (1, 2, 4, 4), dtype=torch.int64)
+
+        outputs = self.detconb.train_step(
+            data_batch=dict(img=img, img_metas={}, gt_semantic_seg=gt_semantic_seg),
+            optimizer=None)
+
+        assert "loss" in outputs
+        assert "log_vars" in outputs
+        assert "num_samples" in outputs


### PR DESCRIPTION
### Classification
- [x] `otx/algorithms/classification/adapters/mmcls/data/datasets.py` : 24%
(only `SelfSLDataset`)
- [x] `otx/algorithms/classification/adapters/mmcls/data/pipelines.py` : 100%
(for all methods)
- [x] `otx/algorithms/classification/adapters/mmcls/models/classifiers/byol.py` : 89%
- [x] `otx/algorithms/classification/adapters/mmcls/models/heads/contrastive_head.py` : 100%
- [x] `otx/algorithms/classification/adapters/mmcls/models/necks/selfsl_mlp.py` : 100%

### Semantic Segmentation
- [x] `otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py` : 82%
(except for `LoadImageFromOTXDataset` and `LoadAnnotationFromOTXDataset`)
- [x] `otx/algorithms/segmentation/adapters/mmseg/models/losses/detcon_loss.py` : 80%
- [x] `otx/algorithms/segmentation/adapters/mmseg/models/necks/selfsl_mlp.py` : 100%
- [x] `otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py` : 88%
- [ ] ~`otx/algorithms/segmentation/adapters/mmseg/utils/data_utils.py::create_pseudo_masks`~
This method is required to move the location, so it will be proceeded in other PR.