### PR TITLE
[TEST] Add mpa.modules.models unit test

### DIFF
--- a/tests/unit/mpa/modules/heads/test_semisl_cls_head.py
+++ b/tests/unit/mpa/modules/heads/test_semisl_cls_head.py
@@ -1,0 +1,119 @@
+import pytest
+import torch
+from mmcls.models.builder import build_head
+
+from otx.mpa.modules.models.heads.semisl_cls_head import (
+    SemiLinearClsHead,
+    SemiNonLinearClsHead,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestSemiSLClsHead:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        """Semi-SL for Classification Head Settings."""
+        self.in_channels = 1280
+        self.num_classes = 10
+        self.head_cfg = dict(
+            type="SemiLinearClsHead",
+            in_channels=self.in_channels,
+            num_classes=self.num_classes,
+        )
+
+    @e2e_pytest_unit
+    def test_build_semisl_cls_head(self):
+        """Verifies that SemiSLClsHead builds."""
+        head = build_head(self.head_cfg)
+        assert isinstance(head, SemiLinearClsHead)
+
+        head_cfg = dict(
+            type="SemiNonLinearClsHead",
+            in_channels=self.in_channels,
+            num_classes=self.num_classes,
+        )
+        head = build_head(head_cfg)
+        assert isinstance(head, SemiNonLinearClsHead)
+
+    @e2e_pytest_unit
+    def test_build_semisl_cls_head_type_error(self):
+        """Verifies that SemiSLClsHead parameters check with TypeError."""
+        with pytest.raises(TypeError):
+            self.head_cfg["num_classes"] = [1]
+            build_head(self.head_cfg)
+        with pytest.raises(TypeError):
+            self.head_cfg["in_channels"] = [1]
+            build_head(self.head_cfg)
+        with pytest.raises(TypeError):
+            self.head_cfg["loss"] = [1]
+            build_head(self.head_cfg)
+        with pytest.raises(TypeError):
+            self.head_cfg["topk"] = [1]
+            build_head(self.head_cfg)
+        with pytest.raises(TypeError):
+            self.head_cfg["unlabeled_coef"] = [1]
+            build_head(self.head_cfg)
+        with pytest.raises(TypeError):
+            self.head_cfg["min_threshold"] = [1]
+            build_head(self.head_cfg)
+
+    @e2e_pytest_unit
+    def test_build_semisl_cls_head_value_error(self):
+        """Verifies that SemiSLClsHead parameters check with ValueError."""
+        with pytest.raises(ValueError):
+            self.head_cfg["num_classes"] = 0
+            build_head(self.head_cfg)
+        with pytest.raises(ValueError):
+            self.head_cfg["num_classes"] = -1
+            build_head(self.head_cfg)
+        with pytest.raises(ValueError):
+            self.head_cfg["in_channels"] = 0
+            build_head(self.head_cfg)
+        with pytest.raises(ValueError):
+            self.head_cfg["in_channels"] = -1
+            build_head(self.head_cfg)
+
+    @e2e_pytest_unit
+    def test_forward(self, mocker):
+        """Verifies that SemiSLClsHead forward function works."""
+        head = build_head(self.head_cfg)
+        labeled_batch_size = 16
+        unlabeled_batch_size = 64
+
+        dummy_gt = torch.randint(self.num_classes, (labeled_batch_size,))
+        labeled = torch.rand(labeled_batch_size, self.in_channels)
+        unlabeled_weak = torch.rand(unlabeled_batch_size, self.in_channels)
+        unlabeled_strong = torch.rand(unlabeled_batch_size, self.in_channels)
+
+        mocker.patch("torch.cuda.is_available", return_value=False)
+
+        dummy_data = {
+            "labeled": labeled,
+            "unlabeled_weak": unlabeled_weak,
+            "unlabeled_strong": unlabeled_strong,
+        }
+        head.classwise_acc = head.classwise_acc.cpu()
+        loss = head.forward_train(dummy_data, dummy_gt)
+
+        assert isinstance(loss, dict)
+        assert len(loss) == 3
+        assert isinstance(loss["accuracy"], dict)
+        assert len(loss["accuracy"]) == 2
+
+        # No Unlabeled Data
+        dummy_feature = torch.rand(labeled_batch_size, self.in_channels)
+        loss = head.forward_train(dummy_feature, dummy_gt)
+
+        assert isinstance(loss, dict)
+        assert len(loss) == 3
+        assert isinstance(loss["accuracy"], dict)
+        assert len(loss["accuracy"]) == 2
+
+    @e2e_pytest_unit
+    def test_simple_test(self):
+        """Verifies that SemiSLClsHead simple_test function works."""
+        head = build_head(self.head_cfg)
+        dummy_feature = torch.rand(3, self.in_channels)
+        features = head.simple_test(dummy_feature)
+        assert len(features) == 3
+        assert len(features[0]) == self.num_classes

--- a/tests/unit/mpa/modules/models/detectors/test_custom_atss_detector.py
+++ b/tests/unit/mpa/modules/models/detectors/test_custom_atss_detector.py
@@ -1,0 +1,131 @@
+import torch
+from mmdet.models.builder import build_detector
+
+from otx.mpa.modules.models.detectors.custom_atss_detector import CustomATSS
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestCustomATSS:
+    @e2e_pytest_unit
+    def test_custom_atss_build(self):
+        model_cfg = dict(
+            type="CustomATSS",
+            backbone=dict(
+                avg_down=False,
+                base_channels=64,
+                conv_cfg=None,
+                dcn=None,
+                deep_stem=False,
+                depth=18,
+                dilations=(1, 1, 1, 1),
+                frozen_stages=-1,
+                in_channels=3,
+                init_cfg=None,
+                norm_cfg=dict(requires_grad=True, type="BN"),
+                norm_eval=True,
+                num_stages=4,
+                out_indices=(0, 1, 2, 3),
+                plugins=None,
+                pretrained=None,
+                stage_with_dcn=(False, False, False, False),
+                stem_channels=None,
+                strides=(1, 2, 2, 2),
+                style="pytorch",
+                type="mmdet.ResNet",
+                with_cp=False,
+                zero_init_residual=True,
+            ),
+            neck=dict(
+                type="FPN",
+                in_channels=[64, 128, 256, 512],
+                out_channels=64,
+                start_level=1,
+                add_extra_convs="on_output",
+                num_outs=5,
+                relu_before_extra_convs=True,
+            ),
+            bbox_head=dict(
+                type="CustomATSSHead",
+                num_classes=2,
+                in_channels=64,
+                stacked_convs=4,
+                feat_channels=64,
+                anchor_generator=dict(
+                    type="AnchorGenerator",
+                    ratios=[1.0],
+                    octave_base_scale=8,
+                    scales_per_octave=1,
+                    strides=[8, 16, 32, 64, 128],
+                ),
+                bbox_coder=dict(
+                    type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[0.1, 0.1, 0.2, 0.2]
+                ),
+                loss_cls=dict(type="FocalLoss", use_sigmoid=True, gamma=2.0, alpha=0.25, loss_weight=1.0),
+                loss_bbox=dict(type="GIoULoss", loss_weight=2.0),
+                loss_centerness=dict(type="CrossEntropyLoss", use_sigmoid=True, loss_weight=1.0),
+                use_qfl=False,
+                qfl_cfg=dict(type="QualityFocalLoss", use_sigmoid=True, beta=2.0, loss_weight=1.0),
+            ),
+        )
+
+        model = build_detector(model_cfg)
+        assert isinstance(model, CustomATSS)
+
+    @e2e_pytest_unit
+    def test_custom_atss_load_state_dict_pre_hook(self):
+        chkpt_classes = ["person", "car"]
+        model_classes = ["tree", "car", "person"]
+        chkpt_dict = {
+            "bbox_head.atss_cls.weight": torch.tensor(
+                [
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                ]
+            ),
+            "bbox_head.atss_cls.bias": torch.tensor(
+                [
+                    [1],
+                    [2],
+                ]
+            ),
+        }
+        model_dict = {
+            "bbox_head.atss_cls.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                ]
+            ),
+            "bbox_head.atss_cls.bias": torch.tensor(
+                [
+                    [3],
+                    [4],
+                    [5],
+                ]
+            ),
+        }
+        gt_dict = {
+            "bbox_head.atss_cls.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                ]
+            ),
+            "bbox_head.atss_cls.bias": torch.tensor(
+                [
+                    [3],
+                    [2],
+                    [1],
+                ]
+            ),
+        }
+
+        class Model:
+            def state_dict(self):
+                return model_dict
+
+        CustomATSS.load_state_dict_pre_hook(Model(), model_classes, chkpt_classes, chkpt_dict, "")
+        for k, gt in gt_dict.items():
+            assert (chkpt_dict[k] != gt).sum() == 0

