### PR TITLE
Adpat timeout value of torch.dist.init_process_group depending on elapsed time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 - Refine input data in-memory caching (<https://github.com/openvinotoolkit/training_extensions/pull/2416>)
-- Adapt timeout value of initialization for distributed training(<https://github.com/openvinotoolkit/training_extensions/pull/2422>)
+- Adapt timeout value of initialization for distributed training (<https://github.com/openvinotoolkit/training_extensions/pull/2422>)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Enhancements
 
 - Refine input data in-memory caching (<https://github.com/openvinotoolkit/training_extensions/pull/2416>)
+- Adapt timeout value of initialization for distributed training(<https://github.com/openvinotoolkit/training_extensions/pull/2422>)
 
 ### Bug fixes
 

--- a/src/otx/algorithms/common/tasks/base_task.py
+++ b/src/otx/algorithms/common/tasks/base_task.py
@@ -138,7 +138,11 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
     def _setup_distributed_training():
         if not dist.is_initialized():
             torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
-            dist.init_process_group(backend="nccl", init_method="env://", timeout=timedelta(seconds=30))
+            dist.init_process_group(
+                backend="nccl",
+                init_method="env://",
+                timeout=timedelta(seconds=int(os.environ.get("TORCH_DIST_TIMEOUT", 30)))
+            )
             rank = dist.get_rank()
             logger.info(f"Dist info: rank {rank} / {dist.get_world_size()} world_size")
             if rank != 0:

--- a/src/otx/algorithms/common/tasks/base_task.py
+++ b/src/otx/algorithms/common/tasks/base_task.py
@@ -141,7 +141,7 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
             dist.init_process_group(
                 backend="nccl",
                 init_method="env://",
-                timeout=timedelta(seconds=int(os.environ.get("TORCH_DIST_TIMEOUT", 30)))
+                timeout=timedelta(seconds=int(os.environ.get("TORCH_DIST_TIMEOUT", 30))),
             )
             rank = dist.get_rank()
             logger.info(f"Dist info: rank {rank} / {dist.get_world_size()} world_size")

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -247,8 +247,13 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
 
     if args.gpus:
         multigpu_manager = MultiGPUManager(
-            train, args.gpus, args.rdzv_endpoint, args.base_rank, args.world_size,
-            datetime.datetime.fromtimestamp(start_time))
+            train,
+            args.gpus,
+            args.rdzv_endpoint,
+            args.base_rank,
+            args.world_size,
+            datetime.datetime.fromtimestamp(start_time),
+        )
         if (
             multigpu_manager.is_available()
             and not template.task_type.is_anomaly  # anomaly tasks don't use this way for multi-GPU training

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -246,7 +246,9 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
     (config_manager.output_path / "logs").mkdir(exist_ok=True, parents=True)
 
     if args.gpus:
-        multigpu_manager = MultiGPUManager(train, args.gpus, args.rdzv_endpoint, args.base_rank, args.world_size)
+        multigpu_manager = MultiGPUManager(
+            train, args.gpus, args.rdzv_endpoint, args.base_rank, args.world_size,
+            datetime.datetime.fromtimestamp(start_time))
         if (
             multigpu_manager.is_available()
             and not template.task_type.is_anomaly  # anomaly tasks don't use this way for multi-GPU training

--- a/src/otx/cli/utils/multi_gpu.py
+++ b/src/otx/cli/utils/multi_gpu.py
@@ -132,7 +132,7 @@ class MultiGPUManager:
         rdzv_endpoint: str = "localhost:0",
         base_rank: int = 0,
         world_size: int = 0,
-        start_time: Optional[datetime.datetime] = None
+        start_time: Optional[datetime.datetime] = None,
     ):
         if ":" not in rdzv_endpoint:
             raise ValueError("rdzv_endpoint must be in form <host>:<port>.")
@@ -155,7 +155,7 @@ class MultiGPUManager:
         if start_time is not None:
             elapsed_time = datetime.datetime.now() - start_time
             if elapsed_time > datetime.timedelta(seconds=20):
-                os.environ["TORCH_DIST_TIMEOUT"] = str(int(elapsed_time.total_seconds()*1.5))
+                os.environ["TORCH_DIST_TIMEOUT"] = str(int(elapsed_time.total_seconds() * 1.5))
 
     def is_available(self) -> bool:
         """Check multi GPU training is available.

--- a/src/otx/cli/utils/multi_gpu.py
+++ b/src/otx/cli/utils/multi_gpu.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import datetime
 import logging
 import os
 import signal
@@ -118,6 +119,8 @@ class MultiGPUManager:
         rdzv_endpoint (str): Rendezvous endpoint for multi-node training.
         base_rank (int): Base rank of the worker.
         world_size (int): Total number of workers in a worker group.
+        start_time (Optional[datetime.datetime]): Time when process starts.
+            This value is used to decide timeout argument of distributed training.
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -129,6 +132,7 @@ class MultiGPUManager:
         rdzv_endpoint: str = "localhost:0",
         base_rank: int = 0,
         world_size: int = 0,
+        start_time: Optional[datetime.datetime] = None
     ):
         if ":" not in rdzv_endpoint:
             raise ValueError("rdzv_endpoint must be in form <host>:<port>.")
@@ -147,6 +151,11 @@ class MultiGPUManager:
         self._world_size = world_size
         self._main_pid = os.getpid()
         self._processes: List[mp.Process] = []
+
+        if start_time is not None:
+            elapsed_time = datetime.datetime.now() - start_time
+            if elapsed_time > datetime.timedelta(seconds=25):
+                os.environ["TORCH_DIST_TIMEOUT"] = str(int(elapsed_time.total_seconds()*1.5))
 
     def is_available(self) -> bool:
         """Check multi GPU training is available.

--- a/src/otx/cli/utils/multi_gpu.py
+++ b/src/otx/cli/utils/multi_gpu.py
@@ -154,7 +154,7 @@ class MultiGPUManager:
 
         if start_time is not None:
             elapsed_time = datetime.datetime.now() - start_time
-            if elapsed_time > datetime.timedelta(seconds=25):
+            if elapsed_time > datetime.timedelta(seconds=20):
                 os.environ["TORCH_DIST_TIMEOUT"] = str(int(elapsed_time.total_seconds()*1.5))
 
     def is_available(self) -> bool:

--- a/tests/unit/cli/utils/test_multi_gpu.py
+++ b/tests/unit/cli/utils/test_multi_gpu.py
@@ -1,10 +1,10 @@
+import datetime
 import os
 import socket
 from contextlib import closing
 from copy import deepcopy
 
 import pytest
-import torch
 
 from otx.cli.utils import multi_gpu
 from otx.cli.utils.multi_gpu import (
@@ -193,7 +193,12 @@ class TestMultiGPUManager:
 
     @e2e_pytest_unit
     def test_init(self, mocker):
-        MultiGPUManager(mocker.MagicMock(), "0,1", "localhost:0")
+        elapsed_second = 180
+        start_time = datetime.datetime.now() - datetime.timedelta(seconds=elapsed_second)
+        MultiGPUManager(mocker.MagicMock(), "0,1", "localhost:0", start_time=start_time)
+
+        # check torch.dist.init_process_group timeout value is adapted if elapsed time is more than 20 seconds.
+        assert int(self.mock_os.environ.get("TORCH_DIST_TIMEOUT", 30)) >= int(elapsed_second * 1.5)
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("num_gpu", [4, 10])


### PR DESCRIPTION
### Summary
When huge dataset is used, more than 30 seconds is used to prepare dataset, which raises an error when training with multi GPU because current `torch.dist.init_process_group` timeout is set as 30.
So, I implemented a feature to adapt timeout value if process start time is given.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
