### PR TITLE
Fix default dict

### DIFF
--- a/otx/algorithms/common/tasks/nncf_task.py
+++ b/otx/algorithms/common/tasks/nncf_task.py
@@ -162,7 +162,7 @@ class NNCFBaseTask(IOptimizationTask):  # pylint: disable=too-many-instance-attr
         # last batch size of 1 causes undefined behaviour for batch normalization
         # when initializing and training NNCF
         if self._data_cfg is not None:
-            data_loader = self._recipe_cfg.data.get("train_dataloader", {})
+            data_loader = self._recipe_cfg.data.get("train_dataloader", ConfigDict())
             samples_per_gpu = data_loader.get("samples_per_gpu", self._recipe_cfg.data.get("samples_per_gpu"))
             otx_dataset = get_configs_by_keys(self._data_cfg.data.train, "otx_dataset")
             assert len(otx_dataset) == 1


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
`Dict()` makes an attribute access error using dot(`.`) operator. (e.g. `train_dataloader.drop_last`)

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
