### PR TITLE
[release 1.4.0] XAI: Return saliency maps for Mask RCNN IR async infer

### DIFF
--- a/src/otx/algorithms/detection/adapters/openvino/task.py
+++ b/src/otx/algorithms/detection/adapters/openvino/task.py
@@ -164,7 +164,7 @@ class BaseInferencerWithConverter(BaseInferencer):
             else:
                 features = (
                     copy.deepcopy(prediction["feature_vector"].reshape(-1)),
-                    copy.deepcopy(prediction["saliency_map"][0]),
+                    self.get_saliency_map(prediction, preprocessing_meta),
                 )
 
             result_handler(id, processed_prediciton, features)

--- a/src/otx/cli/utils/importing.py
+++ b/src/otx/cli/utils/importing.py
@@ -20,6 +20,12 @@ import inspect
 import json
 import os
 
+# TODO: To avoid error during importing yapf dynamically. After the bug is fixed, code should be removed.
+try:
+    import yapf  # noqa: F401
+except ImportError:
+    pass
+
 # pylint: disable=protected-access
 
 SUPPORTED_BACKBONE_BACKENDS = {


### PR DESCRIPTION
### Summary

Fix the issue [CVS-116159](https://jira.devtools.intel.com/browse/CVS-116159)
Add for **async inference** calculating saliency maps from predictions (Mask RCNN IR) 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
