### PR TITLE
[DOC][FIX] Fix workspace name typo in docs

### DIFF
--- a/docs/source/guide/tutorials/advanced/hpo_tutorial.rst
+++ b/docs/source/guide/tutorials/advanced/hpo_tutorial.rst
@@ -15,9 +15,9 @@ First, let's build a workspace. You can do this by running the following command
 
     [*] Load Model Template ID: Custom_Image_Classification_MobileNet-V3-large-1x
     [*] Load Model Name: MobileNet-V3-large-1x
-    [*] Saving data configuration file to: ./otx-workspace-CLASSIFICATION-MobileNet-V3-large-1x/data.yaml
+    [*] Saving data configuration file to: ./otx-workspace-CLASSIFICATION/data.yaml
 
-    (otx) ...$ cd ./otx-workspace-CLASSIFICATION-MobileNet-V3-large-1x
+    (otx) ...$ cd ./otx-workspace-CLASSIFICATION
 
 .. note::
 

--- a/docs/source/guide/tutorials/base/how_to_train/classification.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/classification.rst
@@ -102,13 +102,13 @@ Let's prepare an OpenVINO™ Training Extensions classification workspase runnin
 
   [*] Load Model Template ID: Custom_Image_Classification_MobileNet-V3-large-1x
   [*] Load Model Name: MobileNet-V3-large-1x
-  [*] Saving data configuration file to: ./otx-workspace-CLASSIFICATION-MobileNet-V3-large-1x/data.yaml
+  [*] Saving data configuration file to: ./otx-workspace-CLASSIFICATION/data.yaml
 
-  (otx) ...$ cd ./otx-workspace-CLASSIFICATION-MobileNet-V3-large-1x
+  (otx) ...$ cd ./otx-workspace-CLASSIFICATION
 
 It will create **otx-workspace-CLASSIFICATION** with all necessery configs for MobileNet-V3-large-1x, prepared ``data.yaml`` to simplify CLI commands launch and splitted dataset.
 
-2. To start training we need to call ``otx train``
+3. To start training we need to call ``otx train``
 command in our worspace:
 
 .. code-block::


### PR DESCRIPTION
## Summary
`otx-workspace-CLASSIFICATION-MobileNet-V3-large-1x` -> `otx-workspace-CLASSIFICATION`