### PR TITLE
[CI] Fix build doc and  labeler setting

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,31 @@
 # See help here: https://github.com/marketplace/actions/labeler
 
-dependencies:
-  - "requirements/*"
-  - "setup.py"
 CLI:
   - "otx/cli/**/*"
-SDK:
-  - "otx/sdk/**/*"
-tests:
-  - "tests/**/*"
-tasks:
+API:
+  - "otx/api/**/*"
+ALGO:
   - "otx/algorithms/**/*"
+TEST:
+  - "tests/**/*"
+DOC:
+  - "doc/**/*"
+  - "./**/*.md"
+  - "LICENSE"
+  - "third-party-programs.txt"
+BUILD:
+  - ".ci/**/*"
+  - ".github/**/*"
+  - ".flake8"
+  - ".isort.cfg"
+  - ".mdlrc"
+  - ".pre-commit-config.yaml"
+  - "markdownlint.rb"
+  - "setup.py"
+  - "pyproject.toml"
+  - "tox.ini"
+  - "MANIFEST.in"
+DEPENDENCY:
+  - "requirements/*"
+  - "setup.py"
+  - "pyproject.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,8 @@ name: Build Docs
 
 on:
   push:
-    branches: [feature/otx]
+    branches:
+      - develop
   workflow_dispatch: # run on request (no need for PR)
 
 jobs:


### PR DESCRIPTION
Enabling doc build for develop branch.
(+ Refine labeler setting, but not sure difference btw .github/labeler.yaml vs .github/workflows/labeler.yaml)