### PR TITLE
Action task supports multi GPU training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
-- Action task supports multi GPU training.
+- Action task supports multi GPU training. (<https://github.com/openvinotoolkit/training_extensions/pull/2057>)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
--
+- Action task supports multi GPU training.
 
 ### Enhancements
 

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -197,7 +197,7 @@ class MMActionTask(OTXActionTask):
         self._config = recipe_cfg
         return recipe_cfg
 
-    def _configure_device(self, cfg, training):
+    def _configure_device(self, cfg: Config, training: bool):
         """Setting device for training and inference."""
         cfg.distributed = False
         if torch.distributed.is_initialized():
@@ -221,7 +221,7 @@ class MMActionTask(OTXActionTask):
             cfg.device = "cuda"
 
     @staticmethod
-    def configure_distributed(cfg):
+    def configure_distributed(cfg: Config):
         """Patching for distributed training."""
         if hasattr(cfg, "dist_params") and cfg.dist_params.get("linear_scale_lr", False):
             new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -158,8 +158,9 @@ class MMActionTask(OTXActionTask):
 
         recipe_cfg.work_dir = self._output_path
         recipe_cfg.resume = self._resume
-        recipe_cfg.distributed = False
         recipe_cfg.omnisource = False
+
+        self._configure_device(recipe_cfg, training)
 
         if data_cfg is not None:
             recipe_cfg.merge_from_dict(data_cfg)
@@ -195,6 +196,40 @@ class MMActionTask(OTXActionTask):
 
         self._config = recipe_cfg
         return recipe_cfg
+
+    def _configure_device(self, cfg, training):
+        """Setting device for training and inference."""
+        cfg.distributed = False
+        if torch.distributed.is_initialized():
+            cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
+            if training:  # TODO multi GPU is available only in training. Evaluation needs to be supported later.
+                cfg.distributed = True
+                self.configure_distributed(cfg)
+        elif "gpu_ids" not in cfg:
+            gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
+            logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")
+            if gpu_ids is not None:
+                cfg.gpu_ids = range(len(gpu_ids.split(",")))
+            else:
+                cfg.gpu_ids = range(1)
+
+        # consider "cuda" and "cpu" device only
+        if not torch.cuda.is_available():
+            cfg.device = "cpu"
+            cfg.gpu_ids = range(-1, 0)
+        else:
+            cfg.device = "cuda"
+
+    @staticmethod
+    def configure_distributed(cfg):
+        """Patching for distributed training."""
+        if hasattr(cfg, "dist_params") and cfg.dist_params.get("linear_scale_lr", False):
+            new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
+            logger.info(
+                f"enabled linear scaling rule to the learning rate. \
+                changed LR from {cfg.optimizer.lr} to {new_lr}"
+            )
+            cfg.optimizer.lr = new_lr
 
     # pylint: disable=too-many-branches, too-many-statements
     def _train_model(

--- a/otx/algorithms/action/task.py
+++ b/otx/algorithms/action/task.py
@@ -67,6 +67,7 @@ from otx.api.usecases.evaluation.f_measure import FMeasure
 from otx.api.usecases.evaluation.metrics_helper import MetricsHelper
 from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from otx.api.utils.vis_utils import get_actmap
+from otx.cli.utils.multi_gpu import is_multigpu_child_process
 
 logger = get_logger()
 
@@ -430,6 +431,9 @@ class OTXActionTask(OTXTask, ABC):
 
     def save_model(self, output_model: ModelEntity):
         """Save best model weights in ActionTrainTask."""
+        if is_multigpu_child_process():
+            return
+
         logger.info("called save_model")
         buffer = io.BytesIO()
         hyperparams_str = ids_to_strings(cfg_helper.convert(self._hyperparams, dict, enum_to_str=True))

--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -18,6 +18,7 @@ import io
 import os
 import shutil
 import tempfile
+import logging
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import Any, Dict, Iterable, List, Optional
@@ -29,7 +30,7 @@ from otx.algorithms.common.adapters.mmcv.hooks import OTXLoggerHook
 from otx.algorithms.common.adapters.mmcv.hooks.cancel_hook import CancelInterfaceHook
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.utils import UncopiableDefaultDict
-from otx.algorithms.common.utils.logger import get_logger
+from otx.algorithms.common.utils.logger import get_logger, set_all_logger_level
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.explain_parameters import ExplainParameters
 from otx.api.entities.inference_parameters import InferenceParameters
@@ -136,7 +137,10 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
         if not dist.is_initialized():
             torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
             dist.init_process_group(backend="nccl", init_method="env://", timeout=timedelta(seconds=30))
-            logger.info(f"Dist info: rank {dist.get_rank()} / {dist.get_world_size()} world_size")
+            rank = dist.get_rank()
+            logger.info(f"Dist info: rank {rank} / {dist.get_world_size()} world_size")
+            if rank != 0:
+                set_all_logger_level(logging.ERROR)
 
     def _get_tmp_dir(self):
         self._work_dir_is_temp = True

--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -15,10 +15,10 @@
 # and limitations under the License.
 
 import io
+import logging
 import os
 import shutil
 import tempfile
-import logging
 from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import Any, Dict, Iterable, List, Optional

--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -30,7 +30,7 @@ from otx.algorithms.common.adapters.mmcv.hooks import OTXLoggerHook
 from otx.algorithms.common.adapters.mmcv.hooks.cancel_hook import CancelInterfaceHook
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.utils import UncopiableDefaultDict
-from otx.algorithms.common.utils.logger import get_logger, set_all_logger_level
+from otx.algorithms.common.utils.logger import get_logger
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.explain_parameters import ExplainParameters
 from otx.api.entities.inference_parameters import InferenceParameters
@@ -140,7 +140,7 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
             rank = dist.get_rank()
             logger.info(f"Dist info: rank {rank} / {dist.get_world_size()} world_size")
             if rank != 0:
-                set_all_logger_level(logging.ERROR)
+                logging.disable(logging.WARNING)
 
     def _get_tmp_dir(self):
         self._work_dir_is_temp = True

--- a/otx/algorithms/common/utils/logger.py
+++ b/otx/algorithms/common/utils/logger.py
@@ -152,3 +152,10 @@ def get_logger():
     #     return _logger
     # return _DummyLogger('dummy')
     return _logger
+
+
+def set_all_logger_level(level):
+    """Set the threshold for all exsisting logger to level."""
+    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
+    for each_logger in loggers:
+        each_logger.setLevel(level)

--- a/otx/algorithms/common/utils/logger.py
+++ b/otx/algorithms/common/utils/logger.py
@@ -152,10 +152,3 @@ def get_logger():
     #     return _logger
     # return _DummyLogger('dummy')
     return _logger
-
-
-def set_all_logger_level(level):
-    """Set the threshold for all exsisting logger to level."""
-    loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
-    for each_logger in loggers:
-        each_logger.setLevel(level)

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -229,9 +229,7 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
 
     if args.gpus:
         multigpu_manager = MultiGPUManager(train, args.gpus, args.rdzv_endpoint, args.base_rank, args.world_size)
-        if template.task_type in (TaskType.ACTION_CLASSIFICATION, TaskType.ACTION_DETECTION):
-            print("Multi-GPU training for action tasks isn't supported yet. A single GPU will be used for a training.")
-        elif (
+        if (
             multigpu_manager.is_available()
             and not template.task_type.is_anomaly  # anomaly tasks don't use this way for multi-GPU training
         ):

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -24,7 +24,6 @@ from typing import Optional
 
 from otx.api.entities.inference_parameters import InferenceParameters
 from otx.api.entities.model import ModelEntity
-from otx.api.entities.model_template import TaskType
 from otx.api.entities.resultset import ResultSetEntity
 from otx.api.entities.subset import Subset
 from otx.api.entities.task_environment import TaskEnvironment

--- a/tests/e2e/cli/action/test_action_classification.py
+++ b/tests/e2e/cli/action/test_action_classification.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import copy
 import os
 
 import pytest
+import torch
 
 from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import Registry
@@ -30,6 +32,7 @@ args = {
 
 otx_dir = os.getcwd()
 
+MULTI_GPU_UNAVAILABLE = torch.cuda.device_count() <= 1
 TT_STABILITY_TESTS = os.environ.get("TT_STABILITY_TESTS", False)
 if TT_STABILITY_TESTS:
     default_template = parse_model_template(
@@ -87,3 +90,13 @@ class TestToolsOTXActionClassification:
             pytest.skip(reason="[CVS-106939] MoViNet fails with POT")
         tmp_dir_path = tmp_dir_path / "action_cls"
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_multi_gpu_train(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_cls/test_multi_gpu"
+        args1 = copy.deepcopy(args)
+        args1["--gpus"] = "0,1"
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1)

--- a/tests/e2e/cli/action/test_action_detection.py
+++ b/tests/e2e/cli/action/test_action_detection.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import copy
 import os
 
 import pytest
+import torch
 
 from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import Registry
@@ -30,6 +32,7 @@ args = {
 
 otx_dir = os.getcwd()
 
+MULTI_GPU_UNAVAILABLE = torch.cuda.device_count() <= 1
 TT_STABILITY_TESTS = os.environ.get("TT_STABILITY_TESTS", False)
 if TT_STABILITY_TESTS:
     default_template = parse_model_template(
@@ -86,3 +89,13 @@ class TestToolsOTXActionDetection:
     def test_pot_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "action_det"
         pot_eval_testing(template, tmp_dir_path, otx_dir, args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_multi_gpu_train(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_det/test_multi_gpu"
+        args1 = copy.deepcopy(args)
+        args1["--gpus"] = "0,1"
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1)

--- a/tests/integration/cli/action/test_action_classification.py
+++ b/tests/integration/cli/action/test_action_classification.py
@@ -7,6 +7,7 @@ import os
 from copy import deepcopy
 
 import pytest
+import torch
 
 from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import Registry
@@ -29,6 +30,7 @@ args = {
 
 otx_dir = os.getcwd()
 
+MULTI_GPU_UNAVAILABLE = torch.cuda.device_count() <= 1
 TT_STABILITY_TESTS = os.environ.get("TT_STABILITY_TESTS", False)
 if TT_STABILITY_TESTS:
     default_template = parse_model_template(
@@ -77,3 +79,13 @@ class TestToolsOTXActionClassification:
         decrease_bs_args["train_params"].extend(["--learning_parameters.auto_decrease_batch_size", "true"])
         tmp_dir_path = tmp_dir_path / "action_cls_auto_decrease_batch_size"
         otx_train_testing(template, tmp_dir_path, otx_dir, decrease_bs_args)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(MULTI_GPU_UNAVAILABLE, reason="The number of gpu is insufficient")
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_multi_gpu_train(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_cls/test_multi_gpu"
+        args1 = deepcopy(args)
+        args1["--gpus"] = "0,1"
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR enables multi GPU training to action task.
Current multi GPU training needs to be refactored because code flow for multi GPU enablement in each tasks are all different.
I'll refactored it after this pr is merged and at that time I'll implement unit test for that.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
