### PR TITLE
[FIX] Keep `ote_config_helper` name for external backward compatibility

### DIFF
--- a/otx/api/configuration/__init__.py
+++ b/otx/api/configuration/__init__.py
@@ -14,8 +14,7 @@ The configuration helper module can be imported as `otx_config_helper` and imple
 #
 
 
-# TODO: Remove cfg_helper once https://jira.devtools.intel.com/browse/CVS-67869 is done:
-import otx.api.configuration.helper as otx_config_helper
+import otx.api.configuration.helper as ote_config_helper  # for 'ote' backward compatibility
 import otx.api.configuration.helper as cfg_helper  # pylint: disable=reimported
 from otx.api.configuration.elements import metadata_keys
 from otx.api.configuration.elements.configurable_enum import ConfigurableEnum
@@ -28,7 +27,7 @@ from .default_model_parameters import DefaultModelParameters
 __all__ = [
     "metadata_keys",
     "cfg_helper",
-    "otx_config_helper",
+    "ote_config_helper",
     "ConfigurableEnum",
     "ModelLifecycle",
     "Action",

--- a/otx/api/configuration/elements/utils.py
+++ b/otx/api/configuration/elements/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for attr package.
 
 This module contains utility functions to use with the attr package, concerning for instance parameter validation
-or serialization. They are used within the otx_config_helper or the configuration elements.
+or serialization. They are used within the cfg_helper or the configuration elements.
 """
 # Copyright (C) 2021-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0

--- a/otx/api/entities/task_environment.py
+++ b/otx/api/entities/task_environment.py
@@ -6,7 +6,7 @@
 
 from typing import List, Optional, Type, TypeVar
 
-from otx.api.configuration import ConfigurableParameters, otx_config_helper
+from otx.api.configuration import ConfigurableParameters, cfg_helper
 from otx.api.entities.label import LabelEntity
 from otx.api.entities.label_schema import LabelSchemaEntity
 from otx.api.entities.model import ModelConfiguration, ModelEntity
@@ -102,7 +102,7 @@ class TaskEnvironment:
         # Otherwise, update the base config according to what is stored in the repo.
         base_config = instance_of(header=self.__hyper_parameters.header)
 
-        otx_config_helper.substitute_values(base_config, value_input=self.__hyper_parameters, allow_missing_values=True)
+        cfg_helper.substitute_values(base_config, value_input=self.__hyper_parameters, allow_missing_values=True)
 
         return base_config
 

--- a/tests/unit/api/configuration/test_configuration_helper.py
+++ b/tests/unit/api/configuration/test_configuration_helper.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from omegaconf import OmegaConf
 
-from otx.api.configuration import otx_config_helper
+from otx.api.configuration import cfg_helper
 from otx.api.configuration.elements import metadata_keys
 from otx.api.configuration.enums import AutoHPOState, ModelLifecycle
 from tests.unit.api.configuration.dummy_config import (
@@ -56,17 +56,17 @@ class TestConfigurationHelper:
         )
 
         # Convert config to dictionary and to yaml string
-        cfg = otx_config_helper.convert(config, dict)
-        cfg_yaml = otx_config_helper.convert(config, str)
+        cfg = cfg_helper.convert(config, dict)
+        cfg_yaml = cfg_helper.convert(config, str)
 
         # Reconstruct the config from dictionary and from yaml string
-        reconstructed_config = otx_config_helper.create(cfg)
-        reconstructed_config_from_yaml = otx_config_helper.create(cfg_yaml)
+        reconstructed_config = cfg_helper.create(cfg)
+        reconstructed_config_from_yaml = cfg_helper.create(cfg_yaml)
 
         # Compare the config dictionaries. Order of some parameters may change in the conversion, so dictionary
         # comparison will work while comparing objects or yaml strings directly likely does not result in equality.
-        assert cfg == otx_config_helper.convert(reconstructed_config, dict)
-        assert cfg == otx_config_helper.convert(reconstructed_config_from_yaml, dict)
+        assert cfg == cfg_helper.convert(reconstructed_config, dict)
+        assert cfg == cfg_helper.convert(reconstructed_config_from_yaml, dict)
 
     @pytest.mark.priority_medium
     @pytest.mark.unit
@@ -112,12 +112,12 @@ class TestConfigurationHelper:
 
         # Act
         # Convert config to dictionary and to yaml string
-        cfg = otx_config_helper.convert(config, dict)
-        cfg_yaml = otx_config_helper.convert(config, str)
+        cfg = cfg_helper.convert(config, dict)
+        cfg_yaml = cfg_helper.convert(config, str)
 
         # Reconstruct the config from dictionary and from yaml string
-        reconstructed_config = otx_config_helper.create(cfg)
-        reconstructed_config_from_yaml = otx_config_helper.create(cfg_yaml)
+        reconstructed_config = cfg_helper.create(cfg)
+        reconstructed_config_from_yaml = cfg_helper.create(cfg_yaml)
 
         # Assert
         assert old_state != new_state
@@ -128,8 +128,8 @@ class TestConfigurationHelper:
             reconstructed_config_from_yaml.get_metadata(parameter_name=test_parameter_name)[metadata_key] == new_state
         )
         # Compare the config dictionaries
-        assert cfg == otx_config_helper.convert(reconstructed_config, dict)
-        assert cfg == otx_config_helper.convert(reconstructed_config_from_yaml, dict)
+        assert cfg == cfg_helper.convert(reconstructed_config, dict)
+        assert cfg == cfg_helper.convert(reconstructed_config_from_yaml, dict)
 
     @pytest.mark.priority_medium
     @pytest.mark.unit
@@ -159,12 +159,12 @@ class TestConfigurationHelper:
             header="Dataset Manager configuration -- TEST ONLY",
         )
 
-        cfg_from_yaml = otx_config_helper.create(self.__get_path_to_file("./dummy_config.yaml"))
+        cfg_from_yaml = cfg_helper.create(self.__get_path_to_file("./dummy_config.yaml"))
 
         # Compare the config dictionaries. Order of some parameters may change in the conversion, so dictionary
         # comparison will work while comparing objects or yaml strings directly likely does not result in equality.
-        cfg_dict = otx_config_helper.convert(config, dict)
-        cfg_from_yaml_dict = otx_config_helper.convert(cfg_from_yaml, dict)
+        cfg_dict = cfg_helper.convert(config, dict)
+        cfg_from_yaml_dict = cfg_helper.convert(cfg_from_yaml, dict)
 
         # Check the parameter groups individually, to narrow down any errors more easily
         cfg_subset_parameters = cfg_dict.pop("subset_parameters")
@@ -207,7 +207,7 @@ class TestConfigurationHelper:
         # input validation upon config creation.
         broken_config_path = self.__get_path_to_file("dummy_broken_config.yaml")
         with pytest.raises(ValueError) as error:
-            config = otx_config_helper.create(broken_config_path)
+            config = cfg_helper.create(broken_config_path)
 
         assert "Invalid value set for epochs: -5 is out of bounds." == str(error.value)
 
@@ -215,7 +215,7 @@ class TestConfigurationHelper:
         # value. Config should now be created correctly. Finally, assert that the value for epochs has been corrected
         dict_config = OmegaConf.load(broken_config_path)
         dict_config.learning_parameters.epochs.value = 10
-        config = otx_config_helper.create(dict_config)
+        config = cfg_helper.create(dict_config)
         assert config.learning_parameters.epochs == 10
 
     @pytest.mark.priority_medium
@@ -252,7 +252,7 @@ class TestConfigurationHelper:
         )
 
         # Assert that config passes validation initially
-        assert otx_config_helper.validate(config)
+        assert cfg_helper.validate(config)
 
         # Set invalid test_proportion, and assert that this raises an error upon validation
         with pytest.raises(ValueError):
@@ -260,7 +260,7 @@ class TestConfigurationHelper:
 
         # Assert that validation passes again after restoring a value that is within the bounds
         config.subset_parameters.test_proportion = 0.25
-        assert otx_config_helper.validate(config)
+        assert cfg_helper.validate(config)
 
         # Set value that is not one of the options for dummy_selectable, assert that this raises a ValueError
         with pytest.raises(ValueError):
@@ -268,7 +268,7 @@ class TestConfigurationHelper:
 
         # Assert that validation passes again after restoring to a value that is in the options list
         config.dummy_selectable = "option_c"
-        assert otx_config_helper.validate(config)
+        assert cfg_helper.validate(config)
 
     @pytest.mark.priority_medium
     @pytest.mark.unit
@@ -298,7 +298,7 @@ class TestConfigurationHelper:
         9. Check that the parameter values have been changed correctly in the config
         """
         # Initialize the config from yaml
-        config = otx_config_helper.create(self.__get_path_to_file("dummy_config.yaml"))
+        config = cfg_helper.create(self.__get_path_to_file("dummy_config.yaml"))
 
         # Assert that the values are set according to what is specified in the yaml
         assert config.subset_parameters.test_proportion == 0.15
@@ -310,7 +310,7 @@ class TestConfigurationHelper:
         config_dict.number_of_samples_for_auto_train.value = 50
 
         # Substitute values from this dict
-        otx_config_helper.substitute_values(config, value_input=config_dict)
+        cfg_helper.substitute_values(config, value_input=config_dict)
 
         # Assert that the values are changed in the config, according to what was substituted above
         assert config.subset_parameters.test_proportion == 0.05
@@ -319,8 +319,8 @@ class TestConfigurationHelper:
         # Convert config_dict to actual config object, and then use that as input for the value substitution
         config_dict.subset_parameters.test_proportion.value = 0.80
         config_dict.number_of_samples_for_auto_train.value = 500
-        reconstructed_config = otx_config_helper.create(config_dict)
-        otx_config_helper.substitute_values(config, value_input=reconstructed_config)
+        reconstructed_config = cfg_helper.create(config_dict)
+        cfg_helper.substitute_values(config, value_input=reconstructed_config)
 
         # Assert that the values are changed in the config, according to what was substituted above
         assert config.subset_parameters.test_proportion == 0.80
@@ -353,7 +353,7 @@ class TestConfigurationHelper:
             model lifecycle did not change
         """
         # Initialize the config from yaml
-        config = otx_config_helper.create(self.__get_path_to_file("dummy_config.yaml"))
+        config = cfg_helper.create(self.__get_path_to_file("dummy_config.yaml"))
 
         # Assert that the values are set according to what is specified in the yaml
         assert config.subset_parameters.test_proportion == 0.15
@@ -364,12 +364,12 @@ class TestConfigurationHelper:
         assert config.get_metadata("dummy_selectable")["affects_outcome_of"] == ModelLifecycle.INFERENCE
 
         # Load the config again from the yaml and change some of the values
-        config_2 = otx_config_helper.create(self.__get_path_to_file("dummy_config.yaml"))
+        config_2 = cfg_helper.create(self.__get_path_to_file("dummy_config.yaml"))
         config_2.subset_parameters.test_proportion = 0.05
         config_2.dummy_float_selectable = 4.0
         config_2.dummy_selectable = SomeEnumSelectable.TEST_NAME1
 
-        otx_config_helper.substitute_values_for_lifecycle(config, config_2, model_lifecycle=ModelLifecycle.INFERENCE)
+        cfg_helper.substitute_values_for_lifecycle(config, config_2, model_lifecycle=ModelLifecycle.INFERENCE)
 
         assert config.subset_parameters.test_proportion == 0.15
         assert config.dummy_selectable == SomeEnumSelectable.TEST_NAME1
@@ -402,7 +402,7 @@ class TestConfigurationHelper:
             model lifecycle did not change
         """
         # Initialize the config from yaml
-        config = otx_config_helper.create(self.__get_path_to_file("dummy_config.yaml"))
+        config = cfg_helper.create(self.__get_path_to_file("dummy_config.yaml"))
 
         # Assert that the values are set according to what is specified in the yaml
         assert config.subset_parameters.test_proportion == 0.15
@@ -413,12 +413,12 @@ class TestConfigurationHelper:
         assert config.get_metadata("dummy_selectable")["affects_outcome_of"] == ModelLifecycle.INFERENCE
 
         # Load the config again from the yaml and change some of the values
-        config_2 = otx_config_helper.create(self.__get_path_to_file("dummy_config.yaml"))
+        config_2 = cfg_helper.create(self.__get_path_to_file("dummy_config.yaml"))
         config_2.subset_parameters.test_proportion = 0.05
         config_2.dummy_float_selectable = 4.0
         config_2.dummy_selectable = SomeEnumSelectable.TEST_NAME1
 
-        otx_config_helper.substitute_values_for_lifecycle(
+        cfg_helper.substitute_values_for_lifecycle(
             config,
             config_2,
             model_lifecycle=[ModelLifecycle.INFERENCE, ModelLifecycle.NONE],
@@ -456,7 +456,7 @@ class TestConfigurationHelper:
         config.subset_parameters.test_proportion = 0.3
         config.dummy_selectable = SomeEnumSelectable.OPTION_C
 
-        config_dict = otx_config_helper.convert(config, target=dict, values_only=True)
+        config_dict = cfg_helper.convert(config, target=dict, values_only=True)
 
         assert config_dict["subset_parameters"]["test_proportion"] == 0.3
         assert config_dict["dummy_selectable"] == SomeEnumSelectable.OPTION_C

--- a/tests/unit/api/entities/test_model.py
+++ b/tests/unit/api/entities/test_model.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from otx.api.configuration import ConfigurableParameters, otx_config_helper
+from otx.api.configuration import ConfigurableParameters, cfg_helper
 from otx.api.entities.annotation import NullAnnotationSceneEntity
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
@@ -256,7 +256,7 @@ class TestModelEntity:
         dummy_template = __get_path_to_file("./dummy_template.yaml")
         model_template = parse_model_template(dummy_template)
         hyper_parameters = model_template.hyper_parameters.data
-        params = otx_config_helper.create(hyper_parameters)
+        params = cfg_helper.create(hyper_parameters)
         labels_schema = LabelSchemaEntity.from_labels(labels_list)
         environment = TaskEnvironment(
             model=None,

--- a/tests/unit/api/entities/test_task_environment.py
+++ b/tests/unit/api/entities/test_task_environment.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from otx.api.configuration import ConfigurableParameters, otx_config_helper
+from otx.api.configuration import ConfigurableParameters, cfg_helper
 from otx.api.entities.id import ID
 from otx.api.entities.label import Domain, LabelEntity
 from otx.api.entities.label_schema import LabelSchemaEntity
@@ -54,7 +54,7 @@ def environment():
     dummy_template = __get_path_to_file("./dummy_template.yaml")
     model_template = parse_model_template(dummy_template)
     hyper_parameters = model_template.hyper_parameters.data
-    params = otx_config_helper.create(hyper_parameters)
+    params = cfg_helper.create(hyper_parameters)
     labels_schema = LabelSchemaEntity.from_labels(labels_list)
     environment = TaskEnvironment(
         model=None,


### PR DESCRIPTION
- Keep `ote_config_helper` for Geti / Geti SDK
- Use replacy `otx_config_helper` use in OTX by `cfg_helper` (same module w/ diff name)