### PR TITLE
[FIX] Refactor OTX CLI argparse with template

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -383,10 +383,6 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
 
         # Create OTX-workspace
         # Check whether the workspace is existed or not
-        print(f"[*] Workspace Path: {self.workspace_root}")
-        print(f"[*] Load Model Template ID: {self.template.model_template_id}")
-        print(f"[*] Load Model Name: {self.template.name}")
-
         if self.check_workspace() and not self.rebuild:
             return
         if self.rebuild:
@@ -396,6 +392,9 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         elif not self.check_workspace():
             self.workspace_root = Path(set_workspace(task=self.task_type))
         self.workspace_root.mkdir(exist_ok=True, parents=True)
+        print(f"[*] Workspace Path: {self.workspace_root}")
+        print(f"[*] Load Model Template ID: {self.template.model_template_id}")
+        print(f"[*] Load Model Name: {self.template.name}")
 
         template_dir = Path(self.template.model_template_path).parent
 

--- a/otx/cli/registry/registry.py
+++ b/otx/cli/registry/registry.py
@@ -17,6 +17,8 @@
 import copy
 import glob
 import os
+from pathlib import Path
+from typing import Optional
 
 import yaml
 
@@ -111,7 +113,21 @@ def find_and_parse_model_template(path_or_id):
         return path_or_id
 
     # 1. Find from path
-    if os.path.exists(path_or_id):
+    if is_template(path_or_id):
         return parse_model_template(path_or_id)
     # 2. Find from id or Name
     return Registry(get_otx_root_path()).get(path_or_id, skip_error=True)
+
+
+def is_template(template_path: Optional[str]) -> bool:
+    """A function that determines whether the corresponding template path is a template.
+
+    Args:
+        template_path (str): The path of the file you want to know if it is a template.
+
+    Returns:
+        bool: True if template_path is template file else False.
+    """
+    if template_path and Path(template_path).is_file() and "template" in Path(template_path).name:
+        return True
+    return False

--- a/otx/cli/registry/registry.py
+++ b/otx/cli/registry/registry.py
@@ -21,7 +21,7 @@ import os
 import yaml
 
 from otx.api.entities.model_template import parse_model_template
-from otx.cli.utils.importing import get_backbone_list
+from otx.cli.utils.importing import get_backbone_list, get_otx_root_path
 
 
 class Registry:
@@ -68,11 +68,15 @@ class Registry:
             templates = [template for template in templates if str(template.task_type).lower() == task_type.lower()]
         return Registry(templates=templates)
 
-    def get(self, template_id):
-        """Returns a model template with specified template_id."""
+    def get(self, template_id, skip_error=False):
+        """Returns a model template with specified template_id or template.name."""
 
-        templates = [template for template in self.templates if template.model_template_id == template_id]
+        templates = [
+            template for template in self.templates if template_id in (template.model_template_id, template.name)
+        ]
         if not templates:
+            if skip_error:
+                return None
             raise ValueError(f"Could not find a template with {template_id} in registry.")
         return templates[0]
 
@@ -100,9 +104,14 @@ class Registry:
 def find_and_parse_model_template(path_or_id):
     """In first function attempts to read a model template from disk under assumption that a path is passed.
 
-    If the attempt is failed, it tries to find template in registry under assumption that an ID is passed.
+    If the attempt is failed, it tries to find template in registry under assumption that an ID or name is passed.
     """
+    # Return None Type
+    if not path_or_id:
+        return path_or_id
 
+    # 1. Find from path
     if os.path.exists(path_or_id):
         return parse_model_template(path_or_id)
-    return Registry(".").get(path_or_id)
+    # 2. Find from id or Name
+    return Registry(get_otx_root_path()).get(path_or_id, skip_error=True)

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -16,10 +16,11 @@
 
 import argparse
 import sys
+from argparse import RawTextHelpFormatter
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-from otx.api.entities.model_template import parse_model_template
+from otx.api.entities.model_template import ModelTemplate, parse_model_template
 from otx.cli.registry import find_and_parse_model_template
 
 
@@ -170,18 +171,24 @@ def get_parser_and_hprams_data():
 
     template = parsed.template
     hyper_parameters = {}
-    parser = argparse.ArgumentParser()
-    if is_template(template):
-        template_config = find_and_parse_model_template(template)
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
+    template_config = find_and_parse_model_template(template)
+    template_help_str = (
+        "Enter the path or ID or name of the template file. \n"
+        "This can be omitted if you have train-data-roots or run inside a workspace."
+    )
+
+    if isinstance(template_config, ModelTemplate):
+        sys.argv[sys.argv.index(template)] = template_config.model_template_path
         hyper_parameters = template_config.hyper_parameters.data
-        parser.add_argument("template")
+        parser.add_argument("template", help=template_help_str)
     elif Path("./template.yaml").exists():
         # Workspace Environments
         template_config = parse_model_template("./template.yaml")
         hyper_parameters = template_config.hyper_parameters.data
-        parser.add_argument("--template", required=False, default="./template.yaml")
+        parser.add_argument("template", nargs="?", default="./template.yaml", help=template_help_str)
     else:
-        parser.add_argument("--template", required=False)
+        parser.add_argument("template", nargs="?", default=None, help=template_help_str)
 
     return parser, hyper_parameters, params
 

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -191,17 +191,3 @@ def get_parser_and_hprams_data():
         parser.add_argument("template", nargs="?", default=None, help=template_help_str)
 
     return parser, hyper_parameters, params
-
-
-def is_template(template_path: Optional[str]) -> bool:
-    """A function that determines whether the corresponding template path is a template.
-
-    Args:
-        template_path (str): The path of the file you want to know if it is a template.
-
-    Returns:
-        bool: True if template_path is template file else False.
-    """
-    if template_path and Path(template_path).is_file() and "template" in Path(template_path).name:
-        return True
-    return False

--- a/tests/unit/cli/utils/test_parser.py
+++ b/tests/unit/cli/utils/test_parser.py
@@ -170,7 +170,7 @@ def test_add_hyper_parameters_sub_parser(mocker):
 
 
 @e2e_pytest_unit
-def test_get_parser_and_hprams_data_with_template(mocker, tmp_dir):
+def test_get_parser_and_hprams_data_with_fake_template(mocker, tmp_dir):
     # prepare
     tmp_dir = Path(tmp_dir)
     fake_template_file = tmp_dir / "template.yaml"
@@ -178,15 +178,13 @@ def test_get_parser_and_hprams_data_with_template(mocker, tmp_dir):
     mock_argv = ["otx train", str(fake_template_file), "params", "--left-args"]
     mocker.patch("sys.argv", mock_argv)
     mock_template = mocker.patch.object(target_package, "find_and_parse_model_template")
-    mock_hyper_parameters = mocker.MagicMock()
-    mock_template.return_value.hyper_parameters.data = mock_hyper_parameters
 
     # run
     parser, hyper_parameters, params = get_parser_and_hprams_data()
 
     # check
     mock_template.assert_called_once()
-    assert hyper_parameters == mock_hyper_parameters
+    assert hyper_parameters == {}
     assert params == ["params", "--left-args"]
     assert isinstance(parser, ArgumentParser)
 


### PR DESCRIPTION
## Summary
Now see "template" instead of "--template" in help messages.
![image](https://user-images.githubusercontent.com/38045080/219397583-97a6dc96-9f13-489c-9030-3c5b4db3e9df.png)
And OTX can receive file path or template ID or model name as template input.
![image](https://user-images.githubusercontent.com/38045080/219398669-3c538253-56af-4996-a19e-0b42b93fe6f0.png)
