### PR TITLE
Support multi GPU training using torchrun

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/tasks/stage.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/stage.py
@@ -180,12 +180,10 @@ class Stage:
             self._distributed = True
             self.cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
         elif "gpu_ids" not in self.cfg:
-            gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
-            logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")
-            if gpu_ids is not None:
-                self.cfg.gpu_ids = range(len(gpu_ids.split(",")))
-            else:
-                self.cfg.gpu_ids = range(1)
+            self.cfg.gpu_ids = range(1)
+        else:
+            if len(self.cfg.gpu_ids) != 0:
+                raise ValueError("length of cfg.gpu_ids should be 1 when training with single GPU.")
 
         # consider "cuda" and "cpu" device only
         if not torch.cuda.is_available():

--- a/otx/algorithms/common/adapters/mmcv/tasks/stage.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/stage.py
@@ -181,9 +181,8 @@ class Stage:
             self.cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
         elif "gpu_ids" not in self.cfg:
             self.cfg.gpu_ids = range(1)
-        else:
-            if len(self.cfg.gpu_ids) != 0:
-                raise ValueError("length of cfg.gpu_ids should be 1 when training with single GPU.")
+        elif len(self.cfg.gpu_ids) != 1:
+            raise ValueError("length of cfg.gpu_ids should be 1 when training with single GPU.")
 
         # consider "cuda" and "cpu" device only
         if not torch.cuda.is_available():

--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -19,9 +19,11 @@ import os
 import shutil
 import tempfile
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from typing import Any, Dict, Iterable, List, Optional
 
 import torch
+from torch import distributed as dist
 
 from otx.algorithms.common.adapters.mmcv.hooks import OTXLoggerHook
 from otx.algorithms.common.adapters.mmcv.hooks.cancel_hook import CancelInterfaceHook
@@ -97,11 +99,7 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
         self._labels = task_environment.get_labels(include_empty=False)
         self._work_dir_is_temp = False
         self._output_path = output_path
-        if self._output_path is None:
-            self._output_path = tempfile.mkdtemp(prefix="OTX-task-")
-            self._work_dir_is_temp = True
-        else:
-            os.makedirs(self._output_path, exist_ok=True)
+        self._output_path = output_path if output_path is not None else self._get_tmp_dir()
         self._time_monitor: Optional[TimeMonitorCallback] = None
         self.on_hook_initialized = OnHookInitialized(self)
         self._learning_curves = UncopiableDefaultDict(OTXLoggerHook.Curve)
@@ -119,6 +117,32 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
 
         # This is for hpo, and this should be removed
         self.project_path = self._output_path
+
+        if self._is_multi_gpu_training():
+            self._setup_multigpu_training()
+
+    @staticmethod
+    def _is_multi_gpu_training():
+        multi_gpu_env = ["MASTER_ADDR", "MASTER_PORT", "LOCAL_WORLD_SIZE", "WORLD_SIZE", "LOCAL_RANK", "RANK"]
+        for env in multi_gpu_env:
+            if env not in os.environ:
+                return False
+
+        return torch.cuda.is_available()
+
+    @staticmethod
+    def _setup_multigpu_training():
+        if not dist.is_initialized():
+            torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+            dist.init_process_group(backend="nccl", init_method="env://", timeout=timedelta(seconds=30))
+            logger.info(f"Dist info: rank {dist.get_rank()} / {dist.get_world_size()} world_size")
+
+    def _get_tmp_dir(self):
+        self._work_dir_is_temp = True
+        # If training is excuted with torchrun, set all trainings' output directory same
+        if "TORCHELASTIC_RUN_ID" in os.environ:
+            return os.path.join(tempfile.gettempdir(), f"OTX-task-torchelastic-{os.environ['TORCHELASTIC_RUN_ID']}")
+        return tempfile.mkdtemp(prefix="OTX-task-")
 
     def _load_model(self):
         """Loading model from checkpoint."""

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -133,7 +133,7 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
 
     @staticmethod
     def _is_multi_gpu_training():
