### PR TITLE
Bugfix : remove early stop hook while decreasing batch size

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -64,15 +64,17 @@ def adapt_batch_size(train_func: Callable, cfg, datasets: List, validate: bool =
         else:
             copied_cfg.runner["max_epochs"] = 1
 
-        otx_prog_hook_idx = None
+        idx_hooks_to_remove = []
         for i, hook in enumerate(copied_cfg.custom_hooks):
             if not validate and hook["type"] == "AdaptiveTrainSchedulingHook":
                 hook["enable_eval_before_run"] = False
-            elif hook["type"] == "OTXProgressHook":
-                otx_prog_hook_idx = i
+            if hook["type"] == "OTXProgressHook" or "earlystoppinghook" in hook["type"].lower():
+                idx_hooks_to_remove.append(i)
 
-        if otx_prog_hook_idx is not None:
-            del copied_cfg.custom_hooks[otx_prog_hook_idx]
+        if idx_hooks_to_remove:
+            idx_hooks_to_remove.sort()
+            for i in reversed(idx_hooks_to_remove):
+                del copied_cfg.custom_hooks[i]
 
         new_datasets = [SubDataset(datasets[0], batch_size)]
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Generally, early stop hook doesn't make problem because it isn't executed while warmup iter.
But in some case where it's executed from first iteration, it could be problematic.
So, I remove it while decreasing batch size.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
