### PR TITLE
Switch to PTQ for sseg

### DIFF
--- a/src/otx/algorithms/action/adapters/openvino/task.py
+++ b/src/otx/algorithms/action/adapters/openvino/task.py
@@ -334,4 +334,4 @@ class ActionOpenVINOTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IOpti
 
         if optimization_parameters is not None:
             optimization_parameters.update_progress(100, None)
-        logger.info("POT optimization completed")
+        logger.info("PTQ optimization completed")

--- a/src/otx/algorithms/anomaly/tasks/openvino.py
+++ b/src/otx/algorithms/anomaly/tasks/openvino.py
@@ -333,7 +333,7 @@ class OpenVINOTask(IInferenceTask, IEvaluationTask, IOptimizationTask, IDeployme
 
         if optimization_parameters is not None:
             optimization_parameters.update_progress(100, None)
-        logger.info("POT optimization completed")
+        logger.info("PTQ optimization completed")
 
     def load_inferencer(self) -> OpenVINOInferencer:
         """Create the OpenVINO inferencer object.

--- a/src/otx/algorithms/segmentation/adapters/openvino/task.py
+++ b/src/otx/algorithms/segmentation/adapters/openvino/task.py
@@ -403,4 +403,4 @@ class OpenVINOSegmentationTask(IDeploymentTask, IInferenceTask, IEvaluationTask,
 
         if optimization_parameters is not None:
             optimization_parameters.update_progress(100, None)
-        logger.info("POT optimization completed")
+        logger.info("PTQ optimization completed")

--- a/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/ptq_optimization_config.py
@@ -18,7 +18,6 @@ advanced_parameters = AdvancedQuantizationParameters(
             statistics_type=StatisticsType.QUANTILE, aggregator_type=AggregatorType.MAX, quantile_outlier_prob=1e-4
         ),
     ),
-    backend_params={"use_pot": True},
 )
 
 preset = QuantizationPreset.MIXED

--- a/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_s_mod2/ptq_optimization_config.py
@@ -18,7 +18,6 @@ advanced_parameters = AdvancedQuantizationParameters(
             statistics_type=StatisticsType.QUANTILE, aggregator_type=AggregatorType.MAX, quantile_outlier_prob=1e-4
         ),
     ),
-    backend_params={"use_pot": True},
 )
 
 preset = QuantizationPreset.MIXED

--- a/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_x_mod3/ptq_optimization_config.py
@@ -18,7 +18,6 @@ advanced_parameters = AdvancedQuantizationParameters(
             statistics_type=StatisticsType.QUANTILE, aggregator_type=AggregatorType.MAX, quantile_outlier_prob=1e-4
         ),
     ),
-    backend_params={"use_pot": True},
 )
 
 preset = QuantizationPreset.PERFORMANCE

--- a/src/otx/algorithms/visual_prompting/tasks/openvino.py
+++ b/src/otx/algorithms/visual_prompting/tasks/openvino.py
@@ -487,4 +487,4 @@ class OpenVINOVisualPromptingTask(IInferenceTask, IEvaluationTask, IOptimization
 
         if optimization_parameters is not None:
             optimization_parameters.update_progress(100, None)
-        logger.info("POT optimization completed")
+        logger.info("PTQ optimization completed")


### PR DESCRIPTION
### Summary

ocr_lite_hrnet_x_mod3 |   | POT | POT via PTQ | PTQ
-- | -- | -- | -- | --
regression_voc_cls_decr | 0.7236 | 0.0956 | 0.1562 | 0.364
kitti_18 | 0.45 |   |  0.029  | 0.27
voc_person_car_24 | 0.636 |   | 0.0151  | 0.586

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
