### PR TITLE
Removed nncf_quantization_pruning part from efficientnet_v2 compression config

### DIFF
--- a/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/compression_config.json
+++ b/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/compression_config.json
@@ -31,45 +31,5 @@
       }
     }
   },
-  "nncf_quantization_pruning": {
-    "nncf": {
-      "coeff_decrease_lr_for_nncf": 1.0
-    },
-    "nncf_config": {
-      "compression": [
-        {
-          "algorithm": "filter_pruning",
-          "pruning_init": 0.1,
-          "params": {
-            "schedule": "baseline",
-            "pruning_flops_target": 0.1,
-            "filter_importance": "geometric_median",
-            "prune_downsample_convs": true
-          }
-        },
-        {
-          "algorithm": "quantization",
-          "preset": "mixed",
-          "initializer": {
-            "range": {
-              "num_init_samples": 8192
-            },
-            "batchnorm_adaptation": {
-              "num_bn_adaptation_samples": 8192
-            }
-          }
-        }
-      ],
-      "accuracy_aware_training": {
-        "mode": "adaptive_compression_level",
-        "params": {
-          "maximal_absolute_accuracy_degradation": 0.01,
-          "initial_training_phase_epochs": 100,
-          "patience_epochs": 100,
-          "maximal_total_epochs": 200
-        }
-      }
-    }
-  },
-  "order_of_parts": ["nncf_quantization", "nncf_quantization_pruning"]
+  "order_of_parts": ["nncf_quantization"]
 }

--- a/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/compression_config.json
+++ b/otx/algorithms/classification/configs/efficientnet_v2_s_cls_incr/compression_config.json
@@ -38,6 +38,16 @@
     "nncf_config": {
       "compression": [
         {
+          "algorithm": "filter_pruning",
+          "pruning_init": 0.1,
+          "params": {
+            "schedule": "baseline",
+            "pruning_flops_target": 0.1,
+            "filter_importance": "geometric_median",
+            "prune_downsample_convs": true
+          }
+        },
+        {
           "algorithm": "quantization",
           "preset": "mixed",
           "initializer": {


### PR DESCRIPTION
### Summary
Pruning is not supported for EfficientNet-v2 but NNCF, but config still contains `nncf_quantization_pruning` part. Removed `nncf_quantization_pruning` from compression config.


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md)
- [ ] I have updated the [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

### License

- [x] I submit _my code changes_ under the same [MIT License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2023 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
