### PR TITLE
Fix bug that auto batch size doesn't consider distributed training

### DIFF
--- a/src/otx/algorithms/common/adapters/torch/utils/bs_search_algo.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/bs_search_algo.py
@@ -178,7 +178,7 @@ class BsSearchAlgo:
             elif self._mem_lower_bound <= mem_usage <= self._mem_upper_bound:
                 break
             else:
-                estimation_pct = 0.87
+                estimation_pct = 0.82
 
         if drop_last and (self._max_bs // 2 < estimated_bs < self._max_bs):
             estimated_bs = self._max_bs // 2

--- a/src/otx/algorithms/common/adapters/torch/utils/bs_search_algo.py
+++ b/src/otx/algorithms/common/adapters/torch/utils/bs_search_algo.py
@@ -36,8 +36,8 @@ class BsSearchAlgo:
         self._max_bs = max_bs
         self._bs_try_history: Dict[int, int] = {}
         _, self._total_mem = torch.cuda.mem_get_info()
-        self._mem_lower_bound = 0.85 * self._total_mem
-        self._mem_upper_bound = 0.9 * self._total_mem
+        self._mem_lower_bound = 0.8 * self._total_mem
+        self._mem_upper_bound = 0.85 * self._total_mem
 
     def _try_batch_size(self, bs: int) -> Tuple[bool, int]:
         cuda_oom = False
@@ -75,7 +75,7 @@ class BsSearchAlgo:
             dist.broadcast(total_try_result, src=0)
 
             cuda_oom = total_try_result[0].bool().item()
-            max_memory_allocated = total_try_result[1].to(torch.int64).item()
+            max_memory_allocated = total_try_result[1].item()
 
         if not cuda_oom:
             # Because heapq only supports min heap, use negatized batch size
@@ -163,7 +163,7 @@ class BsSearchAlgo:
             return self._default_bs
 
         # estimate batch size using equation
-        estimation_pct = 0.87
+        estimation_pct = 0.82
         while True:
             estimated_bs = self._estimate_batch_size(estimation_pct)
             if estimated_bs in self._bs_try_history:

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
@@ -1,4 +1,7 @@
+from typing import Optional, List
+
 import pytest
+import torch
 
 from tests.test_suite.e2e_test_system import e2e_pytest_unit
 from otx.algorithms.common.adapters.torch.utils import BsSearchAlgo
@@ -11,6 +14,8 @@ class TestBsSearchAlgo:
     def setup_test(self, mocker):
         self.mock_torch = mocker.patch.object(bs_search_algo, "torch")
         self.mock_torch.cuda.mem_get_info.return_value = (1, 10000)
+        self.mock_dist = mocker.patch.object(bs_search_algo, "dist")
+        self.mock_dist.is_initialized.return_value = False
 
     def test_init(self, mocker):
         BsSearchAlgo(mocker.MagicMock(), 4, 10)
@@ -39,6 +44,114 @@ class TestBsSearchAlgo:
             return mem_usage
 
         return mock_train_func
+
+    def test_try_batch_size(self):
+        mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=80)
+        bs_search_algo = BsSearchAlgo(mock_train_func, 128, 1000)
+        batch_size = 40
+
+        cuda_oom, max_memory_reserved = bs_search_algo._try_batch_size(batch_size)
+
+        assert cuda_oom is False
+        assert max_memory_reserved == mock_train_func(batch_size)
+        self.mock_torch.cuda.reset_max_memory_cached.assert_called()
+        self.mock_torch.cuda.empty_cache.assert_called()
+
+    def test_try_batch_size_cuda_oom(self):
+        mock_train_func = self.get_mock_train_func(cuda_oom_bound=100, max_runnable_bs=80)
+        bs_search_algo = BsSearchAlgo(mock_train_func, 128, 1000)
+        batch_size = 200
+
+        cuda_oom, _ = bs_search_algo._try_batch_size(batch_size)
+
+        assert cuda_oom is True
+        self.mock_torch.cuda.reset_max_memory_cached.assert_called()
+        self.mock_torch.cuda.empty_cache.assert_called()
+
+    def _prepare_dist_test(self, broadcast_val: torch.Tensor, gather_val: Optional[List[torch.Tensor]] = None):
+        self.mock_dist.is_initialized.return_value = True
+
+        # mocking torch.distributed.broadcast
+        def mock_broadcast(tensor: torch.Tensor, src: int):
+            tensor.copy_(broadcast_val)
+        self.mock_dist.broadcast.side_effect = mock_broadcast
+
+        # mocking torch.distributed.gather if gather_val is given
+        def mock_gather(tensor: torch.Tensor, gather_list: Optional[List[torch.Tensor]] = None, dst: int = 0):
+            for i in range(len(gather_list)):
+                gather_list[i].copy_(gather_val[i])
+        if gather_val is not None:
+            self.mock_dist.gather.side_effect = mock_gather
+
+        # revert some of torch function
+        def mock_tensor_cuda(self, *args, **kwargs):
+            return self
+        torch.Tensor.cuda = mock_tensor_cuda
+        self.mock_torch.tensor = torch.tensor
+        self.mock_torch.int64 = torch.int64
+        self.mock_torch.max = torch.max
+        self.mock_torch.any = torch.any
+        self.mock_torch.stack = torch.stack
+        self.mock_torch.empty = torch.empty
+
+    def test_try_batch_size_distributed_not_rank_0(self):
+        self.mock_dist.get_rank.return_value = 1
+        broadcasted_cuda_oom = False
+        broadcasted_max_memory_reserved = 4000
+        self._prepare_dist_test(
+            broadcast_val=torch.tensor([broadcasted_cuda_oom, broadcasted_max_memory_reserved], dtype=torch.int64)
+        )
+        mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=80)
+        batch_size = 40
+        bs_search_algo = BsSearchAlgo(mock_train_func, 128, 1000)
+        w1_max_memory_reserved = mock_train_func(batch_size)
+
+        cuda_oom, max_memory_reserved = bs_search_algo._try_batch_size(batch_size)
+
+        # check dist.gather is called and get [cuda_oom, maxmemory_reserved] as arguments.
+        self.mock_dist.gather.assert_called_once()
+        assert self.mock_dist.gather.call_args.args[0][0].item() == False
+        assert self.mock_dist.gather.call_args.args[0][1].item() == w1_max_memory_reserved
+        assert self.mock_dist.gather.call_args.kwargs["dst"] == 0
+        # check dist.broadcast is called
+        self.mock_dist.broadcast.assert_called_once()
+        assert self.mock_dist.broadcast.call_args.kwargs["src"] == 0
+        # check broadcased values are returned
+        assert cuda_oom is broadcasted_cuda_oom
+        assert max_memory_reserved == broadcasted_max_memory_reserved
+
+    def test_try_batch_size_distributed_rank_0(self):
+        self.mock_dist.get_rank.return_value = 0
+        self.mock_dist.get_world_size.return_value = 2
+        self._prepare_dist_test(
+            broadcast_val=torch.tensor([True, 4000], dtype=torch.int64),
+            gather_val=[
+                torch.tensor([False, 3000], dtype=torch.int64),
+                torch.tensor([True, 4000], dtype=torch.int64),
+            ]
+        )
+        mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=80)
+        batch_size = 40
+        bs_search_algo = BsSearchAlgo(mock_train_func, 128, 1000)
+        w0_max_memory_reserved = mock_train_func(batch_size)
+
+        cuda_oom, max_memory_reserved = bs_search_algo._try_batch_size(batch_size)
+
+        # check dist.gather is called and get [cuda_oom, max_memory_reserved] as arguments.
+        self.mock_dist.gather.assert_called_once()
+        assert self.mock_dist.gather.call_args.args[0][0].item() == False
+        assert self.mock_dist.gather.call_args.args[0][1].item() == w0_max_memory_reserved
+        assert self.mock_dist.gather.call_args.kwargs["dst"] == 0
+        # check if any process get cuda oom then set cuda_oom to True and
+        # set max_memory_reserved to maximum value of processes'
+        self.mock_dist.broadcast.assert_called_once()
+        self.mock_dist.broadcast.assert_called_once()
+        assert self.mock_dist.broadcast.call_args.kwargs["src"] == 0
+        assert self.mock_dist.broadcast.call_args.args[0][0].item() == True
+        assert self.mock_dist.broadcast.call_args.args[0][1].item() == 4000
+        # check proper values are returned
+        assert cuda_oom is True
+        assert max_memory_reserved == 4000
 
     def test_auto_decrease_batch_size(self):
         mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=80)

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
@@ -31,11 +31,11 @@ class TestBsSearchAlgo:
                 mem_usage = 10000
                 raise RuntimeError("CUDA out of memory.")
             elif batch_size > max_runnable_bs:
