### PR TITLE
Fix H-label classification

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/configurer.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/configurer.py
@@ -133,7 +133,7 @@ class ClassificationConfigurer:
             cfg.model.type = super_type
 
         # Hierarchical
-        if cfg.model.hierarchical:
+        if cfg.model.get("hierarchical"):
             assert cfg.data.train.hierarchical_info == cfg.data.val.hierarchical_info == cfg.data.test.hierarchical_info
             cfg.model.head.hierarchical_info = cfg.data.train.hierarchical_info
 

--- a/src/otx/algorithms/classification/adapters/mmcls/configurer.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/configurer.py
@@ -132,6 +132,11 @@ class ClassificationConfigurer:
             cfg.model.arch_type = cfg.model.type
             cfg.model.type = super_type
 
+        # Hierarchical
+        if cfg.model.hierarchical:
+            assert cfg.data.train.hierarchical_info == cfg.data.val.hierarchical_info == cfg.data.test.hierarchical_info
+            cfg.model.head.hierarchical_info = cfg.data.train.hierarchical_info
+
         # OV-plugin
         ir_model_path = ir_options.get("ir_model_path")
         if ir_model_path:

--- a/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
@@ -327,17 +327,14 @@ class OTXHierarchicalClsDataset(OTXMultilabelClsDataset):
             self.gt_labels.append(class_indices)
         self.gt_labels = np.array(self.gt_labels)
 
-        self._update_heads_information(num_cls_heads)
+        self._update_heads_information()
 
-    def _update_heads_information(self, num_cls_heads: int):
+    def _update_heads_information(self):
         """Update heads information to find the empty heads.
 
         If there are no annotations at a specific head, this should be filtered out to calculate loss correctly.
-
-        Args:
-            num_cls_heads (int): the number of multi-class heads.
-
         """
+        num_cls_heads = self.hierarchical_info["num_multiclass_heads"]
         for head_idx in range(num_cls_heads):
             labels_in_head = self.gt_labels[:, head_idx]  # type: ignore[call-overload]
             if max(labels_in_head) < 0:

--- a/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
@@ -309,9 +309,7 @@ class OTXHierarchicalClsDataset(OTXMultilabelClsDataset):
             if item_labels:
                 num_cls_heads = self.hierarchical_info["num_multiclass_heads"]
 
-                class_indices = [0] * (
-                    self.hierarchical_info["num_multiclass_heads"] + self.hierarchical_info["num_multilabel_classes"]
-                )
+                class_indices = [0] * (num_cls_heads + self.hierarchical_info["num_multilabel_classes"])
                 for j in range(num_cls_heads):
                     class_indices[j] = -1
                 for otx_lbl in item_labels:
@@ -328,6 +326,22 @@ class OTXHierarchicalClsDataset(OTXMultilabelClsDataset):
                 )
             self.gt_labels.append(class_indices)
         self.gt_labels = np.array(self.gt_labels)
+
+        self._update_heads_information(num_cls_heads)
+
+    def _update_heads_information(self, num_cls_heads: int):
+        """Update heads information to find the empty heads.
+
+        If there are no annotations at a specific head, this should be filtered out to calculate loss correctly.
+
+        Args:
+            num_cls_heads (int): the number of multi-class heads.
+
+        """
+        for head_idx in range(num_cls_heads):
+            labels_in_head = self.gt_labels[:, head_idx]  # type: ignore[call-overload]
+            if max(labels_in_head) < 0:
+                self.hierarchical_info["empty_multiclass_head_indices"].append(head_idx)
 
     @staticmethod
     def mean_top_k_accuracy(scores, labels, k=1):

