### PR TITLE
Assign label information to heatmap in resultmedia

### DIFF
--- a/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
+++ b/otx/algorithms/anomaly/adapters/anomalib/callbacks/inference.py
@@ -80,6 +80,7 @@ class AnomalyInferenceCallback(Callback):
                 ResultMediaEntity(
                     name="Anomaly Map",
                     type="anomaly_map",
+                    label=dataset_item.annotation_scene.get_labels()[0],
                     annotation_scene=dataset_item.annotation_scene,
                     numpy=(anomaly_map * 255).cpu().numpy().astype(np.uint8),
                 )

--- a/otx/algorithms/anomaly/tasks/openvino.py
+++ b/otx/algorithms/anomaly/tasks/openvino.py
@@ -196,6 +196,7 @@ class OpenVINOTask(IInferenceTask, IEvaluationTask, IOptimizationTask, IDeployme
             heatmap_media = ResultMediaEntity(
                 name="Anomaly Map",
                 type="anomaly_map",
+                label=label,
                 annotation_scene=dataset_item.annotation_scene,
                 numpy=anomaly_map,
             )


### PR DESCRIPTION
### Summary

Previously the predicted label was not passed to the heatmap in the result media. Fixed by specifying a value for the `label` argument when creating the `ResultMediaEntity` object.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
