### PR TITLE
[FIX] Error message is printed after otx train is done 

### DIFF
--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=too-many-locals
 
+import sys
 from pathlib import Path
 
 from otx.api.entities.inference_parameters import InferenceParameters
@@ -32,7 +33,7 @@ from otx.cli.manager.config_manager import TASK_TYPE_TO_SUB_DIR_NAME
 from otx.cli.utils.hpo import run_hpo
 from otx.cli.utils.importing import get_impl_class
 from otx.cli.utils.io import read_binary, read_label_schema, save_model_data
-from otx.cli.utils.multi_gpu import MultiGPUManager
+from otx.cli.utils.multi_gpu import MultiGPUManager, is_multigpu_child_process
 from otx.cli.utils.parser import (
     MemSizeAction,
     add_hyper_parameters_sub_parser,
@@ -244,10 +245,12 @@ def main():  # pylint: disable=too-many-branches
         assert resultset.performance is not None
         print(resultset.performance)
 
-    task.cleanup()
-
     if args.gpus:
         multigpu_manager.finalize()
+    elif is_multigpu_child_process():
+        sys.exit()
+
+    task.cleanup()
 
     return dict(retcode=0, template=template.name)
 

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -16,7 +16,6 @@
 
 # pylint: disable=too-many-locals
 
-import sys
 from pathlib import Path
 
 from otx.api.entities.inference_parameters import InferenceParameters
@@ -247,10 +246,9 @@ def main():  # pylint: disable=too-many-branches
 
     if args.gpus:
         multigpu_manager.finalize()
-    elif is_multigpu_child_process():
-        sys.exit()
 
-    task.cleanup()
+    if not is_multigpu_child_process():
+        task.cleanup()
 
     return dict(retcode=0, template=template.name)
 

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -99,6 +99,11 @@ def set_arguments_to_argv(key: str, value: Optional[str] = None, after_params: b
                 sys.argv.append(key)
 
 
+def is_multigpu_child_process():
+    """Check current process is a child process for multi GPU training."""
+    return torch.distributed.is_initialized() and os.environ["LOCAL_RANK"] != 0
+
+
 class MultiGPUManager:
     """Class to manage multi GPU training.
 

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -101,7 +101,7 @@ def set_arguments_to_argv(key: str, value: Optional[str] = None, after_params: b
 
 def is_multigpu_child_process():
     """Check current process is a child process for multi GPU training."""
-    return torch.distributed.is_initialized() and os.environ["LOCAL_RANK"] != 0
+    return dist.is_initialized() and os.environ["LOCAL_RANK"] != "0"
 
 
 class MultiGPUManager:

--- a/tests/unit/cli/utils/test_multi_gpu.py
+++ b/tests/unit/cli/utils/test_multi_gpu.py
@@ -11,6 +11,7 @@ from otx.cli.utils.multi_gpu import (
     MultiGPUManager,
     _get_free_port,
     get_gpu_ids,
+    is_multigpu_child_process,
     set_arguments_to_argv,
 )
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
@@ -121,6 +122,27 @@ def test_set_arguments_to_argv_key_after_param_non_val(mock_argv_with_params):
 
     assert new_key_idx > param_idx
     assert "--other_key" in mock_argv_with_params
+
+
+@e2e_pytest_unit
+def test_is_multigpu_child_process(mocker):
+    mocker.patch.object(multi_gpu.dist, "is_initialized", return_value=True)
+    os.environ["LOCAL_RANK"] = "1"
+    assert is_multigpu_child_process()
+
+
+@e2e_pytest_unit
+def test_is_multigpu_child_process_no_initialized(mocker):
+    mocker.patch.object(multi_gpu.dist, "is_initialized", return_value=False)
+    os.environ["LOCAL_RANK"] = "1"
+    assert not is_multigpu_child_process()
+
+
+@e2e_pytest_unit
+def test_is_multigpu_child_process_rank0(mocker):
+    mocker.patch.object(multi_gpu.dist, "is_initialized", return_value=True)
+    os.environ["LOCAL_RANK"] = "0"
+    assert not is_multigpu_child_process()
 
 
 class TestMultiGPUManager:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
When executing `otx train` with multi GPU argument, all processes executes `task.cleanup()`, which makes an error in other late process sometimes.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
