### PR TITLE
[FIX] Wrong opencv version criteria

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ nbmake
 networkx>=2.6,<=2.8.0
 numpy>=1.21.0,<=1.23.4  # np.bool was removed in 1.24.0 which was used in openvino runtime
 omegaconf>=2.1.1
-opencv-python>=4.5.36
+opencv-python>=4.5
 prettytable
 protobuf<3.21.0
 pymongo==3.12.0


### PR DESCRIPTION
- To fix version conflict w/ SC SDK
- There is no opencv==4.5.36 in PyPI, anyway.