### PR TITLE
Bug fix: set gpu_ids properly (develop)

### DIFF
--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -206,12 +206,7 @@ class MMActionTask(OTXActionTask):
                 cfg.distributed = True
                 self.configure_distributed(cfg)
         elif "gpu_ids" not in cfg:
-            gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
-            logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")
-            if gpu_ids is not None:
-                cfg.gpu_ids = range(len(gpu_ids.split(",")))
-            else:
-                cfg.gpu_ids = range(1)
+            cfg.gpu_ids = range(1)
 
         # consider "cuda" and "cpu" device only
         if not torch.cuda.is_available():

--- a/otx/algorithms/classification/adapters/mmcls/configurer.py
+++ b/otx/algorithms/classification/adapters/mmcls/configurer.py
@@ -387,12 +387,7 @@ class ClassificationConfigurer:
                 cfg.distributed = True
                 self.configure_distributed(cfg)
         elif "gpu_ids" not in cfg:
-            gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
-            logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")
-            if gpu_ids is not None:
-                cfg.gpu_ids = range(len(gpu_ids.split(",")))
-            else:
-                cfg.gpu_ids = range(1)
+            cfg.gpu_ids = range(1)
 
         # consider "cuda" and "cpu" device only
         if not torch.cuda.is_available():

--- a/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -549,12 +549,7 @@ class DetectionConfigurer:
                 cfg.distributed = True
                 self.configure_distributed(cfg)
         elif "gpu_ids" not in cfg:
-            gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
-            logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")
-            if gpu_ids is not None:
-                cfg.gpu_ids = range(len(gpu_ids.split(",")))
-            else:
-                cfg.gpu_ids = range(1)
+            cfg.gpu_ids = range(1)
 
         # consider "cuda" and "cpu" device only
         if not torch.cuda.is_available():

--- a/otx/algorithms/segmentation/adapters/mmseg/configurer.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/configurer.py
@@ -381,12 +381,7 @@ class SegmentationConfigurer:
                 cfg.distributed = True
                 self.configure_distributed(cfg)
         elif "gpu_ids" not in cfg:
-            gpu_ids = os.environ.get("CUDA_VISIBLE_DEVICES")
-            logger.info(f"CUDA_VISIBLE_DEVICES = {gpu_ids}")
-            if gpu_ids is not None:
-                cfg.gpu_ids = range(len(gpu_ids.split(",")))
-            else:
-                cfg.gpu_ids = range(1)
+            cfg.gpu_ids = range(1)
 
         # consider "cuda" and "cpu" device only
         if not torch.cuda.is_available():


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->
This is same as #2071 but for develop branch.
gpu_ids should be an iterateable variable which has single element in single GPU training case.
Current implementation doesn't if CUDA_VISIBLE_DEVICES has multiple integers.
This PR fixed the issuu #2070 


### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
