### PR TITLE
Fix e2e tiling tests

### DIFF
--- a/src/otx/algorithms/detection/adapters/mmdet/datasets/dataset.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/datasets/dataset.py
@@ -419,11 +419,7 @@ class ImageTilingDataset(OTXDetDataset):
         """
 
         if dump_maps:
-            if not (np.array(saliency_maps) == None).all():  # noqa
-                return self.tile_dataset.merge_maps(saliency_maps)
-            else:
-                # retutn None for each class for each image
-                return saliency_maps[: self.num_samples]
+            return self.tile_dataset.merge_maps(saliency_maps)
         else:
             return [None] * self.num_samples
 

--- a/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
@@ -485,12 +485,16 @@ class Tile:
             merged_vectors (List[np.ndarray]): Merged vectors for each image.
         """
 
-        vect_per_image = len(feature_vectors) // self.num_images
-        # split vectors on chunks of vectors related to the same image
-        image_vectors = [
-            feature_vectors[x : x + vect_per_image] for x in range(0, len(feature_vectors), vect_per_image)
-        ]
-        return np.average(image_vectors, axis=1)
+        image_vectors: dict = {}
+        for vector, tile in zip(feature_vectors, self.tiles):
+            data_idx = tile.get("index", None) if "index" in tile else tile.get("dataset_idx", None)
+            if data_idx in image_vectors:
+                # tile vectors
+                image_vectors[data_idx].append(vector)
+            else:
+                # whole image vector
+                image_vectors[data_idx] = [vector]
+        return [np.average(image, axis=0) for idx, image in image_vectors.items()]
 
     def merge_maps(self, saliency_maps: Union[List[List[np.ndarray]], List[np.ndarray]]) -> List:
         """Merge tile-level saliency maps to image-level saliency map.

--- a/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
@@ -506,11 +506,24 @@ class Tile:
         Returns:
             merged_maps (List[list | np.ndarray | None]): Merged saliency maps for each image.
         """
+
+        dtype = None
+        for map in saliency_maps:
+            for cl_map in map:
+                # find first class map which is not None
+                if cl_map is not None and dtype is None:
+                    dtype = map[0].dtype
+                    feat_h, feat_w = map[0].shape
+                    break
+            if dtype is not None:
+                break
+        else:
+            # if None for each class for each image
+            return saliency_maps[self.num_images :]
+
         merged_maps = []
         ratios = {}
         num_classes = len(saliency_maps[0])
-        feat_h, feat_w = saliency_maps[0][0].shape
-        dtype = saliency_maps[0][0][0].dtype
 
         for orig_image in self.cached_results:
             img_idx = orig_image["index"]

--- a/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
@@ -519,7 +519,7 @@ class Tile:
                 break
         else:
             # if None for each class for each image
-            return saliency_maps[self.num_images :]
+            return saliency_maps[: self.num_images]
 
         merged_maps = []
         ratios = {}

--- a/src/otx/api/utils/tiler.py
+++ b/src/otx/api/utils/tiler.py
@@ -340,6 +340,9 @@ class Tiler:
 
         image_map_h = int(image_h * ratio[0])
         image_map_w = int(image_w * ratio[1])
+        # happens because of the bug then tile_size for IR in a few times more than original image
+        if image_map_h == 0 or image_map_w == 0:
+            return [None] * num_classes
         merged_map = [np.zeros((image_map_h, image_map_w)) for _ in range(num_classes)]
 
         for (_, saliency_map), meta in features[1:]:


### PR DESCRIPTION
### Summary

This PR fixes the case that made e2e tiling test fail after merging [PR#2240](https://github.com/openvinotoolkit/training_extensions/pull/2240)

### How to test

```
pytest tests/e2e/cli/detection/test_tiling_detection.py
pytest tests/e2e/cli/instance_segmentation/test_tiling_instseg.py
```
e2e for detection
![image](https://github.com/openvinotoolkit/training_extensions/assets/33455576/95dc3db0-a7ba-40e8-a6a0-f6107a83722f)

e2e for segmentation. Failed NNCF tests with CUDA configuration error that probably is my local problem
![image](https://github.com/openvinotoolkit/training_extensions/assets/33455576/724cb54d-d9d3-4de1-9af8-52e8490f6f53)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
