### PR TITLE
[FIX] Bug fix in E2E CLI tests

### DIFF
--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -36,6 +36,7 @@ class TestToolsOTXCLI:
     @e2e_pytest_component
     @pytest.mark.parametrize("build_backbone_args", build_backbone_args, ids=build_backbone_args_ids)
     def test_otx_backbone_build(self, tmp_dir_path, build_backbone_args):
+        tmp_dir_path = tmp_dir_path / build_backbone_args[0] / build_backbone_args[1]
         otx_build_backbone_testing(tmp_dir_path, build_backbone_args)
 
 
@@ -64,6 +65,7 @@ class TestToolsOTXBuildAutoConfig:
     @pytest.mark.parametrize("case", build_auto_config_args.keys())
     def test_otx_build_with_autosplit(self, case, tmp_dir_path):
         otx_dir = os.getcwd()
+        tmp_dir_path = tmp_dir_path / "test_build_auto_config" / case
         otx_build_auto_config(root=tmp_dir_path, otx_dir=otx_dir, args=build_auto_config_args[case])
 
 


### PR DESCRIPTION
## Summary
Resolve some wrong tmp path in cli tests

## Results
`pytest -s -v tests/e2e/cli/test_cli.py`
![image](https://user-images.githubusercontent.com/38045080/218971950-59fe8f0d-0005-4fb5-8f5a-23d1565fd22c.png)
