### PR TITLE
Prevent zero-sized saliency map in tiling if tile size is too big

### DIFF
--- a/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/datasets/tiling.py
@@ -527,8 +527,8 @@ class Tile:
 
         for orig_image in self.cached_results:
             img_idx = orig_image["index"]
-            ratios[img_idx] = np.array([feat_h, feat_w]) / self.tile_size
             image_h, image_w = orig_image["height"], orig_image["width"]
+            ratios[img_idx] = np.array([feat_h / min(self.tile_size, image_h), feat_w / min(self.tile_size, image_w)])
 
             image_map_h = int(image_h * ratios[img_idx][0])
             image_map_w = int(image_w * ratios[img_idx][1])

--- a/src/otx/api/utils/tiler.py
+++ b/src/otx/api/utils/tiler.py
@@ -325,14 +325,13 @@ class Tiler:
         Returns:
             merged_maps (np.ndarray): Merged saliency maps for entire image.
         """
-
         (_, image_saliency_map), image_meta = features[0]
 
         num_classes, feat_h, feat_w = image_saliency_map.shape
         dtype = image_saliency_map[0][0].dtype
 
         image_h, image_w, _ = image_meta["original_shape"]
-        ratio = np.array([feat_h, feat_w]) / self.tile_size
+        ratio = np.array([feat_h / min(self.tile_size, image_h), feat_w / min(self.tile_size, image_w)])
 
         image_map_h = int(image_h * ratio[0])
         image_map_w = int(image_w * ratio[1])


### PR DESCRIPTION
### Summary

If tiler receives an image << tile size, the size of the merged saliency map is zero, because tiler supposes image >> tile size.

Fixes issues with tiling detection: CVS-118396, CVS-118395
In example the calculated saliency map has the 0 size and wasn't added because `tile_size` for the image was too big (8000 tile_size,  300x160 image size)

This change fixes the issue, saliency maps are added:
![image](https://github.com/openvinotoolkit/training_extensions/assets/33455576/9c3294d4-61d2-4e61-9bf3-9427cfe6c622)

- Updated unit tests for TestTilingTileClassifier to cover with tests the case with features merging. Ensured that merge_maps method for Tiler is covered by tests not to trigger Codecov tests to fail.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
