### PR TITLE
Fixed an issue where seeds were not properly reflected in CLI reports

### DIFF
--- a/otx/algorithms/common/tasks/base_task.py
+++ b/otx/algorithms/common/tasks/base_task.py
@@ -319,6 +319,8 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
         if not self.deterministic:
             # deterministic is the same.
             self.deterministic = self.config.get("deterministic", False)
+        self.config["seed"] = self.seed
+        self.config["deterministic"] = self.deterministic
         set_random_seed(self.seed, logger, self.deterministic)
 
     @property

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -285,6 +285,7 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
         results=model_results,
         output_path=config_manager.output_path / "cli_report.log",
     )
+    print(f"otx train CLI report has been generated: {config_manager.output_path / 'cli_report.log'}")
 
     # Latest model folder symbolic link to models
     latest_path = config_manager.workspace_root / "outputs" / "latest_trained_model"


### PR DESCRIPTION
### Summary

Resolve https://github.com/openvinotoolkit/training_extensions/issues/2134
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/da4fdff8-654b-43be-b0e6-8f3994fb6191)
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/e5fbc1d5-d733-41df-b858-34042156c5fd)


### How to test

`otx train`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
