### PR TITLE
Set path to save pseudo masks into workspace

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -406,7 +406,7 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             if learning_parameters:
                 num_workers = getattr(learning_parameters, "num_workers", 0)
                 dataset_config["cache_config"]["num_workers"] = num_workers
-        if str(self.task_type == "SEGMENTATION").upper() and str(self.train_type).upper() == "SELFSUPERVISED":
+        if str(self.task_type).upper() == "SEGMENTATION" and str(self.train_type).upper() == "SELFSUPERVISED":
             # FIXME: manually set a path to save pseudo masks in workspace
             train_type_rel_path = TASK_TYPE_TO_SUB_DIR_NAME[self.train_type]
             train_type_dir = self.workspace_root / train_type_rel_path

--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -406,6 +406,11 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             if learning_parameters:
                 num_workers = getattr(learning_parameters, "num_workers", 0)
                 dataset_config["cache_config"]["num_workers"] = num_workers
+        if str(self.task_type == "SEGMENTATION").upper() and str(self.train_type).upper() == "SELFSUPERVISED":
+            # FIXME: manually set a path to save pseudo masks in workspace
+            train_type_rel_path = TASK_TYPE_TO_SUB_DIR_NAME[self.train_type]
+            train_type_dir = self.workspace_root / train_type_rel_path
+            dataset_config["pseudo_mask_dir"] = train_type_dir / "detcon_mask"
         return dataset_config
 
     def update_data_config(self, data_yaml: dict) -> None:

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -82,6 +82,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
         cache_config: Optional[Dict[str, Any]] = None,
+        **kwargs
     ):
         self.task_type = task_type
         self.domain = task_type.domain
@@ -97,6 +98,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             test_ann_files=test_ann_files,
             unlabeled_data_roots=unlabeled_data_roots,
             unlabeled_file_list=unlabeled_file_list,
+            **kwargs
         )
 
         cache_config = cache_config if cache_config is not None else {}

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -82,7 +82,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
         cache_config: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ):
         self.task_type = task_type
         self.domain = task_type.domain
@@ -98,7 +98,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             test_ann_files=test_ann_files,
             unlabeled_data_roots=unlabeled_data_roots,
             unlabeled_file_list=unlabeled_file_list,
-            **kwargs
+            **kwargs,
         )
 
         cache_config = cache_config if cache_config is not None else {}

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -205,7 +205,6 @@ class SelfSLSegmentationDatasetAdapter(SegmentationDatasetAdapter):
 
         # Load pseudo masks
         total_labels = []
-        print(pseudo_mask_dir)
         os.makedirs(pseudo_mask_dir, exist_ok=True)
         for item in dataset[Subset.TRAINING]:
             img_path = item.media.path

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -192,7 +192,7 @@ class SelfSLSegmentationDatasetAdapter(SegmentationDatasetAdapter):
             DatumaroDataset: Datumaro Dataset
         """
         if pseudo_mask_dir is None:
-            ValueError("pseudo_mask_dir must be set.")
+            raise ValueError("pseudo_mask_dir must be set.")
         if train_data_roots is None:
             raise ValueError("train_data_root must be set.")
 
@@ -205,6 +205,7 @@ class SelfSLSegmentationDatasetAdapter(SegmentationDatasetAdapter):
 
         # Load pseudo masks
         total_labels = []
+        print(pseudo_mask_dir)
         os.makedirs(pseudo_mask_dir, exist_ok=True)
         for item in dataset[Subset.TRAINING]:
             img_path = item.media.path

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -53,7 +53,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
         cache_config: Optional[Dict[str, Any]] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             task_type,
@@ -66,7 +66,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
             unlabeled_data_roots,
             unlabeled_file_list,
             cache_config,
-            **kwargs
+            **kwargs,
         )
         self.updated_label_id: Dict[int, int] = {}
 

--- a/tests/unit/core/data/adapter/test_init.py
+++ b/tests/unit/core/data/adapter/test_init.py
@@ -11,6 +11,9 @@ from tests.unit.core.data.test_helpers import (
     TASK_NAME_TO_TASK_TYPE,
 )
 
+from pathlib import Path
+import shutil
+
 
 @e2e_pytest_unit
 @pytest.mark.parametrize("task_name", TASK_NAME_TO_TASK_TYPE.keys())
@@ -63,18 +66,27 @@ def test_get_dataset_adapter_selfsl_segmentation(task_name, train_type):
     task_type = TASK_NAME_TO_TASK_TYPE[task_name]
     data_root = TASK_NAME_TO_DATA_ROOT[task_name]
 
-    get_dataset_adapter(
-        task_type=task_type,
-        train_type=train_type,
-        train_data_roots=os.path.join(root_path, data_root["train"]),
-    )
+    with pytest.raises(ValueError, match=r"pseudo_mask_dir must be set."):
+        get_dataset_adapter(
+            task_type=task_type,
+            train_type=train_type,
+            train_data_roots=os.path.join(root_path, data_root["train"]),
+        )
 
-    with pytest.raises(ValueError):
         get_dataset_adapter(
             task_type=task_type,
             train_type=train_type,
             test_data_roots=os.path.join(root_path, data_root["test"]),
         )
+
+    tmp_supcon_mask_dir = Path("/tmp/selfsl_supcon_unit_test")
+    get_dataset_adapter(
+        task_type=task_type,
+        train_type=train_type,
+        train_data_roots=os.path.join(root_path, data_root["train"]),
+        pseudo_mask_dir=tmp_supcon_mask_dir,
+    )
+    shutil.rmtree(str(tmp_supcon_mask_dir))
 
 
 # TODO: direct annotation function is only supported in COCO format for now.

--- a/tests/unit/core/data/adapter/test_segmentation_adapter.py
+++ b/tests/unit/core/data/adapter/test_segmentation_adapter.py
@@ -90,9 +90,7 @@ class TestSelfSLSegmentationDatasetAdapter:
         spy_create_pseudo_masks = mocker.spy(SelfSLSegmentationDatasetAdapter, "create_pseudo_masks")
 
         dataset_adapter = SelfSLSegmentationDatasetAdapter(
-            task_type=self.task_type,
-            train_data_roots=self.train_data_roots,
-            pseudo_mask_dir=self.pseudo_mask_dir
+            task_type=self.task_type, train_data_roots=self.train_data_roots, pseudo_mask_dir=self.pseudo_mask_dir
         )
 
         spy_create_pseudo_masks.assert_called()
@@ -109,9 +107,7 @@ class TestSelfSLSegmentationDatasetAdapter:
         """
         shutil.rmtree(self.pseudo_mask_dir, ignore_errors=True)
         dataset_adapter = SelfSLSegmentationDatasetAdapter(
-            task_type=self.task_type,
-            train_data_roots=self.train_data_roots,
-            pseudo_mask_dir=self.pseudo_mask_dir
+            task_type=self.task_type, train_data_roots=self.train_data_roots, pseudo_mask_dir=self.pseudo_mask_dir
         )
         assert os.path.isdir(self.pseudo_mask_dir)
         assert len(os.listdir(self.pseudo_mask_dir)) == 4
