### PR TITLE
[HOTFIX] Replace otx.mpa.logger with mmcv.logger in otx.algorithms.common.utils

### DIFF
--- a/otx/algorithms/common/utils/data.py
+++ b/otx/algorithms/common/utils/data.py
@@ -35,7 +35,7 @@ from otx.api.utils.argument_checks import (
     check_input_parameters_type,
 )
 
-logger = get_logger(name="otx")
+logger = get_logger(name="otx.algorithm.common.utils.data")
 
 
 @check_input_parameters_type({"file_list_path": DirectoryPathCheck})

--- a/otx/algorithms/common/utils/data.py
+++ b/otx/algorithms/common/utils/data.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, Optional, Union
 
 import cv2
 import numpy as np
+from mmcv.utils import get_logger
 
 from otx.api.entities.annotation import NullAnnotationSceneEntity
 from otx.api.entities.dataset_item import DatasetItemEntity
@@ -33,9 +34,8 @@ from otx.api.utils.argument_checks import (
     DirectoryPathCheck,
     check_input_parameters_type,
 )
-from otx.mpa.utils.logger import get_logger
 
-logger = get_logger()
+logger = get_logger(name="otx")
 
 
 @check_input_parameters_type({"file_list_path": DirectoryPathCheck})


### PR DESCRIPTION
## This PR includes:
- Fix circular import error in develop branch

```
Traceback (most recent call last):
  File "./otx/algorithms/detection/tools/detection_sample.py", line 23, in <module>
    from otx.algorithms.common.utils import get_task_class
  File "/home/jeom/ws/otx-dev/otx/algorithms/common/utils/__init__.py", line 22, in <module>
    from .data import get_cls_img_indices, get_image, get_old_new_img_indices
  File "/home/jeom/ws/otx-dev/otx/algorithms/common/utils/data.py", line 25, in <module>
    from otx.mpa.utils.logger import get_logger
  File "/home/jeom/ws/otx-dev/otx/mpa/__init__.py", line 8, in <module>
    from .builder import build, build_workflow_hook
  File "/home/jeom/ws/otx-dev/otx/mpa/builder.py", line 13, in <module>
    from .stage import get_available_types
  File "/home/jeom/ws/otx-dev/otx/mpa/stage.py", line 21, in <module>
    from otx.algorithms.common.adapters.mmcv.utils import (
  File "/home/jeom/ws/otx-dev/otx/algorithms/common/adapters/mmcv/__init__.py", line 27, in <module>
    from .nncf.hooks import CompressionHook
  File "/home/jeom/ws/otx-dev/otx/algorithms/common/adapters/mmcv/nncf/__init__.py", line 8, in <module>
    from .utils import get_fake_input, model_eval, wrap_nncf_model
  File "/home/jeom/ws/otx-dev/otx/algorithms/common/adapters/mmcv/nncf/utils.py", line 29, in <module>
    from otx.algorithms.common.utils import get_arg_spec
ImportError: cannot import name 'get_arg_spec' from partially initialized module 'otx.algorithms.common.utils' (most likely due to a circular import) (/home/jeom/ws/otx-dev/otx/algorithms/common/utils/__init__.py)
```

**This is hotfix, if you have good idea to resolve this issue, please let me know.** 