### PR TITLE
Bug fix: Progress goes 100% and back 0 % repeatedly during auto decrease bs in Geti

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -10,8 +10,6 @@ import numpy as np
 
 from otx.algorithms.common.adapters.torch.utils import adapt_batch_size as adapt_torch_model_bs
 from otx.algorithms.common.utils.logger import get_logger
-from otx.api.entities.train_parameters import default_progress_callback
-from otx.algorithms.common.utils.callback import TrainingProgressCallback
 
 logger = get_logger()
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This pr fixed a bug that progress goes 100% and back 0 % repeatedly during auto decrease bs in Geti by removing progress hook.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
