### PR TITLE
Fix python 3.10 rev number to 12 (3.10.12)

### DIFF
--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Trivy Scanning
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: python -m pip install tox
       - name: Bandit Scanning

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,7 +29,7 @@ jobs:
     name: E2E-Test-py310-${{ matrix.task }}
     uses: ./.github/workflows/run_tests_in_tox.yml
     with:
-      python-version: "3.10"
+      python-version: "3.10.12"
       toxenv-pyver: "py310"
       toxenv-task: ${{ matrix.task }}
       tests-dir: ${{ matrix.test_dir }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Build-Docs

--- a/.github/workflows/docs_stable.yml
+++ b/.github/workflows/docs_stable.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Build-Docs

--- a/.github/workflows/docs_test.yml
+++ b/.github/workflows/docs_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Build-Docs

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
       - name: Code quality checks
@@ -42,7 +42,7 @@ jobs:
             tox-env: "py38"
           - python-version: "3.9"
             tox-env: "py39"
-          - python-version: "3.10"
+          - python-version: "3.10.12"
             tox-env: "py310"
     name: Unit-Test-with-Python${{ matrix.python-version }}
     # This is what will cancel the job concurrency
@@ -113,7 +113,7 @@ jobs:
       cancel-in-progress: true
     uses: ./.github/workflows/run_tests_in_tox.yml
     with:
-      python-version: "3.10"
+      python-version: "3.10.12"
       toxenv-pyver: "py310"
       toxenv-task: ${{ matrix.task }}
       tests-dir: ${{ matrix.test_dir }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.10.12"
       - name: Install pypa/build
         run: python -m pip install build
       - name: Build sdist

--- a/.github/workflows/run_tests_in_tox.yml
+++ b/.github/workflows/run_tests_in_tox.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       python-version:
         type: string
-        default: "3.10"
+        default: "3.10.12"
       toxenv-pyver:
         description: "[py38, py39, py310]"
         type: string
@@ -45,7 +45,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
       - name: Install dependencies
         run: python -m pip install -r requirements/dev.txt
-      - name: E2E Tests
+      - name: Run Tests
         run: tox -vv -e tests-${{ inputs.toxenv-task }}-${{ inputs.toxenv-pyver }} -- ${{ inputs.tests-dir }}
       - name: Upload test results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -43,7 +43,7 @@ jobs:
     name: Regression-Test-py310-${{ matrix.toxenv_task }}
     uses: ./.github/workflows/run_tests_in_tox.yml
     with:
-      python-version: "3.10"
+      python-version: "3.10.12"
       toxenv-pyver: "py310"
       toxenv-task: ${{ matrix.toxenv_task }}
       tests-dir: ${{ matrix.test_dir }}

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@
 <!-- markdownlint-enable  MD042 -->
 
 [![Codecov](https://codecov.io/gh/openvinotoolkit/training_extensions/branch/develop/graph/badge.svg?token=9HVFNMPFGD)](https://codecov.io/gh/openvinotoolkit/training_extensions)
-[![Pre-Merge Test](https://github.com/openvinotoolkit/training_extensions/actions/workflows/pre_merge.yml/badge.svg)](https://github.com/openvinotoolkit/training_extensions/actions/workflows/pre_merge.yml)
-[![Nightly Test](https://github.com/openvinotoolkit/training_extensions/actions/workflows/daily.yml/badge.svg)](https://github.com/openvinotoolkit/training_extensions/actions/workflows/daily.yml)
-[![Build Docs](https://github.com/openvinotoolkit/training_extensions/actions/workflows/docs.yml/badge.svg)](https://github.com/openvinotoolkit/training_extensions/actions/workflows/docs.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Downloads](https://static.pepy.tech/personalized-badge/otx?period=total&units=international_system&left_color=grey&right_color=green&left_text=PyPI%20Downloads)](https://pepy.tech/project/otx)
 


### PR DESCRIPTION
### Summary

* fix python 3.10 rev number to 12 (3.10.12) due to the error while setup with 3.10.13
* remove ci related badges from README.md due to the instability

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
