### PR TITLE
Fix semantic segmentation soft prediction dtype

### DIFF
--- a/src/otx/algorithms/segmentation/adapters/openvino/task.py
+++ b/src/otx/algorithms/segmentation/adapters/openvino/task.py
@@ -240,6 +240,8 @@ class OpenVINOSegmentationTask(IDeploymentTask, IInferenceTask, IEvaluationTask,
                     current_label_soft_prediction = soft_prediction[:, :, label_index]
                     if process_soft_prediction:
                         current_label_soft_prediction = get_activation_map(current_label_soft_prediction)
+                    else:
+                        current_label_soft_prediction = (current_label_soft_prediction * 255).astype(np.uint8)
                     result_media = ResultMediaEntity(
                         name=label.name,
                         type="soft_prediction",

--- a/src/otx/algorithms/segmentation/task.py
+++ b/src/otx/algorithms/segmentation/task.py
@@ -290,6 +290,8 @@ class OTXSegmentationTask(OTXTask, ABC):
                     current_label_soft_prediction = soft_prediction[:, :, label_index]
                     if process_soft_prediction:
                         current_label_soft_prediction = get_activation_map(current_label_soft_prediction)
+                    else:
+                        current_label_soft_prediction = (current_label_soft_prediction * 255).astype(np.uint8)
                     result_media = ResultMediaEntity(
                         name=label.name,
                         type="soft_prediction",

--- a/tests/unit/algorithms/classification/test_xai_classification_validity.py
+++ b/tests/unit/algorithms/classification/test_xai_classification_validity.py
@@ -54,4 +54,4 @@ class TestExplainMethods:
         assert len(saliency_maps) == 2
         assert saliency_maps[0].ndim == 3
         assert saliency_maps[0].shape == (1000, 7, 7)
-        assert (saliency_maps[0][0][0] == self.ref_saliency_vals_cls[template.name]).all()
+        assert np.all(np.abs(saliency_maps[0][0][0] - self.ref_saliency_vals_cls[template.name]) <= 1)

--- a/tests/unit/algorithms/detection/test_xai_detection_validity.py
+++ b/tests/unit/algorithms/detection/test_xai_detection_validity.py
@@ -80,7 +80,7 @@ class TestExplainMethods:
         assert len(saliency_maps) == 2
         assert saliency_maps[0].ndim == 3
         assert saliency_maps[0].shape == self.ref_saliency_shapes[template.name]
-        assert (saliency_maps[0][0][0] == self.ref_saliency_vals_det[template.name]).all()
+        assert np.all(np.abs(saliency_maps[0][0][0] - self.ref_saliency_vals_det[template.name]) <= 1)
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("template", templates_det, ids=templates_det_ids)


### PR DESCRIPTION
### Summary
Geti apply_colormap function requires it to be in uint8, rather than float32
Follow up fix for https://jira.devtools.intel.com/browse/CVS-114142

Apply for the torch task for the unification as well

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
