### PR TITLE
[DEV][HOTFIX] Add accuracy metric in multi label classification

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/data/datasets.py
+++ b/otx/algorithms/classification/adapters/mmcls/data/datasets.py
@@ -281,6 +281,7 @@ class MPAMultilabelClsDataset(MPAClsDataset):
                 if k in metrics:
                     eval_results[k] = v
 
+        eval_results["accuracy"] = eval_results["accuracy-mlc"]
         return eval_results
 
 


### PR DESCRIPTION
### Summary

- Add `accuracy` metric in multi label classification

### Detail
Currently, there is no `accuracy` metric in multi label classification, which results in error during HPO.