### PR TITLE
Split Unittest job for multiple python version

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -35,17 +35,27 @@ jobs:
     runs-on: [self-hosted, linux, x64, dev]
     needs: Code-Quality-Checks
     timeout-minutes: 120
+    strategy:
+      matrix:
+        include:
+          - python-version: "3.8"
+            tox-env: "py38"
+          - python-version: "3.9"
+            tox-env: "py39"
+          - python-version: "3.10"
+            tox-env: "py310"
+    name: Unit-Test-with-Python${{ matrix.python-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Run unit test
-        run: tox -e pre-merge-all-py310 -- tests/unit
+        run: tox -e pre-merge-${{ matrix.tox-env }} -- tests/unit
       - name: Upload coverage reports to Codecov
         run: |
           # If the workflow is triggered from PR then it gets the commit id from the PR.
@@ -63,7 +73,7 @@ jobs:
           # so we use the latest version of codecov uploader binary
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+          ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml -F ${{ matrix.tox-env }}
   Pre-Merge-Integration-Common-Test:
     runs-on: [self-hosted, linux, x64, dev]
     needs: Pre-Merge-Unit-Test

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 isolated_build = true
 skip_missing_interpreters = true
 
-
 [testenv]
 passenv =
     ftp_proxy
@@ -50,7 +49,7 @@ commands =
     pre-commit run --all-files
 
 
-[testenv:pre-merge-{all,ano,cls,det,seg,act}-py{38,39,310}]
+[testenv:pre-merge-{all,ano,cls,det,seg,act}-{py38,py39,py310}]
 deps =
     {[testenv]deps}
     -r{toxinidir}/requirements/dev.txt
@@ -70,9 +69,11 @@ skip_install = true
 commands =
     pre-commit run --all-files
 
-[testenv:pre-merge]
+[testenv:pre-merge-{py38,py39,py310}]
 deps =
-    {[testenv:pre-merge-all-py310]deps}
+    py38: {[testenv:pre-merge-all-py38]deps}
+    py39: {[testenv:pre-merge-all-py39]deps}
+    py310: {[testenv:pre-merge-all-py310]deps}
 use_develop = true
 commands =
     coverage erase


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Added metric of multiple python version to the unittest job in the pre-merge pipeline.
On this PR, 3.8, 3.9, and 3.10 are configured.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
