### PR TITLE
Fix statistic collection error for TileClassifier

### DIFF
--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -12,6 +12,7 @@ from mmdet.models.builder import DETECTORS
 from torch import nn
 
 from otx.algorithms.common.adapters.mmdeploy import is_mmdeploy_enabled
+from otx.algorithms.common.adapters.nncf import no_nncf_trace
 
 from .custom_maskrcnn_detector import CustomMaskRCNN
 
@@ -82,7 +83,10 @@ class TileClassifier(torch.nn.Module):
         Returns:
             torch.Tensor: objectness score
         """
-        return self.sigmoid(self.forward(img))[0][0]
+
+        out = self.forward(img)
+        with no_nncf_trace():
+            return self.sigmoid(out)[0][0]
 
 
 # pylint: disable=too-many-ancestors


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
The problem was caused by inconsistent model structures when test and training.

The sigmoid is used only in `simple_test` method which is executed when NNCF traces a model and builds an internal graph.
Since the sigmoid node is added into the NNCF graph by the graph building process, NNCF expects it to be presented in training phase as well and tries to collect its statistics to determine quantization parameters by passing some data to the model in training mode.
Unfortunately, the sigmoid is not executed in training mode since it is not called while training. This leads `StatisticsNotCollectedError` @eugene123tw faced.

We have to explicitly tell NNCF that the sigmoid is not a part of model structure NNCF should trace so that the sigmoid node is not added into NNCF graph and NNCF does not bother to collect its statistics.



<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
