### PR TITLE
Standalone onnx export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ All notable changes to this project will be documented in this file.
 
 - Make semantic segmentation OpenVINO models compatible with ModelAPI (<https://github.com/openvinotoolkit/training_extensions/pull/2029>).
 - Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>, <https://github.com/openvinotoolkit/training_extensions/pull/2152>).
+<<<<<<< HEAD
 - Enhance exportable code file structure, video inference and default value for demo (<https://github.com/openvinotoolkit/training_extensions/pull/2051>).
+=======
+- Refactoring of ONNX export functionality (<https://github.com/openvinotoolkit/training_extensions/pull/2155>).
+>>>>>>> 81db95455 (Update changelog)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,8 @@ All notable changes to this project will be documented in this file.
 
 - Make semantic segmentation OpenVINO models compatible with ModelAPI (<https://github.com/openvinotoolkit/training_extensions/pull/2029>).
 - Support label hierarchy through LabelTree in LabelSchema for classification task (<https://github.com/openvinotoolkit/training_extensions/pull/2149>, <https://github.com/openvinotoolkit/training_extensions/pull/2152>).
-<<<<<<< HEAD
 - Enhance exportable code file structure, video inference and default value for demo (<https://github.com/openvinotoolkit/training_extensions/pull/2051>).
-=======
 - Refactoring of ONNX export functionality (<https://github.com/openvinotoolkit/training_extensions/pull/2155>).
->>>>>>> 81db95455 (Update changelog)
 
 ### Bug fixes
 

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -57,6 +57,7 @@ from otx.api.entities.model import ModelPrecision
 from otx.api.entities.model_template import TaskType
 from otx.api.entities.subset import Subset
 from otx.api.entities.task_environment import TaskEnvironment
+from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from otx.core.data import caching
 
 logger = get_logger()
@@ -447,7 +448,7 @@ class MMActionTask(OTXActionTask):
 
         return predictions, metric
 
-    def _export_model(self, precision: ModelPrecision, dump_features: bool = True):
+    def _export_model(self, precision: ModelPrecision, export_format: ExportType, dump_features: bool):
         """Main export function."""
         self._init_task(export=True)
 
@@ -463,18 +464,21 @@ class MMActionTask(OTXActionTask):
         self._precision[0] = precision
         half_precision = precision == ModelPrecision.FP16
 
-        exporter = Exporter(cfg, state_dict, deploy_cfg, f"{self._output_path}/openvino", half_precision)
+        exporter = Exporter(cfg, state_dict, deploy_cfg, f"{self._output_path}/openvino",
+                             half_precision, onnx_only=export_format==ExportType.ONNX)
         exporter.export()
-        bin_file = [f for f in os.listdir(self._output_path) if f.endswith(".bin")][0]
-        xml_file = [f for f in os.listdir(self._output_path) if f.endswith(".xml")][0]
-        onnx_file = [f for f in os.listdir(self._output_path) if f.endswith(".onnx")][0]
-        results = {
-            "outputs": {
-                "bin": os.path.join(self._output_path, bin_file),
-                "xml": os.path.join(self._output_path, xml_file),
-                "onnx": os.path.join(self._output_path, onnx_file),
-            }
-        }
+
+        results = {"outputs": {}}
+
+        if export_format == ExportType.ONNX:
+            onnx_file = [f for f in os.listdir(self._output_path) if f.endswith(".onnx")][0]
+            results["outputs"]["onnx"] = os.path.join(self._output_path, onnx_file)
+        else:
+            bin_file = [f for f in os.listdir(self._output_path) if f.endswith(".bin")][0]
+            xml_file = [f for f in os.listdir(self._output_path) if f.endswith(".xml")][0]
+            results["outputs"]["bin"] = os.path.join(self._output_path, bin_file)
+            results["outputs"]["xml"] = os.path.join(self._output_path, xml_file)
+
         return results
 
     # This should be removed

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -19,7 +19,7 @@ import os
 import time
 from copy import deepcopy
 from functools import partial
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch
 from mmaction import __version__
@@ -474,7 +474,7 @@ class MMActionTask(OTXActionTask):
         )
         exporter.export()
 
-        results = {"outputs": {}}
+        results: Dict[str, Dict[str, str]] = {"outputs": {}}
 
         if export_format == ExportType.ONNX:
             onnx_file = [f for f in os.listdir(self._output_path) if f.endswith(".onnx")][0]

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -464,8 +464,14 @@ class MMActionTask(OTXActionTask):
         self._precision[0] = precision
         half_precision = precision == ModelPrecision.FP16
 
-        exporter = Exporter(cfg, state_dict, deploy_cfg, f"{self._output_path}/openvino",
-                             half_precision, onnx_only=export_format==ExportType.ONNX)
+        exporter = Exporter(
+            cfg,
+            state_dict,
+            deploy_cfg,
+            f"{self._output_path}/openvino",
+            half_precision,
+            onnx_only=export_format == ExportType.ONNX,
+        )
         exporter.export()
 
         results = {"outputs": {}}

--- a/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
+++ b/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
@@ -57,7 +57,8 @@ class Exporter:
     """Export class for action recognition model using mmdeploy framework."""
 
     def __init__(
-        self, recipe_cfg: Config, weights: OrderedDict, deploy_cfg: Config, work_dir: str, half_precision: bool
+        self, recipe_cfg: Config, weights: OrderedDict, deploy_cfg: Config, work_dir: str, half_precision: bool,
+        onnx_only: bool,
     ):
         """Initialize Exporter.
 
@@ -80,6 +81,7 @@ class Exporter:
         self.context_info = {"deploy_cfg": deploy_cfg}
         if half_precision:
             self.deploy_cfg.backend_config.mo_options["flags"] = ["--compress_to_fp16"]
+        self.onnx_only = onnx_only
 
     def _get_model(self) -> torch.nn.Module:
         """Prepare torch model for exporting."""
@@ -127,6 +129,9 @@ class Exporter:
                 self.deploy_cfg.ir_config.input_names,
                 self.deploy_cfg.ir_config.output_names,
             )
+
+            if self.onnx_only:
+                return
 
             from_onnx(
                 self.work_dir + ".onnx",

--- a/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
+++ b/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
@@ -57,7 +57,12 @@ class Exporter:
     """Export class for action recognition model using mmdeploy framework."""
 
     def __init__(
-        self, recipe_cfg: Config, weights: OrderedDict, deploy_cfg: Config, work_dir: str, half_precision: bool,
+        self,
+        recipe_cfg: Config,
+        weights: OrderedDict,
+        deploy_cfg: Config,
+        work_dir: str,
+        half_precision: bool,
         onnx_only: bool,
     ):
         """Initialize Exporter.
@@ -68,6 +73,7 @@ class Exporter:
             deploy_cfg (Config): deploy config which contains deploy info
             work_dir (str): path to save onnx and openvino xml file
             half_precision (bool): whether to use half-precision(FP16)
+            onnx_only (bool): whether to export pnly onnx model
         """
 
         self.task_processor = build_task_processor(recipe_cfg, deploy_cfg, "cpu")

--- a/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
+++ b/otx/algorithms/action/adapters/mmaction/utils/export_utils.py
@@ -73,7 +73,7 @@ class Exporter:
             deploy_cfg (Config): deploy config which contains deploy info
             work_dir (str): path to save onnx and openvino xml file
             half_precision (bool): whether to use half-precision(FP16)
-            onnx_only (bool): whether to export pnly onnx model
+            onnx_only (bool): whether to export only onnx model
         """
 
         self.task_processor = build_task_processor(recipe_cfg, deploy_cfg, "cpu")

--- a/otx/algorithms/action/task.py
+++ b/otx/algorithms/action/task.py
@@ -249,7 +249,7 @@ class OTXActionTask(OTXTask, ABC):
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX
             if precision == ModelPrecision.FP16:
-                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+                raise RuntimeError("Export to FP16 ONNX is not supported")
         elif export_type == ExportType.OPENVINO:
             output_model.model_format = ModelFormat.OPENVINO
             output_model.optimization_type = ModelOptimizationType.MO

--- a/otx/algorithms/anomaly/tasks/inference.py
+++ b/otx/algorithms/anomaly/tasks/inference.py
@@ -275,7 +275,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX
             if precision == ModelPrecision.FP16:
-                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+                raise RuntimeError("Export to FP16 ONNX is not supported")
         elif export_type == ExportType.OPENVINO:
             output_model.model_format = ModelFormat.OPENVINO
             output_model.optimization_type = ModelOptimizationType.MO

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -556,11 +556,11 @@ class MMClassificationTask(OTXClassificationTask):
         cfg = self.configure(False, "test", None)
 
         self._precision[0] = precision
+        assert len(self._precision) == 1
         export_options: Dict[str, Any] = {}
         export_options["deploy_cfg"] = self._init_deploy_cfg(cfg)
 
-        assert len(self._precision) == 1
-        export_options["precision"] = str(self._precision[0])
+        export_options["precision"] = str(precision)
         export_options["type"] = str(export_format)
 
         export_options["deploy_cfg"]["dump_features"] = dump_features
@@ -573,7 +573,7 @@ class MMClassificationTask(OTXClassificationTask):
                     output_names.append("saliency_map")
         export_options["model_builder"] = getattr(self, "model_builder", build_classifier)
 
-        if self._precision[0] == ModelPrecision.FP16:
+        if precision == ModelPrecision.FP16:
             export_options["deploy_cfg"]["backend_config"]["mo_options"]["flags"].append("--compress_to_fp16")
 
         if export_format == ExportType.ONNX:

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -577,7 +577,7 @@ class MMClassificationTask(OTXClassificationTask):
             export_options["deploy_cfg"]["backend_config"]["mo_options"]["flags"].append("--compress_to_fp16")
 
         if export_format == ExportType.ONNX:
-            export_options["deploy_cfg"]["backend_config"] = {"type" : "onnxruntime"}
+            export_options["deploy_cfg"]["backend_config"] = {"type": "onnxruntime"}
 
         exporter = ClassificationExporter()
         results = exporter.run(

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -66,6 +66,7 @@ from otx.api.entities.inference_parameters import InferenceParameters
 from otx.api.entities.model import ModelPrecision
 from otx.api.entities.subset import Subset
 from otx.api.entities.task_environment import TaskEnvironment
+from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from otx.core.data import caching
 from otx.core.data.noisy_label_detection import LossDynamicsTrackingHook
 
@@ -549,7 +550,7 @@ class MMClassificationTask(OTXClassificationTask):
 
         return eval_predictions, saliency_maps
 
-    def _export_model(self, precision, dump_features):
+    def _export_model(self, precision: ModelPrecision, export_format: ExportType, dump_features: bool):
         self._init_task(export=True)
 
         cfg = self.configure(False, "test", None)
@@ -557,9 +558,10 @@ class MMClassificationTask(OTXClassificationTask):
         self._precision[0] = precision
         export_options: Dict[str, Any] = {}
         export_options["deploy_cfg"] = self._init_deploy_cfg(cfg)
-        if export_options.get("precision", None) is None:
-            assert len(self._precision) == 1
-            export_options["precision"] = str(self._precision[0])
+
+        assert len(self._precision) == 1
+        export_options["precision"] = str(self._precision[0])
+        export_options["type"] = str(export_format)
 
         export_options["deploy_cfg"]["dump_features"] = dump_features
         if dump_features:
@@ -573,6 +575,9 @@ class MMClassificationTask(OTXClassificationTask):
 
         if self._precision[0] == ModelPrecision.FP16:
             export_options["deploy_cfg"]["backend_config"]["mo_options"]["flags"].append("--compress_to_fp16")
+
+        if export_format == ExportType.ONNX:
+            export_options["deploy_cfg"]["backend_config"] = {"type" : "onnxruntime"}
 
         exporter = ClassificationExporter()
         results = exporter.run(

--- a/otx/algorithms/classification/adapters/mmcls/utils/exporter.py
+++ b/otx/algorithms/classification/adapters/mmcls/utils/exporter.py
@@ -46,7 +46,7 @@ class ClassificationExporter(Exporter):
         return super().run(cfg, **kwargs)
 
     @staticmethod
-    def naive_export(output_dir, model_builder, precision, cfg, model_name="model"):
+    def naive_export(output_dir, model_builder, precision, export_type, cfg, model_name="model"):
         """Export procedure with pytorch backend."""
         from mmcls.datasets.pipelines import Compose
 
@@ -62,7 +62,7 @@ class ClassificationExporter(Exporter):
         fake_data = get_fake_data(cfg)
         opset_version = 11
 
-        NaiveExporter.export2openvino(
+        NaiveExporter.export2backend(
             output_dir,
             model_builder,
             cfg,
@@ -72,4 +72,5 @@ class ClassificationExporter(Exporter):
             input_names=["data"],
             output_names=["logits"],
             opset_version=opset_version,
+            export_type=export_type,
         )

--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -251,7 +251,6 @@ class OTXClassificationTask(OTXTask, ABC):
             output_model.optimization_type = ModelOptimizationType.ONNX
             if precision == ModelPrecision.FP16:
                 raise RuntimeError(f"Export to FP16 ONNX is not supported")
-
         elif export_type == ExportType.OPENVINO:
             output_model.model_format = ModelFormat.OPENVINO
             output_model.optimization_type = ModelOptimizationType.MO

--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -245,35 +245,46 @@ class OTXClassificationTask(OTXTask, ABC):
         """Export function of OTX Classification Task."""
 
         logger.info("Exporting the model")
-        if export_type != ExportType.OPENVINO:
-            raise RuntimeError(f"not supported export type {export_type}")
-        output_model.model_format = ModelFormat.OPENVINO
-        output_model.optimization_type = ModelOptimizationType.MO
 
-        results = self._export_model(precision, dump_features)
+        export_type = ExportType.ONNX
+
+        if export_type == ExportType.ONNX:
+            output_model.model_format = ModelFormat.ONNX
+            output_model.optimization_type = ModelOptimizationType.ONNX
+            if precision == ModelPrecision.FP16:
+                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+
+        elif export_type == ExportType.OPENVINO:
+            output_model.model_format = ModelFormat.OPENVINO
+            output_model.optimization_type = ModelOptimizationType.MO
+        else:
+            raise RuntimeError(f"not supported export type {export_type}")
+
+        results = self._export_model(precision, export_type, dump_features)
         outputs = results.get("outputs")
         logger.debug(f"results of run_task = {outputs}")
         if outputs is None:
             raise RuntimeError(results.get("msg"))
 
-        bin_file = outputs.get("bin")
-        xml_file = outputs.get("xml")
-        onnx_file = outputs.get("onnx")
+        if export_type == ExportType.ONNX:
+            onnx_file = outputs.get("onnx")
+            with open(onnx_file, "rb") as f:
+                output_model.set_data("model.onnx", f.read())
+        else:
+            bin_file = outputs.get("bin")
+            xml_file = outputs.get("xml")
 
-        inference_config = get_cls_inferencer_configuration(self._task_environment.label_schema)
-        deploy_cfg = get_cls_deploy_config(self._task_environment.label_schema, inference_config)
-        ir_extra_data = get_cls_model_api_configuration(self._task_environment.label_schema, inference_config)
-        ir_extra_data[("otx_config",)] = json.dumps(deploy_cfg, ensure_ascii=False)
-        embed_ir_model_data(xml_file, ir_extra_data)
+            inference_config = get_cls_inferencer_configuration(self._task_environment.label_schema)
+            deploy_cfg = get_cls_deploy_config(self._task_environment.label_schema, inference_config)
+            ir_extra_data = get_cls_model_api_configuration(self._task_environment.label_schema, inference_config)
+            ir_extra_data[("otx_config",)] = json.dumps(deploy_cfg, ensure_ascii=False)
+            embed_ir_model_data(xml_file, ir_extra_data)
 
-        if xml_file is None or bin_file is None or onnx_file is None:
-            raise RuntimeError("invalid status of exporting. bin and xml or onnx should not be None")
-        with open(bin_file, "rb") as f:
-            output_model.set_data("openvino.bin", f.read())
-        with open(xml_file, "rb") as f:
-            output_model.set_data("openvino.xml", f.read())
-        with open(onnx_file, "rb") as f:
-            output_model.set_data("model.onnx", f.read())
+            with open(bin_file, "rb") as f:
+                output_model.set_data("openvino.bin", f.read())
+            with open(xml_file, "rb") as f:
+                output_model.set_data("openvino.xml", f.read())
+
         output_model.precision = self._precision
         output_model.has_xai = dump_features
         output_model.set_data(
@@ -506,7 +517,7 @@ class OTXClassificationTask(OTXTask, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _export_model(self, precision, dump_features):
+    def _export_model(self, precision: ModelPrecision, export_format: ExportType, dump_features: bool):
         """Export model and return the results."""
         raise NotImplementedError
 

--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -246,8 +246,6 @@ class OTXClassificationTask(OTXTask, ABC):
 
         logger.info("Exporting the model")
 
-        export_type = ExportType.ONNX
-
         if export_type == ExportType.ONNX:
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX

--- a/otx/algorithms/classification/task.py
+++ b/otx/algorithms/classification/task.py
@@ -250,7 +250,7 @@ class OTXClassificationTask(OTXTask, ABC):
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX
             if precision == ModelPrecision.FP16:
-                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+                raise RuntimeError("Export to FP16 ONNX is not supported")
         elif export_type == ExportType.OPENVINO:
             output_model.model_format = ModelFormat.OPENVINO
             output_model.optimization_type = ModelOptimizationType.MO

--- a/otx/algorithms/common/adapters/mmcv/hooks/checkpoint_hook.py
+++ b/otx/algorithms/common/adapters/mmcv/hooks/checkpoint_hook.py
@@ -44,7 +44,7 @@ class CheckpointHookWithValResults(Hook):  # pylint: disable=too-many-instance-a
         max_keep_ckpts=-1,
         sync_buffer=False,
         **kwargs,
-    ):
+    ) -> None:
         self.interval = interval
         self.by_epoch = by_epoch
         self.save_optimizer = save_optimizer

--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -19,6 +19,7 @@ class Exporter:
         logger.info("export!")
 
         precision = kwargs.pop("precision", "FP32")
+        export_type = kwargs.pop("type", "OPENVINO")
         if precision not in ("FP32", "FP16", "INT8"):
             raise NotImplementedError
         logger.info(f"Model will be exported with precision {precision}")
@@ -43,6 +44,7 @@ class Exporter:
                     cfg.work_dir,
                     model_builder,
                     precision,
+                    export_type,
                     cfg,
                     deploy_cfg,
                     model_name,
@@ -83,6 +85,7 @@ class Exporter:
         output_dir,
         model_builder,
         precision,
+        export_type,
         cfg,
         deploy_cfg,
         model_name="model",
@@ -92,7 +95,7 @@ class Exporter:
 
         if precision == "FP16":
             deploy_cfg.backend_config.mo_options.flags.append("--compress_to_fp16")
-        MMdeployExporter.export2openvino(output_dir, model_builder, cfg, deploy_cfg, model_name=model_name)
+        MMdeployExporter.export2backend(output_dir, model_builder, cfg, deploy_cfg, export_type, model_name=model_name)
 
     @staticmethod
     def naive_export(output_dir, model_builder, precision, cfg, model_name="model"):

--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -50,7 +50,7 @@ class Exporter:
                     model_name,
                 )
             else:
-                self.naive_export(cfg.work_dir, model_builder, precision, cfg, model_name)
+                self.naive_export(cfg.work_dir, model_builder, precision, export_type, cfg, model_name)
         except RuntimeError as ex:
             # output_model.model_status = ModelStatus.FAILED
             # raise RuntimeError('Optimization was unsuccessful.') from ex
@@ -98,6 +98,6 @@ class Exporter:
         MMdeployExporter.export2backend(output_dir, model_builder, cfg, deploy_cfg, export_type, model_name=model_name)
 
     @staticmethod
-    def naive_export(output_dir, model_builder, precision, cfg, model_name="model"):
+    def naive_export(output_dir, model_builder, precision, export_type, cfg, model_name="model"):
         """Export using pytorch backend."""
         raise NotImplementedError()

--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -67,14 +67,14 @@ class Exporter:
                 "partitioned": [
                     {
                         f"{os.path.splitext(name)[0]}": {
-                            "bin": os.path.join(cfg.work_dir, name.replace(".xml", ".bin")),
-                            "xml": os.path.join(cfg.work_dir, name),
+                            "bin": os.path.join(cfg.work_dir, name.replace(".onnx", ".bin")),
+                            "xml": os.path.join(cfg.work_dir, name.replace(".onnx", ".xml")),
+                            "onnx": os.path.join(cfg.work_dir, name),
                         }
                     }
                     for name in os.listdir(cfg.work_dir)
-                    if name.endswith(".xml")
-                    and name != f"{model_name}.xml"
-                    and name.replace(".xml", ".bin") in os.listdir(cfg.work_dir)
+                    if name.endswith(".onnx")
+                    and name != f"{model_name}.onnx"
                 ],
             },
             "msg": "",

--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -73,8 +73,7 @@ class Exporter:
                         }
                     }
                     for name in os.listdir(cfg.work_dir)
-                    if name.endswith(".onnx")
-                    and name != f"{model_name}.onnx"
+                    if name.endswith(".onnx") and name != f"{model_name}.onnx"
                 ],
             },
             "msg": "",

--- a/otx/algorithms/common/adapters/mmdeploy/apis.py
+++ b/otx/algorithms/common/adapters/mmdeploy/apis.py
@@ -183,11 +183,12 @@ if is_mmdeploy_enabled():
         """MMdeployExporter for mmdeploy exporting."""
 
         @staticmethod
-        def export2openvino(
+        def export2backend(
             output_dir: str,
             model_builder: Callable,
             cfg: mmcv.Config,
             deploy_cfg: mmcv.Config,
+            export_type: str,
             *,
             model_name: str = "model",
         ):
@@ -234,15 +235,15 @@ if is_mmdeploy_enabled():
                     model_name=model_name,
                 )
             )
-
-            for onnx_path in onnx_paths:
-                deploy_cfg_ = deepcopy(deploy_cfg)
-                update_deploy_cfg(onnx_path, deploy_cfg_)
-                MMdeployExporter.onnx2openvino(
-                    output_dir,
-                    onnx_path,
-                    deploy_cfg_,
-                )
+            if not "ONNX" in export_type:
+                for onnx_path in onnx_paths:
+                    deploy_cfg_ = deepcopy(deploy_cfg)
+                    update_deploy_cfg(onnx_path, deploy_cfg_)
+                    MMdeployExporter.onnx2openvino(
+                        output_dir,
+                        onnx_path,
+                        deploy_cfg_,
+                    )
 
         @staticmethod
         def extract_partition(

--- a/otx/algorithms/common/adapters/mmdeploy/apis.py
+++ b/otx/algorithms/common/adapters/mmdeploy/apis.py
@@ -226,6 +226,7 @@ if is_mmdeploy_enabled():
                     input_data,
                     cfg,
                     deploy_cfg,
+                    export_type,
                     model_name=model_name,
                 )
 
@@ -255,6 +256,7 @@ if is_mmdeploy_enabled():
             input_data: Any,
             cfg: mmcv.Config,
             deploy_cfg: mmcv.Config,
+            export_type: str,
             *,
             model_name: str = "model",
         ):
@@ -276,15 +278,16 @@ if is_mmdeploy_enabled():
                 partition_cfgs,
             )
 
