### PR TITLE
[FIX][Releasev0.5.1]Remove use_adaptve_interval term checking part

### DIFF
--- a/external/model-preparation-algorithm/mpa_tasks/apis/task.py
+++ b/external/model-preparation-algorithm/mpa_tasks/apis/task.py
@@ -185,14 +185,6 @@ class BaseTask:
                 del self._model_cfg["fp16"]
         self._precision = [ModelPrecision.FP32]
 
-        # Add/remove adaptive interval hook
-        if self._recipe_cfg.get("use_adaptive_interval", False):
-            self._recipe_cfg.adaptive_validation_interval = self._recipe_cfg.get(
-                "adaptive_validation_interval", dict(max_interval=5)
-            )
-        else:
-            self._recipe_cfg.pop("adaptive_validation_interval", None)
-
         # Add/remove early stop hook
         if "early_stop" in self._recipe_cfg:
             remove_custom_hook(self._recipe_cfg, "EarlyStoppingHook")


### PR DESCRIPTION
Current release 0.5.0 do not use adaptive interval hook if there is no use_adaptive_interval in recipe file.
Although we expect our default is using adaptive interval hook, but there is no use_adaptive_interval flag in detection's recipe file
Therefore the default behavior of detection is not using adaptive interval hook, and this causes severe underfitting of detection model. 
To fix this issue without modifying mpa submodule, this PR deletes the checking part of use_adaptive_interval flag.
From this PR, all task will use adaptive interval hook if there is adaptive_validation_interval attributes in recipe files.