### PR TITLE
Temporary skip deployment evaluation test for segnext_s

### DIFF
--- a/tests/e2e/cli/semantic_segmentation/test_segmentation.py
+++ b/tests/e2e/cli/semantic_segmentation/test_segmentation.py
@@ -168,6 +168,8 @@ class TestToolsMPASegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates_inc_segnext, ids=templates_ids_inc_segnext)
     def test_otx_eval_deployment(self, template, tmp_dir_path):
+        if template.name == "SegNext-s":
+            pytest.skip(reason="Issue#2237 Exported segnext_s model shows different accuracy per execution")
         tmp_dir_path = tmp_dir_path / "segmentation"
         otx_eval_deployment_testing(template, tmp_dir_path, otx_dir, args, threshold=0.0)
 


### PR DESCRIPTION
### Summary
Exported segnext_s sometimes shows different evaluation score(https://github.com/openvinotoolkit/training_extensions/issues/2237)
Therefore this PR add skip mark for deployment eval test for segnext_s model until we can solve this issue.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
