### PR TITLE
Fix i-seg e2e test code

### DIFF
--- a/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
@@ -89,7 +89,7 @@ else:
 
 class TestToolsMPAInstanceSegmentation:
     @e2e_pytest_component
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     def test_otx_train(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_train_testing(template, tmp_dir_path, otx_dir, args0)
@@ -100,7 +100,7 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     def test_otx_resume(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg/test_resume"
         otx_resume_testing(template, tmp_dir_path, otx_dir, args0)
@@ -114,7 +114,7 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.parametrize("dump_features", [True, False])
     def test_otx_export(self, template, tmp_dir_path, dump_features):
         tmp_dir_path = tmp_dir_path / "ins_seg"
@@ -122,21 +122,21 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     def test_otx_export_fp16(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_export_testing(template, tmp_dir_path, half_precision=True)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     def test_otx_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.skip(reason="Issue#2290: MaskRCNN shows degraded performance when inferencing in OpenVINO")
     @pytest.mark.parametrize("half_precision", [True, False])
     def test_otx_eval_openvino(self, template, tmp_dir_path, half_precision):
@@ -145,14 +145,14 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     def test_otx_explain(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.skip(reason="Issue#2290: MaskRCNN shows degraded performance when inferencing in OpenVINO")
     def test_otx_explain_openvino(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
@@ -160,14 +160,14 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     def test_otx_demo(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         otx_demo_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.skip(reason="Issue#2290: MaskRCNN shows degraded performance when inferencing in OpenVINO")
     def test_otx_demo_openvino(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
@@ -175,7 +175,7 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.skip(reason="Issue#2290: MaskRCNN shows degraded performance when inferencing in OpenVINO")
     def test_otx_deploy_openvino(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
@@ -183,7 +183,7 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.skip(reason="Issue#2290: MaskRCNN shows degraded performance when inferencing in OpenVINO")
     def test_otx_eval_deployment(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
@@ -191,7 +191,7 @@ class TestToolsMPAInstanceSegmentation:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_with_experimental)
+    @pytest.mark.parametrize("template", templates_with_experimental, ids=templates_ids_with_experimental)
     @pytest.mark.skip(reason="Issue#2290: MaskRCNN shows degraded performance when inferencing in OpenVINO")
     def test_otx_demo_deployment(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"


### PR DESCRIPTION
### Summary
Wrong values are passed to `pytest.mark.parametrize`.
This PR fixes it.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
