### PR TITLE
[FIX][Release1.0] Fix action task sample codes and unit tests

### DIFF
--- a/otx/algorithms/action/tools/sample_classification.py
+++ b/otx/algorithms/action/tools/sample_classification.py
@@ -49,9 +49,12 @@ VAL_DATA_ROOTS = "tests/assets/cvat_dataset/action_classification/train"
 
 def load_test_dataset(model_template):
     """Load Sample dataset for detection."""
+
+    algo_backend = model_template.hyper_parameters.parameter_overrides["algo_backend"]
+    train_type = algo_backend["train_type"]["default_value"]
     dataset_adapter = get_dataset_adapter(
         model_template.task_type,
-        model_template.train_type,
+        train_type,
         train_data_roots=TRAIN_DATA_ROOTS,
         val_data_roots=VAL_DATA_ROOTS,
     )

--- a/otx/algorithms/action/tools/sample_detection.py
+++ b/otx/algorithms/action/tools/sample_detection.py
@@ -46,9 +46,11 @@ VAL_DATA_ROOTS = "tests/assets/cvat_dataset/action_detection/train"
 
 def load_test_dataset(model_template):
     """Load Sample dataset for detection."""
+    algo_backend = model_template.hyper_parameters.parameter_overrides["algo_backend"]
+    train_type = algo_backend["train_type"]["default_value"]
     dataset_adapter = get_dataset_adapter(
         model_template.task_type,
-        model_template.train_type,
+        train_type,
         train_data_roots=TRAIN_DATA_ROOTS,
         val_data_roots=VAL_DATA_ROOTS,
     )

--- a/tests/unit/algorithms/action/tools/test_action_sample_classification.py
+++ b/tests/unit/algorithms/action/tools/test_action_sample_classification.py
@@ -49,7 +49,9 @@ def test_load_test_dataset() -> None:
 
     class MockTemplate:
         task_type = TaskType.ACTION_CLASSIFICATION
-        train_type = TrainType.INCREMENTAL.value
+        hyper_parameters = Config(
+            {"parameter_overrides": {"algo_backend": {"train_type": {"default_value": TrainType.INCREMENTAL.value}}}}
+        )
 
     dataset, label_schema = load_test_dataset(MockTemplate())
     isinstance(dataset, DatasetEntity)

--- a/tests/unit/algorithms/action/tools/test_action_sample_detection.py
+++ b/tests/unit/algorithms/action/tools/test_action_sample_detection.py
@@ -50,7 +50,9 @@ def test_load_test_dataset() -> None:
 
     class MockTemplate:
         task_type = TaskType.ACTION_DETECTION
-        train_type = TrainType.INCREMENTAL.value
+        hyper_parameters = Config(
+            {"parameter_overrides": {"algo_backend": {"train_type": {"default_value": TrainType.INCREMENTAL.value}}}}
+        )
 
     dataset, label_schema = load_test_dataset(MockTemplate())
     isinstance(dataset, DatasetEntity)


### PR DESCRIPTION
This PR includes hot fix for runtime errors in action tasks sample codes
**Main Cause**
Changed dataset adapter requires train_type(INCREMENTAL, SEMSUPERVISED, etc). However according changes in action sample code are invalid.

**Solution**
Add new codes for valid train_type searching in model template class.

**Changes**
1. Change sample codes to search train_type properly.
2. Change unit test codes to reflect otx side changes.