### PR TITLE
Do not skip full img tile classifier + Fix Sequencial Export Issue

### DIFF
--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -35,12 +35,12 @@ class Exporter:
             pipeline += cfg.data.test.get("pipeline", [])
             cfg.data.test.pipeline = pipeline
         for pipeline in cfg.data.test.pipeline:
-            if pipeline.get('transforms', None):
+            if pipeline.get("transforms", None):
                 transforms = pipeline.transforms
-                if transforms[-1].type == 'Collect':
-                    for collect_key in transforms[-1]['keys']:
-                        if collect_key != 'img':
-                            transforms[-1]['keys'].remove(collect_key)
+                if transforms[-1].type == "Collect":
+                    for collect_key in transforms[-1]["keys"]:
+                        if collect_key != "img":
+                            transforms[-1]["keys"].remove(collect_key)
 
         model_builder = kwargs.get("model_builder")
         try:

--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -34,6 +34,13 @@ class Exporter:
             pipeline = dataset.get("pipeline", [])
             pipeline += cfg.data.test.get("pipeline", [])
             cfg.data.test.pipeline = pipeline
+        for pipeline in cfg.data.test.pipeline:
+            if pipeline.get('transforms', None):
+                transforms = pipeline.transforms
+                if transforms[-1].type == 'Collect':
+                    for collect_key in transforms[-1]['keys']:
+                        if collect_key != 'img':
+                            transforms[-1]['keys'].remove(collect_key)
 
         model_builder = kwargs.get("model_builder")
         try:

--- a/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
+++ b/otx/algorithms/common/adapters/mmcv/tasks/exporter.py
@@ -37,10 +37,11 @@ class Exporter:
         for pipeline in cfg.data.test.pipeline:
             if pipeline.get("transforms", None):
                 transforms = pipeline.transforms
-                if transforms[-1].type == "Collect":
-                    for collect_key in transforms[-1]["keys"]:
-                        if collect_key != "img":
-                            transforms[-1]["keys"].remove(collect_key)
+                for transform in transforms:
+                    if transform.type == "Collect":
+                        for collect_key in transform["keys"]:
+                            if collect_key != "img":
+                                transform["keys"].remove(collect_key)
 
         model_builder = kwargs.get("model_builder")
         try:

--- a/otx/algorithms/common/adapters/mmdeploy/apis.py
+++ b/otx/algorithms/common/adapters/mmdeploy/apis.py
@@ -254,7 +254,7 @@ if is_mmdeploy_enabled():
             model_name: str = "model",
         ):
             """Function for extracting partition."""
