### PR TITLE
Add sampling tiling dataset method

### DIFF
--- a/otx/algorithms/common/configs/training_base.py
+++ b/otx/algorithms/common/configs/training_base.py
@@ -388,4 +388,17 @@ class BaseConfig(ConfigurableParameters):
             affects_outcome_of=ModelLifecycle.NONE,
         )
 
+        tile_sampling_ratio = configurable_float(
+            header="Sampling Ratio for entire tiling",
+            description="Since tiling train and validation to all tile from large image, "
+            "usually it takes lots of time than normal training."
+            "The tile_sampling_ratio is ratio for sampling entire tile dataset."
+            "Sampling tile dataset would save lots of time for training and validation time."
+            "Note that sampling will be applied to training and validation dataset, not test dataset.",
+            default_value=1.0,
+            min_value=0.000001,
+            max_value=1.0,
+            affects_outcome_of=ModelLifecycle.NONE,
+        )
+
     tiling_parameters = add_parameter_group(BaseTilingParameters)

--- a/otx/algorithms/detection/adapters/mmdet/datasets/dataset.py
+++ b/otx/algorithms/detection/adapters/mmdet/datasets/dataset.py
@@ -32,6 +32,7 @@ from otx.algorithms.detection.adapters.mmdet.evaluation import eval_segm
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.label import Domain, LabelEntity
+from otx.api.entities.subset import Subset
 from otx.api.utils.shape_factory import ShapeFactory
 
 from .tiling import Tile
@@ -326,6 +327,7 @@ class ImageTilingDataset:
             after NMS, only top max_per_img will be kept. Defaults to 200.
         max_annotation (int, optional): Limit the number of ground truth by
             randomly select 5000 due to RAM OOM. Defaults to 5000.
