### PR TITLE
Generate OTX cli_report.log in output folder (otx train only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
-- Add Generating feature cli_report.log in output for otx training (<https://github.com/openvinotoolkit/training_extensions/pull/1959>)
+- Add generating feature cli_report.log in output for otx training (<https://github.com/openvinotoolkit/training_extensions/pull/1959>)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
--
+- Add Generating feature cli_report.log in output for otx training (<https://github.com/openvinotoolkit/training_extensions/pull/1959>)
 
 ### Enhancements
 
--
+- Clean up and refactor the output of the OTX CLI (<https://github.com/openvinotoolkit/training_extensions/pull/1946>)
 
 ### Bug fixes
 

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -16,6 +16,8 @@
 
 # pylint: disable=too-many-locals
 
+import datetime
+import time
 from pathlib import Path
 
 from otx.api.entities.inference_parameters import InferenceParameters
@@ -38,6 +40,7 @@ from otx.cli.utils.parser import (
     add_hyper_parameters_sub_parser,
     get_parser_and_hprams_data,
 )
+from otx.cli.utils.report import get_otx_report
 from otx.core.data.adapter import get_dataset_adapter
 
 
@@ -154,11 +157,13 @@ def get_args():
     return parser.parse_args(), override_param
 
 
-def main():  # pylint: disable=too-many-branches
+def main():  # pylint: disable=too-many-branches, too-many-statements
     """Main function that is used for model training."""
+    start_time = time.time()
+    mode = "train"
     args, override_param = get_args()
 
-    config_manager = ConfigManager(args, workspace_root=args.workspace, mode="train")
+    config_manager = ConfigManager(args, workspace_root=args.workspace, mode=mode)
     # Auto-Configuration for model template
     config_manager.configure_template()
 
@@ -228,7 +233,8 @@ def main():  # pylint: disable=too-many-branches
 
     task.train(dataset, output_model, train_parameters=TrainParameters())
 
-    save_model_data(output_model, str(config_manager.output_path / "models"))
+    model_path = config_manager.output_path / "models"
+    save_model_data(output_model, str(model_path))
     # Latest model folder symbolic link to models
     latest_path = config_manager.workspace_root / "outputs" / "latest_trained_model"
     if latest_path.exists():
@@ -237,6 +243,7 @@ def main():  # pylint: disable=too-many-branches
         latest_path.parent.mkdir(exist_ok=True, parents=True)
     latest_path.symlink_to(config_manager.output_path.resolve())
 
+    performance = None
     if config_manager.data_config["val_subset"]["data_root"]:
         validation_dataset = dataset.get_subset(Subset.VALIDATION)
         predicted_validation_dataset = task.infer(
@@ -250,8 +257,23 @@ def main():  # pylint: disable=too-many-branches
             prediction_dataset=predicted_validation_dataset,
         )
         task.evaluate(resultset)
-        assert resultset.performance is not None
-        print(resultset.performance)
+        performance = resultset.performance
+        assert performance is not None
+        print(performance)
+
+    end_time = time.time()
+    sec = end_time - start_time
+    total_time = str(datetime.timedelta(seconds=sec))
+    print("otx train time elapsed: ", total_time)
+    model_results = {"time elapsed": total_time, "score": performance, "model_path": str(model_path.absolute())}
+    get_otx_report(
+        mode=mode,
+        model_template=config_manager.template,
+        task_config=task.config,
+        data_config=config_manager.data_config,
+        results=model_results,
+        output_path=config_manager.output_path / "cli_report.log",
+    )
 
     if args.gpus:
         multigpu_manager.finalize()

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -267,7 +267,6 @@ def main():  # pylint: disable=too-many-branches, too-many-statements
     print("otx train time elapsed: ", total_time)
     model_results = {"time elapsed": total_time, "score": performance, "model_path": str(model_path.absolute())}
     get_otx_report(
-        mode=mode,
         model_template=config_manager.template,
         task_config=task.config,
         data_config=config_manager.data_config,

--- a/otx/cli/utils/report.py
+++ b/otx/cli/utils/report.py
@@ -1,0 +1,124 @@
+"""Report Generating for OTX CLI."""
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+from pprint import pformat
+from typing import Any, Dict
+
+import torch
+
+import otx
+from otx.api.entities.model_template import ModelTemplate
+
+
+def get_otx_report(
+    mode: str,
+    model_template: ModelTemplate,
+    task_config: Dict[str, Any],
+    data_config: Dict[str, Dict[str, str]],
+    results: Dict[str, Any],
+    output_path: str,
+):
+    """Generate CLI reports."""
+    dash_line = "-" * 60 + "\n\n"
+    # Header
+    report_str = f"OTX {mode.upper()} Report\n"
+    report_str += dash_line
+    report_str += f"Current path: {Path.cwd()}\n"
+    report_str += f"sys.argv: {sys.argv}\n"
+    report_str += f"OTX: {otx.__version__}\n"
+    # 1. Machine Environment
+    report_str += sub_title_to_str("Running Environments")
+    report_str += env_info_to_str()
+
+    # 2. Task Information (Task, Train-type, Etc.)
+    if model_template and task_config:
+        report_str += sub_title_to_str("Template Information")
+        report_str += template_info_to_str(model_template)
+
+    # 3. Dataset Configuration
+    if data_config:
+        report_str += sub_title_to_str("Dataset Information")
+        report_str += data_config_to_str(data_config)
+
+    # 4. Configurations
+    report_str += sub_title_to_str("Configurations")
+    report_str += task_config_to_str(task_config)
+    # 5. Result Summary
+    report_str += sub_title_to_str("Results")
+    for key, value in results.items():
+        report_str += f"\t{key}: {pformat(value)}\n"
+
+    Path(output_path).write_text(report_str, encoding="UTF-8")
+
+
+def sub_title_to_str(title: str):
+    """Add sub title for report."""
+    dash_line = "-" * 60
+    report_str = ""
+    report_str += dash_line + "\n\n"
+    report_str += title + "\n\n"
+    report_str += dash_line + "\n"
+    return report_str
+
+
+def env_info_to_str():
+    """Get Environments."""
+    report_str = ""
+    env_info = {}
+    try:
+        from mmcv.utils.env import collect_env
+
+        env_info = collect_env()
+        if "PyTorch compiling details" in env_info:
+            env_info.pop("PyTorch compiling details")
+    except ModuleNotFoundError:
+        env_info["sys.platform"] = sys.platform
+        env_info["Python"] = sys.version.replace("\n", "")
+
+        cuda_available = torch.cuda.is_available()
+        env_info["CUDA available"] = cuda_available
+
+        if cuda_available:
+            devices = defaultdict(list)
+            for k in range(torch.cuda.device_count()):
+                devices[torch.cuda.get_device_name(k)].append(str(k))
+            for name, device_ids in devices.items():
+                env_info["GPU " + ",".join(device_ids)] = name
+        env_info["PyTorch"] = torch.__version__
+    for key, value in env_info.items():
+        report_str += f"\t{key}: {value}\n"
+    return report_str
+
+
+def template_info_to_str(model_template: ModelTemplate):
+    """Get Template information."""
+    report_str = ""
+    for key, value in model_template.__dict__.items():
+        report_str += f"\t{key}: {pformat(value)}\n"
+    return report_str
+
+
+def data_config_to_str(data_config: Dict[str, Dict[str, str]]):
+    """Get Dataset configuration."""
+    report_str = ""
+    for subset_key, subset_value in data_config.items():
+        report_str += f"{subset_key}:\n"
+        for key, value in subset_value.items():
+            report_str += f"\t{key}: {value}\n"
+    return report_str
+
+
+def task_config_to_str(task_config: Dict[str, Any]):
+    """Get Task configuration."""
+    report_str = ""
+    not_target = ["log_config"]
+    for target, value in task_config.items():
+        if target not in not_target:
+            report_str += target + ": "
+            model_str = pformat(value)
+            report_str += model_str + "\n"
+    return report_str

--- a/otx/cli/utils/report.py
+++ b/otx/cli/utils/report.py
@@ -15,7 +15,6 @@ from otx.api.entities.model_template import ModelTemplate
 
 
 def get_otx_report(
-    mode: str,
     model_template: ModelTemplate,
     task_config: Dict[str, Any],
     data_config: Dict[str, Dict[str, str]],
@@ -25,7 +24,7 @@ def get_otx_report(
     """Generate CLI reports."""
     dash_line = "-" * 60 + "\n\n"
     # Header
-    report_str = f"OTX {mode.upper()} Report\n"
+    report_str = get_otx_cli_ascii_banner()
     report_str += dash_line
     report_str += f"Current path: {Path.cwd()}\n"
     report_str += f"sys.argv: {sys.argv}\n"
@@ -122,3 +121,17 @@ def task_config_to_str(task_config: Dict[str, Any]):
             model_str = pformat(value)
             report_str += model_str + "\n"
     return report_str
+
+
+def get_otx_cli_ascii_banner():
+    """Get OTX ASCII banner."""
+    return """
+
+ ██████╗     ████████╗    ██╗  ██╗
+██╔═══██╗    ╚══██╔══╝    ╚██╗██╔╝
+██║   ██║       ██║        ╚███╔╝
+██║   ██║       ██║        ██╔██╗
+╚██████╔╝       ██║       ██╔╝ ██╗
+ ╚═════╝        ╚═╝       ╚═╝  ╚═╝
+
+"""

--- a/tests/unit/cli/tools/test_train.py
+++ b/tests/unit/cli/tools/test_train.py
@@ -121,6 +121,7 @@ def test_main(mocker, mock_args, mock_config_manager, mock_dataset_adapter, mock
     mocker.patch.object(target_package, "read_label_schema")
     mocker.patch.object(target_package, "read_binary")
     mocker.patch("otx.cli.tools.train.Path.symlink_to")
+    mocker.patch("otx.cli.tools.train.get_otx_report")
     mocker.patch.object(
         target_package,
         "run_hpo",

--- a/tests/unit/cli/utils/test_report.py
+++ b/tests/unit/cli/utils/test_report.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+from pprint import pformat
+
+from otx.api.entities.model_template import ModelTemplate
+from otx.cli.utils.report import (
+    data_config_to_str,
+    env_info_to_str,
+    get_otx_report,
+    sub_title_to_str,
+    task_config_to_str,
+    template_info_to_str,
+)
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class MockModelTemplate(ModelTemplate):
+    """Mock class for ModelTemplate."""
+
+    def __init__(self):
+        self.test1 = "abc"
+        self.test2 = "cba"
+
+
+@e2e_pytest_unit
+def test_sub_title_to_str():
+    expected = "-" * 60 + "\n\n" + "test" + "\n\n" + "-" * 60 + "\n"
+    result = sub_title_to_str("test")
+    assert expected == result
+
+
+@e2e_pytest_unit
+def test_env_info_to_str(mocker):
+    expected = "\tOTX: 1.2\n"
+    mocker.patch("mmcv.utils.env.collect_env", return_value={"OTX": "1.2"})
+    result = env_info_to_str()
+    assert expected == result
+
+
+@e2e_pytest_unit
+def test_template_info_to_str():
+    mock_template = MockModelTemplate()
+    expected = f"\ttest1: {pformat('abc')}\n" + f"\ttest2: {pformat('cba')}\n"
+    result = template_info_to_str(mock_template)
+    assert expected == result
+
+
+@e2e_pytest_unit
+def test_data_config_to_str():
+    data_config = {
+        "train_subset": {"data-roots": "aaa"},
+        "val_subset": {"data-roots": "aaa"},
+    }
+    expected = "train_subset:\n\tdata-roots: aaa\nval_subset:\n\tdata-roots: aaa\n"
+    result = data_config_to_str(data_config)
+    assert expected == result
+
+
+@e2e_pytest_unit
+def test_task_config_to_str():
+    task_config = {"a": "b", "b": "c"}
+    expected = "a: 'b'\nb: 'c'\n"
+    result = task_config_to_str(task_config)
+    assert expected == result
+
+
+@e2e_pytest_unit
+def test_get_otx_report(tmp_dir):
+    report_path = Path(tmp_dir) / "report.log"
+    model_template = MockModelTemplate()
+    task_config = {"a": "b", "b": "c"}
+    data_config = {
+        "train_subset": {"data-roots": "aaa"},
+        "val_subset": {"data-roots": "aaa"},
+    }
+    get_otx_report(
+        mode="train",
+        model_template=model_template,
+        task_config=task_config,
+        data_config=data_config,
+        results={"time": "0:01"},
+        output_path=str(report_path),
+    )
+    assert report_path.exists()

--- a/tests/unit/cli/utils/test_report.py
+++ b/tests/unit/cli/utils/test_report.py
@@ -73,7 +73,6 @@ def test_get_otx_report(tmp_dir):
         "val_subset": {"data-roots": "aaa"},
     }
     get_otx_report(
-        mode="train",
         model_template=model_template,
         task_config=task_config,
         data_config=data_config,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add the function to generate a report that bundles multiple summaries while dumping the config used by the task to otx train.
![image](https://user-images.githubusercontent.com/38045080/228793721-988e46b8-b917-4077-bc3d-22c55b5a0b65.png)

The contents of `cli_report.log` are shown below.
```

 ██████╗     ████████╗    ██╗  ██╗
██╔═══██╗    ╚══██╔══╝    ╚██╗██╔╝
██║   ██║       ██║        ╚███╔╝
██║   ██║       ██║        ██╔██╗
╚██████╔╝       ██║       ██╔╝ ██╗
 ╚═════╝        ╚═╝       ╚═╝  ╚═╝

------------------------------------------------------------

Current path: /home/harimkan/workspace/repo/otx-fork/otx-workspace-CLASSIFICATION
sys.argv: ['otx train']
OTX: 1.2.0rc0
------------------------------------------------------------

Running Environments

------------------------------------------------------------
	sys.platform: linux
	Python: 3.9.13 (main, Aug 25 2022, 23:26:10) [GCC 11.2.0]
	CUDA available: True
	GPU 0,1: NVIDIA GeForce RTX 3090
	CUDA_HOME: /usr/local/cuda
	NVCC: Cuda compilation tools, release 11.7, V11.7.64
	GCC: gcc (Ubuntu 9.5.0-1ubuntu1~22.04) 9.5.0
	PyTorch: 1.13.1+cu117
	TorchVision: 0.14.1+cu117
	OpenCV: 4.7.0
	MMCV: 1.7.0
	MMCV Compiler: GCC 9.3
	MMCV CUDA Compiler: 11.7
------------------------------------------------------------

Template Information

------------------------------------------------------------
	model_template_id: 'Custom_Image_Classification_EfficinetNet-B0'
	model_template_path: 'template.yaml'
	name: 'EfficientNet-B0'
	task_family: <TaskFamily.VISION: 1>
	task_type: CLASSIFICATION
	instantiation: <InstantiationType.CLASS: 2>
	summary: 'Class-Incremental Image Classification for EfficientNet-B0'
	framework: 'OTEClassification v1.2.3'
	max_nodes: 1
	application: None
	dependencies: []
	initial_weights: None
	training_targets: [<TargetDevice.GPU: 3>, <TargetDevice.CPU: 2>]
	inference_targets: []
	dataset_requirements: DatasetRequirements(classes=None)
	model_optimization_methods: []
	hyper_parameters: HyperParameterData(base_path='./configuration.yaml', parameter_overrides={'learning_parameters': {'batch_size': {'default_value': 64, 'auto_hpo_state': 'POSSIBLE'}, 'learning_rate': {'default_value': 0.0049, 'auto_hpo_state': 'POSSIBLE'}, 'learning_rate_warmup_iters': {'default_value': 0}, 'num_iters': {'default_value': 90}}, 'nncf_optimization': {'enable_quantization': {'default_value': True}, 'enable_pruning': {'default_value': False}, 'pruning_supported': {'default_value': True}, 'maximal_accuracy_degradation': {'default_value': 1.0}}, 'algo_backend': {'train_type': {'default_value': 'Incremental'}}})
	is_trainable: True
	capabilities: ['compute_representations']
	grpc_address: None
	entrypoints: EntryPoints(base='otx.algorithms.classification.tasks.ClassificationTrainTask', openvino='otx.algorithms.classification.tasks.ClassificationOpenVINOTask', nncf='otx.algorithms.classification.tasks.nncf.ClassificationNNCFTask')
	base_model_path: ''
	exportable_code_paths: ExportableCodePaths(default=None, openvino=None)
	task_type_sort_priority: -1
	gigaflops: 0.81
	size: 4.09
	hpo: None
------------------------------------------------------------

Dataset Information

------------------------------------------------------------
train_subset:
	data_root: /home/harimkan/workspace/datasets/cifar10/initial_data/train
val_subset:
	data_root: /home/harimkan/workspace/datasets/cifar10/initial_data/val
test_subset:
	data_root: /home/harimkan/workspace/datasets/cifar10/initial_data/test
------------------------------------------------------------

Configurations

------------------------------------------------------------
model: {'backbone': {'pretrained': True,
              'type': 'otx.OTXEfficientNet',
              'version': 'b0'},
 'head': {'in_channels': -1,
          'loss': {'loss_weight': 1.0, 'type': 'CrossEntropyLoss'},
          'num_classes': 1000,
          'topk': (1, 5),
          'type': 'CustomLinearClsHead'},
 'hierarchical': False,
 'multilabel': False,
 'neck': {'type': 'GlobalAveragePooling'},
 'pretrained': None,
 'task': 'classification',
 'type': 'SAMImageClassifier'}
dist_params: {'backend': 'nccl', 'linear_scale_lr': True}
cudnn_benchmark: True
seed: 5
deterministic: False
hparams: {'dummy': 0}
task_adapt: {'op': 'REPLACE', 'type': 'mpa'}
log_level: 'INFO'
optimizer: {'lr': 0.0049, 'momentum': 0.9, 'type': 'SGD', 'weight_decay': 0.0005}
optimizer_config: {'grad_clip': None, 'type': 'SAMOptimizerHook'}
runner: {'max_epochs': 90, 'type': 'EpochRunnerWithCancel'}
workflow: [('train', 1)]
lr_config: {'min_lr_ratio': 0.0001,
 'policy': 'CosineAnnealing',
 'warmup': None,
 'warmup_iters': 0}
evaluation: {'metric': ['accuracy', 'class_accuracy']}
load_from: None
resume_from: None
checkpoint_config: {'interval': 1, 'max_keep_ckpts': 1, 'type': 'CheckpointHookWithValResults'}
fp16: {'loss_scale': 512.0}
train_type: 'Incremental'
data: {'samples_per_gpu': 64,
 'test': {'domain': <Domain.CLASSIFICATION: 2>,
          'empty_label': None,
          'labels': None,
          'otx_dataset': None,
          'pipeline': [{'size': 224, 'type': 'Resize'},
                       {'mean': [123.675, 116.28, 103.53],
                        'std': [58.395, 57.12, 57.375],
                        'to_rgb': False,
                        'type': 'Normalize'},
                       {'keys': ['img'], 'type': 'ImageToTensor'},
                       {'keys': ['img'], 'type': 'Collect'}],
          'test_mode': True,
          'type': 'OTXClsDataset'},
 'test_dataloader': {},
 'train': {'domain': <Domain.CLASSIFICATION: 2>,
           'empty_label': None,
           'labels': None,
           'otx_dataset': None,
           'pipeline': [{'size': 224, 'type': 'Resize'},
                        {'direction': 'horizontal',
                         'flip_prob': 0.5,
                         'type': 'RandomFlip'},
                        {'config_str': 'augmix-m5-w3', 'type': 'AugMixAugment'},
                        {'angle': (-10, 10), 'p': 0.35, 'type': 'RandomRotate'},
                        {'keys': ['img'], 'type': 'PILImageToNDArray'},
                        {'mean': [123.675, 116.28, 103.53],
                         'std': [58.395, 57.12, 57.375],
                         'to_rgb': False,
                         'type': 'Normalize'},
                        {'keys': ['img'], 'type': 'ImageToTensor'},
                        {'keys': ['gt_label'], 'type': 'ToTensor'},
                        {'keys': ['img', 'gt_label'],
                         'meta_keys': {'filename',
                                       'flip',
                                       'flip_direction',
                                       'ignored_labels',
                                       'img_norm_cfg',
                                       'img_shape',
                                       'ori_filename',
                                       'ori_shape',
                                       'pad_shape',
                                       'scale_factor'},
                         'type': 'Collect'}],
           'type': 'OTXClsDataset'},
 'train_dataloader': {},
 'val': {'domain': <Domain.CLASSIFICATION: 2>,
         'empty_label': None,
         'labels': None,
         'otx_dataset': None,
         'pipeline': [{'size': 224, 'type': 'Resize'},
                      {'mean': [123.675, 116.28, 103.53],
                       'std': [58.395, 57.12, 57.375],
                       'to_rgb': False,
                       'type': 'Normalize'},
                      {'keys': ['img'], 'type': 'ImageToTensor'},
                      {'keys': ['img'], 'type': 'Collect'}],
         'test_mode': True,
         'type': 'OTXClsDataset'},
 'val_dataloader': {},
 'workers_per_gpu': 2}
early_stop_metric: 'accuracy'
early_stop: {'iteration_patience': 0, 'patience': 8, 'start': 3}
custom_hooks: [{'enable_adaptive_interval_hook': False,
  'enable_eval_before_run': True,
  'type': 'AdaptiveTrainSchedulingHook'},
 {'interval': 1,
  'iteration_patience': 0,
  'metric': 'accuracy',
  'patience': 8,
  'priority': 75,
  'start': 3,
  'type': 'LazyEarlyStoppingHook'},
 {'init_callback': 'otx.algorithms.common.tasks.training_base.OnHookInitialized',
  'type': 'CancelInterfaceHook'},
 {'priority': 71,
  'time_monitor': <otx.algorithms.common.utils.callback.TrainingProgressCallback object at 0x7f0c4488b4c0>,
  'type': 'OTXProgressHook',
  'verbose': True},
 {'priority': 'LOWEST', 'type': 'ForceTrainModeHook'},
 {'priority': 'VERY_LOW', 'type': 'MemCacheHook'}]
------------------------------------------------------------

Results

------------------------------------------------------------
	time elapsed: '0:00:13.886423'
	score: Performance(score: 0.7236842105263158, dashboard: (3 metric groups))
	model_path: '/home/harimkan/workspace/repo/otx-fork/otx-workspace-CLASSIFICATION/outputs/20230330_180006_train/models'

```

### How to test

```
(otx) otx train
# unit-test
(otx) pytest -s -v tests/unit/cli/utils/test_report.py
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
