### PR TITLE
Fix 'None' node issue in label schema mapping in case of label deletion (develop)

### DIFF
--- a/src/otx/api/serialization/label_mapper.py
+++ b/src/otx/api/serialization/label_mapper.py
@@ -139,9 +139,13 @@ class LabelTreeMapper:
 
         label_map = {label_id: all_labels.get(IDMapper().backward(label_id)) for label_id in instance["nodes"]}
         for label in label_map.values():
-            output.add_node(label)
+            if label:
+                output.add_node(label)
         for edge in instance["edges"]:
-            output.add_edge(label_map[edge[0]], label_map[edge[1]])
+            node1 = label_map.get(edge[0])
+            node2 = label_map.get(edge[1])
+            if node1 and node2:
+                output.add_edge(node1, node2)
 
         return output
 

--- a/tests/unit/api/serialization/test_label_mapper.py
+++ b/tests/unit/api/serialization/test_label_mapper.py
@@ -325,3 +325,30 @@ class TestLabelTreeMapper:
         }
         with pytest.raises(ValueError):
             LabelTreeMapper.backward(instance=forward, all_labels=labels)
+        # Checking label deletion case
+        forward = {
+            "type": "tree",
+            "directed": True,
+            "nodes": ["0", "0_1", "0_2", "0_1_1", "0_2_1"],
+            "edges": [("0_1", "0"), ("0_2", "0"), ("0_1_1", "0_1"), ("0_2_1", "0_2")],
+        }
+        labels = {
+            ID("0"): self.label_0,
+            ID("0_1"): self.label_0_1,
+            # ID("0_2"): self.label_0_2,
+            ID("0_1_1"): self.label_0_1_1,
+            # ID("0_1_2"): self.label_0_1_2,
+            ID("0_2_1"): self.label_0_2_1,
+        }
+        expected_backward = LabelTree()
+        for node in labels.values():
+            expected_backward.add_node(node)
+        for parent, child in [
+            (self.label_0, self.label_0_1),
+            # (self.label_0, self.label_0_2),
+            (self.label_0_1, self.label_0_1_1),
+            # (self.label_0_2, self.label_0_2_1),
+        ]:
+            expected_backward.add_child(parent, child)
+        actual_backward = LabelTreeMapper.backward(instance=forward, all_labels=labels)
+        assert LabelTreeMapper.forward(actual_backward) == LabelTreeMapper.forward(expected_backward)


### PR DESCRIPTION
### Summary

Copy of https://github.com/openvinotoolkit/training_extensions/pull/2300

### How to test

Unit test

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
