### PR TITLE
[FIX] tiling unit-test

### DIFF
--- a/tests/unit/algorithms/detection/tiling/test_tiling_detection_unittest.py
+++ b/tests/unit/algorithms/detection/tiling/test_tiling_detection_unittest.py
@@ -132,7 +132,7 @@ class TestTilingDetection(unittest.TestCase):
         """Test that the testing dataloader is built correctly for tiling"""
 
         dataset = build_dataset(self.test_data_cfg)
-        stride = (1 - self.tile_cfg["overlap_ratio"]) * self.tile_cfg["tile_size"]
+        stride = int((1 - self.tile_cfg["overlap_ratio"]) * self.tile_cfg["tile_size"])
         num_tile_rows = ((self.height - self.tile_cfg["tile_size"]) // stride) + 1
         num_tile_cols = ((self.width - self.tile_cfg["tile_size"]) // stride) + 1
         # +1 for the original image


### PR DESCRIPTION
# Summary
* This unit test could seldomly occur an error since the effect of rounding of floating point.
* In the [Tiling implementation](https://github.com/openvinotoolkit/training_extensions/blob/releases/v1.0.0/otx/algorithms/detection/adapters/mmdet/data/tiling.py#L85), the type of stride is `int`, however, in the unit test, it is different. it is set to `float`. 
* One counter-example: `tile_size=171`, `170 < (1-overlap_ratio) * tile_size` , `0.0 <= overlap_ratio <= 0.5`. Then we could reproduce the error
![image](https://user-images.githubusercontent.com/80735344/220817813-b545509e-b523-4b20-af79-b75caa1e6736.png)

* After converting the type, we could resolve the error case
![image](https://user-images.githubusercontent.com/80735344/220817852-8224f0bb-93a8-4cbe-b65a-352c725599a8.png)
