### PR TITLE
Bugfix: workspace is made by all of processes when multi GPU training with torchrun

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -24,6 +24,7 @@ from otx.cli.utils.errors import (
     NotSupportedError,
 )
 from otx.cli.utils.importing import get_otx_root_path
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 from otx.cli.utils.parser import gen_param_help, gen_params_dict_from_args
 from otx.core.data.manager.dataset_manager import DatasetManager
 
@@ -437,6 +438,8 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         """
 
         # Create OTX-workspace
+        if is_multigpu_child_process():
+            return
         # Check whether the workspace is existed or not
         if self.check_workspace() and not self.rebuild:
             return

--- a/otx/cli/utils/multi_gpu.py
+++ b/otx/cli/utils/multi_gpu.py
@@ -106,7 +106,7 @@ def set_arguments_to_argv(keys: Union[str, List[str]], value: Optional[str] = No
 
 def is_multigpu_child_process():
     """Check current process is a child process for multi GPU training."""
-    return dist.is_initialized() and os.environ["LOCAL_RANK"] != "0"
+    return (dist.is_initialized() or "TORCHELASTIC_RUN_ID" in os.environ) and os.environ["LOCAL_RANK"] != "0"
 
 
 class MultiGPUManager:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
When multi processes execute OTX train by `torchrun`, all of processes try to make workspace, which makes an error.
This PR fixes that bug.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
