### PR TITLE
Support storage cache for action task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Support direct annotation input for COCO format (<https://github.com/openvinotoolkit/training_extensions/pull/1921>)
 - Action task supports multi GPU training. (<https://github.com/openvinotoolkit/training_extensions/pull/2057>)
+- Support storage cache in Apache Arrow using Datumaro for action tasks (<https://github.com/openvinotoolkit/training_extensions/pull/2087>)
 
 ### Enhancements
 

--- a/otx/algorithms/action/configs/classification/configuration.yaml
+++ b/otx/algorithms/action/configs/classification/configuration.yaml
@@ -294,6 +294,28 @@ algo_backend:
       type: UI_RULES
     visible_in_ui: false
     warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme fort storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 type: CONFIGURABLE_PARAMETERS

--- a/otx/algorithms/action/configs/classification/configuration.yaml
+++ b/otx/algorithms/action/configs/classification/configuration.yaml
@@ -297,7 +297,7 @@ algo_backend:
   storage_cache_scheme:
     affects_outcome_of: TRAINING
     default_value: NONE
-    description: Scheme fort storage cache
+    description: Scheme for storage cache
     editable: true
     enum_name: StorageCacheScheme
     header: Scheme for storage cache

--- a/otx/algorithms/action/configs/detection/configuration.yaml
+++ b/otx/algorithms/action/configs/detection/configuration.yaml
@@ -294,6 +294,28 @@ algo_backend:
       type: UI_RULES
     visible_in_ui: false
     warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme fort storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
 type: CONFIGURABLE_PARAMETERS

--- a/otx/algorithms/action/configs/detection/configuration.yaml
+++ b/otx/algorithms/action/configs/detection/configuration.yaml
@@ -297,7 +297,7 @@ algo_backend:
   storage_cache_scheme:
     affects_outcome_of: TRAINING
     default_value: NONE
-    description: Scheme fort storage cache
+    description: Scheme for storage cache
     editable: true
     enum_name: StorageCacheScheme
     header: Scheme for storage cache

--- a/otx/algorithms/classification/configs/configuration.yaml
+++ b/otx/algorithms/classification/configs/configuration.yaml
@@ -390,7 +390,7 @@ algo_backend:
   storage_cache_scheme:
     affects_outcome_of: TRAINING
     default_value: NONE
-    description: Scheme fort storage cache
+    description: Scheme for storage cache
     editable: true
     enum_name: StorageCacheScheme
     header: Scheme for storage cache

--- a/otx/algorithms/detection/configs/detection/configuration.yaml
+++ b/otx/algorithms/detection/configs/detection/configuration.yaml
@@ -298,7 +298,7 @@ algo_backend:
   storage_cache_scheme:
     affects_outcome_of: TRAINING
     default_value: NONE
-    description: Scheme fort storage cache
+    description: Scheme for storage cache
     editable: true
     enum_name: StorageCacheScheme
     header: Scheme for storage cache

--- a/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -298,7 +298,7 @@ algo_backend:
   storage_cache_scheme:
     affects_outcome_of: TRAINING
     default_value: NONE
-    description: Scheme fort storage cache
+    description: Scheme for storage cache
     editable: true
     enum_name: StorageCacheScheme
     header: Scheme for storage cache

--- a/otx/algorithms/segmentation/configs/configuration.yaml
+++ b/otx/algorithms/segmentation/configs/configuration.yaml
@@ -328,7 +328,7 @@ algo_backend:
   storage_cache_scheme:
     affects_outcome_of: TRAINING
     default_value: NONE
-    description: Scheme fort storage cache
+    description: Scheme for storage cache
     editable: true
     enum_name: StorageCacheScheme
     header: Scheme for storage cache

--- a/otx/core/data/adapter/action_dataset_adapter.py
+++ b/otx/core/data/adapter/action_dataset_adapter.py
@@ -7,18 +7,17 @@
 # pylint: disable=invalid-name, too-many-locals, no-member, too-many-arguments
 import os
 import os.path as osp
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from datumaro.components.annotation import AnnotationType
-from datumaro.components.annotation import Bbox as DatumaroBbox
-from datumaro.components.dataset import Dataset as DatumaroDataset
+from datumaro.components.annotation import Bbox as DatumBbox
+from datumaro.components.dataset import Dataset as DatumDataset
 
 from otx.api.entities.annotation import Annotation
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.id import ID
 from otx.api.entities.image import Image
-from otx.api.entities.label import LabelEntity
 from otx.api.entities.metadata import MetadataItemEntity, VideoMetadata
 from otx.api.entities.subset import Subset
 from otx.core.data.adapter.base_dataset_adapter import BaseDatasetAdapter
@@ -26,6 +25,9 @@ from otx.core.data.adapter.base_dataset_adapter import BaseDatasetAdapter
 
 class ActionBaseDatasetAdapter(BaseDatasetAdapter):
     """BaseDataset Adpater for Action tasks inherited by BaseDatasetAdapter."""
+
+    VIDEO_FRAME_SEP = "##"
+    EMPTY_FRAME_LABEL_NAME = "EmptyFrame"
 
     def _import_dataset(
         self,
@@ -37,7 +39,7 @@ class ActionBaseDatasetAdapter(BaseDatasetAdapter):
         test_ann_files: Optional[str] = None,
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
-    ) -> Dict[Subset, DatumaroDataset]:
+    ) -> Dict[Subset, DatumDataset]:
         """Import multiple videos that have CVAT format annotation.
 
         Args:
@@ -51,101 +53,48 @@ class ActionBaseDatasetAdapter(BaseDatasetAdapter):
             unlabeled_file_list (Optional[str]): Path of unlabeled file list
 
         Returns:
-            DatumaroDataset: Datumaro Dataset
+            DatumDataset: Datumaro Dataset
         """
         dataset = {}
         if train_data_roots is None and test_data_roots is None:
             raise ValueError("At least 1 data_root is needed to train/test.")
 
-        if train_data_roots:
+        # Construct dataset for training, validation, testing
+        if train_data_roots is not None:
             dataset[Subset.TRAINING] = self._prepare_cvat_pair_data(train_data_roots)
             if val_data_roots:
                 dataset[Subset.VALIDATION] = self._prepare_cvat_pair_data(val_data_roots)
-        if test_data_roots:
+            self.is_train_phase = True
+        if test_data_roots is not None and train_data_roots is None:
             dataset[Subset.TESTING] = self._prepare_cvat_pair_data(test_data_roots)
+            self.is_train_phase = False
 
         return dataset
 
-    def _prepare_cvat_pair_data(self, path: str) -> List[DatumaroDataset]:
+    def _prepare_cvat_pair_data(self, path: str) -> DatumDataset:
         """Preparing a list of DatumaroDataset."""
-        cvat_data_list = []
-        for cvat_data in os.listdir(path):
-            cvat_data_path = osp.join(path, cvat_data)
-            cvat_data_list.append(DatumaroDataset.import_from(cvat_data_path, "cvat"))
-        return cvat_data_list
+        cvat_dataset_list = []
+        for video_name in os.listdir(path):
+            cvat_data_path = osp.join(path, video_name)
+            dataset = DatumDataset.import_from(cvat_data_path, "cvat")
+            for item in dataset:
+                item.id = f"{video_name}{self.VIDEO_FRAME_SEP}{item.id}"
+            cvat_dataset_list.append(dataset)
 
-    # pylint: disable=protected-access, too-many-nested-blocks
-    def _prepare_label_information(self, datumaro_dataset: dict) -> Dict[str, Any]:
-        """Prepare and reorganize the label information for merging multiple video information.
+        dataset = DatumDataset.from_extractors(*cvat_dataset_list, merge_policy="union")
+        # set source path for storage cache
+        dataset._source_path = path
 
-        Description w/ examples:
-
-        [Making overall categories]
-        Suppose that video1 has labels=[0, 1, 2] and video2 has labels=[0, 1, 4],
-        then the overall label should include all label informations as [0, 1, 2, 4].
-
-        [Reindexing the each label index of multiple video datasets]
-        In this case, if the label for 'video1/frame_000.jpg' is 2, then the index of label is set to 2.
-        For the case of video2, if the label for 'video2/frame_000.jpg' is 4, then the index of label is set to 2.
-        However, Since overall labels are [0, 1, 2, 4], 'video2/frame_000.jpg' should has the label index as 3.
-
-        """
-        outputs = {
-            "label_entities": [],
-        }  # type: dict
-
-        # Making overall categories
-        has_EmptyFrame = False
-        category_names: List[str] = []  # to check the duplicate case
-        subset = list(datumaro_dataset.keys())[0]
-        for cvat_data in datumaro_dataset[subset]:
-            categories = cvat_data.categories().get(AnnotationType.label, None)
-            if categories is not None:
-                indices = categories._indices
-                for name in indices:
-                    if name == "EmptyFrame":
-                        has_EmptyFrame = True
-                        continue
-                    if name not in category_names:
-                        category_names.append(name)
-        category_names.sort()
-
-        if has_EmptyFrame:
-            category_names.append("EmptyFrame")
-
-        # Reindexing the each label index of multiple video datasets
-        for subset_data in datumaro_dataset.values():
-            for cvat_data in subset_data:
-                for cvat_data_item in cvat_data:
-                    categories = cvat_data.categories().get(AnnotationType.label, None)
-                    if categories is not None:
-                        for annotation in cvat_data_item.annotations:
-                            ann_name = self.get_ann_name(categories._indices, annotation.label)
-                            if ann_name is not None:
-                                annotation.label = self.get_ann_label(category_names, ann_name)
-
-        # Generate label_entity list according to overall categories
-        outputs["label_entities"] = [
-            LabelEntity(name=name, domain=self.domain, is_empty=False, id=ID(index))
-            for index, name in enumerate(category_names)
+        # make sure empty frame label has the last label index
+        dst_labels = [
+            (float("inf"), category.name) if category.name == self.EMPTY_FRAME_LABEL_NAME else (label, category.name)
+            for label, category in enumerate(dataset.categories()[AnnotationType.label])
         ]
-        return outputs
+        dst_labels.sort()
+        dst_labels = [name for _, name in dst_labels]
+        dataset.transform("project_labels", dst_labels=dst_labels)
 
-    @staticmethod
-    def get_ann_name(indices: Dict[str, int], label: int) -> Optional[str]:
-        """Get action name from index."""
-        for _name, _label in indices.items():
-            if _label == label:
-                return _name
-        return None
-
-    @staticmethod
-    def get_ann_label(category_names: List[str], ann_name: str) -> Optional[int]:
-        """Get action index from name."""
-        for idx, name in enumerate(category_names):
-            if name == ann_name:
-                return idx
-        return None
+        return dataset
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Get DatasetEntity.
@@ -169,19 +118,20 @@ class ActionClassificationDatasetAdapter(ActionBaseDatasetAdapter):
 
         dataset_items: List[DatasetItemEntity] = []
         for subset, subset_data in self.dataset.items():
-            for datumaro_items in subset_data:
+            for _, datumaro_items in subset_data.subsets().items():
                 for datumaro_item in datumaro_items:
-                    image = Image(file_path=datumaro_item.media.path)
-                    video_name = datumaro_item.media.path.split("/")[-3]
+                    image = self.datum_media_2_otx_media(datumaro_item.media)
+                    assert isinstance(image, Image)
                     shapes: List[Annotation] = []
                     for annotation in datumaro_item.annotations:
                         if annotation.type == AnnotationType.label:
                             shapes.append(self._get_label_entity(annotation))
 
+                    video_name, frame_idx = datumaro_item.id.split(self.VIDEO_FRAME_SEP)
                     metadata_item = MetadataItemEntity(
                         data=VideoMetadata(
                             video_id=video_name,
-                            frame_idx=int(datumaro_item.media.path.split("/")[-1].split(".")[0].lstrip("0")),
+                            frame_idx=int(frame_idx),
                             is_empty_frame=False,
                         )
                     )
@@ -190,6 +140,7 @@ class ActionClassificationDatasetAdapter(ActionBaseDatasetAdapter):
                         image, self._get_ann_scene_entity(shapes), subset=subset, metadata=[metadata_item]
                     )
                     dataset_items.append(dataset_item)
+
         return DatasetEntity(items=dataset_items)
 
 
@@ -208,23 +159,25 @@ class ActionDetectionDatasetAdapter(ActionBaseDatasetAdapter):
 
         dataset_items: List[DatasetItemEntity] = []
         for subset, subset_data in self.dataset.items():
-            for datumaro_items in subset_data:
+            for _, datumaro_items in subset_data.subsets().items():
                 for datumaro_item in datumaro_items:
-                    image = Image(file_path=datumaro_item.media.path)
-                    video_name = datumaro_item.media.path.split("/")[-3]
+                    image = self.datum_media_2_otx_media(datumaro_item.media)
+                    assert isinstance(image, Image)
                     shapes: List[Annotation] = []
                     is_empty_frame = False
                     for annotation in datumaro_item.annotations:
-                        if isinstance(annotation, DatumaroBbox):
-                            if self.label_entities[annotation.label].name == "EmptyFrame":
+                        if isinstance(annotation, DatumBbox):
+                            if self.label_entities[annotation.label].name == self.EMPTY_FRAME_LABEL_NAME:
                                 is_empty_frame = True
                                 shapes.append(self._get_label_entity(annotation))
                             else:
                                 shapes.append(self._get_original_bbox_entity(annotation))
+
+                    video_name, frame_name = datumaro_item.id.split(self.VIDEO_FRAME_SEP)
                     metadata_item = MetadataItemEntity(
                         data=VideoMetadata(
                             video_id=video_name,
-                            frame_idx=int(datumaro_item.media.path.split("/")[-1].split(".")[0].split("_")[-1]),
+                            frame_idx=int(frame_name.split("_")[-1]),
                             is_empty_frame=is_empty_frame,
                         )
                     )
@@ -233,7 +186,8 @@ class ActionDetectionDatasetAdapter(ActionBaseDatasetAdapter):
                     )
                     dataset_items.append(dataset_item)
 
-        if self.label_entities[-1].name == "EmptyFrame":
-            self.label_entities = self.label_entities[:-1]
+        found = [i for i, entity in enumerate(self.label_entities) if entity.name == self.EMPTY_FRAME_LABEL_NAME]
+        if found:
+            self.label_entities.pop(found[0])
 
         return DatasetEntity(items=dataset_items)

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -99,10 +99,11 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             unlabeled_file_list=unlabeled_file_list,
         )
 
-        if cache_config is None:
-            cache_config = {}
+        cache_config = cache_config if cache_config is not None else {}
         for subset, dataset in self.dataset.items():
-            self.dataset[subset] = init_arrow_cache(dataset, **cache_config)
+            # cache these subsets only
+            if subset not in (Subset.TRAINING, Subset.VALIDATION, Subset.UNLABELED, Subset.PSEUDOLABELED):
+                self.dataset[subset] = init_arrow_cache(dataset, **cache_config)
 
         self.category_items: Dict[DatumAnnotationType, DatumCategories]
         self.label_groups: List[str]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
- Refactored `action_dataset_adapter.py` for storage cache
  - Datumaro is in charge of merging categories and reindexing labels instead of OTX
- Cache-able subsets are `TRAINING`, `VALIDATION`, `UNLABELED`, `PSEUDOLABELED` only

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
