### PR TITLE
Enable configurable confidence threshold for ov export and inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
--
+- Enable configurable confidence threshold for otx eval and export(<https://github.com/openvinotoolkit/training_extensions/pull/2388>)
 
 ### Enhancements
 

--- a/docs/source/guide/tutorials/base/how_to_train/detection.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/detection.rst
@@ -369,7 +369,7 @@ Please note, by default, the optimal confidence threshold is detected based on v
 .. code-block::
 
   (otx) ...$ otx export --load-weights ../outputs/weights.pth \
-                      --output ../outputs
+                      --output ../outputs \
                       params \
                       --postprocessing.confidence_threshold 0.5 \
                       --postprocessing.result_based_confidence_threshold false

--- a/docs/source/guide/tutorials/base/how_to_train/detection.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/detection.rst
@@ -359,6 +359,22 @@ using ``otx eval`` and passing the IR model path to the ``--load-weights`` param
   Performance(score: 0.5487693710118504, dashboard: (1 metric groups))
 
 
+4. ``Optional`` Additionally, we can tune confidence threshold via the command line.
+Learn more about template-specific parameters using ``otx export params --help``.
+
+For example, if there are too many False-Positive predictions (there we have a prediction, but don't have annotated object for it), we can suppress its number by increasing the confidence threshold as it is shown below.
+
+Please note, by default, the optimal confidence threshold is detected based on validation results to maximize the final F1 metric. To set a custom confidence threshold, please disable ``result_based_confidence_threshold`` option.
+
+.. code-block::
+
+  (otx) ...$ otx export --load-weights ../outputs/weights.pth \
+                      --output ../outputs
+                      params \
+                      --postprocessing.confidence_threshold 0.5 \
+                      --postprocessing.result_based_confidence_threshold false
+
+
 *************
 Optimization
 *************

--- a/src/otx/algorithms/detection/adapters/openvino/task.py
+++ b/src/otx/algorithms/detection/adapters/openvino/task.py
@@ -434,10 +434,12 @@ class OpenVINODetectionTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IO
         if self.model is None:
             raise RuntimeError("load_inferencer failed, model is None")
         _hparams = copy.deepcopy(self.hparams)
-        self.confidence_threshold = float(
-            np.frombuffer(self.model.get_data("confidence_threshold"), dtype=np.float32)[0]
-        )
-        _hparams.postprocessing.confidence_threshold = self.confidence_threshold
+        if _hparams.postprocessing.result_based_confidence_threshold:
+            self.confidence_threshold = float(
+                np.frombuffer(self.model.get_data("confidence_threshold"), dtype=np.float32)[0]
+            )
+            _hparams.postprocessing.confidence_threshold = self.confidence_threshold
+        logger.info(f"Confidence Threshold: {_hparams.postprocessing.confidence_threshold}")
         _hparams.postprocessing.use_ellipse_shapes = self.config.postprocessing.use_ellipse_shapes
         async_requests_num = get_default_async_reqs_num()
         args = [

--- a/src/otx/algorithms/detection/task.py
+++ b/src/otx/algorithms/detection/task.py
@@ -83,13 +83,14 @@ class OTXDetectionTask(OTXTask, ABC):
         )
         self._anchors: Dict[str, int] = {}
 
-        if self._hyperparams.postprocessing.result_based_confidence_threshold:
-            self.confidence_threshold = 0.0  # Use all predictions to compute best threshold
-        elif hasattr(self._hyperparams, "postprocessing"):
-            if hasattr(self._hyperparams.postprocessing, "confidence_threshold"):
-                self.confidence_threshold = self._hyperparams.postprocessing.confidence_threshold
-            else:
-                self.confidence_threshold = 0.0
+        if (
+            not self._hyperparams.postprocessing.result_based_confidence_threshold
+            and hasattr(self._hyperparams, "postprocessing")
+            and hasattr(self._hyperparams.postprocessing, "confidence_threshold")
+        ):
+            self.confidence_threshold = self._hyperparams.postprocessing.confidence_threshold
+        else:
+            self.confidence_threshold = 0.0
 
         if task_environment.model is not None:
             self._load_model()

--- a/src/otx/algorithms/detection/task.py
+++ b/src/otx/algorithms/detection/task.py
@@ -84,8 +84,8 @@ class OTXDetectionTask(OTXTask, ABC):
         self._anchors: Dict[str, int] = {}
 
         if (
-            not self._hyperparams.postprocessing.result_based_confidence_threshold
-            and hasattr(self._hyperparams, "postprocessing")
+            hasattr(self._hyperparams, "postprocessing")
+            and not getattr(self._hyperparams.postprocessing, "result_based_confidence_threshold", False)
             and hasattr(self._hyperparams.postprocessing, "confidence_threshold")
         ):
             self.confidence_threshold = self._hyperparams.postprocessing.confidence_threshold

--- a/src/otx/cli/tools/demo.py
+++ b/src/otx/cli/tools/demo.py
@@ -35,6 +35,7 @@ from otx.cli.utils.importing import get_impl_class
 from otx.cli.utils.io import read_label_schema, read_model
 from otx.cli.utils.parser import (
     add_hyper_parameters_sub_parser,
+    get_override_param,
     get_parser_and_hprams_data,
 )
 
@@ -87,7 +88,7 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
-    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+    override_param = get_override_param(params)
 
     return parser.parse_args(), override_param
 

--- a/src/otx/cli/tools/eval.py
+++ b/src/otx/cli/tools/eval.py
@@ -30,6 +30,7 @@ from otx.cli.utils.io import read_model
 from otx.cli.utils.nncf import is_checkpoint_nncf
 from otx.cli.utils.parser import (
     add_hyper_parameters_sub_parser,
+    get_override_param,
     get_parser_and_hprams_data,
 )
 from otx.core.data.adapter import get_dataset_adapter
@@ -68,7 +69,7 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
-    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+    override_param = get_override_param(params)
 
     return parser.parse_args(), override_param
 

--- a/src/otx/cli/tools/explain.py
+++ b/src/otx/cli/tools/explain.py
@@ -33,6 +33,7 @@ from otx.cli.utils.io import (
 from otx.cli.utils.nncf import is_checkpoint_nncf
 from otx.cli.utils.parser import (
     add_hyper_parameters_sub_parser,
+    get_override_param,
     get_parser_and_hprams_data,
 )
 
@@ -88,7 +89,7 @@ def get_args():
         help="Weight of the saliency map when overlaying the input image with saliency map.",
     )
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
-    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+    override_param = get_override_param(params)
 
     return parser.parse_args(), override_param
 

--- a/src/otx/cli/tools/export.py
+++ b/src/otx/cli/tools/export.py
@@ -26,7 +26,7 @@ from otx.cli.manager import ConfigManager
 from otx.cli.utils.importing import get_impl_class
 from otx.cli.utils.io import read_binary, read_label_schema, save_model_data
 from otx.cli.utils.nncf import is_checkpoint_nncf
-from otx.cli.utils.parser import add_hyper_parameters_sub_parser, get_parser_and_hprams_data
+from otx.cli.utils.parser import add_hyper_parameters_sub_parser, get_override_param, get_parser_and_hprams_data
 
 
 def get_args():
@@ -64,7 +64,7 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
-    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+    override_param = get_override_param(params)
 
     return parser.parse_args(), override_param
 

--- a/src/otx/cli/tools/export.py
+++ b/src/otx/cli/tools/export.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 # Update environment variables for CLI use
 import otx.cli  # noqa: F401
-from otx.api.configuration.helper import create
 from otx.api.entities.model import ModelEntity, ModelOptimizationType, ModelPrecision
 from otx.api.entities.task_environment import TaskEnvironment
 from otx.api.usecases.adapters.model_adapter import ModelAdapter
@@ -27,12 +26,12 @@ from otx.cli.manager import ConfigManager
 from otx.cli.utils.importing import get_impl_class
 from otx.cli.utils.io import read_binary, read_label_schema, save_model_data
 from otx.cli.utils.nncf import is_checkpoint_nncf
-from otx.cli.utils.parser import get_parser_and_hprams_data
+from otx.cli.utils.parser import add_hyper_parameters_sub_parser, get_parser_and_hprams_data
 
 
 def get_args():
     """Parses command line arguments."""
-    parser, _, _ = get_parser_and_hprams_data()
+    parser, hyper_parameters, params = get_parser_and_hprams_data()
 
     parser.add_argument(
         "--load-weights",
@@ -64,12 +63,15 @@ def get_args():
         default="openvino",
     )
 
-    return parser.parse_args()
+    add_hyper_parameters_sub_parser(parser, hyper_parameters, modes=("INFERENCE",))
+    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+
+    return parser.parse_args(), override_param
 
 
 def main():
     """Main function that is used for model exporting."""
-    args = get_args()
+    args, override_param = get_args()
     config_manager = ConfigManager(args, mode="export", workspace_root=args.workspace)
     # Auto-Configuration for model template
     config_manager.configure_template()
@@ -88,7 +90,7 @@ def main():
     task_class = get_impl_class(template.entrypoints.nncf if is_nncf else template.entrypoints.base)
 
     # Get hyper parameters schema.
-    hyper_parameters = create(template.hyper_parameters.data)
+    hyper_parameters = config_manager.get_hyparams_config(override_param)
     assert hyper_parameters
 
     environment = TaskEnvironment(

--- a/src/otx/cli/tools/optimize.py
+++ b/src/otx/cli/tools/optimize.py
@@ -32,6 +32,7 @@ from otx.cli.utils.importing import get_impl_class
 from otx.cli.utils.io import read_model, save_model_data
 from otx.cli.utils.parser import (
     add_hyper_parameters_sub_parser,
+    get_override_param,
     get_parser_and_hprams_data,
 )
 from otx.core.data.adapter import get_dataset_adapter
@@ -70,7 +71,7 @@ def get_args():
     )
 
     add_hyper_parameters_sub_parser(parser, hyper_parameters)
-    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+    override_param = get_override_param(params)
 
     return parser.parse_args(), override_param
 

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -38,6 +38,7 @@ from otx.cli.utils.multi_gpu import MultiGPUManager, is_multigpu_child_process
 from otx.cli.utils.parser import (
     MemSizeAction,
     add_hyper_parameters_sub_parser,
+    get_override_param,
     get_parser_and_hprams_data,
 )
 from otx.cli.utils.report import get_otx_report
@@ -161,7 +162,7 @@ def get_args():
 
     sub_parser = add_hyper_parameters_sub_parser(parser, hyper_parameters, return_sub_parser=True)
     # TODO: Temporary solution for cases where there is no template input
-    override_param = [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]
+    override_param = get_override_param(params)
     if not hyper_parameters and "params" in params:
         if "params" in params:
             params = params[params.index("params") :]

--- a/src/otx/cli/utils/parser.py
+++ b/src/otx/cli/utils/parser.py
@@ -259,3 +259,8 @@ def get_parser_and_hprams_data():
         parser.add_argument("template", nargs="?", default=None, help=template_help_str)
 
     return parser, hyper_parameters, params
+
+
+def get_override_param(params):
+    """Get override param list from params."""
+    return [f"params.{param[2:].split('=')[0]}" for param in params if param.startswith("--")]

--- a/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/test_task.py
@@ -179,6 +179,27 @@ class TestMMDetectionTask:
         assert isinstance(model, CustomATSS)
 
     @e2e_pytest_unit
+    def test_load_postprocessing(self):
+        """Test _load_postprocessing function."""
+        mock_model_data = {
+            "config": {"postprocessing": {"use_ellipse_shapes": {"value": True}}},
+            "confidence_threshold": 0.75,
+        }
+        self.det_task._load_postprocessing(mock_model_data)
+        assert self.det_task._hyperparams.postprocessing.use_ellipse_shapes == True
+        assert self.det_task.confidence_threshold == 0.75
+
+        mock_model_data = {
+            "config": {"postprocessing": {"use_ellipse_shapes": {"value": False}}},
+            "confidence_threshold": 0.75,
+        }
+        self.det_task._hyperparams.postprocessing.result_based_confidence_threshold = False
+        self.det_task._hyperparams.postprocessing.confidence_threshold = 0.45
+        self.det_task._load_postprocessing(mock_model_data)
+        assert self.det_task._hyperparams.postprocessing.use_ellipse_shapes == False
+        assert self.det_task.confidence_threshold == 0.45
+
+    @e2e_pytest_unit
     def test_train(self, mocker) -> None:
         """Test train function."""
 


### PR DESCRIPTION
### Summary
This PR includes enabling to control confidence threshold during eval(torch, ov models) and export.
From now on user can control confidence threshold via turning off result_based_threshold and setting confidence threshold through cli or configuration.yaml.

This is for https://github.com/openvinotoolkit/training_extensions/issues/2291, a request for changing variables during evaluation and export procedure. Other variables such as input sizes and iou_threshold will be controlled after those variables can be controlled by configurable parameters.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
0. Train object detection model
1. Export model through $ otx export -o outputs/exported/origin/
2. Eval model throuhg $ otx eval --load-weights outputs/exported/origin/openvino.xml
3. Eval model through $ otx eval --load-weights outputs/exported/origin/openvino.xml params --postprocessing.result_based_confidence_threshold false --postprocessing.confidence_threshold 0.95
4. Export model through $ otx export -o outputs/exported/0.95/ params --postprocessing.result_based_confidence false --postprocessing.confidence_threshold 0.95
5. Eval model through $ otx eval --load-weights outputs/exported/0.95/openvino.xml

You can see largely degraded performance in step 3 and results of step 3 and step 5 are same.
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [x] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
