### PR TITLE
[DEV][HOTFIX] Update mask dimension in `test_detcon.py`

### DIFF
--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
@@ -199,7 +199,7 @@ class TestDetConB:
         setattr(self.detconb, "in_index", [0, 1])
         setattr(self.detconb, "input_transform", "resize_concat")
         img = torch.randn((1, 2, 3, 4, 4))
-        gt_semantic_seg = torch.randint(0, 3, (1, 2, 4, 4), dtype=torch.int64)
+        gt_semantic_seg = torch.randint(0, 3, (1, 1, 2, 4, 4), dtype=torch.int64)
 
         outputs = self.detconb.train_step(
             data_batch=dict(img=img, img_metas={}, gt_semantic_seg=gt_semantic_seg), optimizer=None


### PR DESCRIPTION
After merging supcon for seg, there is the issue not matching mask dimension in `forward_train` in `detcon.py` during unit test.

* Fix
![image](https://user-images.githubusercontent.com/97221135/217739249-fbe45c9d-8d46-42ff-ada9-624ba2065bc9.png)