-        return "LOCAL_RANK" in os.environ
+        return "LOCAL_RANK" in os.environ and torch.cuda.is_available()
 
     @staticmethod
     def _setup_multigpu_training():

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -130,7 +130,12 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
 
     @staticmethod
     def _is_multi_gpu_training():
-        return "LOCAL_RANK" in os.environ and torch.cuda.is_available()
+        multi_gpu_env = ["MASTER_ADDR", "MASTER_PORT", "LOCAL_WORLD_SIZE", "WORLD_SIZE", "LOCAL_RANK", "RANK"]
+        for env in multi_gpu_env:
+            if env not in os.environ:
+                return False
+
+        return torch.cuda.is_available()
 
     @staticmethod
     def _setup_multigpu_training():

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -143,8 +143,7 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
         self._work_dir_is_temp = True
         # If training is excuted with torchrun, set all trainings' output directory same
         if "TORCHELASTIC_RUN_ID" in os.environ:
-            return os.path.join(
-                tempfile.gettempdir(), f"OTX-task-torchelastic-{os.environ['TORCHELASTIC_RUN_ID']}")
+            return os.path.join(tempfile.gettempdir(), f"OTX-task-torchelastic-{os.environ['TORCHELASTIC_RUN_ID']}")
         return tempfile.mkdtemp(prefix="OTX-task-")
 
     def _run_task(self, stage_module, mode=None, dataset=None, **kwargs):

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -137,7 +137,7 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
         if not dist.is_initialized():
             torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
             dist.init_process_group(backend="nccl", init_method="env://", timeout=timedelta(seconds=30))
-            logger.info(f"dist info world_size = {dist.get_world_size()}, rank = {dist.get_rank()}")
+            logger.info(f"Dist info: rank {dist.get_rank()} / {dist.get_world_size()} world_size")
 
     def _get_tmp_dir(self):
         self._work_dir_is_temp = True

--- a/otx/algorithms/common/tasks/training_base.py
+++ b/otx/algorithms/common/tasks/training_base.py
@@ -90,7 +90,11 @@ class BaseTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload):
         self._anchors = {}  # type: Dict[str, int]
         self._work_dir_is_temp = False
         if output_path is None:
-            output_path = tempfile.mkdtemp(prefix="OTX-task-")
+            if "TORCHELASTIC_RUN_ID" in os.environ:
+                output_path = os.path.join(tempfile.gettempdir(),
+                                           f"OTX-task-torchelastic-{os.environ['TORCHELASTIC_RUN_ID ']}")
+            else:
+                output_path = tempfile.mkdtemp(prefix="OTX-task-")
             self._work_dir_is_temp = True
         self._output_path = output_path
         logger.info(f"created output path at {self._output_path}")

--- a/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -65,7 +65,7 @@ class DetectionConfigurer:
         logger.info(f"configure!: training={training}")
 
         self.configure_base(cfg, data_cfg, data_classes, model_classes)
-        self.configure_device(cfg)
+        self.configure_device(cfg, training)
         self.configure_model(cfg, ir_options)
         self.configure_ckpt(cfg, model_ckpt)
         self.configure_data(cfg, training, data_cfg)
@@ -540,13 +540,14 @@ class DetectionConfigurer:
                 if hook["type"] == opt_key:
                     update_hook(opt, custom_hooks, idx, hook)
 
-    def configure_device(self, cfg):
+    def configure_device(self, cfg, training):
         """Setting device for training and inference."""
         cfg.distributed = False
         if torch.distributed.is_initialized():
-            cfg.distributed = True
-            self.configure_distributed(cfg)
             cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
+            if training:
+                cfg.distributed = True
+                self.configure_distributed(cfg)
         elif "gpu_ids" not in cfg:
             gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
             logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")

