### PR TITLE
Enable `deterministic` for anomalib and visual prompting

### DIFF
--- a/src/otx/algorithms/anomaly/tasks/train.py
+++ b/src/otx/algorithms/anomaly/tasks/train.py
@@ -67,7 +67,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
         if seed:
             logger.info(f"Setting seed to {seed}")
             seed_everything(seed, workers=True)
-        config.trainer.deterministic = deterministic
+        self.config.trainer.deterministic = "warn" if deterministic else deterministic
 
         logger.info("Training Configs '%s'", config)
 

--- a/src/otx/algorithms/anomaly/tasks/train.py
+++ b/src/otx/algorithms/anomaly/tasks/train.py
@@ -67,7 +67,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
         if seed:
             logger.info(f"Setting seed to {seed}")
             seed_everything(seed, workers=True)
-        self.config.trainer.deterministic = "warn" if deterministic else deterministic
+        config.trainer.deterministic = "warn" if deterministic else deterministic
 
         logger.info("Training Configs '%s'", config)
 

--- a/src/otx/algorithms/visual_prompting/tasks/train.py
+++ b/src/otx/algorithms/visual_prompting/tasks/train.py
@@ -65,7 +65,7 @@ class TrainingTask(InferenceTask, ITrainingTask):
         if seed:
             logger.info(f"Setting seed to {seed}")
             seed_everything(seed, workers=True)
-        self.config.trainer.deterministic = deterministic
+        self.config.trainer.deterministic = "warn" if deterministic else deterministic
 
         logger.info("Training Configs '%s'", self.config)
 

--- a/tests/e2e/cli/anomaly/test_anomaly_classification.py
+++ b/tests/e2e/cli/anomaly/test_anomaly_classification.py
@@ -58,7 +58,7 @@ class TestToolsAnomalyClassification:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/anomaly/test_anomaly_detection.py
+++ b/tests/e2e/cli/anomaly/test_anomaly_detection.py
@@ -58,7 +58,7 @@ class TestToolsAnomalyDetection:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/anomaly/test_anomaly_segmentation.py
+++ b/tests/e2e/cli/anomaly/test_anomaly_segmentation.py
@@ -58,7 +58,7 @@ class TestToolsAnomalySegmentation:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/e2e/cli/visual_prompting/test_visual_prompting.py
+++ b/tests/e2e/cli/visual_prompting/test_visual_prompting.py
@@ -19,9 +19,6 @@ from tests.test_suite.run_test_command import (
     otx_export_testing,
     otx_resume_testing,
     otx_train_testing,
-    pot_eval_testing,
-    pot_optimize_testing,
-    pot_validate_fq_testing,
 )
 
 args = {

--- a/tests/e2e/cli/visual_prompting/test_visual_prompting.py
+++ b/tests/e2e/cli/visual_prompting/test_visual_prompting.py
@@ -73,11 +73,11 @@ class TestToolsVisualPrompting:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "visual_prompting"
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
         template_work_dir = get_template_dir(template, tmp_dir_path)
         args1 = copy.deepcopy(args)
         args1["--load-weights"] = f"{template_work_dir}/trained_{template.model_template_id}/models/weights.pth"
-        otx_train_testing(template, tmp_dir_path, otx_dir, args1, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")

--- a/tests/integration/cli/anomaly/test_anomaly_classification.py
+++ b/tests/integration/cli/anomaly/test_anomaly_classification.py
@@ -42,7 +42,7 @@ class TestToolsAnomalyClassification:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/anomaly/test_anomaly_detection.py
+++ b/tests/integration/cli/anomaly/test_anomaly_detection.py
@@ -42,7 +42,7 @@ class TestToolsAnomalyDetection:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/anomaly/test_anomaly_segmentation.py
+++ b/tests/integration/cli/anomaly/test_anomaly_segmentation.py
@@ -42,7 +42,7 @@ class TestToolsAnomalySegmentation:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)

--- a/tests/integration/cli/visual_prompting/test_visual_prompting.py
+++ b/tests/integration/cli/visual_prompting/test_visual_prompting.py
@@ -61,7 +61,7 @@ class TestVisualPromptingCLI:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "visual_prompting"
-        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=False)
+        otx_train_testing(template, tmp_dir_path, otx_dir, args, deterministic=True)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Those tasks are implemented based on pytorch lightning.
In order to use `deterministic=True`, it should be set as `deterministic=warn` for `Trainer` (because otx supports `torch==1.13`), but otx only gets `deterministic` argument as `bool`.
So, inner patching in `task.train` is required to use `deterministic=True`.

Reference:
https://github.com/Lightning-AI/lightning/blob/a020506a81a671e380872aa5e435647b549e14e6/src/pytorch_lightning/trainer/connectors/accelerator_connector.py#L222-L227

- [x] Update `deterministic` from `False` to `True`
- [x] Remove unused pot test modules in visual prompting e2e test

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```shell
$ tox -e tests-ano-py310 -- tests/integration/cli/anomaly
================================================================= short test summary info ==================================================================FAILED tests/integration/cli/anomaly/test_anomaly_classification.py::TestToolsAnomalyClassification::test_nncf_optimize[ote_anomaly_classification_stfpm] - AssertionError: Traceback (most recent call last):
FAILED tests/integration/cli/anomaly/test_anomaly_classification.py::TestToolsAnomalyClassification::test_nncf_optimize[ote_anomaly_classification_padim] - AssertionError: Traceback (most recent call last):
FAILED tests/integration/cli/anomaly/test_anomaly_detection.py::TestToolsAnomalyDetection::test_nncf_optimize[ote_anomaly_detection_stfpm] - AssertionError: Traceback (most recent call last):
FAILED tests/integration/cli/anomaly/test_anomaly_detection.py::TestToolsAnomalyDetection::test_nncf_optimize[ote_anomaly_detection_padim] - AssertionError: Traceback (most recent call last):
FAILED tests/integration/cli/anomaly/test_anomaly_segmentation.py::TestToolsAnomalySegmentation::test_nncf_optimize[ote_anomaly_segmentation_stfpm] - AssertionError: Traceback (most recent call last):
FAILED tests/integration/cli/anomaly/test_anomaly_segmentation.py::TestToolsAnomalySegmentation::test_nncf_optimize[ote_anomaly_segmentation_padim] - AssertionError: Traceback (most recent call last):
=================================================== 6 failed, 57 passed, 1 warning in 723.59s (0:12:03) ====================================================
-> All fails occurred because nvcc is unavailable in ikvensx010

$ tox -e tests-visprompt-py310 -- tests/integration/cli/visual_prompting
=================================================== 8 passed, 2 skipped, 1 warning in 169.33s (0:02:49) ====================================================

$ tox -e tests-ano-py310 -- tests/e2e/cli/anomaly
-WIP-

$ tox -e tests-visprompt-py310 -- tests/e2e/cli/visual_prompting
========================================================= 7 passed, 1 warning in 176.92s (0:02:56) =========================================================
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
