### PR TITLE
Add mmcls.VisionTransformer backbone support

### DIFF
--- a/otx/algorithms/__init__.py
+++ b/otx/algorithms/__init__.py
@@ -3,4 +3,4 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-TRANSFORMER_BACKBONES = ["VisionTransformer", "T2T_ViT", "TNT", "Conformer"]
+TRANSFORMER_BACKBONES = ["VisionTransformer", "T2T_ViT", "Conformer"]

--- a/otx/algorithms/__init__.py
+++ b/otx/algorithms/__init__.py
@@ -2,3 +2,5 @@
 
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
+TRANSFORMER_BACKBONES = ["VisionTransformer", "T2T_ViT", "TNT", "Conformer"]

--- a/otx/algorithms/classification/configs/configuration.yaml
+++ b/otx/algorithms/classification/configs/configuration.yaml
@@ -10,7 +10,7 @@ learning_parameters:
       stable. A larger batch size has higher memory requirements.
     editable: true
     header: Batch size
-    max_value: 512
+    max_value: 2048
     min_value: 1
     type: INTEGER
     ui_rules:

--- a/otx/algorithms/common/configs/training_base.py
+++ b/otx/algorithms/common/configs/training_base.py
@@ -65,7 +65,7 @@ class BaseConfig(ConfigurableParameters):
         batch_size = configurable_integer(
             default_value=5,
             min_value=1,
-            max_value=512,
+            max_value=2048,
             header="Batch size",
             description="The number of training samples seen in each iteration of training. Increasing thisvalue "
             "improves training time and may make the training more stable. A larger batch size has higher "

--- a/otx/cli/builder/builder.py
+++ b/otx/cli/builder/builder.py
@@ -28,8 +28,8 @@ import torch
 from mmcv.utils import Registry, build_from_cfg
 from torch import nn
 
-from otx.api.entities.model_template import TaskType
 from otx.algorithms import TRANSFORMER_BACKBONES
+from otx.api.entities.model_template import TaskType
 from otx.cli.utils.importing import (
     get_backbone_list,
     get_backbone_registry,
@@ -102,8 +102,8 @@ def update_backbone_args(backbone_config: dict, registry: Registry, backend: str
 
 def update_channels(model_config: MPAConfig, out_channels: Any):
     """Update in_channel of head or neck."""
-    if hasattr(model_config.model, "neck"):
-        if model_config.model.neck.type == "GlobalAveragePooling":
+    if hasattr(model_config.model, "neck") and model_config.model.neck:
+        if model_config.model.neck.get("type", None) == "GlobalAveragePooling":
             model_config.model.neck.pop("in_channels", None)
         else:
             print(f"\tUpdate model.neck.in_channels: {out_channels}")

--- a/otx/cli/builder/builder.py
+++ b/otx/cli/builder/builder.py
@@ -29,6 +29,7 @@ from mmcv.utils import Registry, build_from_cfg
 from torch import nn
 
 from otx.api.entities.model_template import TaskType
+from otx.algorithms import TRANSFORMER_BACKBONES
 from otx.cli.utils.importing import (
     get_backbone_list,
     get_backbone_registry,
@@ -212,6 +213,12 @@ class Builder:
             out_channels = -1
             if hasattr(model_config.model, "head"):
                 model_config.model.head.in_channels = -1
+            # TODO: This is a hard coded part of the Transformer backbone and needs to be refactored.
+            if backend == "mmcls" and backbone_class in TRANSFORMER_BACKBONES:
+                if hasattr(model_config.model, "neck"):
+                    model_config.model.neck = None
+                if hasattr(model_config.model, "head"):
+                    model_config.model.head["type"] = "VisionTransformerClsHead"
         else:
             # Need to update in/out channel configuration here
             out_channels = get_backbone_out_channels(backbone)

--- a/otx/cli/builder/supported_backbone/mmcls.json
+++ b/otx/cli/builder/supported_backbone/mmcls.json
@@ -11,7 +11,7 @@
       "options": {
         "arch": ["tiny", "small", "base"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.ConvMixer": {
       "required": ["arch"],
@@ -287,7 +287,7 @@
     "mmcls.T2T_ViT": {
       "required": [],
       "options": {},
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.TIMMBackbone": {
       "required": ["model_name"],
@@ -299,7 +299,7 @@
       "options": {
         "arch": ["base", "small"]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     },
     "mmcls.PCPVT": {
       "required": ["arch"],
@@ -341,7 +341,7 @@
           "deit-base"
         ]
       },
-      "available": []
+      "available": ["CLASSIFICATION"]
     }
   }
 }

--- a/otx/cli/builder/supported_backbone/mmcls.json
+++ b/otx/cli/builder/supported_backbone/mmcls.json
@@ -299,7 +299,7 @@
       "options": {
         "arch": ["base", "small"]
       },
-      "available": ["CLASSIFICATION"]
+      "available": []
     },
     "mmcls.PCPVT": {
       "required": ["arch"],

--- a/otx/mpa/cls/inferrer.py
+++ b/otx/mpa/cls/inferrer.py
@@ -56,6 +56,7 @@ class ClsInferrer(ClsStage):
         dump_saliency_map = kwargs.get("dump_saliency_map", False)
         # TODO: It looks like we need to modify that code in an appropriate way.
         if model_cfg.model.head.get("type", None) == "VisionTransformerClsHead":
+            dump_features = False
             dump_saliency_map = False
         eval = kwargs.get("eval", False)
         outputs = self.infer(

--- a/otx/mpa/cls/inferrer.py
+++ b/otx/mpa/cls/inferrer.py
@@ -11,6 +11,7 @@ from mmcls.datasets import build_dataloader as mmcls_build_dataloader
 from mmcls.datasets import build_dataset as mmcls_build_dataset
 from mmcv import Config, ConfigDict
 
+from otx.algorithms import TRANSFORMER_BACKBONES
 from otx.algorithms.common.adapters.mmcv.utils import (
     build_data_parallel,
     build_dataloader,
@@ -53,6 +54,9 @@ class ClsInferrer(ClsStage):
         model_builder = kwargs.get("model_builder", None)
         dump_features = kwargs.get("dump_features", False)
         dump_saliency_map = kwargs.get("dump_saliency_map", False)
+        # TODO: It looks like we need to modify that code in an appropriate way.
+        if model_cfg.model.head.get("type", None) == "VisionTransformerClsHead":
+            dump_saliency_map = False
         eval = kwargs.get("eval", False)
         outputs = self.infer(
             cfg,

--- a/otx/mpa/cls/stage.py
+++ b/otx/mpa/cls/stage.py
@@ -9,13 +9,12 @@ import torch
 from mmcv import ConfigDict, build_from_cfg
 
 from otx.algorithms.classification.adapters.mmcls.utils.builder import build_classifier
+from otx.algorithms import TRANSFORMER_BACKBONES
 from otx.mpa.stage import Stage
 from otx.mpa.utils.config_utils import recursively_update_cfg, update_or_add_custom_hook
 from otx.mpa.utils.logger import get_logger
 
 logger = get_logger()
-
-TRANSFORMER_BACKBONES = ["VisionTransformer", "T2T_ViT", "TNT", "Conformer"]
 
 
 class ClsStage(Stage):
@@ -95,6 +94,8 @@ class ClsStage(Stage):
         if layer.__class__.__name__ in TRANSFORMER_BACKBONES and isinstance(output, (tuple, list)):
             # mmcls.VisionTransformer outputs Tuple[List[...]] and the last index of List is the final logit.
             _, output = output
+            if cfg.model.head.type != "VisionTransformerClsHead":
+                raise ValueError(f"{layer.__class__.__name__ } needs VisionTransformerClsHead as head")
 
         in_channels = output.shape[1]
         if cfg.model.get("neck") is not None:

--- a/otx/mpa/cls/stage.py
+++ b/otx/mpa/cls/stage.py
@@ -8,8 +8,8 @@ import numpy as np
 import torch
 from mmcv import ConfigDict, build_from_cfg
 
-from otx.algorithms.classification.adapters.mmcls.utils.builder import build_classifier
 from otx.algorithms import TRANSFORMER_BACKBONES
+from otx.algorithms.classification.adapters.mmcls.utils.builder import build_classifier
 from otx.mpa.stage import Stage
 from otx.mpa.utils.config_utils import recursively_update_cfg, update_or_add_custom_hook
 from otx.mpa.utils.logger import get_logger

--- a/otx/mpa/cls/stage.py
+++ b/otx/mpa/cls/stage.py
@@ -92,7 +92,7 @@ class ClsStage(Stage):
         if isinstance(output, (tuple, list)):
             output = output[-1]
 
-        if layer.__class__.__name__ in TRANSFORMER_BACKBONES:
+        if layer.__class__.__name__ in TRANSFORMER_BACKBONES and isinstance(output, (tuple, list)):
             # mmcls.VisionTransformer outputs Tuple[List[...]] and the last index of List is the final logit.
             _, output = output
 

--- a/otx/mpa/cls/stage.py
+++ b/otx/mpa/cls/stage.py
@@ -15,6 +15,8 @@ from otx.mpa.utils.logger import get_logger
 
 logger = get_logger()
 
+TRANSFORMER_BACKBONES = ["VisionTransformer", "T2T_ViT", "TNT", "Conformer"]
+
 
 class ClsStage(Stage):
     MODEL_BUILDER = build_classifier
@@ -89,6 +91,11 @@ class ClsStage(Stage):
         output = layer(torch.rand([1] + list(input_shape)))
         if isinstance(output, (tuple, list)):
             output = output[-1]
+
+        if layer.__class__.__name__ in TRANSFORMER_BACKBONES:
+            # mmcls.VisionTransformer outputs Tuple[List[...]] and the last index of List is the final logit.
+            _, output = output
+
         in_channels = output.shape[1]
         if cfg.model.get("neck") is not None:
             if cfg.model.neck.get("in_channels") is not None:

--- a/otx/mpa/modules/hooks/recording_forward_hooks.py
+++ b/otx/mpa/modules/hooks/recording_forward_hooks.py
@@ -20,7 +20,6 @@ from typing import Sequence, Union
 import torch
 
 from otx import MMCLS_AVAILABLE
-from otx.algorithms import TRANSFORMER_BACKBONES
 
 if MMCLS_AVAILABLE:
     from mmcls.models.necks.gap import GlobalAveragePooling

--- a/otx/mpa/modules/hooks/recording_forward_hooks.py
+++ b/otx/mpa/modules/hooks/recording_forward_hooks.py
@@ -117,12 +117,10 @@ class ActivationMapHook(BaseRecordingForwardHook):
 
 
 class FeatureVectorHook(BaseRecordingForwardHook):
-    def func(self, feature_map: Union[torch.Tensor, Sequence[torch.Tensor]]) -> torch.Tensor:
+    @staticmethod
+    def func(feature_map: Union[torch.Tensor, Sequence[torch.Tensor]]) -> torch.Tensor:
         """Generate the feature vector by average pooling feature maps."""
-        if self._module.backbone.__class__.__name__ in TRANSFORMER_BACKBONES and isinstance(feature_map[-1], (tuple, list)):
-            # mmcls.VisionTransformer outputs Tuple[List[...]] and the last index of List is the final logit.
-            feature_vector, _ = feature_map[-1]
-        elif isinstance(feature_map, (list, tuple)):
+        if isinstance(feature_map, (list, tuple)):
             # aggregate feature maps from Feature Pyramid Network
             feature_vector = [torch.nn.functional.adaptive_avg_pool2d(f, (1, 1)) for f in feature_map]
             feature_vector = torch.cat(feature_vector, 1)

--- a/otx/mpa/modules/hooks/recording_forward_hooks.py
+++ b/otx/mpa/modules/hooks/recording_forward_hooks.py
@@ -20,6 +20,7 @@ from typing import Sequence, Union
 import torch
 
 from otx import MMCLS_AVAILABLE
+from otx.algorithms import TRANSFORMER_BACKBONES
 
 if MMCLS_AVAILABLE:
     from mmcls.models.necks.gap import GlobalAveragePooling
@@ -116,10 +117,12 @@ class ActivationMapHook(BaseRecordingForwardHook):
 
 
 class FeatureVectorHook(BaseRecordingForwardHook):
-    @staticmethod
-    def func(feature_map: Union[torch.Tensor, Sequence[torch.Tensor]]) -> torch.Tensor:
+    def func(self, feature_map: Union[torch.Tensor, Sequence[torch.Tensor]]) -> torch.Tensor:
         """Generate the feature vector by average pooling feature maps."""
-        if isinstance(feature_map, (list, tuple)):
+        if self._module.backbone.__class__.__name__ in TRANSFORMER_BACKBONES and isinstance(feature_map[-1], (tuple, list)):
+            # mmcls.VisionTransformer outputs Tuple[List[...]] and the last index of List is the final logit.
+            feature_vector, _ = feature_map[-1]
+        elif isinstance(feature_map, (list, tuple)):
             # aggregate feature maps from Feature Pyramid Network
             feature_vector = [torch.nn.functional.adaptive_avg_pool2d(f, (1, 1)) for f in feature_map]
             feature_vector = torch.cat(feature_vector, 1)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

New Backbone Support
- mmcls.VisionTransformer
- mmcls.T2T_ViT
- mmcls.Conformer

mmcls.VisionTransformer support
- [X] otx find with mmcls transformer backbones
- [X] otx build with mmcls transformer backbones
- [X] otx train with mmcls transformer backbones

Things to know:
The current implementation uses `dump_feature` and `dump_saliency_map` as **False** in infer when using `VisionTransformerClsHead` due to the different output structure of transformer.

### How to test

```
(otx) otx find --task classification --backbone mmcls
(otx) otx build --task classification
(otx) cd otx-workspace-CLASSIFICATION
# Edit data.yaml
(otx) otx build --backbone mmcls.VisionTransformer
(otx) otx train
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [X] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [X] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