--- a/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -545,7 +545,7 @@ class DetectionConfigurer:
         cfg.distributed = False
         if torch.distributed.is_initialized():
             cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
-            if training:
+            if training:  # TODO multi GPU is available only in training. Evaluation needs to be supported later.
                 cfg.distributed = True
                 self.configure_distributed(cfg)
         elif "gpu_ids" not in cfg:

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -215,7 +215,6 @@ def main():  # pylint: disable=too-many-branches, too-many-statements
         )
 
     (config_manager.output_path / "logs").mkdir(exist_ok=True, parents=True)
-    task = task_class(task_environment=environment, output_path=str(config_manager.output_path / "logs"))
 
     if args.gpus:
         multigpu_manager = MultiGPUManager(main, args.gpus, args.rdzv_endpoint, args.base_rank, args.world_size)
@@ -228,6 +227,8 @@ def main():  # pylint: disable=too-many-branches, too-many-statements
             multigpu_manager.setup_multi_gpu_train(
                 str(config_manager.output_path), hyper_parameters if args.enable_hpo else None
             )
+
+    task = task_class(task_environment=environment, output_path=str(config_manager.output_path / "logs"))
 
     output_model = ModelEntity(dataset, environment.get_model_configuration())
 

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -6,6 +6,7 @@
 
 import json
 import logging
+import os
 import re
 import shutil
 from copy import deepcopy
@@ -553,7 +554,11 @@ def run_hpo(
             "Currently supported task types are classification, detection, segmentation and anomaly"
             f"{task_type} is not supported yet."
         )
