### PR TITLE
Enabled regression testing workflow

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,14 +1,17 @@
 #########################################################
 ## Python Environment with CUDA
 #########################################################
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG NO_PROXY
-ARG action_runner_url
 ARG ver_cuda="11.7.1"
 
 FROM nvidia/cuda:${ver_cuda}-devel-ubuntu20.04 AS python_base_cuda
 LABEL maintainer="OpenVINO Training Extensions Development Team"
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG action_runner_url
+ARG uid
+ARG gid
 
 # Setup proxies
 ENV http_proxy=$HTTP_PROXY
@@ -37,19 +40,15 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # set /tmp folder cleaning schedule at 7PM every day which is older than a day
 RUN echo "0 19 * * * find /tmp/* -mtime +1 -exec rm -rf {} \;" >> ./cron_clean_tmp.txt && \
     crontab cron_clean_tmp.txt && \
-    # Create a non-root user
-    useradd -m validation
+    # Create a non-root user with having given UID & GID
+    groupadd -r -g ${gid} validation && \
+    useradd -l -r -m validation -g ${gid} -u ${uid} && \
+    echo "${gid}:${uid}"
 
 USER validation
 
 WORKDIR /home/validation
 
-# Install Conda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh --quiet && \
-    bash /home/validation/miniconda.sh -b -p /home/validation/conda && \
-    rm ~/miniconda.sh
-ENV PATH "/home/validation/conda/bin:${PATH}"
-RUN conda install python=3.10
 
 #########################################################
 ## OTX Development Env

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 VER_CUDA="11.7.1"
-ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v2.299.1/actions-runner-linux-x64-2.299.1.tar.gz"
+ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v2.304.0/actions-runner-linux-x64-2.304.0.tar.gz"
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   key="$1"
@@ -55,6 +55,8 @@ docker build -f .ci/Dockerfile \
 --build-arg NO_PROXY="${no_proxy:?}" \
 --build-arg ver_cuda="$VER_CUDA" \
 --build-arg action_runner_url="$ACTIONS_RUNNER_URL" \
+--build-arg gid="$(id -g)" \
+--build-arg uid="$UID" \
 --tag "$DOCKER_REG_ADDR"/ote/ci/cu"$VER_CUDA"/runner:"$TAG" \
 --tag "$DOCKER_REG_ADDR"/ote/ci/cu"$VER_CUDA"/runner:latest .; RET=$?
 

--- a/.github/workflows/run_tests_in_tox.yml
+++ b/.github/workflows/run_tests_in_tox.yml
@@ -21,10 +21,14 @@ on:
       upload-artifact:
         type: boolean
         default: false
-
+      runs-on:
+        type: string
+        default: "['self-hosted', 'Linux', 'X64', 'dev']"
 jobs:
   run_tests_in_tox:
-    runs-on: [self-hosted, linux, x64, dev]
+    # tricky workaround to pass list from the string input type
+    # https://github.com/orgs/community/discussions/11692
+    runs-on: ${{ fromJson(inputs.runs-on) }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -3,28 +3,42 @@ name: Weekly Test
 on:
   workflow_dispatch: # run on request (no need for PR)
   schedule:
-    # every 12AM on Sunday
-    - cron: "0 0 * * 0"
+    # # every 12AM on Sunday
+    # - cron: "0 0 * * 0"
+    # every 12AM on Mon to Fri
+    - cron: "0 19 * * 1-5"
 
 jobs:
-  Weekly-Tests:
-    runs-on: [self-hosted, linux, x64, dev]
-    timeout-minutes: 1440
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: python -m pip install -r requirements/dev.txt
-      - name: Regression Tests
-        run: tox -e tests-all-py310 -- tests/regression
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results
-          path: .tox/test-results.xml
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
+  Regression-Tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: "act"
+            test_dir: "tests/regression/action"
+            runs_on: "['self-hosted', 'Linux', 'X64', 'dmount']"
+          - task: "ano"
+            test_dir: "tests/regression/anomaly"
+            runs_on: "['self-hosted', 'Linux', 'X64', 'dmount']"
+          - task: "cls"
+            test_dir: "tests/regression/classification"
+            runs_on: "['self-hosted', 'Linux', 'X64', 'dmount']"
+          - task: "det"
+            test_dir: "tests/regression/detection"
+            runs_on: "['self-hosted', 'Linux', 'X64', 'dmount']"
+          - task: "iseg"
+            test_dir: "tests/regression/instance_segmentation"
+            runs_on: "['self-hosted', 'Linux', 'X64', 'dmount']"
+          - task: "seg"
+            test_dir: "tests/regression/semantic_segmentation"
+            runs_on: "['self-hosted', 'Linux', 'X64', 'dmount']"
+    name: Regression-Test-py310-${{ matrix.task }}
+    uses: ./.github/workflows/run_tests_in_tox.yml
+    with:
+      python-version: "3.10"
+      toxenv-pyver: "py310"
+      toxenv-task: ${{ matrix.task }}
+      tests-dir: ${{ matrix.test_dir }}
+      runs-on: ${{ matrix.runs_on }}
+      timeout-minutes: 1440
+      upload-artifact: true

--- a/tests/regression/regression_config.json
+++ b/tests/regression/regression_config.json
@@ -3,180 +3,180 @@
     "classification": {
       "supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/test",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/test",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset/test/airplane"
+          "--train-data-roots": "classification/cifar10_subset_cls_decr/train",
+          "--val-data-roots": "classification/cifar10_subset_cls_decr/test",
+          "--test-data-roots": "classification/cifar10_subset_cls_decr/test",
+          "--input": "classification/cifar10_subset/test/airplane"
         },
         "multi_label": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset_cls_decr",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset_cls_decr",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset_cls_decr",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset/images/test"
+          "--train-data-roots": "classification/multi_label_coco_subset_cls_decr",
+          "--val-data-roots": "classification/multi_label_coco_subset_cls_decr",
+          "--test-data-roots": "classification/multi_label_coco_subset_cls_decr",
+          "--input": "classification/multi_label_coco_subset/images/test"
         },
         "h_label": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/h_label_cifar10_subset",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/h_label_cifar10_subset",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/h_label_cifar10_subset",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/h_label_cifar10_subset/images/test/airplane"
+          "--train-data-roots": "classification/h_label_cifar10_subset",
+          "--val-data-roots": "classification/h_label_cifar10_subset",
+          "--test-data-roots": "classification/h_label_cifar10_subset",
+          "--input": "classification/h_label_cifar10_subset/images/test/airplane"
         },
         "supcon": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/test",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/test"
+          "--train-data-roots": "classification/cifar10_subset_cls_decr/train",
+          "--val-data-roots": "classification/cifar10_subset_cls_decr/test",
+          "--test-data-roots": "classification/cifar10_subset_cls_decr/test"
         }
       },
       "class_incr": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset/test",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset/test"
+          "--train-data-roots": "classification/cifar10_subset/train",
+          "--val-data-roots": "classification/cifar10_subset/test",
+          "--test-data-roots": "classification/cifar10_subset/test"
         },
         "multi_label": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/multi_label_coco_subset"
+          "--train-data-roots": "classification/multi_label_coco_subset",
+          "--val-data-roots": "classification/multi_label_coco_subset",
+          "--test-data-roots": "classification/multi_label_coco_subset"
         }
       },
       "semi_supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/test",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/test",
-          "--unlabeled-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_unlabeled"
+          "--train-data-roots": "classification/cifar10_subset_cls_decr/train",
+          "--val-data-roots": "classification/cifar10_subset_cls_decr/test",
+          "--test-data-roots": "classification/cifar10_subset_cls_decr/test",
+          "--unlabeled-data-roots": "classification/cifar10_unlabeled"
         }
       },
       "self_supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/classification/cifar10_subset_cls_decr/train"