--- a/tests/unit/mpa/modules/models/detectors/test_custom_single_stage_detector.py
+++ b/tests/unit/mpa/modules/models/detectors/test_custom_single_stage_detector.py
@@ -1,0 +1,187 @@
+import torch
+
+from otx.mpa.modules.models.backbones import imgclsmob
+from otx.mpa.modules.models.detectors.custom_single_stage_detector import (
+    CustomSingleStageDetector,
+)
+from otx.mpa.modules.models.heads import custom_anchor_generator
+
+__all__ = ["imgclsmob", "custom_anchor_generator"]
+
+from mmdet.models.builder import build_detector
+
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestCustomSingleStageDetector:
+    @e2e_pytest_unit
+    def test_custom_single_stage_detector_build(self):
+        model_cfg = dict(
+            type="CustomSingleStageDetector",
+            backbone=dict(
+                type="mmdet.mobilenetv2_w1", out_indices=(4, 5), frozen_stages=-1, norm_eval=False, pretrained=True
+            ),
+            neck=None,
+            bbox_head=dict(
+                type="CustomSSDHead",
+                num_classes=80,
+                in_channels=(int(96.0), int(320.0)),
+                use_depthwise=True,
+                norm_cfg=dict(type="BN"),
+                act_cfg=dict(type="ReLU"),
+                init_cfg=dict(type="Xavier", layer="Conv2d", distribution="uniform"),
+                loss_balancing=False,
+                anchor_generator=dict(
+                    type="SSDAnchorGeneratorClustered",
+                    strides=(16, 32),
+                    reclustering_anchors=True,
+                    widths=[
+                        [
+                            38.641007923271076,
+                            92.49516032784699,
+                            271.4234764938237,
+                            141.53469410876247,
+                        ],
+                        [
+                            206.04136086566515,
+                            386.6542727907841,
+                            716.9892752215089,
+                            453.75609561761405,
+                            788.4629155558277,
+                        ],
+                    ],
+                    heights=[
+                        [
+                            48.9243877087132,
+                            147.73088476194903,
+                            158.23569788707474,
+                            324.14510379107367,
+                        ],
+                        [
+                            587.6216059488938,
+                            381.60024152086544,
+                            323.5988913027747,
+                            702.7486097568518,
+                            741.4865860938451,
+                        ],
+                    ],
+                ),
+                bbox_coder=dict(
+                    type="DeltaXYWHBBoxCoder",
+                    target_means=(0.0, 0.0, 0.0, 0.0),
+                    target_stds=(0.1, 0.1, 0.2, 0.2),
+                ),
+            ),
+        )
+
+        model = build_detector(model_cfg)
+        assert isinstance(model, CustomSingleStageDetector)
+
+    @e2e_pytest_unit
+    def test_custom_single_stage_detector_load_state_dict_pre_hook(self):
+        chkpt_classes = ["person", "car"]
+        model_classes = ["tree", "car", "person"]
+        chkpt_dict = {
+            "bbox_head.cls_convs.0.weight": torch.tensor(
+                [
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                    [0, 0, 0, 0],  # BG
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                    [0, 0, 0, 0],  # BG
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                    [0, 0, 0, 0],  # BG
+                ]
+            ),
+            "bbox_head.cls_convs.0.bias": torch.tensor(
+                [
+                    [1],
+                    [2],
+                    [0],  # BG
+                    [1],
+                    [2],
+                    [0],  # BG
+                    [1],
+                    [2],
+                    [0],  # BG
+                ]
+            ),
+        }
+        model_dict = {
+            "bbox_head.cls_convs.0.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                    [0, 0, 0, 0],  # BG
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                    [0, 0, 0, 0],  # BG
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                    [0, 0, 0, 0],  # BG
+                ]
+            ),
+            "bbox_head.cls_convs.0.bias": torch.tensor(
+                [
+                    [3],
+                    [4],
+                    [5],
+                    [0],  # BG
+                    [3],
+                    [4],
+                    [5],
+                    [0],  # BG
+                    [3],
+                    [4],
+                    [5],
+                    [0],  # BG
+                ]
+            ),
+        }
+        gt_dict = {
+            "bbox_head.cls_convs.0.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                    [0, 0, 0, 0],  # BG
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                    [0, 0, 0, 0],  # BG
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                    [0, 0, 0, 0],  # BG
+                ]
+            ),
+            "bbox_head.cls_convs.0.bias": torch.tensor(
+                [
+                    [3],
+                    [2],
+                    [1],
+                    [0],  # BG
+                    [3],
+                    [2],
+                    [1],
+                    [0],  # BG
+                    [3],
+                    [2],
+                    [1],
+                    [0],  # BG
+                ]
+            ),
+        }
+
+        class Model:
+            def state_dict(self):
+                return model_dict
+
+        CustomSingleStageDetector.load_state_dict_pre_hook(Model(), model_classes, chkpt_classes, chkpt_dict, "")
+        for k, gt in gt_dict.items():
+            assert (chkpt_dict[k] != gt).sum() == 0

