### PR TITLE
Fix GT vs prediction order mismatch due to different sorting result

### DIFF
--- a/otx/api/usecases/evaluation/f_measure.py
+++ b/otx/api/usecases/evaluation/f_measure.py
@@ -678,9 +678,6 @@ class FMeasure(IPerformanceProvider):
         if len(prediction_dataset) == 0 or len(ground_truth_dataset) == 0:
             raise ValueError("Cannot compute the F-measure of an empty result set.")
 
-        ground_truth_dataset.sort_items()
-        prediction_dataset.sort_items()
-
         labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=False)
         classes = [label.name for label in labels]
         boxes_pair = _FMeasureCalculator(


### PR DESCRIPTION
### Summary

* Remove gt.sort_items() & pred.sort_item() in F1 computation
  which have been resulted in gt vs prediction order mismatch while IoU computation
* Assuming same image order in GT and prediction dataset

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
