### PR TITLE
Align label order between Geti and OTX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix the bug that auto adapt batch size is unavailable with IterBasedRunner (<https://github.com/openvinotoolkit/training_extensions/pull/2182>)
 - Fix the bug that learning rate isn't scaled when multi-GPU trianing is enabled(<https://github.com/openvinotoolkit/training_extensions/pull/2254>)
+- Fix the bug that label order is misaligned when model is deployed from Geti (<https://github.com/openvinotoolkit/training_extensions/pull/2369>)
 
 ### Known issues
 

--- a/src/otx/api/entities/label_schema.py
+++ b/src/otx/api/entities/label_schema.py
@@ -41,9 +41,9 @@ def natural_sort_label_id(target: Union[ID, LabelEntity, ScoredLabel]) -> List:
 
     if isinstance(target, (LabelEntity, ScoredLabel)):
         target = target.id_
-    if isinstance(target, int):
-        return [target]
-    return [int(t) if t.isdigit() else t for t in re.split(r"(\d+)", target)]
+    if target.isdecimal():
+        return [int(target)]
+    return [target]
 
 
 class LabelGroupExistsException(ValueError):

--- a/src/otx/api/entities/label_schema.py
+++ b/src/otx/api/entities/label_schema.py
@@ -41,8 +41,8 @@ def natural_sort_label_id(target: Union[ID, LabelEntity, ScoredLabel]) -> List:
 
     if isinstance(target, (LabelEntity, ScoredLabel)):
         target = target.id_
-    if target.isdecimal():
-        return [int(target)]
+    if isinstance(target, str) and target.isdecimal():
+        return ["", int(target)]  # "" is added for the case where id of some lables is None
     return [target]
 
 

--- a/src/otx/api/entities/label_schema.py
+++ b/src/otx/api/entities/label_schema.py
@@ -21,14 +21,14 @@ from otx.api.entities.scored_label import ScoredLabel
 logger = logging.getLogger(__name__)
 
 
-def natural_sort_label_id(target: Union[ID, LabelEntity, ScoredLabel]) -> List:
+def natural_sort_label_id(target: Union[ID, LabelEntity, ScoredLabel]) -> List[Union[int, str]]:
     """Generates a natural sort key for a LabelEntity object based on its ID.
 
     Args:
     target (Union[ID, LabelEntity]): The ID or LabelEntity or ScoredLabel object to be sorted.
 
     Returns:
-    List[int]: A list of integers representing the numeric substrings in the ID
+    List[Union[int, str]]: A list of integers representing the numeric substrings in the ID
     in the order they appear.
 
     Example:

--- a/tests/unit/api/entities/test_label_schema.py
+++ b/tests/unit/api/entities/test_label_schema.py
@@ -25,7 +25,6 @@ from tests.unit.api.constants.components import OtxSdkComponent
 from tests.unit.api.constants.requirements import Requirements
 
 
-
 def get_label_entity(id_val: str):
     return LabelEntity(name=id_val, domain=Domain.DETECTION, id=ID(id_val))
 

--- a/tests/unit/api/entities/test_label_schema.py
+++ b/tests/unit/api/entities/test_label_schema.py
@@ -5,7 +5,7 @@
 #
 
 import pytest
-from networkx.classes.reportviews import EdgeDataView, NodeView, OutMultiEdgeDataView
+from networkx.classes.reportviews import NodeView, OutMultiEdgeDataView
 
 from otx.api.entities.color import Color
 from otx.api.entities.id import ID
@@ -19,9 +19,33 @@ from otx.api.entities.label_schema import (
     LabelSchemaEntity,
     LabelTree,
     ScoredLabel,
+    natural_sort_label_id,
 )
 from tests.unit.api.constants.components import OtxSdkComponent
 from tests.unit.api.constants.requirements import Requirements
+
+
+
+def get_label_entity(id_val: str):
+    return LabelEntity(name=id_val, domain=Domain.DETECTION, id=ID(id_val))
+
+
+def get_scored_label(id_val: str):
+    return ScoredLabel(label=get_label_entity(id_val))
+
+
+@pytest.mark.priority_medium
+@pytest.mark.unit
+@pytest.mark.reqids(Requirements.REQ_1)
+@pytest.mark.parametrize("id_val", ["3", "fake1name2"])
+@pytest.mark.parametrize("target_class", [ID, get_label_entity, get_scored_label])
+def test_natural_sort_label_id(id_val: str, target_class):
+    target = target_class(id_val)
+
+    if id_val.isdecimal():
+        assert natural_sort_label_id(target) == [int(id_val)]
+    else:
+        assert natural_sort_label_id(target) == [id_val]
 
 
 @pytest.mark.components(OtxSdkComponent.OTX_API)

--- a/tests/unit/api/entities/test_label_schema.py
+++ b/tests/unit/api/entities/test_label_schema.py
@@ -42,7 +42,7 @@ def test_natural_sort_label_id(id_val: str, target_class):
     target = target_class(id_val)
 
     if id_val.isdecimal():
-        assert natural_sort_label_id(target) == [int(id_val)]
+        assert natural_sort_label_id(target) == ["", int(id_val)]
     else:
         assert natural_sort_label_id(target) == [id_val]
 

--- a/tests/unit/api/usecases/exportable_code/test_prediction_to_annotation_converter.py
+++ b/tests/unit/api/usecases/exportable_code/test_prediction_to_annotation_converter.py
@@ -750,7 +750,6 @@ class TestSegmentationToAnnotation:
             )
             label_schema = LabelSchemaEntity(label_groups=[label_group, other_label_group])
             converter = ClassificationToAnnotationConverter(label_schema=label_schema)
-            assert converter.labels == non_empty_labels + other_non_empty_labels
             assert not converter.empty_label
             assert converter.label_schema == label_schema
             assert converter.hierarchical


### PR DESCRIPTION
### Summary
When model is deployed from Geti and then run it on local, order of label is wrong.
It's because Geti makes label using hexadecimal and then sorts it by str order as below
<img width="138" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/92974184/ed07cd7a-f683-4094-b7f6-0f653c3c810b">
But OTX sorts it by integer in string. What 'sorts it by integer in string.' means is that label is split by integer and integer format string is converted to real integer and then all split partt are wrapped by list. And that list is used as key for sorting. For example, if label id is "123abc123" then key is [123, "abc", 123].
This difference makes misalignment between Geti and OTX, so I changed function making sorting key to return original id if id isn't decimal format.
Some latent problem from change may exists, so please let me know if you have suspicious part.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
