### PR TITLE
Boost up Image numpy accessing speed through PIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Update ModelAPI configuration(<https://github.com/openvinotoolkit/training_extensions/pull/2564>)
 - Add Anomaly modelAPI changes (<https://github.com/openvinotoolkit/training_extensions/pull/2563>)
+- Update Image numpy access (<https://github.com/openvinotoolkit/training_extensions/pull/2586>)
 
 ## \[v1.4.3\]
 

--- a/src/otx/api/entities/image.py
+++ b/src/otx/api/entities/image.py
@@ -94,8 +94,7 @@ class Image(IMedia2DEntity):
         if self.__data is None:
             try:
                 image = PILImage.open(self.__file_path)
-                image.draft("RGB", (image.width, image.height))
-                image = np.asarray(image)
+                image = np.asarray(image.convert("RGB"))
             except ValueError:
                 image = cv2.cvtColor(cv2.imread(self.__file_path), cv2.COLOR_BGR2RGB)
             return image

--- a/src/otx/api/entities/image.py
+++ b/src/otx/api/entities/image.py
@@ -36,13 +36,17 @@ class Image(IMedia2DEntity):
         size: Optional[Union[Tuple[int, int], Callable[[], Tuple[int, int]]]] = None,
     ):
         if (data is None) == (file_path is None):
-            raise ValueError("Either path to image file or image data should be provided.")
+            raise ValueError(
+                "Either path to image file or image data should be provided."
+            )
         self.__data: Optional[Union[np.ndarray, Callable[[], np.ndarray]]] = data
         self.__file_path: Optional[str] = file_path
         self.__height: Optional[int] = None
         self.__width: Optional[int] = None
         # TODO: refactor this
-        self.__size: Optional[Union[Tuple[int, int], Callable[[], Tuple[int, int]]]] = size
+        self.__size: Optional[
+            Union[Tuple[int, int], Callable[[], Tuple[int, int]]]
+        ] = size
 
     def __str__(self):
         """String representation of the image. Returns the image format, name and dimensions."""
@@ -93,7 +97,7 @@ class Image(IMedia2DEntity):
         """
         if self.__data is None:
             img = PILImage.open(self.__file_path)
-            img.draft('RGB', (img.width, img.height))
+            img.draft("RGB", (img.width, img.height))
             return np.asarray(img)
         if callable(self.__data):
             return self.__data()
@@ -127,7 +131,9 @@ class Image(IMedia2DEntity):
             raise ValueError("Numpy array is None, and thus cannot be cropped")
 
         if len(data.shape) < 2:
-            raise ValueError("This image is one dimensional, and thus cannot be cropped")
+            raise ValueError(
+                "This image is one dimensional, and thus cannot be cropped"
+            )
 
         return roi.shape.crop_numpy_array(data)
 

--- a/src/otx/api/entities/image.py
+++ b/src/otx/api/entities/image.py
@@ -10,6 +10,7 @@ from typing import Optional, Tuple, Callable, Union
 import cv2
 import imagesize
 import numpy as np
+from PIL import Image as PILImage
 
 from otx.api.entities.annotation import Annotation
 from otx.api.entities.media import IMedia2DEntity
@@ -91,7 +92,9 @@ class Image(IMedia2DEntity):
             np.ndarray: NumPy representation of the image.
         """
         if self.__data is None:
-            return cv2.cvtColor(cv2.imread(self.__file_path), cv2.COLOR_BGR2RGB)
+            img = PILImage.open(self.__file_path)
+            img.draft('RGB', (img.width, img.height))
+            return np.asarray(img)
         if callable(self.__data):
             return self.__data()
         return self.__data

--- a/src/otx/api/entities/image.py
+++ b/src/otx/api/entities/image.py
@@ -36,17 +36,13 @@ class Image(IMedia2DEntity):
         size: Optional[Union[Tuple[int, int], Callable[[], Tuple[int, int]]]] = None,
     ):
         if (data is None) == (file_path is None):
-            raise ValueError(
-                "Either path to image file or image data should be provided."
-            )
+            raise ValueError("Either path to image file or image data should be provided.")
         self.__data: Optional[Union[np.ndarray, Callable[[], np.ndarray]]] = data
         self.__file_path: Optional[str] = file_path
         self.__height: Optional[int] = None
         self.__width: Optional[int] = None
         # TODO: refactor this
-        self.__size: Optional[
-            Union[Tuple[int, int], Callable[[], Tuple[int, int]]]
-        ] = size
+        self.__size: Optional[Union[Tuple[int, int], Callable[[], Tuple[int, int]]]] = size
 
     def __str__(self):
         """String representation of the image. Returns the image format, name and dimensions."""
@@ -131,9 +127,7 @@ class Image(IMedia2DEntity):
             raise ValueError("Numpy array is None, and thus cannot be cropped")
 
         if len(data.shape) < 2:
-            raise ValueError(
-                "This image is one dimensional, and thus cannot be cropped"
-            )
+            raise ValueError("This image is one dimensional, and thus cannot be cropped")
 
         return roi.shape.crop_numpy_array(data)
 

--- a/src/otx/api/entities/image.py
+++ b/src/otx/api/entities/image.py
@@ -92,9 +92,13 @@ class Image(IMedia2DEntity):
             np.ndarray: NumPy representation of the image.
         """
         if self.__data is None:
-            img = PILImage.open(self.__file_path)
-            img.draft("RGB", (img.width, img.height))
-            return np.asarray(img)
+            try:
+                image = PILImage.open(self.__file_path)
+                image.draft("RGB", (image.width, image.height))
+                image = np.asarray(image)
+            except ValueError:
+                image = cv2.cvtColor(cv2.imread(self.__file_path), cv2.COLOR_BGR2RGB)
+            return image
         if callable(self.__data):
             return self.__data()
         return self.__data


### PR DESCRIPTION
### Summary

Speed up when getting access to Image numpy through PIL inspired by https://github.com/libvips/pyvips/issues/179#issuecomment-618936358.

As a result, the data time is 3 times faster than previous one and overall E2E time is reduced by 30%.

Before PR: 
![image](https://github.com/openvinotoolkit/training_extensions/assets/89109581/d1f05157-092f-48b9-be3f-3b4561e3b06c)

After PR: 
![image](https://github.com/openvinotoolkit/training_extensions/assets/89109581/98a927cd-c6f9-407f-8684-d57514b93c67)

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>



MNV2-ATSS | Before PR | After PR
-- | -- | --
mAP | 0.8517 | 0.8517
E2E time | 15:37 | 10:46
Total epoch | 70 | 70



</div>

<!--EndFragment-->
</body>

</html>


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
