### PR TITLE
bugfix: using auto adapt batch size with IterBasedRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - Fix backward compatibility with OpenVINO SSD-like detection models from OTE 0.5 (<https://github.com/openvinotoolkit/training_extensions/pull/1970>)
+- Fix the bug that auto adapt batch size is unavailable with IterBasedRunner (<https://github.com/openvinotoolkit/training_extensions/pull/2182>)
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[v1.4.0\]
+
+### New features
+
+### Enhancements
+
+### Bug fixes
+
+- Fix the bug that auto adapt batch size is unavailable with IterBasedRunner (<https://github.com/openvinotoolkit/training_extensions/pull/2182>)
+
+### Known issues
+
+
 ## \[v1.3.0\]
 
 ### New features
@@ -72,7 +85,6 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - Fix backward compatibility with OpenVINO SSD-like detection models from OTE 0.5 (<https://github.com/openvinotoolkit/training_extensions/pull/1970>)
-- Fix the bug that auto adapt batch size is unavailable with IterBasedRunner (<https://github.com/openvinotoolkit/training_extensions/pull/2182>)
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 
 ### Known issues
 
-
 ## \[v1.3.0\]
 
 ### New features

--- a/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -122,6 +122,7 @@ def _set_batch_size(cfg, batch_size: int):
     else:
         cfg.data.train_dataloader["samples_per_gpu"] = batch_size
 
+
 def _set_max_epoch(cfg, max_epoch: int):
     if cfg.runner.get("type") == "AccuracyAwareRunner":  # nncf case
         if "nncf_config" in cfg.runner:

--- a/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -129,10 +129,12 @@ def _set_max_epoch(cfg, max_epoch: int):
             _set_value_at_dict_in_dict(
                 cfg.runner["nncf_config"], "accuracy_aware_training.params.maximal_total_epochs", max_epoch
             )
-    elif "iterbased" in cfg.runner["type"].lower():
-        cfg.runner["max_iters"] = max_epoch
     else:
-        cfg.runner["max_epochs"] = max_epoch
+        runner_type = cfg.runner.get("type")
+        if runner_type is not None and "iterbased" in runner_type.lower():
+            cfg.runner["max_iters"] = max_epoch
+        else:
+            cfg.runner["max_epochs"] = max_epoch
 
 
 class SubDataset:

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
@@ -65,14 +65,16 @@ def mock_dataset(mocker):
 @pytest.mark.parametrize("not_increase", [True, False])
 @pytest.mark.parametrize("is_action_task", [True, False])
 @pytest.mark.parametrize("is_iter_based_runner", [True, False])
-def test_adapt_batch_size(mocker, mock_adapt_algo_cls, common_cfg, mock_dataset, not_increase, is_action_task, is_iter_based_runner):
+def test_adapt_batch_size(
+    mocker, mock_adapt_algo_cls, common_cfg, mock_dataset, not_increase, is_action_task, is_iter_based_runner
+):
     # prepare
     mock_train_func = mocker.MagicMock()
     new_bs = DEFAULT_BS // 2 if not_increase else DEFAULT_BS + 2
 
     max_eph_name = "max_epochs"
     if is_iter_based_runner:
-        common_cfg.runner = {'type': 'IterBasedRunnerWithCancel', 'max_iters': 100}
+        common_cfg.runner = {"type": "IterBasedRunnerWithCancel", "max_iters": 100}
         max_eph_name = "max_iters"
 
     if is_action_task:

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
@@ -44,14 +44,12 @@ def common_cfg(mocker):
     return mock_cfg
 
 
-@pytest.fixture
-def mock_cfg_not_action(common_cfg):
+def set_mock_cfg_not_action(common_cfg):
     common_cfg.data.train_dataloader = {"samples_per_gpu": DEFAULT_BS}
     return common_cfg
 
 
-@pytest.fixture
-def mock_cfg_action(common_cfg):
+def set_mock_cfg_action(common_cfg):
     common_cfg.data.videos_per_gpu = DEFAULT_BS
     common_cfg.domain = "ACTION_CLASSIFICATION"
     return common_cfg
@@ -65,19 +63,34 @@ def mock_dataset(mocker):
 
 
 @pytest.mark.parametrize("not_increase", [True, False])
-def test_adapt_batch_size_not_action_task(mocker, mock_adapt_algo_cls, mock_cfg_not_action, mock_dataset, not_increase):
+@pytest.mark.parametrize("is_action_task", [True, False])
+@pytest.mark.parametrize("is_iter_based_runner", [True, False])
+def test_adapt_batch_size(mocker, mock_adapt_algo_cls, common_cfg, mock_dataset, not_increase, is_action_task, is_iter_based_runner):
     # prepare
     mock_train_func = mocker.MagicMock()
     new_bs = DEFAULT_BS // 2 if not_increase else DEFAULT_BS + 2
 
+    max_eph_name = "max_epochs"
+    if is_iter_based_runner:
+        common_cfg.runner = {'type': 'IterBasedRunnerWithCancel', 'max_iters': 100}
+        max_eph_name = "max_iters"
+
+    if is_action_task:
+        mock_config = set_mock_cfg_action(common_cfg)
+    else:
+        mock_config = set_mock_cfg_not_action(common_cfg)
+
     # execute
-    adapt_batch_size(mock_train_func, mock_cfg_not_action, mock_dataset, False, not_increase)
+    adapt_batch_size(mock_train_func, mock_config, mock_dataset, False, not_increase)
 
     # check adapted batch size is applied
-    assert mock_cfg_not_action.data.train_dataloader["samples_per_gpu"] == new_bs
+    if is_action_task:
+        assert mock_config.data.videos_per_gpu == new_bs
+    else:
+        assert mock_config.data.train_dataloader["samples_per_gpu"] == new_bs
     # check leanring rate is updated depending on adapted batch size
     bs_change_ratio = new_bs / DEFAULT_BS
-    assert mock_cfg_not_action.optimizer.lr == pytest.approx(DEFAULT_LR * sqrt(bs_change_ratio))
+    assert mock_config.optimizer.lr == pytest.approx(DEFAULT_LR * sqrt(bs_change_ratio))
     # check adapt function gets proper arguments
     assert mock_adapt_algo_cls.call_args.kwargs["default_bs"] == DEFAULT_BS
     assert mock_adapt_algo_cls.call_args.kwargs["max_bs"] == TRAINSET_SIZE
@@ -85,41 +98,11 @@ def test_adapt_batch_size_not_action_task(mocker, mock_adapt_algo_cls, mock_cfg_
     assert len(mock_train_func.call_args_list[0].kwargs["dataset"][0]) == DEFAULT_BS
     assert len(mock_train_func.call_args_list[1].kwargs["dataset"][0]) == new_bs
     # check max epoch is set as 1 to reduce time
-    assert mock_train_func.call_args_list[0].kwargs["cfg"].runner["max_epochs"] == 1
-    assert mock_train_func.call_args_list[1].kwargs["cfg"].runner["max_epochs"] == 1
+    assert mock_train_func.call_args_list[0].kwargs["cfg"].runner[max_eph_name] == 1
+    assert mock_train_func.call_args_list[1].kwargs["cfg"].runner[max_eph_name] == 1
     # check eval before run is disabled to reduce time
     assert not mock_train_func.call_args_list[0].kwargs["cfg"].custom_hooks[0]["enable_eval_before_run"]
     assert not mock_train_func.call_args_list[1].kwargs["cfg"].custom_hooks[0]["enable_eval_before_run"]
-    # check OTXProgressHook is removed
-    assert len(mock_train_func.call_args_list[0].kwargs["cfg"].custom_hooks) == 1
-
-
-@pytest.mark.parametrize("not_increase", [True, False])
-def test_adapt_batch_size_action_task(mocker, mock_adapt_algo_cls, mock_cfg_action, mock_dataset, not_increase):
-    # prepare
-    mock_train_func = mocker.MagicMock()
-    new_bs = DEFAULT_BS // 2 if not_increase else DEFAULT_BS + 2
-
-    # execute
-    adapt_batch_size(mock_train_func, mock_cfg_action, mock_dataset, True, not_increase)
-
-    # check adapted batch size is applied
-    assert mock_cfg_action.data.videos_per_gpu == new_bs
-    # check leanring rate is updated depending on adapted batch size
-    bs_change_ratio = new_bs / DEFAULT_BS
-    assert mock_cfg_action.optimizer.lr == pytest.approx(DEFAULT_LR * sqrt(bs_change_ratio))
-    # check adapt function gets proper arguments
-    assert mock_adapt_algo_cls.call_args.kwargs["default_bs"] == DEFAULT_BS
-    assert mock_adapt_algo_cls.call_args.kwargs["max_bs"] == TRAINSET_SIZE
-    # check length of dataset is decreased to reduce time
-    assert len(mock_train_func.call_args_list[0].kwargs["dataset"][0]) == DEFAULT_BS
-    assert len(mock_train_func.call_args_list[1].kwargs["dataset"][0]) == new_bs
-    # check max epoch is set as 1 to reduce time
-    assert mock_train_func.call_args_list[0].kwargs["cfg"].runner["max_epochs"] == 1
-    assert mock_train_func.call_args_list[1].kwargs["cfg"].runner["max_epochs"] == 1
-    # check eval before run is enabled if validate is set as True
-    assert mock_train_func.call_args_list[0].kwargs["cfg"].custom_hooks[0]["enable_eval_before_run"]
-    assert mock_train_func.call_args_list[1].kwargs["cfg"].custom_hooks[0]["enable_eval_before_run"]
     # check OTXProgressHook is removed
     assert len(mock_train_func.call_args_list[0].kwargs["cfg"].custom_hooks) == 1
 


### PR DESCRIPTION
### Summary
Fix an issue #2180 
There is no code to handle IterBasedRunner in auto adapt batch size code, so I added it.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
