### PR TITLE
[FIX] Add kornia==0.6.9 in requirements/anomaly.txt

### DIFF
--- a/requirements/anomaly.txt
+++ b/requirements/anomaly.txt
@@ -1,3 +1,4 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Anomaly Requirements.
 anomalib==0.4.0rc2
+kornia==0.6.9


### PR DESCRIPTION
## This PR includes:
- Add kornia==0.6.9 in requirements/anomaly.txt to resolve unit test failure.

Below failed TCs are reproducible with `pytest tests/unit/algorithms/anomaly/` on current develop branch. 
(commit hash: `a2b8557a5869c1eb7bdbeb36057f3a77430e046e`)

```
TestInferenceTask.test_inference[ANOMALY_CLASSIFICATION] - RuntimeError: expand(torch.FloatTensor{[1, 1, 1, 33, 33]}, size=[1, -1, -1, -1]): the number of sizes provided (4) must be greater or equal to the number of dimensions in the tensor (5)
... (same errors)
TestTrainTask.test_train_and_load[ANOMALY_SEGMENTATION] - RuntimeError: expand(torch.FloatTensor{[1, 1, 1, 33, 33]}, size=[1, -1, -1, -1]): the number of sizes provided (4) must be greater or equal to the number of dimensions in the tensor (5)
```


### Before
`kornia==0.6.10`
<img width="765" alt="image" src="https://user-images.githubusercontent.com/72460430/219993332-9aec34aa-fd45-42b7-9527-39055b1f972d.png">

### After
`kornia==0.6.9`
<img width="619" alt="image" src="https://user-images.githubusercontent.com/72460430/219992923-b926fabd-081f-4da3-98b2-b4be53e20608.png">

