### PR TITLE
bugfix: auto adapt batch size doesn't work with cls incr case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - Fix async mode inference for demo in exportable code (<https://github.com/openvinotoolkit/training_extensions/pull/2154>)
+- Fix a bug that auto adapt batch size doesn't work with cls incr case (<https://github.com/openvinotoolkit/training_extensions/pull/2199>)
 
 ### Known issues
 

--- a/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -145,9 +145,9 @@ class SubDataset:
 
         self.fullset = fullset
         self.num_samples = num_samples
-        self.img_indices =  {  # for class incremental case
+        self.img_indices = {  # for class incremental case
             "old": [i for i in range(num_samples // 2)],
-            "new": [i for i in range(num_samples // 2, num_samples)]
+            "new": [i for i in range(num_samples // 2, num_samples)],
         }
 
     def __len__(self) -> int:

--- a/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -145,6 +145,10 @@ class SubDataset:
 
         self.fullset = fullset
         self.num_samples = num_samples
+        self.img_indices =  {  # for class incremental case
+            "old": [i for i in range(num_samples // 2)],
+            "new": [i for i in range(num_samples // 2, num_samples)]
+        }
 
     def __len__(self) -> int:
         """Get length of subset."""

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
@@ -133,7 +133,10 @@ class TestSubDataset:
 
     def test_init(self, mocker):
         fullset = mocker.MagicMock()
-        SubDataset(fullset, 3)
+        subset = SubDataset(fullset, 3)
+
+        # test for class incremental case. If below assert can't be passed, ClsIncrSampler can't work well.
+        assert len(subset.img_indices["new"]) / len(subset.img_indices["old"]) + 1 <= self.num_samples
 
     @pytest.mark.parametrize("num_samples", [-1, 0])
     def test_init_w_wrong_num_samples(self, mocker, num_samples):


### PR DESCRIPTION
### Summary

- Fix a but that auto adapt batch size doesn't work with cls incr case.
- It fixes #2194 

It's because `ClsIncrSampler` uses old dataset versus new dataset ratio, but subset for auto adapt batch size doesn't consider it.
This PR adds a code to set old dataset versus new dataset ratio as proper value which can works well with `ClsIncrSampler`.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
