### PR TITLE
Bump otx version to 1.4.0rc2

### DIFF
--- a/src/otx/__init__.py
+++ b/src/otx/__init__.py
@@ -3,5 +3,5 @@
 # Copyright (C) 2021-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.0rc1"
+__version__ = "1.4.0rc2"
 # NOTE: Sync w/ src/otx/api/usecases/exportable_code/demo/requirements.txt on release

--- a/src/otx/api/usecases/exportable_code/demo/requirements.txt
+++ b/src/otx/api/usecases/exportable_code/demo/requirements.txt
@@ -1,4 +1,4 @@
 openvino==2023.0
 openvino-model-api==0.1.2
-otx==1.4.0rc1
+otx==1.4.0rc2
 numpy>=1.21.0,<=1.23.5  # np.bool was removed in 1.24.0 which was used in openvino runtime


### PR DESCRIPTION
### Summary

Bump otx version to 1.4.0rc2