### PR TITLE
Add seed, deterministic commands for otx train

### DIFF
--- a/docs/source/guide/get_started/quick_start_guide/cli_commands.rst
+++ b/docs/source/guide/get_started/quick_start_guide/cli_commands.rst
@@ -97,6 +97,8 @@ Building workspace folder
       --model MODEL         Enter the name of the model you want to use. (Ex. EfficientNet-B0).
       --backbone BACKBONE   Available Backbone Type can be found using 'otx find --backbone {framework}'.
                             If there is an already created backbone configuration yaml file, enter the corresponding path.
+      --deterministic       Set deterministic to True, default=False.
+      --seed SEED           Set seed for configuration.
 
 
 For example, the following command line will create an object detection ``Custom_Object_Detection_Gen3_ATSS`` model template with ResNet backbone from `mmdetection <https://github.com/open-mmlab/mmdetection>`_:
@@ -201,6 +203,8 @@ However, if you created a workspace with ``otx build``, the training process can
                             Total number of workers in a worker group.
       --mem-cache-size PARAMS.ALGO_BACKEND.MEM_CACHE_SIZE
                             Size of memory pool for caching decoded data to load data faster. For example, you can use digits for bytes size (e.g. 1024) or a string with size units (e.g. 7KiB = 7 * 2^10, 3MB = 3 * 10^6, and 2G = 2 * 2^30).
+      --deterministic       Set deterministic to True, default=False.
+      --seed SEED           Change seed for training.
       --data DATA           The data.yaml path want to use in train task.
 
 

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -48,7 +48,6 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
     MPAConfig,
     update_or_add_custom_hook,
 )
-from otx.algorithms.common.utils import set_random_seed
 from otx.algorithms.common.utils.data import get_dataset
 from otx.algorithms.common.utils.logger import get_logger
 from otx.api.entities.datasets import DatasetEntity
@@ -82,7 +81,7 @@ class MMActionTask(OTXActionTask):
         self._recipe_cfg.domain = self._task_type.domain
         self._config = self._recipe_cfg
 
-        set_random_seed(self._recipe_cfg.get("seed", 5), logger, self._recipe_cfg.get("deterministic", False))
+        self.set_seed()
 
         # Belows may go to the configure function
         patch_data_pipeline(self._recipe_cfg, self.data_pipeline_path)

--- a/otx/algorithms/action/task.py
+++ b/otx/algorithms/action/task.py
@@ -99,7 +99,12 @@ class OTXActionTask(OTXTask, ABC):
         self.data_pipeline_path = os.path.join(self._model_dir, "data_pipeline.py")
 
     def train(
-        self, dataset: DatasetEntity, output_model: ModelEntity, train_parameters: Optional[TrainParameters] = None
+        self,
+        dataset: DatasetEntity,
+        output_model: ModelEntity,
+        train_parameters: Optional[TrainParameters] = None,
+        seed: Optional[int] = None,
+        deterministic: bool = False,
     ):
         """Train function for OTX action task.
 
@@ -113,6 +118,8 @@ class OTXActionTask(OTXTask, ABC):
             self._should_stop = False
             self._is_training = False
             return
+        self.seed = seed
+        self.deterministic = deterministic
 
         # Set OTX LoggerHook & Time Monitor
         if train_parameters:

--- a/otx/algorithms/anomaly/tasks/train.py
+++ b/otx/algorithms/anomaly/tasks/train.py
@@ -57,8 +57,8 @@ class TrainingTask(InferenceTask, ITrainingTask):
             dataset (DatasetEntity): Input dataset.
             output_model (ModelEntity): Output model to save the model weights.
             train_parameters (TrainParameters): Training parameters
-            seed: (Optional[int]): Setting seed to a value other than 0
-            deterministic: Setting PytorchLightning trainer's deterministic flag.
+            seed (Optional[int]): Setting seed to a value other than 0
+            deterministic (bool): Setting PytorchLightning trainer's deterministic flag.
         """
         logger.info("Training the model.")
 

