### PR TITLE
[FIX] Add SKIP mark and edit eval threshold for E2E tests

### DIFF
--- a/tests/e2e/cli/anomaly/test_anomaly_classification.py
+++ b/tests/e2e/cli/anomaly/test_anomaly_classification.py
@@ -73,7 +73,7 @@ class TestToolsAnomalyClassification:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval_openvino(self, template, tmp_dir_path):
-        otx_eval_openvino_testing(template, tmp_dir_path, otx_dir, args, threshold=0.0)
+        otx_eval_openvino_testing(template, tmp_dir_path, otx_dir, args, threshold=0.05)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/detection/test_instance_segmentation.py
+++ b/tests/e2e/cli/detection/test_instance_segmentation.py
@@ -118,6 +118,7 @@ class TestToolsMPAInstanceSegmentation:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    @pytest.mark.skip(reason="CVS-104657")
     def test_otx_eval_openvino(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_eval_openvino_testing(template, tmp_dir_path, otx_dir, args, threshold=0.2)


### PR DESCRIPTION
# This PR includes
* Edit the threshold (openvino eval) for anomaly classification: 0.00 --> 0.05
* Add SKIP mark to instance segmentation export