+          "--train-data-roots": "classification/cifar10_subset_cls_decr/train"
         }
       }
     },
     "detection": {
       "supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr/images/test"
+          "--train-data-roots": "detection/coco_subset_cls_decr",
+          "--val-data-roots": "detection/coco_subset_cls_decr",
+          "--test-data-roots": "detection/coco_subset_cls_decr",
+          "--input": "detection/coco_subset_cls_decr/images/test"
         }
       },
       "class_incr": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset"
+          "--train-data-roots": "detection/coco_subset",
+          "--val-data-roots": "detection/coco_subset",
+          "--test-data-roots": "detection/coco_subset"
         }
       },
       "semi_supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--unlabeled-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset/images/unlabeled"
+          "--train-data-roots": "detection/coco_subset_cls_decr",
+          "--val-data-roots": "detection/coco_subset_cls_decr",
+          "--test-data-roots": "detection/coco_subset_cls_decr",
+          "--unlabeled-data-roots": "detection/coco_subset/images/unlabeled"
         }
       },
       "tiling": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset/images/test"
+          "--train-data-roots": "detection/coco_subset_cls_decr",
+          "--val-data-roots": "detection/coco_subset_cls_decr",
+          "--test-data-roots": "detection/coco_subset_cls_decr",
+          "--input": "detection/coco_subset/images/test"
         }
       }
     },
     "segmentation": {
       "supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/val",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/test",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/test/images"
+          "--train-data-roots": "segmentation/regression_voc_cls_decr/train",
+          "--val-data-roots": "segmentation/regression_voc_cls_decr/val",
+          "--test-data-roots": "segmentation/regression_voc_cls_decr/tests",
+          "--input": "segmentation/regression_voc_cls_decr/test/images"
         }
       },
       "class_incr": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_sl/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_sl/val",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_sl/test"
+          "--train-data-roots": "segmentation/regression_voc_sl/train",
+          "--val-data-roots": "segmentation/regression_voc_sl/val",
+          "--test-data-roots": "segmentation/regression_voc_sl/test"
         }
       },
       "semi_supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/val",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/test",
-          "--unlabeled-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_semisl/unlabeled"
+          "--train-data-roots": "segmentation/regression_voc_cls_decr/train",
+          "--val-data-roots": "segmentation/regression_voc_cls_decr/val",
+          "--test-data-roots": "segmentation/regression_voc_cls_decr/test",
+          "--unlabeled-data-roots": "segmentation/regression_voc_semisl/unlabeled"
         }
       },
       "self_supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/segmentation/regression_voc_cls_decr/train"
+          "--train-data-roots": "segmentation/regression_voc_cls_decr/train"
         }
       }
     },
     "instance_segmentation": {
       "supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr/images/test"
+          "--train-data-roots": "detection/coco_subset_cls_decr",
+          "--val-data-roots": "detection/coco_subset_cls_decr",
+          "--test-data-roots": "detection/coco_subset_cls_decr",
+          "--input": "detection/coco_subset_cls_decr/images/test"
         }
       },
       "class_incr": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset"
+          "--train-data-roots": "detection/coco_subset",
+          "--val-data-roots": "detection/coco_subset",
+          "--test-data-roots": "detection/coco_subset"
         }
       },
       "tiling": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset_cls_decr",
