### PR TITLE
Set `paired_bn` to `False` as default in `OVModel`

### DIFF
--- a/otx/core/ov/models/ov_model.py
+++ b/otx/core/ov/models/ov_model.py
@@ -45,7 +45,7 @@ class OVModel(torch.nn.Module):  # pylint: disable=too-many-instance-attributes
         features_to_keep: Optional[List] = None,
         remove_normalize: bool = False,
         merge_bn: bool = True,
-        paired_bn: bool = True,
+        paired_bn: bool = False,
         init_weight: Union[bool, Callable] = False,
         verify_shape: bool = True,
     ):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Resolve https://github.com/openvinotoolkit/training_extensions/issues/2122
In the case of MMOVBackbone + normal head (LinearClsHead), the `paired_bn` variable causes batch normalization to be patched, resulting in size mismatching in training.
Modify this to default to False and make it available to normal heads as well.

### How to test

```
otx build --task classification
cd otx-workspace-CLASSIFICATION
Edit data.yaml with data paths
otx build --backbone mmcls.MMOVBackbone
otx train

------------------------------------------------------
2023-05-10 16:17:48,286 | INFO : called save_model
2023-05-10 16:17:48,307 | INFO : Final model performance: Performance(score: 0.125, dashboard: (23 metric groups))
2023-05-10 16:17:48,308 | INFO : train done.
otx train time elapsed:  0:00:21.203964
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
