### PR TITLE
Upgrade torch version to 2.0.1 & pre-commit in v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,6 @@ default_language_version:
   ruby: 2.7.2
 
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
-        args: [--line-length, "120"]
-        files: '^(src/otx/v2)/.*\.py'
-
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.3
@@ -19,7 +12,7 @@ repos:
         exclude: "src/otx/recipes"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.6.0"
+    rev: "v1.6.1"
     hooks:
       - id: mypy
         files: '^(src/otx/v2)/.*\.py'
@@ -59,7 +52,7 @@ repos:
 
   # Ruff
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.1.0"
+    rev: "v0.1.2"
     hooks:
       - id: ruff
         exclude: "tests|src/otx/recipes|src/otx/v2/demo|src/otx/v2/pseudo_code|src/otx/algorithms|src/otx/v2/api/entities"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ base = [
     "bayesian-optimization>=1.2.0",
     "tensorboard>=2.11.0",
     "multiprocess",
-    "torch==2.0.0",
+    "torch==2.0.1",
 ]
 openvino = [
     "nncf==2.5.0",
@@ -96,7 +96,7 @@ anomaly = [
     "kornia==0.6.9",
 ]
 classification = [
-    "mmpretrain==1.0.*",
+    "mmpretrain==1.0.1",
     "mmdeploy",
     "timm==0.6.12",
     "pytorchcv",


### PR DESCRIPTION
### Summary

- Upgrade to torch==2.0.1
- Remove black
Replace black with ruff. According to the author of ruff, it is 30x faster than black and 99% compatible. As can be seen from the changes, it is indeed compatible in our case. For more details, you could refer to this [link](https://twitter.com/charliermarsh/status/1716861072374657497?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet).
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/3f75bafa-3e47-4405-beb2-560b539e23fb)

- Update pre-commit version (mypy & ruff)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
