### PR TITLE
Reduce the depth of aumix process

### DIFF
--- a/otx/algorithms/classification/configs/base/data/data_pipeline.py
+++ b/otx/algorithms/classification/configs/base/data/data_pipeline.py
@@ -22,7 +22,7 @@ __resize_target_size = 224
 __train_pipeline = [
     dict(type="Resize", size=__resize_target_size),
     dict(type="RandomFlip", flip_prob=0.5, direction="horizontal"),
-    dict(type="AugMixAugment", config_str="augmix-m5-w3"),
+    dict(type="AugMixAugment", config_str="augmix-m5-w3-d1"),
     dict(type="RandomRotate", p=0.35, angle=(-10, 10)),
     dict(type="PILImageToNDArray", keys=["img"]),
     dict(type="Normalize", **__img_norm_cfg),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Recently, we found that current AugMix pre-processing needs much time even though it helps to model accuracy.
So, we reduced the iteration number of AugMix (4 --> 1).

The table below represents the results.
![image](https://user-images.githubusercontent.com/80735344/233276250-83abf32b-a9e3-4983-8fcd-bf64f096244a.png)

Since this change is quite simple, I didn't include it in the CHANGELOG.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
