### PR TITLE
Fixed wrong data_path patching for anomalib regression tests

### DIFF
--- a/tests/regression/regression_test_helpers.py
+++ b/tests/regression/regression_test_helpers.py
@@ -148,7 +148,8 @@ def load_regression_configuration(
         # update data_path using data_root setting
         data_paths = reg_config["data_path"][task_type]
         for key, value in data_paths.items():
-            data_paths[key] = os.path.join(data_root, value)
+            if key != "train_params":
+                data_paths[key] = os.path.join(data_root, value)
 
         result["data_path"] = data_paths
 


### PR DESCRIPTION
### Summary

data_path patching (applying ci dataset root) should not be applied to the "train_params" for the anomalib