### PR TITLE
Move the import checks from otx __init__.py to each algorithm

### DIFF
--- a/otx/__init__.py
+++ b/otx/__init__.py
@@ -5,28 +5,3 @@
 
 __version__ = "1.2.0rc0"
 # NOTE: Sync w/ otx/api/usecases/exportable_code/demo/requirements.txt on release
-
-MMCLS_AVAILABLE = True
-MMDET_AVAILABLE = True
-MMSEG_AVAILABLE = True
-MMACTION_AVAILABLE = True
-
-try:
-    import mmcls  # noqa: F401
-except ImportError:
-    MMCLS_AVAILABLE = False
-
-try:
-    import mmdet  # noqa: F401
-except ImportError:
-    MMDET_AVAILABLE = False
-
-try:
-    import mmseg  # noqa: F401
-except ImportError:
-    MMSEG_AVAILABLE = False
-
-try:
-    import mmaction  # noqa: F401
-except ImportError:
-    MMACTION_AVAILABLE = False

--- a/otx/algorithms/action/__init__.py
+++ b/otx/algorithms/action/__init__.py
@@ -6,3 +6,10 @@
 import os
 
 os.environ["FEATURE_FLAGS_OTX_ACTION_TASKS"] = "1"
+
+MMACTION_AVAILABLE = True
+
+try:
+    import mmaction  # noqa: F401
+except ImportError:
+    MMACTION_AVAILABLE = False

--- a/otx/algorithms/classification/__init__.py
+++ b/otx/algorithms/classification/__init__.py
@@ -14,12 +14,9 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-# The import required to register the backbone used by the OTX Template with the Registry.
-import otx.algorithms.common.adapters.mmcv.models as OTXBackbones
+MMCLS_AVAILABLE = True
 
-from .task import OTXClassificationTask
-
-__all__ = [
-    "OTXBackbones",
-    "OTXClassificationTask",
-]
+try:
+    import mmcls  # noqa: F401
+except ImportError:
+    MMCLS_AVAILABLE = False

--- a/otx/algorithms/classification/adapters/mmcls/__init__.py
+++ b/otx/algorithms/classification/adapters/mmcls/__init__.py
@@ -15,6 +15,9 @@
 # and limitations under the License.
 
 
+# The import required to register the backbone used by the OTX Template with the Registry.
+import otx.algorithms.common.adapters.mmcv.models as OTXBackbones
+
 from .datasets import OTXClsDataset, SelfSLDataset
 from .models import BYOL, ConstrastiveHead, SelfSLMLP
 from .optimizer import LARS
@@ -28,11 +31,4 @@ get_root_logger().propagate = False
 # isort:on
 # fmt: on
 
-__all__ = [
-    "OTXClsDataset",
-    "SelfSLDataset",
-    "BYOL",
-    "SelfSLMLP",
-    "ConstrastiveHead",
-    "LARS",
-]
+__all__ = ["OTXClsDataset", "SelfSLDataset", "BYOL", "SelfSLMLP", "ConstrastiveHead", "LARS", "OTXBackbones"]

--- a/otx/algorithms/common/adapters/mmcv/hooks/recording_forward_hook.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks/recording_forward_hook.py
@@ -20,7 +20,7 @@ from typing import List, Sequence, Union
 
 import torch
 
-from otx import MMCLS_AVAILABLE
+from otx.algorithms.classification import MMCLS_AVAILABLE
 
 if MMCLS_AVAILABLE:
     from mmcls.models.necks.gap import GlobalAveragePooling

--- a/otx/algorithms/detection/__init__.py
+++ b/otx/algorithms/detection/__init__.py
@@ -2,3 +2,10 @@
 
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
+MMDET_AVAILABLE = True
+
+try:
+    import mmdet  # noqa: F401
+except ImportError:
+    MMDET_AVAILABLE = False

--- a/otx/algorithms/segmentation/__init__.py
+++ b/otx/algorithms/segmentation/__init__.py
@@ -3,6 +3,9 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from .task import OTXSegmentationTask
+MMSEG_AVAILABLE = True
 
-__all__ = ["OTXSegmentationTask"]
+try:
+    import mmseg  # noqa: F401
+except ImportError:
+    MMSEG_AVAILABLE = False

--- a/otx/cli/__init__.py
+++ b/otx/cli/__init__.py
@@ -5,7 +5,7 @@
 
 import os
 
-from otx import MMACTION_AVAILABLE
-
-if MMACTION_AVAILABLE:
-    os.environ["FEATURE_FLAGS_OTX_ACTION_TASKS"] = "1"
+# How to make an Action Template invisible in Geti
+# Check FEATURE_FLAGS_OTX_ACTION_TASKS in the API to determine whether to use the Action
+# Always 1 in the OTX CLI
+os.environ["FEATURE_FLAGS_OTX_ACTION_TASKS"] = "1"


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Identified an unnecessary import when running the OTX CLI and fixed it.
![image](https://user-images.githubusercontent.com/38045080/231637134-84d918ad-a208-441e-a2a5-995ea641489b.png)


### How to test

Compare 'otx train -h' before and after PR

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
