### PR TITLE
Enable resuming with `weights.pth` saved by visual prompting

### DIFF
--- a/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/config/visual_prompting_config.py
+++ b/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/config/visual_prompting_config.py
@@ -66,8 +66,7 @@ def get_visual_promtping_config(
 
     if mode == "train":
         # update model_checkpoint
-        if model_checkpoint:
-            config.model.checkpoint = model_checkpoint
+        config.model.checkpoint = model_checkpoint
 
         # update resume_from_checkpoint
         config.trainer.resume_from_checkpoint = resume_from_checkpoint

--- a/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/config/visual_prompting_config.py
+++ b/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/config/visual_prompting_config.py
@@ -66,7 +66,8 @@ def get_visual_promtping_config(
 
     if mode == "train":
         # update model_checkpoint
-        config.model.checkpoint = model_checkpoint
+        if model_checkpoint:
+            config.model.checkpoint = model_checkpoint
 
         # update resume_from_checkpoint
         config.trainer.resume_from_checkpoint = resume_from_checkpoint

--- a/src/otx/algorithms/visual_prompting/tasks/inference.py
+++ b/src/otx/algorithms/visual_prompting/tasks/inference.py
@@ -404,7 +404,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
            Dict: Model info.
         """
         if not self._model_ckpt:
-            logger.warn(f"model checkpoint is not set, return empty dictionary.")
+            logger.warn("model checkpoint is not set, return empty dictionary.")
             return {}
         return torch.load(self._model_ckpt, map_location="cpu")
 

--- a/src/otx/algorithms/visual_prompting/tasks/inference.py
+++ b/src/otx/algorithms/visual_prompting/tasks/inference.py
@@ -134,17 +134,10 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
         resume_from_checkpoint: Optional[str] = None
         if self.mode == "train" and self.task_environment.model is not None:
             # when args.load_weights or args.resume_from is set
-            resume_from_checkpoint = model_checkpoint = self.task_environment.model.model_adapters.get("path", None)  # type: ignore  # noqa: E501
             if self.task_environment.model.model_adapters.get("resume", False):
-                if resume_from_checkpoint.endswith(".pth"):  # type: ignore
-                    logger.info("[*] Pytorch checkpoint cannot be used for resuming. It will be supported.")
-                    resume_from_checkpoint = None
-                else:
-                    model_checkpoint = None
+                resume_from_checkpoint = self.task_environment.model.model_adapters.get("path", None)
             else:
-                # If not resuming, set resume_from_checkpoint to None to avoid training in resume environment
-                # and saving to configuration.
-                resume_from_checkpoint = None
+                model_checkpoint = self.task_environment.model.model_adapters.get("path", None)
 
         config = get_visual_promtping_config(
             task_name=self.model_name,
@@ -191,18 +184,20 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
                 "No trained model in project yet. Created new model with '%s'",
                 self.model_name,
             )
-        elif ("path" in otx_model.model_adapters) and (
-            otx_model.model_adapters.get("path").endswith(".ckpt")  # type: ignore[attr-defined]
-        ):
-            # pytorch lightning checkpoint
-            if not otx_model.model_adapters.get("resume"):
-                # If not resuming, just load weights in LightningModule
-                logger.info("Load pytorch lightning checkpoint.")
+        elif otx_model.model_adapters.get("resume", False):
+            # If resuming, pass this part to load checkpoint in Trainer
+            logger.info(f"To resume {otx_model.model_adapters.get('path')}, the checkpoint will be loaded in Trainer.")
+            
         else:
-            # pytorch checkpoint saved by otx
+            # Load state_dict
             buffer = io.BytesIO(otx_model.get_data("weights.pth"))
             model_data = torch.load(buffer, map_location=torch.device("cpu"))
-            if model_data.get("model", None) and model_data.get("config", None):
+            if model_data.get("state_dict", None) and model_data.get("pytorch-lightning_version", None):
+                # Load state_dict from pytorch lightning checkpoint or weights.pth saved by visual prompting task
+                state_dict = model_data["state_dict"]
+
+            elif model_data.get("model", None) and model_data.get("config", None):
+                # Load state_dict from checkpoint saved by otx other tasks
                 if model_data["config"]["model"]["backbone"] != self.config["model"]["backbone"]:
                     logger.warning(
                         "Backbone of the model in the Task Environment is different from the one in the template. "
@@ -210,10 +205,10 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
                     )
                     self.config["model"]["backbone"] = model_data["config"]["model"]["backbone"]
                 state_dict = model_data["model"]
-                logger.info("Load pytorch checkpoint from weights.pth.")
+                
             else:
+                # Load state_dict from naive pytorch checkpoint
                 state_dict = model_data
-                logger.info("Load pytorch checkpoint.")
 
         try:
             model = get_model(config=self.config, state_dict=state_dict)
@@ -406,11 +401,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
         Returns:
            Dict: Model info.
         """
-        return {
-            "model": self.model.state_dict(),
-            "config": self.get_config(),
-            "version": self.trainer.logger.version,
-        }
+        return torch.load(self._model_ckpt, map_location="cpu")
 
     def save_model(self, output_model: ModelEntity) -> None:
         """Save the model after training is completed.

--- a/src/otx/algorithms/visual_prompting/tasks/inference.py
+++ b/src/otx/algorithms/visual_prompting/tasks/inference.py
@@ -196,6 +196,9 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
             model_data = torch.load(buffer, map_location=torch.device("cpu"))
             if model_data.get("state_dict", None) and model_data.get("pytorch-lightning_version", None):
                 # Load state_dict from pytorch lightning checkpoint or weights.pth saved by visual prompting task
+                # In pytorch lightning checkpoint, there are metas: epoch, global_step, pytorch-lightning_version,
+                # state_dict, loops, callbacks, optimizer_states, lr_schedulers, hparams_name, hyper_parameters.
+                # To confirm if it is from pytorch lightning, check if one or two of them is in model_data.
                 state_dict = model_data["state_dict"]
 
             elif model_data.get("model", None) and model_data.get("config", None):

--- a/src/otx/algorithms/visual_prompting/tasks/inference.py
+++ b/src/otx/algorithms/visual_prompting/tasks/inference.py
@@ -106,7 +106,7 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
         self.optimization_type = ModelOptimizationType.MO
 
         self.trainer: Trainer
-        self._model_ckpt: str
+        self._model_ckpt: Optional[str] = None
 
         self.timestamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
 
@@ -403,6 +403,9 @@ class InferenceTask(IInferenceTask, IEvaluationTask, IExportTask, IUnload):
         Returns:
            Dict: Model info.
         """
+        if not self._model_ckpt:
+            logger.warn(f"model checkpoint is not set, return empty dictionary.")
+            return {}
         return torch.load(self._model_ckpt, map_location="cpu")
 
     def save_model(self, output_model: ModelEntity) -> None:

--- a/tests/unit/algorithms/visual_prompting/adapters/pytorch_lightning/config/test_visual_prompting_config.py
+++ b/tests/unit/algorithms/visual_prompting/adapters/pytorch_lightning/config/test_visual_prompting_config.py
@@ -49,7 +49,10 @@ def test_get_visual_promtping_config(
     assert config.get("callback", False)
     assert config.get("trainer", False)
     if mode == "train":
-        assert config.get("model").get("checkpoint", None) == model_checkpoint
+        if model_checkpoint:
+            assert config.get("model").get("checkpoint", None) == model_checkpoint
+        else:
+            assert config.get("model").get("checkpoint", None) != model_checkpoint
         assert config.get("trainer").get("resume_from_checkpoint", None) == resume_from_checkpoint
 
 

--- a/tests/unit/algorithms/visual_prompting/adapters/pytorch_lightning/config/test_visual_prompting_config.py
+++ b/tests/unit/algorithms/visual_prompting/adapters/pytorch_lightning/config/test_visual_prompting_config.py
@@ -48,12 +48,9 @@ def test_get_visual_promtping_config(
     assert config.get("optimizer", False)
     assert config.get("callback", False)
     assert config.get("trainer", False)
-    if model_checkpoint is not None:
-        if mode == "train":
-            assert config.get("model").get("checkpoint") == model_checkpoint
-        else:
-            assert config.get("model").get("checkpoint") != model_checkpoint
-            assert config.get("trainer").get("resume_from_checkpoint", None) == resume_from_checkpoint
+    if mode == "train":
+        assert config.get("model").get("checkpoint", None) == model_checkpoint
+        assert config.get("trainer").get("resume_from_checkpoint", None) == resume_from_checkpoint
 
 
 @e2e_pytest_unit

--- a/tests/unit/algorithms/visual_prompting/tasks/test_inference.py
+++ b/tests/unit/algorithms/visual_prompting/tasks/test_inference.py
@@ -79,11 +79,14 @@ class TestInferenceTask:
     @e2e_pytest_unit
     @pytest.mark.parametrize("path", [None, "checkpoint.ckpt", "checkpoint.pth"])
     @pytest.mark.parametrize("resume", [True, False])
-    @pytest.mark.parametrize("load_return_value", [
+    @pytest.mark.parametrize(
+        "load_return_value",
+        [
             {"state_dict": {"layer": "weights"}, "pytorch-lightning_version": "version"},
             {"model": {"layer": "weights"}, "config": {"model": {"backbone": "sam_vit_b"}}},
-            {}
-    ])
+            {},
+        ],
+    )
     def test_load_model(self, mocker, load_inference_task, path: str, resume: bool, load_return_value: Dict[str, Any]):
         """Test load_model."""
         mocker_segment_anything = mocker.patch(

--- a/tests/unit/algorithms/visual_prompting/tasks/test_inference.py
+++ b/tests/unit/algorithms/visual_prompting/tasks/test_inference.py
@@ -60,7 +60,6 @@ class TestInferenceTask:
         assert inference_task.config.dataset.task == "visual_prompting"
         if path:
             if resume:
-                assert inference_task.config.model.checkpoint is None
                 assert inference_task.config.trainer.resume_from_checkpoint == path
             else:
                 assert inference_task.config.model.checkpoint == path

--- a/tests/unit/algorithms/visual_prompting/tasks/test_train.py
+++ b/tests/unit/algorithms/visual_prompting/tasks/test_train.py
@@ -30,6 +30,7 @@ class TestTrainingTask:
         """Test train."""
         mocker_trainer = mocker.patch("otx.algorithms.visual_prompting.tasks.train.Trainer")
         mocker_save = mocker.patch("torch.save")
+        mocker.patch.object(self.training_task, "model_info")
 
         dataset = generate_visual_prompting_dataset()
         output_model = ModelEntity(


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
https://github.com/openvinotoolkit/training_extensions/pull/2274#discussion_r1255219663
For this, it was needed to save metas for pytorch lightning in `weights.pth`.
It was implemented by loading best checkpoint saved in `Trainer.checkpoint_callback` and saving metas in `weights.pth`.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```python
$ tox -vv -e unittest-all-py310-pt1 -- tests/unit/algorithms/visual_prompting/adapters/pytorch_lightning/config/test_visual_prompting_config.py
=============================================================== 7 passed, 1 warning in 0.72s ===============================================================
Name                                                                                                                Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------------------------------------------------------------------------
src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/config/visual_prompting_config.py                       43      7    84%   56, 102-103, 106, 111-113


$ tox -vv -e unittest-all-py310-pt1 --  tests/unit/algorithms/visual_prompting/tasks/test_inference.py
============================================================= 31 passed, 17 warnings in 24.33s =============================================================
Name                                                                                                                Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------------------------------------------------------------------------
src/otx/algorithms/visual_prompting/tasks/inference.py                                                                213     28    87%   96, 115-123, 178, 218-219, 224, 337, 347, 352, 387, 434, 438-447, 454-455, 459-460


$ tox -vv -e unittest-all-py310-pt1 --  tests/unit/algorithms/visual_prompting/tasks/test_train.py
============================================================== 1 passed, 10 warnings in 2.22s ==============================================================
Name                                                                                                                Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------------------------------------------------------------------------
src/otx/algorithms/visual_prompting/tasks/train.py                                                                     41      4    90%   88-89, 96-97


$ tox -vv -e tests-all-py310-pt1 -- tests/integration/cli/visual_prompting/test_visual_prompting.py
=================================================== 8 passed, 2 skipped, 2 warnings in 108.48s (0:01:48) ===================================================

$ tox -vv -e tests-all-py310-pt1 -- tests/e2e/cli/visual_prompting/test_visual_prompting.py
======================================================== 10 passed, 2 warnings in 274.07s (0:04:34) ========================================================
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
