### PR TITLE
Set persistent_workers and pin_memory as True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 - Introduce channel_last parameter to improve the performance (<https://github.com/openvinotoolkit/training_extensions/pull/2205>)
 - Decrease a time for making a workspace (<https://github.com/openvinotoolkit/training_extensions/pull/2223>)
+- Set persistent_workers and pin_memory as True in detection task (<https://github.com/openvinotoolkit/training_extensions/pull/2224>)
 
 ### Bug fixes
 

--- a/otx/algorithms/classification/adapters/mmcls/nncf/builder.py
+++ b/otx/algorithms/classification/adapters/mmcls/nncf/builder.py
@@ -83,6 +83,7 @@ def build_nncf_classifier(  # pylint: disable=too-many-locals,too-many-statement
             subset="val",
             dataloader_builder=mmcls_build_dataloader,
             distributed=distributed,
+            persistent_workers=False,
         )
 
         # This data and state dict will be used to build NNCF graph later
@@ -110,6 +111,7 @@ def build_nncf_classifier(  # pylint: disable=too-many-locals,too-many-statement
                 subset="val",
                 dataloader_builder=mmcls_build_dataloader,
                 distributed=distributed,
+                persistent_workers=False,
             )
 
         model_eval_fn = partial(

--- a/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -564,7 +564,13 @@ def patch_persistent_workers(config: Config):
         )
         if workers_per_gpu == 0:
             dataloader_cfg["persistent_workers"] = False
-            data_cfg[f"{subset}_dataloader"] = dataloader_cfg
+        elif "persistent_workers" not in dataloader_cfg:
+            dataloader_cfg["persistent_workers"] = True
+
+        if "pin_memory" not in dataloader_cfg:
+            dataloader_cfg["pin_memory"] = True
+
+        data_cfg[f"{subset}_dataloader"] = dataloader_cfg
 
 
 def get_adaptive_num_workers():

--- a/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -99,6 +99,7 @@ class DetectionConfigurer:
         patch_fp16(cfg)
         patch_adaptive_interval_training(cfg)
         patch_early_stopping(cfg)
+        patch_persistent_workers(cfg)
 
         if data_cfg is not None:
             align_data_config_with_recipe(data_cfg, cfg)
@@ -217,17 +218,6 @@ class DetectionConfigurer:
         if super_type:
             cfg.data.train.org_type = cfg.data.train.type
             cfg.data.train.type = super_type
-
-        for subset in ["train", "val", "test", "unlabeled"]:
-            if subset not in cfg.data:
-                continue
-            dataloader_cfg = cfg.data.get(f"{subset}_dataloader", {})
-            for key in ["persistent_workers", "pin_memory"]:
-                if key not in dataloader_cfg:
-                    dataloader_cfg[key] = True
-            cfg.data[f"{subset}_dataloader"] = dataloader_cfg
-
-        patch_persistent_workers(cfg)
 
     def configure_regularization(self, cfg, training):  # noqa: C901
         """Patch regularization parameters."""

--- a/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -99,7 +99,6 @@ class DetectionConfigurer:
         patch_fp16(cfg)
         patch_adaptive_interval_training(cfg)
         patch_early_stopping(cfg)
-        patch_persistent_workers(cfg)
 
         if data_cfg is not None:
             align_data_config_with_recipe(data_cfg, cfg)
@@ -218,6 +217,17 @@ class DetectionConfigurer:
         if super_type:
             cfg.data.train.org_type = cfg.data.train.type
             cfg.data.train.type = super_type
+
+        for subset in ["train", "val", "test", "unlabeled"]:
+            if subset not in cfg.data:
+                continue
+            dataloader_cfg = cfg.data.get(f"{subset}_dataloader", {})
+            for key in ["persistent_workers", "pin_memory"]:
+                if key not in dataloader_cfg:
+                    dataloader_cfg[key] = True
+            cfg.data[f"{subset}_dataloader"] = dataloader_cfg
+
+        patch_persistent_workers(cfg)
 
     def configure_regularization(self, cfg, training):  # noqa: C901
         """Patch regularization parameters."""

--- a/otx/algorithms/detection/adapters/mmdet/nncf/builder.py
+++ b/otx/algorithms/detection/adapters/mmdet/nncf/builder.py
@@ -94,6 +94,7 @@ def build_nncf_detector(  # pylint: disable=too-many-locals,too-many-statements
             subset="val",
             dataloader_builder=mmdet_build_dataloader,
             distributed=distributed,
+            persistent_workers=False,
         )
 
         # This data and state dict will be used to build NNCF graph later
@@ -121,6 +122,7 @@ def build_nncf_detector(  # pylint: disable=too-many-locals,too-many-statements
                 subset="val",
                 dataloader_builder=mmdet_build_dataloader,
                 distributed=distributed,
+                persistent_workers=False,
             )
 
         model_eval_fn = partial(


### PR DESCRIPTION
### Summary

Set persistent_workers and pin_memory as True in all tasks, which can decrease data loader time.
When training with persistent_workers in nncf, nncf saves dataloaders in cfg. It makes an error when deepcopy `cfg` in `train_model` function of each tasks because datalaoder with persistent_workers aren't pickleable.
So, I set `persistent_workers` as False in nncf.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
