### PR TITLE
Return raw anomaly maps as metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+- Return raw anomaly map instead of colormap as metadata to prevent applying colormap conversion twice (<https://github.com/openvinotoolkit/training_extensions/pull/2217>)
 - Hotfix: use 0 confidence threshold when computing best threshold based on F1
 
 ## \[v1.2.2\]

--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -20,7 +20,6 @@ import numpy as np
 import pytorch_lightning as pl
 import torch
 from anomalib.models import AnomalyModule
-from anomalib.post_processing import anomaly_map_to_color_map
 from pytorch_lightning.callbacks import Callback
 from torch import Tensor
 
@@ -82,7 +81,7 @@ class AnomalyInferenceCallback(Callback):
                     name="Anomaly Map",
                     type="anomaly_map",
                     annotation_scene=dataset_item.annotation_scene,
-                    numpy=anomaly_map_to_color_map(anomaly_map.squeeze().numpy(), normalize=False),
+                    numpy=(anomaly_map * 255).astype(np.uint8),
                 )
             )
 

--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -81,7 +81,7 @@ class AnomalyInferenceCallback(Callback):
                     name="Anomaly Map",
                     type="anomaly_map",
                     annotation_scene=dataset_item.annotation_scene,
-                    numpy=(anomaly_map * 255).astype(np.uint8),
+                    numpy=(anomaly_map * 255).cpu().numpy().astype(np.uint8),
                 )
             )
 

--- a/otx/algorithms/anomaly/tasks/openvino.py
+++ b/otx/algorithms/anomaly/tasks/openvino.py
@@ -24,7 +24,6 @@ from zipfile import ZipFile
 import numpy as np
 from addict import Dict as ADDict
 from anomalib.deploy import OpenVINOInferencer
-from anomalib.post_processing import anomaly_map_to_color_map
 from compression.api import DataLoader
 from compression.engines.ie_engine import IEEngine
 from compression.graph import load_model, save_model
@@ -193,7 +192,7 @@ class OpenVINOTask(IInferenceTask, IEvaluationTask, IOptimizationTask, IDeployme
                 raise ValueError(f"Unknown task type: {self.task_type}")
 
             dataset_item.append_labels([ScoredLabel(label=label, probability=float(probability))])
-            anomaly_map = anomaly_map_to_color_map(image_result.anomaly_map, normalize=False)
+            anomaly_map = (image_result.anomaly_map * 255).astype(np.uint8)
             heatmap_media = ResultMediaEntity(
                 name="Anomaly Map",
                 type="anomaly_map",


### PR DESCRIPTION
### Summary

Fix for https://jira.devtools.intel.com/browse/CVS-112271

Colormap conversion was applied twice after a recent change on Geti side. This PR fixes this by removing the color conversion on OTX side and passing the raw anomaly map instead.

### How to test

See details in JIRA ticket.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
