### PR TITLE
Fix improper issue output in ConfigManager

### DIFF
--- a/otx/cli/manager/config_manager.py
+++ b/otx/cli/manager/config_manager.py
@@ -171,9 +171,12 @@ class ConfigManager:  # pylint: disable=too-many-instance-attributes
         else:
             task_type = self.task_type
             if not task_type and not model:
-                if not hasattr(self.args, "train_data_roots"):
-                    raise ConfigValueError("Can't find the argument 'train_data_roots'")
-                task_type = self.auto_task_detection(self.args.train_data_roots)
+                if self.mode in ["train", "build"]:
+                    if not hasattr(self.args, "train_data_roots"):
+                        raise ConfigValueError("Can't find the argument 'train_data_roots'")
+                    task_type = self.auto_task_detection(self.args.train_data_roots)
+                else:
+                    raise ConfigValueError("No appropriate template or task-type was found.")
             self.template = self._get_template(task_type, model=model)
             self.train_type = self._get_train_type()
         self.task_type = self.template.task_type

--- a/tests/unit/cli/manager/test_config_manager.py
+++ b/tests/unit/cli/manager/test_config_manager.py
@@ -399,6 +399,24 @@ class TestConfigManager:
         assert config_manager.model == "template_name"
         assert config_manager.train_type == "Incremental"
 
+        mocker.patch(
+            "otx.cli.manager.config_manager.ConfigManager.check_workspace", return_value=False
+        )
+        mocker.patch(
+            "otx.cli.manager.config_manager.hasattr", return_value=False
+        )
+        empty_args = mocker.MagicMock()
+        empty_args.template = None
+        config_manager = ConfigManager(args=empty_args, mode="train")
+        config_manager.template = None
+        config_manager.task_type = None
+        with pytest.raises(ConfigValueError, match="Can't find the argument 'train_data_roots'"):
+            config_manager.configure_template()
+
+        config_manager = ConfigManager(args=empty_args, mode="eval")
+        with pytest.raises(ConfigValueError, match="No appropriate template or task-type was found."):
+            config_manager.configure_template()
+
     @e2e_pytest_unit
     def test__check_rebuild(self, mocker):
         mock_template = mocker.MagicMock()

--- a/tests/unit/cli/manager/test_config_manager.py
+++ b/tests/unit/cli/manager/test_config_manager.py
@@ -399,12 +399,8 @@ class TestConfigManager:
         assert config_manager.model == "template_name"
         assert config_manager.train_type == "Incremental"
 
-        mocker.patch(
-            "otx.cli.manager.config_manager.ConfigManager.check_workspace", return_value=False
-        )
-        mocker.patch(
-            "otx.cli.manager.config_manager.hasattr", return_value=False
-        )
+        mocker.patch("otx.cli.manager.config_manager.ConfigManager.check_workspace", return_value=False)
+        mocker.patch("otx.cli.manager.config_manager.hasattr", return_value=False)
         empty_args = mocker.MagicMock()
         empty_args.template = None
         config_manager = ConfigManager(args=empty_args, mode="train")


### PR DESCRIPTION
### Summary

Resolves
- #2150
- #2163 
- #2250

### How to test

- Case of No workspace & No template args (otx eval & export)
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/6d56a57d-3eeb-407c-8d9b-40774ea5b819)
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/cb968311-c76e-42a8-adb8-d47c96b10726)

`python -m pytest -s -v tests/unit/cli/manager/test_config_manager.py`
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/49acef83-95a3-4302-ba73-db3d7d600b97)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
