### PR TITLE
[ENHANCE] Update backbone lists

### DIFF
--- a/otx/cli/builder/supported_backbone/mmcls.json
+++ b/otx/cli/builder/supported_backbone/mmcls.json
@@ -1,5 +1,154 @@
 {
   "backbones": {
+    "mmcls.AlexNet": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.Conformer": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["tiny", "small", "base"]
+      },
+      "available": []
+    },
+    "mmcls.ConvMixer": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["768/32", "1024/20", "1536/20"]
+      },
+      "available": []
+    },
+    "mmcls.ConvNeXt": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["tiny", "small", "base", "large", "xlarge"]
+      },
+      "available": []
+    },
+    "mmcls.CSPDarkNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [53]
+      },
+      "available": []
+    },
+    "mmcls.CSPResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50]
+      },
+      "available": []
+    },
+    "mmcls.CSPResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50]
+      },
+      "available": []
+    },
+    "mmcls.DistilledVisionTransformer": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.DenseNet": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["121", "169", "201", "161"]
+      },
+      "available": []
+    },
+    "mmcls.EfficientFormer": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["l1", "l3", "l7"]
+      },
+      "available": []
+    },
+    "mmcls.EfficientNet": {
+      "required": ["arch"],
+      "options": {
+        "arch": [
+          "b0",
+          "b1",
+          "b2",
+          "b3",
+          "b4",
+          "b5",
+          "b6",
+          "b7",
+          "b8",
+          "es",
+          "em",
+          "el"
+        ]
+      },
+      "available": []
+    },
+    "mmcls.HorNet": {
+      "required": ["arch"],
+      "options": {
+        "arch": [
+          "tiny",
+          "tiny-gf",
+          "small",
+          "small-gf",
+          "base",
+          "base-gf",
+          "base-gf384",
+          "large",
+          "large-gf",
+          "large-gf384"
+        ]
+      },
+      "available": []
+    },
+    "mmcls.HRNet": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["w32", "w18", "w30", "w40", "w44", "w48", "w64"]
+      },
+      "available": []
+    },
+    "mmcls.LeNet5": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.MlpMixer": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["base", "small", "large"]
+      },
+      "available": []
+    },
+    "mmcls.MobileNetV2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.MobileNetV3": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["small", "large"]
+      },
+      "available": []
+    },
+    "mmcls.MViT": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["base", "tiny", "small", "large"]
+      },
+      "available": []
+    },
+    "mmcls.PoolFormer": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["s12", "s24", "s36", "m36", "m48"]
+      },
+      "available": []
+    },
     "mmcls.RegNet": {
       "required": ["arch"],
       "options": {
@@ -16,70 +165,97 @@
       },
       "available": []
     },
