### PR TITLE
Fix e2e failed case of visual prompting task

### DIFF
--- a/src/otx/algorithms/visual_prompting/tasks/inference.py
+++ b/src/otx/algorithms/visual_prompting/tasks/inference.py
@@ -31,6 +31,7 @@ from omegaconf import DictConfig, ListConfig
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import TQDMProgressBar
 
+from otx.algorithms.common.utils import set_random_seed
 from otx.algorithms.common.utils.logger import get_logger
 from otx.algorithms.visual_prompting.adapters.pytorch_lightning.callbacks import (
     InferenceCallback,
@@ -104,11 +105,21 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
         self.precision = [ModelPrecision.FP32]
         self.optimization_type = ModelOptimizationType.MO
 
-        self.model = self.load_model(otx_model=task_environment.model)
-
         self.trainer: Trainer
 
         self.timestamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+
+    def set_seed(self):
+        """Set seed and deterministic."""
+        if self.seed is None:
+            # If the seed is not present via task.train, it will be found in the recipe.
+            self.seed = self.config.get("seed", 5)
+        if not self.deterministic:
+            # deterministic is the same.
+            self.deterministic = self.config.get("deterministic", False)
+        self.config["seed"] = self.seed
+        self.config["deterministic"] = self.deterministic
+        set_random_seed(self.seed, logger, self.deterministic)
 
     def get_config(self) -> Union[DictConfig, ListConfig]:
         """Get Visual Prompting Config from task environment.
@@ -226,6 +237,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             DatasetEntity: Output dataset with predictions.
         """
         logger.info("Performing inference on the validation set using the base torch model.")
+        self.model = self.load_model(otx_model=self.task_environment.model)
         datamodule = OTXVisualPromptingDataModule(config=self.config.dataset, dataset=dataset)
 
         logger.info("Inference Configs '%s'", self.config)
@@ -330,6 +342,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
                 "The saliency maps and representation vector outputs will not be dumped in the exported model."
             )
 
+        self.model = self.load_model(otx_model=self.task_environment.model)
         if export_type == ExportType.ONNX:
             output_model.model_format = ModelFormat.ONNX
             output_model.optimization_type = ModelOptimizationType.ONNX

--- a/src/otx/algorithms/visual_prompting/tasks/train.py
+++ b/src/otx/algorithms/visual_prompting/tasks/train.py
@@ -16,7 +16,7 @@
 
 from typing import Optional
 
-from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import (
     EarlyStopping,
     LearningRateMonitor,
@@ -62,12 +62,14 @@ class TrainingTask(InferenceTask, ITrainingTask):
 
         logger.info("Training the model.")
 
-        if seed:
-            logger.info(f"Setting seed to {seed}")
-            seed_everything(seed, workers=True)
+        self.seed = seed
+        self.deterministic = deterministic
+        self.set_seed()
         self.config.trainer.deterministic = "warn" if deterministic else deterministic
 
         logger.info("Training Configs '%s'", self.config)
+
+        self.model = self.load_model(otx_model=self.task_environment.model)
 
         datamodule = OTXVisualPromptingDataModule(config=self.config.dataset, dataset=dataset)
         loggers = CSVLogger(save_dir=self.output_path, name=".", version=self.timestamp)

--- a/tests/unit/algorithms/visual_prompting/tasks/test_inference.py
+++ b/tests/unit/algorithms/visual_prompting/tasks/test_inference.py
@@ -94,7 +94,8 @@ class TestInferenceTask:
             "otx.algorithms.visual_prompting.adapters.pytorch_lightning.models.SegmentAnything"
         )
 
-        load_inference_task(path=path, resume=resume)
+        inference_task = load_inference_task(path=path, resume=resume)
+        inference_task.load_model(otx_model=inference_task.task_environment.model)
 
         mocker_segment_anything.assert_called_once()
 
@@ -111,7 +112,8 @@ class TestInferenceTask:
             return_value=dict(config=dict(model=dict(backbone="sam_vit_b")), model={}),
         )
 
-        load_inference_task(path="checkpoint.pth", resume=resume)
+        inference_task = load_inference_task(path="checkpoint.pth", resume=resume)
+        inference_task.load_model(otx_model=inference_task.task_environment.model)
 
         mocker_segment_anything.assert_called_once()
         mocker_io_bytes_io.assert_called_once()
@@ -162,6 +164,7 @@ class TestInferenceTask:
         )
 
         inference_task = load_inference_task(output_path=None)
+        inference_task.model = inference_task.load_model(otx_model=inference_task.task_environment.model)
         setattr(inference_task, "trainer", None)
         mocker.patch.object(inference_task, "trainer")
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Related ticket: CVS-118394
Fix that e2e test for visual prompting task has sometimes failed as moving `load_model` after `set_seed`.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
Tried e2e 20 times to check if there is any failed case.
```python
import subprocess
for _ in range(20):
    subprocess.run("tox -vv -e tests-visprompt-py310 -- tests/e2e/cli/visual_prompting", shell=True)

=================== 7 passed, 1 warning in 104.51s (0:01:44) ===================
```
Any failed case is not detected on 20 trials.

```
$ tox -vv -e unittest-all-py310 -- tests/unit/algorithms/visual_prompting

====================== 177 passed, 106 warnings in 29.37s ======================
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [x] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
