### PR TITLE
[FIX] Fix otx train --help issue

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -442,6 +442,10 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             )
             print(f"[*] \t- Updated: {str(train_type_dir / 'pot_optimization_config.json')}")
 
+        if not (self.workspace_root / "data.yaml").exists():
+            data_yaml = self._get_arg_data_yaml()
+            self._export_data_cfg(data_yaml, str((self.workspace_root / "data.yaml")))
+
         self.template = parse_model_template(str(self.workspace_root / "template.yaml"))
 
     def _copy_config_files(self, target_dir: Path, file_name: str, dest_dir: Path) -> None:

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -114,12 +114,13 @@ def get_args():
 
     sub_parser = add_hyper_parameters_sub_parser(parser, hyper_parameters, return_sub_parser=True)
     # TODO: Temporary solution for cases where there is no template input
-    if not hyper_parameters:
-        _, params = sub_parser.parse_known_args()
+    if not hyper_parameters and "params" in params:
         if "params" in params:
             params = params[params.index("params") :]
             for param in params:
-                if param.startswith("--"):
+                if param == "--help":
+                    print("Without template configuration, hparams information is unknown.")
+                elif param.startswith("--"):
                     sub_parser.add_argument(
                         f"{param}",
                         dest=f"params.{param[2:]}",

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -15,9 +15,11 @@
 # and limitations under the License.
 
 import argparse
+import sys
 from pathlib import Path
 from typing import Dict, Optional, Union
 
+from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import find_and_parse_model_template
 
 
@@ -161,7 +163,10 @@ def get_parser_and_hprams_data():
     # TODO: Declaring pre_parser to get the template
     pre_parser = argparse.ArgumentParser(add_help=False)
     pre_parser.add_argument("template", nargs="?", default=None)
-    parsed, params = pre_parser.parse_known_args()
+    parsed, _ = pre_parser.parse_known_args()
+    params = []
+    if "params" in sys.argv:
+        params = sys.argv[sys.argv.index("params") :]
 
     template = parsed.template
     hyper_parameters = {}
@@ -170,6 +175,11 @@ def get_parser_and_hprams_data():
         template_config = find_and_parse_model_template(template)
         hyper_parameters = template_config.hyper_parameters.data
         parser.add_argument("template")
+    elif Path("./template.yaml").exists():
+        # In workspace, environments
+        template_config = parse_model_template("./template.yaml")
+        hyper_parameters = template_config.hyper_parameters.data
+        parser.add_argument("--template", required=False, default="./template.yaml")
     else:
         parser.add_argument("--template", required=False)
 


### PR DESCRIPTION
## Summary
Fixed a bug where information was not output properly when `otx train --help`

## Result
`otx train --help`
![image](https://user-images.githubusercontent.com/38045080/218900305-010c7d3a-3d3d-4ab3-bebb-f6c92355d17f.png)

`otx train otx/algorithms/detection/configs/detection/mobilenetv2_atss/template.yaml params --help`
![image](https://user-images.githubusercontent.com/38045080/218900414-c3a3ec52-782b-4faf-a047-664420b57c45.png)

`otx train params --help` without workspace or template args
![image](https://user-images.githubusercontent.com/38045080/218900344-48a67cd2-1f20-4fc1-b0dd-9fe4b306efc5.png)

`otx train params --help` in workspace
![image](https://user-images.githubusercontent.com/38045080/218900576-76f5a90b-c599-47fe-a711-79c157caab11.png)
