### PR TITLE
[ENHANCE] Add --data args to otx train to use custom path of data.yaml

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -97,18 +97,30 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         self.data_format: str = ""
         self.data_config: Dict[str, dict] = {}
 
+    @property
+    def data_config_file_path(self) -> Path:
+        """The path of the data configuration yaml to use for the task.
+
+        Raises:
+            FileNotFoundError: If data is received as args from otx train and the file does not exist, Error.
+
+        Returns:
+            Path: Path of target data configuration file.
+        """
+        if "data" in self.args and self.args.data:
+            if Path(self.args.data).exists():
+                return Path(self.args.data)
+            raise FileNotFoundError(f"Not found: {self.args.data}")
+        return self.workspace_root / "data.yaml"
+
     def check_workspace(self) -> bool:
         """Check that the class's workspace_root is an actual workspace folder.
 
         Returns:
             bool: true for workspace else false
         """
-        default_workspace_components = {
-            "template_path": self.workspace_root / "template.yaml",
-            "data_path": self.workspace_root / "data.yaml",
-        }
-        has_template_yaml = default_workspace_components["template_path"].exists()
-        has_data_yaml = default_workspace_components["data_path"].exists()
+        has_template_yaml = (self.workspace_root / "template.yaml").exists()
+        has_data_yaml = self.data_config_file_path.exists()
         return has_template_yaml and has_data_yaml
 
     def configure_template(self, model: str = None) -> None:
@@ -151,7 +163,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
 
     def configure_data_config(self, update_data_yaml: bool = True) -> None:
         """Configure data_config according to the situation and create data.yaml."""
-        data_yaml_path = self.workspace_root / "data.yaml"
+        data_yaml_path = self.data_config_file_path
         data_yaml = configure_dataset(self.args, data_yaml_path=data_yaml_path)
         if self.mode in ("train", "build"):
             use_auto_split = data_yaml["data"]["train"]["data-roots"] and not data_yaml["data"]["val"]["data-roots"]
@@ -163,6 +175,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
                 self._save_data(splitted_dataset, default_data_folder_name, data_yaml)
         if update_data_yaml:
             self._export_data_cfg(data_yaml, str(data_yaml_path))
+            print(f"[*] Update data configuration file to: {str(data_yaml_path)}")
         self.update_data_config(data_yaml)
 
     def _get_train_type(self, ignore_args: bool = False) -> str:
@@ -289,7 +302,6 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
     def _export_data_cfg(self, data_cfg: Dict[str, Dict[str, Dict[str, Any]]], output_path: str) -> None:
         """Export the data configuration file to output_path."""
         Path(output_path).write_text(OmegaConf.to_yaml(data_cfg), encoding="utf-8")
-        print(f"[*] Saving data configuration file to: {output_path}")
 
     def get_hyparams_config(self) -> ConfigurableParameters:
         """Separates the input params received from args and updates them.."""

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -111,6 +111,12 @@ def get_args():
         default=0,
         help="Total number of workers in a worker group.",
     )
+    parser.add_argument(
+        "--data",
+        type=str,
+        default=None,
+        help="The data.yaml path want to use in train task.",
+    )
 
     sub_parser = add_hyper_parameters_sub_parser(parser, hyper_parameters, return_sub_parser=True)
     # TODO: Temporary solution for cases where there is no template input

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -171,12 +171,12 @@ def get_parser_and_hprams_data():
     template = parsed.template
     hyper_parameters = {}
     parser = argparse.ArgumentParser()
-    if template and template.endswith("yaml") and Path(template).is_file():
+    if is_template(template):
         template_config = find_and_parse_model_template(template)
         hyper_parameters = template_config.hyper_parameters.data
         parser.add_argument("template")
     elif Path("./template.yaml").exists():
-        # In workspace, environments
+        # Workspace Environments
         template_config = parse_model_template("./template.yaml")
         hyper_parameters = template_config.hyper_parameters.data
         parser.add_argument("--template", required=False, default="./template.yaml")
@@ -184,3 +184,17 @@ def get_parser_and_hprams_data():
         parser.add_argument("--template", required=False)
 
     return parser, hyper_parameters, params
+
+
+def is_template(template_path: Optional[str]) -> bool:
+    """A function that determines whether the corresponding template path is a template.
+
+    Args:
+        template_path (str): The path of the file you want to know if it is a template.
+
+    Returns:
+        bool: True if template_path is template file else False.
+    """
+    if template_path and Path(template_path).is_file() and "template" in Path(template_path).name:
+        return True
+    return False


### PR DESCRIPTION
## Summary
Modify CLI args so that data.yaml to be used for training (otx train) can be used through a customized path.
'+ Modify template file check (in command) method

requested by @JihwanEom 

## How to use
`(otx) otx train --data data/config/yaml/path`