### PR TITLE
Update CI test report format from xml to csv

### DIFF
--- a/.github/workflows/run_tests_in_tox.yml
+++ b/.github/workflows/run_tests_in_tox.yml
@@ -45,6 +45,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ inputs.toxenv-task }}-${{ inputs.toxenv-pyver }}
-          path: .tox/tests-${{ inputs.toxenv-task }}-${{ inputs.toxenv-pyver }}.xml
+          path: .tox/tests-${{ inputs.toxenv-task }}-${{ inputs.toxenv-pyver }}.csv
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ inputs.upload-artifact && always() }}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,4 @@ pytest-timeout
 pytest-mock
 onnx==1.13.0
 onnxruntime==1.14.1
+pytest-csv

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 isolated_build = true
 skip_missing_interpreters = true
 
+[pytest]
+addopts = --csv=.tox/tests-{env:TOXENV_TASK}-{env:TOXENV_PYVER}.csv
+
 [testenv]
 passenv =
     ftp_proxy
@@ -58,7 +61,7 @@ deps =
 use_develop = true
 commands =
     coverage erase
-    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/{envname}.xml {posargs:tests/integration/{[testenv]test_dir}}
+    coverage run -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv {posargs:tests/integration/{[testenv]test_dir}}
     coverage report -m --fail-under=0
     coverage xml -o {toxworkdir}/coverage.xml
 
@@ -135,7 +138,7 @@ deps =
 use_develop = true
 commands =
     coverage erase
-    coverage run -m pytest -ra --showlocals --junitxml={toxworkdir}/test-results-{envname}.xml {posargs:tests/regression}
+    coverage run -m pytest -ra --showlocals --csv={toxworkdir}/test-results-{envname}.csv {posargs:tests/regression}
     python tests/regression/summarize_test_results.py --output_path {toxworkdir}
 
 


### PR DESCRIPTION
### Summary
The current CI system performs e2e and regression tests, and the test reports are in XML format with columns that require manual interpretation. To simplify the interpretation and make it easier to analyze the results, we have made changes to convert the reports into a CSV format that shows the pass or fail status for each test case.

**Before**
![image](https://github.com/openvinotoolkit/training_extensions/assets/55648198/c5f755ff-7de4-460e-9dd5-5fcce4ef7a65)

**After**
![image](https://github.com/openvinotoolkit/training_extensions/assets/55648198/48620720-989f-4160-b977-1bf0f734e2ea)

Test Results from CI: https://github.com/openvinotoolkit/training_extensions/actions/runs/5331211012

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
