### PR TITLE
[FIX] Resolve input parameter override issue with sub train types

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -303,11 +303,13 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         """Export the data configuration file to output_path."""
         Path(output_path).write_text(OmegaConf.to_yaml(data_cfg), encoding="utf-8")
 
-    def get_hyparams_config(self) -> ConfigurableParameters:
+    def get_hyparams_config(self, override_param: Optional[List] = None) -> ConfigurableParameters:
         """Separates the input params received from args and updates them.."""
         hyper_parameters = self.template.hyper_parameters.data
         type_hint = gen_param_help(hyper_parameters)
-        updated_hyper_parameters = gen_params_dict_from_args(self.args, type_hint=type_hint)
+        updated_hyper_parameters = gen_params_dict_from_args(
+            self.args, override_param=override_param, type_hint=type_hint
+        )
         override_parameters(updated_hyper_parameters, hyper_parameters)
         return create(hyper_parameters)
 

--- a/otx/cli/tools/demo.py
+++ b/otx/cli/tools/demo.py
@@ -40,7 +40,7 @@ ESC_BUTTON = 27
 
 def get_args():
     """Parses command line arguments."""
-    parser, hyper_parameters, _ = get_parser_and_hprams_data()
+    parser, hyper_parameters, params = get_parser_and_hprams_data()
 
     parser.add_argument(
         "-i",
@@ -73,8 +73,9 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
+    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
 
-    return parser.parse_args()
+    return parser.parse_args(), override_param
 
 
 def get_predictions(task, frame):
@@ -103,14 +104,14 @@ def main():
     """Main function that is used for model demonstration."""
 
     # Dynamically create an argument parser based on override parameters.
-    args = get_args()
+    args, override_param = get_args()
 
     config_manager = ConfigManager(args, mode="eval")
     # Auto-Configuration for model template
     config_manager.configure_template()
 
     # Update Hyper Parameter Configs
-    hyper_parameters = config_manager.get_hyparams_config()
+    hyper_parameters = config_manager.get_hyparams_config(override_param)
 
     # Get classes for Task, ConfigurableParameters and Dataset.
     template = config_manager.template

--- a/otx/cli/tools/eval.py
+++ b/otx/cli/tools/eval.py
@@ -36,7 +36,7 @@ from otx.core.data.adapter import get_dataset_adapter
 
 def get_args():
     """Parses command line arguments."""
-    parser, hyper_parameters, _ = get_parser_and_hprams_data()
+    parser, hyper_parameters, params = get_parser_and_hprams_data()
 
     parser.add_argument(
         "--test-data-roots",
@@ -58,8 +58,9 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
+    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
 
-    return parser.parse_args()
+    return parser.parse_args(), override_param
 
 
 def check_label_schemas(label_schema_a, label_schema_b):
@@ -79,7 +80,7 @@ def main():
     """Main function that is used for model evaluation."""
 
     # Dynamically create an argument parser based on override parameters.
-    args = get_args()
+    args, override_param = get_args()
 
     config_manager = ConfigManager(args, workspace_root=args.work_dir, mode="eval")
     # Auto-Configuration for model template
@@ -89,7 +90,7 @@ def main():
         args.load_weights = str(config_manager.workspace_root / "models/weights.pth")
 
     # Update Hyper Parameter Configs
-    hyper_parameters = config_manager.get_hyparams_config()
+    hyper_parameters = config_manager.get_hyparams_config(override_param)
 
     # Get classes for Task, ConfigurableParameters and Dataset.
     template = config_manager.template

--- a/otx/cli/tools/explain.py
+++ b/otx/cli/tools/explain.py
@@ -36,10 +36,12 @@ from otx.cli.utils.parser import (
 ESC_BUTTON = 27
 SUPPORTED_EXPLAIN_ALGORITHMS = ["activationmap", "eigencam", "classwisesaliencymap"]
 
+# pylint: disable=too-many-locals
+
 
 def get_args():
     """Parses command line arguments."""
-    parser, hyper_parameters, _ = get_parser_and_hprams_data()
+    parser, hyper_parameters, params = get_parser_and_hprams_data()
 
     parser.add_argument(
         "--explain-data-roots",
@@ -70,21 +72,22 @@ def get_args():
         help="weight of the saliency map when overlaying the saliency map",
     )
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
+    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
 
-    return parser.parse_args()
+    return parser.parse_args(), override_param
 
 
 def main():
     """Main function that is used for model explanation."""
 
-    args = get_args()
+    args, override_param = get_args()
 
     config_manager = ConfigManager(args, mode="eval")
     # Auto-Configuration for model template
     config_manager.configure_template()
 
     # Update Hyper Parameter Configs
-    hyper_parameters = config_manager.get_hyparams_config()
+    hyper_parameters = config_manager.get_hyparams_config(override_param)
 
     # Get classes for Task, ConfigurableParameters and Dataset.
     template = config_manager.template

--- a/otx/cli/tools/optimize.py
+++ b/otx/cli/tools/optimize.py
@@ -40,7 +40,7 @@ def get_args():
 
     It dynamically generates help for hyper-parameters which are specific to particular model template.
     """
-    parser, hyper_parameters, _ = get_parser_and_hprams_data()
+    parser, hyper_parameters, params = get_parser_and_hprams_data()
 
     parser.add_argument(
         "--train-data-roots",
@@ -69,15 +69,16 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters)
+    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
 
-    return parser.parse_args()
+    return parser.parse_args(), override_param
 
 
 def main():
     """Main function that is used for model training."""
 
     # Dynamically create an argument parser based on override parameters.
-    args = get_args()
+    args, override_param = get_args()
 
     config_manager = ConfigManager(args, workspace_root=args.work_dir, mode="train")
     # Auto-Configuration for model template
@@ -96,7 +97,7 @@ def main():
         raise RuntimeError(f"Optimization by NNCF is not available for template {args.template}")
 
     # Update Hyper Parameter Configs
-    hyper_parameters = config_manager.get_hyparams_config()
+    hyper_parameters = config_manager.get_hyparams_config(override_param)
 
     # Get classes for Task, ConfigurableParameters and Dataset.
     task_class = get_impl_class(template.entrypoints.openvino if is_pot else template.entrypoints.nncf)

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -120,6 +120,7 @@ def get_args():
 
     sub_parser = add_hyper_parameters_sub_parser(parser, hyper_parameters, return_sub_parser=True)
     # TODO: Temporary solution for cases where there is no template input
+    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
     if not hyper_parameters and "params" in params:
         if "params" in params:
             params = params[params.index("params") :]
@@ -131,12 +132,12 @@ def get_args():
                         f"{param}",
                         dest=f"params.{param[2:]}",
                     )
-    return parser.parse_args()
+    return parser.parse_args(), override_param
 
 
 def main():  # pylint: disable=too-many-branches
     """Main function that is used for model training."""
-    args = get_args()
+    args, override_param = get_args()
 
     config_manager = ConfigManager(args, workspace_root=args.work_dir, mode="train")
     # Auto-Configuration for model template
@@ -157,7 +158,7 @@ def main():  # pylint: disable=too-many-branches
     task_class = get_impl_class(template.entrypoints.base)
 
     # Update Hyper Parameter Configs
-    hyper_parameters = config_manager.get_hyparams_config()
+    hyper_parameters = config_manager.get_hyparams_config(override_param=override_param)
 
     environment = TaskEnvironment(
         model=None,

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 from argparse import RawTextHelpFormatter
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from otx.api.entities.model_template import ModelTemplate, parse_model_template
 from otx.cli.registry import find_and_parse_model_template
@@ -62,12 +62,16 @@ def gen_param_help(hyper_parameters: Dict) -> Dict:
     return _gen_param_help("", hyper_parameters)
 
 
-def gen_params_dict_from_args(args, type_hint: Optional[dict] = None) -> Dict[str, dict]:
+def gen_params_dict_from_args(
+    args, override_param: Optional[List] = None, type_hint: Optional[dict] = None
+) -> Dict[str, dict]:
     """Generates hyper parameters dict from parsed command line arguments."""
 
     params_dict: Dict[str, dict] = {}
     for param_name in dir(args):
         if not param_name.startswith("params."):
+            continue
+        if override_param and param_name not in override_param:
             continue
 
         value_type = None

--- a/tests/unit/cli/tools/test_eval.py
+++ b/tests/unit/cli/tools/test_eval.py
@@ -25,7 +25,7 @@ def test_get_args(mocker):
     )
     mocker.patch.object(target_package, "add_hyper_parameters_sub_parser", return_value=argparse.ArgumentParser())
 
-    parsed_args = get_args()
+    parsed_args, _ = get_args()
 
     assert parsed_args.test_data_roots == "test/data/root"
     assert parsed_args.load_weights == "weight/path"
@@ -46,7 +46,7 @@ def mock_args(mocker, tmp_path):
 
     mock_args.__contains__ = mock_contains
     mock_get_args = mocker.patch("otx.cli.tools.eval.get_args")
-    mock_get_args.return_value = mock_args
+    mock_get_args.return_value = [mock_args, []]
 
     return mock_args
 
@@ -138,7 +138,7 @@ def test_main(
     mocker.patch("builtins.open")
 
     mock_get_args = mocker.patch("otx.cli.tools.eval.get_args")
-    mock_get_args.return_value = mock_args
+    mock_get_args.return_value = [mock_args, []]
 
     ret = main()
     assert ret["retcode"] == 0

--- a/tests/unit/cli/tools/test_optimize.py
+++ b/tests/unit/cli/tools/test_optimize.py
@@ -27,7 +27,7 @@ def test_get_args(mocker):
     )
     mocker.patch.object(target_package, "add_hyper_parameters_sub_parser", return_value=argparse.ArgumentParser())
 
-    parsed_args = get_args()
+    parsed_args, _ = get_args()
 
     assert parsed_args.train_data_roots == "train_data_roots_path"
     assert parsed_args.val_data_roots == "val_data_roots_path"
@@ -52,7 +52,7 @@ def mock_args(mocker, tmp_path):
 
     mock_args.__contains__ = mock_contains
     mock_get_args = mocker.patch("otx.cli.tools.optimize.get_args")
-    mock_get_args.return_value = mock_args
+    mock_get_args.return_value = [mock_args, []]
 
     return mock_args
 
@@ -131,7 +131,7 @@ def test_main(
     mocker.patch("builtins.open")
 
     mock_get_args = mocker.patch("otx.cli.tools.optimize.get_args")
-    mock_get_args.return_value = mock_args
+    mock_get_args.return_value = [mock_args, []]
 
     ret = main()
     assert ret["retcode"] == 0

--- a/tests/unit/cli/tools/test_train.py
+++ b/tests/unit/cli/tools/test_train.py
@@ -35,7 +35,7 @@ def test_get_args(mocker):
     )
     mocker.patch.object(target_package, "add_hyper_parameters_sub_parser", return_value=argparse.ArgumentParser())
 
-    parsed_args = get_args()
+    parsed_args, _ = get_args()
 
     assert parsed_args.train_data_roots == "train/data/root"
     assert parsed_args.val_data_roots == "val/data/root"
@@ -77,7 +77,7 @@ def mock_args(mocker, tmp_path):
 
     mock_args.__contains__ = mock_contains
     mock_get_args = mocker.patch("otx.cli.tools.train.get_args")
-    mock_get_args.return_value = mock_args
+    mock_get_args.return_value = [mock_args, []]
 
     return mock_args
 

--- a/tests/unit/cli/utils/test_parser.py
+++ b/tests/unit/cli/utils/test_parser.py
@@ -84,7 +84,9 @@ def mock_args(mocker):
 
 @e2e_pytest_unit
 def test_gen_params_dict_from_args(mock_args):
-    param_dict = gen_params_dict_from_args(mock_args)
+    param_dict = gen_params_dict_from_args(
+        mock_args, ["params.a.a", "params.a.b", "params.a.c", "params.b", "params.c"]
+    )
 
     assert param_dict["a"]["a"]["value"] == 1
     assert param_dict["a"]["b"]["value"] == 2.1
@@ -103,7 +105,9 @@ def test_gen_params_dict_from_args_with_type_hint(mock_args):
         "c": {"type": str},
     }
 
-    param_dict = gen_params_dict_from_args(mock_args, type_hint)
+    param_dict = gen_params_dict_from_args(
+        mock_args, ["params.a.a", "params.a.b", "params.a.c", "params.b", "params.c"], type_hint
+    )
 
     assert param_dict["a"]["a"]["value"] == "1"
     assert param_dict["a"]["b"]["value"] == 2


### PR DESCRIPTION
## Summary
When using Semisl or Selfsl with param in otx train, there is the issue that some parameters are overridden by incremental
This PR addresses that issue.

reported by @sungchul2 