### PR TITLE
Apply load+resize cache to validation pipelines

### DIFF
--- a/src/otx/algorithms/classification/configs/base/data/data_pipeline.py
+++ b/src/otx/algorithms/classification/configs/base/data/data_pipeline.py
@@ -25,6 +25,7 @@ __train_pipeline = [
         resize_cfg=dict(type="Resize", size=__resize_target_size, downscale_only=True),
         # To be resized in this op only if input is larger than expected size
         # for speed & cache memory efficiency.
+        enable_memcache=True,  # Cache after resizing image
     ),
     dict(type="RandomResizedCrop", size=__resize_target_size, efficientnet_style=True),
     dict(type="RandomFlip", flip_prob=0.5, direction="horizontal"),
@@ -51,6 +52,17 @@ __train_pipeline = [
     ),
 ]
 
+__val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", size=__resize_target_size),
+        enable_memcache=True,  # Cache after resizing image
+    ),
+    dict(type="Normalize", **__img_norm_cfg),
+    dict(type="ImageToTensor", keys=["img"]),
+    dict(type="Collect", keys=["img"]),
+]
+
 __test_pipeline = [
     dict(type="LoadImageFromOTXDataset"),
     dict(type="ResizeTo", size=__resize_target_size),
@@ -63,6 +75,6 @@ __dataset_type = "OTXClsDataset"
 
 data = dict(
     train=dict(type=__dataset_type, pipeline=__train_pipeline),
-    val=dict(type=__dataset_type, test_mode=True, pipeline=__test_pipeline),
+    val=dict(type=__dataset_type, test_mode=True, pipeline=__val_pipeline),
     test=dict(type=__dataset_type, test_mode=True, pipeline=__test_pipeline),
 )

--- a/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
+++ b/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
@@ -191,6 +191,7 @@ class LoadResizeDataFromOTXDataset(LoadImageFromOTXDataset):
             return cached_results
         results = self._load_img(results)
         results = self._load_ann_if_any(results)
+        results.pop("dataset_item", None)  # Prevent deepcopy or caching
         results = self._resize_img_ann_if_any(results)
         self._save_cache(results)
         return results

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -134,7 +134,7 @@ class DetectionConfigurer(BaseConfigurer):
         class_adapt_cfg = dict(type="AdaptClassLabels", src_classes=self.data_classes, dst_classes=self.model_classes)
         pipeline_cfg = tr_data_cfg.pipeline
         for i, operation in enumerate(pipeline_cfg):
-            if operation["type"] == "LoadAnnotationFromOTXDataset":  # insert just after this operation
+            if operation["type"] in ["LoadAnnotationFromOTXDataset", "LoadResizeDataFromOTXDataset"]:  # insert just after this operation
                 op_next_ann = pipeline_cfg[i + 1] if i + 1 < len(pipeline_cfg) else {}
                 if op_next_ann.get("type", "") == class_adapt_cfg["type"]:
                     op_next_ann.update(class_adapt_cfg)

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -134,7 +134,10 @@ class DetectionConfigurer(BaseConfigurer):
         class_adapt_cfg = dict(type="AdaptClassLabels", src_classes=self.data_classes, dst_classes=self.model_classes)
         pipeline_cfg = tr_data_cfg.pipeline
         for i, operation in enumerate(pipeline_cfg):
-            if operation["type"] in ["LoadAnnotationFromOTXDataset", "LoadResizeDataFromOTXDataset"]:  # insert just after this operation
+            if operation["type"] in [
+                "LoadAnnotationFromOTXDataset",
+                "LoadResizeDataFromOTXDataset",
+            ]:  # insert just after this operation
                 op_next_ann = pipeline_cfg[i + 1] if i + 1 < len(pipeline_cfg) else {}
                 if op_next_ann.get("type", "") == class_adapt_cfg["type"]:
                     op_next_ann.update(class_adapt_cfg)

--- a/src/otx/algorithms/detection/configs/base/data/atss_data_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/atss_data_pipeline.py
@@ -49,6 +49,24 @@ train_pipeline = [
         ],
     ),
 ]
