### PR TITLE
Fix label list order for h-label classification

### DIFF
--- a/src/otx/algorithms/classification/adapters/openvino/task.py
+++ b/src/otx/algorithms/classification/adapters/openvino/task.py
@@ -36,6 +36,7 @@ from otx.algorithms.classification.configs import ClassificationConfig
 from otx.algorithms.classification.utils import (
     get_cls_deploy_config,
     get_cls_inferencer_configuration,
+    get_hierarchical_label_list,
 )
 from otx.algorithms.common.utils import OTXOpenVinoDataLoader
 from otx.algorithms.common.utils.ir import check_if_quantized
@@ -76,7 +77,7 @@ from otx.api.usecases.tasks.interfaces.optimization_interface import (
     IOptimizationTask,
     OptimizationType,
 )
-from otx.api.utils.dataset_utils import add_saliency_maps_to_dataset_item, get_hierarchical_label_list
+from otx.api.utils.dataset_utils import add_saliency_maps_to_dataset_item
 
 logger = logging.getLogger(__name__)
 

--- a/src/otx/algorithms/classification/task.py
+++ b/src/otx/algorithms/classification/task.py
@@ -28,6 +28,7 @@ from otx.algorithms.classification.utils import (
     get_cls_deploy_config,
     get_cls_inferencer_configuration,
     get_cls_model_api_configuration,
+    get_hierarchical_label_list,
 )
 from otx.algorithms.classification.utils import (
     get_multihead_class_info as get_hierarchical_info,
@@ -75,7 +76,7 @@ from otx.api.entities.train_parameters import (
 from otx.api.serialization.label_mapper import label_schema_to_bytes
 from otx.api.usecases.evaluation.metrics_helper import MetricsHelper
 from otx.api.usecases.tasks.interfaces.export_interface import ExportType
-from otx.api.utils.dataset_utils import add_saliency_maps_to_dataset_item, get_hierarchical_label_list
+from otx.api.utils.dataset_utils import add_saliency_maps_to_dataset_item
 from otx.api.utils.labels_utils import get_empty_label
 from otx.cli.utils.multi_gpu import is_multigpu_child_process
 

--- a/src/otx/algorithms/classification/utils/__init__.py
+++ b/src/otx/algorithms/classification/utils/__init__.py
@@ -8,10 +8,12 @@ from .cls_utils import (
     get_cls_deploy_config,
     get_cls_inferencer_configuration,
     get_cls_model_api_configuration,
+    get_hierarchical_label_list,
     get_multihead_class_info,
 )
 
 __all__ = [
+    "get_hierarchical_label_list",
     "get_multihead_class_info",
     "get_cls_inferencer_configuration",
     "get_cls_deploy_config",

--- a/src/otx/algorithms/classification/utils/cls_utils.py
+++ b/src/otx/algorithms/classification/utils/cls_utils.py
@@ -117,3 +117,24 @@ def get_cls_model_api_configuration(label_schema: LabelSchemaEntity, inference_c
 
     mapi_config[("model_info", "hierarchical_config")] = json.dumps(hierarchical_config)
     return mapi_config
+
+
+def get_hierarchical_label_list(hierarchical_info, labels):
+    """Return hierarchical labels list which is adjusted to model outputs classes."""
+    hierarchical_labels = []
+    for head_idx in range(hierarchical_info["num_multiclass_heads"]):
+        logits_begin, logits_end = hierarchical_info["head_idx_to_logits_range"][str(head_idx)]
+        for logit in range(0, logits_end - logits_begin):
+            label_str = hierarchical_info["all_groups"][head_idx][logit]
+            label_idx = hierarchical_info["label_to_idx"][label_str]
+            hierarchical_labels.append(labels[label_idx])
+
+    if hierarchical_info["num_multilabel_classes"]:
+        logits_begin = hierarchical_info["num_single_label_classes"]
+        logits_end = len(labels)
+        for logit_idx, logit in enumerate(logits_end - logits_begin):
+            label_str_idx = hierarchical_info["num_multiclass_heads"] + logit_idx
+            label_str = hierarchical_info["all_groups"][label_str_idx][0]
+            label_idx = hierarchical_info["label_to_idx"][label_str]
+            hierarchical_labels.append(labels[label_idx])
+    return hierarchical_labels

--- a/src/otx/algorithms/classification/utils/cls_utils.py
+++ b/src/otx/algorithms/classification/utils/cls_utils.py
@@ -132,7 +132,7 @@ def get_hierarchical_label_list(hierarchical_info, labels):
     if hierarchical_info["num_multilabel_classes"]:
         logits_begin = hierarchical_info["num_single_label_classes"]
         logits_end = len(labels)
-        for logit_idx, logit in enumerate(logits_end - logits_begin):
+        for logit_idx, logit in enumerate(range(0, logits_end - logits_begin)):
             label_str_idx = hierarchical_info["num_multiclass_heads"] + logit_idx
             label_str = hierarchical_info["all_groups"][label_str_idx][0]
             label_idx = hierarchical_info["label_to_idx"][label_str]

--- a/src/otx/api/utils/dataset_utils.py
+++ b/src/otx/api/utils/dataset_utils.py
@@ -272,3 +272,15 @@ def non_linear_normalization(saliency_map: np.ndarray) -> np.ndarray:
     saliency_map = 255.0 / (max_soft_score + 1e-12) * saliency_map
 
     return np.uint8(np.floor(saliency_map))
+
+
+def get_hierarchical_label_list(hierarchical_info, labels):
+    """Return hierarchical labels list which is adjusted to model outputs classes."""
+    hierarchical_labels = []
+    for head_idx in range(hierarchical_info["num_multiclass_heads"]):
+        logits_begin, logits_end = hierarchical_info["head_idx_to_logits_range"][str(head_idx)]
+        for logit in range(0, logits_end - logits_begin):
+            label_str = hierarchical_info["all_groups"][head_idx][logit]
+            otx_label = next(x for x in labels if x.name == label_str)
+            hierarchical_labels.append(otx_label)
+    return hierarchical_labels

--- a/src/otx/api/utils/dataset_utils.py
+++ b/src/otx/api/utils/dataset_utils.py
@@ -272,15 +272,3 @@ def non_linear_normalization(saliency_map: np.ndarray) -> np.ndarray:
     saliency_map = 255.0 / (max_soft_score + 1e-12) * saliency_map
 
     return np.uint8(np.floor(saliency_map))
-
-
-def get_hierarchical_label_list(hierarchical_info, labels):
-    """Return hierarchical labels list which is adjusted to model outputs classes."""
-    hierarchical_labels = []
-    for head_idx in range(hierarchical_info["num_multiclass_heads"]):
-        logits_begin, logits_end = hierarchical_info["head_idx_to_logits_range"][str(head_idx)]
-        for logit in range(0, logits_end - logits_begin):
-            label_str = hierarchical_info["all_groups"][head_idx][logit]
-            otx_label = next(x for x in labels if x.name == label_str)
-            hierarchical_labels.append(otx_label)
-    return hierarchical_labels

--- a/tests/unit/algorithms/classification/tasks/test_classification_openvino_task.py
+++ b/tests/unit/algorithms/classification/tasks/test_classification_openvino_task.py
@@ -182,6 +182,7 @@ class TestOpenVINOClassificationTask:
                 self.fake_input,
             ),
         )
+        self.cls_ov_task.inferencer.model.hierarchical = False
         updpated_dataset = self.cls_ov_task.explain(self.dataset)
 
         assert updpated_dataset is not None


### PR DESCRIPTION
### Summary

This PR fixes the issue with wrong saliency maps for h-label classification.

It is caused by the fact that the order for labels in `label_schema` doesn't correspond with the model outputs order of labels for h-label cls. So then saliency map for the predicted class is added, it uses the wrong index that results in adding the saliency map for the wrong class. 

Not to interfere with the logic of `label_schema`, I added the function `get_hierarchical_label_list` to return the list or labels in order that is used in model output. I use it to return the saliency map for the right predicted class.

Please, make your comment if you suggest moving the function to the different `*_utils.py` file.

Issue: CVS-117964

Saliency map for "young men" class before and after changes:
![image](https://github.com/openvinotoolkit/training_extensions/assets/33455576/050f0045-acb1-4670-b8cb-66615cdfda01)

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
