### PR TITLE
[FIX] Match keys of `required` and `options`

### DIFF
--- a/otx/cli/builder/supported_backbone/mmcls.json
+++ b/otx/cli/builder/supported_backbone/mmcls.json
@@ -199,63 +199,63 @@
     "mmcls.Res2Net": {
       "required": ["depth"],
       "options": {
-        "arch": [50, 101, 152]
+        "depth": [50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNeSt": {
       "required": ["depth"],
       "options": {
-        "arch": [50, 101, 152, 200, 269]
+        "depth": [50, 101, 152, 200, 269]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNet": {
       "required": ["depth"],
       "options": {
-        "arch": [18, 34, 50, 101, 152]
+        "depth": [18, 34, 50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNetV1c": {
       "required": ["depth"],
       "options": {
-        "arch": [18, 34, 50, 101, 152]
+        "depth": [18, 34, 50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNetV1d": {
       "required": ["depth"],
       "options": {
-        "arch": [18, 34, 50, 101, 152]
+        "depth": [18, 34, 50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNet_CIFAR": {
       "required": ["depth"],
       "options": {
-        "arch": [18, 34, 50, 101, 152]
+        "depth": [18, 34, 50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.ResNeXt": {
       "required": ["depth"],
       "options": {
-        "arch": [50, 101, 152]
+        "depth": [50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.SEResNet": {
       "required": ["depth"],
       "options": {
-        "arch": [50, 101, 152]
+        "depth": [50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
     "mmcls.SEResNeXt": {
       "required": ["depth"],
       "options": {
-        "arch": [50, 101, 152]
+        "depth": [50, 101, 152]
       },
       "available": ["CLASSIFICATION"]
     },
@@ -325,7 +325,7 @@
     "mmcls.VGG": {
       "required": ["depth"],
       "options": {
-        "arch": [11, 13, 16, 19]
+        "depth": [11, 13, 16, 19]
       },
       "available": ["CLASSIFICATION"]
     },

--- a/otx/cli/builder/supported_backbone/mmdet.json
+++ b/otx/cli/builder/supported_backbone/mmdet.json
@@ -50,7 +50,7 @@
     "mmdet.EfficientNet": {
       "required": ["arch"],
       "options": {
-        "depth": [
+        "arch": [
           "b0",
           "b1",
           "b2",


### PR DESCRIPTION
**Please decide target branch**

## Issue
When using `otx find`, some arguments for mmx models are not printed.`
![image](https://user-images.githubusercontent.com/97221135/223374662-15a38f9b-d8de-4ef1-94d9-57ff30405986.png)

When using `otx build`, some arguments for mmx models is required to be entered manually.
![image](https://user-images.githubusercontent.com/97221135/223372430-a67db358-24b7-406c-983b-31d12dc5d45a.png)

Assume I don't know the options about the argument and I entered the argument wrongly, `depth`=19.
Then, there is an **'not supported argument'** error.
```shell
Traceback (most recent call last):
  File "venv/otx/lib/python3.8/site-packages/mmcv/utils/registry.py", line 69, in build_from_cfg
    return obj_cls(**args)
  File "venv/otx/lib/python3.8/site-packages/mmcls/models/backbones/resnet.py", line 491, in __init__
    raise KeyError(f'invalid depth {depth} for resnet')
KeyError: 'invalid depth 19 for resnet'
```

It is required to fully provide options about those arguments for those who don't know options.

## Updates
- Update to match keys of `required` and `options` in supported backbones

## Results
- `otx find` normally prints like below and `model.py` is automatically updated well.
```shell
$ otx find --backbone mmcls

+-------+-------------------------+---------------+------------------------------------------+
| Index |      Backbone Type      | Required-Args |                 Options                  |
+-------+-------------------------+---------------+------------------------------------------+
|   1   |      mmcls.AlexNet      |               |                                          |
|   2   |     mmcls.ConvMixer     |      arch     |         768/32, 1024/20, 1536/20         |
|   3   |     mmcls.CSPDarkNet    |     depth     |                    53                    |
|   4   |     mmcls.CSPResNet     |     depth     |                    50                    |
|   5   |     mmcls.CSPResNeXt    |     depth     |                    50                    |
|   6   |      mmcls.DenseNet     |      arch     |            121, 169, 201, 161            |
|   7   |    mmcls.EfficientNet   |      arch     | b0, b1, b2, b3, b4, b5, b6, b7, b8, es,  |
|       |                         |               |                  em, el                  |
|   8   |       mmcls.HRNet       |      arch     |    w32, w18, w30, w40, w44, w48, w64     |
|   9   |    mmcls.MobileNetV2    |               |                                          |
|   10  |    mmcls.MobileNetV3    |      arch     |               small, large               |
|   11  |        mmcls.MViT       |      arch     |         base, tiny, small, large         |
|   12  |     mmcls.PoolFormer    |      arch     |         s12, s24, s36, m36, m48          |
|   13  |       mmcls.RegNet      |      arch     |      regnetx_400mf, regnetx_800mf,       |
|       |                         |               |      regnetx_1.6gf, regnetx_3.2gf,       |
|       |                         |               |      regnetx_4.0gf, regnetx_6.4gf,       |
|       |                         |               |       regnetx_8.0gf, regnetx_12gf        |
|   14  |     mmcls.RepMLPNet     |      arch     |                   base                   |
|   15  |       mmcls.RepVGG      |      arch     |   A0, A1, A2, B0, B1, B1g2, B1g4, B2,    |
|       |                         |               | B2g2, B2g4, B3, B3g2, B3g4, D2se, yolox- |
|       |                         |               |                pai-small                 |
|   16  |      mmcls.Res2Net      |     depth     |               50, 101, 152               |
|   17  |      mmcls.ResNeSt      |     depth     |          50, 101, 152, 200, 269          |
|   18  |       mmcls.ResNet      |     depth     |           18, 34, 50, 101, 152           |
|   19  |     mmcls.ResNetV1c     |     depth     |           18, 34, 50, 101, 152           |
|   20  |     mmcls.ResNetV1d     |     depth     |           18, 34, 50, 101, 152           |
|   21  |    mmcls.ResNet_CIFAR   |     depth     |           18, 34, 50, 101, 152           |
|   22  |      mmcls.ResNeXt      |     depth     |               50, 101, 152               |
|   23  |      mmcls.SEResNet     |     depth     |               50, 101, 152               |
|   24  |     mmcls.SEResNeXt     |     depth     |               50, 101, 152               |
|   25  |    mmcls.ShuffleNetV1   |               |                                          |
|   26  |    mmcls.ShuffleNetV2   |               |                                          |
|   27  |  mmcls.SwinTransformer  |      arch     |         tiny, small, base, large         |
|   28  | mmcls.SwinTransformerV2 |      arch     |  tiny, small, base, large, huge, giant   |
|       |                         | pad_small_map |               True, False                |
|   29  |       mmcls.PCPVT       |      arch     |            base, small, large            |
|   30  |        mmcls.SVT        |      arch     |            base, small, large            |
|   31  |        mmcls.VAN        |      arch     |        b0, b1, b2, b3, b4, b5, b6        |
|   32  |        mmcls.VGG        |     depth     |              11, 13, 16, 19              |
+-------+-------------------------+---------------+------------------------------------------+
```
```python
$ cat model.py

model = dict(
    type='SAMImageClassifier',
    backbone=dict(
        avg_down=False,
        base_channels=64,
        conv_cfg=None,
        deep_stem=False,
        depth=18,
        dilations=(1, 1, 1, 1),
        drop_path_rate=0.0,
        expansion=None,
        frozen_stages=-1,
        in_channels=3,
        init_cfg=[
            dict(layer=['Conv2d'], type='Kaiming'),
            dict(layer=['_BatchNorm', 'GroupNorm'], type='Constant', val=1)
        ],
        norm_cfg=dict(requires_grad=True, type='BN'),
        norm_eval=False,
        num_stages=4,
        out_indices=(3, ),
        stem_channels=64,
        strides=(1, 2, 2, 2),
        style='pytorch',
        type='mmcls.ResNet',
        with_cp=False,
        zero_init_residual=True),
    neck=dict(type='GlobalAveragePooling'),
    head=dict(
        type='CustomLinearClsHead',
        num_classes=1000,
        in_channels=-1,
        loss=dict(type='CrossEntropyLoss', loss_weight=1.0)),
    task='classification')
fp16 = dict(loss_scale=512.0)
load_from = None
custom_imports = dict(imports=['mmcls.models'], allow_failed_imports=False)

```