### PR TITLE
Adjust PTQ fq target

### DIFF
--- a/tests/e2e/cli/semantic_segmentation/reference/Custom_Semantic_Segmentation_SegNext_t/compressed_model.yml
+++ b/tests/e2e/cli/semantic_segmentation/reference/Custom_Semantic_Segmentation_SegNext_t/compressed_model.yml
@@ -2,4 +2,4 @@ TestToolsMPASegmentation:
   nncf:
     number_of_fakequantizers: 408
   ptq:
-    number_of_fakequantizers: 400
+    number_of_fakequantizers: 182


### PR DESCRIPTION
### Summary
After Nikita's PR(https://github.com/openvinotoolkit/training_extensions/pull/2477), which adds the quantization configs for SegNext T S B, PTQ FQ in SegNext_t is dropped from 400 to 182. Based on this actual test result, I'm adjusting the PTQ FQ target. 

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
