### PR TITLE
Match categories between training dataset and validation dataset via name sorting for action task

### DIFF
--- a/otx/core/data/adapter/action_dataset_adapter.py
+++ b/otx/core/data/adapter/action_dataset_adapter.py
@@ -86,9 +86,11 @@ class ActionBaseDatasetAdapter(BaseDatasetAdapter):
         dataset._source_path = path
 
         # make sure empty frame label has the last label index
+        categories = [category.name for category in dataset.categories()[AnnotationType.label]]
+        categories.sort()
         dst_labels = [
-            (float("inf"), category.name) if category.name == self.EMPTY_FRAME_LABEL_NAME else (label, category.name)
-            for label, category in enumerate(dataset.categories()[AnnotationType.label])
+            (float("inf"), category) if category == self.EMPTY_FRAME_LABEL_NAME else (label, category)
+            for label, category in enumerate(categories)
         ]
         dst_labels.sort()
         dst_labels = [name for _, name in dst_labels]


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/openvinotoolkit/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR is for sync category order between training dataset and validation dataset.
Through sorting by name, we can expect that category will never be changed for same dataset.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
Regression test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
