### PR TITLE
Remove deepcopy(self._data_cfg)

### DIFF
--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -154,7 +154,6 @@ class MMActionTask(OTXActionTask):
         # deepcopy all configs to make sure
         # changes under MPA and below does not take an effect to OTX for clear distinction
         recipe_cfg = deepcopy(self._recipe_cfg)
-        data_cfg = deepcopy(self._data_cfg)
         assert recipe_cfg is not None, "'recipe_cfg' is not initialized."
 
         recipe_cfg.work_dir = self._output_path
@@ -163,8 +162,8 @@ class MMActionTask(OTXActionTask):
 
         self._configure_device(recipe_cfg, training)
 
-        if data_cfg is not None:
-            recipe_cfg.merge_from_dict(data_cfg)
+        if self._data_cfg is not None:
+            recipe_cfg.merge_from_dict(self._data_cfg)
 
         if self._task_type == TaskType.ACTION_CLASSIFICATION:
             _dataset_type = "OTXActionClsDataset"

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -164,7 +164,6 @@ class MMClassificationTask(OTXClassificationTask):
         # deepcopy all configs to make sure
         # changes under MPA and below does not take an effect to OTX for clear distinction
         recipe_cfg = deepcopy(self._recipe_cfg)
-        data_cfg = deepcopy(self._data_cfg)
         assert recipe_cfg is not None, "'recipe_cfg' is not initialized."
 
         if self._data_cfg is not None:
@@ -198,7 +197,7 @@ class MMClassificationTask(OTXClassificationTask):
         cfg = configurer.configure(
             recipe_cfg,
             self._model_ckpt,
-            data_cfg,
+            self._data_cfg,
             training,
             subset,
             ir_options,

--- a/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/otx/algorithms/detection/adapters/mmdet/task.py
@@ -178,7 +178,6 @@ class MMDetectionTask(OTXDetectionTask):
         # deepcopy all configs to make sure
         # changes under MPA and below does not take an effect to OTX for clear distinction
         recipe_cfg = deepcopy(self._recipe_cfg)
-        data_cfg = deepcopy(self._data_cfg)
         assert recipe_cfg is not None, "'recipe_cfg' is not initialized."
 
         if self._data_cfg is not None:
@@ -200,7 +199,7 @@ class MMDetectionTask(OTXDetectionTask):
             recipe_cfg,
             train_dataset,
             self._model_ckpt,
-            data_cfg,
+            self._data_cfg,
             training,
             subset,
             ir_options,

--- a/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -149,7 +149,6 @@ class MMSegmentationTask(OTXSegmentationTask):
         # deepcopy all configs to make sure
         # changes under MPA and below does not take an effect to OTX for clear distinction
         recipe_cfg = deepcopy(self._recipe_cfg)
-        data_cfg = deepcopy(self._data_cfg)
         assert recipe_cfg is not None, "'recipe_cfg' is not initialized."
 
         if self._data_cfg is not None:
@@ -170,7 +169,7 @@ class MMSegmentationTask(OTXSegmentationTask):
         cfg = configurer.configure(
             recipe_cfg,
             self._model_ckpt,
-            data_cfg,
+            self._data_cfg,
             training,
             subset,
             ir_options,


### PR DESCRIPTION
### Summary
Remove `deepcopy(self._data_cfg)`. It come from #1537, but MPA was consolidated into OTX.
So it's unnecessary. I also ran cls, det, seg sample code but there is no error.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