--- a/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_non_linear_cls_head.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_non_linear_cls_head.py
@@ -117,6 +117,7 @@ class CustomHierarchicalNonLinearClsHead(
         cls_score = self.classifier(cls_score)
 
         losses = dict(loss=0.0)
+        num_effective_heads_in_batch = 0
         for i in range(self.hierarchical_info["num_multiclass_heads"]):
             if i not in self.hierarchical_info["empty_multiclass_head_indices"]:
                 head_gt = gt_label[:, i]
@@ -128,12 +129,14 @@ class CustomHierarchicalNonLinearClsHead(
                 ]
                 valid_mask = head_gt >= 0
                 head_gt = head_gt[valid_mask].long()
-                head_logits = head_logits[valid_mask, :]
-                multiclass_loss = self.loss(head_logits, head_gt)
-                losses["loss"] += multiclass_loss
+                if len(head_gt) > 0:
+                    head_logits = head_logits[valid_mask, :]
+                    multiclass_loss = self.loss(head_logits, head_gt)
+                    losses["loss"] += multiclass_loss
+                    num_effective_heads_in_batch += 1
 
         if self.hierarchical_info["num_multiclass_heads"] > 1:
-            losses["loss"] /= self.hierarchical_info["num_multiclass_heads"]
+            losses["loss"] /= num_effective_heads_in_batch
 
         if self.compute_multilabel_loss:
             head_gt = gt_label[:, self.hierarchical_info["num_multiclass_heads"] :]

--- a/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_non_linear_cls_head.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_non_linear_cls_head.py
@@ -118,18 +118,19 @@ class CustomHierarchicalNonLinearClsHead(
 
         losses = dict(loss=0.0)
         for i in range(self.hierarchical_info["num_multiclass_heads"]):
-            head_gt = gt_label[:, i]
-            head_logits = cls_score[
-                :,
-                self.hierarchical_info["head_idx_to_logits_range"][str(i)][0] : self.hierarchical_info[
-                    "head_idx_to_logits_range"
-                ][str(i)][1],
-            ]
-            valid_mask = head_gt >= 0
-            head_gt = head_gt[valid_mask].long()
-            head_logits = head_logits[valid_mask, :]
-            multiclass_loss = self.loss(head_logits, head_gt)
-            losses["loss"] += multiclass_loss
+            if i not in self.hierarchical_info["empty_multiclass_head_indices"]:
+                head_gt = gt_label[:, i]
+                head_logits = cls_score[
+                    :,
+                    self.hierarchical_info["head_idx_to_logits_range"][str(i)][0] : self.hierarchical_info[
+                        "head_idx_to_logits_range"
+                    ][str(i)][1],
+                ]
+                valid_mask = head_gt >= 0
+                head_gt = head_gt[valid_mask].long()
+                head_logits = head_logits[valid_mask, :]
+                multiclass_loss = self.loss(head_logits, head_gt)
+                losses["loss"] += multiclass_loss
 
         if self.hierarchical_info["num_multiclass_heads"] > 1:
             losses["loss"] /= self.hierarchical_info["num_multiclass_heads"]

--- a/src/otx/algorithms/classification/utils/cls_utils.py
+++ b/src/otx/algorithms/classification/utils/cls_utils.py
@@ -62,6 +62,7 @@ def get_multihead_class_info(label_schema: LabelSchemaEntity):  # pylint: disabl
         "class_to_group_idx": class_to_idx,
         "all_groups": exclusive_groups + single_label_groups,
         "label_to_idx": label_to_idx,
+        "empty_multiclass_head_indices": [],
     }
     return mixed_cls_heads_info
 

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
@@ -142,9 +142,31 @@ class TestOTXClsDataset:
         dataset = OTXHierarchicalClsDataset(
             otx_dataset=self.dataset, labels=self.dataset.get_labels(), hierarchical_info=class_info
         )
-
         results = np.zeros((len(dataset), dataset.num_classes))
         metrics = dataset.evaluate(results)
 
         assert len(metrics) > 0
         assert metrics["accuracy"] > 0
+
+    @e2e_pytest_unit
+    def test_hierarchical_with_empty_heads(self):
+        self.task_environment, self.dataset = init_environment(
+            self.hyper_parameters, self.model_template, False, True, self.dataset_len
+        )
+        class_info = get_multihead_class_info(self.task_environment.label_schema)
+        dataset = OTXHierarchicalClsDataset(
+            otx_dataset=self.dataset, labels=self.dataset.get_labels(), hierarchical_info=class_info
+        )
+        pseudo_gt_labels = []
+        pseudo_head_idx = 0
+        for label in dataset.gt_labels:
+            pseudo_gt_label = label
+            pseudo_gt_label[pseudo_head_idx] = -1
+            pseudo_gt_labels.append(pseudo_gt_label)
+        pseudo_gt_labels = np.array(pseudo_gt_labels)
+        
+        from copy import deepcopy
+        pseudo_dataset = deepcopy(dataset) 
+        pseudo_dataset.gt_labels = pseudo_gt_labels 
+        pseudo_dataset._update_heads_information(dataset.hierarchical_info["num_multiclass_heads"])
+        assert pseudo_dataset.hierarchical_info["empty_multiclass_head_indices"][pseudo_head_idx] == 0

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
@@ -169,5 +169,5 @@ class TestOTXClsDataset:
 
         pseudo_dataset = deepcopy(dataset)
         pseudo_dataset.gt_labels = pseudo_gt_labels
-        pseudo_dataset._update_heads_information(dataset.hierarchical_info["num_multiclass_heads"])
+        pseudo_dataset._update_heads_information()
         assert pseudo_dataset.hierarchical_info["empty_multiclass_head_indices"][pseudo_head_idx] == 0

--- a/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/data/test_datasets.py
@@ -164,9 +164,10 @@ class TestOTXClsDataset:
             pseudo_gt_label[pseudo_head_idx] = -1
             pseudo_gt_labels.append(pseudo_gt_label)
         pseudo_gt_labels = np.array(pseudo_gt_labels)
-        
+
         from copy import deepcopy
-        pseudo_dataset = deepcopy(dataset) 
-        pseudo_dataset.gt_labels = pseudo_gt_labels 
+
+        pseudo_dataset = deepcopy(dataset)
+        pseudo_dataset.gt_labels = pseudo_gt_labels
         pseudo_dataset._update_heads_information(dataset.hierarchical_info["num_multiclass_heads"])
         assert pseudo_dataset.hierarchical_info["empty_multiclass_head_indices"][pseudo_head_idx] == 0

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_custom_hierarchical_cls_head.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_custom_hierarchical_cls_head.py
@@ -31,6 +31,7 @@ class TestCustomHierarchicalLinearClsHead:
             "num_multilabel_classes": 1,
             "head_idx_to_logits_range": {"0": (0, 2)},
             "num_single_label_classes": 2,
+            "empty_multiclass_head_indices": []
         }
         self.loss = dict(type="CrossEntropyLoss", use_sigmoid=False, reduction="mean", loss_weight=1.0)
         self.multilabel_loss = dict(type=AsymmetricLossWithIgnore.__name__, reduction="sum")

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_custom_hierarchical_cls_head.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_custom_hierarchical_cls_head.py
@@ -31,7 +31,7 @@ class TestCustomHierarchicalLinearClsHead:
             "num_multilabel_classes": 1,
             "head_idx_to_logits_range": {"0": (0, 2)},
             "num_single_label_classes": 2,
