### PR TITLE
[TEST] Unit Test: SupCon for semantic segmentation

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/hooks.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks.py
@@ -589,12 +589,12 @@ class EMAMomentumUpdateHook(Hook):
     :param by_epoch: Whether updating momentum by epoch or not, defaults to False.
     """
 
-    def __init__(self, end_momentum=1.0, update_interval=1, by_epoch=False, **kwargs):
+    def __init__(self, end_momentum: float = 1.0, update_interval: int = 1, by_epoch: bool = False, **kwargs):
         self.by_epoch = by_epoch
         self.end_momentum = end_momentum
         self.update_interval = update_interval
 
-    def before_train_epoch(self, runner):
+    def before_train_epoch(self, runner: BaseRunner):
         """Called before_train_epoch in EMAMomentumUpdateHook."""
         if not self.by_epoch:
             return
@@ -618,7 +618,7 @@ class EMAMomentumUpdateHook(Hook):
             )
             model.momentum = updated_m
 
-    def before_train_iter(self, runner):
+    def before_train_iter(self, runner: BaseRunner):
         """Called before_train_iter in EMAMomentumUpdateHook."""
         if self.by_epoch:
             return
@@ -642,7 +642,7 @@ class EMAMomentumUpdateHook(Hook):
             )
             model.momentum = updated_m
 
-    def after_train_iter(self, runner):
+    def after_train_iter(self, runner: BaseRunner):
         """Called after_train_iter in EMAMomentumUpdateHook."""
         if self.every_n_iters(runner, self.update_interval):
             if is_module_wrapper(runner.model):

--- a/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py
@@ -485,7 +485,7 @@ class SupConDetConB(ClassIncrEncoderDecoder):
         num_samples: int = 16,
         downsample: int = 32,
         input_transform: str = "resize_concat",
-        in_index: List[int] = [0],
+        in_index: Union[List[int], int] = [0],
         align_corners: bool = False,
         loss_cfg: Optional[Dict[str, Any]] = None,
         train_cfg: Optional[Dict[str, Any]] = None,

--- a/tests/unit/algorithms/common/__init__.py
+++ b/tests/unit/algorithms/common/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.common"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/common/adapters/__init__.py
+++ b/tests/unit/algorithms/common/adapters/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.common.adapters"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/common/adapters/mmcv/__init__.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.algorithms.common.adapters.mmcv"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/algorithms/common/adapters/mmcv/test_hooks.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/test_hooks.py
@@ -1,0 +1,112 @@
+import pytest
+from typing import List
+from unittest.mock import Mock, MagicMock
+
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from mmcv.runner import BaseRunner
+from otx.algorithms.common.adapters.mmcv.hooks import TwoCropTransformHook
+
+
+@pytest.fixture
+def mock_iter_runner(mocker):
+    _mock_iter_runner = mocker.patch("mmcv.runner.IterBasedRunner", autospec=True)
+    _mock_iter_runner.data_loader = MagicMock()
+    
+    return _mock_iter_runner
+
+
+
+@pytest.mark.usefixtures("mock_iter_runner")
+class TestTwoCropTransformHook:
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        self.two_crop_transform_hook = TwoCropTransformHook(interval=1)
+
+    def set_mock_name(self, name: str, is_both: bool = True) -> MagicMock:
+        mock_class = MagicMock()
+        mock_class.__class__.__name__ = name
+        if name == "TwoCropTransform":
+            mock_class.is_both = is_both
+        return mock_class
+
+    @e2e_pytest_unit
+    def test_use_not_implemented_by_epoch(self) -> None:
+        with pytest.raises(NotImplementedError):
+            fail_two_crop_transform_hook = TwoCropTransformHook(interval=1, by_epoch=True)
+
+    @e2e_pytest_unit
+    def test_get_dataset(self, mock_iter_runner: BaseRunner) -> None:
+        """Test _get_dataset."""
+        mock_iter_runner.data_loader.dataset = True
+        assert not hasattr(mock_iter_runner.data_loader.dataset, "dataset")
+
+        results = self.two_crop_transform_hook._get_dataset(mock_iter_runner)
+        assert results
+
+    @e2e_pytest_unit
+    def test_get_dataset_repeat_dataset(self, mock_iter_runner: BaseRunner) -> None:
+        """Test _get_dataset when dataset includes child dataset (e.g. RepeatDataset)."""
+        mock_iter_runner.data_loader.dataset.dataset = True
+        assert hasattr(mock_iter_runner.data_loader.dataset, "dataset")
+
+        results = self.two_crop_transform_hook._get_dataset(mock_iter_runner)
+        assert results
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("transforms_order", [["TwoCropTransform", "A", "B"], ["A", "TwoCropTransform", "B"], ["A", "B", "TwoCropTransform"]])
+    def test_find_two_crop_transform(self, transforms_order: List[object]) -> None:
+        """Test _find_two_crop_transform."""
+        transforms = [self.set_mock_name(name) for name in transforms_order]
+
+        results = self.two_crop_transform_hook._find_two_crop_transform(transforms)
+        assert results.__class__.__name__ == "TwoCropTransform"
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("interval,cnt,expected", [(1, 0, True), (2, 0, False), (2, 1, True)])
+    def test_before_train_epoch(self, mock_iter_runner: BaseRunner, interval: int, cnt: int, expected: bool) -> None:
+        """Test before_train_epoch."""
+        if hasattr(mock_iter_runner.data_loader.dataset, "dataset"):
+            del mock_iter_runner.data_loader.dataset.dataset
+
+        setattr(self.two_crop_transform_hook, "interval", interval)
+        setattr(self.two_crop_transform_hook, "cnt", cnt)
+
+        transforms_order = ["TwoCropTransform", "A", "B"]
+        transforms = [self.set_mock_name(name=name) for name in transforms_order]
+        mock_iter_runner.data_loader.dataset.pipeline.transforms = transforms
+                
+        self.two_crop_transform_hook.before_train_epoch(mock_iter_runner)
+
+        assert transforms[0].is_both == expected
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("is_both,interval,cnt,expected",
+        [
+            (False, 1, 0, False),
+            (True, 1, 0, True),
+            (False, 3, 0, False),
+            (True, 3, 0, True),
+            (False, 3, 1, True),
+            (True, 3, 1, False),
+            (True, 2, 0, False)
+        ]
+    )
+    def test_after_train_iter(self, mock_iter_runner: BaseRunner, is_both: bool, interval: int, cnt: int, expected: bool) -> None:
+        """Test after_train_iter."""
+        if hasattr(mock_iter_runner.data_loader.dataset, "dataset"):
+            del mock_iter_runner.data_loader.dataset.dataset
+
+        setattr(self.two_crop_transform_hook, "interval", interval)
+        setattr(self.two_crop_transform_hook, "cnt", cnt)
+
+        transforms_order = ["TwoCropTransform", "A", "B"]
+        transforms = [self.set_mock_name(name=name, is_both=is_both) for name in transforms_order]
+        mock_iter_runner.data_loader.dataset.pipeline.transforms = transforms
+
+        self.two_crop_transform_hook.after_train_iter(mock_iter_runner)
+
+        assert transforms[0].is_both == expected
+        if is_both and interval - cnt == 2:
+            # test cnt initialization
+            assert self.two_crop_transform_hook.cnt == 0

--- a/tests/unit/algorithms/common/adapters/mmcv/test_hooks.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/test_hooks.py
@@ -1,24 +1,23 @@
-import pytest
 from typing import List
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock
 
-from tests.test_suite.e2e_test_system import e2e_pytest_unit
+import pytest
 from mmcv.runner import BaseRunner
+
 from otx.algorithms.common.adapters.mmcv.hooks import TwoCropTransformHook
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
 @pytest.fixture
 def mock_iter_runner(mocker):
     _mock_iter_runner = mocker.patch("mmcv.runner.IterBasedRunner", autospec=True)
     _mock_iter_runner.data_loader = MagicMock()
-    
-    return _mock_iter_runner
 
+    return _mock_iter_runner
 
 
 @pytest.mark.usefixtures("mock_iter_runner")
 class TestTwoCropTransformHook:
-
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
         self.two_crop_transform_hook = TwoCropTransformHook(interval=1)
@@ -33,7 +32,7 @@ class TestTwoCropTransformHook:
     @e2e_pytest_unit
     def test_use_not_implemented_by_epoch(self) -> None:
         with pytest.raises(NotImplementedError):
-            fail_two_crop_transform_hook = TwoCropTransformHook(interval=1, by_epoch=True)
+            TwoCropTransformHook(interval=1, by_epoch=True)
 
     @e2e_pytest_unit
     def test_get_dataset(self, mock_iter_runner: BaseRunner) -> None:
@@ -54,7 +53,10 @@ class TestTwoCropTransformHook:
         assert results
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("transforms_order", [["TwoCropTransform", "A", "B"], ["A", "TwoCropTransform", "B"], ["A", "B", "TwoCropTransform"]])
+    @pytest.mark.parametrize(
+        "transforms_order",
+        [["TwoCropTransform", "A", "B"], ["A", "TwoCropTransform", "B"], ["A", "B", "TwoCropTransform"]],
+    )
     def test_find_two_crop_transform(self, transforms_order: List[object]) -> None:
         """Test _find_two_crop_transform."""
         transforms = [self.set_mock_name(name) for name in transforms_order]
@@ -75,13 +77,14 @@ class TestTwoCropTransformHook:
         transforms_order = ["TwoCropTransform", "A", "B"]
         transforms = [self.set_mock_name(name=name) for name in transforms_order]
         mock_iter_runner.data_loader.dataset.pipeline.transforms = transforms
-                
+
         self.two_crop_transform_hook.before_train_epoch(mock_iter_runner)
 
         assert transforms[0].is_both == expected
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("is_both,interval,cnt,expected",
+    @pytest.mark.parametrize(
+        "is_both,interval,cnt,expected",
         [
             (False, 1, 0, False),
             (True, 1, 0, True),
@@ -89,10 +92,12 @@ class TestTwoCropTransformHook:
             (True, 3, 0, True),
             (False, 3, 1, True),
             (True, 3, 1, False),
-            (True, 2, 0, False)
-        ]
+            (True, 2, 0, False),
+        ],
     )
-    def test_after_train_iter(self, mock_iter_runner: BaseRunner, is_both: bool, interval: int, cnt: int, expected: bool) -> None:
+    def test_after_train_iter(
+        self, mock_iter_runner: BaseRunner, is_both: bool, interval: int, cnt: int, expected: bool
+    ) -> None:
         """Test after_train_iter."""
         if hasattr(mock_iter_runner.data_loader.dataset, "dataset"):
             del mock_iter_runner.data_loader.dataset.dataset

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import numpy as np
 import pytest
 from PIL import Image
@@ -34,23 +36,37 @@ def inputs_PIL():
     }
 
 
+class TestTwoCropTransform:
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker) -> None:
+        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg", return_value=lambda x: x)
+        self.two_crop_transform = TwoCropTransform(view0=[], view1=[])
+
+    @e2e_pytest_unit
+    def test_call(self, mocker, inputs_np: Dict[str, Any]) -> None:
+        """Test __call__."""
+        results = self.two_crop_transform(inputs_np)
+
+        assert isinstance(results, dict)
+        assert "img" in results and results["img"].ndim == 4
+        assert "gt_semantic_seg" in results and results["gt_semantic_seg"].ndim == 3
+        assert "flip" in results and isinstance(results["flip"], list)
+
+    @e2e_pytest_unit
+    def test_call_with_single_pipeline(self, mocker, inputs_np: Dict[str, Any]) -> None:
+        """Test __call__ with single pipeline."""
+        self.two_crop_transform.is_both = False
+
+        results = self.two_crop_transform(inputs_np)
+
+        assert isinstance(results, dict)
+        assert "img" in results and results["img"].ndim == 3
+        assert "gt_semantic_seg" in results and results["gt_semantic_seg"].ndim == 2
+        assert "flip" in results and isinstance(results["flip"], bool)
+
 @e2e_pytest_unit
-def test_two_crop_transform(mocker, inputs_np) -> None:
-    """Test TwoCropTransform."""
-    mocker.patch("otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg", return_value=lambda x: x)
-
-    two_crop_transform = TwoCropTransform(view0=[], view1=[])
-
-    results = two_crop_transform(inputs_np)
-
-    assert isinstance(results, dict)
-    assert "img" in results and results["img"].ndim == 4
-    assert "gt_semantic_seg" in results and results["gt_semantic_seg"].ndim == 3
-    assert "flip" in results and isinstance(results["flip"], list)
-
-
-@e2e_pytest_unit
-def test_random_resized_crop(inputs_PIL) -> None:
+def test_random_resized_crop(inputs_PIL: Dict[str, Any]) -> None:
     """Test RandomResizedCrop."""
     random_resized_crop = RandomResizedCrop(size=(8, 8))
 
@@ -65,7 +81,7 @@ def test_random_resized_crop(inputs_PIL) -> None:
 
 
 @e2e_pytest_unit
-def test_random_color_jitter(inputs_PIL) -> None:
+def test_random_color_jitter(inputs_PIL: Dict[str, Any]) -> None:
     """Test RandomColorJitter."""
     random_color_jitter = RandomColorJitter(p=1.0)
 
@@ -76,7 +92,7 @@ def test_random_color_jitter(inputs_PIL) -> None:
 
 
 @e2e_pytest_unit
-def test_random_grayscale(inputs_PIL) -> None:
+def test_random_grayscale(inputs_PIL: Dict[str, Any]) -> None:
     """Test RandomGrayscale."""
     random_grayscale = RandomGrayscale()
 
@@ -87,7 +103,7 @@ def test_random_grayscale(inputs_PIL) -> None:
 
 
 @e2e_pytest_unit
-def test_random_gaussian_blur(inputs_PIL) -> None:
+def test_random_gaussian_blur(inputs_PIL: Dict[str, Any]) -> None:
     """Test RandomGaussianBlur."""
     random_gaussian_blur = RandomGaussianBlur(p=1.0, kernel_size=3)
 
@@ -98,7 +114,7 @@ def test_random_gaussian_blur(inputs_PIL) -> None:
 
 
 @e2e_pytest_unit
-def test_random_solarization(inputs_np) -> None:
+def test_random_solarization(inputs_np: Dict[str, Any]) -> None:
     """Test RandomSolarization."""
     random_solarization = RandomSolarization(p=1.0)
 
@@ -110,7 +126,7 @@ def test_random_solarization(inputs_np) -> None:
 
 
 @e2e_pytest_unit
-def test_nd_array_to_pil_image(inputs_np) -> None:
+def test_nd_array_to_pil_image(inputs_np: Dict[str, Any]) -> None:
     """Test NDArrayToPILImage."""
     nd_array_to_pil_image = NDArrayToPILImage(keys=["img"])
 
@@ -122,7 +138,7 @@ def test_nd_array_to_pil_image(inputs_np) -> None:
 
 
 @e2e_pytest_unit
-def test_pil_image_to_nd_array(inputs_PIL) -> None:
+def test_pil_image_to_nd_array(inputs_PIL: Dict[str, Any]) -> None:
     """Test PILImageToNDArray."""
     pil_image_to_nd_array = PILImageToNDArray(keys=["img"])
 

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/data/test_pipelines.py
@@ -37,10 +37,11 @@ def inputs_PIL():
 
 
 class TestTwoCropTransform:
-
     @pytest.fixture(autouse=True)
     def setup(self, mocker) -> None:
-        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg", return_value=lambda x: x)
+        mocker.patch(
+            "otx.algorithms.segmentation.adapters.mmseg.data.pipelines.build_from_cfg", return_value=lambda x: x
+        )
         self.two_crop_transform = TwoCropTransform(view0=[], view1=[])
 
     @e2e_pytest_unit
@@ -64,6 +65,7 @@ class TestTwoCropTransform:
         assert "img" in results and results["img"].ndim == 3
         assert "gt_semantic_seg" in results and results["gt_semantic_seg"].ndim == 2
         assert "flip" in results and isinstance(results["flip"], bool)
+
 
 @e2e_pytest_unit
 def test_random_resized_crop(inputs_PIL: Dict[str, Any]) -> None:

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from copy import deepcopy
-from functools import reduce, partial
+from functools import partial, reduce
 from typing import List, Union
 
 import pytest
@@ -53,7 +53,8 @@ def setup_module(monkeypatch, mocker):
         return mock_class()
 
     monkeypatch.setattr(
-        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_backbone", partial(build_mock, MockBackbone)
+        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_backbone",
+        partial(build_mock, MockBackbone),
     )
     monkeypatch.setattr(
         "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_neck", partial(build_mock, MockNeck)
@@ -73,12 +74,13 @@ def setup_module(monkeypatch, mocker):
     )
     mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB.state_dict_hook")
     mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.load_checkpoint")
-    mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.SupConDetConB._decode_head_forward_train",
-                 return_value=(dict(loss=1.0), None))
+    mocker.patch(
+        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.SupConDetConB._decode_head_forward_train",
+        return_value=(dict(loss=1.0), None),
+    )
 
 
 class TestMaskPooling:
-
     @e2e_pytest_unit
     @pytest.mark.parametrize(
         "masks", [torch.Tensor([[[[0, 1], [1, 2]]]]).to(torch.int64), torch.Tensor([[[0, 1], [1, 2]]]).to(torch.int64)]
@@ -233,13 +235,26 @@ class TestSupConDetConB:
     """Test SupConDetConB."""
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("img,gt_semantic_seg,expected", [
-        (torch.ones((1, 2, 3, 4, 4), dtype=torch.float32), torch.ones((1, 1, 2, 4, 4), dtype=torch.int64), True),
-        (torch.ones((1, 3, 4, 4), dtype=torch.float32), torch.ones((1, 1, 4, 4), dtype=torch.int64), False),
-    ])
+    @pytest.mark.parametrize(
+        "img,gt_semantic_seg,expected",
+        [
+            (torch.ones((1, 2, 3, 4, 4), dtype=torch.float32), torch.ones((1, 1, 2, 4, 4), dtype=torch.int64), True),
+            (torch.ones((1, 3, 4, 4), dtype=torch.float32), torch.ones((1, 1, 4, 4), dtype=torch.int64), False),
+        ],
+    )
     def test_forward_train(self, img: torch.Tensor, gt_semantic_seg: torch.Tensor, expected: bool):
         """Test forward_train function."""
-        supcon_detconb = SupConDetConB(backbone={}, neck={}, head={}, decode_head={}, downsample=1, input_transform="resize_concat", in_index=[0, 1], loss_cfg=dict(type="DetConLoss"), task_adapt=dict(dst_classes=1, src_classes=1))
+        supcon_detconb = SupConDetConB(
+            backbone={},
+            neck={},
+            head={},
+            decode_head={},
+            downsample=1,
+            input_transform="resize_concat",
+            in_index=[0, 1],
+            loss_cfg=dict(type="DetConLoss"),
+            task_adapt=dict(dst_classes=1, src_classes=1),
+        )
 
         results = supcon_detconb(img=img, img_metas=[], gt_semantic_seg=gt_semantic_seg)
 

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/segmentors/test_detcon.py
@@ -2,21 +2,83 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from copy import deepcopy
-from functools import reduce
+from functools import reduce, partial
 from typing import List, Union
 
 import pytest
 import torch
 import torch.nn as nn
 
-from otx.algorithms.segmentation.adapters.mmseg import DetConB
+from otx.algorithms.segmentation.adapters.mmseg import DetConB, SupConDetConB
 from otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon import (
     MaskPooling,
 )
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
+@pytest.fixture(autouse=True)
+def setup_module(monkeypatch, mocker):
+    class MockBackbone(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.pipeline1 = nn.Sequential(nn.Conv2d(3, 1, (1, 1), bias=False), nn.Conv2d(1, 1, (1, 1), bias=False))
+            self.pipeline2 = nn.Sequential(
+                nn.Conv2d(3, 1, (1, 1), stride=2, bias=False), nn.Conv2d(1, 1, (1, 1), bias=False)
+            )
+
+        def init_weights(self, init_linear=None):
+            pass
+
+        def forward(self, x):
+            return [self.pipeline1(x), self.pipeline2(x)]
+
+    class MockNeck(nn.Sequential):
+        def __init__(self):
+            super().__init__(nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False))
+
+        def init_weights(self, init_linear=None):
+            pass
+
+    class MockDecodeHead(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.align_corners = None
+            self.num_classes = 1
+            self.out_channels = 1
+
+        def forward(self, x):
+            return x
+
+    def build_mock(mock_class, *args, **kwargs):
+        return mock_class()
+
+    monkeypatch.setattr(
+        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_backbone", partial(build_mock, MockBackbone)
+    )
+    monkeypatch.setattr(
+        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_neck", partial(build_mock, MockNeck)
+    )
+    monkeypatch.setattr(
+        "mmseg.models.segmentors.encoder_decoder.builder.build_backbone", partial(build_mock, MockBackbone)
+    )
+    monkeypatch.setattr(
+        "mmseg.models.segmentors.encoder_decoder.builder.build_head", partial(build_mock, MockDecodeHead)
+    )
+    mocker.patch(
+        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_loss",
+        return_value=lambda *args, **kwargs: dict(loss=1.0),
+    )
+    mocker.patch(
+        "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB._register_state_dict_hook"
+    )
+    mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB.state_dict_hook")
+    mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.load_checkpoint")
+    mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.SupConDetConB._decode_head_forward_train",
+                 return_value=(dict(loss=1.0), None))
+
+
 class TestMaskPooling:
+
     @e2e_pytest_unit
     @pytest.mark.parametrize(
         "masks", [torch.Tensor([[[[0, 1], [1, 2]]]]).to(torch.int64), torch.Tensor([[[0, 1], [1, 2]]]).to(torch.int64)]
@@ -59,50 +121,7 @@ class TestDetConB:
     """Test DetConB."""
 
     @pytest.fixture(autouse=True)
-    def setup(self, monkeypatch, mocker) -> None:
-        class MockBackbone(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.pipeline1 = nn.Sequential(nn.Conv2d(3, 1, (1, 1), bias=False), nn.Conv2d(1, 1, (1, 1), bias=False))
-                self.pipeline2 = nn.Sequential(
-                    nn.Conv2d(3, 1, (1, 1), stride=2, bias=False), nn.Conv2d(1, 1, (1, 1), bias=False)
-                )
-
-            def init_weights(self, init_linear=None):
-                pass
-
-            def forward(self, x):
-                return [self.pipeline1(x), self.pipeline2(x)]
-
-        class MockNeck(nn.Sequential):
-            def __init__(self):
-                super().__init__(nn.Linear(2, 2, bias=False), nn.Linear(2, 2, bias=False))
-
-            def init_weights(self, init_linear=None):
-                pass
-
-        def build_mock_backbone(*args, **kwargs):
-            return MockBackbone()
-
-        def build_mock_neck(*args, **kwargs):
-            return MockNeck()
-
-        monkeypatch.setattr(
-            "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_backbone", build_mock_backbone
-        )
-        monkeypatch.setattr(
-            "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_neck", build_mock_neck
-        )
-        mocker.patch(
-            "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.build_loss",
-            return_value=lambda *args, **kwargs: dict(loss=1.0),
-        )
-        mocker.patch(
-            "otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB._register_state_dict_hook"
-        )
-        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.DetConB.state_dict_hook")
-        mocker.patch("otx.algorithms.segmentation.adapters.mmseg.models.segmentors.detcon.load_checkpoint")
-
+    def setup(self) -> None:
         self.detconb = DetConB(backbone={}, neck={}, head={}, downsample=1, loss_cfg=dict(type="DetConLoss"))
 
     @e2e_pytest_unit
@@ -208,3 +227,20 @@ class TestDetConB:
         assert "loss" in outputs
         assert "log_vars" in outputs
         assert "num_samples" in outputs
+
+
+class TestSupConDetConB:
+    """Test SupConDetConB."""
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("img,gt_semantic_seg,expected", [
+        (torch.ones((1, 2, 3, 4, 4), dtype=torch.float32), torch.ones((1, 1, 2, 4, 4), dtype=torch.int64), True),
+        (torch.ones((1, 3, 4, 4), dtype=torch.float32), torch.ones((1, 1, 4, 4), dtype=torch.int64), False),
+    ])
+    def test_forward_train(self, img: torch.Tensor, gt_semantic_seg: torch.Tensor, expected: bool):
+        """Test forward_train function."""
+        supcon_detconb = SupConDetConB(backbone={}, neck={}, head={}, decode_head={}, downsample=1, input_transform="resize_concat", in_index=[0, 1], loss_cfg=dict(type="DetConLoss"), task_adapt=dict(dst_classes=1, src_classes=1))
+
+        results = supcon_detconb(img=img, img_metas=[], gt_semantic_seg=gt_semantic_seg)
+
+        assert ("loss_detcon" in results) == expected

--- a/tests/unit/mpa/modules/__init__.py
+++ b/tests/unit/mpa/modules/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.mpa.modules"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/mpa/modules/datasets/__init__.py
+++ b/tests/unit/mpa/modules/datasets/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.mpa.modules.datasets"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/mpa/modules/datasets/pipelines/__init__.py
+++ b/tests/unit/mpa/modules/datasets/pipelines/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.mpa.modules.datasets.pipelines"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/mpa/modules/datasets/pipelines/transforms/__init__.py
+++ b/tests/unit/mpa/modules/datasets/pipelines/transforms/__init__.py
@@ -1,0 +1,4 @@
+"""Test for otx.mpa.modules.datasets.pipelines.transforms"""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/tests/unit/mpa/modules/datasets/pipelines/transforms/test_seg_custom_pipelines.py
+++ b/tests/unit/mpa/modules/datasets/pipelines/transforms/test_seg_custom_pipelines.py
@@ -12,13 +12,13 @@ from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
 class TestNormalize:
-
     @e2e_pytest_unit
-    @pytest.mark.parametrize("mean,std,to_rgb,expected",
+    @pytest.mark.parametrize(
+        "mean,std,to_rgb,expected",
         [
-            (1., 1., True, np.array([[[1., 0., 0.]]], dtype=np.float32)),
-            (1., 1., False, np.array([[[-1.,  0.,  0.]]], dtype=np.float32))
-        ]
+            (1.0, 1.0, True, np.array([[[1.0, 0.0, 0.0]]], dtype=np.float32)),
+            (1.0, 1.0, False, np.array([[[-1.0, 0.0, 0.0]]], dtype=np.float32)),
+        ],
     )
     def test_call(self, mean: float, std: float, to_rgb: bool, expected: np.array) -> None:
         """Test __call__."""
@@ -32,7 +32,7 @@ class TestNormalize:
         assert np.all(results["img"] == expected)
 
     @e2e_pytest_unit
-    @pytest.mark.parametrize("mean,std,to_rgb", [(1., 1., True)])
+    @pytest.mark.parametrize("mean,std,to_rgb", [(1.0, 1.0, True)])
     def test_repr(self, mean: float, std: float, to_rgb: bool) -> None:
         """Test __repr__."""
         normalize = Normalize(mean=mean, std=std, to_rgb=to_rgb)
@@ -41,18 +41,13 @@ class TestNormalize:
 
 
 class TestDefaultFormatBundle:
-
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
         self.default_format_bundle = DefaultFormatBundle()
-    
+
     @e2e_pytest_unit
     @pytest.mark.parametrize("img", [np.ones((1, 1)), np.ones((1, 1, 1)), np.ones((1, 1, 1, 1))])
-    @pytest.mark.parametrize("gt_semantic_seg,pixel_weights",
-        [
-            (np.ones((1, 1)), np.ones((1, 1)))
-        ]
-    )
+    @pytest.mark.parametrize("gt_semantic_seg,pixel_weights", [(np.ones((1, 1)), np.ones((1, 1)))])
     def test_call(self, img: np.array, gt_semantic_seg: np.array, pixel_weights: np.array) -> None:
         """Test __call__."""
         inputs = dict(img=img, gt_semantic_seg=gt_semantic_seg, pixel_weights=pixel_weights)
@@ -77,7 +72,7 @@ class TestDefaultFormatBundle:
         inputs = dict(img=img)
 
         with pytest.raises(ValueError):
-            fail_default_format_bundle = self.default_format_bundle(inputs.copy())
+            self.default_format_bundle(inputs.copy())
 
     @e2e_pytest_unit
     def test_repr(self) -> None:
@@ -86,7 +81,6 @@ class TestDefaultFormatBundle:
 
 
 class TestBranchImage:
-
     @pytest.fixture(autouse=True)
     def setup(self) -> None:
         self.branch_image = BranchImage(key_map={"key1": "key2"})
@@ -95,7 +89,7 @@ class TestBranchImage:
     def test_call(self) -> None:
         """Test __call__."""
         inputs = dict(key1="key1", img_fields=["key1"])
-        
+
         results = self.branch_image(inputs.copy())
 
         assert isinstance(results, dict)

--- a/tests/unit/mpa/modules/datasets/pipelines/transforms/test_seg_custom_pipelines.py
+++ b/tests/unit/mpa/modules/datasets/pipelines/transforms/test_seg_custom_pipelines.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pytest
+import torch
+from mmcv.parallel import DataContainer
+
+from otx.mpa.modules.datasets.pipelines.transforms.seg_custom_pipelines import (
+    BranchImage,
+    DefaultFormatBundle,
+    Normalize,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestNormalize:
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("mean,std,to_rgb,expected",
+        [
+            (1., 1., True, np.array([[[1., 0., 0.]]], dtype=np.float32)),
+            (1., 1., False, np.array([[[-1.,  0.,  0.]]], dtype=np.float32))
+        ]
+    )
+    def test_call(self, mean: float, std: float, to_rgb: bool, expected: np.array) -> None:
+        """Test __call__."""
+        normalize = Normalize(mean=mean, std=std, to_rgb=to_rgb)
+        inputs = dict(img=np.arange(3).reshape(1, 1, 3))
+
+        results = normalize(inputs.copy())
+
+        assert "img" in results
+        assert "img_norm_cfg" in results
+        assert np.all(results["img"] == expected)
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("mean,std,to_rgb", [(1., 1., True)])
+    def test_repr(self, mean: float, std: float, to_rgb: bool) -> None:
+        """Test __repr__."""
+        normalize = Normalize(mean=mean, std=std, to_rgb=to_rgb)
+
+        assert repr(normalize) == normalize.__class__.__name__ + f"(mean={mean}, std={std}, to_rgb=" f"{to_rgb})"
+
+
+class TestDefaultFormatBundle:
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        self.default_format_bundle = DefaultFormatBundle()
+    
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("img", [np.ones((1, 1)), np.ones((1, 1, 1)), np.ones((1, 1, 1, 1))])
+    @pytest.mark.parametrize("gt_semantic_seg,pixel_weights",
+        [
+            (np.ones((1, 1)), np.ones((1, 1)))
+        ]
+    )
+    def test_call(self, img: np.array, gt_semantic_seg: np.array, pixel_weights: np.array) -> None:
+        """Test __call__."""
+        inputs = dict(img=img, gt_semantic_seg=gt_semantic_seg, pixel_weights=pixel_weights)
+
+        results = self.default_format_bundle(inputs.copy())
+
+        assert isinstance(results, dict)
+        assert "img" in results
+        assert isinstance(results["img"], DataContainer)
+        assert len(results["img"].data.shape) >= 3
+        assert results["img"].data.dtype == torch.float32
+        assert "gt_semantic_seg" in results
+        assert len(results["gt_semantic_seg"].data.shape) == len(inputs["gt_semantic_seg"].shape) + 1
+        assert results["gt_semantic_seg"].data.dtype == torch.int64
+        assert "pixel_weights" in results
+        assert len(results["pixel_weights"].data.shape) == len(inputs["pixel_weights"].shape) + 1
+        assert results["pixel_weights"].data.dtype == torch.float32
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("img", [np.ones((1,))])
+    def test_call_invalid_shape(self, img: np.array):
+        inputs = dict(img=img)
+
+        with pytest.raises(ValueError):
+            fail_default_format_bundle = self.default_format_bundle(inputs.copy())
+
+    @e2e_pytest_unit
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        assert repr(self.default_format_bundle) == self.default_format_bundle.__class__.__name__
+
+
+class TestBranchImage:
+
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        self.branch_image = BranchImage(key_map={"key1": "key2"})
+
+    @e2e_pytest_unit
+    def test_call(self) -> None:
+        """Test __call__."""
+        inputs = dict(key1="key1", img_fields=["key1"])
+        
+        results = self.branch_image(inputs.copy())
+
+        assert isinstance(results, dict)
+        assert "key2" in results
+        assert results["key1"] == results["key2"]
+        assert "key2" in results["img_fields"]
+
+    @e2e_pytest_unit
+    def test_repr(self) -> None:
+        """Test __repr__."""
+        assert repr(self.branch_image) == self.branch_image.__class__.__name__


### PR DESCRIPTION
# What this PR includes
* update `TwoCropTransform` previously implemented for Self-SL for seg
* add unit test (`TestEMAMomentumUpdateHook`) of `EMAMomentumUpdateHook` for Self-SL for cls
* add unit tests related to SupCon for seg

# Results
- [x] `otx/algorithms/common/adapters/mmcv/hooks.py` : 49%
(Only `TestEMAMomentumUpdateHook` and `TestTwoCropTransformHook`)
- [x] `otx/algorithms/segmentation/adapters/mmseg/data/pipelines.py` : 84%
- [x] `otx/algorithms/segmentation/adapters/mmseg/models/segmentors/detcon.py` : 89%
- [x] `otx/mpa/modules/datasets/pipelines/transforms/seg_custom_pipelines.py` : 100%