-          "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/detection/coco_subset/images/test"
+          "--train-data-roots": "detection/coco_subset_cls_decr",
+          "--val-data-roots": "detection/coco_subset_cls_decr",
+          "--test-data-roots": "detection/coco_subset_cls_decr",
+          "--input": "detection/coco_subset/images/test"
         }
       }
     },
     "action_classification": {
       "supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/action/classification/HMDB51_30percent/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/action/classification/HMDB51_30percent/val",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/action/classification/HMDB51_30percent/val"
+          "--train-data-roots": "action/classification/HMDB51_30percent/train",
+          "--val-data-roots": "action/classification/HMDB51_30percent/val",
+          "--test-data-roots": "action/classification/HMDB51_30percent/val"
         }
       }
     },
     "action_detection": {
       "supervised": {
         "multi_class": {
-          "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/action/detection/JHMDB_5percent/train",
-          "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/action/detection/JHMDB_5percent/test",
-          "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/action/detection/JHMDB_5percent/test"
+          "--train-data-roots": "action/detection/JHMDB_5percent/train",
+          "--val-data-roots": "action/detection/JHMDB_5percent/test",
+          "--test-data-roots": "action/detection/JHMDB_5percent/test"
         }
       }
     },
     "anomaly_classification": {
-      "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec/bottle/test/contamination",
+      "--train-data-roots": "anomaly/mvtec",
+      "--val-data-roots": "anomaly/mvtec",
+      "--test-data-roots": "anomaly/mvtec",
+      "--input": "anomaly/mvtec/bottle/test/contamination",
       "train_params": []
     },
     "anomaly_detection": {
-      "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec/bottle/test/contamination",
+      "--train-data-roots": "anomaly/mvtec",
+      "--val-data-roots": "anomaly/mvtec",
+      "--test-data-roots": "anomaly/mvtec",
+      "--input": "anomaly/mvtec/bottle/test/contamination",
       "train_params": []
     },
     "anomaly_segmentation": {
-      "--train-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--val-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--test-data-roots": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec",
-      "--input": "/storageserver/pvd_data/otx_data_archive/regression_datasets/anomaly/mvtec/bottle/test/contamination",
+      "--train-data-roots": "anomaly/mvtec",
+      "--val-data-roots": "anomaly/mvtec",
+      "--test-data-roots": "anomaly/mvtec",
+      "--input": "anomaly/mvtec/bottle/test/contamination",
       "train_params": []
     }
   },

--- a/tests/regression/regression_test_helpers.py
+++ b/tests/regression/regression_test_helpers.py
@@ -13,6 +13,7 @@
 # and limitations under the License.
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -120,6 +121,8 @@ def load_regression_configuration(
         "model_criteria": 0,
     }
 
+    data_root = os.environ.get("CI_DATA_ROOT", "/storageserver/pvd_data/otx_data_archive/regression_datasets")
+
     if "anomaly" not in task_type:
         if train_type == "" or label_type == "":
             raise ValueError()
@@ -130,12 +133,24 @@ def load_regression_configuration(
         result["kpi_e2e_eval_time_criteria"] = reg_config["kpi_e2e_eval_time_criteria"][task_type][train_type][
             label_type
         ]
-        result["data_path"] = reg_config["data_path"][task_type][train_type][label_type]
+
+        # update data_path using data_root setting
+        data_paths = reg_config["data_path"][task_type][train_type][label_type]
+        for key, value in data_paths.items():
+            data_paths[key] = os.path.join(data_root, value)
+
+        result["data_path"] = data_paths
     else:
         result["regression_criteria"] = reg_config["regression_criteria"][task_type]
         result["kpi_e2e_train_time_criteria"] = reg_config["kpi_e2e_train_time_criteria"][task_type]
         result["kpi_e2e_eval_time_criteria"] = reg_config["kpi_e2e_eval_time_criteria"][task_type]
-        result["data_path"] = reg_config["data_path"][task_type]
+
+        # update data_path using data_root setting
+        data_paths = reg_config["data_path"][task_type][train_type][label_type]
+        for key, value in data_paths.items():
+            data_paths[key] = os.path.join(data_root, value)
+
+        result["data_path"] = data_paths
 
     return result
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ passenv =
     CUDA_VISIBLE_DEVICES
     SNYK_ENDPOINT
     SNYK_TOKEN
+    CI_DATA_ROOT
 test_dir =
     all: cli
     ano: cli/anomaly


### PR DESCRIPTION
### Summary

Enabled regression tests automation through the `weekly` workflow.
tests will be triggered separately for each task and scheduled to run everyday until stabilized the results.

### How to test

To run regression tests on the local machine, you need to prepare regression test datasets and set that path to the `CI_DATA_ROOT` environment variable.

```bash
$ CI_DATA_ROOT=/storageserver/pvd_data//otx_data_archive tox -e tests-all-py310 -- tests/regression
```