--- a/otx/algorithms/anomaly/tasks/train.py
+++ b/otx/algorithms/anomaly/tasks/train.py
@@ -49,6 +49,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
         output_model: ModelEntity,
         train_parameters: TrainParameters,
         seed: Optional[int] = None,
+        deterministic: bool = False,
     ) -> None:
         """Train the anomaly classification model.
 
@@ -56,8 +57,8 @@ class TrainingTask(InferenceTask, ITrainingTask):
             dataset (DatasetEntity): Input dataset.
             output_model (ModelEntity): Output model to save the model weights.
             train_parameters (TrainParameters): Training parameters
-            seed: (Optional[int]): Setting seed to a value other than 0 also marks PytorchLightning trainer's
-                deterministic flag to True.
+            seed: (Optional[int]): Setting seed to a value other than 0
+            deterministic: Setting PytorchLightning trainer's deterministic flag.
         """
         logger.info("Training the model.")
 
@@ -66,7 +67,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
         if seed:
             logger.info(f"Setting seed to {seed}")
             seed_everything(seed, workers=True)
-            config.trainer.deterministic = True
+        config.trainer.deterministic = deterministic
 
         logger.info("Training Configs '%s'", config)
 

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -56,7 +56,6 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
 )
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.nncf_task import NNCFBaseTask
-from otx.algorithms.common.utils import set_random_seed
 from otx.algorithms.common.utils.data import get_dataset
 from otx.algorithms.common.utils.logger import get_logger
 from otx.api.entities.datasets import DatasetEntity
@@ -108,7 +107,7 @@ class MMClassificationTask(OTXClassificationTask):
             self._recipe_cfg.model.head.hierarchical_info = self._hierarchical_info
         self._config = self._recipe_cfg
 
-        set_random_seed(self._recipe_cfg.get("seed", 5), logger, self._recipe_cfg.get("deterministic", False))
+        self.set_seed()
 
         # Belows may go to the configure function
         patch_data_pipeline(self._recipe_cfg, self.data_pipeline_path)