--- a/tests/unit/mpa/modules/models/detectors/test_custom_two_stage_detector.py
+++ b/tests/unit/mpa/modules/models/detectors/test_custom_two_stage_detector.py
@@ -1,0 +1,261 @@
+import torch
+from mmcv.utils import ConfigDict
+from mmdet.models.builder import build_detector
+
+from otx.mpa.modules.models.detectors.custom_two_stage_detector import (
+    CustomTwoStageDetector,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestCustomTwoStageDetector:
+    @e2e_pytest_unit
+    def test_custom_two_stage_detector_build(self):
+        model_cfg = ConfigDict(
+            type="CustomTwoStageDetector",
+            backbone=dict(
+                type="ResNet",
+                depth=50,
+                num_stages=4,
+                out_indices=(0, 1, 2, 3),
+                frozen_stages=1,
+                norm_cfg=dict(type="BN", requires_grad=True),
+                norm_eval=True,
+                style="pytorch",
+            ),
+            neck=dict(type="FPN", in_channels=[256, 512, 1024, 2048], out_channels=256, num_outs=5),
+            rpn_head=dict(
+                type="RPNHead",
+                in_channels=256,
+                feat_channels=256,
+                anchor_generator=dict(
+                    type="AnchorGenerator", scales=[8], ratios=[0.5, 1.0, 2.0], strides=[4, 8, 16, 32, 64]
+                ),
+                bbox_coder=dict(
+                    type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[1.0, 1.0, 1.0, 1.0]
+                ),
+                loss_cls=dict(type="CrossEntropyLoss", use_sigmoid=True, loss_weight=1.0),
+                loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+            ),
+            roi_head=dict(
+                type="StandardRoIHead",
+                bbox_roi_extractor=dict(
+                    type="SingleRoIExtractor",
+                    roi_layer=dict(type="RoIAlign", output_size=7, sampling_ratio=0.0),
+                    out_channels=256,
+                    featmap_strides=[4, 8, 16, 32],
+                ),
+                bbox_head=dict(
+                    type="Shared2FCBBoxHead",
+                    in_channels=256,
+                    fc_out_channels=1024,
+                    roi_feat_size=7,
+                    num_classes=80,
+                    bbox_coder=dict(
+                        type="DeltaXYWHBBoxCoder", target_means=[0.0, 0.0, 0.0, 0.0], target_stds=[0.1, 0.1, 0.2, 0.2]
+                    ),
+                    reg_class_agnostic=False,
+                    loss_cls=dict(type="CrossEntropyLoss", use_sigmoid=False, loss_weight=1.0),
+                    loss_bbox=dict(type="L1Loss", loss_weight=1.0),
+                ),
+            ),
+            # model training and testing settings
+            train_cfg=dict(
+                rpn=dict(
+                    assigner=dict(
+                        type="MaxIoUAssigner",
+                        pos_iou_thr=0.7,
+                        neg_iou_thr=0.3,
+                        min_pos_iou=0.3,
+                        match_low_quality=True,
+                        ignore_iof_thr=-1,
+                    ),
+                    sampler=dict(
+                        type="RandomSampler", num=256, pos_fraction=0.5, neg_pos_ub=-1, add_gt_as_proposals=False
+                    ),
+                    allowed_border=-1,
+                    pos_weight=-1,
+                    debug=False,
+                ),
+                rpn_proposal=dict(
+                    nms_across_levels=False, nms_pre=2000, nms_post=1000, max_num=1000, nms_thr=0.7, min_bbox_size=0
+                ),
+                rcnn=dict(
+                    assigner=dict(
+                        type="MaxIoUAssigner",
+                        pos_iou_thr=0.5,
+                        neg_iou_thr=0.5,
+                        min_pos_iou=0.5,
+                        match_low_quality=False,
+                        ignore_iof_thr=-1,
+                    ),
+                    sampler=dict(
+                        type="RandomSampler", num=512, pos_fraction=0.25, neg_pos_ub=-1, add_gt_as_proposals=True
+                    ),
+                    pos_weight=-1,
+                    debug=False,
+                ),
+            ),
+            test_cfg=dict(
+                rpn=dict(
+                    nms_across_levels=False, nms_pre=1000, nms_post=1000, max_num=1000, nms_thr=0.7, min_bbox_size=0
+                ),
+                rcnn=dict(score_thr=0.05, nms=dict(type="nms", iou_threshold=0.5), max_per_img=100)
+                # soft-nms is also supported for rcnn testing
+                # e.g., nms=dict(type='soft_nms', iou_threshold=0.5, min_score=0.05)
+            ),
+            task_adapt=dict(
+                src_classes=["person", "car"],
+                dst_classes=["tree", "car", "person"],
+            ),
+        )
+
+        model = build_detector(model_cfg)
+        assert isinstance(model, CustomTwoStageDetector)
+
+    @e2e_pytest_unit
+    def test_custom_two_stage_detector_load_state_dict_pre_hook(self):
+        chkpt_classes = ["person", "car"]
+        model_classes = ["tree", "car", "person"]
+        chkpt_dict = {
+            "roi_head.bbox_head.fc_cls.weight": torch.tensor(
+                [
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                ]
+            ),
+            "roi_head.bbox_head.fc_cls.bias": torch.tensor(
+                [
+                    [1],
+                    [2],
+                ]
+            ),
+            "roi_head.bbox_head.fc_reg.weight": torch.tensor(
+                [
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                    [2, 2, 2, 2],
+                    [2, 2, 2, 2],
+                    [2, 2, 2, 2],
+                ]
+            ),
+            "roi_head.bbox_head.fc_reg.bias": torch.tensor(
+                [
+                    [1],
+                    [1],
+                    [1],
+                    [1],
+                    [2],
+                    [2],
+                    [2],
+                    [2],
+                ]
+            ),
+        }
+        model_dict = {
+            "roi_head.bbox_head.fc_cls.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                ]
+            ),
+            "roi_head.bbox_head.fc_cls.bias": torch.tensor(
+                [
+                    [3],
+                    [4],
+                    [5],
+                ]
+            ),
+            "roi_head.bbox_head.fc_reg.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [3, 3, 3, 3],
+                    [3, 3, 3, 3],
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [4, 4, 4, 4],
+                    [4, 4, 4, 4],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                    [5, 5, 5, 5],
+                    [5, 5, 5, 5],
+                    [5, 5, 5, 5],
+                ]
+            ),
+            "roi_head.bbox_head.fc_reg.bias": torch.tensor(
+                [
+                    [3],
+                    [3],
+                    [3],
+                    [3],
+                    [4],
+                    [4],
+                    [4],
+                    [4],
+                    [5],
+                    [5],
+                    [5],
+                    [5],
+                ]
+            ),
+        }
+        gt_dict = {
+            "roi_head.bbox_head.fc_cls.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                ]
+            ),
+            "roi_head.bbox_head.fc_cls.bias": torch.tensor(
+                [
+                    [3],
+                    [2],
+                    [1],
+                ]
+            ),
+            "roi_head.bbox_head.fc_reg.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [3, 3, 3, 3],
+                    [3, 3, 3, 3],
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [2, 2, 2, 2],
+                    [2, 2, 2, 2],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                    [1, 1, 1, 1],
+                ]
+            ),
+            "roi_head.bbox_head.fc_reg.bias": torch.tensor(
+                [
+                    [3],
+                    [3],
+                    [3],
+                    [3],
+                    [2],
+                    [2],
+                    [2],
+                    [2],
+                    [1],
+                    [1],
+                    [1],
+                    [1],
+                ]
+            ),
+        }
+
+        class Model:
+            def state_dict(self):
+                return model_dict
+
+        CustomTwoStageDetector.load_state_dict_pre_hook(Model(), model_classes, chkpt_classes, chkpt_dict, "")
+        for k, gt in gt_dict.items():
+            assert (chkpt_dict[k] != gt).sum() == 0

