### PR TITLE
[ENHANCE] Use FastBiasCorrection for OCR_HRNET_18_MOD2

### DIFF
--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/pot_optimization_config.json
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/pot_optimization_config.json
@@ -5,7 +5,6 @@
       "params": {
         "preset": "mixed",
         "target_device": "ANY",
-        "use_fast_bias": false,
         "range_estimator": {
           "preset": "quantile"
         },


### PR DESCRIPTION
 Speeds up model calibration from ~12h to 20 mins without significant acc drop
 
 Results on V0.5.0 with appropriate IS (dataset - kvasir_seg)

 # | FP32 | INT8 | diff
-- | -- | -- | --
Metric | 0.86799 | 0.8643 | 0.00369