-            deploy_cfg_ = deepcopy(deploy_cfg)
-            update_deploy_cfg(partition_onnx[0], deploy_cfg_)
-            MMdeployExporter.onnx2openvino(
-                output_dir,
-                partition_onnx[0],
-                deploy_cfg_,
-            )
-            deploy_cfg["partition_config"]["apply_marks"] = False
-            reset_mark_function_count()
+            if "ONNX" not in export_type:
+                deploy_cfg_ = deepcopy(deploy_cfg)
+                update_deploy_cfg(partition_onnx[0], deploy_cfg_)
+                MMdeployExporter.onnx2openvino(
+                    output_dir,
+                    partition_onnx[0],
+                    deploy_cfg_,
+                )
+                deploy_cfg["partition_config"]["apply_marks"] = False
+                reset_mark_function_count()
 
         @staticmethod
         def torch2onnx(

--- a/otx/algorithms/common/adapters/mmdeploy/apis.py
+++ b/otx/algorithms/common/adapters/mmdeploy/apis.py
@@ -239,7 +239,7 @@ if is_mmdeploy_enabled():
                     model_name=model_name,
                 )
             )
-            if not "ONNX" in export_type:
+            if "ONNX" not in export_type:
                 for onnx_path in onnx_paths:
                     deploy_cfg_ = deepcopy(deploy_cfg)
                     update_deploy_cfg(onnx_path, deploy_cfg_)