-            "empty_multiclass_head_indices": []
+            "empty_multiclass_head_indices": [],
         }
         self.loss = dict(type="CrossEntropyLoss", use_sigmoid=False, reduction="mean", loss_weight=1.0)
         self.multilabel_loss = dict(type=AsymmetricLossWithIgnore.__name__, reduction="sum")

--- a/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_custom_hierarchical_cls_head.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/models/heads/test_custom_hierarchical_cls_head.py
@@ -24,13 +24,13 @@ class TestCustomHierarchicalLinearClsHead:
 
     @pytest.fixture(autouse=True)
     def setup(self, head_type) -> None:
-        self.num_classes = 3
-        self.head_dim = 5
+        self.num_classes = 6
+        self.head_dim = 10
         self.cls_heads_info = {
-            "num_multiclass_heads": 1,
-            "num_multilabel_classes": 1,
-            "head_idx_to_logits_range": {"0": (0, 2)},
-            "num_single_label_classes": 2,
+            "num_multiclass_heads": 3,
+            "num_multilabel_classes": 0,
+            "head_idx_to_logits_range": {"0": (0, 2), "1": (2, 4), "2": (4, 6)},
+            "num_single_label_classes": 6,
             "empty_multiclass_head_indices": [],
         }
         self.loss = dict(type="CrossEntropyLoss", use_sigmoid=False, reduction="mean", loss_weight=1.0)
@@ -44,13 +44,23 @@ class TestCustomHierarchicalLinearClsHead:
         )
         self.default_head.init_weights()
         self.default_input = torch.ones((2, self.head_dim))
-        self.default_gt = torch.zeros((2, 2))
+        self.default_gt = torch.zeros((2, 3))
 
     @e2e_pytest_unit
     def test_forward(self) -> None:
         result = self.default_head.forward_train(self.default_input, self.default_gt)
         assert "loss" in result