-    "mmcls.ResNet": {
-      "required": ["depth"],
+    "mmcls.RepMLPNet": {
+      "required": ["arch"],
       "options": {
-        "depth": [18, 34, 50, 101, 152]
+        "arch": ["base"]
       },
       "available": []
     },
-    "mmcls.ResNetV1d": {
-      "required": ["depth"],
+    "mmcls.RepVGG": {
+      "required": ["arch"],
       "options": {
-        "depth": [18, 34, 50, 101, 152]
+        "arch": [
+          "A0",
+          "A1",
+          "A2",
+          "B0",
+          "B1",
+          "B1g2",
+          "B1g4",
+          "B2",
+          "B2g2",
+          "B2g4",
+          "B3",
+          "B3g2",
+          "B3g4",
+          "D2se",
+          "yolox-pai-small"
+        ]
       },
       "available": []
     },
-    "mmcls.ResNeXt": {
+    "mmcls.Res2Net": {
       "required": ["depth"],
       "options": {
-        "depth": [50, 101, 152]
+        "arch": [50, 101, 152]
       },
       "available": []
     },
     "mmcls.ResNeSt": {
       "required": ["depth"],
       "options": {
-        "depth": [50, 101, 152, 200, 269]
+        "arch": [50, 101, 152, 200, 269]
+      },
+      "available": []
+    },
+    "mmcls.ResNet": {
+      "required": ["depth"],
+      "options": {
+        "arch": [18, 34, 50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.ResNetV1c": {
+      "required": ["depth"],
+      "options": {
+        "arch": [18, 34, 50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.ResNetV1d": {
+      "required": ["depth"],
+      "options": {
+        "arch": [18, 34, 50, 101, 152]
       },
       "available": []
     },
     "mmcls.ResNet_CIFAR": {
       "required": ["depth"],
       "options": {
-        "depth": [18, 34, 50, 101, 152]
+        "arch": [18, 34, 50, 101, 152]
+      },
+      "available": []
+    },
+    "mmcls.ResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "arch": [50, 101, 152]
       },
       "available": []
     },
     "mmcls.SEResNet": {
       "required": ["depth"],
       "options": {
-        "depth": [50, 101, 152]
+        "arch": [50, 101, 152]
       },
       "available": []
     },
     "mmcls.SEResNeXt": {
       "required": ["depth"],
       "options": {
-        "depth": [50, 101, 152]
+        "arch": [50, 101, 152]
       },
-      "available": []
-    },
-    "mmcls.VGG": {
-      "required": ["depth"],
-      "options": {
-        "depth": [11, 13, 16, 19]
-      },
-      "available": []
-    },
-    "mmcls.LeNet5": {
-      "required": [],
-      "options": {},
-      "available": []
-    },
-    "mmcls.AlexNet": {
-      "required": [],
-      "options": {},
       "available": []
     },
     "mmcls.ShuffleNetV1": {
@@ -92,29 +268,77 @@
       "options": {},
       "available": []
     },
-    "mmcls.MobileNetV2": {
-      "required": [],
-      "options": {},
-      "available": []
-    },
-    "mmcls.MobileNetV3": {
-      "required": [],
-      "options": {},
-      "available": []
-    },
-    "mmcls.VisionTransformer": {
-      "required": [],
-      "options": {},
-      "available": []
-    },
     "mmcls.SwinTransformer": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["tiny", "small", "base", "large"]
+      },
+      "available": []
+    },
+    "mmcls.SwinTransformerV2": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["tiny", "small", "base", "large", "huge", "giant"]
+      },
+      "available": []
+    },
+    "mmcls.T2T_ViT": {
       "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmcls.TIMMBackbone": {
+      "required": ["model_name"],
       "options": {},
       "available": []
     },
     "mmcls.TNT": {
-      "required": [],
-      "options": {},
+      "required": ["arch"],
+      "options": {
+        "arch": ["base", "small"]
+      },
+      "available": []
+    },
+    "mmcls.PCPVT": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["base", "small", "large"]
+      },
+      "available": []
+    },
+    "mmcls.SVT": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["base", "small", "large"]
+      },
+      "available": []
+    },
+    "mmcls.VAN": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["b0", "b1", "b2", "b3", "b4", "b5", "b6"]
+      },
+      "available": []
+    },
+    "mmcls.VGG": {
+      "required": ["depth"],
+      "options": {
+        "arch": [11, 13, 16, 19]
+      },
+      "available": []
+    },
+    "mmcls.VisionTransformer": {
+      "required": ["arch"],
+      "options": {
+        "arch": [
+          "base",
+          "small",
+          "large",
+          "deit-tiny",
+          "deit-small",
+          "deit-base"
+        ]
+      },
       "available": []
     }
   }