-        return None
+        return environment
+
+    if "TORCHELASTIC_RUN_ID" in os.environ:
+        logger.warning("OTX is train by torchrun. HPO isn't available.")
+        return environment
 
     hpo_save_path = (output / "hpo").absolute()
     hpo_runner = HpoRunner(

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -557,7 +557,7 @@ def run_hpo(
         return environment
 
     if "TORCHELASTIC_RUN_ID" in os.environ:
-        logger.warning("OTX is train by torchrun. HPO isn't available.")
+        logger.warning("OTX is trained by torchrun. HPO isn't available.")
         return environment
 
     hpo_save_path = (output / "hpo").absolute()

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -157,7 +157,11 @@ class MultiGPUManager:
             bool:
                 whether multi GPU training is available.
         """
-        return len(self._gpu_ids) > 1
+        return (
+            len(self._gpu_ids) > 1
+            and "TORCHELASTIC_RUN_ID"
+            not in os.environ  # If otx is executed by torchrun, then otx multi gpu interface is disabled.
+        )
 
     def setup_multi_gpu_train(
         self,

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -209,8 +209,6 @@ class MultiGPUManager:
         os.environ["WORLD_SIZE"] = str(world_size)
         os.environ["LOCAL_RANK"] = str(local_rank)
         os.environ["RANK"] = str(rank)
-        torch.cuda.set_device(gpu_ids[local_rank])
-        dist.init_process_group(backend="nccl", world_size=world_size, rank=rank)
         logger.info(f"dist info world_size = {dist.get_world_size()}, rank = {dist.get_rank()}")
 
     @staticmethod

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -19,10 +19,10 @@ import os
 import signal
 import socket
 import sys
-import tempfile
 import threading
 import time
 from contextlib import closing
+from tempfile import TemporaryDirectory
 from typing import Callable, List, Optional, Union
 
 import psutil
@@ -172,7 +172,7 @@ class MultiGPUManager:
                 If output_path is None, make a temporary directory and return it.
         """
         if output_path is None:
-            output_path = tempfile.mkdtemp(prefix="OTX-multi-gpu-")
+            output_path = TemporaryDirectory(prefix="OTX-multi-gpu-").name  # pylint: disable=R1732
 
         if optimized_hyper_parameters is not None:  # if HPO is executed, optimized HPs are applied to child processes
             self._set_optimized_hp_for_child_process(optimized_hyper_parameters)

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -280,7 +280,7 @@ class MultiGPUManager:
         # set CUDA_VISIBLE_DEVICES to make child process use proper GPU
         origin_cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
         if origin_cuda_visible_devices is not None:
-            cuda_visible_devices = origin_cuda_visible_devices.split(',')
+            cuda_visible_devices = origin_cuda_visible_devices.split(",")
         else:
             cuda_visible_devices = [str(i) for i in range(torch.cuda.device_count())]
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join([cuda_visible_devices[gpu_idx] for gpu_idx in self._gpu_ids])

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -14,6 +14,7 @@ from otx.api.entities.model_template import TaskType
 from otx.api.entities.subset import Subset
 from otx.api.entities.task_environment import TaskEnvironment
 from otx.cli.registry import find_and_parse_model_template
+from otx.cli.utils import hpo
 from otx.cli.utils.hpo import (
     HpoCallback,
     HpoDataset,
@@ -653,6 +654,23 @@ def test_run_hpo_not_supported_task(mocker, action_task_env):
     output = "fake"
 
     run_hpo(hpo_time_ratio, output, action_task_env, mocker.MagicMock(), mocker.MagicMock())
+    mock_hpo_runner_instance.run_hpo.assert_not_called()
+
+
+@e2e_pytest_unit
+def test_run_hpo_with_torchrun(mocker, mock_environment):
+    # prepare
+    output = "fake"
+    mock_hpo_runner_instance = mocker.MagicMock()
+    mock_hpo_runner_class = mocker.patch("otx.cli.utils.hpo.HpoRunner")
+    mock_hpo_runner_class.return_value = mock_hpo_runner_instance
+    hpo_time_ratio = "4"
+    mock_environment.model_template.task_type = TaskType.CLASSIFICATION
+    mock_os = mocker.patch.object(hpo, "os", return_value={"TORCHELASTIC_RUN_ID": "1234"})
+    mock_os.environ = {"TORCHELASTIC_RUN_ID": "1234"}
+
+    # run
+    run_hpo(hpo_time_ratio, output, mock_environment, mocker.MagicMock(), mocker.MagicMock())
     mock_hpo_runner_instance.run_hpo.assert_not_called()
 
 

--- a/tests/unit/cli/utils/test_multi_gpu.py
+++ b/tests/unit/cli/utils/test_multi_gpu.py
@@ -2,7 +2,6 @@ import os
 import socket
 from contextlib import closing
 from copy import deepcopy
-from pathlib import Path
 
 import pytest
 import torch

--- a/tests/unit/cli/utils/test_multi_gpu.py
+++ b/tests/unit/cli/utils/test_multi_gpu.py
@@ -207,6 +207,14 @@ class TestMultiGPUManager:
         assert not multigpu_manager.is_available()
 
     @e2e_pytest_unit
+    def test_is_unavailable_by_torchrun(self, mocker):
+        mock_os = mocker.patch.object(multi_gpu, "os")
+        mock_os.environ = {"TORCHELASTIC_RUN_ID": "1234"}
+        multigpu_manager = MultiGPUManager(mocker.MagicMock(), ",".join([str(i) for i in range(4)]), "localhost:0")
+
+        assert not multigpu_manager.is_available()
+
+    @e2e_pytest_unit
     def test_setup_multi_gpu_train(self, mocker):
         # prepare
         mock_initialize_multigpu_train = mocker.patch.object(MultiGPUManager, "initialize_multigpu_train")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
- Support multi GPU training using torchrun(torch.elastic)
- This is for Geti, so `--gpus` flag is used when using OTX cli.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
You can test by adding below line at the begging of command line.
`torchrun --standalone --nnodes=1 --nproc_per_node=2 --no_python`

For example,
`torchrun --standalone --nnodes=1 --nproc_per_node=2 --no_python otx train ...`

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [x] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
