### PR TITLE
Change num_iters for e2e object detection test

### DIFF
--- a/tests/e2e/cli/detection/test_detection.py
+++ b/tests/e2e/cli/detection/test_detection.py
@@ -43,7 +43,7 @@ args0 = {
     "--val-data-roots": "tests/assets/car_tree_bug",
     "--test-data-roots": "tests/assets/car_tree_bug",
     "--input": "tests/assets/car_tree_bug/images/train",
-    "train_params": ["params", "--learning_parameters.num_iters", "4", "--learning_parameters.batch_size", "4"],
+    "train_params": ["params", "--learning_parameters.num_iters", "5", "--learning_parameters.batch_size", "4"],
 }
 
 # Class-Incremental learning w/ 'vehicle', 'person', 'non-vehicle' classes
@@ -52,7 +52,7 @@ args = {
     "--val-data-roots": "tests/assets/car_tree_bug",
     "--test-data-roots": "tests/assets/car_tree_bug",
     "--input": "tests/assets/car_tree_bug/images/train",
-    "train_params": ["params", "--learning_parameters.num_iters", "2", "--learning_parameters.batch_size", "4"],
+    "train_params": ["params", "--learning_parameters.num_iters", "5", "--learning_parameters.batch_size", "4"],
 }
 
 args_semisl = {

--- a/tests/e2e/cli/detection/test_tiling_detection.py
+++ b/tests/e2e/cli/detection/test_tiling_detection.py
@@ -44,7 +44,7 @@ args = {
     "train_params": [
         "params",
         "--learning_parameters.num_iters",
-        "2",
+        "10",
         "--learning_parameters.batch_size",
         "4",
         "--tiling_parameters.enable_tiling",
@@ -58,7 +58,7 @@ args = {
 resume_params = [
     "params",
     "--learning_parameters.num_iters",
-    "4",
+    "15",
     "--learning_parameters.batch_size",
     "4",
 ]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR includes enlarging num_iters for e2e object detection test
Current ATSS model requires some iteration to return appropriate prediction. 
Therefore this PR enlarge overall number of iteration from 6(2 + 4) to 10(5 + 5). 
FYI, enlarging lr do not affect to performance of ATSS.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
E2E test results after incremental training
![image](https://user-images.githubusercontent.com/106788349/227842285-abdeae44-633d-48c7-89f3-55680ccef780.png)

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
