### PR TITLE
Fix incorrect matching of device in semisl_head

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/models/heads/semisl_cls_head.py
+++ b/otx/algorithms/classification/adapters/mmcls/models/heads/semisl_cls_head.py
@@ -31,8 +31,6 @@ class SemiClsHead(OTXHeadMixin):
         )  # the range of threshold will be [min_thr, 1.0]
         self.num_pseudo_label = 0
         self.classwise_acc = torch.ones((self.num_classes,)) * self.min_threshold
-        if torch.cuda.is_available():
-            self.classwise_acc = self.classwise_acc.cuda()
 
     def loss(self, logits, gt_label, pseudo_label=None, mask=None):
         """Loss function in which unlabeled data is considered.
@@ -89,8 +87,6 @@ class SemiClsHead(OTXHeadMixin):
                 max_probs, label_u = torch.max(pseudo_label, dim=-1)
 
                 # select Pseudo-Label using flexible threhold
-                if torch.cuda.is_available():
-                    max_probs = max_probs.cuda()
                 mask = max_probs.ge(self.classwise_acc[label_u]).float()
                 self.num_pseudo_label = mask.sum()
 

--- a/otx/algorithms/classification/adapters/mmcls/models/heads/semisl_cls_head.py
+++ b/otx/algorithms/classification/adapters/mmcls/models/heads/semisl_cls_head.py
@@ -87,6 +87,7 @@ class SemiClsHead(OTXHeadMixin):
                 max_probs, label_u = torch.max(pseudo_label, dim=-1)
 
                 # select Pseudo-Label using flexible threhold
+                self.classwise_acc = self.classwise_acc.to(label_u.device)
                 mask = max_probs.ge(self.classwise_acc[label_u]).float()
                 self.num_pseudo_label = mask.sum()
 


### PR DESCRIPTION
### Summary

Find some strange code. -> CPU training is not working in Semi-SL
Remove cuda() things in semisl_cls_head -> Now Semi-SL with CPU is working

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
