### PR TITLE
[FIX] Data configuration path in data.yaml to absolute path

### DIFF
--- a/otx/cli/utils/config.py
+++ b/otx/cli/utils/config.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-import os
+from pathlib import Path
 
 import yaml
 
@@ -43,25 +43,25 @@ def configure_dataset(args, data_yaml_path=None):
     data_subset_format = {"ann-files": None, "data-roots": None}
     data_config = {"data": {subset: data_subset_format.copy() for subset in ("train", "val", "test")}}
     data_config["data"]["unlabeled"] = {"file-list": None, "data-roots": None}
-    if data_yaml_path is not None and os.path.exists(str(data_yaml_path)):
-        with open(str(data_yaml_path), "r", encoding="UTF-8") as stream:
+    if data_yaml_path and Path(data_yaml_path).exists():
+        with open(Path(data_yaml_path), "r", encoding="UTF-8") as stream:
             data_config = yaml.safe_load(stream)
 
     # The command's args are overridden and use first
     if "train_ann_files" in args and args.train_ann_files:
-        data_config["data"]["train"]["ann-files"] = args.train_ann_files
+        data_config["data"]["train"]["ann-files"] = str(Path(args.train_ann_files).absolute())
     if "train_data_roots" in args and args.train_data_roots:
-        data_config["data"]["train"]["data-roots"] = args.train_data_roots
+        data_config["data"]["train"]["data-roots"] = str(Path(args.train_data_roots).absolute())
     if "val_ann_files" in args and args.val_ann_files:
-        data_config["data"]["val"]["ann-files"] = args.val_ann_files
+        data_config["data"]["val"]["ann-files"] = str(Path(args.val_ann_files).absolute())
     if "val_data_roots" in args and args.val_data_roots:
-        data_config["data"]["val"]["data-roots"] = args.val_data_roots
+        data_config["data"]["val"]["data-roots"] = str(Path(args.val_data_roots).absolute())
     if "unlabeled_file_list" in args and args.unlabeled_file_list:
-        data_config["data"]["unlabeled"]["file-list"] = args.unlabeled_file_list
+        data_config["data"]["unlabeled"]["file-list"] = str(Path(args.unlabeled_file_list).absolute())
     if "unlabeled_data_roots" in args and args.unlabeled_data_roots:
-        data_config["data"]["unlabeled"]["data-roots"] = args.unlabeled_data_roots
+        data_config["data"]["unlabeled"]["data-roots"] = str(Path(args.unlabeled_data_roots).absolute())
     if "test_ann_files" in args and args.test_ann_files:
-        data_config["data"]["test"]["ann-files"] = args.test_ann_files
+        data_config["data"]["test"]["ann-files"] = str(Path(args.test_ann_files).absolute())
     if "test_data_roots" in args and args.test_data_roots:
-        data_config["data"]["test"]["data-roots"] = args.test_data_roots
+        data_config["data"]["test"]["data-roots"] = str(Path(args.test_data_roots).absolute())
     return data_config

--- a/tests/unit/cli/utils/test_config.py
+++ b/tests/unit/cli/utils/test_config.py
@@ -1,4 +1,4 @@
-from os import path as osp
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -59,14 +59,14 @@ def test_configure_dataset(mocker):
     data_config = configure_dataset(mock_args)
 
     # check
