### PR TITLE
[FIX] Change self-sl for cls batch size from 256 to 64

### DIFF
--- a/otx/algorithms/classification/configs/efficientnet_b0_cls_incr/selfsl/hparam.yaml
+++ b/otx/algorithms/classification/configs/efficientnet_b0_cls_incr/selfsl/hparam.yaml
@@ -3,7 +3,7 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 256
+        default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
         default_value: 0

--- a/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/selfsl/hparam.yaml
+++ b/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/selfsl/hparam.yaml
@@ -3,7 +3,7 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 256
+        default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
         default_value: 0

--- a/otx/algorithms/classification/configs/mobilenet_v3_large_075_cls_incr/selfsl/hparam.yaml
+++ b/otx/algorithms/classification/configs/mobilenet_v3_large_075_cls_incr/selfsl/hparam.yaml
@@ -3,7 +3,7 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 256
+        default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
         default_value: 0

--- a/otx/algorithms/classification/configs/mobilenet_v3_large_1_cls_incr/selfsl/hparam.yaml
+++ b/otx/algorithms/classification/configs/mobilenet_v3_large_1_cls_incr/selfsl/hparam.yaml
@@ -3,7 +3,7 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 256
+        default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
         default_value: 0

--- a/otx/algorithms/classification/configs/mobilenet_v3_small_cls_incr/selfsl/hparam.yaml
+++ b/otx/algorithms/classification/configs/mobilenet_v3_small_cls_incr/selfsl/hparam.yaml
@@ -3,7 +3,7 @@ hyper_parameters:
   parameter_overrides:
     learning_parameters:
       batch_size:
-        default_value: 256
+        default_value: 64
         auto_hpo_state: POSSIBLE
       num_workers:
         default_value: 0


### PR DESCRIPTION
batch size=256 was set for experiments with CIFAR datasets (input size=32), but when it is applied to datasets with input size=224 OOM occurs.
In this PR, batch size in self-sl recipes is set from 256 to 64.