### PR TITLE
[FIX] Move imagesize dep from base to api requirement

### DIFF
--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -8,3 +8,4 @@ opencv-python>=4.5
 pymongo==3.12.0
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
+imagesize==1.4.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,6 @@ nbmake
 prettytable
 protobuf>=3.20.0
 pyyaml
-imagesize==1.4.1
 datumaro==1.0.0rc1
 psutil
 scipy>=1.8


### PR DESCRIPTION
`imagesize` is being imported from `otx.api`
(otx/api/entities/image.py)

Without this change, packages like Geti SDK would get import error
after `pip install otx`.