### PR TITLE
Fix a bug that `fp16` key error is raised when training without GPU

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,4 +10,4 @@ scipy>=1.8
 bayesian-optimization>=1.2.0
 tensorboard>=2.11.0
 multiprocess
-pynvml>=11.0.0
+pynvml==11.*

--- a/src/otx/algorithms/common/adapters/mmcv/configurer.py
+++ b/src/otx/algorithms/common/adapters/mmcv/configurer.py
@@ -224,10 +224,6 @@ class BaseConfigurer:
                 cfg.optimizer_config.update(opts)
             else:
                 logger.info("Revert FP16 to FP32 on CPU device")
-                if isinstance(cfg, Config):
-                    del cfg._cfg_dict["fp16"]  # pylint: disable=protected-access
-                elif isinstance(cfg, ConfigDict):
-                    del cfg["fp16"]
 
     def configure_model(self, cfg, data_classes, model_classes, ir_options, **kwargs):
         """Configuration model config settings."""


### PR DESCRIPTION
### Summary
Key error is raised when setting configuration in training a model w/o GPU.
It's because trying to delete `fp16` in `cfg` after `fp16` is already popped from `cfg`.
This PR fixes it.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