--- a/otx/algorithms/common/adapters/mmdeploy/apis.py
+++ b/otx/algorithms/common/adapters/mmdeploy/apis.py
@@ -31,7 +31,7 @@ class NaiveExporter:
     """NaiveExporter for non-mmdeploy export."""
 
     @staticmethod
-    def export2openvino(
+    def export2backend(
         output_dir: str,
         model_builder: Callable,
         cfg: mmcv.Config,
@@ -44,6 +44,7 @@ class NaiveExporter:
         opset_version: int = 11,
         dynamic_axes: Optional[Dict[Any, Any]] = None,
         mo_transforms: str = "",
+        export_type: str,
     ):
         """Function for exporting to openvino."""
         input_data = scatter(collate([input_data], samples_per_gpu=1), [-1])[0]
@@ -62,6 +63,9 @@ class NaiveExporter:
             opset_version=opset_version,
             dynamic_axes=dynamic_axes,
         )
+
+        if "ONNX" in export_type:
+            return
 
         def get_normalize_cfg(cfg):
             def _get_normalize_cfg(cfg_):

--- a/otx/algorithms/common/adapters/mmdeploy/apis.py
+++ b/otx/algorithms/common/adapters/mmdeploy/apis.py
@@ -44,7 +44,7 @@ class NaiveExporter:
         opset_version: int = 11,
         dynamic_axes: Optional[Dict[Any, Any]] = None,
         mo_transforms: str = "",
