### PR TITLE
[OTX][Hot-fix] Fix conflicts of same module names in test by adding init file

### DIFF
--- a/tests/unit/algorithms/action/__init__.py
+++ b/tests/unit/algorithms/action/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/tests/unit/algorithms/segmentation/__init__.py
+++ b/tests/unit/algorithms/segmentation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.


### PR DESCRIPTION
When collecting pytests test files, it searches upwards until it can find the last folder which still contains an __init__.py file in order to find the package root. The conflict happened between tests/unit/algorithms/action/test_helpers.py and unit/algorithms/segmentation/test_helpers.py. It mainly can resolve by using different name or adding __init__.py for each folder. I resolved it by adding __init__.py for each.