### PR TITLE
Fix export bug for Geti

### DIFF
--- a/src/otx/algorithms/action/adapters/mmaction/task.py
+++ b/src/otx/algorithms/action/adapters/mmaction/task.py
@@ -467,6 +467,7 @@ class MMActionTask(OTXActionTask):
 
     def _export_model(self, precision: ModelPrecision, export_format: ExportType, dump_features: bool):
         """Main export function."""
+        self._data_cfg = None
         self._init_task(export=True)
 
         cfg = self.configure(False, "test", None)

--- a/src/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/task.py
@@ -549,6 +549,7 @@ class MMClassificationTask(OTXClassificationTask):
         return eval_predictions, saliency_maps
 
     def _export_model(self, precision: ModelPrecision, export_format: ExportType, dump_features: bool):
+        self._data_cfg = None
         self._init_task(export=True)
 
         cfg = self.configure(False, "test", None)

--- a/src/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/task.py
@@ -493,6 +493,7 @@ class MMDetectionTask(OTXDetectionTask):
         dump_features: bool,
     ):
         """Main export function of OTX MMDetection Task."""
+        self._data_cfg = None
         self._init_task(export=True)
 
         cfg = self.configure(False, "test", None)

--- a/src/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -423,6 +423,7 @@ class MMSegmentationTask(OTXSegmentationTask):
     ):
         """Export function of OTX Segmentation Task."""
         # copied from OTX inference_task.py
+        self._data_cfg = None
         self._init_task(export=True)
 
         cfg = self.configure(False, "test", None)

--- a/tests/unit/algorithms/action/adapters/mmaction/test_task.py
+++ b/tests/unit/algorithms/action/adapters/mmaction/test_task.py
@@ -130,13 +130,6 @@ class MockExporter:
             f.write(dummy_data)
 
 
