### PR TITLE
[Tests] Add tests for losses

### DIFF
--- a/tests/unit/mpa/modules/losses/test_cross_focal_loss.py
+++ b/tests/unit/mpa/modules/losses/test_cross_focal_loss.py
@@ -1,0 +1,43 @@
+"""Test cross focal loss."""
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import torch
+
+from otx.mpa.modules.models.losses.cross_focal_loss import CrossSigmoidFocalLoss
+
+
+class TestCrossFocalLoss:
+    """Test cross focal loss."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Create the loss object"""
+        self.predictions = torch.tensor([[0, 1, 0], [0, 1, 0], [0, 0, 1]], dtype=torch.float32)
+        self.labels = torch.tensor([1, 1, 2])
+        self.loss = CrossSigmoidFocalLoss(num_classes=3)
+
+    def test_loss_computation(self):
+        """Test loss output."""
+        assert np.round(self.loss(self.predictions, self.labels).item(), decimals=4) == 0.0885
+
+    @pytest.mark.xfail(reason="This should fail as the masks are different")
+    def test_loss_computation_with_mask(self):
+        """Tests loss output with ignored label is provided."""
+        valid_label_mask1 = torch.ones((3, 3))
+        loss1 = self.loss(self.predictions, self.labels, valid_label_mask=valid_label_mask1)
+        valid_label_mask2 = torch.zeros((3, 3))
+        loss2 = self.loss(self.predictions, self.labels, valid_label_mask=valid_label_mask2)
+        assert loss1 != loss2
+
+    def test_reduction(self):
+        """Test reduction."""
+
+        loss1 = self.loss(self.predictions, self.labels, reduction_override="none")
+        loss2 = self.loss(self.predictions, self.labels, reduction_override="mean")
+        loss3 = self.loss(self.predictions, self.labels, reduction_override="sum")
+        assert loss1.shape == (3, 3)
+        assert loss2 != loss3

--- a/tests/unit/mpa/modules/losses/test_l2sp_loss.py
+++ b/tests/unit/mpa/modules/losses/test_l2sp_loss.py
@@ -1,0 +1,93 @@
+"""Test L2SP loss with ignore."""
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+from torchvision.models import resnet18
+
+from otx.mpa.modules.models.losses.l2sp_loss import L2SPLoss
+
+
+class DummyModel(nn.Module):
+    """Creates a dummy model for testing purposes."""
+
+    def __init__(self, set_init_weights: float = 0.0):
+        super().__init__()
+        self.fc = nn.Linear(4, 1)
+        self.cnn = nn.Conv2d(1, 1, 1)
+        self._set_weights(set_init_weights)
+
+    def _set_weights(self, set_init_weights: float = 0.0):
+        """Sets weights of all the parameters with a given value."""
+        for param in self.parameters():
+            param.data.fill_(set_init_weights)
+
+
+class TestL2SPLoss:
+    """Test L2SP loss."""
+
+    @pytest.fixture(scope="class")
+    def model_checkpoint(self):
+        """Create a model checkpoint."""
+        with TemporaryDirectory() as tmp_path:
+            model = DummyModel(set_init_weights=1.0)
+            model_ckpt = tmp_path + "/model.ckpt"
+            torch.save(model.state_dict(), model_ckpt)
+            yield model_ckpt
+
+    def test_loss(self, model_checkpoint):
+        """Test loss output."""
+        new_model = DummyModel(set_init_weights=0.0)
+        loss = L2SPLoss(new_model, model_checkpoint)
+
+        assert np.round(loss().item(), 4).item() == 0.0007
+
+        new_model = DummyModel(set_init_weights=1.0)
+        loss = L2SPLoss(new_model, model_checkpoint)
+        assert loss().item() == 0.0
+
+    def test_value_error(self, model_checkpoint):
+        """Test ValueError."""
+        model = DummyModel()
+
+        with pytest.raises(ValueError):
+            L2SPLoss(model, model_ckpt=None)
+
+        with pytest.raises(ValueError):
+            L2SPLoss(model, model_checkpoint, loss_weight=-1.0)
+
+    def test_state_dict(self):
+        """Test model load with weights stored under state_dict key."""
+        with TemporaryDirectory() as tmp_path:
+            model = DummyModel(set_init_weights=1.0)
+            model_ckpt = tmp_path + "/model.ckpt"
+            torch.save({"state_dict": model.state_dict()}, model_ckpt)
+            new_model = DummyModel(set_init_weights=1.0)
+            loss = L2SPLoss(new_model, model_ckpt)
+            assert loss().item() == 0.0
+
+    def test_backbone(self):
+        """Test model load with backbone weights.
+
+        This tests the case when the new model has backbone param whereas the source model as the backbone layers
+        directly.
+        """
+        with TemporaryDirectory() as tmp_path:
+            model = DummyModel()
+            for param, value in resnet18(pretrained=True).named_children():
+                setattr(model, param, value)
+            model_ckpt = tmp_path + "/model.ckpt"
+            torch.save(model.state_dict(), model_ckpt)
+
+            new_model = DummyModel()
+            setattr(new_model, "backbone", resnet18(pretrained=True))
+            # new_model.load_state_dict(torch.load(model_ckpt))
+            loss = L2SPLoss(new_model, model_ckpt)
+            assert loss().item() == 0.0

--- a/tests/unit/mpa/modules/losses/test_utils.py
+++ b/tests/unit/mpa/modules/losses/test_utils.py
@@ -1,0 +1,29 @@
+"""Test utils."""
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from otx.mpa.modules.models.losses.utils import LossEqualizer
+
+
+class TestLossEqualizer:
+    """Test loss equalizer."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Create the loss object"""
+        weights = {"loss_a": 1.0, "loss_b": 2.0, "loss_c": 3.0}
+        self.loss_equalizer = LossEqualizer(weights, momentum=0)
+
+    def test_loss_equalizer(self):
+        """Test value"""
+        losses = {
+            "loss_a": torch.tensor(10.0),
+            "loss_b": torch.tensor(4.0),
+            "loss_c": torch.tensor(1.0),
+        }
+        result = {val.item() for val in self.loss_equalizer.reweight(losses).values()}
+        assert result == {2.5, 5.0, 7.5}


### PR DESCRIPTION
# Description

- Adds tests for cross focal loss, l2sp loss and utils
- I didn't add cross entropy loss with ignore as I didn't understand it very well. It depends on base pixel loss and mpa pixel base so these aren't being tested as well.