### PR TITLE
bugfix: enabling lr scale during distributed training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - Fix the bug that auto adapt batch size is unavailable with IterBasedRunner (<https://github.com/openvinotoolkit/training_extensions/pull/2182>)
+- Fix the bug that learning rate ins't scaled when multi-GPU trianing (<https://github.com/openvinotoolkit/training_extensions/pull/2254>)
 
 ### Known issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.
 ### Bug fixes
 
 - Fix the bug that auto adapt batch size is unavailable with IterBasedRunner (<https://github.com/openvinotoolkit/training_extensions/pull/2182>)
-- Fix the bug that learning rate ins't scaled when multi-GPU trianing (<https://github.com/openvinotoolkit/training_extensions/pull/2254>)
+- Fix the bug that learning rate isn't scaled when multi-GPU trianing is enabled(<https://github.com/openvinotoolkit/training_extensions/pull/2254>)
 
 ### Known issues
 

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -22,6 +22,7 @@ from functools import partial
 from typing import Dict, Optional, Union
 
 import torch
+from torch import distributed as dist
 from mmaction import __version__
 from mmaction.apis import train_model
 from mmaction.datasets import build_dataloader, build_dataset
@@ -234,7 +235,7 @@ class MMActionTask(OTXActionTask):
     def configure_distributed(cfg: Config):
         """Patching for distributed training."""
         if hasattr(cfg, "dist_params") and cfg.dist_params.get("linear_scale_lr", False):
-            new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
+            new_lr = dist.get_world_size() * cfg.optimizer.lr
             logger.info(
                 f"enabled linear scaling rule to the learning rate. \
                 changed LR from {cfg.optimizer.lr} to {new_lr}"

--- a/otx/algorithms/action/adapters/mmaction/task.py
+++ b/otx/algorithms/action/adapters/mmaction/task.py
@@ -22,7 +22,6 @@ from functools import partial
 from typing import Dict, Optional, Union
 
 import torch
-from torch import distributed as dist
 from mmaction import __version__
 from mmaction.apis import train_model
 from mmaction.datasets import build_dataloader, build_dataset
@@ -30,6 +29,7 @@ from mmaction.models import build_model as build_videomodel
 from mmaction.utils import collect_env
 from mmcv.runner import CheckpointLoader, load_checkpoint, wrap_fp16_model
 from mmcv.utils import Config, ConfigDict, ProgressBar, get_git_hash
+from torch import distributed as dist
 
 from otx.algorithms.action.adapters.mmaction import (
     Exporter,

--- a/otx/algorithms/classification/adapters/mmcls/configurer.py
+++ b/otx/algorithms/classification/adapters/mmcls/configurer.py
@@ -451,7 +451,7 @@ class ClassificationConfigurer:
     def configure_distributed(cfg):
         """Patching for distributed training."""
         if hasattr(cfg, "dist_params") and cfg.dist_params.get("linear_scale_lr", False):
-            new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
+            new_lr = dist.get_world_size() * cfg.optimizer.lr
             logger.info(
                 f"enabled linear scaling rule to the learning rate. \
                 changed LR from {cfg.optimizer.lr} to {new_lr}"

--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -385,13 +385,6 @@ class MMClassificationTask(OTXClassificationTask):
 
         if cfg.distributed:
             torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
-            if cfg.dist_params.get("linear_scale_lr", False):
-                new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
-                logger.info(
-                    f"enabled linear scaling rule to the learning rate. \
-                    changed LR from {cfg.optimizer.lr} to {new_lr}"
-                )
-                cfg.optimizer.lr = new_lr
 
         validate = bool(cfg.data.get("val", None))
         if validate:

--- a/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -608,7 +608,7 @@ class DetectionConfigurer:
     def configure_distributed(cfg):
         """Patching for distributed training."""
         if hasattr(cfg, "dist_params") and cfg.dist_params.get("linear_scale_lr", False):
-            new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
+            new_lr = dist.get_world_size() * cfg.optimizer.lr
             logger.info(
                 f"enabled linear scaling rule to the learning rate. \
                 changed LR from {cfg.optimizer.lr} to {new_lr}"

--- a/otx/algorithms/segmentation/adapters/mmseg/configurer.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/configurer.py
@@ -489,7 +489,7 @@ class SegmentationConfigurer:
     def configure_distributed(cfg: Config) -> None:
         """Patching for distributed training."""
         if hasattr(cfg, "dist_params") and cfg.dist_params.get("linear_scale_lr", False):
-            new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
+            new_lr = dist.get_world_size() * cfg.optimizer.lr
             logger.info(
                 f"enabled linear scaling rule to the learning rate. \
                 changed LR from {cfg.optimizer.lr} to {new_lr}"

--- a/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -375,13 +375,6 @@ class MMSegmentationTask(OTXSegmentationTask):
 
         if cfg.distributed:
             torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
-            if cfg.dist_params.get("linear_scale_lr", False):
-                new_lr = len(cfg.gpu_ids) * cfg.optimizer.lr
-                logger.info(
-                    f"enabled linear scaling rule to the learning rate. \
-                    changed LR from {cfg.optimizer.lr} to {new_lr}"
-                )
-                cfg.optimizer.lr = new_lr
 
         validate = bool(cfg.data.get("val", None))
 

--- a/otx/recipes/stages/segmentation/incremental.py
+++ b/otx/recipes/stages/segmentation/incremental.py
@@ -21,8 +21,6 @@ log_config = dict(
     ],
 )
 
-dist_params = dict(backend="nccl", linear_scale_lr=False)
-
 runner = dict(type="EpochRunnerWithCancel", max_epochs=300)
 
 checkpoint_config = dict(by_epoch=True, interval=1)

--- a/otx/recipes/stages/segmentation/selfsl.py
+++ b/otx/recipes/stages/segmentation/selfsl.py
@@ -27,8 +27,6 @@ log_config = dict(
     ],
 )
 
-dist_params = dict(backend="nccl", linear_scale_lr=False)
-
 runner = dict(type="EpochBasedRunner", max_epochs=10)
 
 checkpoint_config = dict(by_epoch=True, interval=1)

--- a/otx/recipes/stages/segmentation/semisl.py
+++ b/otx/recipes/stages/segmentation/semisl.py
@@ -25,8 +25,6 @@ log_config = dict(
     ],
 )
 
-dist_params = dict(backend="nccl", linear_scale_lr=False)
-
 runner = dict(type="EpochRunnerWithCancel", max_epochs=300)
 
 checkpoint_config = dict(

--- a/tests/unit/algorithms/action/adapters/mmaction/test_task.py
+++ b/tests/unit/algorithms/action/adapters/mmaction/test_task.py
@@ -382,3 +382,22 @@ class TestMMActionTask:
             3. Check output model attributes
         """
         self.test_export(mocker, ModelPrecision.FP32, ExportType.ONNX)
+
+    @e2e_pytest_unit
+    def test_configure_distributed(self, mocker) -> None:
+        """Test configure_distributed function.
+
+        <Steps>
+            1. Create config for test
+            2. Run MMActionTask.configure_distributed
+            3. Check updated learning rate
+        """
+        mock_dist = mocker.patch.object(target_file, "dist")
+        world_size = 2
+        mock_dist.get_world_size.return_value = world_size
+        origin_lr = 0.01
+        config = Config({"optimizer": {"lr": origin_lr}, "dist_params": {"linear_scale_lr": True}})
+
+        MMActionTask.configure_distributed(config)
+
+        assert config.optimizer.lr == pytest.approx(origin_lr * world_size)

--- a/tests/unit/algorithms/classification/adapters/mmcls/test_configurer.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/test_configurer.py
@@ -6,6 +6,7 @@ import tempfile
 from mmcv.utils import ConfigDict
 
 from otx.algorithms.common.adapters.mmcv.utils.config_utils import MPAConfig
+from otx.algorithms.classification.adapters.mmcls import configurer
 from otx.algorithms.classification.adapters.mmcls.configurer import (
     ClassificationConfigurer,
     IncrClassificationConfigurer,
@@ -75,10 +76,14 @@ class TestClassificationConfigurer:
             "torch.distributed.is_initialized",
             return_value=True,
         )
+        world_size = 2
+        mocker.patch.object(configurer, "dist").get_world_size.return_value = world_size
         mocker.patch("os.environ", return_value={"LOCAL_RANK": 2})
         config = copy.deepcopy(self.model_cfg)
+        origin_lr = config.optimizer.lr
         self.configurer.configure_device(config, True)
         assert config.distributed is True
+        assert config.optimizer.lr == pytest.approx(origin_lr * world_size)
 
         mocker.patch(
             "torch.distributed.is_initialized",

--- a/tests/unit/algorithms/detection/adapters/mmdet/test_configurer.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/test_configurer.py
@@ -7,6 +7,7 @@ from mmcv.utils import ConfigDict
 
 from otx.api.entities.model_template import TaskType
 from otx.algorithms.common.adapters.mmcv.utils.config_utils import MPAConfig
+from otx.algorithms.detection.adapters.mmdet import configurer
 from otx.algorithms.detection.adapters.mmdet.configurer import (
     DetectionConfigurer,
     IncrDetectionConfigurer,
@@ -72,10 +73,14 @@ class TestDetectionConfigurer:
             "torch.distributed.is_initialized",
             return_value=True,
         )
+        world_size = 2
+        mocker.patch.object(configurer, "dist").get_world_size.return_value = world_size
         mocker.patch("os.environ", return_value={"LOCAL_RANK": 2})
         config = copy.deepcopy(self.model_cfg)
+        origin_lr = config.optimizer.lr
         self.configurer.configure_device(config, True)
         assert config.distributed is True
+        assert config.optimizer.lr == pytest.approx(origin_lr * world_size)
 
         mocker.patch(
             "torch.distributed.is_initialized",


### PR DESCRIPTION
### Summary

- Current OTX doesn't scale learning rate when multi GPU training. Fix it to scale lr.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
