### PR TITLE
[ENHANCE] Support model partition for mmdeploy export

### DIFF
--- a/otx/algorithms/classification/tasks/inference.py
+++ b/otx/algorithms/classification/tasks/inference.py
@@ -209,16 +209,16 @@ class ClassificationInferenceTask(
         outputs = results.get("outputs")
         logger.debug(f"results of run_task = {outputs}")
         if outputs is None:
-            logger.error(f"error while exporting model, result is None: {results.get('msg')}")
-        else:
-            bin_file = outputs.get("bin")
-            xml_file = outputs.get("xml")
-            if xml_file is None or bin_file is None:
-                raise RuntimeError("invalid status of exporting. bin and xml should not be None")
-            with open(bin_file, "rb") as f:
-                output_model.set_data("openvino.bin", f.read())
-            with open(xml_file, "rb") as f:
-                output_model.set_data("openvino.xml", f.read())
+            raise RuntimeError(results.get("msg"))
+
+        bin_file = outputs.get("bin")
+        xml_file = outputs.get("xml")
+        if xml_file is None or bin_file is None:
+            raise RuntimeError("invalid status of exporting. bin and xml should not be None")
+        with open(bin_file, "rb") as f:
+            output_model.set_data("openvino.bin", f.read())
+        with open(xml_file, "rb") as f:
+            output_model.set_data("openvino.xml", f.read())
         output_model.precision = [ModelPrecision.FP32]
         output_model.set_data(
             "label_schema.json",

--- a/otx/algorithms/detection/tasks/inference.py
+++ b/otx/algorithms/detection/tasks/inference.py
@@ -245,27 +245,27 @@ class DetectionInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluationT
         outputs = results.get("outputs")
         logger.debug(f"results of run_task = {outputs}")
         if outputs is None:
-            logger.error(f"error while exporting model, result is None: {results.get('msg')}")
-        else:
-            bin_file = outputs.get("bin")
-            xml_file = outputs.get("xml")
-            if xml_file is None or bin_file is None:
-                raise RuntimeError("invalid status of exporting. bin and xml should not be None")
-            with open(bin_file, "rb") as f:
-                output_model.set_data("openvino.bin", f.read())
-            with open(xml_file, "rb") as f:
-                output_model.set_data("openvino.xml", f.read())
-            output_model.set_data(
-                "confidence_threshold",
-                np.array([self.confidence_threshold], dtype=np.float32).tobytes(),
-            )
-            output_model.set_data("config.json", config_to_bytes(self._hyperparams))
-            output_model.precision = [ModelPrecision.FP32]
-            output_model.optimization_methods = self._optimization_methods
-            output_model.set_data(
-                "label_schema.json",
-                label_schema_to_bytes(self._task_environment.label_schema),
-            )
+            raise RuntimeError(results.get("msg"))
+
+        bin_file = outputs.get("bin")
+        xml_file = outputs.get("xml")
+        if xml_file is None or bin_file is None:
+            raise RuntimeError("invalid status of exporting. bin and xml should not be None")
+        with open(bin_file, "rb") as f:
+            output_model.set_data("openvino.bin", f.read())
+        with open(xml_file, "rb") as f:
+            output_model.set_data("openvino.xml", f.read())
+        output_model.set_data(
+            "confidence_threshold",
+            np.array([self.confidence_threshold], dtype=np.float32).tobytes(),
+        )
+        output_model.set_data("config.json", config_to_bytes(self._hyperparams))
+        output_model.precision = [ModelPrecision.FP32]
+        output_model.optimization_methods = self._optimization_methods
+        output_model.set_data(
+            "label_schema.json",
+            label_schema_to_bytes(self._task_environment.label_schema),
+        )
         logger.info("Exporting completed")
 
     def _init_recipe_hparam(self) -> dict:

--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -164,20 +164,19 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
         outputs = results.get("outputs")
         logger.debug(f"results of run_task = {outputs}")
         if outputs is None:
-            logger.error(f"error while exporting model, result is None: {results.get('msg')}")
-            # output_model.model_status = ModelStatus.FAILED
-        else:
-            bin_file = outputs.get("bin")
-            xml_file = outputs.get("xml")
-            if xml_file is None or bin_file is None:
-                raise RuntimeError("invalid status of exporting. bin and xml should not be None")
-            with open(bin_file, "rb") as f:
-                output_model.set_data("openvino.bin", f.read())
-            with open(xml_file, "rb") as f:
-                output_model.set_data("openvino.xml", f.read())
-            output_model.precision = [ModelPrecision.FP32]
-            output_model.optimization_methods = self._optimization_methods
-            output_model.set_data("label_schema.json", label_schema_to_bytes(self._task_environment.label_schema))
+            raise RuntimeError(results.get("msg"))
+
+        bin_file = outputs.get("bin")
+        xml_file = outputs.get("xml")
+        if xml_file is None or bin_file is None:
+            raise RuntimeError("invalid status of exporting. bin and xml should not be None")
+        with open(bin_file, "rb") as f:
+            output_model.set_data("openvino.bin", f.read())
+        with open(xml_file, "rb") as f:
+            output_model.set_data("openvino.xml", f.read())
+        output_model.precision = [ModelPrecision.FP32]
+        output_model.optimization_methods = self._optimization_methods
+        output_model.set_data("label_schema.json", label_schema_to_bytes(self._task_environment.label_schema))
         logger.info("Exporting completed")
 
     def _init_recipe(self):

--- a/otx/mpa/deploy/apis.py
+++ b/otx/mpa/deploy/apis.py
@@ -5,16 +5,24 @@
 import os
 import time
 from collections.abc import Mapping
+from copy import deepcopy
 from functools import partial
 from subprocess import CalledProcessError
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import mmcv
 import numpy as np
+import onnx
 import torch
 from mmcv.parallel import collate, scatter
 
-from .utils import is_mmdeploy_enabled, mmdeploy_init_model_helper, numpy_2_list
+from .utils import numpy_2_list
+from .utils.mmdeploy import (
+    is_mmdeploy_enabled,
+    mmdeploy_init_model_helper,
+    update_deploy_cfg,
+)
+from .utils.onnx import prepare_onnx_for_openvino
 
 
 class NaiveExporter:
@@ -155,10 +163,15 @@ class NaiveExporter:
 
 if is_mmdeploy_enabled():
     import mmdeploy.apis.openvino as openvino_api
-    from mmdeploy.apis import build_task_processor, torch2onnx
+    from mmdeploy.apis import (
+        build_task_processor,
+        extract_model,
+        get_predefined_partition_cfg,
+        torch2onnx,
+    )
     from mmdeploy.apis.openvino import get_input_info_from_cfg, get_mo_options_from_cfg
     from mmdeploy.core import FUNCTION_REWRITER
-    from mmdeploy.utils import get_ir_config
+    from mmdeploy.utils import get_backend_config, get_ir_config, get_partition_config
 
     class MMdeployExporter:
         @staticmethod
@@ -169,6 +182,7 @@ if is_mmdeploy_enabled():
             deploy_cfg: mmcv.Config,
             *,
             model_name: str = "model",
+            partition: bool = True,
         ):
 
             task_processor = build_task_processor(cfg, deploy_cfg, "cpu")
@@ -192,20 +206,39 @@ if is_mmdeploy_enabled():
             else:
                 input_data = np.zeros(input_data_cfg["shape"], dtype=np.uint8)
 
-            onnx_path = MMdeployExporter.torch2onnx(
-                output_dir,
-                input_data,
-                cfg,
-                deploy_cfg,
-                model_name=model_name,
+            onnx_paths = []
+            onnx_paths.append(
+                MMdeployExporter.torch2onnx(
+                    output_dir,
+                    input_data,
+                    cfg,
+                    deploy_cfg,
+                    model_name=model_name,
+                )
             )
 
-            MMdeployExporter.onnx2openvino(
-                output_dir,
-                onnx_path,
-                deploy_cfg,
-                model_name=model_name,
-            )
+            partition_cfgs = get_partition_config(deploy_cfg)
+            if partition and partition_cfgs:
+                partition_cfgs = partition_cfgs.get("partition_cfg", None)
+                onnx_paths.extend(
+                    MMdeployExporter.partition_onnx(
+                        output_dir,
+                        onnx_paths[0],
+                        partition_cfgs,
+                    )
+                )
+
+            for i, onnx_path in enumerate(onnx_paths):
+                mo_options = {}
+                if i > 0:
+                    mo_options = partition_cfgs[i - 1].get("mo_options", {})
+                deploy_cfg_ = deepcopy(deploy_cfg)
+                update_deploy_cfg(onnx_path, deploy_cfg_, mo_options)
+                MMdeployExporter.onnx2openvino(
+                    output_dir,
+                    onnx_path,
+                    deploy_cfg_,
+                )
 
         @staticmethod
         def torch2onnx(
@@ -229,29 +262,56 @@ if is_mmdeploy_enabled():
             return os.path.join(output_dir, onnx_file_name)
 
         @staticmethod
+        def partition_onnx(
+            output_dir,
+            onnx_path: str,
+            partition_cfgs: Union[mmcv.ConfigDict, List[mmcv.ConfigDict]],
+        ) -> Tuple[str, ...]:
+            partitioned_paths = []
+
+            if not isinstance(partition_cfgs, list):
+                partition_cfgs = [partition_cfgs]
+
+            for partition_cfg in partition_cfgs:
+                save_file = partition_cfg["save_file"]
+                save_path = os.path.join(output_dir, save_file)
+                start = partition_cfg["start"]
+                end = partition_cfg["end"]
+                dynamic_axes = partition_cfg.get("dynamic_axes", None)
+
+                extract_model(onnx_path, start, end, dynamic_axes=dynamic_axes, save_file=save_path)
+                partitioned_paths.append(save_path)
+            return tuple(partitioned_paths)
+
+        @staticmethod
         def onnx2openvino(
             output_dir: str,
             onnx_path: str,
             deploy_cfg: Union[str, mmcv.Config],
             *,
-            model_name: str = "model",
+            model_name: Optional[str] = None,
         ) -> Tuple[str, str]:
+
             input_info = get_input_info_from_cfg(deploy_cfg)
             output_names = get_ir_config(deploy_cfg).output_names
             mo_options = get_mo_options_from_cfg(deploy_cfg)
 
-            if model_name:
-                mo_options.args += f'--model_name "{model_name}" '
+            if not model_name:
+                model_name = os.path.basename(onnx_path).replace(".onnx", "")
+            mo_options.args += f'--model_name "{model_name}" '
+
+            onnx_ready_path = os.path.join(os.path.dirname(onnx_path), f"{model_name}_ready.onnx")
+            prepare_onnx_for_openvino(onnx_path, os.path.join(os.path.dirname(onnx_path), f"{model_name}_ready.onnx"))
 
             try:
-                openvino_api.from_onnx(onnx_path, output_dir, input_info, output_names, mo_options)
+                openvino_api.from_onnx(onnx_ready_path, output_dir, input_info, output_names, mo_options)
             except CalledProcessError as e:
                 # NOTE: mo returns non zero return code (245) even though it successfully generate IR
                 cur_time = time.time()
                 time_threshold = 5
-                if (
+                if not (
                     e.returncode == 245
-                    and {model_name + ".bin", model_name + ".xml"} - set(os.listdir(output_dir))
+                    and not {model_name + ".bin", model_name + ".xml"} - set(os.listdir(output_dir))
                     and (
                         os.path.getmtime(os.path.join(output_dir, model_name + ".bin")) - cur_time < time_threshold
                         and os.path.getmtime(os.path.join(output_dir, model_name + ".xml")) - cur_time < time_threshold

--- a/otx/mpa/deploy/apis.py
+++ b/otx/mpa/deploy/apis.py
@@ -160,21 +160,6 @@ if is_mmdeploy_enabled():
     from mmdeploy.core import FUNCTION_REWRITER
     from mmdeploy.utils import get_ir_config
 
-    @FUNCTION_REWRITER.register_rewriter(
-        "mmdeploy.core.optimizers.function_marker.mark_tensors",
-        backend="openvino",
-    )
-    def remove_mark__openvino(ctx, xs: Any, *args, **kwargs):
-        """Disable all marks for openvino backend
-
-        As the Node `mark` is not able to be traced, we just return original input
-        for the function `mark_tensors`.
-
-        Args:
-            xs (Any): Input structure which contains tensor.
-        """
-        return xs
-
     class MMdeployExporter:
         @staticmethod
         def export2openvino(

--- a/otx/mpa/deploy/apis.py
+++ b/otx/mpa/deploy/apis.py
@@ -182,7 +182,6 @@ if is_mmdeploy_enabled():
             deploy_cfg: mmcv.Config,
             *,
             model_name: str = "model",
-            partition: bool = True,
         ):
 
             task_processor = build_task_processor(cfg, deploy_cfg, "cpu")
@@ -218,7 +217,7 @@ if is_mmdeploy_enabled():
             )
 
             partition_cfgs = get_partition_config(deploy_cfg)
-            if partition and partition_cfgs:
+            if partition_cfgs:
                 partition_cfgs = partition_cfgs.get("partition_cfg", None)
                 onnx_paths.extend(
                     MMdeployExporter.partition_onnx(

--- a/otx/mpa/deploy/utils/__init__.py
+++ b/otx/mpa/deploy/utils/__init__.py
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from .mmdeploy import is_mmdeploy_enabled, mmdeploy_init_model_helper
+from .mmdeploy import is_mmdeploy_enabled
 from .utils import numpy_2_list, sync_batchnorm_2_batchnorm
 
 __all__ = [
     "is_mmdeploy_enabled",
-    "mmdeploy_init_model_helper",
     "sync_batchnorm_2_batchnorm",
     "numpy_2_list",
 ]

--- a/otx/mpa/deploy/utils/onnx.py
+++ b/otx/mpa/deploy/utils/onnx.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import onnx
+
+
+def remove_nodes_by_op_type(onnx_model, op_type):
+    # TODO: support more nodes
+
+    supported_op_types = ["Mark", "Conv"]
+    assert op_type in supported_op_types
+
+    target_nodes = []
+    for node in onnx_model.graph.node:
+        if node.op_type == op_type:
+            target_nodes.append(node)
+
+    output_names = [i.name for i in onnx_model.graph.output]
+
+    for target_node in target_nodes:
+        in_port = target_node.input[0]
+        out_port = target_node.output[0]
+
+        out_nodes = [node for node in onnx_model.graph.node if out_port in node.input]
+        for out_node in out_nodes:
+            for i, j in enumerate(out_node.input):
+                if j == out_port:
+                    out_node.input[i] = in_port
+
+        if out_port in output_names:
+            in_nodes = [node for node in onnx_model.graph.node if in_port in node.output]
+            for in_node in in_nodes:
+                for i, j in enumerate(in_node.output):
+                    if j == in_port:
+                        in_node.output[i] = out_port
+
+        onnx_model.graph.node.remove(target_node)
+
+    onnx.checker.check_model(onnx_model)
+    return onnx_model
+
+
+def prepare_onnx_for_openvino(in_path, out_path):
+    onnx_model = onnx.load(in_path)
+    onnx_model = remove_nodes_by_op_type(onnx_model, "Mark")
+    onnx.checker.check_model(onnx_model)
+    onnx.save(onnx_model, out_path)

--- a/otx/mpa/deploy/utils/onnx.py
+++ b/otx/mpa/deploy/utils/onnx.py
@@ -8,7 +8,7 @@ import onnx
 def remove_nodes_by_op_type(onnx_model, op_type):
     # TODO: support more nodes
 
-    supported_op_types = ["Mark", "Conv"]
+    supported_op_types = ["Mark", "Conv", "Gemm"]
     assert op_type in supported_op_types
 
     target_nodes = []

--- a/otx/mpa/exporter_mixin.py
+++ b/otx/mpa/exporter_mixin.py
@@ -64,12 +64,20 @@ class ExporterMixin(object):
                 "msg": f"exception {type(ex)}: {ex}\n\n{traceback.format_exc()}",
             }
 
-        bin_file = [f for f in os.listdir(cfg.work_dir) if f.endswith(".bin")][0]
-        xml_file = [f for f in os.listdir(cfg.work_dir) if f.endswith(".xml")][0]
         return {
             "outputs": {
-                "bin": os.path.join(cfg.work_dir, bin_file),
-                "xml": os.path.join(cfg.work_dir, xml_file),
+                "bin": os.path.join(cfg.work_dir, f"{model_name}.bin"),
+                "xml": os.path.join(cfg.work_dir, f"{model_name}.xml"),
+                "partitioned": [
+                    {
+                        "bin": os.path.join(cfg.work_dir, name.replace(".xml", ".bin")),
+                        "xml": os.path.join(cfg.work_dir, name),
+                    }
+                    for name in os.listdir(cfg.work_dir)
+                    if name.endswith(".xml")
+                    and name != f"{model_name}.xml"
+                    and name.replace(".xml", ".bin") in os.listdir(cfg.work_dir)
+                ],
             },
             "msg": "",
         }

--- a/otx/mpa/modules/models/detectors/custom_atss_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_atss_detector.py
@@ -4,6 +4,7 @@
 
 import functools
 
+import torch
 from mmdet.models.builder import DETECTORS
 from mmdet.models.detectors.atss import ATSS
 
@@ -72,14 +73,17 @@ class CustomATSS(SAMDetectorMixin, L2SPDetectorMixin, ATSS):
 
 
 if is_mmdeploy_enabled():
-    from mmdeploy.core import FUNCTION_REWRITER
+    from mmdeploy.core import FUNCTION_REWRITER, mark
+    from mmdeploy.utils import is_dynamic_shape
 
     from otx.mpa.modules.hooks.recording_forward_hooks import (
         DetSaliencyMapHook,
         FeatureVectorHook,
     )
 
-    @FUNCTION_REWRITER.register_rewriter("otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.simple_test")
+    @FUNCTION_REWRITER.register_rewriter(
+        "otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.simple_test"
+    )
     def custom_atss__simple_test(ctx, self, img, img_metas, **kwargs):
         feat = self.extract_feat(img)
         outs = self.bbox_head(feat)
@@ -88,3 +92,35 @@ if is_mmdeploy_enabled():
         cls_scores = outs[0]
         saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
         return (*bbox_results, feature_vector, saliency_map)
+
+    @mark(
+        "custom_atss_forward",
+        inputs=["input"],
+        outputs=["dets", "labels", "feats", "saliencies"]
+    )
+    def __forward_impl(ctx, self, img, img_metas, **kwargs):
+        assert isinstance(img, torch.Tensor)
+
+        deploy_cfg = ctx.cfg
+        is_dynamic_flag = is_dynamic_shape(deploy_cfg)
+        # get origin input shape as tensor to support onnx dynamic shape
+        img_shape = torch._shape_as_tensor(img)[2:]
+        if not is_dynamic_flag:
+            img_shape = [int(val) for val in img_shape]
+        img_metas[0]["img_shape"] = img_shape
+        return self.simple_test(img, img_metas, **kwargs)
+
+    @FUNCTION_REWRITER.register_rewriter(
+        "otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.forward"
+    )
+    def custom_atss__forward(ctx, self, img, img_metas=None, return_loss=False, **kwargs):
+        if img_metas is None:
+            img_metas = [{}]
+        else:
+            assert len(img_metas) == 1, "do not support aug_test"
+            img_metas = img_metas[0]
+
+        if isinstance(img, list):
+            img = img[0]
+
+        return __forward_impl(ctx, self, img, img_metas=img_metas, **kwargs)

--- a/otx/mpa/modules/models/detectors/custom_atss_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_atss_detector.py
@@ -81,9 +81,7 @@ if is_mmdeploy_enabled():
         FeatureVectorHook,
     )
 
-    @FUNCTION_REWRITER.register_rewriter(
-        "otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.simple_test"
-    )
+    @FUNCTION_REWRITER.register_rewriter("otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.simple_test")
     def custom_atss__simple_test(ctx, self, img, img_metas, **kwargs):
         feat = self.extract_feat(img)
         outs = self.bbox_head(feat)
@@ -93,11 +91,7 @@ if is_mmdeploy_enabled():
         saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
         return (*bbox_results, feature_vector, saliency_map)
 
-    @mark(
-        "custom_atss_forward",
-        inputs=["input"],
-        outputs=["dets", "labels", "feats", "saliencies"]
-    )
+    @mark("custom_atss_forward", inputs=["input"], outputs=["dets", "labels", "feats", "saliencies"])
     def __forward_impl(ctx, self, img, img_metas, **kwargs):
         assert isinstance(img, torch.Tensor)
 
@@ -110,9 +104,7 @@ if is_mmdeploy_enabled():
         img_metas[0]["img_shape"] = img_shape
         return self.simple_test(img, img_metas, **kwargs)
 
-    @FUNCTION_REWRITER.register_rewriter(
-        "otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.forward"
-    )
+    @FUNCTION_REWRITER.register_rewriter("otx.mpa.modules.models.detectors.custom_atss_detector.CustomATSS.forward")
     def custom_atss__forward(ctx, self, img, img_metas=None, return_loss=False, **kwargs):
         if img_metas is None:
             img_metas = [{}]

--- a/otx/mpa/modules/models/detectors/custom_maskrcnn_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_maskrcnn_detector.py
@@ -98,11 +98,7 @@ if is_mmdeploy_enabled():
         out = self.roi_head.simple_test(x, proposals, img_metas, rescale=False)
         return (*out, feature_vector, saliency_map)
 
-    @mark(
-        "custom_maskrcnn_forward",
-        inputs=["input"],
-        outputs=["dets", "labels", "masks", "feats", "saliencies"]
-    )
+    @mark("custom_maskrcnn_forward", inputs=["input"], outputs=["dets", "labels", "masks", "feats", "saliencies"])
     def __forward_impl(ctx, self, img, img_metas, **kwargs):
         assert isinstance(img, torch.Tensor)
 

--- a/otx/mpa/modules/models/detectors/custom_maskrcnn_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_maskrcnn_detector.py
@@ -4,6 +4,7 @@
 
 import functools
 
+import torch
 from mmdet.models.builder import DETECTORS
 from mmdet.models.detectors.mask_rcnn import MaskRCNN
 
@@ -76,7 +77,8 @@ class CustomMaskRCNN(SAMDetectorMixin, L2SPDetectorMixin, MaskRCNN):
 
 
 if is_mmdeploy_enabled():
-    from mmdeploy.core import FUNCTION_REWRITER
+    from mmdeploy.core import FUNCTION_REWRITER, mark
+    from mmdeploy.utils import is_dynamic_shape
 
     from otx.mpa.modules.hooks.recording_forward_hooks import (
         ActivationMapHook,
@@ -95,3 +97,35 @@ if is_mmdeploy_enabled():
             proposals, _ = self.rpn_head.simple_test_rpn(x, img_metas)
         out = self.roi_head.simple_test(x, proposals, img_metas, rescale=False)
         return (*out, feature_vector, saliency_map)
+
+    @mark(
+        "custom_maskrcnn_forward",
+        inputs=["input"],
+        outputs=["dets", "labels", "masks", "feats", "saliencies"]
+    )
+    def __forward_impl(ctx, self, img, img_metas, **kwargs):
+        assert isinstance(img, torch.Tensor)
+
+        deploy_cfg = ctx.cfg
+        is_dynamic_flag = is_dynamic_shape(deploy_cfg)
+        # get origin input shape as tensor to support onnx dynamic shape
+        img_shape = torch._shape_as_tensor(img)[2:]
+        if not is_dynamic_flag:
+            img_shape = [int(val) for val in img_shape]
+        img_metas[0]["img_shape"] = img_shape
+        return self.simple_test(img, img_metas, **kwargs)
+
+    @FUNCTION_REWRITER.register_rewriter(
+        "otx.mpa.modules.models.detectors.custom_maskrcnn_detector.CustomMaskRCNN.forward"
+    )
+    def custom_maskrcnn__forward(ctx, self, img, img_metas=None, return_loss=False, **kwargs):
+        if img_metas is None:
+            img_metas = [{}]
+        else:
+            assert len(img_metas) == 1, "do not support aug_test"
+            img_metas = img_metas[0]
+
+        if isinstance(img, list):
+            img = img[0]
+
+        return __forward_impl(ctx, self, img, img_metas=img_metas, **kwargs)

--- a/otx/mpa/modules/models/detectors/custom_single_stage_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_single_stage_detector.py
@@ -4,6 +4,7 @@
 
 import functools
 
+import torch
 from mmdet.models.builder import DETECTORS
 from mmdet.models.detectors.single_stage import SingleStageDetector
 
@@ -126,7 +127,8 @@ class CustomSingleStageDetector(SAMDetectorMixin, L2SPDetectorMixin, SingleStage
 
 
 if is_mmdeploy_enabled():
-    from mmdeploy.core import FUNCTION_REWRITER
+    from mmdeploy.core import FUNCTION_REWRITER, mark
+    from mmdeploy.utils import is_dynamic_shape
 
     from otx.mpa.modules.hooks.recording_forward_hooks import (
         DetSaliencyMapHook,
@@ -144,3 +146,35 @@ if is_mmdeploy_enabled():
         cls_scores = outs[0]
         saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
         return (*bbox_results, feature_vector, saliency_map)
+
+    @mark(
+        "custom_ssd_forward",
+        inputs=["input"],
+        outputs=["dets", "labels", "feats", "saliencies"]
+    )
+    def __forward_impl(ctx, self, img, img_metas, **kwargs):
+        assert isinstance(img, torch.Tensor)
+
+        deploy_cfg = ctx.cfg
+        is_dynamic_flag = is_dynamic_shape(deploy_cfg)
+        # get origin input shape as tensor to support onnx dynamic shape
+        img_shape = torch._shape_as_tensor(img)[2:]
+        if not is_dynamic_flag:
+            img_shape = [int(val) for val in img_shape]
+        img_metas[0]["img_shape"] = img_shape
+        return self.simple_test(img, img_metas, **kwargs)
+
+    @FUNCTION_REWRITER.register_rewriter(
+        "otx.mpa.modules.models.detectors.custom_single_stage_detector.CustomSingleStageDetector.forward"
+    )
+    def custom_ssd__forward(ctx, self, img, img_metas=None, return_loss=False, **kwargs):
+        if img_metas is None:
+            img_metas = [{}]
+        else:
+            assert len(img_metas) == 1, "do not support aug_test"
+            img_metas = img_metas[0]
+
+        if isinstance(img, list):
+            img = img[0]
+
+        return __forward_impl(ctx, self, img, img_metas=img_metas, **kwargs)

--- a/otx/mpa/modules/models/detectors/custom_single_stage_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_single_stage_detector.py
@@ -147,11 +147,7 @@ if is_mmdeploy_enabled():
         saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
         return (*bbox_results, feature_vector, saliency_map)
 
-    @mark(
-        "custom_ssd_forward",
-        inputs=["input"],
-        outputs=["dets", "labels", "feats", "saliencies"]
-    )
+    @mark("custom_ssd_forward", inputs=["input"], outputs=["dets", "labels", "feats", "saliencies"])
     def __forward_impl(ctx, self, img, img_metas, **kwargs):
         assert isinstance(img, torch.Tensor)
 

--- a/otx/mpa/modules/models/detectors/custom_yolox_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_yolox_detector.py
@@ -131,11 +131,7 @@ if is_mmdeploy_enabled():
         saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
         return (*bbox_results, feature_vector, saliency_map)
 
-    @mark(
-        "custom_yolox_forward",
-        inputs=["input"],
-        outputs=["dets", "labels", "feats", "saliencies"]
-    )
+    @mark("custom_yolox_forward", inputs=["input"], outputs=["dets", "labels", "feats", "saliencies"])
     def __forward_impl(ctx, self, img, img_metas, **kwargs):
         assert isinstance(img, torch.Tensor)
 
@@ -148,9 +144,7 @@ if is_mmdeploy_enabled():
         img_metas[0]["img_shape"] = img_shape
         return self.simple_test(img, img_metas, **kwargs)
 
-    @FUNCTION_REWRITER.register_rewriter(
-        "otx.mpa.modules.models.detectors.custom_yolox_detector.CustomYOLOX.forward"
-    )
+    @FUNCTION_REWRITER.register_rewriter("otx.mpa.modules.models.detectors.custom_yolox_detector.CustomYOLOX.forward")
     def custom_yolox__forward(ctx, self, img, img_metas=None, return_loss=False, **kwargs):
         if img_metas is None:
             img_metas = [{}]

--- a/otx/mpa/modules/models/detectors/custom_yolox_detector.py
+++ b/otx/mpa/modules/models/detectors/custom_yolox_detector.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
 import functools
 
 import torch
@@ -107,7 +111,8 @@ class CustomYOLOX(SAMDetectorMixin, L2SPDetectorMixin, YOLOX):
 
 
 if is_mmdeploy_enabled():
-    from mmdeploy.core import FUNCTION_REWRITER
+    from mmdeploy.core import FUNCTION_REWRITER, mark
+    from mmdeploy.utils import is_dynamic_shape
 
     from otx.mpa.modules.hooks.recording_forward_hooks import (
         DetSaliencyMapHook,
@@ -125,3 +130,35 @@ if is_mmdeploy_enabled():
         cls_scores = outs[0]
         saliency_map = DetSaliencyMapHook(self).func(cls_scores, cls_scores_provided=True)
         return (*bbox_results, feature_vector, saliency_map)
+
+    @mark(
+        "custom_yolox_forward",
+        inputs=["input"],
+        outputs=["dets", "labels", "feats", "saliencies"]
+    )
+    def __forward_impl(ctx, self, img, img_metas, **kwargs):
+        assert isinstance(img, torch.Tensor)
+
+        deploy_cfg = ctx.cfg
+        is_dynamic_flag = is_dynamic_shape(deploy_cfg)
+        # get origin input shape as tensor to support onnx dynamic shape
+        img_shape = torch._shape_as_tensor(img)[2:]
+        if not is_dynamic_flag:
+            img_shape = [int(val) for val in img_shape]
+        img_metas[0]["img_shape"] = img_shape
+        return self.simple_test(img, img_metas, **kwargs)
+
+    @FUNCTION_REWRITER.register_rewriter(
+        "otx.mpa.modules.models.detectors.custom_yolox_detector.CustomYOLOX.forward"
+    )
+    def custom_yolox__forward(ctx, self, img, img_metas=None, return_loss=False, **kwargs):
+        if img_metas is None:
+            img_metas = [{}]
+        else:
+            assert len(img_metas) == 1, "do not support aug_test"
+            img_metas = img_metas[0]
+
+        if isinstance(img, list):
+            img = img[0]
+
+        return __forward_impl(ctx, self, img, img_metas=img_metas, **kwargs)

--- a/otx/mpa/utils/mo_wrapper.py
+++ b/otx/mpa/utils/mo_wrapper.py
@@ -122,9 +122,9 @@ def generate_ir(output_path, model_path, silent, save_xml=True, **mo_kwargs):
     cur_time = time.time()
     time_threshold = 5
     model_name = mo_kwargs.get("model_name", "model")
-    if (
+    if not (
         ret == 245
-        and {f"{model_name}.bin", f"{model_name}.xml"} - set(os.listdir(model_path))
+        and not {f"{model_name}.bin", f"{model_name}.xml"} - set(os.listdir(model_path))
         and (
             os.path.getmtime(os.path.join(model_path, f"{model_name}.bin")) - cur_time < time_threshold
             and os.path.getmtime(os.path.join(model_path, f"{model_name}.xml")) - cur_time < time_threshold

--- a/tests/unit/mpa/deploy/test_deploy_apis.py
+++ b/tests/unit/mpa/deploy/test_deploy_apis.py
@@ -94,6 +94,7 @@ if is_mmdeploy_enabled():
                     config,
                     deploy_config,
                 )
+                assert isinstance(onnx_path, str)
                 assert os.path.exists(onnx_path)
 
                 openvino_paths = MMdeployExporter.onnx2openvino(

--- a/tests/unit/mpa/deploy/test_deploy_apis.py
+++ b/tests/unit/mpa/deploy/test_deploy_apis.py
@@ -56,6 +56,8 @@ class TestNaiveExporter:
 
 
 if is_mmdeploy_enabled():
+    from mmdeploy.core import FUNCTION_REWRITER, mark
+
     from otx.mpa.deploy.apis import MMdeployExporter
 
     class TestMMdeployExporter:
@@ -146,3 +148,71 @@ if is_mmdeploy_enabled():
                 )
                 assert [f for f in os.listdir(tempdir) if f.endswith(".xml")]
                 assert [f for f in os.listdir(tempdir) if f.endswith(".bin")]
+
+        @e2e_pytest_unit
+        def test_partition(self):
+            from otx.algorithms.classification.adapters.mmcls.utils.builder import (
+                build_classifier,
+            )
+
+            config = create_config()
+            deploy_config = Config(
+                {
+                    "ir_config": {
+                        "type": "onnx",
+                        "input_names": ["input"],
+                        "output_names": ["output"],
+                    },
+                    "codebase_config": {
+                        "type": "mmcls",
+                        "task": "Classification",
+                    },
+                    "backend_config": {
+                        "type": "openvino",
+                        "model_inputs": [
+                            {
+                                "opt_shapes": {
+                                    "input": [1, 3, 50, 50],
+                                }
+                            }
+                        ],
+                    },
+                    "partition_config": {
+                        "apply_marks": True,
+                        "partition_cfg": [
+                            {
+                                "save_file": "partition.onnx",
+                                "start": ["test:input"],
+                                "end": ["test:output"],
+                                "output_names": ["output"],
+                                "mo_options": {
+                                    "_delete_": True,
+                                    "args": {},
+                                    "flags": [],
+                                },
+                            }
+                        ],
+                    },
+                }
+            )
+            create_model("mmcls")
+
+            @FUNCTION_REWRITER.register_rewriter("tests.unit.mpa.deploy.test_helpers.MockModel.forward")
+            @mark("test", inputs=["input"], outputs=["output"])
+            def forward(ctx, self, *args, **kwargs):
+                return ctx.origin_func(self, *args, **kwargs)
+
+            with tempfile.TemporaryDirectory() as tempdir:
+                MMdeployExporter.export2openvino(
+                    tempdir,
+                    build_classifier,
+                    config,
+                    deploy_config,
+                )
+                files = os.listdir(tempdir)
+                assert "model.onnx" in files
+                assert "model.xml" in files
+                assert "model.bin" in files
+                assert "partition.onnx" in files
+                assert "partition.xml" in files
+                assert "partition.bin" in files

--- a/tests/unit/mpa/deploy/test_helpers.py
+++ b/tests/unit/mpa/deploy/test_helpers.py
@@ -6,47 +6,48 @@ import torch
 from mmcv.utils import Config
 
 
+class MockModel(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(3, 3, 3)
+        self.conv2 = torch.nn.Conv2d(3, 3, 3)
+        self.linear = torch.nn.Linear(3, 1)
+
+    def forward(self, img, img_metas=None, **kwargs):
+        if isinstance(img, list):
+            img = img[0]
+        if img.shape[-1] == 3:
+            img = img.permute(0, 3, 1, 2)
+
+        x = self.conv1(img)
+        x = self.conv2(img)
+        x = torch.mean(x, dim=(2, 3))
+        x = self.linear(x)
+        return x
+
+    def forward_dummy(self, img, img_metas=None, **kwargs):
+        if isinstance(img, list):
+            img = img[0]
+        if img.shape[-1] == 3:
+            img = img.permute(0, 3, 1, 2)
+
+        x = self.conv1(img)
+        x = self.conv2(img)
+        x = torch.mean(x, dim=(2, 3))
+        x = self.linear(x)
+        return x
+
+    def train_step(self, *args, **kwargs):
+        return dict()
+
+    def init_weights(self, *args, **kwargs):
+        pass
+
+    def set_step_params(self, *args, **kwargs):
+        pass
+
+
 def create_model(lib="mmcls"):
-    class MockModel(torch.nn.Module):
-        def __init__(self, *args, **kwargs):
-            super().__init__()
-            self.conv1 = torch.nn.Conv2d(3, 3, 3)
-            self.conv2 = torch.nn.Conv2d(3, 3, 3)
-            self.linear = torch.nn.Linear(3, 1)
-
-        def forward(self, img, img_metas=None, **kwargs):
-            if isinstance(img, list):
-                img = img[0]
-            if img.shape[-1] == 3:
-                img = img.permute(0, 3, 1, 2)
-
-            x = self.conv1(img)
-            x = self.conv2(img)
-            x = torch.mean(x, dim=(2, 3))
-            x = self.linear(x)
-            return x
-
-        def forward_dummy(self, img, img_metas=None, **kwargs):
-            if isinstance(img, list):
-                img = img[0]
-            if img.shape[-1] == 3:
-                img = img.permute(0, 3, 1, 2)
-
-            x = self.conv1(img)
-            x = self.conv2(img)
-            x = torch.mean(x, dim=(2, 3))
-            x = self.linear(x)
-            return x
-
-        def train_step(self, *args, **kwargs):
-            return dict()
-
-        def init_weights(self, *args, **kwargs):
-            pass
-
-        def set_step_params(self, *args, **kwargs):
-            pass
-
     if lib == "mmcls":
         from mmcls.models import CLASSIFIERS
 

--- a/tests/unit/mpa/deploy/utils/test_deploy_utils_onnx.py
+++ b/tests/unit/mpa/deploy/utils/test_deploy_utils_onnx.py
@@ -27,6 +27,14 @@ def test_remove_nodes_by_op_type():
         assert os.path.exists(onnx_path)
 
         onnx_model = onnx.load(onnx_path)
+        onnx_model = remove_nodes_by_op_type(onnx_model, "Gemm")
+        nodes = []
+        for node in onnx_model.graph.node:
+            if node.op_type == "Gemm":
+                nodes.append(node)
+        assert not nodes
+
+        onnx_model = onnx.load(onnx_path)
         onnx_model = remove_nodes_by_op_type(onnx_model, "Conv")
         nodes = []
         for node in onnx_model.graph.node:

--- a/tests/unit/mpa/deploy/utils/test_deploy_utils_onnx.py
+++ b/tests/unit/mpa/deploy/utils/test_deploy_utils_onnx.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2021-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os
+import tempfile
+
+import onnx
+import torch
+
+from otx.mpa.deploy.apis import NaiveExporter
+from otx.mpa.deploy.utils.onnx import prepare_onnx_for_openvino, remove_nodes_by_op_type
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from tests.unit.mpa.deploy.test_helpers import create_model
+
+
+@e2e_pytest_unit
+def test_remove_nodes_by_op_type():
+    model = create_model("mmcls")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        onnx_path = NaiveExporter.torch2onnx(
+            tempdir,
+            model,
+            {"img": [torch.zeros((1, 50, 50, 3))], "img_metas": []},
+        )
+        assert os.path.exists(onnx_path)
+
+        onnx_model = onnx.load(onnx_path)
+        onnx_model = remove_nodes_by_op_type(onnx_model, "Conv")
+        nodes = []
+        for node in onnx_model.graph.node:
+            if node.op_type == "Conv":
+                nodes.append(node)
+        assert not nodes
+
+
+@e2e_pytest_unit
+def test_prepare_onnx_for_openvino():
+
+    model = create_model("mmcls")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        onnx_path = NaiveExporter.torch2onnx(
+            tempdir,
+            model,
+            {"img": [torch.zeros((1, 50, 50, 3))], "img_metas": []},
+        )
+        assert os.path.exists(onnx_path)
+
+        prepare_onnx_for_openvino(onnx_path, onnx_path)
+        onnx_model = onnx.load(onnx_path)
+        nodes = []
+        for node in onnx_model.graph.node:
+            if node.op_type == "Mark":
+                nodes.append(node)
+        assert not nodes


### PR DESCRIPTION
### Summary
[model partitioning](https://github.com/open-mmlab/mmdeploy/blob/master/docs/en/07-developer-guide/partition_model.md) is a feature from `mmdeploy` to partition single pytorch model into multiple onnx models. To achieve it, `mmdeploy` uses `mark` to label each part of the model.
`mark` was disabled because I thought model partition would not be needed in OTX but `tiling` requires this feature to boost inference speed.

### Changes
- re-enabled `mark` feature
- supported model partitioning in `MMdeployExporter`
- added unit tests for model partition

### Unit test
![image](https://user-images.githubusercontent.com/11530592/218024086-c693ae2c-822d-4f56-b85b-296de122b973.png)

### Ticket
CVS-102976, CVS-103571