### PR TITLE
Stabilize multi GPU training

### DIFF
--- a/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -494,7 +494,7 @@ def patch_early_stopping(config: Config):
 
 
 def patch_persistent_workers(config: Config):
-    """persistent_workers is turned off in some conditions.
+    """Set persistent_workers as False in some conditions.
 
     persistent_workers is set as 0 in two cases below:
     case 1) num_workers is 0
@@ -529,7 +529,7 @@ def get_adaptive_num_workers(num_dataloader: int = 1) -> Union[int, None]:
     if num_gpus == 0:
         logger.warning("There is no GPUs. Use existing num_worker value.")
         return None
-    return min(multiprocessing.cpu_count() // num_dataloader // num_gpus, 8)  # max available num_workers is 8
+    return min(multiprocessing.cpu_count() // (num_dataloader * num_gpus), 8)  # max available num_workers is 8
 
 
 def patch_from_hyperparams(config: Config, hyperparams):

--- a/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/config_utils.py
@@ -494,7 +494,15 @@ def patch_early_stopping(config: Config):
 
 
 def patch_persistent_workers(config: Config):
-    """If num_workers is 0, persistent_workers must be False."""
+    """persistent_workers is turned off in some conditions.
+
+    persistent_workers is set as 0 in two cases below:
+    case 1) num_workers is 0
+    case 2) semi-SL with distributed training. Because it uses two data loaders in each processes,
+            it makes workers for data loaders unstable, which makes errors during training.
+
+    """
+    dist_semi_sl = "unlabeled" in config.data and torch.distributed.is_initialized()
     data_cfg = config.data
     for subset in ["train", "val", "test", "unlabeled"]:
         if subset not in data_cfg:
@@ -504,7 +512,7 @@ def patch_persistent_workers(config: Config):
             "workers_per_gpu",
             data_cfg.get("workers_per_gpu", 0),
         )
-        if workers_per_gpu == 0:
+        if workers_per_gpu == 0 or dist_semi_sl:
             dataloader_cfg["persistent_workers"] = False
         elif "persistent_workers" not in dataloader_cfg:
             dataloader_cfg["persistent_workers"] = True
@@ -515,13 +523,13 @@ def patch_persistent_workers(config: Config):
         data_cfg[f"{subset}_dataloader"] = dataloader_cfg
 
 
-def get_adaptive_num_workers() -> Union[int, None]:
+def get_adaptive_num_workers(num_dataloader: int = 1) -> Union[int, None]:
     """Measure appropriate num_workers value and return it."""
     num_gpus = torch.cuda.device_count()
     if num_gpus == 0:
         logger.warning("There is no GPUs. Use existing num_worker value.")
         return None
-    return min(multiprocessing.cpu_count() // num_gpus, 8)  # max available num_workers is 8
+    return min(multiprocessing.cpu_count() // num_dataloader // num_gpus, 8)  # max available num_workers is 8
 
 
 def patch_from_hyperparams(config: Config, hyperparams):
@@ -575,13 +583,14 @@ def patch_from_hyperparams(config: Config, hyperparams):
                     ),
                 )
             )
+    is_semi_sl = hyperparams.algo_backend.train_type.name == "Semisupervised"
 
     if hyperparams.learning_parameters.auto_num_workers:
-        adapted_num_worker = get_adaptive_num_workers()
+        adapted_num_worker = get_adaptive_num_workers(2 if is_semi_sl else 1)
         if adapted_num_worker is not None:
             hparams.data.workers_per_gpu = adapted_num_worker
 
