### PR TITLE
[Enhance] Run integration test on each task's environment

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -62,14 +62,69 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
           ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -Z true -U $HTTP_PROXY -f .tox/coverage.xml
-  Pre-Merge-Integration-Test:
+  Pre-Merge-Integration-Common-Test:
     runs-on: [self-hosted, linux, x64, dev]
     needs: Pre-Merge-Unit-Test
-    timeout-minutes: 360
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Integration-testing
-        run: tox -e pre-merge -- tests/integration/cli
+        run: tox -e pre-merge -- tests/integration/cli/test_cli.py
+  Pre-Merge-Integration-Cls-Test:
+    runs-on: [self-hosted, linux, x64, dev]
+    needs: Pre-Merge-Unit-Test
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install -r requirements/dev.txt
+      - name: Integration-testing
+        run: tox -e pre-merge-cls
+  Pre-Merge-Integration-Det-Test:
+    runs-on: [self-hosted, linux, x64, dev]
+    needs: Pre-Merge-Unit-Test
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install -r requirements/dev.txt
+      - name: Integration-testing
+        run: tox -e pre-merge-det
+  Pre-Merge-Integration-Seg-Test:
+    runs-on: [self-hosted, linux, x64, dev]
+    needs: Pre-Merge-Unit-Test
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install -r requirements/dev.txt
+      - name: Integration-testing
+        run: tox -e pre-merge-seg
+  Pre-Merge-Integration-Action-Test:
+    runs-on: [self-hosted, linux, x64, dev]
+    needs: Pre-Merge-Unit-Test
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install -r requirements/dev.txt
+      - name: Integration-testing
+        run: tox -e pre-merge-action
+  Pre-Merge-Integration-Anomaly-Test:
+    runs-on: [self-hosted, linux, x64, dev]
+    needs: Pre-Merge-Unit-Test
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python -m pip install -r requirements/dev.txt
+      - name: Integration-testing
+        run: tox -e pre-merge-anomaly

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ psutil
 scipy>=1.8
 bayesian-optimization>=1.2.0
 tensorboard>=2.11.0
+multiprocess

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,95 @@ commands =
     coverage report -m --fail-under=0
     coverage xml -o {toxworkdir}/coverage.xml
 
+[testenv:pre-merge-cls]
+deps =
+    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
+    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    -r{toxinidir}/requirements/api.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/openvino.txt
+    -r{toxinidir}/requirements/classification.txt
+    -r{toxinidir}/requirements/dev.txt
+use_develop = true
+commands =
+    coverage erase
+    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results.xml tests/integration/cli/classification
+    coverage report -m --fail-under=0
+    coverage xml -o {toxworkdir}/coverage.xml
+
+[testenv:pre-merge-det]
+deps =
+    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
+    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    -r{toxinidir}/requirements/api.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/openvino.txt
+    -r{toxinidir}/requirements/detection.txt
+    -r{toxinidir}/requirements/dev.txt
+use_develop = true
+commands =
+    coverage erase
+    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results.xml tests/integration/cli/detection
+    coverage report -m --fail-under=0
+    coverage xml -o {toxworkdir}/coverage.xml
+
+[testenv:pre-merge-seg]
+deps =
+    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
+    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    -r{toxinidir}/requirements/api.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/openvino.txt
+    -r{toxinidir}/requirements/segmentation.txt
+    -r{toxinidir}/requirements/dev.txt
+use_develop = true
+commands =
+    coverage erase
+    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results.xml tests/integration/cli/segmentation
+    coverage report -m --fail-under=0
+    coverage xml -o {toxworkdir}/coverage.xml
+
+[testenv:pre-merge-action]
+deps =
+    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
+    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    -r{toxinidir}/requirements/api.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/openvino.txt
+    -r{toxinidir}/requirements/action.txt
+    -r{toxinidir}/requirements/dev.txt
+use_develop = true
+commands =
+    coverage erase
+    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results.xml tests/integration/cli/action
+    coverage report -m --fail-under=0
+    coverage xml -o {toxworkdir}/coverage.xml
+
+[testenv:pre-merge-anomaly]
+deps =
+    torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
+    torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
+    mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    -r{toxinidir}/requirements/api.txt
+    -r{toxinidir}/requirements/base.txt
+    -r{toxinidir}/requirements/openvino.txt
+    -r{toxinidir}/requirements/anomaly.txt
+    -r{toxinidir}/requirements/dev.txt
+use_develop = true
+commands =
+    coverage erase
+    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results.xml tests/integration/cli/anomaly
+    coverage report -m --fail-under=0
+    coverage xml -o {toxworkdir}/coverage.xml
 
 [testenv:build-doc]
 deps =


### PR DESCRIPTION
### Summary
This PR adds pre-merge tests with `pip install .[each_task]` to tox and applies them to github action for keeping it available to run each task with `pip install .[each_task]`.

### Add multiprocess package in requirement/base.txt
Currently merged [PR](https://github.com/openvinotoolkit/training_extensions/issues/1694) uses `multiprocess`. But action task doesn't install it, so it makes an error for that (other tasks installed it). So I added it as requirement.