### PR TITLE
Change the way to get subset data in datumaro adapter

### DIFF
--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -166,12 +166,20 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             subsets = list(dataset.subsets().keys())
 
             for s in [subset, "default"]:
-                if subset == "test":
-                    s = "val"
+                if subset == "val" and s != "default":
+                    s = "valid"
                 exact_subset = get_close_matches(s, subsets)
+                print(subset, s, subsets, exact_subset)
 
                 if exact_subset:
                     return dataset.subsets()[exact_subset[0]].as_dataset()
+                elif subset == "test":
+                    # If there is not test dataset in data.yml, then validation set will be test dataset
+                    s = "valid"
+                    exact_subset = get_close_matches(s, subsets)
+                    print(subset, s, subsets, exact_subset)
+                    if exact_subset:
+                        return dataset.subsets()[exact_subset[0]].as_dataset()
 
         raise ValueError("Can't find proper dataset.")
 

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -169,7 +169,6 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
                 if subset == "val" and s != "default":
                     s = "valid"
                 exact_subset = get_close_matches(s, subsets)
-                print(subset, s, subsets, exact_subset)
 
                 if exact_subset:
                     return dataset.subsets()[exact_subset[0]].as_dataset()
@@ -177,7 +176,6 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
                     # If there is not test dataset in data.yml, then validation set will be test dataset
                     s = "valid"
                     exact_subset = get_close_matches(s, subsets)
-                    print(subset, s, subsets, exact_subset)
                     if exact_subset:
                         return dataset.subsets()[exact_subset[0]].as_dataset()
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Current datumaro adapater get any dataset as validation dataset if "val" is in subset name.
Therefore if a dataset has subsets such as ["train", "trainval", "val"] the validation dataset for this dataset would be "trainval".
This PR fixes this issue by using get_close_matches function in difflib.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
Train with VOC dataset.
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
