### PR TITLE
Bring explain confidence threshold from task

### DIFF
--- a/otx/algorithms/detection/task.py
+++ b/otx/algorithms/detection/task.py
@@ -577,7 +577,9 @@ class OTXDetectionTask(OTXTask, ABC):
                 # Include the background as the last category
                 labels.append(LabelEntity("background", Domain.DETECTION))
 
-            shapes = self._get_shapes(detection, dataset_item.width, dataset_item.height, 0.4, use_ellipse_shapes)
+            shapes = self._get_shapes(
+                detection, dataset_item.width, dataset_item.height, self.confidence_threshold, use_ellipse_shapes
+            )
             predicted_scored_labels = []
             for shape in shapes:
                 predicted_scored_labels += shape.get_labels()


### PR DESCRIPTION
### Summary
Current detection task add saliency map if prediction's confidence threshold is over 0.4.
This kind of implementation is vulnerable to model whose confidence threshold is lower than 0.4
Therefore this PR set explain confidence threshold from task, which is set by model data from model weights file.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
E2E
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
