### PR TITLE
Add supcon seg for regression

### DIFF
--- a/otx/algorithms/detection/configs/detection/cspdarknet_yolox/data_pipeline.py
+++ b/otx/algorithms/detection/configs/detection/cspdarknet_yolox/data_pipeline.py
@@ -48,7 +48,7 @@ test_pipeline = [
         img_scale=(416, 416),
         flip=False,
         transforms=[
-            dict(type="Resize", keep_ratio=False),
+            dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Pad", size=(416, 416), pad_val=114.0),
             dict(type="Normalize", **__img_norm_cfg),

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/__init__.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/__init__.py
@@ -1,0 +1,15 @@
+"""Initialization of OCR-Lite-HRnet-18-mod2 model for SupCon Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/__init__.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/__init__.py
@@ -1,4 +1,4 @@
-"""Initialization of OCR-Lite-HRnet-18-mod2 model for SupCon Segmentation Task."""
+"""Initialization of OCR-Lite-HRnet-18 model for SupCon Segmentation Task."""
 
 # Copyright (C) 2022 Intel Corporation
 #

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/data_pipeline.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/data_pipeline.py
@@ -1,0 +1,18 @@
+"""Data Pipeline of HR-Net model for Segmentation Task."""
+
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+_base_ = ["../../base/data/supcon/data_pipeline.py"]

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/hparam.yaml
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/hparam.yaml
@@ -1,0 +1,8 @@
+# Hyperparameters.
+hyper_parameters:
+  parameter_overrides:
+    learning_parameters:
+      enable_supcon:
+        default_value: True
+      learning_rate_warmup_iters:
+        default_value: 50

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/model.py
@@ -1,0 +1,84 @@
+"""Model configuration of OCR-Lite-HRnet-18-mod2 model for SupCon Segmentation Task."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+# pylint: disable=invalid-name
+
+_base_ = [
+    "../../../../../recipes/stages/segmentation/supcon.py",
+    "../../../../common/adapters/mmcv/configs/backbones/lite_hrnet_18.py",
+]
+
+model = dict(
+    type="SupConDetConB",
+    pretrained=(
+        "https://storage.openvinotoolkit.org/repositories/"
+        "openvino_training_extensions/models/custom_semantic_segmentation/"
+        "litehrnet18_imagenet1k_rsc.pth"
+    ),
+    num_classes=256,
+    num_samples=16,
+    downsample=4,
+    input_transform="resize_concat",
+    in_index=[0, 1, 2, 3],
+    neck=dict(
+        type="SelfSLMLP",
+        in_channels=600,
+        hid_channels=256,
+        out_channels=128,
+        norm_cfg=dict(type="BN1d", requires_grad=True),
+        with_avg_pool=False,
+    ),
+    head=dict(
+        type="DetConHead",
+        predictor=dict(
+            type="SelfSLMLP",
+            in_channels=128,
+            hid_channels=256,
+            out_channels=128,
+            norm_cfg=dict(type="BN1d", requires_grad=True),
+            with_avg_pool=False,
+        ),
+        loss_cfg=dict(type="DetConLoss", temperature=0.1),
+    ),
+    decode_head=dict(
+        type="FCNHead",
+        in_channels=[40, 80, 160, 320],
+        in_index=[0, 1, 2, 3],
+        input_transform="multiple_select",
+        channels=40,
+        kernel_size=1,
+        num_convs=1,
+        concat_input=False,
+        dropout_ratio=-1,
+        num_classes=2,
+        norm_cfg=dict(type="BN", requires_grad=True),
+        align_corners=False,
+        enable_aggregator=True,
+        loss_decode=[
+            dict(
+                type="CrossEntropyLoss",
+                use_sigmoid=False,
+                loss_weight=1.0,
+            ),
+        ],
+    ),
+)
+
+load_from = None
+
+resume_from = None
+
+fp16 = dict(loss_scale=512.0)

--- a/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/model.py
+++ b/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18/supcon/model.py
@@ -1,4 +1,5 @@
-"""Model configuration of OCR-Lite-HRnet-18-mod2 model for SupCon Segmentation Task."""
+"""Model configuration of OCR-Lite-HRnet-18 model for SupCon Segmentation Task."""
+
 
 # Copyright (C) 2022 Intel Corporation
 #

--- a/otx/api/configuration/helper/convert.py
+++ b/otx/api/configuration/helper/convert.py
@@ -8,7 +8,7 @@ This function can be used to convert a OTX configuration object to a dictionary 
 
 
 from enum import Enum
-from typing import Type, TypeVar
+from typing import Any, Type, TypeVar
 
 import yaml
 from omegaconf import DictConfig, OmegaConf
@@ -128,6 +128,7 @@ def convert(
         config_id = config_dict.get("id", None)
         config_dict["id"] = str(config_id) if config_id is not None else None
 
+    result: Any = None
     if target == str:
         result = yaml.dump(config_dict)
     elif target == dict:

--- a/tests/e2e/cli/detection/test_detection.py
+++ b/tests/e2e/cli/detection/test_detection.py
@@ -46,7 +46,7 @@ args0 = {
     "--val-data-roots": "tests/assets/car_tree_bug",
     "--test-data-roots": "tests/assets/car_tree_bug",
     "--input": "tests/assets/car_tree_bug/images/train",
-    "train_params": ["params", "--learning_parameters.num_iters", "6", "--learning_parameters.batch_size", "4"],
+    "train_params": ["params", "--learning_parameters.num_iters", "15", "--learning_parameters.batch_size", "4"],
 }
 
 # Class-Incremental learning w/ 'vehicle', 'person', 'non-vehicle' classes

--- a/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
@@ -51,7 +51,7 @@ args = {
     "--val-data-roots": "tests/assets/car_tree_bug",
     "--test-data-roots": "tests/assets/car_tree_bug",
     "--input": "tests/assets/car_tree_bug/images/train",
-    "train_params": ["params", "--learning_parameters.num_iters", "4", "--learning_parameters.batch_size", "2"],
+    "train_params": ["params", "--learning_parameters.num_iters", "5", "--learning_parameters.batch_size", "2"],
 }
 
 # Training params for resume, num_iters*2

--- a/tests/regression/regression_config.json
+++ b/tests/regression/regression_config.json
@@ -92,6 +92,11 @@
           "--val-data-roots": "segmentation/regression_voc_cls_decr/val",
           "--test-data-roots": "segmentation/regression_voc_cls_decr/test",
           "--input": "segmentation/regression_voc_cls_decr/test/images"
+        },
+        "supcon": {
+          "--train-data-roots": "segmentation/regression_voc_cls_decr/train",
+          "--val-data-roots": "segmentation/regression_voc_cls_decr/val",
+          "--test-data-roots": "segmentation/regression_voc_cls_decr/test"
         }
       },
       "class_incr": {
@@ -424,6 +429,14 @@
             "Lite-HRNet-18-mod2": 0.087,
             "Lite-HRNet-18": 0.302,
             "Lite-HRNet-x-mod3": 0.041
+          }
+        },
+        "supcon": {
+          "train": {
+            "Lite-HRNet-s-mod2": 0.691,
+            "Lite-HRNet-18-mod2": 0.676,
+            "Lite-HRNet-18": 0.682,
+            "Lite-HRNet-x-mod3": 0.698
           }
         }
       },
