### PR TITLE
Fix tiling config loading bug

### DIFF
--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -335,20 +335,6 @@ def patch_tiling(config, hparams, dataset=None):
 
         if dataset and dataset.purpose != DatasetPurpose.INFERENCE and hparams.tiling_parameters.enable_adaptive_params:
             adaptive_tile_params(hparams.tiling_parameters, dataset)
-            tiling_params = ConfigDict(
-                tile_size=int(hparams.tiling_parameters.tile_size),
-                overlap_ratio=float(hparams.tiling_parameters.tile_overlap),
-                max_per_img=int(hparams.tiling_parameters.tile_max_number),
-            )
-            config.update(
-                ConfigDict(
-                    data=ConfigDict(
-                        train=tiling_params,
-                        val=tiling_params,
-                        test=tiling_params,
-                    )
-                )
-            )
 
         if dataset and dataset.purpose == DatasetPurpose.INFERENCE:
             config.get("data", ConfigDict()).get("val_dataloader", ConfigDict()).update(ConfigDict(samples_per_gpu=1))
@@ -370,6 +356,20 @@ def patch_tiling(config, hparams, dataset=None):
 
             config.data.train.filter_empty_gt = False
 
+        tiling_params = ConfigDict(
+                tile_size=int(hparams.tiling_parameters.tile_size),
+                overlap_ratio=float(hparams.tiling_parameters.tile_overlap),
+                max_per_img=int(hparams.tiling_parameters.tile_max_number),
+            )
+        config.update(
+            ConfigDict(
+                data=ConfigDict(
+                    train=tiling_params,
+                    val=tiling_params,
+                    test=tiling_params,
+                )
+            )
+        )
         config.update(dict(evaluation=dict(iou_thr=[0.5])))
 
     return config

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -357,10 +357,10 @@ def patch_tiling(config, hparams, dataset=None):
             config.data.train.filter_empty_gt = False
 
         tiling_params = ConfigDict(
-                tile_size=int(hparams.tiling_parameters.tile_size),
-                overlap_ratio=float(hparams.tiling_parameters.tile_overlap),
-                max_per_img=int(hparams.tiling_parameters.tile_max_number),
-            )
+            tile_size=int(hparams.tiling_parameters.tile_size),
+            overlap_ratio=float(hparams.tiling_parameters.tile_overlap),
+            max_per_img=int(hparams.tiling_parameters.tile_max_number),
+        )
         config.update(
             ConfigDict(
                 data=ConfigDict(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Fix bug as tiling parameters are not loaded correctly during torch inference. 
* Remove tile image cache mechanism and crop tile directly from `dataset_entity`

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
