### PR TITLE
Disable ignore mode in CLI

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -510,6 +510,11 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
                     )
 
                     config = MPAConfig.fromfile(str(target_dir / file_name))
+                    # FIXME: In the CLI, there is currently no case for using the ignore label.
+                    # so the workspace's model patches ignore to False.
+                    if config.get("ignore", None):
+                        config.ignore = False
+                        print("In the CLI, Update ignore to false in model configuration.")
                     config.dump(str(dest_dir / file_name))
                 except Exception as exc:
                     raise CliException(f"{self.task_type} requires mmcv-full to be installed.") from exc


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Confirmed unintended loss patching in Instance-segmentation: Mask-RCNN was unintentionally using `FocalLoss` even without the ignore label. (This should use the original `CrossEntropyLoss`.)
![image](https://user-images.githubusercontent.com/38045080/231946062-1bc9735f-3505-4830-b8c7-c61f8676800b.png)

In the CLI, there is currently no case where ignore label comes in, so we agreed to patch ignore to False in the CLI first.
This should be fixed in the future when ignore label is available in the OTX CLI. (This does not affect Geti or the api, as the actual template still uses ignore=True.)

### How to test

`otx build --task instance_segmentation`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
