### PR TITLE
Update inst-seg end2end test fake quantization 

### DIFF
--- a/tests/e2e/cli/detection/test_tiling_detection.py
+++ b/tests/e2e/cli/detection/test_tiling_detection.py
@@ -240,7 +240,7 @@ class TestToolsTilingDetection:
     def test_ptq_optimize(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
         if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
@@ -249,7 +249,7 @@ class TestToolsTilingDetection:
     def test_ptq_validate_fq(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
         if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_validate_fq_testing(template, tmp_dir_path, otx_dir, "detection", type(self).__name__)
 
     @e2e_pytest_component
@@ -258,5 +258,5 @@ class TestToolsTilingDetection:
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
         if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/e2e/cli/detection/test_tiling_detection.py
+++ b/tests/e2e/cli/detection/test_tiling_detection.py
@@ -239,8 +239,6 @@ class TestToolsTilingDetection:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_optimize(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
-        if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
@@ -248,8 +246,6 @@ class TestToolsTilingDetection:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_validate_fq(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
-        if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_validate_fq_testing(template, tmp_dir_path, otx_dir, "detection", type(self).__name__)
 
     @e2e_pytest_component
@@ -257,6 +253,4 @@ class TestToolsTilingDetection:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
-        if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/e2e/cli/detection/test_tiling_detection.py
+++ b/tests/e2e/cli/detection/test_tiling_detection.py
@@ -239,6 +239,8 @@ class TestToolsTilingDetection:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_optimize(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
@@ -246,6 +248,8 @@ class TestToolsTilingDetection:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_validate_fq(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
         ptq_validate_fq_testing(template, tmp_dir_path, otx_dir, "detection", type(self).__name__)
 
     @e2e_pytest_component
@@ -253,4 +257,6 @@ class TestToolsTilingDetection:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_det"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
         ptq_eval_testing(template, tmp_dir_path, otx_dir, args)

--- a/tests/e2e/cli/instance_segmentation/reference/Custom_Counting_Instance_Segmentation_MaskRCNN_SwinT_FP16/compressed_model.yml
+++ b/tests/e2e/cli/instance_segmentation/reference/Custom_Counting_Instance_Segmentation_MaskRCNN_SwinT_FP16/compressed_model.yml
@@ -1,0 +1,10 @@
+TestToolsOTXInstanceSegmentation:
+  nncf:
+    number_of_fakequantizers: 193
+  ptq:
+    number_of_fakequantizers: 200
+TestToolsTilingInstanceSegmentation:
+  nncf:
+    number_of_fakequantizers: 193
+  ptq:
+    number_of_fakequantizers: 200

--- a/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
@@ -275,6 +275,9 @@ class TestToolsOTXInstanceSegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_optimize(self, template, tmp_dir_path):
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+
         tmp_dir_path = tmp_dir_path / "ins_seg"
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
@@ -283,6 +286,8 @@ class TestToolsOTXInstanceSegmentation:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_validate_fq(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
         ptq_validate_fq_testing(template, tmp_dir_path, otx_dir, "instance_segmentation", type(self).__name__)
 
     @e2e_pytest_component
@@ -290,6 +295,8 @@ class TestToolsOTXInstanceSegmentation:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
         ptq_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component

--- a/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
@@ -276,7 +276,7 @@ class TestToolsOTXInstanceSegmentation:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_optimize(self, template, tmp_dir_path):
         if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
 
         tmp_dir_path = tmp_dir_path / "ins_seg"
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
@@ -287,7 +287,7 @@ class TestToolsOTXInstanceSegmentation:
     def test_ptq_validate_fq(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_validate_fq_testing(template, tmp_dir_path, otx_dir, "instance_segmentation", type(self).__name__)
 
     @e2e_pytest_component
@@ -296,7 +296,7 @@ class TestToolsOTXInstanceSegmentation:
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "ins_seg"
         if "MaskRCNN-ConvNeXt" in template.name:
-            pytest.skip("CVS-118373	ConvNeXt Compilation Error in PTQ")
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_eval_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component

--- a/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/e2e/cli/instance_segmentation/test_instance_segmentation.py
@@ -277,7 +277,6 @@ class TestToolsOTXInstanceSegmentation:
     def test_ptq_optimize(self, template, tmp_dir_path):
         if "MaskRCNN-ConvNeXt" in template.name:
             pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
-
         tmp_dir_path = tmp_dir_path / "ins_seg"
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
 

--- a/tests/e2e/cli/instance_segmentation/test_tiling_instseg.py
+++ b/tests/e2e/cli/instance_segmentation/test_tiling_instseg.py
@@ -239,7 +239,8 @@ class TestToolsTilingInstanceSegmentation:
         tmp_dir_path = tmp_dir_path / "tiling_ins_seg"
         if template.entrypoints.nncf is None:
             pytest.skip("nncf entrypoint is none")
-
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         nncf_eval_openvino_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
@@ -247,6 +248,8 @@ class TestToolsTilingInstanceSegmentation:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_optimize(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_ins_seg"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
@@ -254,6 +257,8 @@ class TestToolsTilingInstanceSegmentation:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_validate_fq(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_ins_seg"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_validate_fq_testing(template, tmp_dir_path, otx_dir, "instance_segmentation", type(self).__name__)
 
     @e2e_pytest_component
@@ -261,4 +266,6 @@ class TestToolsTilingInstanceSegmentation:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "tiling_ins_seg"
+        if "MaskRCNN-ConvNeXt" in template.name:
+            pytest.skip("CVS-118373 ConvNeXt Compilation Error in PTQ")
         ptq_eval_testing(template, tmp_dir_path, otx_dir, args)


### PR DESCRIPTION
### Summary

```python
=============================== warnings summary ===============================
venv/lib/python3.8/site-packages/_pytest/config/__init__.py:755
  /home/yuchunli/training_extensions/venv/lib/python3.8/site-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.test_suite.fixtures
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============ 67 passed, 45 skipped, 1 warning in 6025.52s (1:40:25) ============
```

```python
=============================== warnings summary ===============================
venv/lib/python3.8/site-packages/_pytest/config/__init__.py:755
  /home/yuchunli/training_extensions/venv/lib/python3.8/site-packages/_pytest/config/__init__.py:755: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.test_suite.fixtures
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============ 60 passed, 36 skipped, 1 warning in 4973.57s (1:22:53) ============
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
