### PR TITLE
Contrain yapf verison lesser than 0.40.0

### DIFF
--- a/requirements/action.txt
+++ b/requirements/action.txt
@@ -4,3 +4,4 @@ mmcv-full==1.7.0
 mmaction2==0.24.1
 mmdet==2.28.1
 mmdeploy==0.14.0
+yapf<0.40.0  # it should be removed after https://github.com/google/yapf/issues/1118 is solved 

--- a/requirements/classification.txt
+++ b/requirements/classification.txt
@@ -5,3 +5,4 @@ mmcls==0.25.0
 timm==0.6.12
 mmdeploy==0.14.0
 pytorchcv
+yapf<0.40.0  # it should be removed after https://github.com/google/yapf/issues/1118 is solved 

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -8,3 +8,4 @@ timm==0.6.12
 mmdeploy==0.14.0
 mmengine==0.7.4
 scikit-image
+yapf<0.40.0  # it should be removed after https://github.com/google/yapf/issues/1118 is solved 

--- a/requirements/segmentation.txt
+++ b/requirements/segmentation.txt
@@ -7,3 +7,4 @@ mmdeploy==0.14.0
 timm==0.6.12
 pytorchcv
 einops==0.6.1
+yapf<0.40.0  # it should be removed after https://github.com/google/yapf/issues/1118 is solved 


### PR DESCRIPTION
### Summary
An error occurs intermittently when import yapf as below
![image](https://github.com/openvinotoolkit/training_extensions/assets/92974184/e0ba550f-e13d-4179-ba68-2d17b599db10)


It come from a file which appear since 0.40.0.
To solve this error, make a constraint to version of yapf package.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
