### PR TITLE
Update unit tests for XAI 

### DIFF
--- a/tests/unit/algorithms/classification/test_xai_classification_validity.py
+++ b/tests/unit/algorithms/classification/test_xai_classification_validity.py
@@ -63,8 +63,8 @@ class TestExplainMethods:
         assert len(saliency_maps) == 2
         assert saliency_maps[0].ndim == 3
         assert saliency_maps[0].shape == saliency_map_ref_shape
-        actual_sal_vals = saliency_maps[0][0][0].astype(np.int8)
-        ref_sal_vals = self.ref_saliency_vals_cls[template.name].astype(np.int8)
+        actual_sal_vals = saliency_maps[0][0][0].astype(np.uint8)
+        ref_sal_vals = self.ref_saliency_vals_cls[template.name].astype(np.uint8)
         assert np.all(np.abs(actual_sal_vals - ref_sal_vals) <= 1)
 
 

--- a/tests/unit/algorithms/detection/test_xai_detection_validity.py
+++ b/tests/unit/algorithms/detection/test_xai_detection_validity.py
@@ -35,11 +35,11 @@ class TestExplainMethods:
 
     ref_saliency_vals_det = {
         "MobileNetV2-ATSS": np.array([67, 216, 255, 57], dtype=np.uint8),
-        "ResNeXt101-ATSS": np.array([75, -42, -27, -83], dtype=np.int8),
+        "ResNeXt101-ATSS": np.array([ 75, 214, 229, 173], dtype=np.uint8),
         "YOLOX-TINY": np.array([80, 28, 42, 53, 49, 68, 72, 75, 69, 57, 65, 6, 157], dtype=np.uint8),
-        "YOLOX-S": np.array([75, -78, -105, -97, -106, -108, -112, -112, -109, -112, -109, -114, -67], dtype=np.int8),
-        "YOLOX-L": np.array([43, 28, 0, 6, 7, 19, 22, 17, 14, 18, 25, 7, 34], dtype=np.int8),
-        "YOLOX-X": np.array([-1, -112, 83, 76, 83, 86, 82, 90, 91, 93, 110, 104, 83], dtype=np.int8),
+        "YOLOX-S": np.array([ 75, 178, 151, 159, 150, 148, 144, 144, 147, 144, 147, 142, 189], dtype=np.uint8),
+        "YOLOX-L": np.array([43, 28, 0, 6, 7, 19, 22, 17, 14, 18, 25, 7, 34], dtype=np.uint8),
+        "YOLOX-X": np.array([255, 144,  83,  76,  83,  86,  82,  90,  91,  93, 110, 104,  83], dtype=np.uint8),
         "SSD": np.array([119, 72, 118, 35, 39, 30, 31, 31, 36, 28, 44, 23, 61], dtype=np.uint8),
     }
 
@@ -92,8 +92,8 @@ class TestExplainMethods:
         assert len(saliency_maps) == 2
         assert saliency_maps[0].ndim == 3
         assert saliency_maps[0].shape == self.ref_saliency_shapes[template.name]
-        actual_sal_vals = saliency_maps[0][0][0].astype(np.int8)
-        ref_sal_vals = self.ref_saliency_vals_det[template.name].astype(np.int8)
+        actual_sal_vals = saliency_maps[0][0][0].astype(np.uint8)
+        ref_sal_vals = self.ref_saliency_vals_det[template.name].astype(np.uint8)
         assert np.all(np.abs(actual_sal_vals - ref_sal_vals) <= 1)
 
     @e2e_pytest_unit

--- a/tests/unit/algorithms/detection/test_xai_detection_validity.py
+++ b/tests/unit/algorithms/detection/test_xai_detection_validity.py
@@ -35,11 +35,11 @@ class TestExplainMethods:
 
     ref_saliency_vals_det = {
         "MobileNetV2-ATSS": np.array([67, 216, 255, 57], dtype=np.uint8),
-        "ResNeXt101-ATSS": np.array([ 75, 214, 229, 173], dtype=np.uint8),
+        "ResNeXt101-ATSS": np.array([75, 214, 229, 173], dtype=np.uint8),
         "YOLOX-TINY": np.array([80, 28, 42, 53, 49, 68, 72, 75, 69, 57, 65, 6, 157], dtype=np.uint8),
-        "YOLOX-S": np.array([ 75, 178, 151, 159, 150, 148, 144, 144, 147, 144, 147, 142, 189], dtype=np.uint8),
+        "YOLOX-S": np.array([75, 178, 151, 159, 150, 148, 144, 144, 147, 144, 147, 142, 189], dtype=np.uint8),
         "YOLOX-L": np.array([43, 28, 0, 6, 7, 19, 22, 17, 14, 18, 25, 7, 34], dtype=np.uint8),
-        "YOLOX-X": np.array([255, 144,  83,  76,  83,  86,  82,  90,  91,  93, 110, 104,  83], dtype=np.uint8),
+        "YOLOX-X": np.array([255, 144, 83, 76, 83, 86, 82, 90, 91, 93, 110, 104, 83], dtype=np.uint8),
         "SSD": np.array([119, 72, 118, 35, 39, 30, 31, 31, 36, 28, 44, 23, 61], dtype=np.uint8),
     }
 


### PR DESCRIPTION
### Summary

Change int8 to uint8 to XAI-validity checks to prevent unin8 -> int8 conversion and overflow, which caused turning saliency reference numbers to negative.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
