### PR TITLE
Make anomaly task compatible with older albumentations versions

### DIFF
--- a/requirements/anomaly.txt
+++ b/requirements/anomaly.txt
@@ -1,6 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Anomaly Requirements.
-albumentations>=1.3.0
 torchvision<0.15.1
 torchtext<0.15.1
 anomalib==0.5.1

--- a/src/otx/algorithms/anomaly/tasks/inference.py
+++ b/src/otx/algorithms/anomaly/tasks/inference.py
@@ -338,7 +338,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             model.set_rt_info(value, ["model_info", key])
         # Add transforms
         if "transform" in metadata:
-            for transform_dict in metadata["transform"]["transform"]["transforms"]:
+            for transform_dict in metadata["transform"]["transforms"]:
                 transform = transform_dict.pop("__class_fullname__")
                 if transform == "Normalize":
                     model.set_rt_info(self._serialize_list(transform_dict["mean"]), ["model_info", "mean_values"])
@@ -425,7 +425,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             else:
                 transform = self.trainer.datamodule.train_dataloader().dataset.transform
         metadata = {
-            "transform": transform.to_dict(),
+            "transform": transform._to_dict(),
             "image_threshold": image_threshold,
             "pixel_threshold": pixel_threshold,
             "image_shape": list(self.config.model.input_size),

--- a/src/otx/algorithms/anomaly/tasks/inference.py
+++ b/src/otx/algorithms/anomaly/tasks/inference.py
@@ -338,7 +338,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             model.set_rt_info(value, ["model_info", key])
         # Add transforms
         if "transform" in metadata:
-            for transform_dict in metadata["transform"]["transforms"]:
+            for transform_dict in metadata["transform"]["transform"]["transforms"]:
                 transform = transform_dict.pop("__class_fullname__")
                 if transform == "Normalize":
                     model.set_rt_info(self._serialize_list(transform_dict["mean"]), ["model_info", "mean_values"])
@@ -425,7 +425,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             else:
                 transform = self.trainer.datamodule.train_dataloader().dataset.transform
         metadata = {
-            "transform": transform._to_dict(),
+            "transform": {"transform": transform._to_dict()},
             "image_threshold": image_threshold,
             "pixel_threshold": pixel_threshold,
             "image_shape": list(self.config.model.input_size),

--- a/src/otx/algorithms/anomaly/tasks/inference.py
+++ b/src/otx/algorithms/anomaly/tasks/inference.py
@@ -425,6 +425,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             else:
                 transform = self.trainer.datamodule.train_dataloader().dataset.transform
         metadata = {
+            # TODO: Replace with transform.to_dict() when OTX supports albumentations 1.3.0
             "transform": {"transform": transform._to_dict()},
             "image_threshold": image_threshold,
             "pixel_threshold": pixel_threshold,


### PR DESCRIPTION
### Summary

Makes the anomaly task compatible with older albumentations versions that do not have the `Compose.to_dict` method

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
