### PR TITLE
Fix a performance drop while training EfficientNetV2 with multi-GPU

### DIFF
--- a/src/otx/algorithms/action/adapters/mmaction/task.py
+++ b/src/otx/algorithms/action/adapters/mmaction/task.py
@@ -31,7 +31,6 @@ from mmcv.runner import CheckpointLoader, load_checkpoint, wrap_fp16_model
 from mmcv.utils import Config, ConfigDict, ProgressBar, get_git_hash
 from torch import distributed as dist
 
-from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.action.adapters.mmaction import (
     Exporter,
 )
@@ -50,6 +49,7 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
     MPAConfig,
     update_or_add_custom_hook,
 )
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.configs.configuration_enums import BatchSizeAdaptType
 from otx.algorithms.common.utils import append_dist_rank_suffix
 from otx.algorithms.common.utils.data import get_dataset

--- a/src/otx/algorithms/action/adapters/mmaction/task.py
+++ b/src/otx/algorithms/action/adapters/mmaction/task.py
@@ -31,6 +31,7 @@ from mmcv.runner import CheckpointLoader, load_checkpoint, wrap_fp16_model
 from mmcv.utils import Config, ConfigDict, ProgressBar, get_git_hash
 from torch import distributed as dist
 
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.action.adapters.mmaction import (
     Exporter,
 )
@@ -310,7 +311,7 @@ class MMActionTask(OTXActionTask):
         model.CLASSES = target_classes
 
         if cfg.distributed:
-            torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+            convert_sync_batchnorm(model)
 
         validate = bool(cfg.data.get("val", None))
 

--- a/src/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/task.py
@@ -29,7 +29,6 @@ from mmcls.utils import collect_env
 from mmcv.runner import wrap_fp16_model
 from mmcv.utils import Config, ConfigDict
 
-from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms import TRANSFORMER_BACKBONES
 from otx.algorithms.classification.adapters.mmcls.utils.exporter import (
     ClassificationExporter,
@@ -58,6 +57,7 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
     MPAConfig,
     update_or_add_custom_hook,
 )
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.configs.configuration_enums import BatchSizeAdaptType
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.nncf_task import NNCFBaseTask

