### PR TITLE
[FIX] Move mmdeploy requirement from openvino to tasks

### DIFF
--- a/requirements/classification.txt
+++ b/requirements/classification.txt
@@ -1,3 +1,6 @@
 mmcv-full==1.7.0
 mmcls==0.25.0
 timm
+# FIXME: Below is the only one left as git+https install
+# But, the latest one on PyPI is 0.2.0. Might need custom build & upload
+mmdeploy @ git+https://git@github.com/open-mmlab/mmdeploy@v0.12.0

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -3,3 +3,6 @@ mmdet==2.28.1
 pytorchcv
 mmcls==0.25.0
 timm
+# FIXME: Below is the only one left as git+https install
+# But, the latest one on PyPI is 0.2.0. Might need custom build & upload
+mmdeploy @ git+https://git@github.com/open-mmlab/mmdeploy@v0.12.0

--- a/requirements/openvino.txt
+++ b/requirements/openvino.txt
@@ -6,6 +6,3 @@ openmodelzoo-modelapi==2022.3.0
 openvino==2022.3.0
 openvino-dev==2022.3.0
 openvino-telemetry>=2022.1.0
-# FIXME: Below is the only one left as git+https install
-# But, the latest one on PyPI is 0.2.0. Might need custom build & upload
-mmdeploy @ git+https://git@github.com/open-mmlab/mmdeploy@v0.12.0

--- a/requirements/segmentation.txt
+++ b/requirements/segmentation.txt
@@ -1,3 +1,6 @@
 mmcv-full==1.7.0
 mmsegmentation==0.30.0
 scikit-image
+# FIXME: Below is the only one left as git+https install
+# But, the latest one on PyPI is 0.2.0. Might need custom build & upload
+mmdeploy @ git+https://git@github.com/open-mmlab/mmdeploy@v0.12.0


### PR DESCRIPTION
## Summary
Anomaly does not use `mmdeploy`, but it is difficult to install due to its dependency.
So I move this to each algorithm requirement.