--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -176,7 +176,12 @@ class OTXClassificationTask(OTXTask, ABC):
         return dataset
 
     def train(
-        self, dataset: DatasetEntity, output_model: ModelEntity, train_parameters: Optional[TrainParameters] = None
+        self,
+        dataset: DatasetEntity,
+        output_model: ModelEntity,
+        train_parameters: Optional[TrainParameters] = None,
+        seed: Optional[int] = None,
+        deterministic: bool = False,
     ):
         """Train function for OTX classification task.
 
@@ -190,6 +195,8 @@ class OTXClassificationTask(OTXTask, ABC):
             self._should_stop = False
             self._is_training = False
             return
+        self.seed = seed
+        self.deterministic = deterministic
 
         # Set OTX LoggerHook & Time Monitor
         if train_parameters:

--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -313,7 +313,7 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
 
     def set_seed(self):
         """Set seed and deterministic."""
-        if self.seed is not None:
+        if self.seed is None:
             # If the seed is not present via task.train, it will be found in the recipe.
             self.seed = self.config.get("seed", 5)
         if not self.deterministic:

--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -29,7 +29,7 @@ from torch import distributed as dist
 from otx.algorithms.common.adapters.mmcv.hooks import OTXLoggerHook
 from otx.algorithms.common.adapters.mmcv.hooks.cancel_hook import CancelInterfaceHook
 from otx.algorithms.common.configs.training_base import TrainType
-from otx.algorithms.common.utils import UncopiableDefaultDict
+from otx.algorithms.common.utils import UncopiableDefaultDict, set_random_seed
 from otx.algorithms.common.utils.logger import get_logger
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.explain_parameters import ExplainParameters
@@ -114,6 +114,8 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
         self._precision = [ModelPrecision.FP32]
         self._optimization_methods: List[OptimizationMethod] = []
         self._is_training = False
+        self.seed: Optional[int] = None
+        self.deterministic: bool = False
 
         self.override_configs: Dict[str, str] = {}
 
@@ -184,7 +186,12 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
 
     @abstractmethod
     def train(
-        self, dataset: DatasetEntity, output_model: ModelEntity, train_parameters: Optional[TrainParameters] = None
+        self,
+        dataset: DatasetEntity,
+        output_model: ModelEntity,
+        train_parameters: Optional[TrainParameters] = None,
+        seed: Optional[int] = None,
+        deterministic: bool = False,
     ):
         """Train function for OTX task."""
         raise NotImplementedError
@@ -303,6 +310,16 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
                 is_in_docker = is_in_docker or any("docker" in line for line in f)
         is_in_docker = is_in_docker or os.path.exists("/.dockerenv")
         return is_in_docker
+
+    def set_seed(self):
+        """Set seed and deterministic."""
+        if self.seed is not None:
+            # If the seed is not present via task.train, it will be found in the recipe.
+            self.seed = self.config.get("seed", 5)
+        if not self.deterministic:
+            # deterministic is the same.
+            self.deterministic = self.config.get("deterministic", False)
+        set_random_seed(self.seed, logger, self.deterministic)
 
     @property
     def config(self):

--- a/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/otx/algorithms/detection/adapters/mmdet/task.py
@@ -51,7 +51,6 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
 )
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.nncf_task import NNCFBaseTask
-from otx.algorithms.common.utils import set_random_seed
 from otx.algorithms.common.utils.data import get_dataset
 from otx.algorithms.common.utils.logger import get_logger
 from otx.algorithms.detection.adapters.mmdet.configurer import (
@@ -106,7 +105,7 @@ class MMDetectionTask(OTXDetectionTask):
         self._recipe_cfg.domain = self._task_type.domain
         self._config = self._recipe_cfg
 
-        set_random_seed(self._recipe_cfg.get("seed", 5), logger, self._recipe_cfg.get("deterministic", False))
+        self.set_seed()
 
         # Belows may go to the configure function
         patch_data_pipeline(self._recipe_cfg, self.data_pipeline_path)

--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -158,7 +158,12 @@ class OTXDetectionTask(OTXTask, ABC):
         return None
 
     def train(
-        self, dataset: DatasetEntity, output_model: ModelEntity, train_parameters: Optional[TrainParameters] = None
+        self,
+        dataset: DatasetEntity,
+        output_model: ModelEntity,
+        train_parameters: Optional[TrainParameters] = None,
+        seed: Optional[int] = None,
+        deterministic: bool = False,
     ):
         """Train function for OTX detection task.
 
@@ -172,6 +177,8 @@ class OTXDetectionTask(OTXTask, ABC):
             self._should_stop = False
             self._is_training = False
             return
+        self.seed = seed
+        self.deterministic = deterministic
 
         # Set OTX LoggerHook & Time Monitor
         if train_parameters:

--- a/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -48,7 +48,6 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
 )
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.nncf_task import NNCFBaseTask
-from otx.algorithms.common.utils import set_random_seed
 from otx.algorithms.common.utils.data import get_dataset
 from otx.algorithms.common.utils.logger import get_logger
 from otx.algorithms.segmentation.adapters.mmseg.configurer import (
@@ -94,7 +93,7 @@ class MMSegmentationTask(OTXSegmentationTask):
         self._recipe_cfg.domain = self._task_type.domain
         self._config = self._recipe_cfg
 
-        set_random_seed(self._recipe_cfg.get("seed", 5), logger, self._recipe_cfg.get("deterministic", False))
+        self.set_seed()
 
         # Belows may go to the configure function
         patch_data_pipeline(self._recipe_cfg, self.data_pipeline_path)

--- a/otx/algorithms/segmentation/task.py
+++ b/otx/algorithms/segmentation/task.py
@@ -149,7 +149,12 @@ class OTXSegmentationTask(OTXTask, ABC):
         return dataset
 
     def train(
-        self, dataset: DatasetEntity, output_model: ModelEntity, train_parameters: Optional[TrainParameters] = None
+        self,
+        dataset: DatasetEntity,
+        output_model: ModelEntity,
+        train_parameters: Optional[TrainParameters] = None,
+        seed: Optional[int] = None,
+        deterministic: bool = False,
     ):
         """Train function for OTX segmentation task.
 
@@ -163,6 +168,8 @@ class OTXSegmentationTask(OTXTask, ABC):
             self._should_stop = False
             self._is_training = False
             return
+        self.seed = seed
+        self.deterministic = deterministic
 
         # Set OTX LoggerHook & Time Monitor
         if train_parameters:

--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -527,12 +527,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
                     )
 
                     config = MPAConfig.fromfile(str(target_dir / file_name))
-                    # FIXME: In the CLI, there is currently no case for using the ignore label.
-                    # so the workspace's model patches ignore to False.
-                    # FIXME: Segmentation -> ignore=True
-                    if config.get("ignore", None):
-                        config.ignore = False
-                        print("In the CLI, Update ignore to false in model configuration.")
+                    self._patch_cli_configs(config)
                     config.dump(str(dest_dir / file_name))
                 except Exception as exc:
                     raise CliException(f"{self.task_type} requires mmcv-full to be installed.") from exc
@@ -540,3 +535,15 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
                 config = OmegaConf.load(str(target_dir / file_name))
                 (dest_dir / file_name).write_text(OmegaConf.to_yaml(config))
             print(f"[*] \t- Updated: {str(dest_dir / file_name)}")
+
+    def _patch_cli_configs(self, config):
+        """Patch for CLI configurations."""
+        if config.get("ignore", None):
+            # FIXME: In the CLI, there is currently no case for using the ignore label.
+            # so the workspace's model patches ignore to False.
+            config.ignore = False
+            print("In the CLI, Update ignore to false in model configuration.")
+        if hasattr(config, "deterministic") and hasattr(self.args, "deterministic"):
+            config.deterministic = self.args.deterministic
+        if hasattr(config, "seed") and hasattr(self.args, "seed"):
+            config.seed = self.args.seed

--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -545,5 +545,5 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             print("In the CLI, Update ignore to false in model configuration.")
         if hasattr(config, "deterministic") and hasattr(self.args, "deterministic"):
             config.deterministic = self.args.deterministic
-        if hasattr(config, "seed") and hasattr(self.args, "seed"):
+        if hasattr(config, "seed") and hasattr(self.args, "seed") and self.args.seed:
             config.seed = self.args.seed

--- a/otx/cli/tools/build.py
+++ b/otx/cli/tools/build.py
@@ -78,6 +78,16 @@ def get_args():
         help="Available Backbone Type can be found using 'otx find --backbone {framework}'.\n"
         "If there is an already created backbone configuration yaml file, enter the corresponding path.",
     )
+    parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Set deterministic to True, default=False.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Set seed for configuration.",
+    )
 
     return parser.parse_args()
 

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -135,6 +135,16 @@ def get_args():
         "(e.g. 7KiB = 7 * 2^10, 3MB = 3 * 10^6, and 2G = 2 * 2^30).",
     )
     parser.add_argument(
+        "--deterministic",
+        action="store_true",
+        help="Set deterministic to True, default=False.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Set seed for training.",
+    )
+    parser.add_argument(
         "--data",
         type=str,
         default=None,

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -257,7 +257,9 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
 
     output_model = ModelEntity(dataset, environment.get_model_configuration())
 
-    task.train(dataset, output_model, train_parameters=TrainParameters())
+    task.train(
+        dataset, output_model, train_parameters=TrainParameters(), seed=args.seed, deterministic=args.deterministic
+    )
 
     model_path = config_manager.output_path / "models"
     save_model_data(output_model, str(model_path))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Modified to set seed and deterministic for testing and experimentation via CLI commands (train & build)
Modify Task's train function to get seed and deterministic value.

### How to test

```
(otx) otx build [~] --seed 1234 --deterministic
(otx) otx train [~] --seed 1234 --deterministic
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