-def mock_data_pipeline(config: Config, *args, **kwargs):
-    config.data = {}
-    for subset in ["train", "val", "test", "unlabeled"]:
-        config.data[f"{subset}_dataloader"] = {}
-    return True
-
-
 class TestMMActionTask:
     """Test class for MMActionTask.
 
@@ -204,10 +197,6 @@ class TestMMActionTask:
         mocker.patch.object(MMActionTask, "build_model", return_value=MockModel("cls"))
         mocker.patch.object(MMActionTask, "get_model_ckpt", return_value="fake_weight")
         mocker.patch(
-            "otx.algorithms.action.adapters.mmaction.task.patch_data_pipeline",
-            side_effect=mock_data_pipeline,
-        )
-        mocker.patch(
             "otx.algorithms.action.adapters.mmaction.task.build_data_parallel",
             return_value=MockModel("cls"),
         )
@@ -241,10 +230,6 @@ class TestMMActionTask:
         )
         mocker.patch.object(MMActionTask, "build_model", return_value=MockModel("det"))
         mocker.patch(
-            "otx.algorithms.action.adapters.mmaction.task.patch_data_pipeline",
-            side_effect=mock_data_pipeline,
-        )
-        mocker.patch(
             "otx.algorithms.action.adapters.mmaction.task.build_data_parallel",
             return_value=MockModel("det"),
         )
@@ -275,10 +260,6 @@ class TestMMActionTask:
         )
         mocker.patch.object(MMActionTask, "build_model", return_value=MockModel("cls"))
         mocker.patch(
-            "otx.algorithms.action.adapters.mmaction.task.patch_data_pipeline",
-            side_effect=mock_data_pipeline,
-        )
-        mocker.patch(
             "otx.algorithms.action.adapters.mmaction.task.build_data_parallel",
             return_value=MockModel("cls"),
         )
@@ -297,10 +278,6 @@ class TestMMActionTask:
             return_value=MockDataLoader(self.det_dataset),
         )
         mocker.patch.object(MMActionTask, "build_model", return_value=MockModel("det"))
-        mocker.patch(
-            "otx.algorithms.action.adapters.mmaction.task.patch_data_pipeline",
-            side_effect=mock_data_pipeline,
-        )
         mocker.patch(
             "otx.algorithms.action.adapters.mmaction.task.build_data_parallel",
             return_value=MockModel("det"),
@@ -401,3 +378,66 @@ class TestMMActionTask:
         MMActionTask.configure_distributed(config)
 
         assert config.optimizer.lr == pytest.approx(origin_lr * world_size)
+
+    @e2e_pytest_unit
+    def test_geti_scenario(self, mocker):
+        """Test Geti scenario.
+
+        Train -> Eval -> Export
+        """
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.build_dataset",
+            return_value=MockDataset(self.cls_dataset, "cls"),
+        )
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.build_dataloader",
+            return_value=MockDataLoader(self.cls_dataset),
+        )
+        mocker.patch.object(MMActionTask, "build_model", return_value=MockModel("cls"))
+        mocker.patch.object(MMActionTask, "get_model_ckpt", return_value="fake_weight")
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.build_data_parallel",
+            return_value=MockModel("cls"),
+        )
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.train_model",
+            return_value=True,
+        )
+        mocker.patch("torch.load", return_value={"state_dict": np.ndarray([1, 1, 1])})
+
+        # mock for testing num_workers
+        num_cpu = 20
+        mock_multiprocessing = mocker.patch.object(config_utils, "multiprocessing")
+        mock_multiprocessing.cpu_count.return_value = num_cpu
+        num_gpu = 5
+        mock_torch = mocker.patch.object(config_utils, "torch")
+        mock_torch.cuda.device_count.return_value = num_gpu
+
+        _config = ModelConfiguration(ActionConfig(), self.cls_label_schema)
+        output_model = ModelEntity(self.cls_dataset, _config)
+        self.cls_task.train(self.cls_dataset, output_model)
+
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.build_dataset",
+            return_value=MockDataset(self.cls_dataset, "cls"),
+        )
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.build_dataloader",
+            return_value=MockDataLoader(self.cls_dataset),
+        )
+        mocker.patch.object(MMActionTask, "build_model", return_value=MockModel("cls"))
+        mocker.patch(
+            "otx.algorithms.action.adapters.mmaction.task.build_data_parallel",
+            return_value=MockModel("cls"),
+        )
+
+        inference_parameters = InferenceParameters(is_evaluation=True)
+        outputs = self.cls_task.infer(self.cls_dataset, inference_parameters)
+
+        mocker.patch("otx.algorithms.action.adapters.mmaction.task.Exporter", return_value=MockExporter(self.cls_task))
+        mocker.patch("torch.load", return_value={})
+        mocker.patch("torch.nn.Module.load_state_dict", return_value=True)
+
+        export_type = ExportType.OPENVINO
+        precision = ModelPrecision.FP32
+        self.cls_task.export(export_type, output_model, precision, False)

--- a/tests/unit/algorithms/classification/adapters/mmcls/test_task.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/test_task.py
@@ -441,3 +441,85 @@ class TestMMClassificationTask:
         outputs = self.mc_cls_task.explain(self.mc_cls_dataset, explain_parameters)
         assert isinstance(outputs, DatasetEntity)
         assert len(outputs) == 200
+
+    @e2e_pytest_unit
+    def test_geti_scenario(self, mocker):
+        """Test Geti scenario.
+
+        Train -> Eval -> Export
+        """
+
+        def _mock_train_model(*args, **kwargs):
+            with open(os.path.join(self.mc_cls_task._output_path, "latest.pth"), "wb") as f:
+                torch.save({"dummy": torch.randn(1, 3, 3, 3)}, f)
+
+        # TRAIN
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.build_dataset",
+            return_value=MockDataset(self.mc_cls_dataset),
+        )
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.build_dataloader",
+            return_value=MockDataLoader(self.mc_cls_dataset),
+        )
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.train_model",
+            side_effect=_mock_train_model,
+        )
+        mocker.patch.object(MMClassificationTask, "build_model", return_value=MockModel())
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.build_data_parallel",
+            return_value=MockModel(),
+        )
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.FeatureVectorHook",
+            return_value=nullcontext(),
+        )
+
+        # mock for testing num_workers
+        num_cpu = 20
+        mock_multiprocessing = mocker.patch.object(config_utils, "multiprocessing")
+        mock_multiprocessing.cpu_count.return_value = num_cpu
+        num_gpu = 5
+        mock_torch = mocker.patch.object(config_utils, "torch")
+        mock_torch.cuda.device_count.return_value = num_gpu
+
+        _config = ModelConfiguration(ClassificationConfig("header"), self.mc_cls_label_schema)
+        output_model = ModelEntity(self.mc_cls_dataset, _config)
+        self.mc_cls_task.train(self.mc_cls_dataset, output_model)
+
+        # INFERENCE
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.build_dataset",
+            return_value=MockDataset(self.mc_cls_dataset),
+        )
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.build_dataloader",
+            return_value=MockDataLoader(self.mc_cls_dataset),
+        )
+        mocker.patch.object(MMClassificationTask, "build_model", return_value=MockModel())
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.build_data_parallel",
+            return_value=MockModel(),
+        )
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.FeatureVectorHook",
+            return_value=nullcontext(),
+        )
+
+        inference_parameters = InferenceParameters(is_evaluation=True)
+        outputs = self.mc_cls_task.infer(self.mc_cls_dataset.with_empty_annotations(), inference_parameters)
+
+        # EXPORT
+        mocker.patch(
+            "otx.algorithms.classification.adapters.mmcls.task.ClassificationExporter",
+            return_value=MockExporter(self.mc_cls_task),
+        )
+        mocker.patch(
+            "otx.algorithms.classification.task.embed_ir_model_data",
+            return_value=True,
+        )
+
+        export_type = ExportType.OPENVINO
+        precision = ModelPrecision.FP32
+        self.mc_cls_task.export(export_type, output_model, precision, False)

--- a/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
@@ -446,3 +446,101 @@ class TestMMDetectionTask:
         inference_parameters = InferenceParameters(is_evaluation=True)
         det_task._infer_model(self.det_dataset, inference_parameters)
         assert ssd_cfg.model.bbox_head.anchor_generator != det_task.config.model.bbox_head.anchor_generator
+
+    @e2e_pytest_unit
+    def test_geti_scenario(self, mocker):
+        """Test Geti scenario.
+
+        Train -> Eval -> Export
+        """
+
+        # TRAIN
+        def _mock_train_detector_det(*args, **kwargs):
+            with open(os.path.join(self.det_task._output_path, "latest.pth"), "wb") as f:
+                torch.save({"dummy": torch.randn(1, 3, 3, 3)}, f)
+
+        def _mock_train_detector_iseg(*args, **kwargs):
+            with open(os.path.join(self.iseg_task._output_path, "latest.pth"), "wb") as f:
+                torch.save({"dummy": torch.randn(1, 3, 3, 3)}, f)
+
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.build_dataset",
+            return_value=MockDataset(self.det_dataset, "det"),
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.build_dataloader",
+            return_value=MockDataLoader(self.det_dataset),
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.patch_data_pipeline",
+            return_value=True,
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.train_detector",
+            side_effect=_mock_train_detector_det,
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.single_gpu_test",
+            return_value=[
+                np.array([np.array([[0, 0, 1, 1, 0.1]]), np.array([[0, 0, 1, 1, 0.2]]), np.array([[0, 0, 1, 1, 0.7]])])
+            ]
+            * 100,
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.FeatureVectorHook",
+            return_value=nullcontext(),
+        )
+
+        # mock for testing num_workers
+        num_cpu = 20
+        mock_multiprocessing = mocker.patch.object(config_utils, "multiprocessing")
+        mock_multiprocessing.cpu_count.return_value = num_cpu
+        num_gpu = 5
+        mock_torch = mocker.patch.object(config_utils, "torch")
+        mock_torch.cuda.device_count.return_value = num_gpu
+
+        _config = ModelConfiguration(DetectionConfig(), self.det_label_schema)
+        output_model = ModelEntity(self.det_dataset, _config)
+        self.det_task.train(self.det_dataset, output_model)
+
+        # INFER
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.build_dataset",
+            return_value=MockDataset(self.det_dataset, "det"),
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.build_dataloader",
+            return_value=MockDataLoader(self.det_dataset),
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.patch_data_pipeline",
+            return_value=True,
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.single_gpu_test",
+            return_value=[
+                np.array([np.array([[0, 0, 1, 1, 0.1]]), np.array([[0, 0, 1, 1, 0.2]]), np.array([[0, 0, 1, 1, 0.7]])])
+            ]
+            * 100,
+        )
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.FeatureVectorHook",
+            return_value=nullcontext(),
+        )
+
+        inference_parameters = InferenceParameters(is_evaluation=True)
+        outputs = self.det_task.infer(self.det_dataset, inference_parameters)
+
+        # EXPORT
+        mocker.patch(
+            "otx.algorithms.detection.adapters.mmdet.task.DetectionExporter",
+            return_value=MockExporter(self.det_task),
+        )
+        mocker.patch(
+            "otx.algorithms.detection.task.embed_ir_model_data",
+            return_value=True,
+        )
+
+        export_type = ExportType.OPENVINO
+        precision = ModelPrecision.FP32
+        self.det_task.export(export_type, output_model, precision, False)


### PR DESCRIPTION
### Summary
This PR includes fixing bug during export procedure in Geti.
Latest develop(after 8a8b1e5) raise errors when someone use same OTX task for various jobs such as train, eval, export.
By defining _data_cfg for all task(train, eval, export) will guarantee each task's independence.
Also this PR adds unit tests for checking such scenario, which use OTX task for various jobs.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
Unit-test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
