### PR TITLE
[Bug] Fix eval segm multiprocess spawn issue

### DIFF
--- a/src/otx/algorithms/detection/adapters/mmdet/evaluation/evaluator.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/evaluation/evaluator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from multiprocessing import Pool
+import multiprocessing as mp
 from typing import Dict, List, Tuple
 
 import mmcv
@@ -300,54 +300,47 @@ class Evaluator:
         """
         assert len(results) == len(self.annotation[0]), "number of images should be equal!"
         num_imgs = len(results)
-        pool = Pool(self.nproc)  # pylint: disable=consider-using-with
         eval_results = []
-        for class_id in range(self.num_classes):
-            # get gt and det bboxes of this class
-            cls_dets, cls_scores = self.get_mask_det_results(results, class_id)
-            cls_gts = self.annotation[class_id]
 
-            # compute tp and fp for each image with multiple processes
-            tpfpmiou = pool.starmap(
-                tpfpmiou_func, zip(cls_dets, cls_gts, cls_scores, [iou_thr for _ in range(num_imgs)])
-            )
-            tp, fp, miou = tuple(zip(*tpfpmiou))  # pylint: disable=invalid-name
+        ctx = mp.get_context("spawn")
+        with ctx.Pool(self.nproc) as p:
+            for class_id in range(self.num_classes):
+                # get gt and det bboxes of this class
+                cls_dets, cls_scores = self.get_mask_det_results(results, class_id)
+                cls_gts = self.annotation[class_id]
 
-            # NOTE: Use the following instead as Coverage could not pick up thread pool func.
-            # tp, fp, miou = [], [], []
-            # for i in range(num_imgs):
-            #     _tp, _fp, _miou = tpfpmiou_func(cls_dets[i], cls_gts[i], cls_scores[i], iou_thr)
-            #     tp.append(_tp)
-            #     fp.append(_fp)
-            #     miou.append(_miou)
+                # compute tp and fp for each image with multiple processes
+                tpfpmiou = p.starmap(
+                    tpfpmiou_func, zip(cls_dets, cls_gts, cls_scores, [iou_thr for _ in range(num_imgs)])
+                )
+        tp, fp, miou = tuple(zip(*tpfpmiou))  # pylint: disable=invalid-name
 
-            # sort all det bboxes by score, also sort tp and fp
-            cls_scores = np.hstack(cls_scores)
-            num_dets = cls_scores.shape[0]
-            num_gts = np.sum([len(cls_gts) for cls_gts in cls_gts])
-            sort_inds = np.argsort(cls_scores)[::-1]
-            tp = np.hstack(tp)[sort_inds]  # pylint: disable=invalid-name
-            fp = np.hstack(fp)[sort_inds]  # pylint: disable=invalid-name
-            # calculate recall and precision with tp and fp
-            tp = np.cumsum(tp)  # pylint: disable=invalid-name
-            fp = np.cumsum(fp)  # pylint: disable=invalid-name
-            eps = np.finfo(np.float32).eps
-            recalls = tp / np.maximum(num_gts, eps)
-            precisions = tp / np.maximum((tp + fp), eps)
-            miou = np.mean(np.stack(miou))
-            # calculate AP
-            ap = average_precision(recalls, precisions, "area")  # pylint: disable=invalid-name
-            eval_results.append(
-                {
-                    "num_gts": num_gts,
-                    "num_dets": num_dets,
-                    "recall": recalls,
-                    "precision": precisions,
-                    "ap": ap,
-                    "miou": miou,
-                }
-            )
-        pool.close()
+        # sort all det bboxes by score, also sort tp and fp
+        cls_scores = np.hstack(cls_scores)
+        num_dets = cls_scores.shape[0]
+        num_gts = np.sum([len(cls_gts) for cls_gts in cls_gts])
+        sort_inds = np.argsort(cls_scores)[::-1]
+        tp = np.hstack(tp)[sort_inds]  # pylint: disable=invalid-name
+        fp = np.hstack(fp)[sort_inds]  # pylint: disable=invalid-name
+        # calculate recall and precision with tp and fp
+        tp = np.cumsum(tp)  # pylint: disable=invalid-name
+        fp = np.cumsum(fp)  # pylint: disable=invalid-name
+        eps = np.finfo(np.float32).eps
+        recalls = tp / np.maximum(num_gts, eps)
+        precisions = tp / np.maximum((tp + fp), eps)
+        miou = np.mean(np.stack(miou))
+        # calculate AP
+        ap = average_precision(recalls, precisions, "area")  # pylint: disable=invalid-name
+        eval_results.append(
+            {
+                "num_gts": num_gts,
+                "num_dets": num_dets,
+                "recall": recalls,
+                "precision": precisions,
+                "ap": ap,
+                "miou": miou,
+            }
+        )
 
         metrics = {"mAP": 0.0, "mIoU": 0.0}
         mious, aps = [], []

--- a/src/otx/algorithms/detection/adapters/mmdet/evaluation/evaluator.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/evaluation/evaluator.py
@@ -303,44 +303,44 @@ class Evaluator:
         eval_results = []
 
         ctx = mp.get_context("spawn")
-        for class_id in range(self.num_classes):
-            # get gt and det bboxes of this class
-            cls_dets, cls_scores = self.get_mask_det_results(results, class_id)
-            cls_gts = self.annotation[class_id]
+        with ctx.Pool(self.nproc) as p:
+            for class_id in range(self.num_classes):
+                # get gt and det bboxes of this class
+                cls_dets, cls_scores = self.get_mask_det_results(results, class_id)
+                cls_gts = self.annotation[class_id]
 
-            # compute tp and fp for each image with multiple processes
-            with ctx.Pool(self.nproc) as p:
+                # compute tp and fp for each image with multiple processes
                 tpfpmiou = p.starmap(
                     tpfpmiou_func, zip(cls_dets, cls_gts, cls_scores, [iou_thr for _ in range(num_imgs)])
                 )
-            tp, fp, miou = tuple(zip(*tpfpmiou))  # pylint: disable=invalid-name
+                tp, fp, miou = tuple(zip(*tpfpmiou))  # pylint: disable=invalid-name
 
-            # sort all det bboxes by score, also sort tp and fp
-            cls_scores = np.hstack(cls_scores)
-            num_dets = cls_scores.shape[0]
-            num_gts = np.sum([len(cls_gts) for cls_gts in cls_gts])
-            sort_inds = np.argsort(cls_scores)[::-1]
-            tp = np.hstack(tp)[sort_inds]  # pylint: disable=invalid-name
-            fp = np.hstack(fp)[sort_inds]  # pylint: disable=invalid-name
-            # calculate recall and precision with tp and fp
-            tp = np.cumsum(tp)  # pylint: disable=invalid-name
-            fp = np.cumsum(fp)  # pylint: disable=invalid-name
-            eps = np.finfo(np.float32).eps
-            recalls = tp / np.maximum(num_gts, eps)
-            precisions = tp / np.maximum((tp + fp), eps)
-            miou = np.mean(np.stack(miou))
-            # calculate AP
-            ap = average_precision(recalls, precisions, "area")  # pylint: disable=invalid-name
-            eval_results.append(
-                {
-                    "num_gts": num_gts,
-                    "num_dets": num_dets,
-                    "recall": recalls,
-                    "precision": precisions,
-                    "ap": ap,
-                    "miou": miou,
-                }
-            )
+                # sort all det bboxes by score, also sort tp and fp
+                cls_scores = np.hstack(cls_scores)
+                num_dets = cls_scores.shape[0]
+                num_gts = np.sum([len(cls_gts) for cls_gts in cls_gts])
+                sort_inds = np.argsort(cls_scores)[::-1]
+                tp = np.hstack(tp)[sort_inds]  # pylint: disable=invalid-name
+                fp = np.hstack(fp)[sort_inds]  # pylint: disable=invalid-name
+                # calculate recall and precision with tp and fp
+                tp = np.cumsum(tp)  # pylint: disable=invalid-name
+                fp = np.cumsum(fp)  # pylint: disable=invalid-name
+                eps = np.finfo(np.float32).eps
+                recalls = tp / np.maximum(num_gts, eps)
+                precisions = tp / np.maximum((tp + fp), eps)
+                miou = np.mean(np.stack(miou))
+                # calculate AP
+                ap = average_precision(recalls, precisions, "area")  # pylint: disable=invalid-name
+                eval_results.append(
+                    {
+                        "num_gts": num_gts,
+                        "num_dets": num_dets,
+                        "recall": recalls,
+                        "precision": precisions,
+                        "ap": ap,
+                        "miou": miou,
+                    }
+                )
 
         metrics = {"mAP": 0.0, "mIoU": 0.0}
         mious, aps = [], []


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

User `ctx = mp.get_context("spawn")` avoiding HPO multiprocess issue.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
