### PR TITLE
[FIX] Add yaml recipes to package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include requirements *
 recursive-include otx *.pyx
 recursive-exclude otx *.c *.html
-recursive-include otx/recipes *.yaml
+recursive-include otx *.yaml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include requirements *
 recursive-include otx *.pyx
 recursive-exclude otx *.c *.html
+recursive-include otx/recipes *.yaml

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from pkg_resources import Requirement
 from setuptools import Extension, find_packages, setup
 
 try:
-    from torch.utils.cpp_extension import BuildExtension, CppExtension
+    from torch.utils.cpp_extension import BuildExtension
 
     cmd_class = {"build_ext": BuildExtension}
 except ModuleNotFoundError:

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ def find_yaml_recipes():
     """Find YAML recipe files in the package."""
     results = defaultdict(list)
 
-    for root, _, files in os.walk(os.path.join("otx", "recipes")):
+    for root, _, files in os.walk("otx"):
         module = ".".join(root.split(os.sep))
         for file in files:
             _, ext = os.path.splitext(file)


### PR DESCRIPTION
From https://github.com/openvinotoolkit/training_extensions/pull/1694#issuecomment-1430627172, we observed that our package setup doesn't include `otx/**/*.yaml` when installing our package. This PR fixes it.