### PR TITLE
Merge load / resize / cache to optimize data loading efficiency for semantic segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 - Refine input data in-memory caching (<https://github.com/openvinotoolkit/training_extensions/pull/2416>)
 - Adapt timeout value of initialization for distributed training (<https://github.com/openvinotoolkit/training_extensions/pull/2422>)
+- Optimize data loading by merging load & resize operations w/ caching support for cls/det/iseg/sseg (<https://github.com/openvinotoolkit/training_extensions/pull/2438>, <https://github.com/openvinotoolkit/training_extensions/pull/2453>, <https://github.com/openvinotoolkit/training_extensions/pull/2460>)
 
 ### Bug fixes
 

--- a/src/otx/algorithms/segmentation/adapters/mmseg/datasets/__init__.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/datasets/__init__.py
@@ -18,6 +18,7 @@ from .dataset import MPASegDataset, get_annotation_mmseg_format
 from .pipelines import (
     LoadAnnotationFromOTXDataset,
     LoadImageFromOTXDataset,
+    LoadResizeDataFromOTXDataset,
     MaskCompose,
     ProbCompose,
     TwoCropTransform,
@@ -26,6 +27,7 @@ from .pipelines import (
 __all__ = [
     "LoadAnnotationFromOTXDataset",
     "LoadImageFromOTXDataset",
+    "LoadResizeDataFromOTXDataset",
     "MaskCompose",
     "ProbCompose",
     "TwoCropTransform",

--- a/src/otx/algorithms/segmentation/adapters/mmseg/datasets/pipelines/__init__.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/datasets/pipelines/__init__.py
@@ -15,7 +15,7 @@
 # and limitations under the License.
 
 from .compose import MaskCompose, ProbCompose
-from .loads import LoadAnnotationFromOTXDataset, LoadImageFromOTXDataset
+from .loads import LoadAnnotationFromOTXDataset, LoadImageFromOTXDataset, LoadResizeDataFromOTXDataset
 from .transforms import TwoCropTransform
 
 __all__ = [
@@ -23,5 +23,6 @@ __all__ = [
     "ProbCompose",
     "LoadImageFromOTXDataset",
     "LoadAnnotationFromOTXDataset",
+    "LoadResizeDataFromOTXDataset",
     "TwoCropTransform",
 ]

--- a/src/otx/algorithms/segmentation/adapters/mmseg/datasets/pipelines/loads.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/datasets/pipelines/loads.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, Optional
-import numpy as np
 
+import numpy as np
 from mmseg.datasets.builder import PIPELINES, build_from_cfg
 
 import otx.algorithms.common.adapters.mmcv.pipelines.load_image_from_otx_dataset as load_image_base
@@ -51,8 +51,8 @@ class LoadResizeDataFromOTXDataset(load_image_base.LoadResizeDataFromOTXDataset)
         # Split image & mask from cached 4D map
         img = results["img"]
         if img.shape[-1] == 4:
-            results["img"] = img[:,:,:-1]
-            results["gt_semantic_seg"] = img[:,:,-1]
+            results["img"] = img[:, :, :-1]
+            results["gt_semantic_seg"] = img[:, :, -1]
         return results
 
     def _save_cache(self, results: Dict[str, Any]):

--- a/src/otx/algorithms/segmentation/configs/base/data/data_pipeline.py
+++ b/src/otx/algorithms/segmentation/configs/base/data/data_pipeline.py
@@ -20,8 +20,16 @@ __img_scale = (544, 544)
 __crop_size = (512, 512)
 
 train_pipeline = [
-    dict(type="LoadImageFromOTXDataset", enable_memcache=True),
-    dict(type="LoadAnnotationFromOTXDataset", use_otx_adapter=True),
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        load_ann_cfg=dict(type="LoadAnnotationFromOTXDataset", use_otx_adapter=True),
+        resize_cfg=dict(
+            type="Resize",
+            img_scale=__img_scale,
+            downscale_only=True,
+        ),  # Resize to intermediate size if org image is bigger
+        enable_memcache=True,  # Cache after resizing image & annotations
+    ),
     dict(type="Resize", img_scale=__img_scale, ratio_range=(0.5, 2.0)),
     dict(type="RandomCrop", crop_size=__crop_size, cat_max_ratio=0.75),
     dict(type="RandomFlip", prob=0.5, direction="horizontal"),

--- a/tests/unit/algorithms/segmentation/adapters/mmseg/datasets/pipelines/test_loads.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/datasets/pipelines/test_loads.py
@@ -5,8 +5,9 @@
 import numpy as np
 import pytest
 
-from otx.algorithms.segmentation.adapters.mmseg.datasets.pipelines.loads import (
+from otx.algorithms.segmentation.adapters.mmseg.datasets.pipelines import (
     LoadAnnotationFromOTXDataset,
+    LoadResizeDataFromOTXDataset,
 )
 from otx.api.entities.annotation import (
     Annotation,
@@ -18,7 +19,13 @@ from otx.api.entities.image import Image
 from otx.api.entities.label import Domain, LabelEntity
 from otx.api.entities.scored_label import ScoredLabel
 from otx.api.entities.shapes.rectangle import Rectangle
+from otx.core.data.caching import MemCacheHandlerSingleton
+
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from tests.test_suite.e2e_test_system import e2e_pytest_unit
+from tests.unit.algorithms.detection.test_helpers import generate_det_dataset
+
+from typing import Iterator, List, Optional, Sequence, Tuple
 
 
 def label_entity(name="test label") -> LabelEntity:
@@ -26,7 +33,7 @@ def label_entity(name="test label") -> LabelEntity:
 
 
 def dataset_item() -> DatasetItemEntity:
-    image: Image = Image(data=np.random.randint(low=0, high=255, size=(10, 16, 3)))
+    image: Image = Image(data=np.random.randint(low=0, high=255, size=(10, 16, 3)).astype(np.uint8))
     annotation: Annotation = Annotation(shape=Rectangle.generate_full_box(), labels=[ScoredLabel(label_entity())])
     annotation_scene: AnnotationSceneEntity = AnnotationSceneEntity(
         annotations=[annotation], kind=AnnotationSceneKind.ANNOTATION
@@ -50,4 +57,42 @@ class TestLoadAnnotationFromOTXDataset:
     def test_call(self) -> None:
         loaded_annotations: dict = self.pipeline(self.results)
         assert "gt_semantic_seg" in loaded_annotations
-        assert loaded_annotations["dataset_item"] == self.dataset_item
+
+
+@e2e_pytest_unit
+@pytest.mark.parametrize("mode", ["singleprocessing", "multiprocessing"])
+def test_load_resize_data_from_otx_dataset_call(mocker, mode):
+    """Test LoadResizeDataFromOTXDataset."""
+    item: DatasetItemEntity = dataset_item()
+    MemCacheHandlerSingleton.create(mode, item.numpy.size * 2)
+    op = LoadResizeDataFromOTXDataset(
+        use_otx_adapter=True,
+        load_ann_cfg=dict(
+            type="LoadAnnotationFromOTXDataset",
+            use_otx_adapter=True,
+        ),
+        resize_cfg=dict(
+            type="Resize",
+            img_scale=(8, 5),  # (w, h)
+        ),  # 10x16 -> 5x8
+    )
+    src_dict = dict(
+        dataset_item=item,
+        width=item.width,
+        height=item.height,
+        index=0,
+        ann_info=dict(labels=[label_entity()]),
+        seg_fields=[],
+    )
+    dst_dict = op(src_dict)
+    assert dst_dict["ori_shape"][0] == 10
+    assert dst_dict["img_shape"][0] == 5  # height
+    assert dst_dict["img_shape"][1] == 8  # width
+    assert dst_dict["img"].shape == dst_dict["img_shape"]
+    assert dst_dict["img"].shape[:2] == dst_dict["gt_semantic_seg"].shape[:2]
+    assert "gt_semantic_seg" not in src_dict  # src_dict not affected
+    op._load_img = mocker.MagicMock()
+    dst_dict_from_cache = op(src_dict)
+    assert op._load_img.call_count == 0  # _load_img() should not be called
+    assert np.array_equal(dst_dict["img"], dst_dict_from_cache["img"])
+    assert np.array_equal(dst_dict["gt_semantic_seg"], dst_dict_from_cache["gt_semantic_seg"])


### PR DESCRIPTION
### Summary

**[Changes]**
* Extend https://github.com/openvinotoolkit/training_extensions/pull/2453 to semantic segmentation models
(all models are sharing the same data pipeline for base incremental learning recipe)
* Enable GT mask caching (after polygon -> mask computation & resizing)

**[Results (sampled)]**

* kvasir_seg/100 (500x500 ~ 1Kx1K) / LiteHRNet_s_mod2 (512x512) / default setting (num_workers=2)
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



Branch | Size | Cache | Data time | Iter time | E2E time | Accuracy
-- | -- | -- | -- | -- | -- | --
develop | 512x512 | off | 0.0245 | 0.1450 | 44.32 | 0.8517
  | 256x256 | off | 0.0066 | 0.1104 | 45.54 | 0.8637
  | 256x256 | 95M/2G | 0.0050 | 0.1078 | 35.86 | 0.8523
feat/load-resize-cache-seg | 256x256 | off | 0.0082 | 0.1127 | 37.31 | 0.8214
  | 256x256 | **30M/2G** | 0.0059 | 0.1056 | 37.54 | 0.8567



</div>

<!--EndFragment-->
</body>

</html>


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
