### PR TITLE
Fix the CustomNonLinearClsHead when the batch_size is set to 1

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_cls_head.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_cls_head.py
@@ -42,6 +42,13 @@ class CustomNonLinearClsHead(NonLinearClsHead):
 
     def forward_train(self, cls_score, gt_label):
         """Forward_train fuction of CustomNonLinearHead class."""
+        # NOTE, when the batch_size is set to 1, this raise an error at BatchNorm1d
+        # To avoid this, use simple trick to pretend batch size as 2.
+        # If loss type isn't IBLoss, the output loss will be same
+        bs = cls_score.shape[0]
+        if bs == 1 and self.loss_type != "IBLoss":
+            cls_score = torch.cat([cls_score, cls_score], dim=0)
+            gt_label = torch.cat([gt_label, gt_label], dim=0)
         logit = self.classifier(cls_score)
         losses = self.loss(logit, gt_label, feature=cls_score)
         return losses


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR introduces a new trick to avoid an error that happens in the bs=1 case at the `BN1d` included at the `CustomNonLinearClsHead`. For now, just applying to the `loss != IBLoss`, need to consider further cases.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

`otx train src/otx/algorithms/classification/configs/mobilenet_v3_large_1_cls_incr/template.yaml --train-data-roots tests/assets/classification_dataset --val-data-roots tests/assets/classification_dataset params --learning_parameters.batch_size 1`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
