### PR TITLE
Turn off persistent worker if num_worker is zero in classification task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - Fix a bug that auto adapt batch size doesn't work with cls incr case (<https://github.com/openvinotoolkit/training_extensions/pull/2199>)
+- Fix a bug that persistent worker is True even if num_workers is zero (<https://github.com/openvinotoolkit/training_extensions/pull/2208>)
 
 ### Known issues
 

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -252,14 +252,16 @@ class MMClassificationTask(OTXClassificationTask):
 
         # Data loader
         mm_dataset = build_dataset(cfg.data.test)
+        workers_per_gpu = cfg.data.test_dataloader.get("workers_per_gpu", 0)
         dataloader = build_dataloader(
             mm_dataset,
             samples_per_gpu=cfg.data.test_dataloader.get("samples_per_gpu", 1),
-            workers_per_gpu=cfg.data.test_dataloader.get("workers_per_gpu", 0),
+            workers_per_gpu=workers_per_gpu,
             num_gpus=len(cfg.gpu_ids),
             dist=cfg.distributed,
             seed=cfg.get("seed", None),
             shuffle=False,
+            persistent_workers=(workers_per_gpu > 0),
         )
 
         # Model


### PR DESCRIPTION
### Summary
error is raised when persistent worker is True and num_worker is zero.
So, add a code to turn off persistent worker if num_worker is zero in classification task.
I think other tasks are ok due to reasons below:

- detection : default value of persistent worker is false
- segmentation : default value of persistent worker is true but set it false
- action : default value of persistent worker is false

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