-
+            reset_mark_function_count()
             model_onnx = MMdeployExporter.torch2onnx(
                 output_dir,
                 input_data,

--- a/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
+++ b/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
@@ -132,6 +132,7 @@ class Tile:
         Returns:
             Dict: annotation with some other useful information for data pipeline.
         """
+        result["full_res_image"] = True
         result["tile_box"] = (0, 0, result["img_shape"][1], result["img_shape"][0])
         result["dataset_idx"] = dataset_idx
         result["original_shape_"] = result["img_shape"]
@@ -179,6 +180,7 @@ class Tile:
             y_1 = loc_i
             y_2 = loc_i + self.tile_size
             tile = copy.deepcopy(_tile)
+            tile["full_res_image"] = False
             tile["original_shape_"] = img_shape
             tile["ori_shape"] = (y_2 - y_1, x_2 - x_1, 3)
             tile["img_shape"] = tile["ori_shape"]

--- a/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
+++ b/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
@@ -141,6 +141,7 @@ class Tile:
         Returns:
             Dict: annotation with some other useful information for data pipeline.
         """
+        result["full_res_image"] = True
         result["tile_box"] = (0, 0, result["img_shape"][1], result["img_shape"][0])
         result["dataset_idx"] = dataset_idx
         result["original_shape_"] = result["img_shape"]
@@ -188,6 +189,7 @@ class Tile:
             y_1 = loc_i
             y_2 = min(loc_i + self.tile_size, height)
             tile = copy.deepcopy(_tile)
+            tile["full_res_image"] = False
             tile["original_shape_"] = img_shape
             tile["ori_shape"] = (y_2 - y_1, x_2 - x_1, 3)
             tile["img_shape"] = tile["ori_shape"]

--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -160,7 +160,7 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
             mask_results.append([])
         return bbox_results, mask_results
 
-    def simple_test(self, img, img_metas, proposals=None, rescale=False):
+    def simple_test(self, img, img_metas, proposals=None, rescale=False, full_res_image=False):
         """Simple test.
 
         Tile classifier is used to filter out images without any objects.
@@ -175,8 +175,8 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
         Returns:
             tuple: MaskRCNN output
         """
-
         keep = self.tile_classifier.simple_test(img) > 0.45
+        keep = full_res_image[0] | keep
 
         results = []
         for _ in range(len(img)):

--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -157,6 +157,7 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
             img_metas (list): image meta data
             proposals (list, optional): proposals. Defaults to None.
             rescale (bool, optional): rescale. Defaults to False.
+            full_res_image (bool, optional): if the image is full resolution or not. Defaults to False.
 
         Returns:
             tuple: MaskRCNN output

--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -163,6 +163,8 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
             tuple: MaskRCNN output
         """
         keep = self.tile_classifier.simple_test(img) > 0.45
+        if isinstance(full_res_image, bool):
+            full_res_image = [full_res_image]
         keep = full_res_image[0] | keep
 
         if not keep:

--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -171,6 +171,7 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
             img_metas (list): image meta data
             proposals (list, optional): proposals. Defaults to None.
             rescale (bool, optional): rescale. Defaults to False.
+            full_res_image (bool, optional): if the image is full resolution or not. Defaults to False.
 
         Returns:
             tuple: MaskRCNN output

--- a/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -146,7 +146,7 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
         losses.update(rcnn_loss)
         return losses
 
-    def simple_test(self, img, img_metas, proposals=None, rescale=False):
+    def simple_test(self, img, img_metas, proposals=None, rescale=False, full_res_image=False):
         """Simple test.
 
         Tile classifier is used to filter out images without any objects.
@@ -162,6 +162,7 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
             tuple: MaskRCNN output
         """
         keep = self.tile_classifier.simple_test(img) > 0.45
+        keep = full_res_image[0] | keep
 
         if not keep:
             tmp_results = []

--- a/otx/algorithms/detection/adapters/mmdet/nncf/builder.py
+++ b/otx/algorithms/detection/adapters/mmdet/nncf/builder.py
@@ -136,6 +136,13 @@ def build_nncf_detector(  # pylint: disable=too-many-locals,too-many-statements
     for pipeline in config.data.test.pipeline:
         if not pipeline.type.startswith("LoadImage"):
             test_pipeline.append(pipeline)
+        if pipeline.get("transforms", None):
+            transforms = pipeline.transforms
+            for transform in transforms:
+                if transform.type == "Collect":
+                    for collect_key in transform["keys"]:
+                        if collect_key != "img":
+                            transform["keys"].remove(collect_key)
 
     test_pipeline = Compose(test_pipeline)
     get_fake_input_fn = partial(

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -346,6 +346,10 @@ def patch_tiling(config, hparams, dataset=None):
             logger.info(f"Patch model from: {config.model.type} to CustomMaskRCNNTileOptimized")
             config.model.type = "CustomMaskRCNNTileOptimized"
 
+            for subset in ('val', 'test'):
+                if config.data[subset].pipeline[0]['transforms'][-1]['type'] == 'Collect':
+                    config.data[subset].pipeline[0]['transforms'][-1]['keys'].append('full_res_image')
+
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002
                 logger.info(

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -342,9 +342,9 @@ def patch_tiling(config, hparams, dataset=None):
             logger.info(f"Patch model from: {config.model.type} to CustomMaskRCNNTileOptimized")
             config.model.type = "CustomMaskRCNNTileOptimized"
 
-            for subset in ('val', 'test'):
-                if config.data[subset].pipeline[0]['transforms'][-1]['type'] == 'Collect':
-                    config.data[subset].pipeline[0]['transforms'][-1]['keys'].append('full_res_image')
+            for subset in ("val", "test"):
+                if config.data[subset].pipeline[0]["transforms"][-1]["type"] == "Collect":
+                    config.data[subset].pipeline[0]["transforms"][-1]["keys"].append("full_res_image")
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -343,8 +343,10 @@ def patch_tiling(config, hparams, dataset=None):
             config.model.type = "CustomMaskRCNNTileOptimized"
 
             for subset in ("val", "test"):
-                if config.data[subset].pipeline[0]["transforms"][-1]["type"] == "Collect":
-                    config.data[subset].pipeline[0]["transforms"][-1]["keys"].append("full_res_image")
+                if "transforms" in config.data[subset].pipeline[0]:
+                    transforms = config.data[subset].pipeline[0]["transforms"]
+                    if transforms[-1]["type"] == "Collect":
+                        transforms["keys"].append("full_res_image")
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -347,8 +347,10 @@ def patch_tiling(config, hparams, dataset=None):
             config.model.type = "CustomMaskRCNNTileOptimized"
 
             for subset in ("val", "test"):
-                if config.data[subset].pipeline[0]["transforms"][-1]["type"] == "Collect":
-                    config.data[subset].pipeline[0]["transforms"][-1]["keys"].append("full_res_image")
+                if "transforms" in config.data[subset].pipeline[0]:
+                    transforms = config.data[subset].pipeline[0]["transforms"]
+                    if transforms[-1]["type"] == "Collect":
+                        transforms["keys"].append("full_res_image")
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -350,7 +350,7 @@ def patch_tiling(config, hparams, dataset=None):
                 if "transforms" in config.data[subset].pipeline[0]:
                     transforms = config.data[subset].pipeline[0]["transforms"]
                     if transforms[-1]["type"] == "Collect":
-                        transforms["keys"].append("full_res_image")
+                        transforms[-1]["keys"].append("full_res_image")
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -342,6 +342,10 @@ def patch_tiling(config, hparams, dataset=None):
             logger.info(f"Patch model from: {config.model.type} to CustomMaskRCNNTileOptimized")
             config.model.type = "CustomMaskRCNNTileOptimized"
 
+            for subset in ('val', 'test'):
+                if config.data[subset].pipeline[0]['transforms'][-1]['type'] == 'Collect':
+                    config.data[subset].pipeline[0]['transforms'][-1]['keys'].append('full_res_image')
+
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002
                 logger.info(

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -346,9 +346,9 @@ def patch_tiling(config, hparams, dataset=None):
             logger.info(f"Patch model from: {config.model.type} to CustomMaskRCNNTileOptimized")
             config.model.type = "CustomMaskRCNNTileOptimized"
 
-            for subset in ('val', 'test'):
-                if config.data[subset].pipeline[0]['transforms'][-1]['type'] == 'Collect':
-                    config.data[subset].pipeline[0]['transforms'][-1]['keys'].append('full_res_image')
+            for subset in ("val", "test"):
+                if config.data[subset].pipeline[0]["transforms"][-1]["type"] == "Collect":
+                    config.data[subset].pipeline[0]["transforms"][-1]["keys"].append("full_res_image")
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002

--- a/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -346,7 +346,7 @@ def patch_tiling(config, hparams, dataset=None):
                 if "transforms" in config.data[subset].pipeline[0]:
                     transforms = config.data[subset].pipeline[0]["transforms"]
                     if transforms[-1]["type"] == "Collect":
-                        transforms["keys"].append("full_res_image")
+                        transforms[-1]["keys"].append("full_res_image")
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002

--- a/otx/api/configuration/helper/convert.py
+++ b/otx/api/configuration/helper/convert.py
@@ -8,7 +8,7 @@ This function can be used to convert a OTX configuration object to a dictionary 
 
 
 from enum import Enum
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Dict, Any, Union
 
 import yaml
 from omegaconf import DictConfig, OmegaConf
@@ -98,7 +98,7 @@ def convert(
     enum_to_str: bool = False,
     id_to_str: bool = False,
     values_only: bool = False,
-) -> ConvertTypeVar:
+) -> Any:
     """Convert a configuration object to either a yaml string, a dictionary or an OmegaConf DictConfig object.
 
     Args:
@@ -129,11 +129,10 @@ def convert(
         config_dict["id"] = str(config_id) if config_id is not None else None
 
     if target == str:
-        result = yaml.dump(config_dict)
+        return yaml.dump(config_dict)
     elif target == dict:
-        result = config_dict  # type: ignore
+        return config_dict
     elif target == DictConfig:
-        result = OmegaConf.create(config_dict)
+        return OmegaConf.create(config_dict)
     else:
         raise ValueError("Unsupported conversion target! Supported target types are [str, dict, DictConfig]")
-    return result  # type: ignore

--- a/otx/api/configuration/helper/convert.py
+++ b/otx/api/configuration/helper/convert.py
@@ -8,7 +8,7 @@ This function can be used to convert a OTX configuration object to a dictionary 
 
 
 from enum import Enum
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Dict, Any, Union
 
 import yaml
 from omegaconf import DictConfig, OmegaConf
@@ -98,7 +98,7 @@ def convert(
     enum_to_str: bool = False,
     id_to_str: bool = False,
     values_only: bool = False,
-) -> ConvertTypeVar:
+) -> Any:
     """Convert a configuration object to either a yaml string, a dictionary or an OmegaConf DictConfig object.
 
     Args:
@@ -129,11 +129,10 @@ def convert(
         config_dict["id"] = str(config_id) if config_id is not None else None
 
     if target == str:
-        result = yaml.dump(config_dict)
+        return yaml.dump(config_dict)
     elif target == dict:
-        result = config_dict
+        return config_dict
     elif target == DictConfig:
-        result = OmegaConf.create(config_dict)
+        return OmegaConf.create(config_dict)
     else:
         raise ValueError("Unsupported conversion target! Supported target types are [str, dict, DictConfig]")
-    return result  # type: ignore


### PR DESCRIPTION
### Summary

* Always predict full res image samples when the tile classifier is enabled as it may skip full-resolution images.
* Fix sequential model export issue by resetting partition count for tile classifier

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
