### PR TITLE
[FIX] Fix feature dumping for MaskRCNN models (InstSegm, RotDet)

### DIFF
--- a/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/deployment.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/deployment.py
@@ -3,7 +3,7 @@
 _base_ = ["../../base/deployments/base_instance_segmentation_dynamic.py"]
 
 ir_config = dict(
-    output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"],
+    output_names=["boxes", "labels", "masks"],
 )
 
 backend_config = dict(

--- a/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/deployment.py
+++ b/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/deployment.py
@@ -3,7 +3,7 @@
 _base_ = ["../../base/deployments/base_instance_segmentation_dynamic.py"]
 
 ir_config = dict(
-    output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"],
+    output_names=["boxes", "labels", "masks"],
 )
 
 backend_config = dict(

--- a/otx/algorithms/detection/configs/rotated_detection/efficientnetb2b_maskrcnn/deployment.py
+++ b/otx/algorithms/detection/configs/rotated_detection/efficientnetb2b_maskrcnn/deployment.py
@@ -3,7 +3,7 @@
 _base_ = ["../../base/deployments/base_instance_segmentation_dynamic.py"]
 
 ir_config = dict(
-    output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"],
+    output_names=["boxes", "labels", "masks"],
 )
 
 backend_config = dict(

--- a/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/deployment.py
+++ b/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/deployment.py
@@ -3,7 +3,7 @@
 _base_ = ["../../base/deployments/base_instance_segmentation_dynamic.py"]
 
 ir_config = dict(
-    output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"],
+    output_names=["boxes", "labels", "masks"],
 )
 
 backend_config = dict(


### PR DESCRIPTION
Hot-fix in addition to this PR: https://github.com/openvinotoolkit/training_extensions/pull/1708
Remove default feature vector and saliency map dumping during export for 
- Instance Segmentation 
- Rotated Detection models