-                mem_usage = 8500 + 1500 * batch_size / (cuda_oom_bound - max_runnable_bs)
+                mem_usage = 9000 + 1000 * batch_size / (cuda_oom_bound - max_runnable_bs)
             else:
-                mem_usage = 8500 * batch_size / max_runnable_bs
+                mem_usage = 9000 * batch_size / max_runnable_bs
 
-            self.mock_torch.cuda.max_memory_allocated.return_value = mem_usage
+            self.mock_torch.cuda.max_memory_reserved.return_value = mem_usage
             return mem_usage
 
         return mock_train_func
@@ -71,7 +71,7 @@ class TestBsSearchAlgo:
         adapted_bs = bs_search_algo.find_big_enough_batch_size()
 
         if expected_bs is None:
-            assert 7500 <= mock_train_func(adapted_bs) <= 8500
+            assert 8000 <= mock_train_func(adapted_bs) <= 9000
         else:
             assert adapted_bs == expected_bs
 
@@ -88,10 +88,10 @@ class TestBsSearchAlgo:
                 mem_usage = 10000
                 raise RuntimeError("CUDA out of memory.")
             elif batch_size > 100:
-                mem_usage = 9000
+                mem_usage = 9500
             else:
                 mem_usage = 1000
-            self.mock_torch.cuda.max_memory_allocated.return_value = mem_usage
+            self.mock_torch.cuda.max_memory_reserved.return_value = mem_usage
             return mem_usage
 
         bs_search_algo = BsSearchAlgo(mock_train_func, 64, 1000)