--- a/src/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/task.py
@@ -29,6 +29,7 @@ from mmcls.utils import collect_env
 from mmcv.runner import wrap_fp16_model
 from mmcv.utils import Config, ConfigDict
 
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms import TRANSFORMER_BACKBONES
 from otx.algorithms.classification.adapters.mmcls.utils.exporter import (
     ClassificationExporter,
@@ -384,7 +385,7 @@ class MMClassificationTask(OTXClassificationTask):
         model.train()
 
         if cfg.distributed:
-            torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+            convert_sync_batchnorm(model)
 
         validate = bool(cfg.data.get("val", None))
         if validate:

--- a/src/otx/algorithms/common/adapters/torch/utils/__init__.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .bs_search_algo import BsSearchAlgo
-from .utils import model_from_timm, convert_sync_batchnorm
+from .utils import convert_sync_batchnorm, model_from_timm
 
 __all__ = ["BsSearchAlgo", "model_from_timm", "convert_sync_batchnorm"]

--- a/src/otx/algorithms/common/adapters/torch/utils/__init__.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/__init__.py
@@ -4,5 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .bs_search_algo import BsSearchAlgo
+from .utils import model_from_timm, convert_sync_batchnorm
 
-__all__ = ["BsSearchAlgo"]
+__all__ = ["BsSearchAlgo", "model_from_timm", "convert_sync_batchnorm"]

--- a/src/otx/algorithms/common/adapters/torch/utils/utils.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/utils.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from torch.nn import Module
 from timm.models.layers import convert_sync_batchnorm as timm_cvt_sycnbn
+from torch.nn import Module
 
 
 def model_from_timm(model: Module) -> bool:
@@ -17,7 +17,7 @@ def model_from_timm(model: Module) -> bool:
     Returns:
         bool : whether model comes from timm or not.
     """
-    if "timm" in model.__module__.split('.'):
+    if "timm" in model.__module__.split("."):
         return True
 
     is_fisrt = True
@@ -34,7 +34,7 @@ def model_from_timm(model: Module) -> bool:
 
 def convert_sync_batchnorm(model: Module):
     """Convert BatchNorm layers to SyncBatchNorm layers.
-    
+
     Args:
         model (Module): model containing batchnorm layers.
     """

--- a/src/otx/algorithms/common/adapters/torch/utils/utils.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/utils.py
@@ -1,0 +1,44 @@
+"""Collections of util functions related to torch."""
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch.nn import Module
+from timm.models.layers import convert_sync_batchnorm as timm_cvt_sycnbn
+
+
+def model_from_timm(model: Module) -> bool:
+    """Check a model comes from timm module.
+
+    Args:
+        model (Module): model to check it comes from timm module.
+
+    Returns:
+        bool : whether model comes from timm or not.
+    """
+    if "timm" in model.__module__.split('.'):
+        return True
+
+    is_fisrt = True
+    for sub_module in model.modules():
+        if is_fisrt:  # First module is the module itself.
+            is_fisrt = False
+            continue
+
+        if model_from_timm(sub_module):
+            return True
+
+    return False
+
+
+def convert_sync_batchnorm(model: Module):
+    """Convert BatchNorm layers to SyncBatchNorm layers.
+    
+    Args:
+        model (Module): model containing batchnorm layers.
+    """
+    if model_from_timm(model):
+        timm_cvt_sycnbn(model)
+    else:
+        torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/src/otx/algorithms/common/adapters/torch/utils/utils.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/utils.py
@@ -4,8 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from timm.models.layers import convert_sync_batchnorm as timm_cvt_sycnbn
 from torch.nn import Module
+
+try:
+    from timm.models.layers import convert_sync_batchnorm as timm_cvt_sycnbn
+except ImportError:
+    timm_cvt_sycnbn = None
 
 
 def model_from_timm(model: Module) -> bool:
@@ -38,7 +42,7 @@ def convert_sync_batchnorm(model: Module):
     Args:
         model (Module): model containing batchnorm layers.
     """
-    if model_from_timm(model):
+    if timm_cvt_sycnbn is not None and model_from_timm(model):
         timm_cvt_sycnbn(model)
     else:
         torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/src/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/task.py
@@ -32,7 +32,6 @@ from mmdet.datasets import build_dataloader, build_dataset, replace_ImageToTenso
 from mmdet.models.detectors import DETR, TwoStageDetector
 from mmdet.utils import collect_env
 
-from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.adapters.mmcv.hooks import LossDynamicsTrackingHook
 from otx.algorithms.common.adapters.mmcv.hooks.recording_forward_hook import (
     ActivationMapHook,
@@ -50,6 +49,7 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
     MPAConfig,
     update_or_add_custom_hook,
 )
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.configs.configuration_enums import BatchSizeAdaptType
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.nncf_task import NNCFBaseTask

--- a/src/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/task.py
@@ -32,6 +32,7 @@ from mmdet.datasets import build_dataloader, build_dataset, replace_ImageToTenso
 from mmdet.models.detectors import DETR, TwoStageDetector
 from mmdet.utils import collect_env
 
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.adapters.mmcv.hooks import LossDynamicsTrackingHook
 from otx.algorithms.common.adapters.mmcv.hooks.recording_forward_hook import (
     ActivationMapHook,
@@ -278,7 +279,7 @@ class MMDetectionTask(OTXDetectionTask):
         model.CLASSES = target_classes
 
         if cfg.distributed:
-            torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+            convert_sync_batchnorm(model)
 
         validate = bool(cfg.data.get("val", None))
 

--- a/src/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -32,6 +32,7 @@ from mmseg.apis import train_segmentor
 from mmseg.datasets import build_dataloader, build_dataset
 from mmseg.utils import collect_env
 
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.adapters.mmcv.hooks.recording_forward_hook import (
     BaseRecordingForwardHook,
     FeatureVectorHook,
@@ -374,7 +375,7 @@ class MMSegmentationTask(OTXSegmentationTask):
         model.CLASSES = target_classes
 
         if cfg.distributed:
-            torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
+            convert_sync_batchnorm(model)
 
         validate = bool(cfg.data.get("val", None))
 

--- a/src/otx/algorithms/segmentation/adapters/mmseg/task.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/task.py
@@ -32,7 +32,6 @@ from mmseg.apis import train_segmentor
 from mmseg.datasets import build_dataloader, build_dataset
 from mmseg.utils import collect_env
 
-from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.adapters.mmcv.hooks.recording_forward_hook import (
     BaseRecordingForwardHook,
     FeatureVectorHook,
@@ -48,6 +47,7 @@ from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
     MPAConfig,
     update_or_add_custom_hook,
 )
+from otx.algorithms.common.adapters.torch.utils import convert_sync_batchnorm
 from otx.algorithms.common.configs.configuration_enums import BatchSizeAdaptType
 from otx.algorithms.common.configs.training_base import TrainType
 from otx.algorithms.common.tasks.nncf_task import NNCFBaseTask

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
@@ -1,9 +1,11 @@
 import pytest
 
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
 from otx.algorithms.common.adapters.torch.utils import BsSearchAlgo
 from otx.algorithms.common.adapters.torch.utils import bs_search_algo
 
 
+@e2e_pytest_unit
 class TestBsSearchAlgo:
     @pytest.fixture(autouse=True)
     def setup_test(self, mocker):

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_utils.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_utils.py
@@ -1,0 +1,48 @@
+"""Tests for util functions related to torch."""
+
+from unittest.mock import  MagicMock
+
+import pytest
+
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from otx.algorithms.common.adapters.torch.utils import utils as target_module
+from otx.algorithms.common.adapters.torch.utils import model_from_timm, convert_sync_batchnorm
+
+
+class OrdinaryModule:
+    def __init__(self):
+        self.module_arr = [MagicMock() for _ in range(3)]
+
+    def modules(self):
+        return self.module_arr
+
+
+def get_module(is_timm: bool = False):
+    module = OrdinaryModule()
+    if is_timm:
+        timm_sub_module = MagicMock()
+        timm_sub_module.__module__ = "timm.fake"
+        module.module_arr.append(timm_sub_module)
+
+    return module
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize("is_timm", [True, False])
+def test_model_from_timm(is_timm):
+    assert model_from_timm(get_module(is_timm)) is is_timm
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize("is_timm", [True, False])
+def test_convert_sync_batchnorm(mocker, is_timm):
+    mock_timm_cvt_sycnbn = mocker.patch.object(target_module, "timm_cvt_sycnbn")
+    mock_torch = mocker.patch.object(target_module, "torch")
+    model = get_module(is_timm)
+
+    convert_sync_batchnorm(model)
+
+    if is_timm:
+        mock_timm_cvt_sycnbn.assert_called_once()
+    else:
+        mock_torch.nn.SyncBatchNorm.convert_sync_batchnorm.assert_called_once()

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_utils.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for util functions related to torch."""
 
-from unittest.mock import  MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
### Summary
This PR fixes #2253 
The reason of performance drop is not to use a function converting `BatchNorm` to `SyncBatchNorm` from `timm`.
There is additional code in timm's function to deal with some cases in timm's model, so I should have used that function for models from `timm` like `EfficientNetV2`.
So, I changed code to use `timm`'s function for `timm`'s model.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