-        export_type: str,
+        export_type: str = "OPENVINO",
     ):
         """Function for exporting to openvino."""
         input_data = scatter(collate([input_data], samples_per_gpu=1), [-1])[0]

--- a/otx/algorithms/common/utils/mask_to_bbox.py
+++ b/otx/algorithms/common/utils/mask_to_bbox.py
@@ -44,7 +44,7 @@ def mask_to_border(mask):
     return border
 
 
-def mask2bbox(mask):
+def mask2bbox(mask) -> List[List[int]]:
     """Mask to bounding boxes.
 
     Args:
@@ -53,7 +53,7 @@ def mask2bbox(mask):
     Returns:
         List[int]: Bounding box coordinates
     """
-    bboxes: List[int] = []
+    bboxes: List[List[int]] = []
 
     mask = mask_to_border(mask)
     print(np.unique(mask))

--- a/otx/algorithms/common/utils/mask_to_bbox.py
+++ b/otx/algorithms/common/utils/mask_to_bbox.py
@@ -51,7 +51,7 @@ def mask2bbox(mask) -> List[List[int]]:
         mask (np.ndarray): Input binary mask
 
     Returns:
-        List[int]: Bounding box coordinates
+        List[List[int]]: Bounding box coordinates
     """
     bboxes: List[List[int]] = []
 

--- a/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/otx/algorithms/detection/adapters/mmdet/task.py
@@ -500,7 +500,7 @@ class MMDetectionTask(OTXDetectionTask):
             export_options["deploy_cfg"]["backend_config"]["mo_options"]["flags"].append("--compress_to_fp16")
 
         if export_format == ExportType.ONNX:
-            export_options["deploy_cfg"]["backend_config"] = {"type" : "onnxruntime"}
+            export_options["deploy_cfg"]["backend_config"] = {"type": "onnxruntime"}
 
         exporter = DetectionExporter()
         results = exporter.run(

--- a/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/otx/algorithms/detection/adapters/mmdet/task.py
@@ -86,6 +86,7 @@ from otx.api.entities.model import (
 from otx.api.entities.subset import Subset
 from otx.api.entities.task_environment import TaskEnvironment
 from otx.api.serialization.label_mapper import label_schema_to_bytes
+from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from otx.core.data import caching
 from otx.core.data.noisy_label_detection import LossDynamicsTrackingHook
 
@@ -470,6 +471,7 @@ class MMDetectionTask(OTXDetectionTask):
     def _export_model(
         self,
         precision: ModelPrecision,
+        export_format: ExportType,
         dump_features: bool,
     ):
         """Main export function of OTX MMDetection Task."""
@@ -480,9 +482,9 @@ class MMDetectionTask(OTXDetectionTask):
         self._precision[0] = precision
         export_options: Dict[str, Any] = {}
         export_options["deploy_cfg"] = self._init_deploy_cfg(cfg)
-        if export_options.get("precision", None) is None:
-            assert len(self._precision) == 1
-            export_options["precision"] = str(self._precision[0])
+        assert len(self._precision) == 1
+        export_options["precision"] = str(self._precision[0])
+        export_options["type"] = str(export_format)
 
         export_options["deploy_cfg"]["dump_features"] = dump_features
         if dump_features:
@@ -496,6 +498,9 @@ class MMDetectionTask(OTXDetectionTask):
 
         if self._precision[0] == ModelPrecision.FP16:
             export_options["deploy_cfg"]["backend_config"]["mo_options"]["flags"].append("--compress_to_fp16")
+
+        if export_format == ExportType.ONNX:
+            export_options["deploy_cfg"]["backend_config"] = {"type" : "onnxruntime"}
 
         exporter = DetectionExporter()
         results = exporter.run(

--- a/otx/algorithms/detection/adapters/mmdet/utils/exporter.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/exporter.py
@@ -41,7 +41,7 @@ class DetectionExporter(Exporter):
         return super().run(cfg, **kwargs)
 
     @staticmethod
-    def naive_export(output_dir, model_builder, precision, cfg, model_name="model"):
+    def naive_export(output_dir, model_builder, precision, export_type, cfg, model_name="model"):
         """Export using torch.onnx directly."""
         from mmdet.apis.inference import LoadImage
         from mmdet.datasets.pipelines import Compose
@@ -58,7 +58,7 @@ class DetectionExporter(Exporter):
         fake_data = get_fake_data(cfg)
         opset_version = 11
 
-        NaiveExporter.export2openvino(
+        NaiveExporter.export2backend(
             output_dir,
             model_builder,
             cfg,
@@ -68,4 +68,5 @@ class DetectionExporter(Exporter):
             input_names=["image"],
             output_names=["boxes", "labels"],
             opset_version=opset_version,
+            export_type=export_type,
         )

--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -300,34 +300,41 @@ class OTXDetectionTask(OTXTask, ABC):
     ):
         """Export function of OTX Detection Task."""
         logger.info("Exporting the model")
-        if export_type != ExportType.OPENVINO:
-            raise RuntimeError(f"not supported export type {export_type}")
-        output_model.model_format = ModelFormat.OPENVINO
-        output_model.optimization_type = ModelOptimizationType.MO
 
-        results = self._export_model(precision, dump_features)
+        if export_type == ExportType.ONNX:
+            output_model.model_format = ModelFormat.ONNX
+            output_model.optimization_type = ModelOptimizationType.ONNX
+            if precision == ModelPrecision.FP16:
+                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+        elif export_type == ExportType.OPENVINO:
+            output_model.model_format = ModelFormat.OPENVINO
+            output_model.optimization_type = ModelOptimizationType.MO
+        else:
+            raise RuntimeError(f"not supported export type {export_type}")
+
+        results = self._export_model(precision, export_type, dump_features)
         outputs = results.get("outputs")
         logger.debug(f"results of run_task = {outputs}")
         if outputs is None:
             raise RuntimeError(results.get("msg"))
 
-        bin_file = outputs.get("bin")
-        xml_file = outputs.get("xml")
-        onnx_file = outputs.get("onnx")
+        if export_type == ExportType.ONNX:
+            onnx_file = outputs.get("onnx")
+            with open(onnx_file, "rb") as f:
+                output_model.set_data("model.onnx", f.read())
+        else:
+            bin_file = outputs.get("bin")
+            xml_file = outputs.get("xml")
 
-        ir_extra_data = get_det_model_api_configuration(
+            ir_extra_data = get_det_model_api_configuration(
             self._task_environment.label_schema, self._task_type, self.confidence_threshold
-        )
-        embed_ir_model_data(xml_file, ir_extra_data)
+            )
+            embed_ir_model_data(xml_file, ir_extra_data)
 
-        if xml_file is None or bin_file is None or onnx_file is None:
-            raise RuntimeError("invalid status of exporting. bin and xml or onnx should not be None")
-        with open(bin_file, "rb") as f:
-            output_model.set_data("openvino.bin", f.read())
-        with open(xml_file, "rb") as f:
-            output_model.set_data("openvino.xml", f.read())
-        with open(onnx_file, "rb") as f:
-            output_model.set_data("model.onnx", f.read())
+            with open(bin_file, "rb") as f:
+                output_model.set_data("openvino.bin", f.read())
+            with open(xml_file, "rb") as f:
+                output_model.set_data("openvino.xml", f.read())
 
         if self._hyperparams.tiling_parameters.enable_tile_classifier:
             tile_classifier = None
@@ -337,10 +344,14 @@ class OTXDetectionTask(OTXTask, ABC):
                     break
             if tile_classifier is None:
                 raise RuntimeError("invalid status of exporting. tile_classifier should not be None")
-            with open(tile_classifier["bin"], "rb") as f:
-                output_model.set_data("tile_classifier.bin", f.read())
-            with open(tile_classifier["xml"], "rb") as f:
-                output_model.set_data("tile_classifier.xml", f.read())
+            if export_type == ExportType.ONNX:
+                with open(tile_classifier["onnx"], "rb") as f:
+                    output_model.set_data("tile_classifier.onnx", f.read())
+            else:
+                with open(tile_classifier["bin"], "rb") as f:
+                    output_model.set_data("tile_classifier.bin", f.read())
+                with open(tile_classifier["xml"], "rb") as f:
+                    output_model.set_data("tile_classifier.xml", f.read())
 
         output_model.set_data(
             "confidence_threshold",
@@ -357,7 +368,7 @@ class OTXDetectionTask(OTXTask, ABC):
         logger.info("Exporting completed")
 
     @abstractmethod
-    def _export_model(self, precision: ModelPrecision, dump_features: bool):
+    def _export_model(self, precision: ModelPrecision, export_format: ExportType, dump_features: bool):
         """Main export function using training backend."""
         raise NotImplementedError
 

--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -54,8 +54,6 @@ from otx.api.entities.metrics import (
 )
 from otx.api.entities.model import (
     ModelEntity,
-    ModelFormat,
-    ModelOptimizationType,
     ModelPrecision,
 )
 from otx.api.entities.model_template import TaskType
@@ -301,16 +299,7 @@ class OTXDetectionTask(OTXTask, ABC):
         """Export function of OTX Detection Task."""
         logger.info("Exporting the model")
 
-        if export_type == ExportType.ONNX:
-            output_model.model_format = ModelFormat.ONNX
-            output_model.optimization_type = ModelOptimizationType.ONNX
-            if precision == ModelPrecision.FP16:
-                raise RuntimeError("Export to FP16 ONNX is not supported")
-        elif export_type == ExportType.OPENVINO:
-            output_model.model_format = ModelFormat.OPENVINO
-            output_model.optimization_type = ModelOptimizationType.MO
-        else:
-            raise RuntimeError(f"not supported export type {export_type}")
+        self._update_model_export_metadata(output_model, export_type, precision, dump_features)
 
         results = self._export_model(precision, export_type, dump_features)
         outputs = results.get("outputs")
@@ -358,9 +347,6 @@ class OTXDetectionTask(OTXTask, ABC):
             np.array([self.confidence_threshold], dtype=np.float32).tobytes(),
         )
         output_model.set_data("config.json", config_to_bytes(self._hyperparams))
-        output_model.precision = self._precision
-        output_model.optimization_methods = self._optimization_methods
-        output_model.has_xai = dump_features
         output_model.set_data(
             "label_schema.json",
             label_schema_to_bytes(self._task_environment.label_schema),

--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -305,7 +305,7 @@ class OTXDetectionTask(OTXTask, ABC):
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX
             if precision == ModelPrecision.FP16:
-                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+                raise RuntimeError("Export to FP16 ONNX is not supported")
         elif export_type == ExportType.OPENVINO:
             output_model.model_format = ModelFormat.OPENVINO
             output_model.optimization_type = ModelOptimizationType.MO
@@ -327,7 +327,7 @@ class OTXDetectionTask(OTXTask, ABC):
             xml_file = outputs.get("xml")
 
             ir_extra_data = get_det_model_api_configuration(
-            self._task_environment.label_schema, self._task_type, self.confidence_threshold
+                self._task_environment.label_schema, self._task_type, self.confidence_threshold
             )
             embed_ir_model_data(xml_file, ir_extra_data)
 

--- a/otx/algorithms/segmentation/adapters/mmseg/configurer.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/configurer.py
@@ -45,7 +45,7 @@ logger = get_logger()
 class SegmentationConfigurer:
     """Patch config to support otx train."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.task_adapt_type: Optional[str] = None
         self.task_adapt_op: str = "REPLACE"
         self.org_model_classes: List[str] = []