-    assert data_config["data"]["train"]["ann-files"] == mock_args.train_ann_files
-    assert data_config["data"]["train"]["data-roots"] == mock_args.train_data_roots
-    assert data_config["data"]["val"]["ann-files"] == mock_args.val_ann_files
-    assert data_config["data"]["val"]["data-roots"] == mock_args.val_data_roots
-    assert data_config["data"]["unlabeled"]["file-list"] == mock_args.unlabeled_file_list
-    assert data_config["data"]["unlabeled"]["data-roots"] == mock_args.unlabeled_data_roots
-    assert data_config["data"]["test"]["ann-files"] == mock_args.test_ann_files
-    assert data_config["data"]["test"]["data-roots"] == mock_args.test_data_roots
+    assert data_config["data"]["train"]["ann-files"] == str(Path(mock_args.train_ann_files).absolute())
+    assert data_config["data"]["train"]["data-roots"] == str(Path(mock_args.train_data_roots).absolute())
+    assert data_config["data"]["val"]["ann-files"] == str(Path(mock_args.val_ann_files).absolute())
+    assert data_config["data"]["val"]["data-roots"] == str(Path(mock_args.val_data_roots).absolute())
+    assert data_config["data"]["unlabeled"]["file-list"] == str(Path(mock_args.unlabeled_file_list).absolute())
+    assert data_config["data"]["unlabeled"]["data-roots"] == str(Path(mock_args.unlabeled_data_roots).absolute())
+    assert data_config["data"]["test"]["ann-files"] == str(Path(mock_args.test_ann_files).absolute())
+    assert data_config["data"]["test"]["data-roots"] == str(Path(mock_args.test_data_roots).absolute())
 
 
 @e2e_pytest_unit
@@ -74,12 +74,12 @@ def test_configure_dataset_with_data_args(mocker):
     mock_args = mocker.MagicMock()
 
     with TemporaryDirectory() as tmp_dir:
-        data_yaml_path = osp.join(tmp_dir, "data.yaml")
+        data_yaml_path = Path(tmp_dir) / "data.yaml"
         mock_data = {"data": {"train": {"ann-files": "a", "data-roots": "b"}}}
         with open(data_yaml_path, "w") as f:
             yaml.dump(mock_data, f)
 
-        data_config = configure_dataset(mock_args, data_yaml_path)
+        data_config = configure_dataset(mock_args, str(data_yaml_path))
 
     assert data_config["data"]["train"]["ann-files"] == mock_data["data"]["train"]["ann-files"]
     assert data_config["data"]["train"]["data-roots"] == mock_data["data"]["train"]["data-roots"]

--- a/tests/unit/cli/utils/test_parser.py
+++ b/tests/unit/cli/utils/test_parser.py
@@ -175,7 +175,7 @@ def test_get_parser_and_hprams_data_with_template(mocker, tmp_dir):
     tmp_dir = Path(tmp_dir)
     fake_template_file = tmp_dir / "template.yaml"
     fake_template_file.write_text("fake")
-    mock_argv = ["otx train", str(fake_template_file), "--left-args"]
+    mock_argv = ["otx train", str(fake_template_file), "params", "--left-args"]
     mocker.patch("sys.argv", mock_argv)
     mock_template = mocker.patch.object(target_package, "find_and_parse_model_template")
     mock_hyper_parameters = mocker.MagicMock()
@@ -187,14 +187,14 @@ def test_get_parser_and_hprams_data_with_template(mocker, tmp_dir):
     # check
     mock_template.assert_called_once()
     assert hyper_parameters == mock_hyper_parameters
-    assert params == ["--left-args"]
+    assert params == ["params", "--left-args"]
     assert isinstance(parser, ArgumentParser)
 
 
 @e2e_pytest_unit
 def test_get_parser_and_hprams_data(mocker):
     # prepare
-    mock_argv = ["otx train", "--left-args"]
+    mock_argv = ["otx train", "params", "--left-args"]
     mocker.patch("sys.argv", mock_argv)
 
     # run
@@ -202,5 +202,5 @@ def test_get_parser_and_hprams_data(mocker):
 
     # check
     assert hyper_parameters == {}
-    assert params == ["--left-args"]
+    assert params == ["params", "--left-args"]
     assert isinstance(parser, ArgumentParser)


### PR DESCRIPTION
## Summary
Modify data paths of `data.yaml` to be entered as absolute paths instead of relative paths
Both absolute and relative paths can be received in commands, but they are displayed as absolute paths in data.yaml.

Thank you for the reporting @jaegukhyun 



++ Unit test fail that occurs in develop has been hot-fixed here.