--- a/otx/cli/builder/supported_backbone/mmcls.json
+++ b/otx/cli/builder/supported_backbone/mmcls.json
@@ -1,9 +1,10 @@
 {
+  "version": "0.25.0",
   "backbones": {
     "mmcls.AlexNet": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.Conformer": {
       "required": ["arch"],
@@ -17,7 +18,7 @@
       "options": {
         "arch": ["768/32", "1024/20", "1536/20"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ConvNeXt": {
       "required": ["arch"],
@@ -31,21 +32,21 @@
       "options": {
         "depth": [53]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.CSPResNet": {
       "required": ["depth"],
       "options": {
         "depth": [50]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.CSPResNeXt": {
       "required": ["depth"],
       "options": {
         "depth": [50]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.DistilledVisionTransformer": {
       "required": [],
@@ -57,7 +58,7 @@
       "options": {
         "arch": ["121", "169", "201", "161"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.EfficientFormer": {
       "required": ["arch"],
@@ -84,7 +85,7 @@
           "el"
         ]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.HorNet": {
       "required": ["arch"],
@@ -109,7 +110,7 @@
       "options": {
         "arch": ["w32", "w18", "w30", "w40", "w44", "w48", "w64"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.LeNet5": {
       "required": [],
@@ -126,28 +127,28 @@
     "mmcls.MobileNetV2": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.MobileNetV3": {
       "required": ["arch"],
       "options": {
         "arch": ["small", "large"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.MViT": {
       "required": ["arch"],
       "options": {
         "arch": ["base", "tiny", "small", "large"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.PoolFormer": {
       "required": ["arch"],
       "options": {
         "arch": ["s12", "s24", "s36", "m36", "m48"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.RegNet": {
       "required": ["arch"],
@@ -163,14 +164,14 @@
           "regnetx_12gf"
         ]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.RepMLPNet": {
       "required": ["arch"],
       "options": {
         "arch": ["base"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.RepVGG": {
       "required": ["arch"],
@@ -193,94 +194,95 @@
           "yolox-pai-small"
         ]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.Res2Net": {
       "required": ["depth"],
       "options": {
         "arch": [50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNeSt": {
       "required": ["depth"],
       "options": {
         "arch": [50, 101, 152, 200, 269]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNet": {
       "required": ["depth"],
       "options": {
         "arch": [18, 34, 50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNetV1c": {
       "required": ["depth"],
       "options": {
         "arch": [18, 34, 50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNetV1d": {
       "required": ["depth"],
       "options": {
         "arch": [18, 34, 50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNet_CIFAR": {
       "required": ["depth"],
       "options": {
         "arch": [18, 34, 50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNeXt": {
       "required": ["depth"],
       "options": {
         "arch": [50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.SEResNet": {
       "required": ["depth"],
       "options": {
         "arch": [50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.SEResNeXt": {
       "required": ["depth"],
       "options": {
         "arch": [50, 101, 152]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ShuffleNetV1": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ShuffleNetV2": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.SwinTransformer": {
       "required": ["arch"],
       "options": {
         "arch": ["tiny", "small", "base", "large"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.SwinTransformerV2": {
-      "required": ["arch"],
+      "required": ["arch", "pad_small_map"],
       "options": {
-        "arch": ["tiny", "small", "base", "large", "huge", "giant"]
+        "arch": ["tiny", "small", "base", "large", "huge", "giant"],
+        "pad_small_map": [true, false]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.T2T_ViT": {
       "required": [],
@@ -304,28 +306,28 @@
       "options": {
         "arch": ["base", "small", "large"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.SVT": {
       "required": ["arch"],
       "options": {
         "arch": ["base", "small", "large"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.VAN": {
       "required": ["arch"],
       "options": {
         "arch": ["b0", "b1", "b2", "b3", "b4", "b5", "b6"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.VGG": {
       "required": ["depth"],
       "options": {
         "arch": [11, 13, 16, 19]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.VisionTransformer": {
       "required": ["arch"],

--- a/otx/cli/builder/supported_backbone/mmdet.json
+++ b/otx/cli/builder/supported_backbone/mmdet.json
@@ -1,5 +1,88 @@
 {
   "backbones": {
+    "mmdet.CSPDarknet": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["P5", "P6"]
+      },
+      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmdet.Darknet": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmdet.DetectoRS_ResNet": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": [
+        "Classification",
+        "ATSS",
+        "YOLOX",
+        "Segmentation",
+        "Mask-RCNN"
+      ]
+    },
+    "mmdet.DetectoRS_ResNeXt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": [
+        "Classification",
+        "ATSS",
+        "YOLOX",
+        "Segmentation",
+        "Mask-RCNN"
+      ]
+    },
+    "mmdet.EfficientNet": {
+      "required": ["arch"],
+      "options": {
+        "depth": [
+          "b0",
+          "b1",
+          "b2",
+          "b3",
+          "b4",
+          "b5",
+          "b6",
+          "b7",
+          "b8",
+          "es",
+          "em",
+          "el"
+        ]
+      },
+      "available": []
+    },
+    "mmdet.HourglassNet": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmdet.HRNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmdet.MobileNetV2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmdet.PyramidVisionTransformer": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmdet.PyramidVisionTransformerV2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
     "mmdet.RegNet": {
       "required": ["arch"],
       "options": {
@@ -13,6 +96,32 @@
           "regnetx_8.0gf",
           "regnetx_12gf"
         ]
+      },
+      "available": [
+        "Classification",
+        "ATSS",
+        "YOLOX",
+        "Segmentation",
+        "Mask-RCNN"
+      ]
+    },
+    "mmdet.Res2Net": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152]
+      },
+      "available": [
+        "Classification",
+        "ATSS",
+        "YOLOX",
+        "Segmentation",
+        "Mask-RCNN"
+      ]
+    },
+    "mmdet.ResNeSt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152, 200]
       },
       "available": [
         "Classification",
@@ -69,72 +178,22 @@
       },
       "available": ["Classification", "ATSS", "Segmentation"]
     },
-    "mmdet.HRNet": {
-      "required": ["extra"],
+    "mmdet.SwinTransformer": {
+      "required": [],
       "options": {},
       "available": []
     },
-    "mmdet.Res2Net": {
-      "required": ["depth"],
+    "mmdet.TridentResNet": {
+      "required": [
+        "depth",
+        "num_branch",
+        "test_branch_idx",
+        "trident_dilations"
+      ],
       "options": {
-        "depth": [50, 101, 152]
+        "depth": [18, 34, 50, 101, 152]
       },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
-    },
-    "mmdet.DetectoRS_ResNet": {
-      "required": ["depth"],
-      "options": {
-        "depth": [50, 101, 152]
-      },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
-    },
-    "mmdet.DetectoRS_ResNeXt": {
-      "required": ["depth"],
-      "options": {
-        "depth": [50, 101, 152]
-      },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
-    },
-    "mmdet.Darknet": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
-    },
-    "mmdet.ResNeSt": {
-      "required": ["depth"],
-      "options": {
-        "depth": [50, 101, 152, 200]
-      },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
-    },
-    "mmdet.CSPDarknet": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+      "available": []
     }
   }
 }

--- a/otx/cli/builder/supported_backbone/mmdet.json
+++ b/otx/cli/builder/supported_backbone/mmdet.json
@@ -5,12 +5,22 @@
       "options": {
         "arch": ["P5", "P6"]
       },
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmdet.Darknet": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmdet.DetectoRS_ResNet": {
       "required": ["depth"],
@@ -18,11 +28,10 @@
         "depth": [50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.DetectoRS_ResNeXt": {
@@ -31,11 +40,10 @@
         "depth": [50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.EfficientNet": {
@@ -56,32 +64,47 @@
           "el"
         ]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmdet.HourglassNet": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmdet.HRNet": {
       "required": ["extra"],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmdet.MobileNetV2": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmdet.PyramidVisionTransformer": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmdet.PyramidVisionTransformerV2": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmdet.RegNet": {
       "required": ["arch"],
@@ -98,11 +121,10 @@
         ]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.Res2Net": {
@@ -111,11 +133,10 @@
         "depth": [50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.ResNeSt": {
@@ -124,11 +145,10 @@
         "depth": [50, 101, 152, 200]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.ResNet": {
@@ -137,11 +157,10 @@
         "depth": [18, 34, 50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.ResNetV1d": {
@@ -150,11 +169,10 @@
         "depth": [18, 34, 50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.ResNeXt": {
@@ -163,11 +181,10 @@
         "depth": [50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmdet.SSDVGG": {
@@ -176,12 +193,17 @@
         "input_size": [300, 512],
         "depth": [11, 16, 19]
       },
-      "available": ["Classification", "ATSS", "Segmentation"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmdet.SwinTransformer": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmdet.TridentResNet": {
       "required": [
@@ -193,7 +215,12 @@
       "options": {
         "depth": [18, 34, 50, 101, 152]
       },
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     }
   }
 }

--- a/otx/cli/builder/supported_backbone/mmdet.json
+++ b/otx/cli/builder/supported_backbone/mmdet.json
@@ -1,4 +1,5 @@
 {
+  "version": "2.28.1",
   "backbones": {
     "mmdet.CSPDarknet": {
       "required": ["arch"],

--- a/otx/cli/builder/supported_backbone/mmseg.json
+++ b/otx/cli/builder/supported_backbone/mmseg.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.30.0",
   "backbones": {
     "mmseg.BEiT": {
       "required": [],

--- a/otx/cli/builder/supported_backbone/mmseg.json
+++ b/otx/cli/builder/supported_backbone/mmseg.json
@@ -3,62 +3,81 @@
     "mmseg.BEiT": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmseg.BiSeNetV1": {
       "required": ["backbone_cfg"],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.BiSeNetV2": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.CGNet": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.ERFNet": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmseg.FastSCNN": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.HRNet": {
       "required": ["extra"],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.ICNet": {
       "required": ["backbone_cfg"],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.MAE": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmseg.MixVisionTransformer": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.MobileNetV2": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmseg.MobileNetV3": {
@@ -66,53 +85,45 @@
       "options": {
         "arch": ["small", "large"]
       },
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.ResNeSt": {
       "required": ["depth"],
       "options": {
         "depth": [50, 101, 152, 200]
       },
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.ResNet": {
       "required": ["depth"],
       "options": {
         "depth": [18, 34, 50, 101, 152]
       },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
+      "available": ["CLASSIFICATION", "INSTANCE_SEGMENTATION", "SEGMENTATION"]
     },
     "mmseg.ResNetV1c": {
       "required": ["depth"],
       "options": {
         "depth": [18, 34, 50, 101, 152]
       },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
+      "available": ["CLASSIFICATION", "INSTANCE_SEGMENTATION", "SEGMENTATION"]
     },
     "mmseg.ResNetV1d": {
       "required": ["depth"],
       "options": {
         "depth": [18, 34, 50, 101, 152]
       },
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
+      "available": ["CLASSIFICATION", "INSTANCE_SEGMENTATION", "SEGMENTATION"]
     },
     "mmseg.ResNeXt": {
       "required": ["depth"],
@@ -120,17 +131,21 @@
         "depth": [50, 101, 152]
       },
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "mmseg.STDCContextPathNet": {
       "required": ["backbone_cfg"],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.STDCNet": {
       "required": [
@@ -145,12 +160,17 @@
         "stdc_type": ["STDCNet1", "STDCNet2"],
         "bottleneck_type": ["add", "cat"]
       },
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "mmseg.SwinTransformer": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.TIMMBackbone": {
       "required": ["model_name"],
@@ -160,22 +180,22 @@
     "mmseg.PCPVT": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.SVT": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.UNet": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": ["CLASSIFICATION", "DETECTION", "SEGMENTATION"]
     },
     "mmseg.VisionTransformer": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": ["CLASSIFICATION"]
     }
   }
 }

--- a/otx/cli/builder/supported_backbone/mmseg.json
+++ b/otx/cli/builder/supported_backbone/mmseg.json
@@ -1,5 +1,80 @@
 {
   "backbones": {
+    "mmseg.BEiT": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmseg.BiSeNetV1": {
+      "required": ["backbone_cfg"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.BiSeNetV2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmseg.CGNet": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmseg.ERFNet": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmseg.FastSCNN": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Mask-RCNN"]
+    },
+    "mmseg.HRNet": {
+      "required": ["extra"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.ICNet": {
+      "required": ["backbone_cfg"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.MAE": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmseg.MixVisionTransformer": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "mmseg.MobileNetV2": {
+      "required": [],
+      "options": {},
+      "available": [
+        "Classification",
+        "ATSS",
+        "YOLOX",
+        "Segmentation",
+        "Mask-RCNN"
+      ]
+    },
+    "mmseg.MobileNetV3": {
+      "required": ["arch"],
+      "options": {
+        "arch": ["small", "large"]
+      },
+      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+    },
+    "mmseg.ResNeSt": {
+      "required": ["depth"],
+      "options": {
+        "depth": [50, 101, 152, 200]
+      },
+      "available": ["Classification", "ATSS", "Mask-RCNN"]
+    },
     "mmseg.ResNet": {
       "required": ["depth"],
       "options": {
@@ -52,93 +127,55 @@
         "Mask-RCNN"
       ]
     },
-    "mmseg.FastSCNN": {
-      "required": [],
+    "mmseg.STDCContextPathNet": {
+      "required": ["backbone_cfg"],
       "options": {},
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": []
     },
-    "mmseg.ResNest": {
-      "required": ["depth"],
+    "mmseg.STDCNet": {
+      "required": [
+        "stdc_type",
+        "in_channels",
+        "channels",
+        "bottleneck_type",
+        "norm_cfg",
+        "act_cfg"
+      ],
       "options": {
-        "depth": [50, 101, 152, 200]
+        "stdc_type": ["STDCNet1", "STDCNet2"],
+        "bottleneck_type": ["add", "cat"]
       },
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": []
     },
-    "mmseg.MobileNetV2": {
+    "mmseg.SwinTransformer": {
       "required": [],
       "options": {},
-      "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
-      ]
+      "available": []
     },
-    "mmseg.CGNet": {
+    "mmseg.TIMMBackbone": {
+      "required": ["model_name"],
+      "options": {},
+      "available": []
+    },
+    "mmseg.PCPVT": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
+      "available": []
     },
-    "mmseg.MobileNetV3": {
+    "mmseg.SVT": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "YOLOX", "Mask-RCNN"]
-    },
-    "mmseg.VisionTransformer": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "Mask-RCNN"]
+      "available": []
     },
     "mmseg.UNet": {
       "required": [],
       "options": {},
       "available": ["Classification", "ATSS", "Mask-RCNN"]
     },
-    "mmseg.HRNet": {
-      "required": ["extra"],
+    "mmseg.VisionTransformer": {
+      "required": [],
       "options": {},
-      "available": []
-    },
-    "mmseg.LiteHRNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.DABNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.DDRNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.BiSeNetV2": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.ShelfNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.EfficientNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.CABiNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
-    },
-    "mmseg.STDCNet": {
-      "required": ["extra"],
-      "options": {},
-      "available": []
+      "available": ["Classification", "ATSS", "Mask-RCNN"]
     }
   }
 }

--- a/otx/cli/builder/supported_backbone/omz.mmcls.json
+++ b/otx/cli/builder/supported_backbone/omz.mmcls.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.0",
   "backbones": {
     "mmcls.MMOVBackbone": {
       "required": ["model_path_or_model"],

--- a/otx/cli/builder/supported_backbone/otx.json
+++ b/otx/cli/builder/supported_backbone/otx.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.0",
   "backbones": {
     "otx.OTXEfficientNet": {
       "required": ["version"],

--- a/otx/cli/builder/supported_backbone/torchvision.json
+++ b/otx/cli/builder/supported_backbone/torchvision.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.14.1",
   "backbones": {
     "torchvision.alexnet": {
       "required": [],

--- a/otx/cli/builder/supported_backbone/torchvision.json
+++ b/otx/cli/builder/supported_backbone/torchvision.json
@@ -3,97 +3,187 @@
     "torchvision.alexnet": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": ["CLASSIFICATION", "INSTANCE_SEGMENTATION", "SEGMENTATION"]
     },
     "torchvision.convnext_tiny": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.convnext_small": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.convnext_large": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.densenet121": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.densenet161": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.densenet169": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.densenet201": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b0": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b1": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b2": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b3": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b4": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b5": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b6": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_b7": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_v2_s": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_v2_m": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.efficientnet_v2_l": {
       "required": [],
       "options": {},
-      "available": []
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.googlenet": {
       "required": [],
@@ -108,37 +198,72 @@
     "torchvision.mnasnet0_5": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.mnasnet0_75": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.mnasnet1_0": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.mnasnet1_3": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.mobilenet_v2": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.mobilenet_v3_large": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.mobilenet_v3_small": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.regnet_y_400mf": {
       "required": [],
@@ -219,181 +344,241 @@
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnet34": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnet50": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnet101": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnet152": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnext50_32x4d": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnext101_32x8d": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.resnext101_64x4d": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.wide_resnet50_2": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.wide_resnet101_2": {
       "required": [],
       "options": {},
       "available": [
-        "Classification",
-        "ATSS",
-        "YOLOX",
-        "Segmentation",
-        "Mask-RCNN"
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
       ]
     },
     "torchvision.shufflenet_v2_x0_5": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.shufflenet_v2_x1_0": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.shufflenet_v2_x1_5": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.shufflenet_v2_x2_0": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.squeezenet1_0": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.squeezenet1_1": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg11": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg11_bn": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg13": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg13_bn": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg16": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg16_bn": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg19": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vgg19_bn": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": [
+        "CLASSIFICATION",
+        "DETECTION",
+        "INSTANCE_SEGMENTATION",
+        "SEGMENTATION"
+      ]
     },
     "torchvision.vit_b_16": {
       "required": [],
@@ -423,32 +608,32 @@
     "torchvision.swin_t": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "torchvision.swin_s": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "torchvision.swin_b": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "torchvision.swin_v2_t": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "torchvision.swin_v2_s": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "torchvision.swin_v2_b": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "torchvision.maxvit_t": {
       "required": [],

--- a/otx/cli/builder/supported_backbone/torchvision.json
+++ b/otx/cli/builder/supported_backbone/torchvision.json
@@ -5,6 +5,216 @@
       "options": {},
       "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
     },
+    "torchvision.convnext_tiny": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.convnext_small": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.convnext_large": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.densenet121": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet161": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet169": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.densenet201": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.efficientnet_b0": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b1": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b2": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b3": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b4": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b5": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b6": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_b7": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_v2_s": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_v2_m": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.efficientnet_v2_l": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.googlenet": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.inception_v3": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.mnasnet0_5": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet0_75": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet1_0": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mnasnet1_3": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mobilenet_v2": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mobilenet_v3_large": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.mobilenet_v3_small": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.regnet_y_400mf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_800mf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_1_6gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_3_2gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_8gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_16gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_32gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_y_128gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_400mf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_800mf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_1_6gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_3_2gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_8gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_16gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
+    "torchvision.regnet_x_32gf": {
+      "required": [],
+      "options": {},
+      "available": []
+    },
     "torchvision.resnet18": {
       "required": [],
       "options": {},
@@ -82,6 +292,17 @@
         "Mask-RCNN"
       ]
     },
+    "torchvision.resnext101_64x4d": {
+      "required": [],
+      "options": {},
+      "available": [
+        "Classification",
+        "ATSS",
+        "YOLOX",
+        "Segmentation",
+        "Mask-RCNN"
+      ]
+    },
     "torchvision.wide_resnet50_2": {
       "required": [],
       "options": {},
@@ -103,6 +324,36 @@
         "Segmentation",
         "Mask-RCNN"
       ]
+    },
+    "torchvision.shufflenet_v2_x0_5": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x1_0": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x1_5": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.shufflenet_v2_x2_0": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.squeezenet1_0": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+    },
+    "torchvision.squeezenet1_1": {
+      "required": [],
+      "options": {},
+      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
     },
     "torchvision.vgg11": {
       "required": [],
@@ -144,90 +395,65 @@
       "options": {},
       "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
     },
-    "torchvision.squeezenet1_0": {
+    "torchvision.vit_b_16": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.squeezenet1_1": {
+    "torchvision.vit_b_32": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.densenet121": {
+    "torchvision.vit_l_16": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.densenet161": {
+    "torchvision.vit_l_32": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.densenet169": {
+    "torchvision.vit_h_14": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.densenet201": {
+    "torchvision.swin_t": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.mobilenet_v2": {
+    "torchvision.swin_s": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.mobilenet_v3_large": {
+    "torchvision.swin_b": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.mobilenet_v3_small": {
+    "torchvision.swin_v2_t": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.mnasnet0_5": {
+    "torchvision.swin_v2_s": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.mnasnet0_75": {
+    "torchvision.swin_v2_b": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     },
-    "torchvision.mnasnet1_0": {
+    "torchvision.maxvit_t": {
       "required": [],
       "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
-    },
-    "torchvision.mnasnet1_3": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
-    },
-    "torchvision.shufflenet_v2_x0_5": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
-    },
-    "torchvision.shufflenet_v2_x1_0": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
-    },
-    "torchvision.shufflenet_v2_x1_5": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
-    },
-    "torchvision.shufflenet_v2_x2_0": {
-      "required": [],
-      "options": {},
-      "available": ["Classification", "ATSS", "Segmentation", "Mask-RCNN"]
+      "available": []
     }
   }
 }

--- a/otx/cli/tools/build.py
+++ b/otx/cli/tools/build.py
@@ -111,6 +111,8 @@ def main():
         if not args.backbone.endswith((".yml", ".yaml", ".json")):
             backbone_config_file = str(config_manager.workspace_root / "backbone.yaml")
             missing_args = builder.build_backbone_config(args.backbone, backbone_config_file)
+        else:
+            backbone_config_file = args.backbone
         if missing_args:
             print(
                 f"[!] {args.backbone} backbone has inputs that the user must enter.\n"

--- a/otx/cli/tools/find.py
+++ b/otx/cli/tools/find.py
@@ -122,6 +122,9 @@ def main():
         row_index = 1
         for _, backbone_meta in all_backbones.items():
             for backbone_type, meta_data in backbone_meta.items():
+                available_task = meta_data.get("available", [])
+                if not available_task or (args.task and args.task.upper() not in available_task):
+                    continue
                 rows = generate_backbone_rows(row_index, backbone_type, meta_data)
                 backbone_table.add_rows(rows)
                 row_index += 1


### PR DESCRIPTION
## Summary
Updated the list of replaceable backbones for the latest OTX.

Updated Lib: version (number of backbone)
mmcls: 0.25.0 (18 -> 32)
mmdet: 2.28.1 (12 -> 19)
mmseg: 0.30.0 (20 -> 24)
torchvision: 0.14.1+cu116 (35 -> 56)

'+ Filtering in otx find

```
(otx) otx find --backbone mmdet
+-------+----------------------------------+-------------------+-------------------------------+
| Index |          Backbone Type           |   Required-Args   |            Options            |
+-------+----------------------------------+-------------------+-------------------------------+
|   1   |         mmdet.CSPDarknet         |        arch       |             P5, P6            |
|   2   |          mmdet.Darknet           |                   |                               |
|   3   |      mmdet.DetectoRS_ResNet      |       depth       |          50, 101, 152         |
|   4   |     mmdet.DetectoRS_ResNeXt      |       depth       |          50, 101, 152         |
|   5   |        mmdet.EfficientNet        |        arch       |                               |
|   6   |        mmdet.HourglassNet        |                   |                               |
|   7   |           mmdet.HRNet            |       extra       |                               |
|   8   |        mmdet.MobileNetV2         |                   |                               |
|   9   |  mmdet.PyramidVisionTransformer  |                   |                               |
|   10  | mmdet.PyramidVisionTransformerV2 |                   |                               |
|   11  |           mmdet.RegNet           |        arch       | regnetx_400mf, regnetx_800mf, |
|       |                                  |                   | regnetx_1.6gf, regnetx_3.2gf, |
|       |                                  |                   | regnetx_4.0gf, regnetx_6.4gf, |
|       |                                  |                   |  regnetx_8.0gf, regnetx_12gf  |
|   12  |          mmdet.Res2Net           |       depth       |          50, 101, 152         |
|   13  |          mmdet.ResNeSt           |       depth       |       50, 101, 152, 200       |
|   14  |           mmdet.ResNet           |       depth       |      18, 34, 50, 101, 152     |
|   15  |         mmdet.ResNetV1d          |       depth       |      18, 34, 50, 101, 152     |
|   16  |          mmdet.ResNeXt           |       depth       |          50, 101, 152         |
|   17  |           mmdet.SSDVGG           |     input_size    |            300, 512           |
|       |                                  |       depth       |           11, 16, 19          |
|   18  |      mmdet.SwinTransformer       |                   |                               |
|   19  |       mmdet.TridentResNet        |       depth       |      18, 34, 50, 101, 152     |
|       |                                  |     num_branch    |                               |
|       |                                  |  test_branch_idx  |                               |
|       |                                  | trident_dilations |                               |
+-------+----------------------------------+-------------------+-------------------------------+

(otx) otx find --backbone mmdet --task instance_segmentation
+-------+-------------------------+-------------------+-------------------------------+
| Index |      Backbone Type      |   Required-Args   |            Options            |
+-------+-------------------------+-------------------+-------------------------------+
|   1   |     mmdet.CSPDarknet    |        arch       |             P5, P6            |
|   2   |      mmdet.Darknet      |                   |                               |
|   3   |  mmdet.DetectoRS_ResNet |       depth       |          50, 101, 152         |
|   4   | mmdet.DetectoRS_ResNeXt |       depth       |          50, 101, 152         |
|   5   |    mmdet.HourglassNet   |                   |                               |
|   6   |       mmdet.HRNet       |       extra       |                               |
|   7   |    mmdet.MobileNetV2    |                   |                               |
|   8   |       mmdet.RegNet      |        arch       | regnetx_400mf, regnetx_800mf, |
|       |                         |                   | regnetx_1.6gf, regnetx_3.2gf, |
|       |                         |                   | regnetx_4.0gf, regnetx_6.4gf, |
|       |                         |                   |  regnetx_8.0gf, regnetx_12gf  |
|   9   |      mmdet.Res2Net      |       depth       |          50, 101, 152         |
|   10  |      mmdet.ResNeSt      |       depth       |       50, 101, 152, 200       |
|   11  |       mmdet.ResNet      |       depth       |      18, 34, 50, 101, 152     |
|   12  |     mmdet.ResNetV1d     |       depth       |      18, 34, 50, 101, 152     |
|   13  |      mmdet.ResNeXt      |       depth       |          50, 101, 152         |
|   14  |       mmdet.SSDVGG      |     input_size    |            300, 512           |
|       |                         |       depth       |           11, 16, 19          |
|   15  |   mmdet.TridentResNet   |       depth       |      18, 34, 50, 101, 152     |
|       |                         |     num_branch    |                               |
|       |                         |  test_branch_idx  |                               |
|       |                         | trident_dilations |                               |
+-------+-------------------------+-------------------+-------------------------------+
```
