### PR TITLE
Move utils HPO uses into HPO directory

### DIFF
--- a/otx/algorithms/common/utils/utils.py
+++ b/otx/algorithms/common/utils/utils.py
@@ -17,7 +17,7 @@
 import importlib
 import inspect
 from collections import defaultdict
-from typing import Callable, Literal, Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import yaml
 
@@ -94,77 +94,3 @@ def get_arg_spec(  # noqa: C901  # pylint: disable=too-many-branches
             if spec.varkw is None and spec.varargs is None:
                 break
     return tuple(args)
-
-
-def left_vlaue_is_better(val1, val2, mode: Literal["max", "min"]) -> bool:
-    """Check left value is better than right value.
-
-    Whether check it's greather or lesser is changed depending on 'model'.
-
-    Args:
-        val1 : value to check that it's bigger than other value.
-        val2 : value to check that it's bigger than other value.
-        mode (Literal['max', 'min']): value to decide whether better means greater or lesser.
-
-    Returns:
-        bool: whether val1 is better than val2.
-    """
-    check_mode_input(mode)
-    if mode == "max":
-        return val1 > val2
-    return val1 < val2
-
-
-def check_positive(value, variable_name: Optional[str] = None, error_message: Optional[str] = None):
-    """Validate that value is positivle.
-
-    Args:
-        value (Any): value to validate.
-        variable_name (Optional[str], optional): name of value. It's used for error message. Defaults to None.
-        error_message (Optional[str], optional): Error message to use when type is different. Defaults to None.
-
-    Raises:
-        ValueError: If value isn't positive, the error is raised.
-    """
-    if value <= 0:
-        if error_message is not None:
-            message = error_message
-        elif variable_name:
-            message = f"{variable_name} should be positive.\n" f"your value : {value}"
-        else:
-            raise ValueError
-        raise ValueError(message)
-
-
-def check_not_negative(value, variable_name: Optional[str] = None, error_message: Optional[str] = None):
-    """Validate that value isn't negative.
-
-    Args:
-        value (Any): value to validate.
-        variable_name (Optional[str], optional): name of value. It's used for error message. Defaults to None.
-        error_message (Optional[str], optional): Error message to use when type is different. Defaults to None.
-
-    Raises:
-        ValueError: If value is negative, the error is raised.
-    """
-    if value < 0:
-        if error_message is not None:
-            message = error_message
-        elif variable_name:
-            message = f"{variable_name} should be positive.\n" f"your value : {value}"
-        else:
-            raise ValueError
-        raise ValueError(message)
-
-
-def check_mode_input(mode: str):
-    """Validate that mode is 'max' or 'min'.
-
-    Args:
-        mode (str): string to validate.
-
-    Raises:
-        ValueError: If 'mode' is not both 'max' and 'min', the error is raised.
-    """
-    if mode not in ["max", "min"]:
-        raise ValueError("mode should be max or min.\n" f"Your value : {mode}")

--- a/otx/hpo/hpo_base.py
+++ b/otx/hpo/hpo_base.py
@@ -21,8 +21,8 @@ from abc import ABC, abstractmethod
 from enum import IntEnum
 from typing import Any, Dict, List, Optional, Union
 
-from otx.algorithms.common.utils.utils import check_mode_input, check_positive
 from otx.hpo.search_space import SearchSpace
+from otx.hpo.utils import check_mode_input, check_positive
 
 logger = logging.getLogger(__name__)
 

--- a/otx/hpo/hyperband.py
+++ b/otx/hpo/hyperband.py
@@ -23,13 +23,13 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from scipy.stats.qmc import LatinHypercube
 
-from otx.algorithms.common.utils.utils import (
+from otx.hpo.hpo_base import HpoBase, Trial, TrialStatus
+from otx.hpo.utils import (
     check_mode_input,
     check_not_negative,
     check_positive,
     left_vlaue_is_better,
 )
-from otx.hpo.hpo_base import HpoBase, Trial, TrialStatus
 
 logger = logging.getLogger(__name__)
 

--- a/otx/hpo/resource_manager.py
+++ b/otx/hpo/resource_manager.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import torch
 
-from otx.algorithms.common.utils.utils import check_positive
+from otx.hpo.utils import check_positive
 
 logger = logging.getLogger(__name__)
 

--- a/otx/hpo/search_space.py
+++ b/otx/hpo/search_space.py
@@ -20,7 +20,7 @@ import math
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from otx.algorithms.common.utils.utils import check_positive
+from otx.hpo.utils import check_positive
 
 logger = logging.getLogger(__name__)
 

--- a/otx/hpo/utils.py
+++ b/otx/hpo/utils.py
@@ -1,0 +1,91 @@
+"""Collections of Utils for HPO."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from typing import Literal, Optional
+
+
+def left_vlaue_is_better(val1, val2, mode: Literal["max", "min"]) -> bool:
+    """Check left value is better than right value.
+
+    Whether check it's greather or lesser is changed depending on 'model'.
+
+    Args:
+        val1 : value to check that it's bigger than other value.
+        val2 : value to check that it's bigger than other value.
+        mode (Literal['max', 'min']): value to decide whether better means greater or lesser.
+
+    Returns:
+        bool: whether val1 is better than val2.
+    """
+    check_mode_input(mode)
+    if mode == "max":
+        return val1 > val2
+    return val1 < val2
+
+
+def check_positive(value, variable_name: Optional[str] = None, error_message: Optional[str] = None):
+    """Validate that value is positivle.
+
+    Args:
+        value (Any): value to validate.
+        variable_name (Optional[str], optional): name of value. It's used for error message. Defaults to None.
+        error_message (Optional[str], optional): Error message to use when type is different. Defaults to None.
+
+    Raises:
+        ValueError: If value isn't positive, the error is raised.
+    """
+    if value <= 0:
+        if error_message is not None:
+            message = error_message
+        elif variable_name:
+            message = f"{variable_name} should be positive.\n" f"your value : {value}"
+        else:
+            raise ValueError
+        raise ValueError(message)
+
+
+def check_not_negative(value, variable_name: Optional[str] = None, error_message: Optional[str] = None):
+    """Validate that value isn't negative.
+
+    Args:
+        value (Any): value to validate.
+        variable_name (Optional[str], optional): name of value. It's used for error message. Defaults to None.
+        error_message (Optional[str], optional): Error message to use when type is different. Defaults to None.
+
+    Raises:
+        ValueError: If value is negative, the error is raised.
+    """
+    if value < 0:
+        if error_message is not None:
+            message = error_message
+        elif variable_name:
+            message = f"{variable_name} should be positive.\n" f"your value : {value}"
+        else:
+            raise ValueError
+        raise ValueError(message)
+
+
+def check_mode_input(mode: str):
+    """Validate that mode is 'max' or 'min'.
+
+    Args:
+        mode (str): string to validate.
+
+    Raises:
+        ValueError: If 'mode' is not both 'max' and 'min', the error is raised.
+    """
+    if mode not in ["max", "min"]:
+        raise ValueError("mode should be max or min.\n" f"Your value : {mode}")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

- Move util functions code into HPO directory to avoid importing openvino during Geti unit test.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
