### PR TITLE
Revert default input size to `Default` due to YOLOX perf regression

### DIFF
--- a/src/otx/algorithms/classification/configs/configuration.yaml
+++ b/src/otx/algorithms/classification/configs/configuration.yaml
@@ -277,11 +277,12 @@ learning_parameters:
     warning: null
   input_size:
     affects_outcome_of: INFERENCE
-    default_value: Auto
+    default_value: Default
     description:
       The input size of the given model could be configured to one of the predefined resolutions.
       Reduced training and inference time could be expected by using smaller input size.
-      Defaults to Auto, in which input size is automatically determined based on dataset statistics.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
     editable: true
     enum_name: InputSizePreset
     header: Configure model input size.

--- a/src/otx/algorithms/detection/configs/detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/detection/configuration.yaml
@@ -245,11 +245,12 @@ learning_parameters:
     warning: null
   input_size:
     affects_outcome_of: INFERENCE
-    default_value: Auto
+    default_value: Default
     description:
       The input size of the given model could be configured to one of the predefined resolutions.
       Reduced training and inference time could be expected by using smaller input size.
-      Defaults to Auto, in which input size is automatically determined based on dataset statistics.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
     editable: true
     enum_name: InputSizePreset
     header: Configure model input size.

--- a/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -245,11 +245,12 @@ learning_parameters:
     warning: null
   input_size:
     affects_outcome_of: INFERENCE
-    default_value: Auto
+    default_value: Default
     description:
       The input size of the given model could be configured to one of the predefined resolutions.
       Reduced training and inference time could be expected by using smaller input size.
-      Defaults to Auto, in which input size is automatically determined based on dataset statistics.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
     editable: true
     enum_name: InputSizePreset
     header: Configure model input size.

--- a/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
@@ -245,11 +245,12 @@ learning_parameters:
     warning: null
   input_size:
     affects_outcome_of: INFERENCE
-    default_value: Auto
+    default_value: Default
     description:
       The input size of the given model could be configured to one of the predefined resolutions.
       Reduced training and inference time could be expected by using smaller input size.
-      Defaults to Auto, in which input size is automatically determined based on dataset statistics.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
     editable: true
     enum_name: InputSizePreset
     header: Configure model input size.


### PR DESCRIPTION
### Summary

* Same as title

### How to test

* CI tests

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
