### PR TITLE
[FIX] Replace deprecated task_type to task in ConfigManager message

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -374,7 +374,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             if not template_lst:
                 raise ValueError(
                     f"[*] {model} is not a type supported by OTX {task_type}."
-                    f"\n[*] Please refer to 'otx find --template --task_type {task_type}'"
+                    f"\n[*] Please refer to 'otx find --template --task {task_type}'"
                 )
             template = template_lst[0]
         else:


### PR DESCRIPTION
## This PR includes:
- Fix deprecated `task_type` message to `task`

### Before
```
ValueError: [*] some_model is not a type supported by OTX CLASSIFICATION.
[*] Please refer to 'otx find --template --task_type CLASSIFICATION'
```
### After
```
ValueError: [*] some_model is not a type supported by OTX CLASSIFICATION.
[*] Please refer to 'otx find --template --task CLASSIFICATION'
```