### PR TITLE
[FIX] Remove 'abstract' constraint from IMedia2D.path interface

### DIFF
--- a/otx/api/entities/media.py
+++ b/otx/api/entities/media.py
@@ -50,9 +50,3 @@ class IMedia2DEntity(IMediaEntity, metaclass=abc.ABCMeta):
     def width(self) -> int:
         """Returns the width representation of the 2D Media object."""
         raise NotImplementedError
-
-    @property
-    @abc.abstractmethod
-    def path(self) -> Optional[str]:
-        """Returns the path of the 2D Media object."""
-        raise NotImplementedError

--- a/otx/api/entities/media.py
+++ b/otx/api/entities/media.py
@@ -50,3 +50,8 @@ class IMedia2DEntity(IMediaEntity, metaclass=abc.ABCMeta):
     def width(self) -> int:
         """Returns the width representation of the 2D Media object."""
         raise NotImplementedError
+
+    @property
+    def path(self) -> Optional[str]:
+        """Returns the path of the 2D Media object."""
+        raise NotImplementedError

--- a/otx/api/usecases/exportable_code/demo/requirements.txt
+++ b/otx/api/usecases/exportable_code/demo/requirements.txt
@@ -1,3 +1,4 @@
 openmodelzoo-modelapi==2022.3.0
-otx @ git+https://github.com/openvinotoolkit/training_extensions/@4019081382eea78b589090802bf1f67caa30850b#egg=otx
+# FIXME: to be replace by PyPI package for release
+otx @ git+https://github.com/openvinotoolkit/training_extensions/@9525becdfa57dfec11931fdf76e76fe7a2563ab6#egg=otx
 numpy>=1.21.0,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/otx/api/usecases/exportable_code/demo/requirements.txt
+++ b/otx/api/usecases/exportable_code/demo/requirements.txt
@@ -1,4 +1,4 @@
 openmodelzoo-modelapi==2022.3.0
 # FIXME: to be replace by PyPI package for release
-otx @ git+https://github.com/openvinotoolkit/training_extensions/@9525becdfa57dfec11931fdf76e76fe7a2563ab6#egg=otx
+otx @ git+https://github.com/openvinotoolkit/training_extensions/@64f6a4061665ff641923a067d2b4a368ab70e574#egg=otx
 numpy>=1.21.0,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/tests/unit/api/entities/test_media.py
+++ b/tests/unit/api/entities/test_media.py
@@ -74,7 +74,7 @@ class TestIMedia2DEntity:
 
         assert type(IMedia2DEntity) is abc.ABCMeta
         abc_methods = IMedia2DEntity.__abstractmethods__
-        assert len(abc_methods) == 5
+        assert len(abc_methods) == 4
         assert "width" in abc_methods
         assert "roi_numpy" in abc_methods
         assert "numpy" in abc_methods


### PR DESCRIPTION
- `IMedia2D.path` abstract method which newly introduced in OTX1.0 is causing errors on `otx.api` user  side (Geti / Geti SDK)
  > TypeError: Can't instantiate abstract class Image with abstract methods path

  (Kind of broken API backward compatibility)
- Removing `@abc.abstractmethod` from path property method -> optional implementation from inheritance.