### PR TITLE
[Anomaly] Bump anomalib version

### DIFF
--- a/requirements/anomaly.txt
+++ b/requirements/anomaly.txt
@@ -1,3 +1,3 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Anomaly Requirements.
-anomalib @ git+https://github.com/openvinotoolkit/anomalib.git@da/loosen-torch-constraints
+anomalib==0.4.0rc2


### PR DESCRIPTION
Following the changes in https://github.com/openvinotoolkit/training_extensions/pull/1662, this PR increments the anomalib version to 0.4.0rc2.