### PR TITLE
Write a docs and cover additional case about configurable input size

### DIFF
--- a/docs/source/guide/explanation/additional_features/config_input_size.rst
+++ b/docs/source/guide/explanation/additional_features/config_input_size.rst
@@ -19,8 +19,8 @@ You can use this feature using the following command:
 
 The available input sizes are currently as follows:
 
-- 64x64 (exclusively for classification)
-- 128x128 (exclusively for classification)
+- 64x64 (only for classification)
+- 128x128 (only for classification)
 - 256x256
 - 384x384
 - 512x512

--- a/docs/source/guide/explanation/additional_features/config_input_size.rst
+++ b/docs/source/guide/explanation/additional_features/config_input_size.rst
@@ -19,13 +19,13 @@ You can use this feature using the following command:
 
 The available input sizes are currently as follows:
 
-64x64 (exclusively for classification)
-128x128 (exclusively for classificatio)
-256x256
-384x384
-512x512
-1024x1024
+- 64x64 (exclusively for classification)
+- 128x128 (exclusively for classificatio)
+- 256x256
+- 384x384
+- 512x512
+- 1024x1024
 
 .. Note::
-    Using smaller input resolutions with datasets having lower image resolutions or larger objects can yield a speed advantage with minimal impact on model performance.
-    But please note that the choice of small input size can potentially influence model performance based on the task, model architecture, and dataset characteristics.
+    Using smaller input size with datasets having lower image resolutions or larger objects can yield a speed advantage with minimal impact on model performance.
+    But note that the choice of small input size can potentially influence model performance based on the task, model architecture, and dataset characteristics.

--- a/docs/source/guide/explanation/additional_features/config_input_size.rst
+++ b/docs/source/guide/explanation/additional_features/config_input_size.rst
@@ -20,7 +20,7 @@ You can use this feature using the following command:
 The available input sizes are currently as follows:
 
 - 64x64 (exclusively for classification)
-- 128x128 (exclusively for classificatio)
+- 128x128 (exclusively for classification)
 - 256x256
 - 384x384
 - 512x512