@@ -121,8 +117,7 @@ class TestSelfSLSegmentationDatasetAdapter:
         spy_create_pseudo_masks = mocker.spy(SelfSLSegmentationDatasetAdapter, "create_pseudo_masks")
 
         _ = dataset_adapter._import_dataset(
-            train_data_roots=self.train_data_roots,
-            pseudo_mask_dir=self.pseudo_mask_dir
+            train_data_roots=self.train_data_roots, pseudo_mask_dir=self.pseudo_mask_dir
         )
 
         spy_create_pseudo_masks.assert_called()
@@ -134,9 +129,7 @@ class TestSelfSLSegmentationDatasetAdapter:
         spy_create_pseudo_masks = mocker.spy(SelfSLSegmentationDatasetAdapter, "create_pseudo_masks")
 
         _ = SelfSLSegmentationDatasetAdapter(
-            task_type=self.task_type,
-            train_data_roots=self.train_data_roots,
-            pseudo_mask_dir=self.pseudo_mask_dir
+            task_type=self.task_type, train_data_roots=self.train_data_roots, pseudo_mask_dir=self.pseudo_mask_dir
         )
 
         spy_create_pseudo_masks.assert_not_called()
@@ -156,9 +149,7 @@ class TestSelfSLSegmentationDatasetAdapter:
         mocker.patch("otx.core.data.adapter.segmentation_dataset_adapter.os.makedirs")
         mocker.patch("otx.core.data.adapter.segmentation_dataset_adapter.cv2.imwrite")
         dataset_adapter = SelfSLSegmentationDatasetAdapter(
-            task_type=self.task_type,
-            train_data_roots=self.train_data_roots,
-            pseudo_mask_dir=self.pseudo_mask_dir
+            task_type=self.task_type, train_data_roots=self.train_data_roots, pseudo_mask_dir=self.pseudo_mask_dir
         )
 
         pseudo_mask = dataset_adapter.create_pseudo_masks(img=np.ones((2, 2)), pseudo_mask_path="")


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR is to set a path where saving pseudo masks, which are used on self-supervised learning for semantic segmentation, into workspace.

### How to test

When workspace was set to `test4/workspace`, pseudo masks were created in the path.
![image](https://github.com/openvinotoolkit/training_extensions/assets/97221135/37d3b48b-1529-4ce3-9f25-356dc3287c38)

tox -e tests-all-py38 -- tests/unit/core/data/adapter/test_segmentation_adapter.py::TestSelfSLSegmentationDatasetAdapter

![image](https://github.com/openvinotoolkit/training_extensions/assets/97221135/037ac705-cb4a-4bd3-ae04-550bdb0f5ac5)


<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
