### PR TITLE
Add workaround for the incorrect meta info M-RCNN (used for XAI)

### DIFF
--- a/src/otx/algorithms/detection/adapters/openvino/model_wrappers/openvino_models.py
+++ b/src/otx/algorithms/detection/adapters/openvino/model_wrappers/openvino_models.py
@@ -136,8 +136,8 @@ class OTXMaskRCNNModel(MaskRCNNModel):
         if classes.shape[0] == 1:
             classes = classes.squeeze(0)
 
-        scale_x = meta["resized_shape"][1] / meta["original_shape"][1]
-        scale_y = meta["resized_shape"][0] / meta["original_shape"][0]
+        scale_x = meta["resized_shape"][0] / meta["original_shape"][1]
+        scale_y = meta["resized_shape"][1] / meta["original_shape"][0]
         boxes[:, 0::2] /= scale_x
         boxes[:, 1::2] /= scale_y
 


### PR DESCRIPTION
### Summary

`meta["resized_shape"]` (generated by mapi) has flipped height and width. To keep mapi version unchanged, I propose this workaround.

![image](https://github.com/openvinotoolkit/training_extensions/assets/17028475/7d5ee6de-e4cc-4b11-a981-91040a7c857c)

Fixes 
https://jira.devtools.intel.com/browse/CVS-117759
https://jira.devtools.intel.com/browse/CVS-117614

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
