### PR TITLE
Remove mmcv pre-install in anomaly tox test environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,18 +25,15 @@ deps =
     py38:  torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp38-cp38-linux_x86_64.whl
     py38:  torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp38-cp38-linux_x86_64.whl
     py38:  torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp38-cp38-linux_x86_64.whl
-    # TODO 'ano' from below could be removed after removing dependency to the mmcv from BaseDatasetAdapter
-    {all,ano,act,cls,det,seg,iseg}-py38: mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
+    {all,act,cls,det,seg,iseg}-py38: mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp38-cp38-manylinux1_x86_64.whl
     py39:  torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp39-cp39-linux_x86_64.whl
     py39:  torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp39-cp39-linux_x86_64.whl
     py39:  torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp39-cp39-linux_x86_64.whl
-    # TODO 'ano' from below could be removed after removing dependency to the mmcv from BaseDatasetAdapter
-    {all,ano,act,cls,det,seg,iseg}-py39:  mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp39-cp39-manylinux1_x86_64.whl
+    {all,act,cls,det,seg,iseg}-py39:  mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp39-cp39-manylinux1_x86_64.whl
     py310: torch @ https://download.pytorch.org/whl/cu117/torch-1.13.1%2Bcu117-cp310-cp310-linux_x86_64.whl
     py310: torchvision @ https://download.pytorch.org/whl/cu117/torchvision-0.14.1%2Bcu117-cp310-cp310-linux_x86_64.whl
     py310: torchtext @ https://download.pytorch.org/whl/torchtext-0.14.1-cp310-cp310-linux_x86_64.whl
-    # TODO 'ano' from below could be removed after removing dependency to the mmcv from BaseDatasetAdapter
-    {all,ano,act,cls,det,seg,iseg}-py310: mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp310-cp310-manylinux1_x86_64.whl
+    {all,act,cls,det,seg,iseg}-py310: mmcv-full @ https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp310-cp310-manylinux1_x86_64.whl
 extras =
     all: full
     ano: anomaly


### PR DESCRIPTION
### Summary

With the removal of the MMCV dependency from OTX/CORE in https://github.com/openvinotoolkit/training_extensions/pull/2293
the anomaly test environment no longer requires an MMCV installation.

In tox, modify the anomaly test environment to not install MMCV.

### How to test

- Install anomaly environment
`tox devenv -e Integration-Test-py39-ano ./venv-anomaly`

Before
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/8d150456-12c2-4603-9330-05d6da3d10d2)

After
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/80defcac-ca92-44d9-868d-be959eb9211f)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
