### PR TITLE
Fix invalid temp_dir inside unit tests

### DIFF
--- a/tests/unit/algorithms/action/adapters/mmaction/utils/test_action_config_utils.py
+++ b/tests/unit/algorithms/action/adapters/mmaction/utils/test_action_config_utils.py
@@ -43,29 +43,28 @@ def test_patch_config() -> None:
     """
 
     cls_datapipeline_path = "otx/algorithms/action/configs/classification/x3d/data_pipeline.py"
-    work_dir = str(tempfile.TemporaryDirectory("OTX-tempdir9104"))
+    with tempfile.TemporaryDirectory() as work_dir:
+        with pytest.raises(NotImplementedError):
+            patch_config(CLS_CONFIG, cls_datapipeline_path, work_dir, TaskType.CLASSIFICATION)
 
-    with pytest.raises(NotImplementedError):
-        patch_config(CLS_CONFIG, cls_datapipeline_path, work_dir, TaskType.CLASSIFICATION)
+        patch_config(CLS_CONFIG, cls_datapipeline_path, work_dir, TaskType.ACTION_CLASSIFICATION)
+        assert CLS_CONFIG.work_dir == work_dir
+        assert CLS_CONFIG.get("train_pipeline", None)
+        for subset in ("train", "val", "test", "unlabeled"):
+            cfg = CLS_CONFIG.data.get(subset, None)
+            if not cfg:
+                continue
+            assert cfg.type == "OTXActionClsDataset"
 
-    patch_config(CLS_CONFIG, cls_datapipeline_path, work_dir, TaskType.ACTION_CLASSIFICATION)
-    assert CLS_CONFIG.work_dir == work_dir
-    assert CLS_CONFIG.get("train_pipeline", None)
-    for subset in ("train", "val", "test", "unlabeled"):
-        cfg = CLS_CONFIG.data.get(subset, None)
-        if not cfg:
-            continue
-        assert cfg.type == "OTXActionClsDataset"
-
-    det_datapipeline_path = "otx/algorithms/action/configs/detection/x3d_fast_rcnn/data_pipeline.py"
-    patch_config(DET_CONFIG, det_datapipeline_path, work_dir, TaskType.ACTION_DETECTION)
-    assert DET_CONFIG.work_dir == work_dir
-    assert DET_CONFIG.get("train_pipeline", None)
-    for subset in ("train", "val", "test", "unlabeled"):
-        cfg = DET_CONFIG.data.get(subset, None)
-        if not cfg:
-            continue
-        assert cfg.type == "OTXActionDetDataset"
+        det_datapipeline_path = "otx/algorithms/action/configs/detection/x3d_fast_rcnn/data_pipeline.py"
+        patch_config(DET_CONFIG, det_datapipeline_path, work_dir, TaskType.ACTION_DETECTION)
+        assert DET_CONFIG.work_dir == work_dir
+        assert DET_CONFIG.get("train_pipeline", None)
+        for subset in ("train", "val", "test", "unlabeled"):
+            cfg = DET_CONFIG.data.get(subset, None)
+            if not cfg:
+                continue
+            assert cfg.type == "OTXActionDetDataset"
 
 
 @e2e_pytest_unit

--- a/tests/unit/algorithms/action/utils/test_action_convert_public_data_to_cvat.py
+++ b/tests/unit/algorithms/action/utils/test_action_convert_public_data_to_cvat.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+import tempfile
+
 import numpy as np
 import pytest
 
@@ -95,24 +97,24 @@ def test_convert_action_cls_dataset_to_datumaro(mocker) -> None:
     """Test convert_jester_dataset_to_datumaro function."""
 
     src_path = "dummy_src_path"
-    dst_path = "dummy_dst_path"
     ann_file = "dummy_ann_file"
 
-    mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.open", return_value=MockFileObject())
-    mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.pathlib.Path.mkdir", return_value=True)
-    # mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.os.makedirs", return_value=True)
-    mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.shutil.copy", return_value=True)
-    mocker.patch(
-        "otx.algorithms.action.utils.convert_public_data_to_cvat.generate_default_cvat_xml_fields",
-        return_value=([], (256, 256, 3), []),
-    )
-    mocker.patch(
-        "otx.algorithms.action.utils.convert_public_data_to_cvat.os.listdir", return_value=(["frame0", "frame1"])
-    )
-    mocker.patch(
-        "otx.algorithms.action.utils.convert_public_data_to_cvat.etree.ElementTree", return_value=MockElementTree()
-    )
-    convert_action_cls_dataset_to_datumaro(src_path, dst_path, ann_file)
+    with tempfile.TemporaryDirectory() as dst_path:
+        mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.open", return_value=MockFileObject())
+        mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.pathlib.Path.mkdir", return_value=True)
+        # mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.os.makedirs", return_value=True)
+        mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.shutil.copy", return_value=True)
+        mocker.patch(
+            "otx.algorithms.action.utils.convert_public_data_to_cvat.generate_default_cvat_xml_fields",
+            return_value=([], (256, 256, 3), []),
+        )
+        mocker.patch(
+            "otx.algorithms.action.utils.convert_public_data_to_cvat.os.listdir", return_value=(["frame0", "frame1"])
+        )
+        mocker.patch(
+            "otx.algorithms.action.utils.convert_public_data_to_cvat.etree.ElementTree", return_value=MockElementTree()
+        )
+        convert_action_cls_dataset_to_datumaro(src_path, dst_path, ann_file)
 
 
 @e2e_pytest_unit

--- a/tests/unit/algorithms/action/utils/test_action_convert_public_data_to_cvat.py
+++ b/tests/unit/algorithms/action/utils/test_action_convert_public_data_to_cvat.py
@@ -122,23 +122,23 @@ def test_convert_ava_dataset_to_datumaro(mocker) -> None:
     """Test convert_ava_dataset_to_datumaro function."""
 
     src_path = "dummy_src_path"
-    dst_path = "dummy_dst_path"
     ann_file = "dummy_ann_file"
 
-    mocker.patch(
-        "otx.algorithms.action.utils.convert_public_data_to_cvat.read_ava_csv",
-        return_value={"video_0": {"frame_idx": [[0, 0, 1, 1, "action"]]}},
-    )
-    mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.os.listdir", return_value=["video_0"])
-    mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.shutil.copytree", return_value=True)
-    mocker.patch(
-        "otx.algorithms.action.utils.convert_public_data_to_cvat.generate_default_cvat_xml_fields",
-        return_value=([], (256, 256, 3), []),
-    )
-    mocker.patch(
-        "otx.algorithms.action.utils.convert_public_data_to_cvat.etree.ElementTree", return_value=MockElementTree()
-    )
-    convert_ava_dataset_to_datumaro(src_path, dst_path, ann_file)
+    with tempfile.TemporaryDirectory() as dst_path:
+        mocker.patch(
+            "otx.algorithms.action.utils.convert_public_data_to_cvat.read_ava_csv",
+            return_value={"video_0": {"frame_idx": [[0, 0, 1, 1, "action"]]}},
+        )
+        mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.os.listdir", return_value=["video_0"])
+        mocker.patch("otx.algorithms.action.utils.convert_public_data_to_cvat.shutil.copytree", return_value=True)
+        mocker.patch(
+            "otx.algorithms.action.utils.convert_public_data_to_cvat.generate_default_cvat_xml_fields",
+            return_value=([], (256, 256, 3), []),
+        )
+        mocker.patch(
+            "otx.algorithms.action.utils.convert_public_data_to_cvat.etree.ElementTree", return_value=MockElementTree()
+        )
+        convert_ava_dataset_to_datumaro(src_path, dst_path, ann_file)
 
 
 @e2e_pytest_unit


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Fix temp_dir created on root in some unit test cases
- tests/unit/algorithms/action/utils/test_action_convert_public_data_to_cvat.py
- tests/unit/algorithms/action/adapters/mmaction/utils/test_action_config_utils.py

Re-address unintended modifications in [this PR](https://github.com/openvinotoolkit/training_extensions/pull/1902)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
