### PR TITLE
[FIX] Fix the condition of supcon for seg

### DIFF
--- a/otx/algorithms/segmentation/tasks/inference.py
+++ b/otx/algorithms/segmentation/tasks/inference.py
@@ -199,7 +199,7 @@ class SegmentationInferenceTask(BaseTask, IInferenceTask, IExportTask, IEvaluati
             self._train_type in RECIPE_TRAIN_TYPE
             and self._train_type == TrainType.INCREMENTAL
             and self._hyperparams.learning_parameters.enable_supcon
-            and "supcon" not in self._model_dir
+            and not self._model_dir.endswith("supcon")
         ):
             self._model_dir = os.path.join(self._model_dir, "supcon")
 

--- a/tests/unit/algorithms/segmentation/tasks/test_segmentation_inference.py
+++ b/tests/unit/algorithms/segmentation/tasks/test_segmentation_inference.py
@@ -116,3 +116,23 @@ class TestOTXSegTaskInference:
         self.seg_train_task.unload()
 
         mock_cleanup.assert_called_once()
+
+    @e2e_pytest_unit
+    @pytest.mark.parametrize("model_dir", ["...", ".../supcon", ".../supcon/workspace"])
+    def test_init_recipe_supcon(self, mocker, model_dir: str):
+        mocker.patch("otx.algorithms.segmentation.tasks.inference.SegmentationInferenceTask._init_model_cfg")
+        mocker.patch("otx.algorithms.segmentation.tasks.inference.patch_default_config")
+        mocker.patch("otx.algorithms.segmentation.tasks.inference.patch_runner")
+        mocker.patch("otx.algorithms.segmentation.tasks.inference.patch_data_pipeline")
+        mocker.patch("otx.algorithms.segmentation.tasks.inference.patch_datasets")
+        mocker.patch("otx.algorithms.segmentation.tasks.inference.patch_evaluation")
+
+        self.seg_train_task._hyperparams.learning_parameters.enable_supcon = True
+        self.seg_train_task._model_dir = model_dir
+
+        self.seg_train_task._init_recipe()
+
+        assert self.seg_train_task._model_dir.endswith("supcon")
+
+        self.seg_train_task._hyperparams.learning_parameters.enable_supcon = False
+        self.seg_train_task._hyperparams._model_dir = os.path.abspath(DEFAULT_SEG_TEMPLATE_DIR)


### PR DESCRIPTION
### Summary
- When training with supcon and using `otx train ... --work-dir=otx-supcon-workspace` to create a workspace including `supcon` text in the path, otx cannot find `supcon` related files (`data_pipeline.py` and `model.py`).
    ```bash
    FileNotFoundError: data_pipeline: training_extensions/otx-supcon-workspace/./data_pipeline.py not founded
    ```
- Change the condition `"supcon" not in self._model_dir` → `not self._model_dir.endswith("supcon")`.
- It is just to find `supcon` directory in the workspace.

### How to test
```bash
$ pytest tests/unit/algorithms/segmentation/tasks/test_segmentation_inference.py::TestOTXSegTaskInference::test_init_recipe_supcon

============================================= 3 passed, 17 warnings in 1.50s =============================================
```
