### PR TITLE
Fix issue that str2bool not being applied in certain cases

### DIFF
--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -146,8 +146,8 @@ def gen_params_dict_from_args(
         # FIXME[HARIM]: There's no template in args, and it's not inside the workspace, but with --workspace,
         # the template is not found in args, so params, which are all bools, go into str.
         # This is a temporary solution.
-        elif value_type is None and isinstance(value, str) and value in ("True", "true", "False", "false"):
-            value_type = bool
+        if isinstance(value, str) and value.lower() in ("true", "false", "1", "0"):
+            value_type = str2bool
 
         leaf_node_dict, node_key = _get_leaf_node(params_dict, origin_key)
         leaf_node_dict[node_key] = {"value": value_type(value) if value_type else value}

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -143,6 +143,11 @@ def gen_params_dict_from_args(
         value_type = None
         if type_hint is not None:
             value_type = type_hint.get(origin_key, {}).get("type", None)
+        # FIXME[HARIM]: There's no template in args, and it's not inside the workspace, but with --workspace,
+        # the template is not found in args, so params, which are all bools, go into str.
+        # This is a temporary solution.
+        elif value_type is None and isinstance(value, str) and value in ("True", "true", "False", "false"):
+            value_type = bool
 
         leaf_node_dict, node_key = _get_leaf_node(params_dict, origin_key)
         leaf_node_dict[node_key] = {"value": value_type(value) if value_type else value}
@@ -249,6 +254,8 @@ def get_parser_and_hprams_data():
         template_config = parse_model_template("./template.yaml")
         hyper_parameters = template_config.hyper_parameters.data
         parser.add_argument("template", nargs="?", default="./template.yaml", help=template_help_str)
+    # TODO: Need fix for how to get hyper_parameters when no template is given and ./template.yaml doesn't exist
+    # Ex. When using --workspace outside of a workspace, but cannot access --workspace from this function.
     else:
         parser.add_argument("template", nargs="?", default=None, help=template_help_str)
 

--- a/otx/cli/utils/parser.py
+++ b/otx/cli/utils/parser.py
@@ -146,7 +146,7 @@ def gen_params_dict_from_args(
         # FIXME[HARIM]: There's no template in args, and it's not inside the workspace, but with --workspace,
         # the template is not found in args, so params, which are all bools, go into str.
         # This is a temporary solution.
-        if isinstance(value, str) and value.lower() in ("true", "false", "1", "0"):
+        if isinstance(value, str) and value.lower() in ("true", "false"):
             value_type = str2bool
 
         leaf_node_dict, node_key = _get_leaf_node(params_dict, origin_key)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

`otx train params --learning_parameters.enable_early_stopping False` in workspace
or
`otx train {template} params --learning_parameters.enable_early_stopping False`
is working well.

However, we noticed that False is used as a string in the command below
`otx train --workspace {workspace-path} params --learning_parameters.enable_early_stopping False`
(Thanks for the report, @jaegukhyun)

I used a workaround for this, and it looks like it needs to be fixed in the future. (CLI flow problem) -> Problem case is that if template is not given and the current folder is not a workspace (use --workspace)

### How to test

`otx train --workspace {workspace-path} params --learning_parameters.enable_early_stopping False`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
