### PR TITLE
Re enable multi GPU test cases

### DIFF
--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -23,6 +23,7 @@ from typing import List, Optional
 import numpy as np
 import torch
 
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 from otx.algorithms.classification.configs.base import ClassificationConfig
 from otx.algorithms.classification.utils import (
     get_cls_deploy_config,
@@ -438,6 +439,9 @@ class OTXClassificationTask(OTXTask, ABC):
 
     def save_model(self, output_model: ModelEntity):
         """Save best model weights in ClassificationTrainTask."""
+        if is_multigpu_child_process():
+            return
+
         logger.info("called save_model")
         buffer = io.BytesIO()
         hyperparams_str = ids_to_strings(cfg_helper.convert(self._hyperparams, dict, enum_to_str=True))

--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -23,7 +23,6 @@ from typing import List, Optional
 import numpy as np
 import torch
 
-from otx.cli.utils.multi_gpu import is_multigpu_child_process
 from otx.algorithms.classification.configs.base import ClassificationConfig
 from otx.algorithms.classification.utils import (
     get_cls_deploy_config,
@@ -78,6 +77,7 @@ from otx.api.usecases.evaluation.metrics_helper import MetricsHelper
 from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from otx.api.utils.dataset_utils import add_saliency_maps_to_dataset_item
 from otx.api.utils.labels_utils import get_empty_label
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 
 logger = get_logger()
 RECIPE_TRAIN_TYPE = {

--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -25,6 +25,7 @@ import pycocotools.mask as mask_util
 import torch
 from mmcv.utils import ConfigDict
 
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 from otx.algorithms.common.tasks.base_task import TRAIN_TYPE_DIR_PATH, OTXTask
 from otx.algorithms.common.utils.callback import (
     InferenceProgressCallback,
@@ -443,6 +444,9 @@ class OTXDetectionTask(OTXTask, ABC):
 
     def save_model(self, output_model: ModelEntity):
         """Save best model weights in DetectionTrainTask."""
+        if is_multigpu_child_process():
+            return
+
         logger.info("called save_model")
         buffer = io.BytesIO()
         hyperparams_str = ids_to_strings(cfg_helper.convert(self._hyperparams, dict, enum_to_str=True))

--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -25,7 +25,6 @@ import pycocotools.mask as mask_util
 import torch
 from mmcv.utils import ConfigDict
 
-from otx.cli.utils.multi_gpu import is_multigpu_child_process
 from otx.algorithms.common.tasks.base_task import TRAIN_TYPE_DIR_PATH, OTXTask
 from otx.algorithms.common.utils.callback import (
     InferenceProgressCallback,
@@ -65,6 +64,7 @@ from otx.api.serialization.label_mapper import label_schema_to_bytes
 from otx.api.usecases.evaluation.metrics_helper import MetricsHelper
 from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from otx.api.utils.dataset_utils import add_saliency_maps_to_dataset_item
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 
 logger = get_logger()
 

--- a/otx/algorithms/segmentation/adapters/mmseg/models/losses/detcon_loss.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/losses/detcon_loss.py
@@ -42,11 +42,11 @@ class DetConLoss(nn.Module):
 
     def get_distributed_tensors(self, target1, target2, batch_size, num_samples, num_features, device):
         """Grab tensors across replicas during distributed training."""
-        num_gpus = torch.cuda.device_count()
-        if num_gpus > 1 and torch.distributed.is_initialized() and self.use_replicator_loss:
+        if torch.distributed.is_initialized() and self.use_replicator_loss:
             # Grab tensor across replicas and expand first dimension
-            target1_large = [torch.zeros_like(target1) for _ in range(num_gpus)]
-            target2_large = [torch.zeros_like(target2) for _ in range(num_gpus)]
+            world_size = dist.get_world_size()
+            target1_large = [torch.zeros_like(target1) for _ in range(world_size)]
+            target2_large = [torch.zeros_like(target2) for _ in range(world_size)]
             dist.all_gather(target1_large, target1)
             dist.all_gather(target2_large, target2)
             target1_large = torch.cat(target1_large, dim=0)

--- a/otx/algorithms/segmentation/adapters/mmseg/models/losses/detcon_loss.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/models/losses/detcon_loss.py
@@ -42,7 +42,7 @@ class DetConLoss(nn.Module):
 
     def get_distributed_tensors(self, target1, target2, batch_size, num_samples, num_features, device):
         """Grab tensors across replicas during distributed training."""
-        if torch.distributed.is_initialized() and self.use_replicator_loss:
+        if dist.is_initialized() and self.use_replicator_loss:
             # Grab tensor across replicas and expand first dimension
             world_size = dist.get_world_size()
             target1_large = [torch.zeros_like(target1) for _ in range(world_size)]

--- a/otx/algorithms/segmentation/task.py
+++ b/otx/algorithms/segmentation/task.py
@@ -67,6 +67,7 @@ from otx.api.utils.segmentation_utils import (
     create_annotation_from_segmentation_map,
     create_hard_prediction_from_soft_prediction,
 )
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 
 logger = get_logger()
 RECIPE_TRAIN_TYPE = {
@@ -293,6 +294,9 @@ class OTXSegmentationTask(OTXTask, ABC):
 
     def save_model(self, output_model: ModelEntity):
         """Save best model weights in SegmentationTrainTask."""
+
+        if is_multigpu_child_process():
+            return
         logger.info("called save_model")
         buffer = io.BytesIO()
         hyperparams_str = ids_to_strings(cfg_helper.convert(self._hyperparams, dict, enum_to_str=True))

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -294,6 +294,8 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
 
     if not is_multigpu_child_process():
         task.cleanup()
+    elif args.gpus and exit_stack is None:
+        multigpu_manager.finalize()
 
     return dict(retcode=0, template=template.name)
 

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -162,7 +162,7 @@ def get_args():
 def main():
     """Main function that invoke train function with ExitStack."""
     with ExitStack() as exit_stack:
-        train(exit_stack)
+        return train(exit_stack)
 
 
 def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-branches, too-many-statements

--- a/otx/cli/utils/hpo.py
+++ b/otx/cli/utils/hpo.py
@@ -447,12 +447,12 @@ class HpoRunner:
                 self._fixed_hp[batch_size_name] = self._train_dataset_size
                 self._environment.set_hyper_parameter_using_str_key(self._fixed_hp)
 
-    def run_hpo(self, train_func: Callable, data_roots: Dict[str, str]) -> Dict[str, Any]:
+    def run_hpo(self, train_func: Callable, data_roots: Dict[str, Dict]) -> Dict[str, Any]:
         """Run HPO and provides optimized hyper parameters.
 
         Args:
             train_func (Callable): training model function
-            data_roots (Dict[str, str]): dataset path of each dataset type
+            data_roots (Dict[str, Dict]): dataset path of each dataset type
 
         Returns:
             Dict[str, Any]: optimized hyper parameters
@@ -537,7 +537,7 @@ class HpoRunner:
 
 
 def run_hpo(
-    hpo_time_ratio: int, output: Path, environment: TaskEnvironment, dataset: DatasetEntity, data_roots: Dict[str, str]
+    hpo_time_ratio: int, output: Path, environment: TaskEnvironment, dataset: DatasetEntity, data_roots: Dict[str, Dict]
 ) -> Optional[TaskEnvironment]:
     """Run HPO and load optimized hyper parameter and best HPO model weight.
 
@@ -546,7 +546,7 @@ def run_hpo(
         output(Path): directory where HPO output is saved
         environment (TaskEnvironment): otx task environment
         dataset (DatasetEntity): dataset to use for training
-        data_roots (Dict[str, str]): dataset path of each dataset type
+        data_roots (Dict[str, Dict]): dataset path of each dataset type
     """
     task_type = environment.model_template.task_type
     if not _check_hpo_enabled_task(task_type):
@@ -632,7 +632,7 @@ class Trainer:
         hp_config (Dict[str, Any]): hyper parameter to use on training
         report_func (Callable): function to report score
         model_template: model template
-        data_roots (Dict[str, str]): dataset path of each dataset type
+        data_roots (Dict[str, Dict]): dataset path of each dataset type
         task_type (TaskType): OTX task type
         hpo_workdir (Union[str, Path]): work directory for HPO
         initial_weight_name (str): initial model weight name for each trials to load
@@ -646,7 +646,7 @@ class Trainer:
         hp_config: Dict[str, Any],
         report_func: Callable,
         model_template,
-        data_roots: Dict[str, str],
+        data_roots: Dict[str, Dict],
         task_type: TaskType,
         hpo_workdir: Union[str, Path],
         initial_weight_name: str,
@@ -772,7 +772,7 @@ def run_trial(
     hp_config: Dict[str, Any],
     report_func: Callable,
     model_template,
-    data_roots: Dict[str, str],
+    data_roots: Dict[str, Dict],
     task_type: TaskType,
     hpo_workdir: Union[str, Path],
     initial_weight_name: str,
@@ -784,7 +784,7 @@ def run_trial(
         hp_config (Dict[str, Any]): hyper parameter to use on training
         report_func (Callable): function to report score
         model_template: model template
-        data_roots (Dict[str, str]): dataset path of each dataset type
+        data_roots (Dict[str, Dict]): dataset path of each dataset type
         task_type (TaskType): OTX task type
         hpo_workdir (Union[str, Path]): work directory for HPO
         initial_weight_name (str): initial model weight name for each trials to load

--- a/otx/cli/utils/report.py
+++ b/otx/cli/utils/report.py
@@ -6,7 +6,7 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 from pprint import pformat
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import torch
 
@@ -19,7 +19,7 @@ def get_otx_report(
     task_config: Dict[str, Any],
     data_config: Dict[str, Dict[str, str]],
     results: Dict[str, Any],
-    output_path: str,
+    output_path: Union[str, Path],
 ):
     """Generate CLI reports."""
     dash_line = "-" * 60 + "\n\n"

--- a/tests/e2e/cli/classification/test_classification.py
+++ b/tests/e2e/cli/classification/test_classification.py
@@ -288,7 +288,6 @@ class TestToolsMultiClassClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -317,7 +316,6 @@ class TestToolsMultiClassSemiSLClassification:
         otx_eval_testing(template, tmp_dir_path, otx_dir, args0)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -533,7 +531,6 @@ class TestToolsMultilabelClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -723,7 +720,6 @@ class TestToolsHierarchicalClassification:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_pot_validate_fq(self, template, tmp_dir_path):
@@ -778,7 +774,6 @@ class TestToolsSelfSLClassification:
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/detection/test_detection.py
+++ b/tests/e2e/cli/detection/test_detection.py
@@ -310,7 +310,6 @@ class TestToolsMPADetection:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -336,7 +335,6 @@ class TestToolsMPASemiSLDetection:
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/detection/test_instance_segmentation.py
+++ b/tests/e2e/cli/detection/test_instance_segmentation.py
@@ -268,7 +268,6 @@ class TestToolsMPAInstanceSegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/segmentation/test_segmentation.py
+++ b/tests/e2e/cli/segmentation/test_segmentation.py
@@ -256,7 +256,6 @@ class TestToolsMPASegmentation:
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -299,7 +298,6 @@ class TestToolsMPASemiSLSegmentation:
         otx_eval_testing(template, tmp_dir_path, otx_dir, args_semisl)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
@@ -345,7 +343,6 @@ class TestToolsMPASelfSLSegmentation:
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -206,7 +206,6 @@ class TestMultiClassClassificationCLI:
         nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_multi_gpu_train(self, template, tmp_dir_path):

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -224,7 +224,6 @@ class TestMultiClassClassificationCLI:
         otx_train_testing(template, tmp_dir_path, otx_dir, args_semisl)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_multi_gpu_train_semisl(self, template, tmp_dir_path):
@@ -242,7 +241,6 @@ class TestMultiClassClassificationCLI:
         otx_train_testing(template, tmp_dir_path, otx_dir, args_selfsl)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_multi_gpu_train_selfsl(self, template, tmp_dir_path):

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -187,7 +187,6 @@ class TestDetectionCLI:
         nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_multi_gpu_train(self, template, tmp_dir_path):

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -202,7 +202,6 @@ class TestDetectionCLI:
         otx_train_testing(template, tmp_dir_path, otx_dir, args_semisl)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_multi_gpu_train_semisl(self, template, tmp_dir_path):

--- a/tests/integration/cli/detection/test_instance_segmentation.py
+++ b/tests/integration/cli/detection/test_instance_segmentation.py
@@ -143,7 +143,6 @@ class TestInstanceSegmentationCLI:
         nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_multi_gpu_train(self, template, tmp_dir_path):

--- a/tests/integration/cli/segmentation/test_segmentation.py
+++ b/tests/integration/cli/segmentation/test_segmentation.py
@@ -171,7 +171,6 @@ class TestSegmentationCLI:
         nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_multi_gpu_train(self, template, tmp_dir_path):
@@ -202,7 +201,6 @@ class TestSegmentationCLI:
         otx_train_testing(template, tmp_dir_path, otx_dir, args_selfsl)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_multi_gpu_train_selfsl(self, template, tmp_dir_path):

--- a/tests/integration/cli/segmentation/test_segmentation.py
+++ b/tests/integration/cli/segmentation/test_segmentation.py
@@ -187,7 +187,6 @@ class TestSegmentationCLI:
         otx_train_testing(template, tmp_dir_path, otx_dir, args_semisl)
 
     @e2e_pytest_component
-    @pytest.mark.skip(reason="CVS-101246 Multi-GPU tests are stuck while CI is running")
     @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_multi_gpu_train_semisl(self, template, tmp_dir_path):

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/test_detcon_loss.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/models/losses/test_detcon_loss.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from otx.algorithms.segmentation.adapters.mmseg.models.losses import detcon_loss as detcon_loss_file
 from otx.algorithms.segmentation.adapters.mmseg.models.losses.detcon_loss import (
     DetConLoss,
     manual_cross_entropy,
@@ -54,7 +55,7 @@ def test_manual_cross_entropy(logits, labels, weight, expected):
     ],
 )
 def test_detcon_loss(mocker, inputs, expected):
-    mocker.patch("torch.cuda.device_count", return_value=0)
+    mocker.patch.object(detcon_loss_file, "dist").is_initialized.return_value = False
     detcon_loss = DetConLoss()
 
     loss = detcon_loss(**inputs)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR includes:

- re-enable multi GPU test cases
- fix a minor bug of multi GPU test cases
- Handling a getting stuck when main process raises an error

**What is fixed bug about?**
After training is done, both rank 0 processes and other processes try to save a model weight using saved model weight by mmXX framework.
Because only rank 0 process can save a model weight every epoch in mmXX framework,
If other processes try to save a model weight after training before rank 0 process doesn't save a model weight yet, error is raised.
Fortunately, left steps after training can be executed by each process independently, it's not huge problem.
But I fixed the bug to remove unnecessary error log.

**Why existing main function in cli/train.py is wrapped?**
It's for handling a getting stuck when main process raises an error. Current implementation deals with case that main process 
accidently exit, by making child process kill itself when it's observed.
But, when main process with child processes raises an error, main process doesn't exit for waiting all child processes done.
For this reason, child process can't know main process runs normally or waits itself after raising an error.
To resolve this issue, only way I can found is registering callback function to raising error using `ExitStack`.
Because `ExitStack` only can be used with `with`, I wrapped the current main function.
If you have any other better idea about this, please let me know. I'll check it :) 

**pre-merge test result**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/92974184/230297148-24488827-9ee9-451e-b564-3193bd6a65aa.png">
<img width="563" alt="image" src="https://user-images.githubusercontent.com/92974184/230297304-342f34e7-0fc4-4046-98fd-8f43a23c041d.png">
I ran enabled tests and all tests are passed.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
pytest -ra --showlocals tests/integration/cli -k "multi_gpu_train"
pytest -ra --showlocals tests/e2e/cli -k "multi_gpu_train"

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
