### PR TITLE
Bug fix: difference between "otx eval" score and evaluation while training

### DIFF
--- a/src/otx/algorithms/segmentation/adapters/openvino/task.py
+++ b/src/otx/algorithms/segmentation/adapters/openvino/task.py
@@ -260,8 +260,6 @@ class OpenVINOSegmentationTask(IDeploymentTask, IInferenceTask, IEvaluationTask,
 
             if dump_soft_prediction:
                 for label_index, label in self._label_dictionary.items():
-                    if label_index == 0:
-                        continue
                     current_label_soft_prediction = soft_prediction[:, :, label_index]
                     if process_soft_prediction:
                         current_label_soft_prediction = get_activation_map(current_label_soft_prediction)

--- a/src/otx/algorithms/segmentation/task.py
+++ b/src/otx/algorithms/segmentation/task.py
@@ -23,7 +23,6 @@ import numpy as np
 import torch
 from mmcv.utils import ConfigDict
 
-from otx.api.entities.label_schema import natural_sort_label_id
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.base_task import TRAIN_TYPE_DIR_PATH, OTXTask
 from otx.algorithms.common.utils.callback import (
@@ -92,7 +91,7 @@ class OTXSegmentationTask(OTXTask, ABC):
         self._model_name = task_environment.model_template.name
         self._train_type = self._hyperparams.algo_backend.train_type
         self.metric = "mDice"
-        self._label_dictionary = dict(enumerate(sorted(self._labels, key=natural_sort_label_id), 1))
+        self._label_dictionary = dict(enumerate(self._labels, 1))
 
         self._model_dir = os.path.join(
             os.path.abspath(os.path.dirname(self._task_environment.model_template.model_template_path)),
@@ -288,8 +287,6 @@ class OTXSegmentationTask(OTXTask, ABC):
 
             if dump_soft_prediction:
                 for label_index, label in self._label_dictionary.items():
-                    if label_index == 0:
-                        continue
                     current_label_soft_prediction = soft_prediction[:, :, label_index]
                     if process_soft_prediction:
                         current_label_soft_prediction = get_activation_map(current_label_soft_prediction)

--- a/src/otx/algorithms/segmentation/task.py
+++ b/src/otx/algorithms/segmentation/task.py
@@ -91,7 +91,7 @@ class OTXSegmentationTask(OTXTask, ABC):
         self._model_name = task_environment.model_template.name
         self._train_type = self._hyperparams.algo_backend.train_type
         self.metric = "mDice"
-        self._label_dictionary = dict(enumerate(self._labels, 1))
+        self._label_dictionary = dict(enumerate(self._labels, 1))  # It should have same order as model class order
 
         self._model_dir = os.path.join(
             os.path.abspath(os.path.dirname(self._task_environment.model_template.model_template_path)),

--- a/src/otx/algorithms/segmentation/task.py
+++ b/src/otx/algorithms/segmentation/task.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 from mmcv.utils import ConfigDict
 
+from otx.api.entities.label_schema import natural_sort_label_id
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.base_task import TRAIN_TYPE_DIR_PATH, OTXTask
 from otx.algorithms.common.utils.callback import (
@@ -91,7 +92,7 @@ class OTXSegmentationTask(OTXTask, ABC):
         self._model_name = task_environment.model_template.name
         self._train_type = self._hyperparams.algo_backend.train_type
         self.metric = "mDice"
-        self._label_dictionary = dict(enumerate(sorted(self._labels), 1))
+        self._label_dictionary = dict(enumerate(sorted(self._labels, key=natural_sort_label_id), 1))
 
         self._model_dir = os.path.join(
             os.path.abspath(os.path.dirname(self._task_environment.model_template.model_template_path)),

--- a/src/otx/api/usecases/evaluation/dice.py
+++ b/src/otx/api/usecases/evaluation/dice.py
@@ -8,7 +8,6 @@
 from typing import Dict, List, Optional, Tuple
 import numpy as np
 
-from otx.api.entities.label_schema import natural_sort_label_id
 from otx.api.entities.label import LabelEntity
 from otx.api.entities.metrics import (
     BarChartInfo,
@@ -114,8 +113,7 @@ class DiceAverage(IPerformanceProvider):
             )
         resultset_labels = set(resultset.prediction_dataset.get_labels() + resultset.ground_truth_dataset.get_labels())
         model_labels = set(resultset.model.configuration.get_label_schema().get_labels(include_empty=False))
-        labels = sorted(resultset_labels.intersection(model_labels), key=natural_sort_label_id)
-        labels_map = {label: i + 1 for i, label in enumerate(labels)}
+        labels = sorted(resultset_labels.intersection(model_labels))
         hard_predictions = []
         hard_references = []
         for prediction_item, reference_item in zip(
@@ -127,6 +125,7 @@ class DiceAverage(IPerformanceProvider):
             except:
                 # when item consists of masks with Image properties
                 # TODO (sungchul): how to add condition to check if polygon or mask?
+                labels_map = {label: i + 1 for i, label in enumerate(labels)}
                 def combine_masks(annotations):
                     combined_mask = None
                     for annotation in annotations:

--- a/src/otx/api/usecases/evaluation/dice.py
+++ b/src/otx/api/usecases/evaluation/dice.py
@@ -8,6 +8,7 @@
 from typing import Dict, List, Optional, Tuple
 import numpy as np
 
+from otx.api.entities.label_schema import natural_sort_label_id
 from otx.api.entities.label import LabelEntity
 from otx.api.entities.metrics import (
     BarChartInfo,
@@ -113,7 +114,7 @@ class DiceAverage(IPerformanceProvider):
             )
         resultset_labels = set(resultset.prediction_dataset.get_labels() + resultset.ground_truth_dataset.get_labels())
         model_labels = set(resultset.model.configuration.get_label_schema().get_labels(include_empty=False))
-        labels = sorted(resultset_labels.intersection(model_labels))
+        labels = sorted(resultset_labels.intersection(model_labels), key=natural_sort_label_id)
         labels_map = {label: i + 1 for i, label in enumerate(labels)}
         hard_predictions = []
         hard_references = []

--- a/src/otx/api/usecases/evaluation/dice.py
+++ b/src/otx/api/usecases/evaluation/dice.py
@@ -126,6 +126,7 @@ class DiceAverage(IPerformanceProvider):
                 # when item consists of masks with Image properties
                 # TODO (sungchul): how to add condition to check if polygon or mask?
                 labels_map = {label: i + 1 for i, label in enumerate(labels)}
+
                 def combine_masks(annotations):
                     combined_mask = None
                     for annotation in annotations:

--- a/src/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/src/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -53,7 +53,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
         self.updated_label_id: Dict[int, int] = {}
 
         if hasattr(self, "data_type_candidates"):
-            if self.data_type_candidates[0] == "voc":
+            if "voc" in self.data_type_candidates[0]:
                 self.set_voc_labels()
 
             if self.data_type_candidates[0] == "common_semantic_segmentation":

--- a/src/otx/core/data/adapter/segmentation_dataset_adapter.py
+++ b/src/otx/core/data/adapter/segmentation_dataset_adapter.py
@@ -55,8 +55,7 @@ class SegmentationDatasetAdapter(BaseDatasetAdapter):
         if hasattr(self, "data_type_candidates"):
             if "voc" in self.data_type_candidates[0]:
                 self.set_voc_labels()
-
-            if self.data_type_candidates[0] == "common_semantic_segmentation":
+            elif self.data_type_candidates[0] == "common_semantic_segmentation":
                 self.set_common_labels()
 
         else:

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/datasets/test_dataset.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/datasets/test_dataset.py
@@ -67,7 +67,7 @@ class TestMPASegDataset:
         self.otx_dataset: DatasetEntity = DatasetEntity(items=[dataset_item()])
         self.pipeline: list[dict] = [{"type": "LoadImageFromOTXDataset", "to_float32": True}]
         self.classes: list[str] = [f"class_{i+1}" for i in range(11)]
-        labels_entities = [label_entity(name, i) for i, name in enumerate(self.classes)]
+        labels_entities = [label_entity(name, str(i)) for i, name in enumerate(self.classes)]
 
         mocker.patch.object(MPASegDataset, "filter_labels", return_value=labels_entities)
 

--- a/tests/unit/algorithms/segmentation/adapters/test_otx_segmentation_task.py
+++ b/tests/unit/algorithms/segmentation/adapters/test_otx_segmentation_task.py
@@ -8,6 +8,8 @@ import torch
 import pytest
 from mmcv import ConfigDict
 
+from otx.api.entities.label import LabelEntity, Domain
+from otx.api.entities.id import ID
 from otx.algorithms.segmentation.adapters.mmseg.task import MMSegmentationTask
 from otx.algorithms.segmentation.adapters.mmseg.models.heads import otx_head_factory
 from otx.api.configuration.helper import create
@@ -67,3 +69,24 @@ class TestMMSegmentationTask:
 
         mocker_load.assert_called_once()
         mocker_save.assert_called_once()
+
+    @e2e_pytest_unit
+    def test_label_order(self, mocker):
+        mocker.patch("otx.algorithms.segmentation.task.os")
+        mocker.patch("otx.algorithms.segmentation.task.TRAIN_TYPE_DIR_PATH")
+        mock_environemnt = mocker.MagicMock()
+
+        fake_label = []
+        for i in range(20):
+            fake_label.append(
+                LabelEntity(
+                    name=f"class_{i}",
+                    domain=Domain.SEGMENTATION,
+                    id=ID(str(i))
+                )
+            )
+        mock_environemnt.get_labels.return_value = fake_label
+        task = MMSegmentationTask(mock_environemnt)
+    
+        for i, label_entity in task._label_dictionary.items():
+            assert label_entity.name == f"class_{i-1}"

--- a/tests/unit/algorithms/segmentation/adapters/test_otx_segmentation_task.py
+++ b/tests/unit/algorithms/segmentation/adapters/test_otx_segmentation_task.py
@@ -78,15 +78,9 @@ class TestMMSegmentationTask:
 
         fake_label = []
         for i in range(20):
-            fake_label.append(
-                LabelEntity(
-                    name=f"class_{i}",
-                    domain=Domain.SEGMENTATION,
-                    id=ID(str(i))
-                )
-            )
+            fake_label.append(LabelEntity(name=f"class_{i}", domain=Domain.SEGMENTATION, id=ID(str(i))))
         mock_environemnt.get_labels.return_value = fake_label
         task = MMSegmentationTask(mock_environemnt)
-    
+
         for i, label_entity in task._label_dictionary.items():
             assert label_entity.name == f"class_{i-1}"


### PR DESCRIPTION
### Summary
I fixed tho bugs in this PR
This PR fixes #2296 

### Wrong label indices order while "otx eval"
There is a huge gap between "otx eval" score and evaluation while training score when number of classes is bigger than 10.
It's because wrong label is assigned when making annotation from predicted result after inference.
The reason of that is `self._label_dictionary` is used when assigning label but `self._label_dictionary` has wrong indices as below
<img width="502" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/92974184/b418d5b6-ed60-46c6-af05-45fb315327f5">
It'll be changed as below with this PR
<img width="509" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/92974184/4242466e-a8bb-4970-a34a-1f9953d7c726">

I fixed the bug by changing `dict(enumerate(sorted(self._labels), 1))` to `dict(enumerate(self._labels, 1))`.
self._labels are already sorted by considering string index as integer index. So, just letting it be can solve the bug.

### Using VOC dataset in segmentation task
I fixed a minor bug related to using voc dataset in segmentation task.
There is if statement to check that current dataset is voc with code below
```
if self.data_type_candidates[0] == "voc":
```
But in latest develop branch, `self.data_type_candidates` has value as below:
<img width="144" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/92974184/303ea63b-5a25-49c9-83af-d95b1e69bdbf">
I think it happens after updating Datumaro, but I'm not sure.
I don't know this solution is ok, so I really appreciate if you check the code.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
