### PR TITLE
Decrease a time for making a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 - Introduce channel_last parameter to improve the performance (<https://github.com/openvinotoolkit/training_extensions/pull/2205>)
+- Decrease a time for making a workspace (<https://github.com/openvinotoolkit/training_extensions/pull/2223>)
 
 ### Bug fixes
 

--- a/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -165,7 +165,10 @@ class MPAConfig(Config):
 
     @property
     def pretty_text(self):
-        """Make python file human-readable."""
+        """Make python file human-readable.
+
+        It's almost same as mmcv.Config's code but code to reformat using yapf is removed to reduce time.
+        """
 
         indent = 4
 

--- a/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -165,17 +165,18 @@ class MPAConfig(Config):
 
     @property
     def pretty_text(self):
+        """Make python file human-readable."""
 
         indent = 4
 
         def _indent(s_, num_spaces):
-            s = s_.split('\n')
+            s = s_.split("\n")
             if len(s) == 1:
                 return s_
             first = s.pop(0)
-            s = [(num_spaces * ' ') + line for line in s]
-            s = '\n'.join(s)
-            s = first + '\n' + s
+            s = [(num_spaces * " ") + line for line in s]
+            s = "\n".join(s)
+            s = first + "\n" + s
             return s
 
         def _format_basic_types(k, v, use_mapping=False):
@@ -186,9 +187,9 @@ class MPAConfig(Config):
 
             if use_mapping:
                 k_str = f"'{k}'" if isinstance(k, str) else str(k)
-                attr_str = f'{k_str}: {v_str}'
+                attr_str = f"{k_str}: {v_str}"
             else:
-                attr_str = f'{str(k)}={v_str}'
+                attr_str = f"{str(k)}={v_str}"
             attr_str = _indent(attr_str, indent)
 
             return attr_str
@@ -196,16 +197,14 @@ class MPAConfig(Config):
         def _format_list(k, v, use_mapping=False):
             # check if all items in the list are dict
             if all(isinstance(_, dict) for _ in v):
-                v_str = '[\n'
-                v_str += '\n'.join(
-                    f'dict({_indent(_format_dict(v_), indent)}),'
-                    for v_ in v).rstrip(',')
+                v_str = "[\n"
+                v_str += "\n".join(f"dict({_indent(_format_dict(v_), indent)})," for v_ in v).rstrip(",")
                 if use_mapping:
                     k_str = f"'{k}'" if isinstance(k, str) else str(k)
-                    attr_str = f'{k_str}: {v_str}'
+                    attr_str = f"{k_str}: {v_str}"
                 else:
-                    attr_str = f'{str(k)}={v_str}'
-                attr_str = _indent(attr_str, indent) + ']'
+                    attr_str = f"{str(k)}={v_str}"
+                attr_str = _indent(attr_str, indent) + "]"
             else:
                 attr_str = _format_basic_types(k, v, use_mapping)
             return attr_str
@@ -213,37 +212,36 @@ class MPAConfig(Config):
         def _contain_invalid_identifier(dict_str):
             contain_invalid_identifier = False
             for key_name in dict_str:
-                contain_invalid_identifier |= \
-                    (not str(key_name).isidentifier())
+                contain_invalid_identifier |= not str(key_name).isidentifier()
             return contain_invalid_identifier
 
         def _format_dict(input_dict, outest_level=False):
-            r = ''
+            r = ""
             s = []
 
             use_mapping = _contain_invalid_identifier(input_dict)
             if use_mapping:
-                r += '{'
+                r += "{"
             for idx, (k, v) in enumerate(input_dict.items()):
                 is_last = idx >= len(input_dict) - 1
-                end = '' if outest_level or is_last else ','
+                end = "" if outest_level or is_last else ","
                 if isinstance(v, dict):
-                    v_str = '\n' + _format_dict(v)
+                    v_str = "\n" + _format_dict(v)
                     if use_mapping:
                         k_str = f"'{k}'" if isinstance(k, str) else str(k)
-                        attr_str = f'{k_str}: dict({v_str}'
+                        attr_str = f"{k_str}: dict({v_str}"
                     else:
-                        attr_str = f'{str(k)}=dict({v_str}'
-                    attr_str = _indent(attr_str, indent) + ')' + end
+                        attr_str = f"{str(k)}=dict({v_str}"
+                    attr_str = _indent(attr_str, indent) + ")" + end
                 elif isinstance(v, list):
                     attr_str = _format_list(k, v, use_mapping) + end
                 else:
                     attr_str = _format_basic_types(k, v, use_mapping) + end
 
                 s.append(attr_str)
-            r += '\n'.join(s)
+            r += "\n".join(s)
             if use_mapping:
-                r += '}'
+                r += "}"
             return r
 
         cfg_dict = self._cfg_dict.to_dict()

--- a/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -161,7 +161,95 @@ class MPAConfig(Config):
         cfg_dict, cfg_text = MPAConfig._file2dict(filename, use_predefined_variables)
         if import_custom_modules and cfg_dict.get("custom_imports", None):
             import_modules_from_strings(**cfg_dict["custom_imports"])
-        return Config(cfg_dict, cfg_text=cfg_text, filename=filename)
+        return MPAConfig(cfg_dict, cfg_text=cfg_text, filename=filename)
+
+    @property
+    def pretty_text(self):
+
+        indent = 4
+
+        def _indent(s_, num_spaces):
+            s = s_.split('\n')
+            if len(s) == 1:
+                return s_
+            first = s.pop(0)
+            s = [(num_spaces * ' ') + line for line in s]
+            s = '\n'.join(s)
+            s = first + '\n' + s
+            return s
+
+        def _format_basic_types(k, v, use_mapping=False):
+            if isinstance(v, str):
+                v_str = f"'{v}'"
+            else:
+                v_str = str(v)
+
+            if use_mapping:
+                k_str = f"'{k}'" if isinstance(k, str) else str(k)
+                attr_str = f'{k_str}: {v_str}'
+            else:
+                attr_str = f'{str(k)}={v_str}'
+            attr_str = _indent(attr_str, indent)
+
+            return attr_str
+
+        def _format_list(k, v, use_mapping=False):
+            # check if all items in the list are dict
+            if all(isinstance(_, dict) for _ in v):
+                v_str = '[\n'
+                v_str += '\n'.join(
+                    f'dict({_indent(_format_dict(v_), indent)}),'
+                    for v_ in v).rstrip(',')
+                if use_mapping:
+                    k_str = f"'{k}'" if isinstance(k, str) else str(k)
+                    attr_str = f'{k_str}: {v_str}'
+                else:
+                    attr_str = f'{str(k)}={v_str}'
+                attr_str = _indent(attr_str, indent) + ']'
+            else:
+                attr_str = _format_basic_types(k, v, use_mapping)
+            return attr_str
+
+        def _contain_invalid_identifier(dict_str):
+            contain_invalid_identifier = False
+            for key_name in dict_str:
+                contain_invalid_identifier |= \
+                    (not str(key_name).isidentifier())
+            return contain_invalid_identifier
+
+        def _format_dict(input_dict, outest_level=False):
+            r = ''
+            s = []
+
+            use_mapping = _contain_invalid_identifier(input_dict)
+            if use_mapping:
+                r += '{'
+            for idx, (k, v) in enumerate(input_dict.items()):
+                is_last = idx >= len(input_dict) - 1
+                end = '' if outest_level or is_last else ','
+                if isinstance(v, dict):
+                    v_str = '\n' + _format_dict(v)
+                    if use_mapping:
+                        k_str = f"'{k}'" if isinstance(k, str) else str(k)
+                        attr_str = f'{k_str}: dict({v_str}'
+                    else:
+                        attr_str = f'{str(k)}=dict({v_str}'
+                    attr_str = _indent(attr_str, indent) + ')' + end
+                elif isinstance(v, list):
+                    attr_str = _format_list(k, v, use_mapping) + end
+                else:
+                    attr_str = _format_basic_types(k, v, use_mapping) + end
+
+                s.append(attr_str)
+            r += '\n'.join(s)
+            if use_mapping:
+                r += '}'
+            return r
+
+        cfg_dict = self._cfg_dict.to_dict()
+        text = _format_dict(cfg_dict, outest_level=True)
+
+        return text
 
 
 def copy_config(cfg):


### PR DESCRIPTION
### Summary
To decrease time for making a workspace, remove a code to reformat the python text using yapf.
This change makes python file saved in workspace a little unprettier, but it's still human readable.
How much time can be saved is as below:

- classification : -0.1 sec
- detection : -1.2 sec
- segmentation : -0.6 sec

Added code is copied from mmcv but remove yapf part.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
