### PR TITLE
Update concurrency settings for pre-merge

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,11 +6,6 @@ on:
     # every UTC 7PM from Mon to Fri
     - cron: "0 19 * * 1-5"
 
-# This is what will cancel the workflow concurrency
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   E2E-tests:
     strategy:

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -12,13 +12,12 @@ on:
       - synchronize
   workflow_dispatch: # run on request (no need for PR)
 
-# This is what will cancel the workflow concurrency
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   Code-Quality-Checks:
+    # This is what will cancel the job concurrency
+    concurrency:
+      group: ${{ github.workflow }}-Linting-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -45,6 +44,10 @@ jobs:
           - python-version: "3.10"
             tox-env: "py310"
     name: Unit-Test-with-Python${{ matrix.python-version }}
+    # This is what will cancel the job concurrency
+    concurrency:
+      group: ${{ github.workflow }}-Unit-${{ github.event.pull_request.number || github.ref }}-${{ matrix.tox-env }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -94,6 +97,10 @@ jobs:
           - task: "ano"
             test_dir: "tests/integration/cli/anomaly"
     name: Integration-Test-py310-${{ matrix.task }}
+    # This is what will cancel the job concurrency
+    concurrency:
+      group: ${{ github.workflow }}-Integration-${{ github.event.pull_request.number || github.ref }}-${{ matrix.task }}
+      cancel-in-progress: true
     uses: ./.github/workflows/run_tests_in_tox.yml
     with:
       python-version: "3.10"


### PR DESCRIPTION
### Summary
By applying reusable workflow to the testing pipelines, the workflow level of concurrency setting leads unexpected job canceling when any job resulted as failure because all jobs shared the same concurrency group setting.
By this PR, those issues can be fixed.

* Pre-merge: Workflow level of concurrency setting leads unexpected job canceling.
To resolve this issue, concurrency setting needs to be moved to each job level.

* Daily: remove concurrency setting