### PR TITLE
Fix wrap() for missing positional argument problem in Geti

### DIFF
--- a/otx/api/entities/dataset_item.py
+++ b/otx/api/entities/dataset_item.py
@@ -7,6 +7,7 @@
 
 import abc
 import copy
+from inspect import signature
 import itertools
 import logging
 from threading import Lock
@@ -493,14 +494,14 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
 
     def wrap(self: T, **kwargs) -> T:
         """Creates a new DatasetItemEntity, overriding only the given arguments to the existing ones for this instance."""
-        return self.__class__(
-            media=kwargs.get("media", self.media),
-            annotation_scene=kwargs.get("annotation_scene", self.annotation_scene),
-            roi=kwargs.get("roi", self.roi),
-            metadata=kwargs.get("metadata", self.get_metadata()),
-            subset=kwargs.get("subset", self.subset),
-            ignored_labels=kwargs.get("ignored_labels", self.ignored_labels),
-        )
+        params = {
+            name: getattr(self, name)
+            for name in signature(self.__class__.__init__).parameters.keys()
+            if hasattr(self, name)
+        }
+        params.update(**kwargs)
+
+        return self.__class__(**params)
 
 
 # TODO: This should be removed in the near future and DatasetItemEntity should have id_ field.
@@ -538,15 +539,3 @@ class DatasetItemEntityWithID(DatasetItemEntity):
 
     def __eq__(self, other):
         return super().__eq__(other) and self.id_ == other.id_
-
-    def wrap(self, **kwargs) -> "DatasetItemEntityWithID":
-        """Creates a new DatasetItemEntityWithID, overriding only the given arguments to the existing ones for this instance."""
-        return self.__class__(
-            media=kwargs.get("media", self.media),
-            annotation_scene=kwargs.get("annotation_scene", self.annotation_scene),
-            roi=kwargs.get("roi", self.roi),
-            metadata=kwargs.get("metadata", self.get_metadata()),
-            subset=kwargs.get("subset", self.subset),
-            ignored_labels=kwargs.get("ignored_labels", self.ignored_labels),
-            id_=kwargs.get("id_", self.id_),
-        )

--- a/otx/api/entities/dataset_item.py
+++ b/otx/api/entities/dataset_item.py
@@ -499,6 +499,7 @@ class DatasetItemEntity(metaclass=abc.ABCMeta):
             for name in signature(self.__class__.__init__).parameters.keys()
             if hasattr(self, name)
         }
+        params.update({"metadata": self.get_metadata()})
         params.update(**kwargs)
 
         return self.__class__(**params)

--- a/tests/unit/api/entities/test_dataset_item.py
+++ b/tests/unit/api/entities/test_dataset_item.py
@@ -982,3 +982,9 @@ class TestDatasetItemEntity:
         assert item.subset != new_subset
         new_item = item.wrap(subset=new_subset)
         assert new_item.subset == new_subset
+
+        if hasattr(item, "id_"):
+            new_id = ID("new_id")
+            assert item.id_ != new_id
+            item.id_ = new_id
+            assert item.id_ == new_id

--- a/tests/unit/api/entities/test_dataset_item.py
+++ b/tests/unit/api/entities/test_dataset_item.py
@@ -971,20 +971,24 @@ class TestDatasetItemEntity:
     def test_wrap(self, func_name):
         constructor = DatasetItemParameters()
         func = getattr(constructor, func_name)
-        item = func()
+        item: DatasetItemEntity = func()
 
         new_media = DatasetItemParameters().generate_random_image()
         assert item.media != new_media
-        new_item = item.wrap(media=new_media)
-        assert new_item.media == new_media
 
         new_subset = Subset.PSEUDOLABELED
         assert item.subset != new_subset
-        new_item = item.wrap(subset=new_subset)
+
+        new_metadata = DatasetItemParameters().metadata()
+        assert item.get_metadata() != new_metadata
+
+        new_item = item.wrap(media=new_media, subset=new_subset, metadata=new_metadata)
+        assert new_item.media == new_media
         assert new_item.subset == new_subset
+        assert new_item.get_metadata() == new_metadata
 
         if hasattr(item, "id_"):
             new_id = ID("new_id")
             assert item.id_ != new_id
-            item.id_ = new_id
+            item = item.wrap(id_=new_id)
             assert item.id_ == new_id


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
 - This patch passes Geti api_on_merge_request: 
1. http://validationreports.sclab.intel.com:8004/reports/build_number_report?test_session_build_number=IMPTOps-59349&environment=mclx77
2. https://ci.iotg.sclab.intel.com/job/IMPT/job/IMPTOps/59349/

### How to test
I added a unit test for this change

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