--- a/docs/source/guide/explanation/additional_features/config_input_size.rst
+++ b/docs/source/guide/explanation/additional_features/config_input_size.rst
@@ -1,0 +1,31 @@
+Configurable Input size
+=======================
+
+You have the option to work with smaller input resolutions to expedite training and inference times,
+or opt for larger input size to enhance overall model capabilities.
+
+Rather than manually modifying values within the data pipeline, a streamlined approach is provided.
+You can change the model's input size by simply adding an argument during `train`, `eval`, or `export`.
+Furthermore, when using a model weight trained on an input size other than the default,
+OTX automatically aligns data pipelines to input size during `eval`` and `export` processes.
+
+You can use this feature using the following command:
+
+.. code-block::
+
+    $ otx train \
+          ... \
+          params --learning_parameters.input_size input_size
+
+The available input sizes are currently as follows:
+
+64x64 (exclusively for classification)
+128x128 (exclusively for classificatio)
+256x256
+384x384
+512x512
+1024x1024
+
+.. Note::
+    Using smaller input resolutions with datasets having lower image resolutions or larger objects can yield a speed advantage with minimal impact on model performance.
+    But please note that the choice of small input size can potentially influence model performance based on the task, model architecture, and dataset characteristics.

--- a/docs/source/guide/explanation/additional_features/config_input_size.rst
+++ b/docs/source/guide/explanation/additional_features/config_input_size.rst
@@ -1,4 +1,4 @@
-Configurable Input size
+Configurable Input Size
 =======================
 
 You have the option to work with smaller input resolutions to expedite training and inference times,

--- a/docs/source/guide/explanation/additional_features/config_input_size.rst
+++ b/docs/source/guide/explanation/additional_features/config_input_size.rst
@@ -1,7 +1,7 @@
 Configurable Input Size
 =======================
 
-You have the option to work with smaller input resolutions to expedite training and inference times,
+This feature makes OTX use smaller input resolutions to expedite training and inference times,
 or opt for larger input size to enhance overall model capabilities.
 
 Rather than manually modifying values within the data pipeline, a streamlined approach is provided.

--- a/docs/source/guide/explanation/additional_features/index.rst
+++ b/docs/source/guide/explanation/additional_features/index.rst
@@ -13,3 +13,4 @@ Additional Features
    noisy_label_detection
    fast_data_loading
    tiling
+   config_input_size

--- a/src/otx/algorithms/classification/adapters/mmcls/configurer.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/configurer.py
@@ -56,12 +56,12 @@ class ClassificationConfigurer(BaseConfigurer):
         self.configure_ckpt(cfg, model_ckpt)
         self.configure_model(cfg, ir_options)
         self.configure_data(cfg, data_cfg)
+        self.configure_input_size(cfg, input_size, model_ckpt)
         self.configure_task(cfg)
         self.configure_hook(cfg)
         self.configure_samples_per_gpu(cfg)
         self.configure_fp16(cfg)
         self.configure_compat_cfg(cfg)
-        self.configure_input_size(cfg, input_size, model_ckpt)
         return cfg
 
     def configure_compatibility(self, cfg, **kwargs):
@@ -284,9 +284,9 @@ class IncrClassificationConfigurer(ClassificationConfigurer):
 class SemiSLClassificationConfigurer(ClassificationConfigurer):
     """Patch config to support semi supervised learning for classification."""
 
-    def configure_data(self, cfg, data_cfg):
-        """Patch cfg.data."""
-        super().configure_data(cfg, data_cfg)
+    def configure_hook(self, cfg):
+        """Update cfg.custom_hooks."""
+        super().configure_hook(cfg)
         # Set unlabeled data hook
         if self.training:
             if cfg.data.get("unlabeled", False) and cfg.data.unlabeled.get("otx_dataset", False):

--- a/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -651,11 +651,11 @@ class InputSizeManager:
         "multiscaleflipaug": ["img_scale"],
     }
     PIPELINE_WRAPPER: Dict[str, List[str]] = {
-        "MultiScaleFlipAug" : ["transforms"],
-        "AutoAugment" : ["policies"],
-        "TwoCropTransform" : ["view0", "view1", "pipeline"],
+        "MultiScaleFlipAug": ["transforms"],
+        "AutoAugment": ["policies"],
+        "TwoCropTransform": ["view0", "view1", "pipeline"],
     }
-    SUBSET_TYPES: Tuple[str, str, str] = ("train", "val", "test", "unlabeled")
+    SUBSET_TYPES: Tuple[str, str, str, str] = ("train", "val", "test", "unlabeled")
 
     def __init__(
         self,
@@ -837,8 +837,10 @@ class InputSizeManager:
                                 for sub_pipeline in sub_pipelines:
                                     self._set_pipeline_size_value(sub_pipeline, scale)
                         else:
-                            raise ValueError("Dataset pipeline in pipeline wrapper type should be"
-                                             "either list[dict] or list[list[dict]].")
+                            raise ValueError(
+                                "Dataset pipeline in pipeline wrapper type should be"
+                                "either list[dict] or list[list[dict]]."
+                            )
 
     @staticmethod
     def _set_size_value(pipeline: Dict, attr: str, scale: Tuple[Union[int, float], Union[int, float]]):

--- a/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -629,7 +629,7 @@ def get_data_cfg(config: Union[Config, ConfigDict], subset: str = "train") -> Co
 class InputSizeManager:
     """Class for changing input size and getting input size value by checking data pipeline.
 
-    NOTE: "resize", "pad", "crop", "mosaic", "randomaffine", "multiscaleflipaug" and "AutoAugment"
+    NOTE: "resize", "pad", "crop", "mosaic", "randomaffine", "multiscaleflipaug" , "AutoAugment" and "TwoCropTransform"
     are considered at now. If other data pipelines exist, it can work differently than expected.
 
     Args:
@@ -649,6 +649,11 @@ class InputSizeManager:
         "mosaic": ["img_scale"],
         "randomaffine": ["border"],
         "multiscaleflipaug": ["img_scale"],
+    }
+    PIPELINE_WRAPPER: Dict[str, List[str]] = {
+        "MultiScaleFlipAug" : ["transforms"],
+        "AutoAugment" : ["policies"],
+        "TwoCropTransform" : ["view0", "view1", "pipeline"],
     }
     SUBSET_TYPES: Tuple[str, str, str] = ("train", "val", "test", "unlabeled")
 
@@ -743,7 +748,7 @@ class InputSizeManager:
         return None
 
     def _estimate_post_img_size(
-        self, pipelines: Dict, default_size: Optional[List[int]] = None
+        self, pipelines: List[Dict], default_size: Optional[List[int]] = None
     ) -> Union[List[int], None]:
         # NOTE: Mosaic isn't considered in this step because Mosaic and following RandomAffine don't change image size
         post_img_size = default_size
@@ -774,9 +779,16 @@ class InputSizeManager:
                 img_size = self._get_size_value(pipeline, "multiscaleflipaug")
                 if img_size is not None:
                     post_img_size = img_size
-                post_img_size = self._estimate_post_img_size(pipeline["transforms"], post_img_size)
-            elif pipeline["type"] == "AutoAugment":
-                post_img_size = self._estimate_post_img_size(pipeline["policies"][0], post_img_size)
+
+        for pipeline_name, sub_pipeline_names in self.PIPELINE_WRAPPER.items():
+            if pipeline_name == pipeline["type"]:
+                for sub_pipeline_name in sub_pipeline_names:
+                    if sub_pipeline_name in pipeline:
+                        sub_pipeline = pipeline[sub_pipeline_name]
+                        if isinstance(sub_pipeline[0], list):
+                            sub_pipeline = sub_pipeline[0]
+                        post_img_size = self._estimate_post_img_size(sub_pipeline, post_img_size)
+                        break
 
         return post_img_size
 
@@ -813,14 +825,20 @@ class InputSizeManager:
                 if updated:
                     break
 
-        if pipeline["type"] == "MultiScaleFlipAug":
-            for sub_pipeline in pipeline["transforms"]:
-                self._set_pipeline_size_value(sub_pipeline, scale)
-
-        if pipeline["type"] == "AutoAugment":
-            for sub_pipelines in pipeline["policies"]:
-                for sub_pipeline in sub_pipelines:
-                    self._set_pipeline_size_value(sub_pipeline, scale)
+        for pipeline_name, sub_pipeline_names in self.PIPELINE_WRAPPER.items():
+            if pipeline_name == pipeline["type"]:
+                for sub_pipeline_name in sub_pipeline_names:
+                    if sub_pipeline_name in pipeline:
+                        if isinstance(pipeline[sub_pipeline_name][0], dict):
+                            for sub_pipeline in pipeline[sub_pipeline_name]:
+                                self._set_pipeline_size_value(sub_pipeline, scale)
+                        elif isinstance(pipeline[sub_pipeline_name][0], list):
+                            for sub_pipelines in pipeline[sub_pipeline_name]:
+                                for sub_pipeline in sub_pipelines:
+                                    self._set_pipeline_size_value(sub_pipeline, scale)
+                        else:
+                            raise ValueError("Dataset pipeline in pipeline wrapper type should be"
+                                             "either list[dict] or list[list[dict]].")
 
     @staticmethod
     def _set_size_value(pipeline: Dict, attr: str, scale: Tuple[Union[int, float], Union[int, float]]):

--- a/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -650,7 +650,7 @@ class InputSizeManager:
         "randomaffine": ["border"],
         "multiscaleflipaug": ["img_scale"],
     }
-    SUBSET_TYPES: Tuple[str, str, str] = ("train", "val", "test")
+    SUBSET_TYPES: Tuple[str, str, str] = ("train", "val", "test", "unlabeled")
 
     def __init__(
         self,
@@ -803,11 +803,15 @@ class InputSizeManager:
         raise RuntimeError("Failed to find pipeline.")
 
     def _set_pipeline_size_value(self, pipeline: Dict, scale: Tuple[Union[int, float], Union[int, float]]):
+        updated = False
         for pipeline_name, pipeline_attrs in self.PIPELINE_TO_CHANGE.items():
             if pipeline_name in pipeline["type"].lower():
                 for pipeline_attr in pipeline_attrs:
                     if pipeline_attr in pipeline:
                         self._set_size_value(pipeline, pipeline_attr, scale)
+                        updated = True
+                if updated:
+                    break
 
         if pipeline["type"] == "MultiScaleFlipAug":
             for sub_pipeline in pipeline["transforms"]:

--- a/src/otx/algorithms/segmentation/adapters/mmseg/configurer.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/configurer.py
@@ -55,12 +55,12 @@ class SegmentationConfigurer(BaseConfigurer):
         self.configure_ckpt(cfg, model_ckpt)
         self.configure_model(cfg, ir_options)
         self.configure_data(cfg, data_cfg)
+        self.configure_input_size(cfg, input_size, model_ckpt)
         self.configure_task(cfg)
         self.configure_hook(cfg)
         self.configure_samples_per_gpu(cfg)
         self.configure_fp16(cfg)
         self.configure_compat_cfg(cfg)
-        self.configure_input_size(cfg, input_size, model_ckpt)
         return cfg
 
     def configure_compatibility(self, cfg, **kwargs):
@@ -195,6 +195,7 @@ class SegmentationConfigurer(BaseConfigurer):
             "train": 512,
             "val": 544,
             "test": 544,
+            "unlabeled": 512,
         }
 
         InputSizeManager(cfg.data, base_input_size).set_input_size(input_size)
@@ -231,9 +232,9 @@ class IncrSegmentationConfigurer(SegmentationConfigurer):
 class SemiSLSegmentationConfigurer(SegmentationConfigurer):
     """Patch config to support semi supervised learning for semantic segmentation."""
 
-    def configure_data(self, cfg: ConfigDict, data_cfg: ConfigDict) -> None:
-        """Patch cfg.data."""
-        super().configure_data(cfg, data_cfg)
+    def configure_hook(self, cfg):
+        """Update cfg.custom_hooks."""
+        super().configure_hook(cfg)
         # Set unlabeled data hook
         if self.training:
             if cfg.data.get("unlabeled", False) and cfg.data.unlabeled.get("otx_dataset", False):

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
@@ -204,8 +204,8 @@ mock_data_pipeline_to_estimate = {
         ],
         "input_size": (500, 500),
     },
-    "two_crop_transform" : {
-        "pipeline" : [
+    "two_crop_transform": {
+        "pipeline": [
             dict(type="Resize", img_scale=(300, 300), keep_ratio=True),
             dict(type="crop", size=(200, 200)),
             dict(type="Pad", size=(400, 400)),
@@ -219,8 +219,8 @@ mock_data_pipeline_to_estimate = {
                 ],
             ),
         ],
-        "input_size" : (600, 600)
-    }
+        "input_size": (600, 600),
+    },
 }
 
 

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
@@ -97,6 +97,18 @@ def mock_data_pipeline():
                 ],
             ],
         ),
+        dict(
+            type="TwoCropTransform",
+            view0=[
+                dict(type="RandomResizedCrop", size=image_size),
+            ],
+            view1=[
+                dict(type="RandomResizedCrop", size=image_size),
+            ],
+            pipeline=[
+                dict(type="Resize", size=image_size),
+            ],
+        ),
     ]
 
 
@@ -192,6 +204,23 @@ mock_data_pipeline_to_estimate = {
         ],
         "input_size": (500, 500),
     },
+    "two_crop_transform" : {
+        "pipeline" : [
+            dict(type="Resize", img_scale=(300, 300), keep_ratio=True),
+            dict(type="crop", size=(200, 200)),
+            dict(type="Pad", size=(400, 400)),
+            dict(
+                type="TwoCropTransform",
+                view0=[
+                    dict(type="RandomResizedCrop", size=(600, 600)),
+                ],
+                view1=[
+                    dict(type="RandomResizedCrop", size=(500, 500)),
+                ],
+            ),
+        ],
+        "input_size" : (600, 600)
+    }
 }
 
 


### PR DESCRIPTION
### Summary
This PR includes two updates as below

- Write a documentation about configurable input size
- make configurable input size consider `unlabeled` pipeline and `TwoCropTransform` data pipeline

Adding a hook for semi-SL is moved into `configure_hook` to make it execute after changing input size.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [x] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