+val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", img_scale=__img_size, keep_ratio=False),
+        enable_memcache=True,  # Cache after resizing image
+    ),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_size,
+        flip=False,
+        transforms=[
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
 test_pipeline = [
     dict(type="LoadImageFromOTXDataset"),
     dict(
@@ -76,7 +94,7 @@ data = dict(
     val=dict(
         type=__dataset_type,
         test_mode=True,
-        pipeline=test_pipeline,
+        pipeline=val_pipeline,
     ),
     test=dict(
         type=__dataset_type,

--- a/src/otx/algorithms/detection/configs/base/data/iseg_efficientnet_data_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/iseg_efficientnet_data_pipeline.py
@@ -50,6 +50,26 @@ train_pipeline = [
     ),
 ]
 
+val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", img_scale=__img_size, keep_ratio=False),
+        enable_memcache=True,  # Cache after resizing image
+    ),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_size,
+        flip=False,
+        transforms=[
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="Pad", size_divisor=32),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+
 test_pipeline = [
     dict(type="LoadImageFromOTXDataset"),
     dict(
@@ -77,7 +97,7 @@ data = dict(
     val=dict(
         type=__dataset_type,
         test_mode=True,
-        pipeline=test_pipeline,
+        pipeline=val_pipeline,
     ),
     test=dict(
         type=__dataset_type,

--- a/src/otx/algorithms/detection/configs/base/data/iseg_resnet_data_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/iseg_resnet_data_pipeline.py
@@ -49,6 +49,25 @@ train_pipeline = [
     ),
 ]
 
+val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", img_scale=__img_size, keep_ratio=False),
+        enable_memcache=True,  # Cache after resizing image
+    ),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_size,
+        flip=False,
+        transforms=[
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+
 test_pipeline = [
     dict(type="LoadImageFromOTXDataset"),
     dict(
@@ -75,7 +94,7 @@ data = dict(
     val=dict(
         type=__dataset_type,
         test_mode=True,
-        pipeline=test_pipeline,
+        pipeline=val_pipeline,
     ),
     test=dict(
         type=__dataset_type,

--- a/src/otx/algorithms/detection/configs/detection/cspdarknet_yolox/data_pipeline.py
+++ b/src/otx/algorithms/detection/configs/detection/cspdarknet_yolox/data_pipeline.py
@@ -1,23 +1,13 @@
 """Data Pipeline of YOLOX model for Detection Task."""
 
-# Copyright (C) 2022 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=invalid-name
 
 __img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 __img_size = (640, 640)
+__img_size_test = (416, 416)
 
 train_pipeline = [
     dict(type="Mosaic", img_scale=__img_size, pad_val=114.0),
@@ -57,16 +47,36 @@ train_pipeline = [
     ),
 ]
 
+val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", img_scale=__img_size_test, keep_ratio=True),
+        enable_memcache=True,  # Cache after resizing image
+    ),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_size_test,
+        flip=False,
+        transforms=[
+            dict(type="RandomFlip"),
+            dict(type="Pad", size=__img_size_test, pad_val=114.0),
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="DefaultFormatBundle"),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
+
 test_pipeline = [
     dict(type="LoadImageFromOTXDataset"),
     dict(
         type="MultiScaleFlipAug",
-        img_scale=(416, 416),
+        img_scale=__img_size_test,
         flip=False,
         transforms=[
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
-            dict(type="Pad", size=(416, 416), pad_val=114.0),
+            dict(type="Pad", size=__img_size_test, pad_val=114.0),
             dict(type="Normalize", **__img_norm_cfg),
             dict(type="DefaultFormatBundle"),
             dict(type="Collect", keys=["img"]),
@@ -101,7 +111,7 @@ data = dict(
     val=dict(
         type=__dataset_type,
         test_mode=True,
-        pipeline=test_pipeline,
+        pipeline=val_pipeline,
     ),
     test=dict(
         type=__dataset_type,

--- a/src/otx/algorithms/detection/configs/detection/mobilenetv2_ssd/data_pipeline.py
+++ b/src/otx/algorithms/detection/configs/detection/mobilenetv2_ssd/data_pipeline.py
@@ -1,18 +1,7 @@
 """Data Pipeline of SSD model for Detection Task."""
 
-# Copyright (C) 2022 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=invalid-name
 
@@ -63,6 +52,23 @@ train_pipeline = [
         ],
     ),
 ]
+val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", img_scale=__img_size, keep_ratio=False),
+        enable_memcache=True,  # Cache after resizing image
+    ),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_size,
+        flip=False,
+        transforms=[
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(type="Collect", keys=["img"]),
+        ],
+    ),
+]
 test_pipeline = [
     dict(type="LoadImageFromOTXDataset"),
     dict(
@@ -85,7 +91,7 @@ data = dict(
     val=dict(
         type=__dataset_type,
         test_mode=True,
-        pipeline=test_pipeline,
+        pipeline=val_pipeline,
     ),
     test=dict(
         type=__dataset_type,

--- a/src/otx/algorithms/segmentation/configs/base/data/data_pipeline.py
+++ b/src/otx/algorithms/segmentation/configs/base/data/data_pipeline.py
@@ -54,6 +54,29 @@ train_pipeline = [
     ),
 ]
 
+val_pipeline = [
+    dict(
+        type="LoadResizeDataFromOTXDataset",
+        resize_cfg=dict(type="Resize", img_scale=__img_scale, keep_ratio=False),
+        enable_memcache=True,  # Cache after resizing image
+        use_otx_adapter=True,
+    ),
+    dict(
+        type="MultiScaleFlipAug",
+        img_scale=__img_scale,
+        flip=False,
+        transforms=[
+            dict(type="RandomFlip"),
+            dict(type="Normalize", **__img_norm_cfg),
+            dict(type="ImageToTensor", keys=["img"]),
+            dict(
+                type="Collect",
+                keys=["img"],
+            ),
+        ],
+    ),
+]
+
 test_pipeline = [
     dict(type="LoadImageFromOTXDataset", use_otx_adapter=True),
     dict(
@@ -75,6 +98,6 @@ test_pipeline = [
 
 data = dict(
     train=dict(type="MPASegDataset", pipeline=train_pipeline),
-    val=dict(type="MPASegDataset", pipeline=test_pipeline),
+    val=dict(type="MPASegDataset", pipeline=val_pipeline),
     test=dict(type="MPASegDataset", pipeline=test_pipeline),
 )


### PR DESCRIPTION
### Summary

**[Changes]**
* Applied `LoadResizeDataFromOTXDataset` to validation pipeline to optimize efficiency & memory usage
  (Separated from test pipeline)
* Fixed minor issue: re-enable AdaptClassLabel op

**[Results]**
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



Task | Dataset | Model | Branch | Cache usage | E2E time
-- | -- | -- | -- | -- | --
Classification | CUB_200_2011_64   (<500x500) | EFFb0 (224x224) | develop | (org   35M) 9M | 10.03
  |   |   | opt/load-resize-cache-val | **1M** | 9.05
Detection | peanut (1920x1080) | YOLOX (640x640) | develop | (org   168M) 64M | 32.05
  |   |   | opt/load-resize-cache-val | **18M** | 32.19
Instance seg | wgisd (2048x1365) | MRCNN-EFFb0   (1042x1024) | develop | (org   942M) 271M | 298.92
  |   |   | opt/load-resize-cache-val | **22M** | 237.91
Semantic seg | kvasir_seg/100   (500x500 ~ 1Kx1K) | LiteHRNet_s_mod2   (512x512) | develop | (org   95M) 30M | 37.64
  |   |   | opt/load-resize-cache-val | **22M** | 36.75



</div>

<!--EndFragment-->
</body>

</html>
[!] org cache usage: caching original decoded image

### How to test

* Integration test

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
