### PR TITLE
XAI: Add softmax activation for cls head output in DetClassProbabilityMapHook

### DIFF
--- a/otx/algorithms/detection/adapters/mmdet/hooks/det_class_probability_map_hook.py
+++ b/otx/algorithms/detection/adapters/mmdet/hooks/det_class_probability_map_hook.py
@@ -55,6 +55,7 @@ class DetClassProbabilityMapHook(BaseRecordingForwardHook):
             cls_scores = feature_map
         else:
             cls_scores = self._get_cls_scores_from_feature_map(feature_map)
+        cls_scores = [torch.softmax(t, dim=1) for t in cls_scores]
 
         batch_size, _, height, width = cls_scores[-1].size()
         saliency_maps = torch.empty(batch_size, self._num_cls_out_channels, height, width)

--- a/tests/unit/algorithms/detection/test_xai_detection_validity.py
+++ b/tests/unit/algorithms/detection/test_xai_detection_validity.py
@@ -26,9 +26,9 @@ class TestExplainMethods:
     }
 
     ref_saliency_vals_det = {
-        "ATSS": np.array([80, 213, 255, 124], dtype=np.uint8),
-        "YOLOX": np.array([99, 38, 42, 57, 50, 71, 75, 81, 75, 61, 70, 5, 177], dtype=np.uint8),
-        "SSD": np.array([191, 133, 160, 60, 63, 50, 51, 51, 57, 54, 83, 71, 148], dtype=np.uint8),
+        "ATSS": np.array([67, 216, 255, 57], dtype=np.uint8),
+        "YOLOX": np.array([80, 28, 42, 53, 49, 68, 72, 75, 69, 57, 65, 6, 157], dtype=np.uint8),
+        "SSD": np.array([119, 72, 118, 35, 39, 30, 31, 31, 36, 28, 44, 23, 61], dtype=np.uint8),
     }
 
     @e2e_pytest_unit


### PR DESCRIPTION
### Summary
Convert raw class scores to distribution with softmax activation.
See the improvement in the fig. below
![image](https://github.com/openvinotoolkit/training_extensions/assets/17028475/7212d88a-99ca-494b-93fc-e0a3920a29e9)


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
