### PR TITLE
[CI] Upgrade actions/setup-python version to v4

### DIFF
--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install dependencies

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Install dependencies


### PR DESCRIPTION
Upgrade actions/setup-python version to v4 to avoid error from some deprecated usage of actions.