### PR TITLE
[CI] Align doc build env w/ test env for API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,15 +15,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install dependencies
-        run: |
-          python -m pip install -r requirements/base.txt
-          python -m pip install -r requirements/anomaly.txt
-          python -m pip install -r requirements/openvino.txt
-          python -m pip install -r requirements/docs.txt
+        run: python -m pip install -r requirements/dev.txt
       - name: Build-Docs
-        run: |
-          cd docs
-          make html
+        run: tox -e build-doc
       - name: Create gh-pages branch
         run: |
           echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT

--- a/tox.ini
+++ b/tox.ini
@@ -71,19 +71,6 @@ allowlist_externals =
     chmod
     rm
     *snyk*
-deps =
-    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
-    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
-    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
-    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
-    -r{toxinidir}/requirements/api.txt
-    -r{toxinidir}/requirements/base.txt
-    -r{toxinidir}/requirements/openvino.txt
-    -r{toxinidir}/requirements/anomaly.txt
-    -r{toxinidir}/requirements/classification.txt
-    -r{toxinidir}/requirements/detection.txt
-    -r{toxinidir}/requirements/segmentation.txt
-    -r{toxinidir}/requirements/action.txt
 use_develop = true
 commands =
     bash -c "pip freeze > snyk-req.txt"

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     pre-commit
     pre-merge
 
+
 [testenv]
 basepython = python3
 passenv =
@@ -14,15 +15,11 @@ passenv =
     CUDA_VISIBLE_DEVICES
     SNYK_ENDPOINT
     SNYK_TOKEN
-
-[testenv:pre-commit]
-skip_install = true
 deps =
     torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
     torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
     torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
     mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
-    -r{toxinidir}/requirements/dev.txt
     -r{toxinidir}/requirements/api.txt
     -r{toxinidir}/requirements/base.txt
     -r{toxinidir}/requirements/openvino.txt
@@ -31,31 +28,39 @@ deps =
     -r{toxinidir}/requirements/detection.txt
     -r{toxinidir}/requirements/segmentation.txt
     -r{toxinidir}/requirements/action.txt
+
+
+[testenv:pre-commit]
+deps =
+    {[testenv]deps}
+    -r{toxinidir}/requirements/dev.txt
+skip_install = true
 commands =
     pre-commit run --all-files
 
 
 [testenv:pre-merge]
 deps =
-    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
-    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
-    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
-    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    {[testenv]deps}
     -r{toxinidir}/requirements/dev.txt
-    -r{toxinidir}/requirements/api.txt
-    -r{toxinidir}/requirements/base.txt
-    -r{toxinidir}/requirements/openvino.txt
-    -r{toxinidir}/requirements/anomaly.txt
-    -r{toxinidir}/requirements/classification.txt
-    -r{toxinidir}/requirements/detection.txt
-    -r{toxinidir}/requirements/segmentation.txt
-    -r{toxinidir}/requirements/action.txt
 use_develop = true
 commands =
     coverage erase
     coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results.xml {posargs:tests/unit tests/integration}
     coverage report -m --fail-under=0
     coverage xml -o {toxworkdir}/coverage.xml
+
+
+[testenv:build-doc]
+deps =
+    {[testenv]deps}
+    -r{toxinidir}/requirements/docs.txt
+use_develop = true
+change_dir = {toxinidir}/docs
+allowlist_externals =
+    make
+commands =
+    make html
 
 
 [testenv:snyk-scan]


### PR DESCRIPTION
### Why?
All runtime deps needed for API doc build

### What?
Align environment

### How?
`tox` to build doc

### Guide
Build doc:
```bash
tox -e build-doc
cd docs/build/html
```
Run web server:
```bash
ssh {YOUR_PC_IP} -L 8000:localhost:8000
cd {OTX_ROOT}/docs/build/html
python3 -m http.server
```
See html doc: in your laptop browser (localhost:8000) 
