### PR TITLE
Fix for the degradation issue of the classification task

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/utils/config_utils.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/utils/config_utils.py
@@ -49,8 +49,6 @@ def patch_datasets(
         for cfg in cfgs:
             cfg.update(kwargs)
 
-    patch_color_conversion(config)
-
 
 def patch_evaluation(config: Config, task: str):
     """Patch evaluation."""

--- a/src/otx/algorithms/classification/adapters/mmcls/utils/config_utils.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/utils/config_utils.py
@@ -20,7 +20,6 @@ from mmcv import Config, ConfigDict
 
 from otx.algorithms.common.adapters.mmcv.utils import (
     get_dataset_configs,
-    patch_color_conversion,
 )
 from otx.algorithms.common.utils.logger import get_logger
 

--- a/src/otx/algorithms/classification/configs/base/data/data_pipeline.py
+++ b/src/otx/algorithms/classification/configs/base/data/data_pipeline.py
@@ -16,7 +16,7 @@
 
 # pylint: disable=invalid-name
 
-__img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+__img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=False)
 __resize_target_size = 224
 
 __train_pipeline = [

--- a/src/otx/algorithms/classification/configs/base/data/data_pipeline.py
+++ b/src/otx/algorithms/classification/configs/base/data/data_pipeline.py
@@ -16,7 +16,7 @@
 
 # pylint: disable=invalid-name
 
-__img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=False)
+__img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 __resize_target_size = 224
 
 __train_pipeline = [

--- a/src/otx/algorithms/classification/configs/configuration.yaml
+++ b/src/otx/algorithms/classification/configs/configuration.yaml
@@ -210,7 +210,7 @@ learning_parameters:
     warning: This is applied exclusively when early stopping is enabled.
   use_adaptive_interval:
     affects_outcome_of: TRAINING
-    default_value: false
+    default_value: true
     description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
     editable: true
     header: Use adaptive validation interval

--- a/src/otx/algorithms/classification/configs/configuration.yaml
+++ b/src/otx/algorithms/classification/configs/configuration.yaml
@@ -277,7 +277,7 @@ learning_parameters:
     warning: null
   input_size:
     affects_outcome_of: INFERENCE
-    default_value: Auto
+    default_value: Default
     description:
       The input size of the given model could be configured to one of the predefined resolutions.
       Reduced training and inference time could be expected by using smaller input size.

--- a/src/otx/recipes/stages/classification/incremental.yaml
+++ b/src/otx/recipes/stages/classification/incremental.yaml
@@ -42,10 +42,6 @@ custom_hooks: [
     start: 3,
     min_delta_ratio: 0.01,
     priority: 75,
-  },
-  {
-    type: AdaptiveRepeatDataHook, 
-    priority: ABOVE_NORMAL
   }
 ]
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR includes,
* Reintroduce the adaptive patience logic for the classification and remove the `AdaptiveRepeatDataHook` to have the same setting as 1.4.3. Only classification used the repeat data to reduce the training time. 
* I'll unify the logic of the `AdaptiveTrainSchedule` and `AdaptiveRepeatData` in the future for all tasks. At the current status, it rather brings confusion.
* Remove `patch_color_conversion` located at `patch_datasets` used at the only `ClassificationConfigurer`. Previously, `patch_color_conversion` was called twice (`BaseConfigurer`, `ClassificationConfigurer`), so, `to_rgb` didn't changed as we expected.
(It was also the root cause of this issue https://github.com/openvinotoolkit/training_extensions/issues/2584, Fortunately, it just affects the classification task.)


After this PR, we could have the numbers below,
<img width="1044" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/80735344/39bf43ee-14ed-4625-b0ef-aa58ff3296cc">



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
