### PR TITLE
Bug fix: value of validation variable is changed after auto decrease batch size

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -408,9 +408,8 @@ class MMClassificationTask(OTXClassificationTask):
             )
 
         if self._hyperparams.learning_parameters.auto_decrease_batch_size:
-            validate = isinstance(self, NNCFBaseTask)  # nncf needs eval hooks
             train_func = partial(train_model, meta=deepcopy(meta), model=deepcopy(model), distributed=False)
-            adapt_batch_size(train_func, cfg, datasets, validate)
+            adapt_batch_size(train_func, cfg, datasets, isinstance(self, NNCFBaseTask))  # nncf needs eval hooks
 
         train_model(
             model,

--- a/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/otx/algorithms/detection/adapters/mmdet/task.py
@@ -279,9 +279,8 @@ class MMDetectionTask(OTXDetectionTask):
         validate = bool(cfg.data.get("val", None))
 
         if self._hyperparams.learning_parameters.auto_decrease_batch_size:
-            validate = isinstance(self, NNCFBaseTask)  # nncf needs eval hooks
             train_func = partial(train_detector, meta=deepcopy(meta), model=deepcopy(model), distributed=False)
-            adapt_batch_size(train_func, cfg, datasets, validate)
+            adapt_batch_size(train_func, cfg, datasets, isinstance(self, NNCFBaseTask))  # nncf needs eval hooks
 
         train_detector(
             model,

--- a/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -372,9 +372,8 @@ class MMSegmentationTask(OTXSegmentationTask):
         validate = bool(cfg.data.get("val", None))
 
         if self._hyperparams.learning_parameters.auto_decrease_batch_size:
-            validate = isinstance(self, NNCFBaseTask)  # nncf needs eval hooks
             train_func = partial(train_segmentor, meta=deepcopy(meta), model=deepcopy(model), distributed=False)
-            adapt_batch_size(train_func, cfg, datasets, validate)
+            adapt_batch_size(train_func, cfg, datasets, isinstance(self, NNCFBaseTask))  # nncf needs eval hooks
 
         train_segmentor(
             model,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR fixes a bug that value of `validation` is changed after auto decrease batch size.
It's same as [this pr](https://github.com/openvinotoolkit/training_extensions/pull/2053) but for develop branch.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
