### PR TITLE
Fix possible bw issue in exportable code

### DIFF
--- a/otx/api/usecases/exportable_code/demo/requirements.txt
+++ b/otx/api/usecases/exportable_code/demo/requirements.txt
@@ -1,4 +1,4 @@
 openvino==2022.3.0
 openmodelzoo-modelapi==2022.3.0
-otx==1.2.3
+otx @ git+https://github.com/openvinotoolkit/training_extensions/@3743a92784f6c2c0e5a4a0a836d4ec7696451b9c#egg=otx
 numpy>=1.21.0,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime

--- a/otx/api/usecases/exportable_code/prediction_to_annotation_converter.py
+++ b/otx/api/usecases/exportable_code/prediction_to_annotation_converter.py
@@ -62,7 +62,7 @@ class DetectionToAnnotationConverter(IPredictionToAnnotationConverter):
         self.labels = labels.get_labels(include_empty=False) if isinstance(labels, LabelSchemaEntity) else labels
         self.label_map = dict(enumerate(self.labels))
         self.use_ellipse_shapes = False
-        self.confidence_threshold = 0.
+        self.confidence_threshold = 0.0
         if configuration is not None:
             if "use_ellipse_shapes" in configuration:
                 self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
@@ -430,7 +430,7 @@ class MaskToAnnotationConverter(IPredictionToAnnotationConverter):
     def __init__(self, labels: LabelSchemaEntity, configuration: Optional[Dict[str, Any]] = None):
         self.labels = labels.get_labels(include_empty=False)
         self.use_ellipse_shapes = False
-        self.confidence_threshold = 0.
+        self.confidence_threshold = 0.0
         if configuration is not None:
             if "use_ellipse_shapes" in configuration:
                 self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
@@ -503,7 +503,7 @@ class RotatedRectToAnnotationConverter(IPredictionToAnnotationConverter):
     def __init__(self, labels: LabelSchemaEntity, configuration: Optional[Dict[str, Any]] = None):
         self.labels = labels.get_labels(include_empty=False)
         self.use_ellipse_shapes = False
-        self.confidence_threshold = 0.
+        self.confidence_threshold = 0.0
         if configuration is not None:
             if "use_ellipse_shapes" in configuration:
                 self.use_ellipse_shapes = configuration["use_ellipse_shapes"]

--- a/otx/api/usecases/exportable_code/prediction_to_annotation_converter.py
+++ b/otx/api/usecases/exportable_code/prediction_to_annotation_converter.py
@@ -61,8 +61,13 @@ class DetectionToAnnotationConverter(IPredictionToAnnotationConverter):
     def __init__(self, labels: Union[LabelSchemaEntity, List], configuration: Optional[Dict[str, Any]] = None):
         self.labels = labels.get_labels(include_empty=False) if isinstance(labels, LabelSchemaEntity) else labels
         self.label_map = dict(enumerate(self.labels))
-        self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
-        self.confidence_threshold = configuration["confidence_threshold"]
+        self.use_ellipse_shapes = False
+        self.confidence_threshold = 0.
+        if configuration is not None:
+            if "use_ellipse_shapes" in configuration:
+                self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
+            if "confidence_threshold" in configuration:
+                self.confidence_threshold = configuration["confidence_threshold"]
 
     def convert_to_annotation(
         self, predictions: np.ndarray, metadata: Optional[Dict[str, np.ndarray]] = None
@@ -424,8 +429,13 @@ class MaskToAnnotationConverter(IPredictionToAnnotationConverter):
 
     def __init__(self, labels: LabelSchemaEntity, configuration: Optional[Dict[str, Any]] = None):
         self.labels = labels.get_labels(include_empty=False)
-        self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
-        self.confidence_threshold = configuration["confidence_threshold"]
+        self.use_ellipse_shapes = False
+        self.confidence_threshold = 0.
+        if configuration is not None:
+            if "use_ellipse_shapes" in configuration:
+                self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
+            if "confidence_threshold" in configuration:
+                self.confidence_threshold = configuration["confidence_threshold"]
 
     def convert_to_annotation(self, predictions: tuple, metadata: Dict[str, Any]) -> AnnotationSceneEntity:
         """Convert predictions to OTX Annotation Scene using the metadata.
@@ -492,8 +502,13 @@ class RotatedRectToAnnotationConverter(IPredictionToAnnotationConverter):
 
     def __init__(self, labels: LabelSchemaEntity, configuration: Optional[Dict[str, Any]] = None):
         self.labels = labels.get_labels(include_empty=False)
-        self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
-        self.confidence_threshold = configuration["confidence_threshold"]
+        self.use_ellipse_shapes = False
+        self.confidence_threshold = 0.
+        if configuration is not None:
+            if "use_ellipse_shapes" in configuration:
+                self.use_ellipse_shapes = configuration["use_ellipse_shapes"]
+            if "confidence_threshold" in configuration:
+                self.confidence_threshold = configuration["confidence_threshold"]
 
     def convert_to_annotation(self, predictions: tuple, metadata: Dict[str, Any]) -> AnnotationSceneEntity:
         """Convert predictions to OTX Annotation Scene using the metadata.


### PR DESCRIPTION
### Summary

Overall, accessing optional parameters should be wrapped with appropriate checks.
Perfectly, our linters shouldn't allow that, but for some reason they do.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
