### PR TITLE
Resolve CLI build bug with lower case

### DIFF
--- a/otx/cli/registry/registry.py
+++ b/otx/cli/registry/registry.py
@@ -74,7 +74,9 @@ class Registry:
         """Returns a model template with specified template_id or template.name."""
 
         templates = [
-            template for template in self.templates if template_id in (template.model_template_id, template.name)
+            template
+            for template in self.templates
+            if str(template_id).upper() in (str(template.model_template_id).upper(), str(template.name).upper())
         ]
         if not templates:
             if skip_error:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Resolve https://github.com/openvinotoolkit/training_extensions/issues/2066
Fixed an issue with lowercase template IDs or model names building to the wrong model.

### How to test
```
otx build yolox
otx build YOLOX
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