--- a/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -440,7 +440,7 @@ class MMSegmentationTask(OTXSegmentationTask):
             export_options["deploy_cfg"]["backend_config"]["mo_options"]["flags"].append("--compress_to_fp16")
 
         if export_format == ExportType.ONNX:
-            export_options["deploy_cfg"]["backend_config"] = {"type" : "onnxruntime"}
+            export_options["deploy_cfg"]["backend_config"] = {"type": "onnxruntime"}
 
         exporter = SegmentationExporter()
         results = exporter.run(

--- a/otx/algorithms/segmentation/adapters/mmseg/utils/exporter.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/utils/exporter.py
@@ -42,7 +42,7 @@ class SegmentationExporter(Exporter):
         return super().run(cfg, **kwargs)
 
     @staticmethod
-    def naive_export(output_dir, model_builder, precision, cfg, model_name="model"):
+    def naive_export(output_dir, model_builder, precision, export_type, cfg, model_name="model"):
         """Export using pytorch backend."""
         from mmseg.apis.inference import LoadImage
         from mmseg.datasets.pipelines import Compose
@@ -59,7 +59,7 @@ class SegmentationExporter(Exporter):
         fake_data = get_fake_data(cfg)
         opset_version = 11
 
-        NaiveExporter.export2openvino(
+        NaiveExporter.export2backend(
             output_dir,
             model_builder,
             cfg,
@@ -69,4 +69,5 @@ class SegmentationExporter(Exporter):
             input_names=["input"],
             output_names=["output"],
             opset_version=opset_version,
+            export_type=export_type,
         )

--- a/otx/algorithms/segmentation/task.py
+++ b/otx/algorithms/segmentation/task.py
@@ -227,7 +227,7 @@ class OTXSegmentationTask(OTXTask, ABC):
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX
             if precision == ModelPrecision.FP16:
-                raise RuntimeError(f"Export to FP16 ONNX is not supported")
+                raise RuntimeError("Export to FP16 ONNX is not supported")
         elif export_type == ExportType.OPENVINO:
             output_model.model_format = ModelFormat.OPENVINO
             output_model.optimization_type = ModelOptimizationType.MO

--- a/otx/algorithms/segmentation/utils/metadata.py
+++ b/otx/algorithms/segmentation/utils/metadata.py
@@ -18,7 +18,7 @@ def get_seg_model_api_configuration(label_schema: LabelSchemaEntity, hyperparams
 
     return {
         ("model_info", "model_type"): "Segmentation",
-        ("model_info", "soft_threshold"): hyperparams.postprocessing.soft_threshold,
-        ("model_info", "blur_strength"): hyperparams.postprocessing.blur_strength,
+        ("model_info", "soft_threshold"): str(hyperparams.postprocessing.soft_threshold),
+        ("model_info", "blur_strength"): str(hyperparams.postprocessing.blur_strength),
         ("model_info", "labels"): all_labels,
     }

--- a/otx/api/configuration/elements/parameter_group.py
+++ b/otx/api/configuration/elements/parameter_group.py
@@ -45,7 +45,7 @@ class ParameterGroup:
         on_setattr=attr.setters.frozen,
     )
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         """Update parameter and group after __init__.
 
         This method is called after the __init__ method to update the parameter and group fields of the ParameterGroup

--- a/otx/api/entities/model.py
+++ b/otx/api/entities/model.py
@@ -80,6 +80,7 @@ class ModelOptimizationType(IntEnum):
     MO = auto()
     NNCF = auto()
     POT = auto()
+    ONNX = auto()
 
 
 class OptimizationMethod(IntEnum):

--- a/otx/api/usecases/tasks/interfaces/export_interface.py
+++ b/otx/api/usecases/tasks/interfaces/export_interface.py
@@ -14,6 +14,7 @@ class ExportType(Enum):
     """Represent the type of export format available through this interface."""
 
     OPENVINO = auto()
+    ONNX = auto()
 
 
 class IExportTask(metaclass=abc.ABCMeta):

--- a/otx/cli/tools/export.py
+++ b/otx/cli/tools/export.py
@@ -56,6 +56,11 @@ def get_args():
         action="store_true",
         help="This flag indicated if model is exported in half precision (FP16).",
     )
+    parser.add_argument(
+        "--model-type",
+        help="Type of the resulting model (OpenVINO or ONNX).",
+        default='openvino',
+    )
 
     return parser.parse_args()
 
@@ -106,7 +111,9 @@ def main():
     exported_model = ModelEntity(None, environment.get_model_configuration())
 
     export_precision = ModelPrecision.FP16 if args.half_precision else ModelPrecision.FP32
-    task.export(ExportType.OPENVINO, exported_model, export_precision, args.dump_features)
+
+    export_type = ExportType.OPENVINO if "openvino" == args.model_type.lower() else ExportType.ONNX
+    task.export(export_type, exported_model, export_precision, args.dump_features)
 
     if not args.output:
         output_path = config_manager.output_path

--- a/otx/cli/tools/export.py
+++ b/otx/cli/tools/export.py
@@ -57,7 +57,7 @@ def get_args():
         help="This flag indicated if model is exported in half precision (FP16).",
     )
     parser.add_argument(
-        "--model-type",
+        "--export-type",
         help="Type of the resulting model (OpenVINO or ONNX).",
         default="openvino",
     )
@@ -112,7 +112,9 @@ def main():
 
     export_precision = ModelPrecision.FP16 if args.half_precision else ModelPrecision.FP32
 
-    export_type = ExportType.OPENVINO if "openvino" == args.model_type.lower() else ExportType.ONNX
+    if not args.export_type.lower() in ["openvino", "onnx"]:
+        raise ValueError("Unsupported export type")
+    export_type = ExportType.OPENVINO if "openvino" == args.export_type.lower() else ExportType.ONNX
     task.export(export_type, exported_model, export_precision, args.dump_features)
 
     if not args.output:

--- a/otx/cli/tools/export.py
+++ b/otx/cli/tools/export.py
@@ -59,7 +59,7 @@ def get_args():
     parser.add_argument(
         "--model-type",
         help="Type of the resulting model (OpenVINO or ONNX).",
-        default='openvino',
+        default="openvino",
     )
 
     return parser.parse_args()

--- a/otx/cli/tools/export.py
+++ b/otx/cli/tools/export.py
@@ -112,7 +112,7 @@ def main():
 
     export_precision = ModelPrecision.FP16 if args.half_precision else ModelPrecision.FP32
 
-    if not args.export_type.lower() in ["openvino", "onnx"]:
+    if args.export_type.lower() not in ["openvino", "onnx"]:
         raise ValueError("Unsupported export type")
     export_type = ExportType.OPENVINO if "openvino" == args.export_type.lower() else ExportType.ONNX
     task.export(export_type, exported_model, export_precision, args.dump_features)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,3 +7,5 @@ pytest
 coverage
 pytest-timeout
 pytest-mock
+onnx==1.13.0
+onnxruntime==1.14.1

--- a/tests/integration/cli/action/test_action_classification.py
+++ b/tests/integration/cli/action/test_action_classification.py
@@ -67,6 +67,20 @@ class TestToolsOTXActionClassification:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_fp16(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_cls"
+        otx_export_testing(template, tmp_dir_path, half_precision=True)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_cls"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval_openvino(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "action_cls"
         otx_eval_openvino_testing(template, tmp_dir_path, otx_dir, args, threshold=1.0)

--- a/tests/integration/cli/action/test_action_detection.py
+++ b/tests/integration/cli/action/test_action_detection.py
@@ -64,6 +64,20 @@ class TestToolsOTXActionDetection:
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_fp16(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_det"
+        otx_export_testing(template, tmp_dir_path, half_precision=True)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "action_det"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval_openvino(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "action_det"
         otx_eval_openvino_testing(template, tmp_dir_path, otx_dir, args, threshold=1.0)

--- a/tests/integration/cli/anomaly/test_anomaly_classification.py
+++ b/tests/integration/cli/anomaly/test_anomaly_classification.py
@@ -57,6 +57,16 @@ class TestToolsAnomalyClassification:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_fp16(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path, half_precision=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 

--- a/tests/integration/cli/anomaly/test_anomaly_detection.py
+++ b/tests/integration/cli/anomaly/test_anomaly_detection.py
@@ -57,6 +57,16 @@ class TestToolsAnomalyDetection:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_fp16(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path, half_precision=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 

--- a/tests/integration/cli/anomaly/test_anomaly_segmentation.py
+++ b/tests/integration/cli/anomaly/test_anomaly_segmentation.py
@@ -57,6 +57,16 @@ class TestToolsAnomalySegmentation:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_fp16(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path, half_precision=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -134,6 +134,12 @@ class TestMultiClassClassificationCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "multi_class_cls"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -112,6 +112,12 @@ class TestDetectionCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "detection"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "detection"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/integration/cli/detection/test_tiling_detection.py
+++ b/tests/integration/cli/detection/test_tiling_detection.py
@@ -70,6 +70,12 @@ class TestTilingDetectionCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "tiling_det"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/integration/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/integration/cli/instance_segmentation/test_instance_segmentation.py
@@ -92,6 +92,12 @@ class TestInstanceSegmentationCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "ins_seg"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/integration/cli/instance_segmentation/test_tiling_instseg.py
+++ b/tests/integration/cli/instance_segmentation/test_tiling_instseg.py
@@ -103,6 +103,12 @@ class TestTilingInstanceSegmentationCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "tiling_ins_seg"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_ins_seg"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/integration/cli/semantic_segmentation/test_segmentation.py
+++ b/tests/integration/cli/semantic_segmentation/test_segmentation.py
@@ -132,6 +132,12 @@ class TestSegmentationCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_export_onnx(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "segmentation"
+        otx_export_testing(template, tmp_dir_path, half_precision=False, is_onnx=True)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "segmentation"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -231,7 +231,7 @@ def otx_export_testing(template, root, dump_features=False, half_precision=False
         save_path = command_line[-1]
         command_line.append("--half-precision")
     if is_onnx:
-        command_line.extend(["--model-type", "onnx"])
+        command_line.extend(["--export-type", "onnx"])
 
     check_run(command_line)
 

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -209,7 +209,7 @@ def otx_hpo_testing(template, root, otx_dir, args):
     assert os.path.exists(f"{template_work_dir}/hpo_trained_{template.model_template_id}/models/label_schema.json")
 
 
-def otx_export_testing(template, root, dump_features=False, half_precision=False, check_ir_meta=False):
+def otx_export_testing(template, root, dump_features=False, half_precision=False, check_ir_meta=False, is_onnx=False):
     template_work_dir = get_template_dir(template, root)
     save_path = f"{template_work_dir}/exported_{template.model_template_id}"
     command_line = [
@@ -230,13 +230,19 @@ def otx_export_testing(template, root, dump_features=False, half_precision=False
         command_line[-1] += "_fp16"
         save_path = command_line[-1]
         command_line.append("--half-precision")
+    if is_onnx:
+        command_line.append("--model-type onnx")
 
     check_run(command_line)
+
     path_to_xml = os.path.join(save_path, "openvino.xml")
-    assert os.path.exists(path_to_xml)
-    assert os.path.exists(os.path.join(save_path, "openvino.bin"))
-    assert os.path.exists(os.path.join(save_path, "model.onnx"))
     assert os.path.exists(os.path.join(save_path, "label_schema.json"))
+    if not is_onnx:
+        assert os.path.exists(path_to_xml)
+        assert os.path.exists(os.path.join(save_path, "openvino.bin"))
+    else:
+        assert os.path.exists(os.path.join(save_path, "model.onnx"))
+        return
 
     if dump_features:
         with open(path_to_xml, encoding="utf-8") as stream:

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -19,6 +19,8 @@ import shutil
 import sys
 from pathlib import Path
 from typing import Dict
+import onnx
+import onnxruntime
 
 import pytest
 import yaml
@@ -241,7 +243,10 @@ def otx_export_testing(template, root, dump_features=False, half_precision=False
         assert os.path.exists(path_to_xml)
         assert os.path.exists(os.path.join(save_path, "openvino.bin"))
     else:
-        assert os.path.exists(os.path.join(save_path, "model.onnx"))
+        path_to_onnx = os.path.join(save_path, "model.onnx")
+        assert os.path.exists(path_to_onnx)
+        onnx.checker.check_model(path_to_onnx)
+        onnxruntime.InferenceSession(path_to_onnx)
         return
 
     if dump_features:

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -245,8 +245,10 @@ def otx_export_testing(template, root, dump_features=False, half_precision=False
     else:
         path_to_onnx = os.path.join(save_path, "model.onnx")
         assert os.path.exists(path_to_onnx)
-        onnx.checker.check_model(path_to_onnx)
-        onnxruntime.InferenceSession(path_to_onnx)
+        # In case of tile classifier mmdeploy inserts mark nodes in onnx, making it non-standard
+        if not os.path.exists(os.path.join(save_path, "tile_classifier.onnx")):
+            onnx.checker.check_model(path_to_onnx)
+            onnxruntime.InferenceSession(path_to_onnx)
         return
 
     if dump_features:

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -231,7 +231,7 @@ def otx_export_testing(template, root, dump_features=False, half_precision=False
         save_path = command_line[-1]
         command_line.append("--half-precision")
     if is_onnx:
-        command_line.append("--model-type onnx")
+        command_line.extend(["--model-type", "onnx"])
 
     check_run(command_line)
 

--- a/tests/unit/algorithms/action/adapters/mmaction/utils/test_action_export_utils.py
+++ b/tests/unit/algorithms/action/adapters/mmaction/utils/test_action_export_utils.py
@@ -129,7 +129,7 @@ class TestExporter:
                 )
             )
         )
-        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", False)
+        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", False, False)
         assert isinstance(exporter.model, Recognizer3D)
         assert exporter.input_tensor.shape == torch.Size([1, 1, 3, 32, 224, 224])
         assert exporter.input_metas is None
@@ -144,12 +144,12 @@ class TestExporter:
                 )
             )
         )
-        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", False)
+        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", False, False)
         assert isinstance(exporter.model, AVAFastRCNN)
         assert exporter.input_tensor.shape == torch.Size([1, 3, 32, 224, 224])
         assert exporter.input_metas is not None
 
-        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", True)
+        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", True, False)
         assert exporter.deploy_cfg.backend_config.mo_options["flags"] == ["--compress_to_fp16"]
 
     @e2e_pytest_unit
@@ -174,5 +174,5 @@ class TestExporter:
                 ir_config=dict(input_names=["input"], output_names=["output"]),
             )
         )
-        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", False)
+        exporter = Exporter(recipe_cfg, None, deploy_cfg, "./tmp_dir/openvino", False, False)
         exporter.export()

--- a/tests/unit/algorithms/anomaly/tasks/test_inference.py
+++ b/tests/unit/algorithms/anomaly/tasks/test_inference.py
@@ -79,3 +79,8 @@ class TestInferenceTask:
         inference_task.export(ExportType.OPENVINO, output_model, dump_features=False)
         assert output_model.get_data("openvino.bin") is not None  # Should not raise an error
         assert not output_model.has_xai
+
+        # 6. Check if ONNX model can be generated
+        inference_task.export(ExportType.OPENVINO, output_model, dump_features=False)
+        assert output_model.get_data("model.onnx") is not None  # Should not raise an error
+        assert not output_model.has_xai

--- a/tests/unit/algorithms/classification/adapters/mmcls/test_task.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/test_task.py
@@ -367,7 +367,7 @@ class TestMMClassificationTask:
 
     @pytest.mark.parametrize("precision", [ModelPrecision.FP16, ModelPrecision.FP32])
     @e2e_pytest_unit
-    def test_export(self, mocker, precision: ModelPrecision, export_type: ExportType=ExportType.OPENVINO) -> None:
+    def test_export(self, mocker, precision: ModelPrecision, export_type: ExportType = ExportType.OPENVINO) -> None:
         """Test export function.
 
         <Steps>

--- a/tests/unit/algorithms/common/adapters/mmcv/tasks/test_exporter.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/tasks/test_exporter.py
@@ -59,7 +59,7 @@ class TestExporter:
     def test_mmdeploy_export(self, mocker):
         from otx.algorithms.common.adapters.mmdeploy.apis import MMdeployExporter
 
-        mock_export_openvino = mocker.patch.object(MMdeployExporter, "export2openvino")
+        mock_export_openvino = mocker.patch.object(MMdeployExporter, "export2backend")
 
         Exporter.mmdeploy_export(
             "", None, "FP16", dict(), mmcv.ConfigDict(backend_config=dict(mo_options=dict(flags=[])))

--- a/tests/unit/algorithms/common/adapters/mmcv/tasks/test_exporter.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/tasks/test_exporter.py
@@ -1,3 +1,4 @@
+from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 import mmcv
 import pytest
 
@@ -29,7 +30,7 @@ class TestExporter:
 
     @e2e_pytest_unit
     def test_run_without_deploy_cfg(self, mocker):
-        def mock_naive_export(output_dir, model_builder, precision, cfg, model_name="model"):
+        def mock_naive_export(output_dir, model_builder, precision, export_type, cfg, model_name="model"):
             pass
 
         self.exporter.naive_export = mock_naive_export
@@ -43,7 +44,9 @@ class TestExporter:
 
     @e2e_pytest_unit
     def test_run_with_deploy_cfg(self, mocker):
-        def mock_mmdeploy_export(output_dir, model_builder, precision, cfg, deploy_cfg, model_name="model"):
+        def mock_mmdeploy_export(
+            output_dir, model_builder, precision, export_type, cfg, deploy_cfg, model_name="model"
+        ):
             pass
 
         self.exporter.mmdeploy_export = mock_mmdeploy_export
@@ -62,7 +65,12 @@ class TestExporter:
         mock_export_openvino = mocker.patch.object(MMdeployExporter, "export2backend")
 
         Exporter.mmdeploy_export(
-            "", None, "FP16", dict(), mmcv.ConfigDict(backend_config=dict(mo_options=dict(flags=[])))
+            "",
+            None,
+            "FP16",
+            ExportType.OPENVINO,
+            dict(),
+            mmcv.ConfigDict(backend_config=dict(mo_options=dict(flags=[]))),
         )
 
         mock_export_openvino.assert_called_once()

--- a/tests/unit/algorithms/common/adapters/mmdeploy/test_deploy_apis.py
+++ b/tests/unit/algorithms/common/adapters/mmdeploy/test_deploy_apis.py
@@ -11,6 +11,7 @@ from mmcv.utils import Config
 
 from otx.algorithms.common.adapters.mmdeploy.apis import NaiveExporter
 from otx.algorithms.common.adapters.mmdeploy.utils import is_mmdeploy_enabled
+from otx.api.usecases.tasks.interfaces.export_interface import ExportType
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
 from tests.unit.algorithms.common.adapters.mmdeploy.test_helpers import (
     create_config,
@@ -148,6 +149,7 @@ if is_mmdeploy_enabled():
                     build_classifier,
                     config,
                     deploy_config,
+                    str(ExportType.OPENVINO),
                 )
                 assert [f for f in os.listdir(tempdir) if f.endswith(".xml")]
                 assert [f for f in os.listdir(tempdir) if f.endswith(".bin")]

--- a/tests/unit/algorithms/common/adapters/mmdeploy/test_deploy_apis.py
+++ b/tests/unit/algorithms/common/adapters/mmdeploy/test_deploy_apis.py
@@ -208,13 +208,7 @@ if is_mmdeploy_enabled():
                 return ctx.origin_func(self, *args, **kwargs)
 
             with tempfile.TemporaryDirectory() as tempdir:
-                MMdeployExporter.export2backend(
-                    tempdir,
-                    build_classifier,
-                    config,
-                    deploy_config,
-                    "OPENVINO"
-                )
+                MMdeployExporter.export2backend(tempdir, build_classifier, config, deploy_config, "OPENVINO")
                 files = os.listdir(tempdir)
                 assert "model.onnx" in files
                 assert "model.xml" in files

--- a/tests/unit/algorithms/common/adapters/mmdeploy/test_deploy_apis.py
+++ b/tests/unit/algorithms/common/adapters/mmdeploy/test_deploy_apis.py
@@ -39,7 +39,7 @@ class TestNaiveExporter:
                 assert os.path.exists(openvino_path)
 
     @e2e_pytest_unit
-    def test_export2openvino(self):
+    def test_export2backend(self):
         from otx.algorithms.classification.adapters.mmcls.utils.builder import (
             build_classifier,
         )
@@ -48,7 +48,7 @@ class TestNaiveExporter:
         create_model("mmcls")
 
         with tempfile.TemporaryDirectory() as tempdir:
-            NaiveExporter.export2openvino(
+            NaiveExporter.export2backend(
                 tempdir,
                 build_classifier,
                 config,
@@ -111,7 +111,7 @@ if is_mmdeploy_enabled():
                     assert os.path.exists(openvino_path)
 
         @e2e_pytest_unit
-        def test_export2openvino(self):
+        def test_export2backend(self):
             from otx.algorithms.classification.adapters.mmcls.utils.builder import (
                 build_classifier,
             )
@@ -143,7 +143,7 @@ if is_mmdeploy_enabled():
             create_model("mmcls")
 
             with tempfile.TemporaryDirectory() as tempdir:
-                MMdeployExporter.export2openvino(
+                MMdeployExporter.export2backend(
                     tempdir,
                     build_classifier,
                     config,
@@ -208,11 +208,12 @@ if is_mmdeploy_enabled():
                 return ctx.origin_func(self, *args, **kwargs)
 
             with tempfile.TemporaryDirectory() as tempdir:
-                MMdeployExporter.export2openvino(
+                MMdeployExporter.export2backend(
                     tempdir,
                     build_classifier,
                     config,
                     deploy_config,
+                    "OPENVINO"
                 )
                 files = os.listdir(tempdir)
                 assert "model.onnx" in files

--- a/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
@@ -301,7 +301,7 @@ class TestMMDetectionTask:
 
     @pytest.mark.parametrize("precision", [ModelPrecision.FP16, ModelPrecision.FP32])
     @e2e_pytest_unit
-    def test_export(self, mocker, precision: ModelPrecision) -> None:
+    def test_export(self, mocker, precision: ModelPrecision, export_type: ExportType=ExportType.OPENVINO) -> None:
         """Test export function.
 
         <Steps>
@@ -321,17 +321,27 @@ class TestMMDetectionTask:
             return_value=True,
         )
 
-        self.det_task.export(ExportType.OPENVINO, _model, precision, False)
+        self.det_task.export(export_type, _model, precision, False)
 
-        assert _model.model_format == ModelFormat.OPENVINO
-        assert _model.optimization_type == ModelOptimizationType.MO
+        assert _model.model_format == ModelFormat.ONNX if export_type == ExportType.ONNX else ModelFormat.OPENVINO
         assert _model.precision[0] == precision
-        assert _model.get_data("openvino.bin") is not None
-        assert _model.get_data("openvino.xml") is not None
-        assert _model.get_data("confidence_threshold") is not None
         assert _model.precision == self.det_task._precision
+
+        if export_type == ExportType.OPENVINO:
+            assert _model.get_data("openvino.bin") is not None
+            assert _model.get_data("openvino.xml") is not None
+            assert _model.optimization_type == ModelOptimizationType.MO
+        else:
+            assert _model.get_data("model.onnx") is not None
+            assert _model.optimization_type == ModelOptimizationType.ONNX
+
+        assert _model.get_data("confidence_threshold") is not None
         assert _model.optimization_methods == self.det_task._optimization_methods
         assert _model.get_data("label_schema.json") is not None
+
+    @e2e_pytest_unit
+    def test_export_onnx(self, mocker) -> None:
+        self.test_export(mocker, ModelPrecision.FP32, ExportType.ONNX)
 
     @e2e_pytest_unit
     def test_explain(self, mocker):

--- a/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
@@ -301,7 +301,7 @@ class TestMMDetectionTask:
 
     @pytest.mark.parametrize("precision", [ModelPrecision.FP16, ModelPrecision.FP32])
     @e2e_pytest_unit
-    def test_export(self, mocker, precision: ModelPrecision, export_type: ExportType=ExportType.OPENVINO) -> None:
+    def test_export(self, mocker, precision: ModelPrecision, export_type: ExportType = ExportType.OPENVINO) -> None:
         """Test export function.
 
         <Steps>

--- a/tests/unit/algorithms/detection/adapters/mmdet/utils/test_exporter.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/utils/test_exporter.py
@@ -46,6 +46,6 @@ def test_run(recipe_cfg, template_dir, mocker):
 def test_naive_export(recipe_cfg, template_dir, mocker):
     exporter = DetectionExporter()
     data_cfg = MPAConfig.fromfile(os.path.join(template_dir, "data_pipeline.py"))
-    mock_export_ov = mocker.patch.object(NaiveExporter, "export2openvino")
-    exporter.naive_export("", build_detector, "FP32", data_cfg)
+    mock_export_ov = mocker.patch.object(NaiveExporter, "export2backend")
+    exporter.naive_export("", build_detector, "FP32", "OPENVINO", data_cfg)
     mock_export_ov.assert_called_once()

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/utils/test_exporter.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/utils/test_exporter.py
@@ -31,6 +31,6 @@ def test_run(mocker):
 def test_naive_export(mocker):
     exporter = SegmentationExporter()
     data_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_SEG_TEMPLATE_DIR, "data_pipeline.py"))
-    mock_export_ov = mocker.patch.object(NaiveExporter, "export2openvino")
-    exporter.naive_export("", build_segmentor, "FP32", data_cfg)
+    mock_export_ov = mocker.patch.object(NaiveExporter, "export2backend")
+    exporter.naive_export("", build_segmentor, "FP32", "OPENVINO", data_cfg)
     mock_export_ov.assert_called_once()

--- a/tests/unit/algorithms/segmentation/test_task.py
+++ b/tests/unit/algorithms/segmentation/test_task.py
@@ -121,9 +121,10 @@ class TestOTXSegmentationTask:
         assert _result_entity.performance == 1.0
 
     @e2e_pytest_unit
-    def test_export(self, otx_model, mocker):
+    @pytest.mark.parametrize("export_type", [ExportType.ONNX, ExportType.OPENVINO])
+    def test_export(self, otx_model, mocker, export_type):
         mocker_open = mocker.patch("builtins.open")
         mocker_open.__enter__.return_value = True
         mocker.patch("otx.algorithms.segmentation.task.embed_ir_model_data", return_value=None)
-        self.seg_task.export(ExportType.OPENVINO, otx_model)
+        self.seg_task.export(export_type, otx_model)
         mocker_open.assert_called()

--- a/tests/unit/api/entities/test_model.py
+++ b/tests/unit/api/entities/test_model.py
@@ -105,7 +105,7 @@ class TestModelOptimizationType:
         """
 
         model_optimization_type = ModelOptimizationType
-        assert len(model_optimization_type) == 4
+        assert len(model_optimization_type) == 5
 
 
 @pytest.mark.components(OtxSdkComponent.OTX_API)

--- a/tests/unit/api/usecases/tasks/interfaces/test_interfaces.py
+++ b/tests/unit/api/usecases/tasks/interfaces/test_interfaces.py
@@ -249,8 +249,9 @@ class TestExportType:
         Test passes if ExportType Enum class length is equal to expected value and its elements have expected
         sequence numbers
         """
-        assert len(ExportType) == 1
+        assert len(ExportType) == 2
         assert ExportType.OPENVINO.value == 1
+        assert ExportType.ONNX.value == 2
 
 
 @pytest.mark.components(OtxSdkComponent.OTX_API)

--- a/tests/unit/cli/tools/test_export.py
+++ b/tests/unit/cli/tools/test_export.py
@@ -26,6 +26,7 @@ def mock_args(mocker, tmp_dir):
     mock_args = mocker.MagicMock()
     mock_args.load_weights = "fake.bin"
     mock_args.output = tmp_dir
+    mock_args.export_type = "openvino"
 
     def mock_contains(self, val):
         return val in self.__dict__


### PR DESCRIPTION
### Summary
New export type is introduced. Now task.export() method can directly generate onnx models, when corresponding export type is specified. Also, the export type could be specified via CLI.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
