### PR TITLE
[ENHANCE] Improved otx find and build commands

### DIFF
--- a/otx/cli/builder/builder.py
+++ b/otx/cli/builder/builder.py
@@ -71,8 +71,8 @@ def update_backbone_args(backbone_config: dict, registry: Registry, backend: str
             missing_args.append(arg)
     if len(missing_args) > 0:
         print(
-            f"[otx build] {backbone_config['type']} requires the argument : {missing_args}"
-            f"\n[otx build] Please refer to {inspect.getfile(backbone_module)}"
+            f"[*] {backbone_config['type']} requires the argument : {missing_args}"
+            f"\n[*] Please refer to {inspect.getfile(backbone_module)}"
         )
     if "out_indices" in backbone_config:
         backbone_config["use_out_indices"] = True
@@ -90,8 +90,8 @@ def update_backbone_args(backbone_config: dict, registry: Registry, backend: str
         if "options" in backbone_data and arg in backbone_data["options"]:
             backbone_config[arg] = backbone_data["options"][arg][0]
             print(
-                f"[otx build] '{arg}' can choose between: {backbone_data['options'][arg]}"
-                f"\n[otx build] '{arg}' default value: {backbone_config[arg]}"
+                f"[*] '{arg}' can choose between: {backbone_data['options'][arg]}"
+                f"\n[*] '{arg}' default value: {backbone_config[arg]}"
             )
         else:
             backbone_config[arg] = "!!!!!!!!!!!INPUT_HERE!!!!!!!!!!!"
@@ -135,7 +135,7 @@ class Builder:
         backbone_type: The type of backbone want to get - {backend.backbone_type} (str)
         output_path: new backbone configuration file output path (Union[Path, str])
         """
-        print(f"[otx build] Backbone Config: {backbone_type}")
+        print(f"[*] Backbone Config: {backbone_type}")
         output_path = output_path if isinstance(output_path, Path) else Path(output_path)
 
         backend, backbone_class = Registry.split_scope_key(backbone_type)
@@ -147,7 +147,7 @@ class Builder:
         missing_args = update_backbone_args(backbone_config, backbone_registry, backend)
         if str(output_path).endswith((".yml", ".yaml", ".json")):
             mmcv.dump({"backbone": backbone_config}, str(output_path.absolute()))
-            print(f"[otx build] Save backbone configuration: {str(output_path.absolute())}")
+            print(f"[*] Save backbone configuration: {str(output_path.absolute())}")
         else:
             raise ValueError("The backbone config support file format is as follows: (.yml, .yaml, .json)")
         return missing_args
@@ -166,7 +166,7 @@ class Builder:
         backbone_config_path: backbone configuration file path (Union[Path, str])
         output_path: new model.py output path (Union[Path, str])
         """
-        print(f"[otx build] Update {model_config_path} with {backbone_config_path}")
+        print(f"[*] Update {model_config_path} with {backbone_config_path}")
         model_config_path = model_config_path if isinstance(model_config_path, Path) else Path(model_config_path)
         backbone_config_path = (
             backbone_config_path if isinstance(backbone_config_path, Path) else Path(backbone_config_path)
@@ -177,13 +177,13 @@ class Builder:
             model_config = MPAConfig.fromfile(str(model_config_path))
             print(f"\tTarget Model: {model_config.model.type}")
         else:
-            raise ValueError(f"[otx build] The model is not properly defined or not found: {model_config_path}")
+            raise ValueError(f"[*] The model is not properly defined or not found: {model_config_path}")
 
         # Get Backbone config from config file
         if backbone_config_path.exists():
             backbone_config = mmcv.load(str(backbone_config_path))
         else:
-            raise ValueError(f"[otx build] The backbone is not found: {str(backbone_config_path)}")
+            raise ValueError(f"[*] The backbone is not found: {str(backbone_config_path)}")
 
         if "backbone" in backbone_config:
             backbone_config = backbone_config["backbone"]
@@ -231,4 +231,4 @@ class Builder:
         if output_path is None:
             output_path = model_config_path
         model_config.dump(str(output_path))
-        print(f"[otx build] Save model configuration: {str(output_path)}")
+        print(f"[*] Save model configuration: {str(output_path)}")

--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -109,7 +109,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         has_data_yaml = default_workspace_components["data_path"].exists()
         return has_template_yaml and has_data_yaml
 
-    def configure_template(self) -> None:
+    def configure_template(self, model: str = None) -> None:
         """Update the template appropriate for the situation."""
         if self.check_workspace():
             # Workspace -> template O
@@ -119,9 +119,9 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             self.template = parse_model_template(self.template)
         else:
             task_type = self.task_type
-            if not task_type:
+            if not task_type and not model:
                 task_type = self.auto_task_detection(self.args.train_data_roots)
-            self.template = self._get_template(task_type)
+            self.template = self._get_template(task_type, model=model)
         self.task_type = self.template.task_type
         self.model = self.template.name
         self.train_type = self._get_train_type()
@@ -153,6 +153,8 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
 
     def auto_task_detection(self, data_roots: str) -> str:
         """Detect task type automatically."""
+        if not data_roots:
+            raise ValueError("Workspace must already exist or one of {task or model or train-data-roots} must exist.")
         self.data_format = self.dataset_manager.get_data_format(data_roots)
         print(f"[*] Detected dataset format: {self.data_format}")
         return self._get_task_type_from_data_format(self.data_format)
@@ -301,7 +303,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         if self.mode == "train" and str(self.train_type).upper() == "SELFSUPERVISED":
             self.data_config["val_subset"] = {"data_root": None}
 
-    def _get_template(self, task_type: str, model: str = None) -> ModelTemplate:
+    def _get_template(self, task_type: str, model: Optional[str] = None) -> ModelTemplate:
         """Returns the appropriate template for each situation.
 
         Args:
@@ -311,7 +313,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         Returns:
             ModelTemplate: Selected model template.
         """
-        otx_registry = OTXRegistry(self.otx_root).filter(task_type=task_type)
+        otx_registry = OTXRegistry(self.otx_root).filter(task_type=task_type if task_type else None)
         if model:
             template_lst = [temp for temp in otx_registry.templates if temp.name.lower() == model.lower()]
             if not template_lst:

--- a/otx/cli/tools/build.py
+++ b/otx/cli/tools/build.py
@@ -59,17 +59,26 @@ def get_args():
         "--unlabeled-file-list",
         help="Comma-separated paths to unlabeled file list",
     )
-    parser.add_argument("--task", help=f"The currently supported options: {SUPPORTED_TASKS}.")
+    parser.add_argument("--task", help=f"The currently supported options: {SUPPORTED_TASKS}.", default="")
     parser.add_argument(
         "--train-type",
         help=f"The currently supported options: {SUPPORTED_TRAIN_TYPE}.",
         type=str,
         default="incremental",
     )
-    parser.add_argument("--workspace-root", help="The path to use as the workspace.")
-    parser.add_argument("--model", help="Input OTX model config file (e.g model.py).", default=None)
-    parser.add_argument("--backbone", help="Enter the backbone configuration file path or available backbone type.")
-    parser.add_argument("--save-backbone-to", help="Enter where to save the backbone configuration file.", default=None)
+    parser.add_argument(
+        "--work-dir",
+        help="Location where the workspace.",
+        default=None,
+    )
+    parser.add_argument(
+        "--model", help="Enter the name of the model you want to use. (Ex. EfficientNet-B0).", default=""
+    )
+    parser.add_argument(
+        "--backbone",
+        help="Available Backbone Type can be found using 'otx find --backbone {framework}'.\n"
+        "If there is an already created backbone configuration yaml file, enter the corresponding path.",
+    )
 
     return parser.parse_args()
 
@@ -79,18 +88,18 @@ def main():
 
     args = get_args()
     config_manager = ConfigManager(args, mode="build")
-    config_manager.task_type = args.task.upper() if args.task else ""
-    config_manager.train_type = args.train_type if args.train_type else ""
-    if args.workspace_root:
-        config_manager.workspace_root = Path(args.workspace_root)
+    config_manager.task_type = args.task.upper()
+    config_manager.train_type = args.train_type
+    if args.work_dir:
+        config_manager.workspace_root = Path(args.work_dir)
 
     # Auto-Configuration for model template
-    config_manager.configure_template()
+    config_manager.configure_template(model=args.model)
 
     if not config_manager.check_workspace():
         new_workspace_path = None
-        if args.workspace_root:
-            new_workspace_path = args.workspace_root
+        if args.work_dir:
+            new_workspace_path = args.work_dir
         config_manager.build_workspace(new_workspace_path=new_workspace_path)
 
     # Auto-Configuration for Dataset configuration
@@ -101,14 +110,15 @@ def main():
         builder = Builder()
         missing_args = []
         if not args.backbone.endswith((".yml", ".yaml", ".json")):
-            if args.save_backbone_to is None:
-                args.save_backbone_to = str(config_manager.workspace_root / "backbone.yaml")
-            missing_args = builder.build_backbone_config(args.backbone, args.save_backbone_to)
-            args.backbone = args.save_backbone_to
-        if args.model:
-            if missing_args:
-                raise ValueError("The selected backbone has inputs that the user must enter.")
-            builder.merge_backbone(args.model, args.backbone)
+            backbone_config_file = str(config_manager.workspace_root / "backbone.yaml")
+            missing_args = builder.build_backbone_config(args.backbone, backbone_config_file)
+        if missing_args:
+            print(
+                f"[!] {args.backbone} backbone has inputs that the user must enter.\n"
+                f"[!] Edit {backbone_config_file} and run 'otx build --backbone backbone.yaml'."
+            )
+        else:
+            builder.merge_backbone(config_manager.workspace_root / "model.py", backbone_config_file)
 
     return dict(retcode=0, task_type=args.task)
 

--- a/otx/cli/tools/find.py
+++ b/otx/cli/tools/find.py
@@ -44,7 +44,7 @@ def parse_args():
     """Parses command line arguments."""
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--task", help="Supported task types.", choices=SUPPORTED_TASKS)
+    parser.add_argument("--task", help=f"The currently supported options: {SUPPORTED_TASKS}.")
     parser.add_argument(
         "--template", action="store_true", help="Shows a list of templates that can be used immediately."
     )
@@ -99,12 +99,10 @@ def main():
     args = parse_args()
 
     otx_root = get_otx_root_path()
-    otx_registry = Registry(otx_root)
-    if args.task:
-        otx_registry = otx_registry.filter(task_type=args.task)
+    otx_registry = Registry(otx_root).filter(task_type=args.task)
 
-    if args.template:
-        template_table = PrettyTable(["TASK", "ID", "NAME", "PATH"])
+    if not args.backbone or args.template:
+        template_table = PrettyTable(["TASK", "ID", "NAME", "BASE PATH"])
         for template in otx_registry.templates:
             relpath = os.path.relpath(template.model_template_path, os.path.abspath("."))
             template_table.add_row(

--- a/otx/cli/utils/tests.py
+++ b/otx/cli/utils/tests.py
@@ -678,7 +678,7 @@ def otx_build_task_testing(root, task):
         "build",
         "--task",
         task,
-        "--workspace-root",
+        "--work-dir",
         os.path.join(root, f"otx-workspace-{task}"),
     ]
     check_run(command_line)
@@ -700,53 +700,19 @@ def otx_build_backbone_testing(root, backbone_args):
         "build",
         "--task",
         f"{task}",
-        "--workspace-root",
+        "--work-dir",
         task_workspace,
     ]
     check_run(command_line)
     assert os.path.exists(task_workspace)
-    # Build Backbone.yaml from backbone type
-    command_line = [
-        "otx",
-        "build",
-        "--backbone",
-        backbone,
-        "--workspace-root",
-        task_workspace,
-        "--save-backbone-to",
-        os.path.join(task_workspace, "backbone.yaml"),
-    ]
-    check_run(command_line)
-    assert os.path.exists(os.path.join(task_workspace, "backbone.yaml"))
-
-    # Build model.py from backbone.yaml
-    command_line = [
-        "otx",
-        "build",
-        "--model",
-        os.path.join(task_workspace, "model.py"),
-        "--backbone",
-        os.path.join(task_workspace, "backbone.yaml"),
-        "--workspace-root",
-        task_workspace,
-    ]
-    check_run(command_line)
-    model_config = MPAConfig.fromfile(os.path.join(task_workspace, "model.py"))
-    assert "model" in model_config, "'model' is not in model configs"
-    assert "backbone" in model_config["model"], "'backbone' is not in model configs"
-    assert (
-        model_config["model"]["backbone"]["type"] == backbone
-    ), f"{model_config['model']['backbone']['type']} != {backbone}"
 
     # Build model.py from backbone type
     command_line = [
         "otx",
         "build",
-        "--model",
-        os.path.join(task_workspace, "model.py"),
         "--backbone",
         backbone,
-        "--workspace-root",
+        "--work-dir",
         task_workspace,
     ]
     check_run(command_line)
@@ -760,7 +726,7 @@ def otx_build_backbone_testing(root, backbone_args):
 
 def otx_build_auto_config(root, otx_dir: str, args: Dict[str, str]):
     workspace_root = os.path.join(root, "otx-workspace")
-    command_line = ["otx", "build", "--workspace-root", workspace_root]
+    command_line = ["otx", "build", "--work-dir", workspace_root]
 
     for option, value in args.items():
         if option in ["--train-data-roots", "--val-data-roots"]:


### PR DESCRIPTION
## Summary
Fixed some unintentional parts of the `otx find and build` commands that did not work.
- Lowercase input support for some arguments in otx find and build (reported by yunchu)
- Resolved an issue where `--model` did not work properly when building Workspace (reported by jihwan)

## Example
The commands below are now supported.
```
# classification template list print
(otx) otx find --task classification
# yolox model workspace build
(otx) otx build --model yolox
```