### PR TITLE
Fix issues in mmengine adapter & CLI side

### DIFF
--- a/src/otx/v2/adapters/torch/dataset.py
+++ b/src/otx/v2/adapters/torch/dataset.py
@@ -49,6 +49,11 @@ class BaseTorchDataset(BaseDataset):
         Example:
         >>> dataset._build_dataet(subset="train")
         torch.utils.data.Dataset()
+        >>> dataset._build_dataset(
+            subset="train",
+            pipeline=[dict(type="Resize", scale=[224, 224])],
+        )
+        Dataset with Resize pipeline
         """
         raise NotImplementedError
 
@@ -162,7 +167,14 @@ class BaseTorchDataset(BaseDataset):
 
         Args:
             subset (str): Enter an available subset of that dataset.
-            pipeline (dict[str, list] | list | None, optional):
+            pipeline (dict[str, list] | list | None, optional): This can take a dict or a list.
+                Case with Dict: In the Semi-SL case,
+                    may want to apply a different pipeline between labeled and unlabeled.
+                    then we can give a dictionary of the form below.
+                    pipeline = {
+                        "train": [...],
+                        "unlabeled": [...]
+                    }
                 Dataset Pipeline. Defaults to None.
             batch_size (int | None, optional): How many samples per batch to load. Defaults to None.
             num_workers (int | None, optional): How many subprocesses to use for data loading.
@@ -189,11 +201,22 @@ class BaseTorchDataset(BaseDataset):
 
         Example:
         >>> dataset.subset_dataloader(subset="train")
-        torch.utils.data.Dataloader()
+        Training Dataloader
         >>> dataset.train_dataloader()
-        torch.utils.data.Dataloader()
+        Training Dataloader
         >>> dataset.train_dataloader(batch_size=4)
-        torch.utils.data.Dataloader() (batch size: 4)
+        Training Dataloader with batch size 4
+        >>> dataset.train_dataloader(
+            pipeline=[dict(type="Resize", scale=[224, 224])],
+        )
+        Training Dataloader with Resize pipeline
+        >>> dataset.train_dataloader(
+            pipeline={
+                "train": [...],
+                "unlabeled": [...]
+            },
+        )
+        Semi-SL Training DataLoader
         """
         # Config Setting
         _config: dict = {}

--- a/src/otx/v2/adapters/torch/dataset.py
+++ b/src/otx/v2/adapters/torch/dataset.py
@@ -31,20 +31,20 @@ class BaseTorchDataset(BaseDataset):
     def _build_dataset(
         self,
         subset: str,
-        pipeline: list | dict | None = None,
-        config: str | dict | None = None,
+        pipeline: list | None = None,
+        config: dict | None = None,
     ) -> TorchDataset | None:
         """Builds a TorchDataset object for the given subset using the specified pipeline and configuration.
 
         Args:
             subset (str): The subset to build the dataset for.
-            pipeline (Optional[Union[list, dict]]): The pipeline to use for the dataset.
+            pipeline (list | None, optional): The pipeline to use for the dataset.
                 Defaults to None.
-            config (Optional[Union[str, dict]]): The configuration to use for the dataset.
+            config (dict | None, optional): The configuration to use for the dataset.
                 Defaults to None.
 
         Returns:
-            Optional[TorchDataset]: The built TorchDataset object, or None if the dataset is empty.
+            TorchDataset | None: The built TorchDataset object, or None if the dataset is empty.
 
         Example:
         >>> dataset._build_dataet(subset="train")
@@ -137,7 +137,7 @@ class BaseTorchDataset(BaseDataset):
     def subset_dataloader(
         self,
         subset: str,
-        pipeline: dict | list | None = None,
+        pipeline: dict[str, list] | list | None = None,
         batch_size: int | None = None,
         num_workers: int | None = None,
         config: str | dict | None = None,
@@ -162,12 +162,12 @@ class BaseTorchDataset(BaseDataset):
 
         Args:
             subset (str): Enter an available subset of that dataset.
-            pipeline (Optional[Union[list, dict]], optional):
+            pipeline (dict[str, list] | list | None, optional):
                 Dataset Pipeline. Defaults to None.
-            batch_size (Optional[int], optional): How many samples per batch to load. Defaults to None.
-            num_workers (Optional[int], optional): How many subprocesses to use for data loading.
+            batch_size (int | None, optional): How many samples per batch to load. Defaults to None.
+            num_workers (int | None, optional): How many subprocesses to use for data loading.
                 ``0`` means that the data will be loaded in the main process. Defaults to None.
-            config (Optional[Union[str, dict]], optional): Path to configuration file or Config.
+            config (str | dict | None, optional): Path to configuration file or Config.
                 Defaults to None.
             shuffle (bool, optional): Set to ``True`` to have the data reshuffled at every epoch. Defaults to True.
             pin_memory (bool, optional): If ``True``, the data loader will copy Tensors
@@ -176,7 +176,7 @@ class BaseTorchDataset(BaseDataset):
                 see the example below. Defaults to False.
             drop_last (bool, optional): value for whether to drop the last data when the batch is not divided up.
                 Defaults to False.
-            sampler (Optional[Union[Sampler, Iterable, Dict]], optional): Defines the strategy to draw
+            sampler (Sampler | (Iterable | dict) | None, optional): Defines the strategy to draw
                 samples from the dataset. Can be any ``Iterable`` with ``__len__``
                 implemented. If specified, :attr:`shuffle` must not be specified.. Defaults to None.
             persistent_workers (bool, optional): If ``True``, the data loader will not shutdown

--- a/src/otx/v2/adapters/torch/dataset.py
+++ b/src/otx/v2/adapters/torch/dataset.py
@@ -46,8 +46,8 @@ class BaseTorchDataset(BaseDataset):
         Returns:
             TorchDataset | None: The built TorchDataset object, or None if the dataset is empty.
 
-        Example:
-        >>> dataset._build_dataet(subset="train")
+        Examples:
+        >>> dataset._build_dataset(subset="train")
         torch.utils.data.Dataset()
         >>> dataset._build_dataset(
             subset="train",

--- a/src/otx/v2/adapters/torch/mmengine/engine.py
+++ b/src/otx/v2/adapters/torch/mmengine/engine.py
@@ -147,6 +147,9 @@ class MMXEngine(Engine):
             if isinstance(visualizer, dict):
                 self.config["visualizer"]["_scope_"] = self.registry.name
 
+        # Update scope for Registry import step
+        kwargs["default_scope"] = self.registry.name
+
         # kwargs -> Update config
         for kwarg_key, kwarg_value in kwargs.items():
             if kwarg_value is None:

--- a/src/otx/v2/adapters/torch/mmengine/mmpretrain/dataset.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmpretrain/dataset.py
@@ -126,22 +126,24 @@ class MMPretrainDataset(MMXDataset):
     def _build_dataset(
         self,
         subset: str,
-        pipeline: list | dict | None = None,
-        config: str | dict | None = None,
+        pipeline: list | None = None,
+        config: dict | None = None,
     ) -> TorchDataset | None:
         """Builds a TorchDataset object for the given subset using the specified pipeline and configuration.
 
         Args:
             subset (str): The subset to build the dataset for.
