### PR TITLE
Fix: ActivationMapHook process backbone instead of neck output

### DIFF
--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_detector.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_detector.py
@@ -99,14 +99,16 @@ if is_mmdeploy_enabled():
     def custom_mask_rcnn__simple_test(ctx, self, img, img_metas, proposals=None, **kwargs):
         """Function for custom_mask_rcnn__simple_test."""
         assert self.with_bbox, "Bbox head must be implemented."
-        x = self.extract_feat(img)
+        x = backbone_out = self.backbone(img)
+        if self.with_neck:
+            x = self.neck(x)
         if proposals is None:
             proposals, _ = self.rpn_head.simple_test_rpn(x, img_metas)
         out = self.roi_head.simple_test(x, proposals, img_metas, rescale=False)
 
         if ctx.cfg["dump_features"]:
             feature_vector = FeatureVectorHook.func(x)
-            saliency_map = ActivationMapHook.func(x[-1])
+            saliency_map = ActivationMapHook.func(backbone_out)
             return (*out, feature_vector, saliency_map)
 
         return out

--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -309,14 +309,16 @@ if is_mmdeploy_enabled():
         assert self.with_bbox, "Bbox head must be implemented."
         tile_prob = self.tile_classifier.simple_test(img)
 
-        x = self.extract_feat(img)
+        x = backbone_out = self.backbone(img)
+        if self.with_neck:
+            x = self.neck(x)
         if proposals is None:
             proposals, _ = self.rpn_head.simple_test_rpn(x, img_metas)
         out = self.roi_head.simple_test(x, proposals, img_metas, rescale=False)
 
         if ctx.cfg["dump_features"]:
             feature_vector = FeatureVectorHook.func(x)
-            saliency_map = ActivationMapHook.func(x[-1])
+            saliency_map = ActivationMapHook.func(backbone_out)
             return (*out, tile_prob, feature_vector, saliency_map)
 
         return (*out, tile_prob)

--- a/requirements/classification.txt
+++ b/requirements/classification.txt
@@ -2,6 +2,6 @@
 # Classification Requirements.
 mmcv-full==1.7.0
 mmcls==0.25.0
-timm
+timm==0.6.12
 mmdeploy==0.14.0
 pytorchcv

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -4,6 +4,6 @@ mmcv-full==1.7.0
 mmdet==2.28.1
 pytorchcv
 mmcls==0.25.0
-timm
+timm==0.6.12
 mmdeploy==0.14.0
 scikit-image

--- a/requirements/segmentation.txt
+++ b/requirements/segmentation.txt
@@ -4,5 +4,5 @@ mmcv-full==1.7.0
 mmsegmentation==0.30.0
 scikit-image
 mmdeploy==0.14.0
-timm
+timm==0.6.12
 pytorchcv


### PR DESCRIPTION
### Summary
ActivationMapHook received neck output instead of backbone (during export) -> XAI for maskrcnn did not work properly. The effect depends on the backbone type.

Potentially fixing CVS-110488

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
