### PR TITLE
Call otx.cli before the TaskType is imported

### DIFF
--- a/src/otx/cli/__init__.py
+++ b/src/otx/cli/__init__.py
@@ -5,6 +5,7 @@
 
 import os
 
+# This must be called before the first TaskType is imported to take effect.
 # How to make an Action Template invisible in Geti
 # Check FEATURE_FLAGS_OTX_ACTION_TASKS in the API to determine whether to use the Action
 # Always 1 in the OTX CLI

--- a/src/otx/cli/tools/demo.py
+++ b/src/otx/cli/tools/demo.py
@@ -20,6 +20,8 @@ from collections import deque
 import cv2
 import numpy as np
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.api.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
 from otx.api.entities.datasets import DatasetEntity, DatasetItemEntity
 from otx.api.entities.image import Image

--- a/src/otx/cli/tools/deploy.py
+++ b/src/otx/cli/tools/deploy.py
@@ -16,6 +16,8 @@
 
 from pathlib import Path
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.api.configuration.helper import create
 from otx.api.entities.model import ModelEntity
 from otx.api.entities.task_environment import TaskEnvironment

--- a/src/otx/cli/tools/eval.py
+++ b/src/otx/cli/tools/eval.py
@@ -17,6 +17,8 @@
 import json
 from pathlib import Path
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.api.entities.inference_parameters import InferenceParameters
 from otx.api.entities.model_template import TaskType
 from otx.api.entities.resultset import ResultSetEntity

--- a/src/otx/cli/tools/explain.py
+++ b/src/otx/cli/tools/explain.py
@@ -16,6 +16,8 @@
 
 from pathlib import Path
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.algorithms.common.utils.logger import get_logger
 from otx.api.entities.explain_parameters import ExplainParameters
 from otx.api.entities.task_environment import TaskEnvironment

--- a/src/otx/cli/tools/export.py
+++ b/src/otx/cli/tools/export.py
@@ -16,6 +16,8 @@
 
 from pathlib import Path
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.api.configuration.helper import create
 from otx.api.entities.model import ModelEntity, ModelOptimizationType, ModelPrecision
 from otx.api.entities.task_environment import TaskEnvironment

--- a/src/otx/cli/tools/optimize.py
+++ b/src/otx/cli/tools/optimize.py
@@ -17,6 +17,8 @@
 import json
 from pathlib import Path
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.api.entities.inference_parameters import InferenceParameters
 from otx.api.entities.model import ModelEntity
 from otx.api.entities.optimization_parameters import OptimizationParameters

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -22,6 +22,8 @@ from contextlib import ExitStack
 from pathlib import Path
 from typing import Optional
 
+# Update environment variables for CLI use
+import otx.cli  # noqa: F401
 from otx.api.entities.model import ModelEntity
 from otx.api.entities.task_environment import TaskEnvironment
 from otx.api.entities.train_parameters import TrainParameters


### PR DESCRIPTION
### Summary

Issue: https://jira.devtools.intel.com/browse/CVS-115068
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/eac8da5e-8f48-463b-8748-a763abbfdf55)

Issue Description : Found issue with environment variable updates not working properly when accessing tools/train.py directly instead of the otx cli 

Issue Cause : The environment variable must be modified before the TaskType is imported for it to work as intended. (Currently, TaskType import -> Environment variable update)

Current Solution: Fix so that otx.cli imports always precede TaskType imports

### How to test

`python src/otx/cli/train.py --train-data-roots {data-path}` is working now
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/e081dc5e-2f54-4db3-9459-7003f7f09d2d)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