-            pipeline (Optional[Union[list, dict]]): The pipeline to use for the dataset.
+            pipeline (list | None, optional): The pipeline to use for the dataset.
                 Defaults to None.
-            config (Optional[Union[str, dict]]): The configuration to use for the dataset.
+            config (dict | None, optional): The configuration to use for the dataset.
                 Defaults to None.
 
         Returns:
             Optional[TorchDataset]: The built TorchDataset object, or None if the dataset is empty.
         """
-        if pipeline is None:
+        dataset_config = config.get("dataset", config) if config is not None else {}
+        if pipeline is None and "pipeline" not in dataset_config:
             semisl = subset == "unlabeled"
-            pipeline = get_default_pipeline(semisl=semisl)
+            default_pipeline = get_default_pipeline(semisl=semisl)
+            pipeline = default_pipeline[subset] if isinstance(default_pipeline, dict) else default_pipeline
         return super()._build_dataset(subset, pipeline, config)

--- a/src/otx/v2/cli/cli.py
+++ b/src/otx/v2/cli/cli.py
@@ -468,7 +468,10 @@ class OTXCLIv2:
         dl_kwargs = self.config_init[subcommand].pop(f"{subset}_dataloader", None)
         dl_kwargs.pop("self", None)
         dl_kwargs.pop("subset", None)
-        dl_kwargs.pop("dataset", None)
+        dataset_config = dl_kwargs.pop("dataset", {})
+        # Pull out the pipeline from Default Config.
+        if "pipeline" not in dl_kwargs or dl_kwargs["pipeline"] is None:
+            dl_kwargs["pipeline"] = dataset_config.get("pipeline", None)
         return dl_kwargs
 
 

--- a/tests/v2/unit/adapters/torch/mmengine/mmpretrain/test_dataset.py
+++ b/tests/v2/unit/adapters/torch/mmengine/mmpretrain/test_dataset.py
@@ -147,23 +147,12 @@ class TestDataset:
         result = dataset._build_dataset(subset="train")
         mock_base_dataset.assert_called_once()
 
-        # config is not None
-        # config is str
-        mock_config = Config({
-            "dataset": {}
-        })
-        mock_fromfile = mocker.patch("otx.v2.adapters.torch.mmengine.dataset.Config.fromfile")
-        mock_fromfile.return_value = mock_config
-        result = dataset._build_dataset(subset="train", config="test.yaml")
-        mock_fromfile.assert_called_once_with(filename="test.yaml")
-        mock_registry.return_value.get.return_value.build.assert_called()
-
         # config is dict
         result = dataset._build_dataset(subset="train", config={})
         mock_registry.return_value.get.return_value.build.assert_called()
 
         # config is Config with pipeline
-        result = dataset._build_dataset(subset="train", config=Config({}), pipeline=[mocker.MagicMock()])
+        result = dataset._build_dataset(subset="train", config={}, pipeline=[mocker.MagicMock()])
         mock_registry.return_value.get.return_value.build.assert_called()
 
     def test_build_dataloader(self, mocker: MockerFixture) -> None:

--- a/tests/v2/unit/adapters/torch/mmengine/test_engine.py
+++ b/tests/v2/unit/adapters/torch/mmengine/test_engine.py
@@ -54,6 +54,7 @@ class TestMMXEngine:
         model = mocker.Mock()
         engine._update_config({}, model=None)
         assert not hasattr(engine.config, "model")
+        assert engine.config.default_scope == "mmengine"
 
         # Test with invalid argument
         model = mocker.Mock()


### PR DESCRIPTION
### Summary

Thanks to Jaeguk, we found a bug that not update dataset.pipeline properly.

- Modify `_build_dataset` to accept config input as dict | None // pipeline input as list | None
- Enable pipeline to update to default only if config.dataset.pipeline does not exist
- Fixed an issue dropping pipelines from the CLI

Thanks to Jaeguk once more, we found a bug that not update mmengine.Runner scope properly.

- Add one line for setting default scope to Runner.default_config

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
