### PR TITLE
Support encrypted dataset training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
+- Support encrypted dataset training (<https://github.com/openvinotoolkit/training_extensions/pull/2209>)
+
 ### Enhancements
 
 ### Bug fixes

--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+import os
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -384,7 +385,11 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         """
         if str(self.train_type).upper() == "INCREMENTAL" and "unlabeled" in subsets:
             subsets.remove("unlabeled")
-        dataset_config: Dict[str, Any] = {"task_type": self.task_type, "train_type": self.train_type}
+        dataset_config: Dict[str, Any] = {
+            "task_type": self.task_type,
+            "train_type": self.train_type,
+            "encryption_key": self.encryption_key,
+        }
         for subset in subsets:
             if f"{subset}_subset" in self.data_config:
                 if self.data_config[f"{subset}_subset"]["data_roots"]:
@@ -579,3 +584,23 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
             config.deterministic = self.args.deterministic
         if hasattr(config, "seed") and hasattr(self.args, "seed") and self.args.seed:
             config.seed = self.args.seed
+
+    @property
+    def encryption_key(self):
+        """Get encryption key from CLI argument or OS environment variables. If it is not specified, return None."""
+        key_from_args = getattr(self.args, "encryption_key", None)
+        key_from_envs = os.environ.get("ENCRYPTION_KEY", None)
+
+        if key_from_args is not None and key_from_envs is not None:
+            raise ValueError(
+                "You have to choose either one of the two, whether encryption_key is "
+                "specified as a CLI argument (--encryption-key=<key>) or specified in "
+                "an environment variable (ENCRYPTION_KEY=<key>). "
+            )
+
+        if key_from_args is not None:
+            return key_from_args
+        if key_from_envs is not None:
+            return key_from_envs
+
+        return None

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -149,7 +149,12 @@ def get_args():
         default=None,
         help="The data.yaml path want to use in train task.",
     )
-    parser.add_argument("--encryption-key", type=str, default=None, help="Encryption key for a")
+    parser.add_argument(
+        "--encryption-key",
+        type=str,
+        default=None,
+        help="Encryption key required to train the encrypted dataset. It is not required the non-encrypted dataset",
+    )
 
     sub_parser = add_hyper_parameters_sub_parser(parser, hyper_parameters, return_sub_parser=True)
     # TODO: Temporary solution for cases where there is no template input

--- a/otx/cli/tools/train.py
+++ b/otx/cli/tools/train.py
@@ -149,6 +149,7 @@ def get_args():
         default=None,
         help="The data.yaml path want to use in train task.",
     )
+    parser.add_argument("--encryption-key", type=str, default=None, help="Encryption key for a")
 
     sub_parser = add_hyper_parameters_sub_parser(parser, hyper_parameters, return_sub_parser=True)
     # TODO: Temporary solution for cases where there is no template input

--- a/otx/core/data/adapter/action_dataset_adapter.py
+++ b/otx/core/data/adapter/action_dataset_adapter.py
@@ -29,7 +29,7 @@ class ActionBaseDatasetAdapter(BaseDatasetAdapter):
     VIDEO_FRAME_SEP = "##"
     EMPTY_FRAME_LABEL_NAME = "EmptyFrame"
 
-    def _import_dataset(
+    def _import_datasets(
         self,
         train_data_roots: Optional[str] = None,
         train_ann_files: Optional[str] = None,
@@ -39,6 +39,7 @@ class ActionBaseDatasetAdapter(BaseDatasetAdapter):
         test_ann_files: Optional[str] = None,
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
+        encryption_key: Optional[str] = None,
     ) -> Dict[Subset, DatumDataset]:
         """Import multiple videos that have CVAT format annotation.
 
@@ -51,6 +52,8 @@ class ActionBaseDatasetAdapter(BaseDatasetAdapter):
             test_ann_files (Optional[str]): Path for test annotation file
             unlabeled_data_roots (Optional[str]): Path for unlabeled data
             unlabeled_file_list (Optional[str]): Path of unlabeled file list
+            encryption_key (Optional[str]): Encryption key to load an encrypted dataset
+                                        (only required for DatumaroBinary format)
 
         Returns:
             DatumDataset: Datumaro Dataset

--- a/otx/core/data/adapter/anomaly_dataset_adapter.py
+++ b/otx/core/data/adapter/anomaly_dataset_adapter.py
@@ -34,7 +34,7 @@ from otx.core.data.adapter.base_dataset_adapter import BaseDatasetAdapter
 class AnomalyBaseDatasetAdapter(BaseDatasetAdapter):
     """BaseDataset Adpater for Anomaly tasks inherited from BaseDatasetAdapter."""
 
-    def _import_dataset(
+    def _import_datasets(
         self,
         train_data_roots: Optional[str] = None,
         train_ann_files: Optional[str] = None,
@@ -44,6 +44,7 @@ class AnomalyBaseDatasetAdapter(BaseDatasetAdapter):
         test_ann_files: Optional[str] = None,
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
+        encryption_key: Optional[str] = None,
     ) -> Dict[Subset, DatumaroDataset]:
         """Import MVTec dataset.
 
@@ -56,6 +57,8 @@ class AnomalyBaseDatasetAdapter(BaseDatasetAdapter):
             test_ann_files (Optional[str]): Path for test annotation file
             unlabeled_data_roots (Optional[str]): Path for unlabeled data
             unlabeled_file_list (Optional[str]): Path of unlabeled file list
+            encryption_key (Optional[str]): Encryption key to load an encrypted dataset
+                                        (only required for DatumaroBinary format)
 
         Returns:
             DatumaroDataset: Datumaro Dataset

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -62,7 +62,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         unlabeled_data_roots (Optional[str]): Path for unlabeled data
         unlabeled_file_list (Optional[str]): Path of unlabeled file list
         encryption_key (Optional[str]): Encryption key to load an encrypted dataset
-                                        (DatumaroBinary format)
+                                        (only required for DatumaroBinary format)
 
     Since all adapters can be used for training and validation,
     the default value of train/val/test_data_roots was set to None.

--- a/otx/core/data/adapter/base_dataset_adapter.py
+++ b/otx/core/data/adapter/base_dataset_adapter.py
@@ -61,6 +61,8 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         test_ann_files (Optional[str]): Path for test annotation file
         unlabeled_data_roots (Optional[str]): Path for unlabeled data
         unlabeled_file_list (Optional[str]): Path of unlabeled file list
+        encryption_key (Optional[str]): Encryption key to load an encrypted dataset
+                                        (DatumaroBinary format)
 
     Since all adapters can be used for training and validation,
     the default value of train/val/test_data_roots was set to None.
@@ -82,13 +84,15 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
         cache_config: Optional[Dict[str, Any]] = None,
+        encryption_key: Optional[str] = None,
+        **kwargs,
     ):
         self.task_type = task_type
         self.domain = task_type.domain
         self.data_type: str
         self.is_train_phase: bool
 
-        self.dataset = self._import_dataset(
+        self.dataset = self._import_datasets(
             train_data_roots=train_data_roots,
             train_ann_files=train_ann_files,
             val_data_roots=val_data_roots,
@@ -97,6 +101,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             test_ann_files=test_ann_files,
             unlabeled_data_roots=unlabeled_data_roots,
             unlabeled_file_list=unlabeled_file_list,
+            encryption_key=encryption_key,
         )
 
         cache_config = cache_config if cache_config is not None else {}
@@ -110,7 +115,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         self.label_entities: List[LabelEntity]
         self.label_schema: LabelSchemaEntity
 
-    def _import_dataset(
+    def _import_datasets(
         self,
         train_data_roots: Optional[str] = None,
         train_ann_files: Optional[str] = None,
@@ -120,8 +125,9 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
         test_ann_files: Optional[str] = None,
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
+        encryption_key: Optional[str] = None,
     ) -> Dict[Subset, DatumDataset]:
-        """Import dataset by using Datumaro.import_from() method.
+        """Import datasets by using Datumaro.import_from() method.
 
         Args:
             train_data_roots (Optional[str]): Path for training data
@@ -132,6 +138,8 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             test_ann_files (Optional[str]): Path for test annotation files
             unlabeled_data_roots (Optional[str]): Path for unlabeled data
             unlabeled_file_list (Optional[str]): Path for unlabeled file list
+            encryption_key (Optional[str]): Encryption key to load an encrypted dataset
+                                            (DatumaroBinary format)
 
         Returns:
             DatumDataset: Datumaro Dataset
@@ -142,53 +150,19 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
 
         # Construct dataset for training, validation, testing, unlabeled
         if train_data_roots is not None:
-            # Find self.data_type and task_type
-            self.data_type_candidates = self._detect_dataset_format(path=train_data_roots)
-            self.data_type = self._select_data_type(self.data_type_candidates)
-
-            dataset_kwargs = {"path": train_data_roots, "format": self.data_type}
-            if train_ann_files is not None:
-                if self.data_type not in ("coco"):
-                    raise NotImplementedError(
-                        f"Specifying '--train-ann-files' is not supported for data type '{self.data_type}'"
-                    )
-                dataset_kwargs["path"] = train_ann_files
-                dataset_kwargs["subset"] = "train"
-            train_dataset = DatumDataset.import_from(**dataset_kwargs)
-
-            # Prepare subsets by using Datumaro dataset
+            train_dataset = self._import_dataset(train_data_roots, train_ann_files, encryption_key, Subset.TRAINING)
             dataset[Subset.TRAINING] = self._get_subset_data("train", train_dataset)
             self.is_train_phase = True
 
             # If validation is manually defined --> set the validation data according to user's input
             if val_data_roots:
-                val_data_candidates = self._detect_dataset_format(path=val_data_roots)
-                val_data_type = self._select_data_type(val_data_candidates)
-                dataset_kwargs = {"path": val_data_roots, "format": val_data_type}
-                if val_ann_files is not None:
-                    if val_data_type not in ("coco"):
-                        raise NotImplementedError(
-                            f"Specifying '--val-ann-files' is not supported for data type '{val_data_type}'"
-                        )
-                    dataset_kwargs["path"] = val_ann_files
-                    dataset_kwargs["subset"] = "val"
-                val_dataset = DatumDataset.import_from(**dataset_kwargs)
+                val_dataset = self._import_dataset(val_data_roots, val_ann_files, encryption_key, Subset.VALIDATION)
                 dataset[Subset.VALIDATION] = self._get_subset_data("val", val_dataset)
             elif "val" in train_dataset.subsets():
                 dataset[Subset.VALIDATION] = self._get_subset_data("val", train_dataset)
 
         if test_data_roots is not None and train_data_roots is None:
-            self.data_type_candidates = self._detect_dataset_format(path=test_data_roots)
-            self.data_type = self._select_data_type(self.data_type_candidates)
-            dataset_kwargs = {"path": test_data_roots, "format": self.data_type}
-            if test_ann_files is not None:
-                if self.data_type not in ("coco"):
-                    raise NotImplementedError(
-                        f"Specifying '--test-ann-files' is not supported for data type '{self.data_type}'"
-                    )
-                dataset_kwargs["path"] = test_ann_files
-                dataset_kwargs["subset"] = "test"
-            test_dataset = DatumDataset.import_from(**dataset_kwargs)
+            test_dataset = self._import_dataset(test_data_roots, test_ann_files, encryption_key, Subset.TESTING)
             dataset[Subset.TESTING] = self._get_subset_data("test", test_dataset)
             self.is_train_phase = False
 
@@ -196,6 +170,30 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             dataset[Subset.UNLABELED] = DatumDataset.import_from(unlabeled_data_roots, format="image_dir")
             if unlabeled_file_list is not None:
                 self._filter_unlabeled_data(dataset[Subset.UNLABELED], unlabeled_file_list)
+        return dataset
+
+    def _import_dataset(self, data_roots: str, ann_files: str, encryption_key: Optional[str], mode: Subset):
+        # Find self.data_type and task_type
+        mode_to_str = {Subset.TRAINING: "train", Subset.VALIDATION: "val", Subset.TESTING: "test"}
+        str_mode = mode_to_str[mode]
+
+        self.data_type_candidates = self._detect_dataset_format(path=data_roots)
+        self.data_type = self._select_data_type(self.data_type_candidates)
+
+        dataset_kwargs = {"path": data_roots, "format": self.data_type}
+        if ann_files is not None:
+            if self.data_type not in ("coco"):
+                raise NotImplementedError(
+                    f"Specifying '--{str_mode}-ann-files' is not supported for data type '{self.data_type}'"
+                )
+            dataset_kwargs["path"] = ann_files
+            dataset_kwargs["subset"] = str_mode
+
+        if encryption_key is not None:
+            dataset_kwargs["encryption_key"] = encryption_key
+
+        dataset = DatumDataset.import_from(**dataset_kwargs)
+
         return dataset
 
     @abstractmethod
@@ -380,7 +378,7 @@ class BaseDatasetAdapter(metaclass=abc.ABCMeta):
             path = getattr(datumaro_media, "path", None)
             size = datumaro_media._size  # pylint: disable=protected-access
 
-            if path and os.path.exists(path):
+            if path and os.path.exists(path) and not datumaro_media.is_encrypted:
                 return Image(file_path=path, size=size)
 
             def helper():

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -156,7 +156,7 @@ class SelfSLSegmentationDatasetAdapter(SegmentationDatasetAdapter):
     """Self-SL for segmentation adapter inherited from SegmentationDatasetAdapter."""
 
     # pylint: disable=protected-access
-    def _import_dataset(
+    def _import_datasets(
         self,
         train_data_roots: Optional[str] = None,
         train_ann_files: Optional[str] = None,
@@ -166,6 +166,7 @@ class SelfSLSegmentationDatasetAdapter(SegmentationDatasetAdapter):
         test_ann_files: Optional[str] = None,
         unlabeled_data_roots: Optional[str] = None,
         unlabeled_file_list: Optional[str] = None,
+        encryption_key: Optional[str] = None,
         pseudo_mask_dir: str = "detcon_mask",
     ) -> Dict[Subset, DatumDataset]:
         """Import custom Self-SL dataset for using DetCon.
@@ -183,6 +184,8 @@ class SelfSLSegmentationDatasetAdapter(SegmentationDatasetAdapter):
             test_ann_files (Optional[str]): Path for test annotation file
             unlabeled_data_roots (Optional[str]): Path for unlabeled data.
             unlabeled_file_list (Optional[str]): Path of unlabeled file list
+            encryption_key (Optional[str]): Encryption key to load an encrypted dataset
+                                        (only required for DatumaroBinary format)
             pseudo_mask_dir (str): Directory to save pseudo masks. Defaults to "detcon_mask".
 
         Returns:

--- a/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -6,7 +6,7 @@
 
 import json
 import os
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import cv2
 import numpy as np
@@ -27,7 +27,6 @@ from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.id import ID
 from otx.api.entities.image import Image
-from otx.api.entities.model_template import TaskType
 from otx.api.entities.subset import Subset
 from otx.core.data.adapter.base_dataset_adapter import BaseDatasetAdapter
 
@@ -41,33 +40,6 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
     It converts DatumaroDataset --> DatasetEntity for semantic segmentation task
     """
 
-    def __init__(
-        self,
-        task_type: TaskType,
-        train_data_roots: Optional[str] = None,
-        train_ann_files: Optional[str] = None,
-        val_data_roots: Optional[str] = None,
-        val_ann_files: Optional[str] = None,
-        test_data_roots: Optional[str] = None,
-        test_ann_files: Optional[str] = None,
-        unlabeled_data_roots: Optional[str] = None,
-        unlabeled_file_list: Optional[str] = None,
-        cache_config: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            task_type,
-            train_data_roots,
-            train_ann_files,
-            val_data_roots,
-            val_ann_files,
-            test_data_roots,
-            test_ann_files,
-            unlabeled_data_roots,
-            unlabeled_file_list,
-            cache_config,
-        )
-        self.updated_label_id: Dict[int, int] = {}
-
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Segmentation."""
         # Prepare label information
@@ -76,6 +48,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
 
         dataset_items: List[DatasetItemEntity] = []
         used_labels: List[int] = []
+        self.updated_label_id: Dict[int, int] = {}
 
         if hasattr(self, "data_type_candidates"):
             if self.data_type_candidates[0] == "voc":

--- a/tests/unit/core/data/adapter/test_segmentation_adapter.py
+++ b/tests/unit/core/data/adapter/test_segmentation_adapter.py
@@ -78,7 +78,7 @@ class TestSelfSLSegmentationDatasetAdapter:
 
     @e2e_pytest_unit
     def test_import_dataset_create_all_masks(self, mocker):
-        """Test _import_dataset when creating all masks.
+        """Test _import_datasets when creating all masks.
 
         This test is for when all masks are not created and it is required to create masks.
         """
@@ -96,7 +96,7 @@ class TestSelfSLSegmentationDatasetAdapter:
     @e2e_pytest_unit
     @pytest.mark.parametrize("idx_remove", [1, 2, 3])
     def test_import_dataset_create_some_uncreated_masks(self, mocker, idx_remove: int):
-        """Test _import_dataset when there are both uncreated and created masks.
+        """Test _import_datasets when there are both uncreated and created masks.
 
         This test is for when there are both created and uncreated masks
         and it is required to either create or just load masks.
@@ -114,7 +114,7 @@ class TestSelfSLSegmentationDatasetAdapter:
         os.remove(os.path.join(self.pseudo_mask_roots, f"000{idx_remove}.png"))
         spy_create_pseudo_masks = mocker.spy(SelfSLSegmentationDatasetAdapter, "create_pseudo_masks")
 
-        _ = dataset_adapter._import_dataset(
+        _ = dataset_adapter._import_datasets(
             train_data_roots=self.train_data_roots,
         )
 
@@ -123,7 +123,7 @@ class TestSelfSLSegmentationDatasetAdapter:
 
     @e2e_pytest_unit
     def test_import_dataset_just_load_masks(self, mocker):
-        """Test _import_dataset when just loading all masks."""
+        """Test _import_datasets when just loading all masks."""
         spy_create_pseudo_masks = mocker.spy(SelfSLSegmentationDatasetAdapter, "create_pseudo_masks")
 
         _ = SelfSLSegmentationDatasetAdapter(


### PR DESCRIPTION
### Summary

- Ticket no. 112208
- Using OTX, users can seamlessly train encrypted datasets created by Datumaro.
- `otx train` with `--encryption-key` CLI argument or `ENCRYPTION_KEY` env vars enables model training with an encrypted dataset.

### How to test
I added tests related to this change.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
