### PR TITLE
Add legacy ssd-like IRs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
--
+- Fix backward compatibility with OpenVINO SSD-like detection models from OTE 0.5 (<https://github.com/openvinotoolkit/training_extensions/pull/1970>)
 
 ### Known issues
 

--- a/otx/algorithms/detection/adapters/openvino/model_wrappers/openvino_models.py
+++ b/otx/algorithms/detection/adapters/openvino/model_wrappers/openvino_models.py
@@ -129,7 +129,11 @@ class BatchBoxesLabelsParser:
             self.labels_layer = None
             self.default_label = default_label
 
-        self.bboxes_layer = self.find_layer_bboxes_output(layers)
+        try:
+            self.bboxes_layer = self.find_layer_bboxes_output(layers)
+        except ValueError:
+            self.bboxes_layer = find_layer_by_name("boxes", layers)
+
         self.input_size = input_size
 
     @staticmethod
@@ -146,7 +150,8 @@ class BatchBoxesLabelsParser:
         """Parse bboxes."""
         # FIXME: here, batch dim of IR must be 1
         bboxes = outputs[self.bboxes_layer]
-        bboxes = bboxes.squeeze(0)
+        if bboxes.shape[0] == 1:
+            bboxes = bboxes.squeeze(0)
         assert bboxes.ndim == 2
         scores = bboxes[:, 4]
         bboxes = bboxes[:, :4]
@@ -156,7 +161,8 @@ class BatchBoxesLabelsParser:
             labels = outputs[self.labels_layer]
         else:
             labels = np.full(len(bboxes), self.default_label, dtype=bboxes.dtype)
-        labels = labels.squeeze(0)
+        if labels.shape[0] == 1:
+            labels = labels.squeeze(0)
 
         detections = [Detection(*bbox, score, label) for label, score, bbox in zip(labels, scores, bboxes)]
         return detections


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

In old SSD-like IRs bbox and label layers have different shapes than in current implementation. Wrapper was fixes to support both IR formats.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
