### PR TITLE
Remove unused HPO weight while HPO is running

### DIFF
--- a/src/otx/cli/utils/hpo.py
+++ b/src/otx/cli/utils/hpo.py
@@ -713,6 +713,7 @@ class Trainer:
         score_report_callback = self._prepare_score_report_callback(task)
         task.train(dataset=dataset, output_model=output_model, train_parameters=score_report_callback)
         self._finalize_trial(task)
+        self._delete_unused_model_weight()
 
     def _prepare_hyper_parameter(self):
         return create(self._model_template.hyper_parameters.data)
@@ -787,6 +788,21 @@ class Trainer:
 
     def _get_weight_dir_path(self) -> Path:
         return self._hpo_workdir / "weight" / self._hp_config["id"]
+
+    def _delete_unused_model_weight(self):
+        """Delete model weights except best and latest model weight."""
+        for json_file in self._hpo_workdir.rglob("*.json"):
+            if not json_file.stem.isnumeric():
+                continue
+            trial_num = json_file.stem
+            weight_dir = self._hpo_workdir / "weight" / trial_num
+            if not weight_dir.exists():
+                continue
+            latest_model_weight = self._task.get_latest_weight(weight_dir)
+            best_model_weight = get_best_hpo_weight(self._hpo_workdir, trial_num)
+            for each_model_weight in weight_dir.iterdir():
+                if str(each_model_weight) not in [latest_model_weight, best_model_weight]:
+                    each_model_weight.unlink()
 
 
 def run_trial(

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -575,6 +575,39 @@ class TestTrainer:
         mock_report_func.assert_called_once_with(0, 0, done=True)  # finilize report
         mock_task.train.assert_not_called()  # check task.train() is called
 
+    @e2e_pytest_unit
+    def test_delete_unused_model_weight(self, mocker, cls_template_path):
+        # prepare
+        trial0_weight_dir = self.hpo_workdir / "weight" / "0"
+        mocker.patch("otx.cli.utils.hpo.TaskManager.get_latest_weight", return_value=str(trial0_weight_dir / "latest.pth"))
+        mocker.patch("otx.cli.utils.hpo.get_best_hpo_weight", return_value=str(trial0_weight_dir / "best.pth"))
+
+        self.hpo_workdir.mkdir()
+        (self.hpo_workdir / "0.json").touch()
+        for i in range(2):
+            weight_dir = self.hpo_workdir / "weight" / str(i)
+            weight_dir.mkdir(parents=True)
+            (weight_dir / "latest.pth").touch()
+            (weight_dir / "best.pth").touch()
+            (weight_dir / "unused.pth").touch()
+
+        # run
+        trainer = Trainer(
+            hp_config={"configuration": {"iterations": 10}, "id": "1"},
+            report_func=mocker.MagicMock(),
+            model_template=find_and_parse_model_template(cls_template_path),
+            data_roots=mocker.MagicMock(),
+            task_type=TaskType.CLASSIFICATION,
+            hpo_workdir=self.hpo_workdir,
+            initial_weight_name="fake",
+            metric="fake",
+        )
+        trainer._delete_unused_model_weight()
+
+
+        assert sorted([f.name for f in (self.hpo_workdir / "weight" / "0").iterdir()]) == sorted(["latest.pth", "best.pth"])
+        assert sorted([f.name for f in (self.hpo_workdir / "weight" / "1").iterdir()]) == sorted(["latest.pth", "best.pth", "unused.pth"])
+
 
 class TestHpoCallback:
     @e2e_pytest_unit

--- a/tests/unit/cli/utils/test_hpo.py
+++ b/tests/unit/cli/utils/test_hpo.py
@@ -579,7 +579,9 @@ class TestTrainer:
     def test_delete_unused_model_weight(self, mocker, cls_template_path):
         # prepare
         trial0_weight_dir = self.hpo_workdir / "weight" / "0"
-        mocker.patch("otx.cli.utils.hpo.TaskManager.get_latest_weight", return_value=str(trial0_weight_dir / "latest.pth"))
+        mocker.patch(
+            "otx.cli.utils.hpo.TaskManager.get_latest_weight", return_value=str(trial0_weight_dir / "latest.pth")
+        )
         mocker.patch("otx.cli.utils.hpo.get_best_hpo_weight", return_value=str(trial0_weight_dir / "best.pth"))
 
         self.hpo_workdir.mkdir()
@@ -604,9 +606,12 @@ class TestTrainer:
         )
         trainer._delete_unused_model_weight()
 
-
-        assert sorted([f.name for f in (self.hpo_workdir / "weight" / "0").iterdir()]) == sorted(["latest.pth", "best.pth"])
-        assert sorted([f.name for f in (self.hpo_workdir / "weight" / "1").iterdir()]) == sorted(["latest.pth", "best.pth", "unused.pth"])
+        assert sorted([f.name for f in (self.hpo_workdir / "weight" / "0").iterdir()]) == sorted(
+            ["latest.pth", "best.pth"]
+        )
+        assert sorted([f.name for f in (self.hpo_workdir / "weight" / "1").iterdir()]) == sorted(
+            ["latest.pth", "best.pth", "unused.pth"]
+        )
 
 
 class TestHpoCallback:


### PR DESCRIPTION
### Summary
Current HPO doesn't remove unused weight while HPO is running.
To save storage usage, I add a code to remove unused model weight even if HPO is running.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
