### PR TITLE
[FIX] Update selfsl args in test_classification.py

### DIFF
--- a/tests/e2e/cli/classification/test_classification.py
+++ b/tests/e2e/cli/classification/test_classification.py
@@ -717,9 +717,11 @@ args_selfsl = {
     "train_params": [
         "params",
         "--learning_parameters.num_iters",
-        "10",
+        "1",
         "--learning_parameters.batch_size",
         "4",
+        "--learning_parameters.learning_rate",
+        "1e-07",
         "--algo_backend.train_type",
         "SELFSUPERVISED",
     ],


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

During e2e test, self-sl for cls outputs nan, because dummy test inputs overflow the model's BN layer.

![image](https://user-images.githubusercontent.com/97221135/225249825-f43c425a-17bc-4eb0-bd69-24e65190c90d.png)

This PR is to adjust self-sl args and minimize weight change to avoid this issue.
Reported by @harimkang.

### How to test
I ran the below command 5 times and the issue doesn't occur anymore.
```bash
$ pytest -s -v tests/e2e/cli/classification/test_classification.py::TestToolsSelfSLClassification::test_otx_selfsl_train

========================== 3 passed, 2 warnings in 47.21s ==========================
```
![image](https://user-images.githubusercontent.com/97221135/225250826-b72ac02f-d5f6-48e4-9d39-f882f9ad41b5.png)


<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
