### PR TITLE
Fix async demo in exportable code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ All notable changes to this project will be documented in this file.
 
 - Make semantic segmentation OpenVINO models compatible with ModelAPI (<https://github.com/openvinotoolkit/training_extensions/pull/2029>).
 - Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>, <https://github.com/openvinotoolkit/training_extensions/pull/2152>)
+- Enhance exportable code file structure, demo and video inference (<https://github.com/openvinotoolkit/training_extensions/pull/2051>).
 
 ### Bug fixes
 
--
+- Fix async mode inference for demo in exportable code (<https://github.com/openvinotoolkit/training_extensions/pull/2154>)
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 - Make semantic segmentation OpenVINO models compatible with ModelAPI (<https://github.com/openvinotoolkit/training_extensions/pull/2029>).
-- Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>, <https://github.com/openvinotoolkit/training_extensions/pull/2152>)
-- Enhance exportable code file structure, demo and video inference (<https://github.com/openvinotoolkit/training_extensions/pull/2051>).
+- Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>, <https://github.com/openvinotoolkit/training_extensions/pull/2152>).
+- Enhance exportable code file structure, video inference and default value for demo (<https://github.com/openvinotoolkit/training_extensions/pull/2051>).
 
 ### Bug fixes
 

--- a/otx/api/usecases/exportable_code/demo/demo_package/executors/asynchronous.py
+++ b/otx/api/usecases/exportable_code/demo/demo_package/executors/asynchronous.py
@@ -8,7 +8,6 @@ from typing import Any, Tuple, Union
 
 import numpy as np
 from openvino.model_zoo.model_api.pipelines import AsyncPipeline
-from openvino.model_zoo.model_api.models.utils import Detection
 
 from otx.api.usecases.exportable_code.demo.demo_package.model_container import (
     ModelContainer,

--- a/otx/api/usecases/exportable_code/demo/demo_package/executors/asynchronous.py
+++ b/otx/api/usecases/exportable_code/demo/demo_package/executors/asynchronous.py
@@ -45,6 +45,7 @@ class AsyncExecutor:
         for frame in streamer:
             results = self.async_pipeline.get_result(next_frame_id_to_show)
             while results:
+                start_time = time.perf_counter()
                 output = self.render_result(results)
                 next_frame_id_to_show += 1
                 self.visualizer.show(output)
@@ -52,6 +53,8 @@ class AsyncExecutor:
                     saved_frames.append(output)
                 if self.visualizer.is_quit():
                     stop_visualization = True
+                # visualize video not faster than the original FPS
+                self.visualizer.video_delay(time.perf_counter() - start_time, streamer)
                 results = self.async_pipeline.get_result(next_frame_id_to_show)
             if stop_visualization:
                 break
@@ -63,6 +66,8 @@ class AsyncExecutor:
             results = self.async_pipeline.get_result(next_frame_id_to_show)
             output = self.render_result(results)
             self.visualizer.show(output)
+            if self.visualizer.output:
+                saved_frames.append(output)
             # visualize video not faster than the original FPS
             self.visualizer.video_delay(time.perf_counter() - start_time, streamer)
         dump_frames(saved_frames, self.visualizer.output, input_stream, streamer)
@@ -70,6 +75,8 @@ class AsyncExecutor:
     def render_result(self, results: Tuple[Any, dict]) -> np.ndarray:
         """Render for results of inference."""
         predictions, frame_meta = results
+        predictions = np.array([[pred.id, pred.score, *pred.get_coords()] for pred in predictions])
+        predictions.shape = len(predictions), 6
         annotation_scene = self.converter.convert_to_annotation(predictions, frame_meta)
         current_frame = frame_meta["frame"]
         output = self.visualizer.draw(current_frame, annotation_scene, frame_meta)

--- a/otx/api/usecases/exportable_code/demo/requirements.txt
+++ b/otx/api/usecases/exportable_code/demo/requirements.txt
@@ -1,4 +1,4 @@
 openvino==2022.3.0
 openmodelzoo-modelapi==2022.3.0
-otx @ git+https://github.com/openvinotoolkit/training_extensions/@fb357c9956cc3865797bfb9a52179625454da275#egg=otx
+otx @ git+https://github.com/openvinotoolkit/training_extensions/@f1ff4bec30b3c1b8347fd6b284281906684de13c#egg=otx
 numpy>=1.21.0,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/otx/api/usecases/exportable_code/demo/requirements.txt
+++ b/otx/api/usecases/exportable_code/demo/requirements.txt
@@ -1,4 +1,4 @@
 openvino==2022.3.0
 openmodelzoo-modelapi==2022.3.0
-otx @ git+https://github.com/openvinotoolkit/training_extensions/@f1ff4bec30b3c1b8347fd6b284281906684de13c#egg=otx
+otx @ git+https://github.com/openvinotoolkit/training_extensions/@5519de55fc0e16cdfd018e2cfa681ad47e61ce52#egg=otx
 numpy>=1.21.0,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/otx/api/utils/vis_utils.py
+++ b/otx/api/utils/vis_utils.py
@@ -73,6 +73,5 @@ def dump_frames(saved_frames: list, output: str, input_path: Union[str, int], ca
             filenames = [f"output_{i}.jpeg" for i, _ in enumerate(saved_frames)]
         for filename, frame in zip(filenames, saved_frames):
             image_path = str(output_path / filename)
-            print(image_path)
             cv2.imwrite(image_path, frame)
             print(f"Image was saved to {image_path}")

--- a/otx/api/utils/vis_utils.py
+++ b/otx/api/utils/vis_utils.py
@@ -69,9 +69,10 @@ def dump_frames(saved_frames: list, output: str, input_path: Union[str, int], ca
         out.release()
         print(f"Video was saved to {video_path}")
     else:
-        if len(filenames) < len(saved_frames):
-            filenames = [f"output_{i}" for i, _ in enumerate(saved_frames)]
+        if len(filenames) != len(saved_frames):
+            filenames = [f"output_{i}.jpeg" for i, _ in enumerate(saved_frames)]
         for filename, frame in zip(filenames, saved_frames):
             image_path = str(output_path / filename)
+            print(image_path)
             cv2.imwrite(image_path, frame)
             print(f"Image was saved to {image_path}")

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -408,6 +408,26 @@ def otx_deploy_openvino_testing(template, root, otx_dir, args):
             "../model",
             "-i",
             os.path.join(otx_dir, args["--input"]),
+            "--inference_type",
+            "sync",
+            "--no_show",
+            "--output",
+            os.path.join(deployment_dir, "output"),
+        ],
+        cwd=os.path.join(deployment_dir, "python"),
+    )
+    assert os.path.exists(os.path.join(deployment_dir, "output"))
+
+    check_run(
+        [
+            "python3",
+            "demo.py",
+            "-m",
+            "../model",
+            "-i",
+            os.path.join(otx_dir, args["--input"]),
+            "--inference_type",
+            "async",
             "--no_show",
             "--output",
             os.path.join(deployment_dir, "output"),


### PR DESCRIPTION
### Summary

This PR fixes the crush of demo in exportable code started in async mode. The issue was caused by the unsupported annotation format returned from async pipeline ([Detection ](https://github.com/openvinotoolkit/open_model_zoo/blob/0d0d466179aebc9ca4262cf74da4e1c056f9eeec/demos/common/python/openvino/model_zoo/model_api/models/utils.py#L22) instance instead of `np.array` instance).
- Converted prediction results to `np.array` format
- Fixed names used for demo outputs if the original input names can't be used 

Related issue: [CVS-84793](https://jira.devtools.intel.com/browse/CVS-84793)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
