### PR TITLE
[FIX] CVS-104282 update representation method of entities

### DIFF
--- a/otx/api/entities/metadata.py
+++ b/otx/api/entities/metadata.py
@@ -108,7 +108,7 @@ class MetadataItemEntity:
 
     def __repr__(self):
         """Prints the model and data of the MetadataItemEntity."""
-        return f"MetadataItemEntity(model={self.model}, data={self.data})"
+        return f"MetadataItemEntity(model={self.model})"
 
     def __eq__(self, other):
         """Returns true if the model and the data match the other MetadataItemEntity."""

--- a/otx/api/entities/metrics.py
+++ b/otx/api/entities/metrics.py
@@ -280,8 +280,10 @@ class CurveMetric(MetricEntity):
     def __repr__(self):
         """Returns the string representation of the object."""
         return (
-            f"CurveMetric with {len(self.xs)} data points"
+            f"CurveMetric(name=`{self.name}`, ys=({len(self.ys)} values), "
+            f"xs=({len(self.xs) if self.xs is not None else 'None'} values))"
         )
+
 
     @staticmethod
     def type():

--- a/otx/api/entities/metrics.py
+++ b/otx/api/entities/metrics.py
@@ -279,9 +279,7 @@ class CurveMetric(MetricEntity):
 
     def __repr__(self):
         """Returns the string representation of the object."""
-        return (
-            f"CurveMetric with {len(self.xs)} data points"
-        )
+        return f"CurveMetric with {len(self.xs)} data points"
 
     @staticmethod
     def type():

--- a/otx/api/entities/metrics.py
+++ b/otx/api/entities/metrics.py
@@ -280,8 +280,7 @@ class CurveMetric(MetricEntity):
     def __repr__(self):
         """Returns the string representation of the object."""
         return (
-            f"CurveMetric(name=`{self.name}`, ys=({len(self.ys)} values), "
-            f"xs=({len(self.xs) if self.xs is not None else 'None'} values))"
+            f"CurveMetric with {len(self.xs)} data points"
         )
 
     @staticmethod

--- a/otx/api/entities/result_media.py
+++ b/otx/api/entities/result_media.py
@@ -91,7 +91,6 @@ class ResultMediaEntity(IMetadata):
             f"name={self.name}, "
             f"type={self.type}, "
             f"annotation_scene={self.annotation_scene}, "
-            f"numpy={self.numpy}, "
             f"roi={self.roi}, "
             f"label={self.label})"
         )

--- a/otx/api/entities/tensor.py
+++ b/otx/api/entities/tensor.py
@@ -50,4 +50,4 @@ class TensorEntity(IMetadata):
 
     def __repr__(self):
         """Returns the representation of the tensor."""
-        return f"{self.__class__.__name__}(name={self.name}, numpy={self.numpy})"
+        return f"{self.__class__.__name__}(name={self.name})"

--- a/tests/unit/api/entities/test_metadata.py
+++ b/tests/unit/api/entities/test_metadata.py
@@ -180,7 +180,7 @@ class TestMetadataItemEntity:
         __repr = repr(test_instance0)
         repr_pattern = (
             r"MetadataItemEntity\(model=\<otx.api.entities.model.ModelEntity object at"
-            r" 0x[a-fA-F0-9]{10,32}\>\, data\=default_i_metadata\)"
+            r" 0x[a-fA-F0-9]{10,32}\>\)"
         )
         assert re.match(repr_pattern, __repr)
 

--- a/tests/unit/api/entities/test_metadata.py
+++ b/tests/unit/api/entities/test_metadata.py
@@ -179,8 +179,7 @@ class TestMetadataItemEntity:
         assert test_instance0 == test_instance1 != test_instance2
         __repr = repr(test_instance0)
         repr_pattern = (
-            r"MetadataItemEntity\(model=\<otx.api.entities.model.ModelEntity object at"
-            r" 0x[a-fA-F0-9]{10,32}\>\)"
+            r"MetadataItemEntity\(model=\<otx.api.entities.model.ModelEntity object at" r" 0x[a-fA-F0-9]{10,32}\>\)"
         )
         assert re.match(repr_pattern, __repr)
 

--- a/tests/unit/api/entities/test_result_media.py
+++ b/tests/unit/api/entities/test_result_media.py
@@ -146,7 +146,6 @@ class TestResultMediaEntity:
         # Checking __repr__ method for ResultMediaEntity class object initialized with default optional parameters
         initialization_params = self.default_result_media_parameters()
         annotation_scene = initialization_params.get("annotation_scene")
-        numpy = initialization_params.get("numpy")
         result_media = ResultMediaEntity(**initialization_params)
         assert repr(result_media) == (
             f"ResultMediaEntity(name=ResultMedia name, type=Test ResultMedia, annotation_scene={annotation_scene}, "
@@ -155,7 +154,6 @@ class TestResultMediaEntity:
         # Checking __repr__ method for ResultMediaEntity class object initialized with specified optional parameters
         initialization_params = self.optional_result_media_parameters()
         annotation_scene = initialization_params.get("annotation_scene")
-        numpy = initialization_params.get("numpy")
         roi = initialization_params.get("roi")
         label = initialization_params.get("label")
         result_media = ResultMediaEntity(**initialization_params)

--- a/tests/unit/api/entities/test_result_media.py
+++ b/tests/unit/api/entities/test_result_media.py
@@ -161,7 +161,7 @@ class TestResultMediaEntity:
         result_media = ResultMediaEntity(**initialization_params)
         assert repr(result_media) == (
             f"ResultMediaEntity(name=ResultMedia name, type=Test ResultMedia, annotation_scene={annotation_scene}, "
-            f"numpy={numpy}, roi={roi}, label={label})"
+            f"roi={roi}, label={label})"
         )
 
     @pytest.mark.priority_medium

--- a/tests/unit/api/entities/test_result_media.py
+++ b/tests/unit/api/entities/test_result_media.py
@@ -150,7 +150,7 @@ class TestResultMediaEntity:
         result_media = ResultMediaEntity(**initialization_params)
         assert repr(result_media) == (
             f"ResultMediaEntity(name=ResultMedia name, type=Test ResultMedia, annotation_scene={annotation_scene}, "
-            f"numpy={numpy}, roi={result_media.roi}, label=None)"
+            f"roi={result_media.roi}, label=None)"
         )
         # Checking __repr__ method for ResultMediaEntity class object initialized with specified optional parameters
         initialization_params = self.optional_result_media_parameters()

--- a/tests/unit/api/entities/test_tensor.py
+++ b/tests/unit/api/entities/test_tensor.py
@@ -139,4 +139,4 @@ class TestTensorEntity:
         Test passes if value returned by __repr__ method is equal to expected
         """
         tensor = self.tensor()
-        assert repr(tensor) == f"TensorEntity(name=Test Tensor, numpy={tensor.numpy})"
+        assert repr(tensor) == f"TensorEntity(name=Test Tensor)"

--- a/tests/unit/api/entities/test_tensor.py
+++ b/tests/unit/api/entities/test_tensor.py
@@ -139,4 +139,4 @@ class TestTensorEntity:
         Test passes if value returned by __repr__ method is equal to expected
         """
         tensor = self.tensor()
-        assert repr(tensor) == f"TensorEntity(name=Test Tensor)"
+        assert repr(tensor) == "TensorEntity(name=Test Tensor)"


### PR DESCRIPTION
String representations of entities should not contain full numpy arrays or other large objects.