### PR TITLE
HOT-FIX: Revert segmentation model's ignore mode in CLI (Develop)

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -512,7 +512,8 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
                     config = MPAConfig.fromfile(str(target_dir / file_name))
                     # FIXME: In the CLI, there is currently no case for using the ignore label.
                     # so the workspace's model patches ignore to False.
-                    if config.get("ignore", None):
+                    # FIXME: Segmentation -> ignore=True
+                    if config.get("ignore", None) and str(self.task_type).upper() not in ("SEGMENTATION"):
                         config.ignore = False
                         print("In the CLI, Update ignore to false in model configuration.")
                     config.dump(str(dest_dir / file_name))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Same with https://github.com/openvinotoolkit/training_extensions/pull/2011
Revert Segmentation ignore mode (there are issues in segmentation now)

![image](https://user-images.githubusercontent.com/38045080/231972827-22dd2dd9-cdc7-46d4-8145-711ca2ee451d.png)


### How to test

`pytest -s -v tests/integration/cli/semantic_segmentation/test_segmentation.py`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
