### PR TITLE
Fix OTX1.1 -> Geti1.4 integration issues

### DIFF
--- a/otx/api/entities/media.py
+++ b/otx/api/entities/media.py
@@ -54,4 +54,4 @@ class IMedia2DEntity(IMediaEntity, metaclass=abc.ABCMeta):
     @property
     def path(self) -> Optional[str]:
         """Returns the path of the 2D Media object."""
-        raise NotImplementedError
+        return None

--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -9,3 +9,4 @@ pymongo==3.12.0
 scikit-learn==0.24.*
 Shapely>=1.7.1,<=1.8.0
 imagesize==1.4.1
+dill>=0.3.6


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Add dill to api dependency for `otx.api`-only use-case
  (Originally, installed by mmdeploy)
* Return None instead of raising exception
  (Geti does not implement `path` method)

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
