### PR TITLE
[DOC] New docs workflow for releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,15 +1,13 @@
-name: Build Docs
+name: Build Docs for the latest
 
 on:
   push:
     branches:
       - develop
-      - releases/v1.0.0
-  workflow_dispatch: # run on request (no need for PR)
 
 jobs:
   Build-Docs:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
     steps:
@@ -21,6 +19,7 @@ jobs:
         run: tox -e build-doc
       - name: Create gh-pages branch
         run: |
+          echo RELEASE_VERSION=${GITHUB_REF#refs/*/} >> $GITHUB_ENV
           echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
           echo SOURCE_BRANCH=${GITHUB_REF#refs/heads/} >> $GITHUB_OUTPUT
           echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
@@ -49,7 +48,10 @@ jobs:
           mkdir -p /tmp/docs_build
           cp -r docs/build/html/* /tmp/docs_build/
           rm -rf ./*
-          cp -r /tmp/docs_build/* ./
+          echo '<html><head><meta http-equiv="refresh" content="0; url=stable/" /></head></html>' > index.html
+          mkdir -p ${{ env.RELEASE_VERSION }}
+          cp -r /tmp/docs_build/* ./${{ env.RELEASE_VERSION }}
+          ln -sf ${{ env.RELEASE_VERSION }} latest
           rm -rf /tmp/docs_build
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/.github/workflows/docs_stable.yml
+++ b/.github/workflows/docs_stable.yml
@@ -1,10 +1,8 @@
-name: Build Docs for the RC
+name: Build Docs for releases
 
 on:
-  push:
-    branches:
-      - "releases/**"
-  workflow_dispatch: # run on request (no need for PR)
+  release:
+    types: [published]
 
 jobs:
   Build-Docs:
@@ -14,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Build-Docs
@@ -24,7 +24,6 @@ jobs:
           echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
           echo SOURCE_BRANCH=${GITHUB_REF#refs/heads/} >> $GITHUB_OUTPUT
           echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> $GITHUB_OUTPUT
-
           existed_in_remote=$(git ls-remote --heads origin gh-pages)
 
           if [[ -z ${existed_in_remote} ]]; then
@@ -52,6 +51,7 @@ jobs:
           echo '<html><head><meta http-equiv="refresh" content="0; url=stable/" /></head></html>' > index.html
           mkdir -p ${{ env.RELEASE_VERSION }}
           cp -r /tmp/docs_build/* ./${{ env.RELEASE_VERSION }}
+          ln -sf ${{ env.RELEASE_VERSION }} stable
           rm -rf /tmp/docs_build
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"


### PR DESCRIPTION
Revised workflow for the Build docs.

* 'docs.yml' will be triggered when merged PR to 'develop' branch and the user can access through following URL.
https://openvinotoolkit.github.io/training_extensions/latest
* 'docs_stable.yml' will be triggered when the new release is published and user can access through following URL.
https://openvinotoolkit.github.io/training_extensions/stable
* 'doc_test.yml' can be used for the testing. As a default this workflow will be triggered when pushed a PR to "releases/**" branches and can access the docs with the branch name suffix to the page URL for this repo.

As a default, https://openvinotoolkit.github.io/training_extensions/index.html contains code to redirect to stable and the document for the specific release could be accessed like below as well.
https://openvinotoolkit.github.io/training_extensions/v1.0.0