-    if hyperparams.algo_backend.train_type.name == "Semisupervised":
+    if is_semi_sl:
         unlabeled_config = ConfigDict(
             data=ConfigDict(
                 unlabeled_dataloader=ConfigDict(

--- a/src/otx/algorithms/common/tasks/base_task.py
+++ b/src/otx/algorithms/common/tasks/base_task.py
@@ -141,7 +141,7 @@ class OTXTask(IInferenceTask, IExportTask, IEvaluationTask, IUnload, ABC):
             dist.init_process_group(
                 backend="nccl",
                 init_method="env://",
-                timeout=timedelta(seconds=int(os.environ.get("TORCH_DIST_TIMEOUT", 30))),
+                timeout=timedelta(seconds=int(os.environ.get("TORCH_DIST_TIMEOUT", 60))),
             )
             rank = dist.get_rank()
             logger.info(f"Dist info: rank {rank} / {dist.get_world_size()} world_size")

--- a/src/otx/cli/utils/multi_gpu.py
+++ b/src/otx/cli/utils/multi_gpu.py
@@ -154,7 +154,7 @@ class MultiGPUManager:
 
         if start_time is not None:
             elapsed_time = datetime.datetime.now() - start_time
-            if elapsed_time > datetime.timedelta(seconds=20):
+            if elapsed_time > datetime.timedelta(seconds=40):
                 os.environ["TORCH_DIST_TIMEOUT"] = str(int(elapsed_time.total_seconds() * 1.5))
 
     def is_available(self) -> bool:

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
@@ -4,6 +4,7 @@ import pytest
 
 from otx.algorithms.common.adapters.mmcv.utils import config_utils
 from otx.algorithms.common.adapters.mmcv.utils.config_utils import (
+    patch_persistent_workers,
     get_adaptive_num_workers,
     InputSizeManager,
     get_configured_input_size,
@@ -13,8 +14,55 @@ from otx.algorithms.common.configs.configuration_enums import InputSizePreset
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
 
 
+def get_data_cfg(workers_per_gpu: int = 2) -> dict:
+    data_cfg = {}
+    for subset in ["train", "val", "test", "unlabeled"]:
+        data_cfg[subset] = "fake"
+        data_cfg[f"{subset}_dataloader"] = {"persistent_workers" : True, "workers_per_gpu" : workers_per_gpu}
+
+    return data_cfg
+
+
 @e2e_pytest_unit
-def test_get_adaptive_num_workers(mocker):
+@pytest.mark.parametrize("workers_per_gpu", [0, 2])
+def test_patch_persistent_workers(mocker, workers_per_gpu):
+    data_cfg = get_data_cfg(workers_per_gpu)
+    config = mocker.MagicMock()
+    config.data = data_cfg
+
+    mock_torch = mocker.patch.object(config_utils, "torch")
+    mock_torch.distributed.is_initialized.return_value = False
+
+    patch_persistent_workers(config)
+
+    for subset in ["train", "val", "test", "unlabeled"]:
+        # check persistent_workers is turned off if workers_per_gpu is 0
+        assert data_cfg[f"{subset}_dataloader"]["persistent_workers"] is (workers_per_gpu != 0)
+        # check pin_memory is automatically set if it doesn't exist
+        assert data_cfg[f"{subset}_dataloader"]["pin_memory"] is True
+
+
+@e2e_pytest_unit
+def test_patch_persistent_workers_dist_semisl(mocker):
+    data_cfg = get_data_cfg()
+    config = mocker.MagicMock()
+    config.data = data_cfg
+
+    mock_torch = mocker.patch.object(config_utils, "torch")
+    mock_torch.distributed.is_initialized.return_value = True
+
+    patch_persistent_workers(config)
+
+    for subset in ["train", "val", "test", "unlabeled"]:
+        # check persistent_workers is turned off in distributed training semi-SL case
+        assert data_cfg[f"{subset}_dataloader"]["persistent_workers"] is False
+        # check pin_memory is automatically set if it doesn't exist
+        assert data_cfg[f"{subset}_dataloader"]["pin_memory"] is True
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize("num_dataloader", [1, 2, 4])
+def test_get_adaptive_num_workers(mocker, num_dataloader):
     num_gpu = 5
     mock_torch = mocker.patch.object(config_utils, "torch")
     mock_torch.cuda.device_count.return_value = num_gpu
@@ -23,7 +71,7 @@ def test_get_adaptive_num_workers(mocker):
     mock_multiprocessing = mocker.patch.object(config_utils, "multiprocessing")
     mock_multiprocessing.cpu_count.return_value = num_cpu
 
-    assert get_adaptive_num_workers() == num_cpu // num_gpu
+    assert get_adaptive_num_workers(num_dataloader) == num_cpu // (num_gpu * num_dataloader)
 
 
 @e2e_pytest_unit

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_config_utils.py
@@ -18,7 +18,7 @@ def get_data_cfg(workers_per_gpu: int = 2) -> dict:
     data_cfg = {}
     for subset in ["train", "val", "test", "unlabeled"]:
         data_cfg[subset] = "fake"
-        data_cfg[f"{subset}_dataloader"] = {"persistent_workers" : True, "workers_per_gpu" : workers_per_gpu}
+        data_cfg[f"{subset}_dataloader"] = {"persistent_workers": True, "workers_per_gpu": workers_per_gpu}
 
     return data_cfg
 

--- a/tests/unit/cli/utils/test_multi_gpu.py
+++ b/tests/unit/cli/utils/test_multi_gpu.py
@@ -197,8 +197,8 @@ class TestMultiGPUManager:
         start_time = datetime.datetime.now() - datetime.timedelta(seconds=elapsed_second)
         MultiGPUManager(mocker.MagicMock(), "0,1", "localhost:0", start_time=start_time)
 
-        # check torch.dist.init_process_group timeout value is adapted if elapsed time is more than 20 seconds.
-        assert int(self.mock_os.environ.get("TORCH_DIST_TIMEOUT", 30)) >= int(elapsed_second * 1.5)
+        # check torch.dist.init_process_group timeout value is adapted if elapsed time is bigger than criteria.
+        assert int(self.mock_os.environ.get("TORCH_DIST_TIMEOUT", 60)) >= int(elapsed_second * 1.5)
 
     @e2e_pytest_unit
     @pytest.mark.parametrize("num_gpu", [4, 10])


### PR DESCRIPTION
### Summary
This PR fixes configuration for multi GPU training as below:

- Increase timeout value for multi GPU to 60. Current value is 30 which is too small for general condition
- Turn off `persistent_workers` in semi-SL task w/ multi-GPU training

If `persistent_workers` is True in semi-SL task w/ multi-GPU training case, execution of DataLoader workers is unstable, which makes errors during training.
To prevent it, `persistent_workers` is turned off.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