+        sampling_ratio (flaot): Ratio for sampling entire tile dataset.
     """
 
     def __init__(
@@ -340,6 +342,7 @@ class ImageTilingDataset:
         max_annotation=5000,
         filter_empty_gt=True,
         test_mode=False,
+        sampling_ratio=1.0,
     ):
         self.dataset = build_dataset(dataset)
         self.CLASSES = self.dataset.CLASSES
@@ -356,6 +359,7 @@ class ImageTilingDataset:
             max_per_img=max_per_img,
             max_annotation=max_annotation,
             filter_empty_gt=False if test_mode else filter_empty_gt,
+            sampling_ratio=sampling_ratio if self.dataset.otx_dataset[0].subset != Subset.TESTING else 1.0,
         )
         self.flag = np.zeros(len(self), dtype=np.uint8)
         self.pipeline = Compose(pipeline)

--- a/otx/algorithms/detection/adapters/mmdet/hooks/__init__.py
+++ b/otx/algorithms/detection/adapters/mmdet/hooks/__init__.py
@@ -4,5 +4,6 @@
 #
 
 from .det_class_probability_map_hook import DetClassProbabilityMapHook
+from .tile_sampling_hook import TileSamplingHook
 
-__all__ = ["DetClassProbabilityMapHook"]
+__all__ = ["DetClassProbabilityMapHook", "TileSamplingHook"]

--- a/otx/algorithms/detection/adapters/mmdet/hooks/tile_sampling_hook.py
+++ b/otx/algorithms/detection/adapters/mmdet/hooks/tile_sampling_hook.py
@@ -1,0 +1,24 @@
+"""Tile Samipling Hook."""
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from random import sample
+
+from mmcv.runner import HOOKS, Hook
+
+
+@HOOKS.register_module()
+class TileSamplingHook(Hook):
+    """Tile Sampling Hook.
+
+    Usually training model with tile requires lots of time due to large images generate plenty of tiles.
+    To save training and validation time, OTX offers samipling method to entire tile datset.
+    Especially tile sampling hook samples tiles whenever epoch starts to train model various tile samples
+    """
+
+    def before_epoch(self, runner):
+        """Sample tiles from training datset when epoch starts."""
+        if hasattr(runner.data_loader.dataset, "tile_dataset"):
+            tile_dataset = runner.data_loader.dataset.tile_dataset
+            tile_dataset.tiles = sample(tile_dataset.tiles_all, tile_dataset.sample_num)

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -356,6 +356,11 @@ def patch_tiling(config, hparams, dataset=None):
 
             config.data.train.filter_empty_gt = False
 
+        config.data.train.sampling_ratio = hparams.tiling_parameters.tile_sampling_ratio
+        config.data.val.sampling_ratio = hparams.tiling_parameters.tile_sampling_ratio
+        if hparams.tiling_parameters.tile_sampling_ratio < 1.0:
+            config.custom_hooks.append(ConfigDict({"type": "TileSamplingHook"}))
+
         tiling_params = ConfigDict(
             tile_size=int(hparams.tiling_parameters.tile_size),
             overlap_ratio=float(hparams.tiling_parameters.tile_overlap),

--- a/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -571,5 +571,23 @@ tiling_parameters:
     visible_in_ui: true
     warning: null
 
+  tile_sampling_ratio:
+    header: Sampling Ratio for entire tiling
+    description: Since tiling train and validation to all tile from large image, usually it takes lots of time than normal training. The tile_sampling_ratio is ratio for sampling entire tile dataset. Sampling tile dataset would save lots of time for training and validation time. Note that sampling will be applied to training and validation dataset, not test dataset.
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    min_value: 0.000001
+    max_value: 1.0
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+
   type: PARAMETER_GROUP
   visible_in_ui: true

--- a/tests/unit/algorithms/detection/adapters/mmdet/hooks/test_tile_sampling_hook.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/hooks/test_tile_sampling_hook.py
@@ -1,0 +1,47 @@
+"""Test tiling sampling hook."""
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import random
+
+from otx.algorithms.detection.adapters.mmdet.hooks.tile_sampling_hook import TileSamplingHook
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+
+
+class TestTilingSamplingHook:
+    """Test class for TileSamplingHook."""
+
+    @e2e_pytest_unit
+    def test_before_epoch(self, mocker):
+        "Test function for before_poch function."
+
+        class MockTileDataset:
+            def __init__(self):
+                self.tiles_all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                self.sample_num = 4
+                self.tiles = [1, 2, 3, 4]
+
+        class MockDataset:
+            def __init__(self, tile_dataset):
+                self.tile_dataset = tile_dataset
+
+        class MockDataLoader:
+            def __init__(self, dataset):
+                self.dataset = dataset
+
+        class MockRunner:
+            def __init__(self, data_loader):
+                self.data_loader = data_loader
+
+        hook = TileSamplingHook()
+        tile_dataset = MockTileDataset()
+        runner = MockRunner(MockDataLoader(MockDataset(tile_dataset)))
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.hooks.tile_sampling_hook.sample", return_value=[5, 6, 7, 8]
+        )
+        hook.before_epoch(runner)
+        assert tile_dataset.tiles[0] == 5
+        assert tile_dataset.tiles[1] == 6
+        assert tile_dataset.tiles[2] == 7
+        assert tile_dataset.tiles[3] == 8

--- a/tests/unit/algorithms/detection/tiling/test_tiling_detection.py
+++ b/tests/unit/algorithms/detection/tiling/test_tiling_detection.py
@@ -26,6 +26,7 @@ from otx.api.entities.image import Image
 from otx.api.entities.label import Domain, LabelEntity
 from otx.api.entities.model import ModelEntity
 from otx.api.entities.model_template import parse_model_template
+from otx.api.entities.subset import Subset
 from otx.api.usecases.adapters.model_adapter import ModelAdapter
 from otx.api.utils.shape_factory import ShapeFactory
 from tests.test_helpers import generate_random_annotated_image
@@ -180,6 +181,21 @@ class TestTilingDetection:
             assert isinstance(data["img"][0], torch.Tensor)
             assert "gt_bboxes" not in data
             assert "gt_labels" not in data
+
+    @e2e_pytest_unit
+    def test_tiling_sampling(self):
+        self.train_data_cfg.sampling_ratio = 0.5
+        dataset = build_dataset(self.train_data_cfg)
+        assert len(dataset) == max(int(len(dataset.tile_dataset.tiles_all) * 0.5), 1)
+
+        self.train_data_cfg.sampling_ratio = 0.01
+        dataset = build_dataset(self.train_data_cfg)
+        assert len(dataset) == max(int(len(dataset.tile_dataset.tiles_all) * 0.01), 1)
+
+        self.test_data_cfg.sampling_ratio = 0.1
+        self.test_data_cfg.dataset.otx_dataset[0].subset = Subset.TESTING
+        dataset = build_dataset(self.test_data_cfg)
+        assert len(dataset) == len(dataset.tile_dataset.tiles_all)
 
     @e2e_pytest_unit
     def test_inference_merge(self):


### PR DESCRIPTION
### Summary
This PR add a new feature called "Sampling tile dataset"
Although tiling method gives promising gain for accuracy for tiny object, it takes lots of time for both training and validation
This feature offers sampling method for tiling via --tiling_parameters.tile_sampling_ratio 
Note that even if user use tile sampling, test dataset will not be sampled. Only training and validation dataset are sampled.
And TilingSamplingHook is also introduced in this PR. This hook will sample tiles from cache before epoch start. 
Note that validation dataset is only sampled once. TilingSamplingHook will sample tiles from training dataset.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
otx train params --tiling_parameters.enable_tiling true --tiling_parameters.tile_sampling_ratio 0.1
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
