### PR TITLE
Add unit test for enabled hierarchy label support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 - Make semantic segmentation OpenVINO models compatible with ModelAPI (<https://github.com/openvinotoolkit/training_extensions/pull/2029>).
-- Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>)
+- Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>, <https://github.com/openvinotoolkit/training_extensions/pull/2152>)
 
 ### Bug fixes
 

--- a/tests/unit/core/data/adapter/test_classification_adapter.py
+++ b/tests/unit/core/data/adapter/test_classification_adapter.py
@@ -112,6 +112,15 @@ class TestOTXClassificationDatasetAdapter:
         assert isinstance(hlabel_train_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(hlabel_train_dataset_adapter.get_label_schema(), LabelSchemaEntity)
 
+        label_tree = hlabel_train_dataset_adapter.get_label_schema().label_tree
+        assert label_tree.num_labels == len(hlabel_train_dataset_adapter.category_items)
+        for label in label_tree.get_labels_in_topological_order():
+            parent = label_tree.get_parent(label)
+            parent_name = "" if parent is None else parent.name
+            assert [i.parent for i in hlabel_train_dataset_adapter.category_items if i.name == label.name][
+                0
+            ] == parent_name
+
         hlabel_test_dataset_adapter = ClassificationDatasetAdapter(
             task_type=self.task_type, test_data_roots=test_data_roots
         )
@@ -119,3 +128,12 @@ class TestOTXClassificationDatasetAdapter:
         assert Subset.TESTING in hlabel_test_dataset_adapter.dataset
         assert isinstance(hlabel_test_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(hlabel_test_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+
+        label_tree = hlabel_test_dataset_adapter.get_label_schema().label_tree
+        assert label_tree.num_labels == len(hlabel_test_dataset_adapter.category_items)
+        for label in label_tree.get_labels_in_topological_order():
+            parent = label_tree.get_parent(label)
+            parent_name = "" if parent is None else parent.name
+            assert [i.parent for i in hlabel_test_dataset_adapter.category_items if i.name == label.name][
+                0
+            ] == parent_name


### PR DESCRIPTION
### Summary
A following work of https://github.com/openvinotoolkit/training_extensions/pull/2149
Added unit tests to cover hierarchy label support in classification as @sovrasov requested.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
