### PR TITLE
[Fix] Missing config.json

### DIFF
--- a/otx/algorithms/detection/tasks/openvino.py
+++ b/otx/algorithms/detection/tasks/openvino.py
@@ -331,8 +331,8 @@ class OpenVINODetectionTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IO
         try:
             if self.model is not None and self.model.get_data("config.json"):
                 return json.loads(self.model.get_data("config.json"))
-        except Exception as e:
-            logger.warning("Failed to load config.json: %s", e)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(f"Failed to load config.json: {e}")
         return {}
 
     def load_inferencer(

--- a/otx/algorithms/detection/tasks/openvino.py
+++ b/otx/algorithms/detection/tasks/openvino.py
@@ -328,8 +328,11 @@ class OpenVINODetectionTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IO
         Returns:
             Dict: config dictionary
         """
-        if self.model is not None and self.model.get_data("config.json"):
-            return json.loads(self.model.get_data("config.json"))
+        try:
+            if self.model is not None and self.model.get_data("config.json"):
+                return json.loads(self.model.get_data("config.json"))
+        except Exception as e:
+            logger.warning("Failed to load config.json: %s", e)
         return {}
 
     def load_inferencer(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ good-names = [
     "i",
     "j",
     "k",
+    "e",
     "ex",
     "Run",
     "_",


### PR DESCRIPTION
## This PR includes:
- Apply try-except when config.json is missing for detection task. 
- Add `e` as good names for pylint.basic (For using the convention `Exception as e`)
- `disable=broad-except` looks reasonable, codes in try statement can cause various errors (`json.JSONDecodeError`, `TypeError`, `ValueError`, `AttributeError`). Both for stability and readability, `disable=broad-except` was adopted.