### PR TITLE
Add dumping hierarchical information to M-API config

### DIFF
--- a/otx/algorithms/classification/utils/cls_utils.py
+++ b/otx/algorithms/classification/utils/cls_utils.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=too-many-nested-blocks, invalid-name
 
+import json
 from operator import itemgetter
 from typing import Any, Dict
 
@@ -103,6 +104,13 @@ def get_cls_model_api_configuration(label_schema: LabelSchemaEntity, inference_c
     for lbl in label_schema.get_labels(include_empty=False):
         all_labels += lbl.name.replace(" ", "_") + " "
     all_labels = all_labels.strip()
-
     mapi_config[("model_info", "labels")] = all_labels
+
+    hierarchical_config = {}
+    hierarchical_config["cls_heads_info"] = get_multihead_class_info(label_schema)
+    hierarchical_config["label_tree_edges"] = []
+    for edge in label_schema.label_tree.edges:  # (child, parent)
+        hierarchical_config["label_tree_edges"].append((edge[0].name.replace(" ", "_"), edge[1].name.replace(" ", "_")))
+
+    mapi_config[("model_info", "hierarchical_config")] = json.dumps(hierarchical_config)
     return mapi_config

--- a/tests/unit/algorithms/classification/utils/test_utils.py
+++ b/tests/unit/algorithms/classification/utils/test_utils.py
@@ -91,4 +91,5 @@ def test_get_cls_model_api_configuration(default_hierarchical_data):
     model_api_cfg = get_cls_model_api_configuration(label_schema, config)
 
     assert len(model_api_cfg) > 0
-    model_api_cfg[("model_info", "confidence_threshold")] = str(config["confidence_threshold"])
+    assert model_api_cfg[("model_info", "confidence_threshold")] == str(config["confidence_threshold"])
+    assert ("model_info", "hierarchical_config") in model_api_cfg


### PR DESCRIPTION
### Summary
Hierarchical info structure and child-parent information from label schema are added to ModelAPI cinfig.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
