### PR TITLE
Added quantization configs for SegNext T S B

### DIFF
--- a/src/otx/algorithms/segmentation/configs/ham_segnext_b/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_b/ptq_optimization_config.py
@@ -1,7 +1,6 @@
 """PTQ config file."""
 from nncf import IgnoredScope
 
-
 ignored_scope = IgnoredScope(
     patterns=["/hamburger/"],
     types=[

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_b/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_b/ptq_optimization_config.py
@@ -1,0 +1,15 @@
+"""PTQ config file."""
+from nncf import IgnoredScope
+
+
+ignored_scope = IgnoredScope(
+    patterns=[
+        "/hamburger/"
+    ],
+    types=[
+        "Add",
+        "MVN",
+        "Divide",
+        "Multiply",
+    ]
+)

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_b/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_b/ptq_optimization_config.py
@@ -3,13 +3,11 @@ from nncf import IgnoredScope
 
 
 ignored_scope = IgnoredScope(
-    patterns=[
-        "/hamburger/"
-    ],
+    patterns=["/hamburger/"],
     types=[
         "Add",
         "MVN",
         "Divide",
         "Multiply",
-    ]
+    ],
 )

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_b/template.yaml
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_b/template.yaml
@@ -48,6 +48,9 @@ hyper_parameters:
         default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
+    pot_parameters:
+      preset:
+        default_value: Mixed
     algo_backend:
       train_type:
         default_value: Incremental

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_s/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_s/ptq_optimization_config.py
@@ -1,7 +1,6 @@
 """PTQ config file."""
 from nncf import IgnoredScope
 
-
 ignored_scope = IgnoredScope(
     patterns=["/hamburger/"],
     types=[

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_s/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_s/ptq_optimization_config.py
@@ -1,0 +1,15 @@
+"""PTQ config file."""
+from nncf import IgnoredScope
+
+
+ignored_scope = IgnoredScope(
+    patterns=[
+        "/hamburger/"
+    ],
+    types=[
+        "Add",
+        "MVN",
+        "Divide",
+        "Multiply",
+    ]
+)

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_s/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_s/ptq_optimization_config.py
@@ -3,13 +3,11 @@ from nncf import IgnoredScope
 
 
 ignored_scope = IgnoredScope(
-    patterns=[
-        "/hamburger/"
-    ],
+    patterns=["/hamburger/"],
     types=[
         "Add",
         "MVN",
         "Divide",
         "Multiply",
-    ]
+    ],
 )

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_s/template.yaml
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_s/template.yaml
@@ -48,6 +48,9 @@ hyper_parameters:
         default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
+    pot_parameters:
+      preset:
+        default_value: Mixed
     algo_backend:
       train_type:
         default_value: Incremental

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_t/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_t/ptq_optimization_config.py
@@ -1,7 +1,6 @@
 """PTQ config file."""
 from nncf import IgnoredScope
 
-
 ignored_scope = IgnoredScope(
     patterns=["/hamburger/"],
     types=[

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_t/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_t/ptq_optimization_config.py
@@ -1,0 +1,15 @@
+"""PTQ config file."""
+from nncf import IgnoredScope
+
+
+ignored_scope = IgnoredScope(
+    patterns=[
+        "/hamburger/"
+    ],
+    types=[
+        "Add",
+        "MVN",
+        "Divide",
+        "Multiply",
+    ]
+)

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_t/ptq_optimization_config.py
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_t/ptq_optimization_config.py
@@ -3,13 +3,11 @@ from nncf import IgnoredScope
 
 
 ignored_scope = IgnoredScope(
-    patterns=[
-        "/hamburger/"
-    ],
+    patterns=["/hamburger/"],
     types=[
         "Add",
         "MVN",
         "Divide",
         "Multiply",
-    ]
+    ],
 )

--- a/src/otx/algorithms/segmentation/configs/ham_segnext_t/template.yaml
+++ b/src/otx/algorithms/segmentation/configs/ham_segnext_t/template.yaml
@@ -48,6 +48,9 @@ hyper_parameters:
         default_value: false
       maximal_accuracy_degradation:
         default_value: 1.0
+    pot_parameters:
+      preset:
+        default_value: Mixed
     algo_backend:
       train_type:
         default_value: Incremental


### PR DESCRIPTION
### Summary

Added PTQ configs for SegNext model family. Results are below.

<html>
<body>
<!--StartFragment-->

Source | Dataset | Model | Accuracy | FPS
-- | -- | -- | -- | --
PT FP32 | kitti | SegNext-T | 37.33 | -
IR FP32 | kitti | SegNext-T | 37.28 | 37.95
IR INT8 | kitti | SegNext-T | 37.84 | 68.25
  |   |   |   |  
PT FP32 | kitti | SegNext-S | 44.34 | -
IR FP32 | kitti | SegNext-S | 44.42 | 23.79
IR INT8 | kitti | SegNext-S | 42.65 | 43.50
  |   |   |   |  
PT FP32 | kitti | SegNext-B | 49.56 | -
IR FP32 | kitti | SegNext-B | 49.52 | 13.06
IR INT8 | kitti | SegNext-B | 31.59 | 23.69
  |   |   |   |  
PT FP32 | cityscapes | SegNext-T | 50.46 | -
IR FP32 | cityscapes | SegNext-T | 50.38 | 30.14
IR INT8 | cityscapes | SegNext-T | 49.53 | 47.14
  |   |   |   |  
PT FP32 | cityscapes | SegNext-S | 52.20 | -
IR FP32 | cityscapes | SegNext-S | 52.15 | 19.84
IR INT8 | cityscapes | SegNext-S | 50.42 | 33.75
  |   |   |   |  
PT FP32 | cityscapes | SegNext-B | 59.77 | -
IR FP32 | cityscapes | SegNext-B | 59.76 | 11.47
IR INT8 | cityscapes | SegNext-B | 59.08 | 20.43

<!--EndFragment-->
</body>
</html>

kitti is a subset with 4 classes 54 training images 50 validation images
cityscapes is a subset with 19 classes 500 training images 185 validation images

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
