### PR TITLE
[HOTFIX][RELEASE1.0] Fixed label_scheme mismatch in classification

### DIFF
--- a/otx/mpa/cls/exporter.py
+++ b/otx/mpa/cls/exporter.py
@@ -41,7 +41,6 @@ class ClsExporter(ExporterMixin, ClsStage):
             return model
 
         kwargs["model_builder"] = model_builder_helper
-
         return super().run(model_cfg, model_ckpt, data_cfg, **kwargs)
 
     @staticmethod

--- a/otx/mpa/cls/incremental/stage.py
+++ b/otx/mpa/cls/incremental/stage.py
@@ -43,7 +43,6 @@ class IncrClsStage(ClsStage):
                 logger.warning('"new_classes" should be defined for incremental learning w/ current model.')
 
             if cfg.model.type in WEIGHT_MIX_CLASSIFIER:
-                cfg.task_adapt.final = self.model_classes
                 cfg.model.task_adapt = ConfigDict(
                     src_classes=self.org_model_classes,
                     dst_classes=self.model_classes,

--- a/otx/mpa/cls/stage.py
+++ b/otx/mpa/cls/stage.py
@@ -143,25 +143,28 @@ class ClsStage(Stage):
         self.configure_classes(cfg)
 
     def configure_classes(self, cfg):
-        model_classes, data_classes = [], []
-        self.model_meta = self.get_model_meta(cfg)
-        train_data_cfg = Stage.get_data_cfg(cfg, "train")
-        if isinstance(train_data_cfg, list):
-            train_data_cfg = train_data_cfg[0]
+        """Patch classes for model and dataset."""
+        self.task_adapt_op = "REPLACE"
+        if "task_adapt" in cfg:
+            self.task_adapt_op = cfg["task_adapt"].get("op", "REPLACE")
 
-        model_classes = Stage.get_model_classes(cfg)
-        data_classes = Stage.get_data_classes(cfg)
+        org_model_classes = self.get_model_classes(cfg)
+        data_classes = self.get_data_classes(cfg)
 
-        if cfg.get("model_classes", []):
-            cfg.model.head.num_classes = len(cfg.model_classes)
-        elif model_classes:
-            cfg.model.head.num_classes = len(model_classes)
-        elif data_classes:
-            cfg.model.head.num_classes = len(data_classes)
-        self.model_meta["CLASSES"] = model_classes
+        # Model classes
+        if self.task_adapt_op == "REPLACE":
+            if len(data_classes) == 0:
+                model_classes = org_model_classes.copy()
+            else:
+                model_classes = data_classes.copy()
+        elif self.task_adapt_op == "MERGE":
+            model_classes = org_model_classes + [cls for cls in data_classes if cls not in org_model_classes]
+        else:
+            raise KeyError(f"{self.task_adapt_op} is not supported for task_adapt options!")
 
-        if not train_data_cfg.get("new_classes", False):  # when train_data_cfg doesn't have 'new_classes' key
-            new_classes = np.setdiff1d(data_classes, model_classes).tolist()
-            train_data_cfg["new_classes"] = new_classes
+        # Model architecture
+        cfg.model.head.num_classes = len(model_classes)
+
+        self.org_model_classes = org_model_classes
         self.model_classes = model_classes
         self.data_classes = data_classes

--- a/otx/mpa/cls/stage.py
+++ b/otx/mpa/cls/stage.py
@@ -167,4 +167,3 @@ class ClsStage(Stage):
 
         self.org_model_classes = org_model_classes
         self.model_classes = model_classes
-        self.data_classes = data_classes

--- a/otx/mpa/cls/trainer.py
+++ b/otx/mpa/cls/trainer.py
@@ -62,14 +62,8 @@ class ClsTrainer(ClsStage):
             cfg.checkpoint_config.meta = dict(mmcls_version=__version__)
             if hasattr(repr_ds, "tasks"):
                 cfg.checkpoint_config.meta["tasks"] = repr_ds.tasks
-            else:
+            if hasattr(repr_ds, "CLASSES"):
                 cfg.checkpoint_config.meta["CLASSES"] = repr_ds.CLASSES
-            if "task_adapt" in cfg:
-                if hasattr(self, "model_tasks"):  # for incremnetal learning
-                    cfg.checkpoint_config.meta.update({"tasks": self.model_tasks})
-                    # instead of update(self.old_tasks), update using "self.model_tasks"
-                else:
-                    cfg.checkpoint_config.meta.update({"CLASSES": self.model_classes})
 
         self.configure_samples_per_gpu(cfg, "train", self.distributed)
         self.configure_fp16_optimizer(cfg, self.distributed)
@@ -83,10 +77,6 @@ class ClsTrainer(ClsStage):
             self._modify_cfg_for_distributed(model, cfg)
 
         self.configure_compat_cfg(cfg)
-
-        # Save config
-        # cfg.dump(osp.join(cfg.work_dir, 'config.py'))
-        # logger.info(f'Config:\n{cfg.pretty_text}')
 
         # register custom eval hooks
         validate = True if cfg.data.get("val", None) else False

--- a/tests/unit/mpa/cls/incremental/test_cls_incremental_stage.py
+++ b/tests/unit/mpa/cls/incremental/test_cls_incremental_stage.py
@@ -15,28 +15,29 @@ class TestOTXIncrClsStage:
 
     @pytest.mark.parametrize("mode", ["MERGE", "REPLACE"])
     @e2e_pytest_unit
-    def test_configure_task_adapt(self, mode):
+    def test_configure_classes(self, mode, mocker):
+
         self.stage.cfg.merge_from_dict(self.data_cfg)
         self.stage.cfg.task_adapt.op = mode
-        model_classes = ["label_0", "label_1", "label_3", "label_n"]
-        self.stage.model_meta = {"CLASSES": model_classes}
-        self.stage.model_classes = model_classes
-        self.stage.data_classes = self.data_cfg.data.train.data_classes
-        self.stage.new_classes = self.data_cfg.data.train.data_classes
-        self.stage.configure_task_adapt(self.stage.cfg, True)
+        origin_model_classes = ["label_0", "label_3", "label_n"]
+        mocker.patch("otx.mpa.cls.incremental.stage.IncrClsStage.get_model_classes", return_value=origin_model_classes)
+        # self.stage.model_meta = {"CLASSES": model_classes}
+        self.stage.data_classes = self.data_cfg.data.train.data_classes  # ["label_0", "label_1"]
+        self.stage.configure_classes(self.stage.cfg)
+        merge_target = ["label_0", "label_1", "label_3", "label_n"]
 
         if mode == "REPLACE":
             assert self.stage.cfg.model.head.num_classes == len(self.stage.data_classes)
         else:
-            assert self.stage.cfg.model.head.num_classes == len(self.stage.data_classes) + len(self.stage.new_classes)
+            assert self.stage.cfg.model.head.num_classes == len(merge_target)
 
     @e2e_pytest_unit
     def test_configure_task_modules(self, monkeypatch, mocker):
         mock_update_hook = mocker.patch("otx.mpa.cls.incremental.stage.update_or_add_custom_hook")
         # some dummy classes
+        self.stage.data_classes = [0, 1]
         self.stage.model_classes = [0, 1]
-        self.stage.dst_classes = [0, 1]
-        self.stage.old_classes = [0, 1]
+        self.stage.org_model_classes = [0, 1]
         self.stage.configure_task_modules(self.stage.cfg)
 
         mock_update_hook.assert_called_once()

--- a/tests/unit/mpa/cls/incremental/test_cls_incremental_stage.py
+++ b/tests/unit/mpa/cls/incremental/test_cls_incremental_stage.py
@@ -21,7 +21,6 @@ class TestOTXIncrClsStage:
         self.stage.cfg.task_adapt.op = mode
         origin_model_classes = ["label_0", "label_3", "label_n"]
         mocker.patch("otx.mpa.cls.incremental.stage.IncrClsStage.get_model_classes", return_value=origin_model_classes)
-        # self.stage.model_meta = {"CLASSES": model_classes}
         self.stage.data_classes = self.data_cfg.data.train.data_classes  # ["label_0", "label_1"]
         self.stage.configure_classes(self.stage.cfg)
         merge_target = ["label_0", "label_1", "label_3", "label_n"]


### PR DESCRIPTION
## Summary
Fix classification label schema mismatch

A problem occurs because the class setting in incremental training and the class setting in the exporter are different. (Occurs when keep using the same Task object, can see it in the sample code.)

However, I'm not familiar with the `mpa/cls` code, so please take a look at @JihwanEom  and @supersoob  even after the merge.