### PR TITLE
Auto num worker edge case

### DIFF
--- a/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/otx/algorithms/classification/adapters/mmcls/task.py
@@ -692,7 +692,9 @@ class MMClassificationTask(OTXClassificationTask):
         )
 
         if self._hyperparams.learning_parameters.auto_num_workers:
-            config.data.workers_per_gpu = get_adaptive_num_workers()
+            adapted_num_worker = get_adaptive_num_workers()
+            if adapted_num_worker is not None:
+                config.data.workers_per_gpu = adapted_num_worker
 
         if self._train_type.value == "Semisupervised":
             unlabeled_config = ConfigDict(

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
@@ -13,6 +13,7 @@ def test_get_adaptive_num_workers(mocker):
 
     assert get_adaptive_num_workers() == num_cpu // num_gpu
 
+
 def test_get_adaptive_num_workers_no_gpu(mocker):
     num_gpu = 0
     mock_torch = mocker.patch.object(config_utils, "torch")

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
@@ -1,0 +1,25 @@
+from otx.algorithms.common.adapters.mmcv.utils import config_utils
+from otx.algorithms.common.adapters.mmcv.utils.config_utils import get_adaptive_num_workers
+
+
+def test_get_adaptive_num_workers(mocker):
+    num_gpu = 5
+    mock_torch = mocker.patch.object(config_utils, "torch")
+    mock_torch.cuda.device_count.return_value = num_gpu
+
+    num_cpu = 20
+    mock_multiprocessing = mocker.patch.object(config_utils, "multiprocessing")
+    mock_multiprocessing.cpu_count.return_value = num_cpu
+
+    assert get_adaptive_num_workers() == num_cpu // num_gpu
+
+def test_get_adaptive_num_workers_no_gpu(mocker):
+    num_gpu = 0
+    mock_torch = mocker.patch.object(config_utils, "torch")
+    mock_torch.cuda.device_count.return_value = num_gpu
+
+    num_cpu = 20
+    mock_multiprocessing = mocker.patch.object(config_utils, "multiprocessing")
+    mock_multiprocessing.cpu_count.return_value = num_cpu
+
+    assert get_adaptive_num_workers() is None


### PR DESCRIPTION
### Summary
Current adaptive num_worker implementation can't deal with edge case where there is no GPU.
This PR fixed it.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
