### PR TITLE
Fix e2e tests for xai_sanity_classification

### DIFF
--- a/src/otx/algorithms/classification/adapters/openvino/task.py
+++ b/src/otx/algorithms/classification/adapters/openvino/task.py
@@ -223,6 +223,8 @@ class ClassificationOpenVINOTask(IDeploymentTask, IInferenceTask, IEvaluationTas
                         label_list = get_hierarchical_label_list(
                             self.inferencer.model.hierarchical_info["cls_heads_info"], label_list
                         )
+                    if saliency_map.ndim == 4 and saliency_map.shape[0] == 1:
+                        saliency_map = saliency_map.squeeze()
 
                     add_saliency_maps_to_dataset_item(
                         dataset_item=dataset_item,


### PR DESCRIPTION
### Summary

This PR fixes e2e tests `test_api_xai_sanity_classification.py`. 
Model API returns 4D saliency map for classification. This fix converts them to 3D, removing the batch dimension, so saliency maps can be processed and added.

This PR is an addition to [PR#2390](https://github.com/openvinotoolkit/training_extensions/pull/2390)

CVS-119863

### How to test

```
pytest tests/e2e/cli/classification/test_api_xai_sanity_classification.py
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