@@ -1601,6 +1614,14 @@
             "Lite-HRNet-18": 446.99,
             "Lite-HRNet-x-mod3": 667.493
           }
+        },
+        "supcon": {
+          "train": {
+            "Lite-HRNet-s-mod2": 241.88,
+            "Lite-HRNet-18-mod2": 279.19,
+            "Lite-HRNet-18": 279.71,
+            "Lite-HRNet-x-mod3": 454.31
+          }
         }
       },
       "class_incr": {
@@ -1992,6 +2013,14 @@
             "Lite-HRNet-18-mod2": 42.2,
             "Lite-HRNet-18": 43.046,
             "Lite-HRNet-x-mod3": 59.053
+          }
+        },
+        "supcon": {
+          "train": {
+            "Lite-HRNet-s-mod2": 13.835,
+            "Lite-HRNet-18-mod2": 16.39,
+            "Lite-HRNet-18": 16.23,
+            "Lite-HRNet-x-mod3": 26.549
           }
         }
       },

--- a/tests/regression/semantic_segmentation/test_segmentation.py
+++ b/tests/regression/semantic_segmentation/test_segmentation.py
@@ -416,6 +416,7 @@ class TestRegressionSegmentation:
 
         assert test_result["passed"] is True, test_result["log"]
 
+
 class TestRegressionSupconSegmentation:
     def setup_method(self):
         self.label_type = "supcon"


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Issue number: https://github.com/openvinotoolkit/training_extensions/issues/2171

This PR includes the supcon tests for regression. 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

tox -e tests-all-py310 -- tests/regression/semantic_segmentation/test_segmentation.py::TestRegressionSupconSegmentation
![image](https://github.com/openvinotoolkit/training_extensions/assets/80735344/a2c91dd8-5321-46f0-a3b2-0e1585c1ee6e)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
