### PR TITLE
Set fail-fast to false to avoid canceling on parallel jobs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   E2E-tests:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - task: "act"

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -35,6 +35,7 @@ jobs:
     needs: Code-Quality-Checks
     timeout-minutes: 120
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: "3.8"
@@ -80,6 +81,7 @@ jobs:
   Integration-Test:
     needs: Unit-Test
     strategy:
+      fail-fast: false
       matrix:
         include:
           - task: "all"


### PR DESCRIPTION
### Summary

Default option of the `fail-fast` to the workflow is `true` so the jobs running as parallel (using matrix) will be
canceled when any instance completed as `failure`.
To avoid this, need to set `fail-fast: false` for the job runs as parallel.
