### PR TITLE
[Test] Add --test-work-dir option to pytest argparser

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,9 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def tmp_dir_path() -> Generator[Path, None, None]:
-    with TemporaryDirectory() as tmp_dir:
+def tmp_dir_path(request) -> Generator[Path, None, None]:
+    prefix = request.config.getoption("--test-work-dir")
+    with TemporaryDirectory(prefix=prefix) as tmp_dir:
         yield Path(tmp_dir)
 
 

--- a/tests/test_suite/pytest_insertions.py
+++ b/tests/test_suite/pytest_insertions.py
@@ -82,6 +82,15 @@ def otx_pytest_addoption_insertion(parser):
         help="Obsolete parameter. Should be removed when CI is changed.",
     )
 
+    parser.addoption(
+        "--test-work-dir",
+        type=str,
+        default=None,
+        help="OTX test requires a certain amount of storage in the test work directory. "
+        "If you don't have enough space on the drive where the default path is located (e.g. /tmp on linux), "
+        "you can use this option to change the test work directory path to a different drive.",
+    )
+
 
 def otx_pytest_generate_tests_insertion(metafunc):
     """


### PR DESCRIPTION
OTX test requires a certain amount of storage in the test work directory. If you don't have enough space on the drive where the default path is located (e.g. /tmp on linux), you can use this option to change the test work directory path to a different drive.