-        assert result["loss"] >= 0
+        assert result["loss"] >= 0 and not torch.isnan(result["loss"])
+
+        empty_head_gt_full = torch.tensor([[-1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]])
+        result_include_empty_full = self.default_head.forward_train(self.default_input, empty_head_gt_full)
+        assert "loss" in result_include_empty_full
+        assert result_include_empty_full["loss"] >= 0 and not torch.isnan(result_include_empty_full["loss"])
+
+        empty_head_gt_partial = torch.tensor([[0.0, 0.0, 0.0], [-1.0, 0.0, 0.0]])
+        result_include_empty_partial = self.default_head.forward_train(self.default_input, empty_head_gt_partial)
+        assert "loss" in result_include_empty_partial
+        assert result_include_empty_partial["loss"] >= 0 and not torch.isnan(result_include_empty_partial["loss"])
 
     @e2e_pytest_unit
     def test_simple_test(self) -> None:

--- a/tests/unit/algorithms/classification/adapters/mmcls/test_configurer.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/test_configurer.py
@@ -22,6 +22,9 @@ class TestClassificationConfigurer:
         self.configurer = ClassificationConfigurer()
         self.model_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model.py"))
         self.data_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "data_pipeline.py"))
+        
+        self.multilabel_model_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model_multilabel.py"))
+        self.hierarchical_model_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model_hierarchical.py"))
 
     @e2e_pytest_unit
     def test_configure(self, mocker):
@@ -118,6 +121,13 @@ class TestClassificationConfigurer:
         self.configurer.configure_model(self.model_cfg, ir_options)
         assert self.model_cfg.model_task
         assert self.model_cfg.model.head.in_channels == 960
+        
+        multilabel_model_cfg = self.multilabel_model_cfg
+        self.configurer.configure_model(multilabel_model_cfg, ir_options)
+        
+        h_label_model_cfg = self.hierarchical_model_cfg
+        self.configurer.configure_model(h_label_model_cfg, ir_options)
+        
 
     @e2e_pytest_unit
     def test_configure_model_not_classification_task(self):

--- a/tests/unit/algorithms/classification/adapters/mmcls/test_configurer.py
+++ b/tests/unit/algorithms/classification/adapters/mmcls/test_configurer.py
@@ -22,9 +22,11 @@ class TestClassificationConfigurer:
         self.configurer = ClassificationConfigurer()
         self.model_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model.py"))
         self.data_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "data_pipeline.py"))
-        
+
         self.multilabel_model_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model_multilabel.py"))
-        self.hierarchical_model_cfg = MPAConfig.fromfile(os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model_hierarchical.py"))
+        self.hierarchical_model_cfg = MPAConfig.fromfile(
+            os.path.join(DEFAULT_CLS_TEMPLATE_DIR, "model_hierarchical.py")
+        )
 
     @e2e_pytest_unit
     def test_configure(self, mocker):
@@ -121,13 +123,12 @@ class TestClassificationConfigurer:
         self.configurer.configure_model(self.model_cfg, ir_options)
         assert self.model_cfg.model_task
         assert self.model_cfg.model.head.in_channels == 960
-        
+
         multilabel_model_cfg = self.multilabel_model_cfg
         self.configurer.configure_model(multilabel_model_cfg, ir_options)
-        
+
         h_label_model_cfg = self.hierarchical_model_cfg
         self.configurer.configure_model(h_label_model_cfg, ir_options)
-        
 
     @e2e_pytest_unit
     def test_configure_model_not_classification_task(self):


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Related ticket: [CVS-114893](https://jira.devtools.intel.com/browse/CVS-114893)

**Issue description**
When there are empty heads that include no annotation, it should be ignored at loss calculation.
However, since it also affects the loss calculation, the loss is going to NaN. 

i.e. figure below represents the 3rd head is an empty head.
![image](https://github.com/openvinotoolkit/training_extensions/assets/80735344/020113bd-4f0d-43d7-98fd-f2c00b12e9ae)

In this case, we should ignore the empty head to avoid the NaN loss.
```python3
  valid_mask = head_gt >= 0         ### In the case of empty head, valid_mask is []
  head_gt = head_gt[valid_mask].long()     ###  So, head_gt = []
  head_logits = head_logits[valid_mask, :]
  multiclass_loss = self.loss(head_logits, head_gt) ### Therefore this loss is going to NaN
  losses["loss"] += multiclass_loss
```


**This PR includes**
* Add logic: check the empty heads that include no annotation.
* Add logic: If there are empty heads, it will be filtered out at loss calculation.
* Add logic: patching the hierarchical information for cfg.model
* Add unit tests to check the functionality of empty heads





### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [X] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
