### PR TITLE
[Fix] Align input tensor for export with deployment.py

### DIFF
--- a/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
+++ b/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
@@ -93,9 +93,9 @@ class Exporter:
     def _get_inputs(self) -> Tuple[torch.Tensor, Optional[Dict[str, Any]]]:
         """Prepare torch model's input and input_metas."""
 
-        height, width = self.deploy_cfg.backend_config.model_inputs[0]["opt_shapes"]["input"][-2:]
+        clip_len, height, width = self.deploy_cfg.backend_config.model_inputs[0]["opt_shapes"]["input"][-3:]
         if isinstance(self.model, AVAFastRCNN):
-            input_tensor = torch.randn(1, 3, 32, height, width)
+            input_tensor = torch.randn(1, 3, clip_len, height, width)
             input_metas = {
                 "img_metas": [
                     [
@@ -109,7 +109,7 @@ class Exporter:
                 ]
             }
         else:
-            input_tensor = torch.randn(1, 1, 3, 32, height, width)
+            input_tensor = torch.randn(1, 1, 3, clip_len, height, width)
             input_metas = None
         return input_tensor, input_metas
 

--- a/otx/algorithms/action/configs/classification/base/base_classification_static.py
+++ b/otx/algorithms/action/configs/classification/base/base_classification_static.py
@@ -15,5 +15,5 @@ codebase_config = dict(type="mmaction", task="VideoRecognition")
 backend_config = dict(
     type="openvino",
     mo_options=dict(args=dict({"--source_layout": "?bctwh"})),
-    model_inputs=[dict(opt_shapes=dict(input=[1, 1, 3, 32, 224, 224]))],
+    model_inputs=[dict(opt_shapes=dict(input=[1, 1, 3, 8, 224, 224]))],
 )


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR is for aligning input tensor's dimension with deployment.py of model template.
Before this PR, the input tensor's clip length is always 32, but we use 8 frames for action classification, this PR brings clip length from deployment.py
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
Normal intg, e2e test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [ ] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
