### PR TITLE
Add a dummy hierarchical config required by MAPI

### DIFF
--- a/src/otx/algorithms/classification/adapters/openvino/task.py
+++ b/src/otx/algorithms/classification/adapters/openvino/task.py
@@ -114,6 +114,16 @@ class ClassificationOpenVINOInferencer(BaseInferencer):
             plugin_config={"PERFORMANCE_HINT": "THROUGHPUT"},
         )
         self.configuration = get_cls_inferencer_configuration(self.label_schema)
+
+        # create a dummy hierarchical config for backward compatibility, which is not actually used
+        if self.configuration["hierarchical"]:
+            try:
+                model_adapter.get_rt_info(["model_info", "hierarchical_config"])
+            except RuntimeError:
+                self.configuration["hierarchical_config"] = json.dumps(
+                    {"cls_heads_info": {"label_to_idx": [], "all_groups": []}, "label_tree_edges": []}
+                )
+
         self.model = Model.create_model(model_adapter, "otx_classification", self.configuration, preload=True)
 
         self.converter = ClassificationToAnnotationConverter(self.label_schema)


### PR DESCRIPTION
### Summary

MAPI fails if the hierarchical config is missing in models coming from OTX 1.2. At the same time in this version of OTX it is not used yet, so we can substitute a dummy one.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
