### PR TITLE
Set segmentation num_workers to 2

### DIFF
--- a/otx/algorithms/segmentation/adapters/mmseg/nncf/builder.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/nncf/builder.py
@@ -95,6 +95,7 @@ def build_nncf_segmentor(  # noqa: C901  # pylint: disable=too-many-locals,too-m
             subset="train",
             dataloader_builder=mmseg_build_dataloader,
             distributed=distributed,
+            persistent_workers=False,
         )
 
         # This data and state dict will be used to build NNCF graph later
@@ -124,6 +125,7 @@ def build_nncf_segmentor(  # noqa: C901  # pylint: disable=too-many-locals,too-m
                 distributed=distributed,
                 # segmentor does not support various sized batch images
                 samples_per_gpu=1,
+                persistent_workers=False,
             )
 
         model_eval_fn = partial(

--- a/otx/algorithms/segmentation/configs/configuration.yaml
+++ b/otx/algorithms/segmentation/configs/configuration.yaml
@@ -129,7 +129,7 @@ learning_parameters:
     affects_outcome_of: NONE
     auto_hpo_state: not_possible
     auto_hpo_value: null
-    default_value: 0
+    default_value: 2
     description:
       Increasing this value might improve training speed however it might
       cause out of memory errors. If the number of workers is set to zero, data loading


### PR DESCRIPTION
### Summary

- Increase default value of segmentation's `num_workers` to 2
- turn off persistent worker while preparing nncf. If not, it makes error when deepcopy `cfg` while auto decrease bs

I validated that num_workers 2 doesn't affect to performance and increase training speed a lot.
Experiments result is as below:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



dataset | dataset size | num worker | val score | test score | e2e time | iter time | data time | val std | test std | repeat
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
kvasir_seg | train12 | 0 | 0.854 | 0.6322 | 0:02:08 | 0.74337 | 0.25478 | 0.020588 | 0.038804 | 10
kvasir_seg | train12 | 2 | 0.847 | 0.6325 | 0:01:50 | 0.62448 | 0.17578 | 0.013202 | 0.024512 | 10
kvasir_seg | train24 | 0 | 0.767 | 0.6654 | 0:03:24 | 0.83331 | 0.33965 | 0.010964 | 0.021823 | 10
kvasir_seg | train24 | 2 | 0.772 | 0.6749 | 0:02:27 | 0.53294 | 0.10857 | 0.012561 | 0.022466 | 10
kvasir_seg | 300 | 0 | 0.894 | 0.8306 | 0:20:42 | 0.85117 | 0.33546 | 0.007668 | 0.019391 | 30
kvasir_seg | 300 | 2 | 0.891 | 0.8210 | 0:11:57 | 0.45704 | 0.01695 | 0.010477 | 0.02473 | 30
personcarvoc | 12 | 0 | 0.68172 | 0.420183 | 0:02:07 | 0.73193 | 0.252037 | 0.02897 | 0.103903 | 30
personcarvoc | 12 | 2 | 0.68006 | 0.436307 | 0:01:51 | 0.62072 | 0.17285 | 0.033724 | 0.080792 | 30
personcarvoc | 24 | 0 | 0.82443 | 0.59731 | 0:03:23 | 0.81956 | 0.332214 | 0.011535 | 0.029787 | 30
personcarvoc | 24 | 2 | 0.82456 | 0.589662 | 0:02:28 | 0.53436 | 0.109382 | 0.012073 | 0.033172 | 30



</div>

<!--EndFragment-->
</body>

</html>


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