@@ -105,16 +105,16 @@ class TestBsSearchAlgo:
                 mem_usage = 10000
                 raise RuntimeError("CUDA out of memory.")
             elif batch_size > 100:
-                mem_usage = 9000
+                mem_usage = 9500
             else:
                 mem_usage = 1000 + batch_size / 1000
-            self.mock_torch.cuda.max_memory_allocated.return_value = mem_usage
+            self.mock_torch.cuda.max_memory_reserved.return_value = mem_usage
             return mem_usage
 
         bs_search_algo = BsSearchAlgo(mock_train_func, 64, 1000)
         adapted_bs = bs_search_algo.find_big_enough_batch_size()
 
-        assert mock_train_func(adapted_bs) <= 8500
+        assert mock_train_func(adapted_bs) <= 9000
 
     def test_find_big_enough_batch_size_drop_last(self):
         mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=180)

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
@@ -31,9 +31,9 @@ class TestBsSearchAlgo:
                 mem_usage = 10000
                 raise RuntimeError("CUDA out of memory.")
             elif batch_size > max_runnable_bs:
-                mem_usage = 9000 + 1000 * batch_size / (cuda_oom_bound - max_runnable_bs)
+                mem_usage = 8500 + 1500 * batch_size / (cuda_oom_bound - max_runnable_bs)
             else:
-                mem_usage = 9000 * batch_size / max_runnable_bs
+                mem_usage = 8500 * batch_size / max_runnable_bs
 
             self.mock_torch.cuda.max_memory_reserved.return_value = mem_usage
             return mem_usage
@@ -71,7 +71,7 @@ class TestBsSearchAlgo:
         adapted_bs = bs_search_algo.find_big_enough_batch_size()
 
         if expected_bs is None:
-            assert 8000 <= mock_train_func(adapted_bs) <= 9000
+            assert 7500 <= mock_train_func(adapted_bs) <= 8500
         else:
             assert adapted_bs == expected_bs
 
@@ -88,7 +88,7 @@ class TestBsSearchAlgo:
                 mem_usage = 10000
                 raise RuntimeError("CUDA out of memory.")
             elif batch_size > 100:
-                mem_usage = 9500
+                mem_usage = 9000
             else:
                 mem_usage = 1000
             self.mock_torch.cuda.max_memory_reserved.return_value = mem_usage
@@ -105,7 +105,7 @@ class TestBsSearchAlgo:
                 mem_usage = 10000
                 raise RuntimeError("CUDA out of memory.")
             elif batch_size > 100:
-                mem_usage = 9500
+                mem_usage = 9000
             else:
                 mem_usage = 1000 + batch_size / 1000
             self.mock_torch.cuda.max_memory_reserved.return_value = mem_usage
@@ -114,7 +114,7 @@ class TestBsSearchAlgo:
         bs_search_algo = BsSearchAlgo(mock_train_func, 64, 1000)
         adapted_bs = bs_search_algo.find_big_enough_batch_size()
 
-        assert mock_train_func(adapted_bs) <= 9000
+        assert mock_train_func(adapted_bs) <= 8500
 
     def test_find_big_enough_batch_size_drop_last(self):
         mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=180)

--- a/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
+++ b/tests/unit/algorithms/common/adapters/torch/utils/test_bs_search_algo.py
@@ -74,18 +74,21 @@ class TestBsSearchAlgo:
         # mocking torch.distributed.broadcast
         def mock_broadcast(tensor: torch.Tensor, src: int):
             tensor.copy_(broadcast_val)
+
         self.mock_dist.broadcast.side_effect = mock_broadcast
 
         # mocking torch.distributed.gather if gather_val is given
         def mock_gather(tensor: torch.Tensor, gather_list: Optional[List[torch.Tensor]] = None, dst: int = 0):
             for i in range(len(gather_list)):
                 gather_list[i].copy_(gather_val[i])
+
         if gather_val is not None:
             self.mock_dist.gather.side_effect = mock_gather
 
         # revert some of torch function
         def mock_tensor_cuda(self, *args, **kwargs):
             return self
+
         torch.Tensor.cuda = mock_tensor_cuda
         self.mock_torch.tensor = torch.tensor
         self.mock_torch.int64 = torch.int64
@@ -128,7 +131,7 @@ class TestBsSearchAlgo:
             gather_val=[
                 torch.tensor([False, 3000], dtype=torch.int64),
                 torch.tensor([True, 4000], dtype=torch.int64),
-            ]
+            ],
         )
         mock_train_func = self.get_mock_train_func(cuda_oom_bound=10000, max_runnable_bs=80)
         batch_size = 40


### PR DESCRIPTION
### Summary
There is an edge case that each result of batch size try of processes are different.
This PR changes it to aggregate results and broadcasts same results to all processes.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
