### PR TITLE
[FIX] Handle unpickable update_progress_callback

### DIFF
--- a/otx/api/entities/train_parameters.py
+++ b/otx/api/entities/train_parameters.py
@@ -14,7 +14,7 @@ class UpdateProgressCallback(Protocol):
     `score: Optional[float] = None`
     """
 
-    def __call__(self, progress: int, score: Optional[float] = None):
+    def __call__(self, progress: float, score: Optional[float] = None):
         """Callback to provide updates about the progress of a task.
 
         It is recommended to call this function at least once per epoch.
@@ -30,7 +30,7 @@ class UpdateProgressCallback(Protocol):
 
 
 # pylint: disable=unused-argument
-def default_progress_callback(progress: int, score: Optional[float] = None):
+def default_progress_callback(progress: float, score: Optional[float] = None):
     """Default progress callback. It is a placeholder (does nothing) and is used in empty TrainParameters."""
 
 

--- a/otx/api/usecases/reporting/time_monitor_callback.py
+++ b/otx/api/usecases/reporting/time_monitor_callback.py
@@ -9,6 +9,7 @@
 import logging
 import math
 import time
+from copy import deepcopy
 from typing import List
 
 import dill
@@ -83,15 +84,18 @@ class TimeMonitorCallback(Callback):
 
     def __deepcopy__(self, memo):
         """Return deepcopy object."""
-        result = self.__class__(
-            self.total_epochs,
-            self.train_steps,
-            self.val_steps,
-            self.test_steps,
-            self.epoch_history,
-            self.step_history,
-            self.update_progress_callback,
-        )
+
+        update_progress_callback = self.update_progress_callback
+        self.update_progress_callback = None
+        self.__dict__["__deepcopy__"] = None
+
+        result = deepcopy(self, memo)
+
+        self.__dict__.pop("__deepcopy__")
+        result.__dict__.pop("__deepcopy__")
+        result.update_progress_callback = update_progress_callback
+        self.update_progress_callback = update_progress_callback
+
         memo[id(self)] = result
         return result
 

--- a/otx/api/usecases/reporting/time_monitor_callback.py
+++ b/otx/api/usecases/reporting/time_monitor_callback.py
@@ -67,6 +67,13 @@ class TimeMonitorCallback(Callback):
 
         self.update_progress_callback = update_progress_callback
 
+    def __getstate__(self):
+        """Return state values to be pickled."""
+        state = self.__dict__
+        # update_progress_callback is not pickable object
+        state["update_progress_callback"] = None
+        return state
+
     def on_train_batch_begin(self, batch, logs=None):
         """Set the value of current step and start the timer."""
         self.current_step += 1
@@ -131,7 +138,8 @@ class TimeMonitorCallback(Callback):
         """Computes the average time taken to complete an epoch based on a running average of `epoch_history` epochs."""
         self.past_epoch_duration.append(time.time() - self.start_epoch_time)
         self._calculate_average_epoch()
-        self.update_progress_callback(self.get_progress())
+        if self.update_progress_callback is not None:
+            self.update_progress_callback(self.get_progress())
 
     def _calculate_average_epoch(self):
         if len(self.past_epoch_duration) > self.epoch_history:

--- a/tests/unit/api/usecases/reporting/test_time_monitor_callback.py
+++ b/tests/unit/api/usecases/reporting/test_time_monitor_callback.py
@@ -93,7 +93,7 @@ class TestTimeMonitorCallback:
             actual_time_monitor_callback=time_monitor_callback,
             expected_epoch_history=5,
             expected_step_history=50,
-            expected_update_progress_callback=None,
+            expected_update_progress_callback=default_progress_callback,
         )
         # Checking attributes of "TimeMonitorCallback" initialized with specified optional parameters
         step_history = 10


### PR DESCRIPTION
### Summary
`update_progress_callback` is not always a pickable object.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