--- a/tests/unit/mpa/modules/models/detectors/test_custom_vfnet_detector.py
+++ b/tests/unit/mpa/modules/models/detectors/test_custom_vfnet_detector.py
@@ -1,0 +1,120 @@
+import torch
+from mmcv.utils import ConfigDict
+from mmdet.models.builder import build_detector
+
+from otx.mpa.modules.models.detectors.custom_vfnet_detector import CustomVFNet
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestCustomVFNet:
+    @e2e_pytest_unit
+    def test_custom_vfnet_build(self):
+        model_cfg = ConfigDict(
+            type="CustomVFNet",
+            backbone=dict(
+                type="ResNet",
+                depth=50,
+                num_stages=4,
+                out_indices=(0, 1, 2, 3),
+                frozen_stages=1,
+                norm_cfg=dict(type="SyncBN", requires_grad=True),
+                norm_eval=True,
+                style="pytorch",
+            ),
+            neck=dict(
+                type="FPN",
+                in_channels=[256, 512, 1024, 2048],
+                out_channels=256,
+                start_level=1,
+                add_extra_convs="on_output",
+                num_outs=5,
+                relu_before_extra_convs=True,
+            ),
+            bbox_head=dict(
+                type="VFNetHead",
+                num_classes=2,
+                in_channels=256,
+                stacked_convs=3,
+                feat_channels=256,
+                strides=[8, 16, 32, 64, 128],
+                center_sampling=False,
+                dcn_on_last_conv=False,
+                use_atss=True,
+                use_vfl=True,
+                loss_cls=dict(
+                    type="VarifocalLoss", use_sigmoid=True, alpha=0.75, gamma=2.0, iou_weighted=True, loss_weight=1.0
+                ),
+                loss_bbox=dict(type="GIoULoss", loss_weight=1.5),
+                loss_bbox_refine=dict(type="GIoULoss", loss_weight=2.0),
+            ),
+            train_cfg=dict(assigner=dict(type="ATSSAssigner", topk=9), allowed_border=-1, pos_weight=-1, debug=False),
+            test_cfg=dict(
+                nms_pre=1000, min_bbox_size=0, score_thr=0.01, nms=dict(type="nms", iou_threshold=0.5), max_per_img=100
+            ),
+            task_adapt=dict(
+                src_classes=["person", "car"],
+                dst_classes=["tree", "car", "person"],
+            ),
+        )
+
+        model = build_detector(model_cfg)
+        assert isinstance(model, CustomVFNet)
+
+    @e2e_pytest_unit
+    def test_custom_vfnet_load_state_dict_pre_hook(self):
+        chkpt_classes = ["person", "car"]
+        model_classes = ["tree", "car", "person"]
+        chkpt_dict = {
+            "bbox_head.vfnet_cls.weight": torch.tensor(
+                [
+                    [1, 1, 1, 1],
+                    [2, 2, 2, 2],
+                ]
+            ),
+            "bbox_head.vfnet_cls.bias": torch.tensor(
+                [
+                    [1],
+                    [2],
+                ]
+            ),
+        }
+        model_dict = {
+            "bbox_head.vfnet_cls.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [4, 4, 4, 4],
+                    [5, 5, 5, 5],
+                ]
+            ),
+            "bbox_head.vfnet_cls.bias": torch.tensor(
+                [
+                    [3],
+                    [4],
+                    [5],
+                ]
+            ),
+        }
+        gt_dict = {
+            "bbox_head.vfnet_cls.weight": torch.tensor(
+                [
+                    [3, 3, 3, 3],
+                    [2, 2, 2, 2],
+                    [1, 1, 1, 1],
+                ]
+            ),
+            "bbox_head.vfnet_cls.bias": torch.tensor(
+                [
+                    [3],
+                    [2],
+                    [1],
+                ]
+            ),
+        }
+
+        class Model:
+            def state_dict(self):
+                return model_dict
+
+        CustomVFNet.load_state_dict_pre_hook(Model(), model_classes, chkpt_classes, chkpt_dict, "")
+        for k, gt in gt_dict.items():
+            assert (chkpt_dict[k] != gt).sum() == 0


### PR DESCRIPTION
## Summary
Copy from https://github.com/intel-innersource/frameworks.ai.algorithms.model-preparation-algorithm/tree/master/tests/unit/mpa/modules/models/detectors
and I modified it to work.

```
---------- coverage: platform linux, python 3.9.13-final-0 -----------
Name                                                               Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------------
otx/mpa/modules/models/detectors/custom_atss_detector.py              72     28    61%   30, 40, 61-62, 86-96, 100-109, 113-122
otx/mpa/modules/models/detectors/custom_single_stage_detector.py      94     34    64%   30, 58-63, 85-91, 142-152, 156-165, 171-180
otx/mpa/modules/models/detectors/custom_two_stage_detector.py         40      6    85%   38, 63-64, 74-76
otx/mpa/modules/models/detectors/custom_vfnet_detector.py             36      3    92%   38, 59-60
```

+ Add unit-test for otx/mpa/modules/models/heads/semisl_cls_head.py

```
otx/mpa/modules/models/heads/semisl_cls_head.py                              83      4    95%   86, 193, 195, 211
```