### PR TITLE
[FIX] re-bugfix: ATSS head loss

### DIFF
--- a/otx/algorithms/detection/adapters/mmdet/models/heads/custom_atss_head.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/heads/custom_atss_head.py
@@ -172,18 +172,16 @@ class CustomATSSHead(CrossDatasetDetectorHead, ATSSHead):
             pos_centerness = centerness[pos_inds]
 
             centerness_targets = self.centerness_target(pos_anchors, pos_bbox_targets)
-            pos_decode_bbox_pred = self.bbox_coder.decode(pos_anchors, pos_bbox_pred)
-            pos_decode_bbox_targets = self.bbox_coder.decode(pos_anchors, pos_bbox_targets)
+            if self.reg_decoded_bbox:
+                pos_bbox_pred = self.bbox_coder.decode(pos_anchors, pos_bbox_pred)
 
             if self.use_qfl:
-                quality[pos_inds] = bbox_overlaps(
-                    pos_decode_bbox_pred.detach(), pos_decode_bbox_targets, is_aligned=True
-                ).clamp(min=1e-6)
+                quality[pos_inds] = bbox_overlaps(pos_bbox_pred.detach(), pos_bbox_targets, is_aligned=True).clamp(
+                    min=1e-6
+                )
 
             # regression loss
-            loss_bbox = self.loss_bbox(
-                pos_decode_bbox_pred, pos_decode_bbox_targets, weight=centerness_targets, avg_factor=1.0
-            )
+            loss_bbox = self.loss_bbox(pos_bbox_pred, pos_bbox_targets, weight=centerness_targets, avg_factor=1.0)
 
             # centerness loss
             loss_centerness = self.loss_centerness(pos_centerness, centerness_targets, avg_factor=num_total_samples)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
- This PR is same as the this[ PR](https://github.com/openvinotoolkit/training_extensions/pull/1880), which fixed the ATSS loss bug.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
