### PR TITLE
Fix mmcls bug not wrapping model in DataParallel on CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - Update ModelAPI configuration(<https://github.com/openvinotoolkit/training_extensions/pull/2564>)
 - Add Anomaly modelAPI changes (<https://github.com/openvinotoolkit/training_extensions/pull/2563>)
+
+### Bug fixes
+
 - Fix IBLoss enablement with DeiT-Tiny when class incremental training (<https://github.com/openvinotoolkit/training_extensions/pull/2595>)
+- Fix mmcls bug not wrapping model in DataParallel on CPUs (<https://github.com/openvinotoolkit/training_extensions/pull/2601>)
 
 ## \[v1.4.3\]
 

--- a/src/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/task.py
@@ -381,6 +381,10 @@ class MMClassificationTask(OTXClassificationTask):
 
         # Model
         model = self.build_model(cfg, fp16=cfg.get("fp16", False))
+        if not torch.cuda.is_available():
+            # NOTE: mmcls does not wrap models w/ DP for CPU training not like mmdet
+            # Raw DataContainer "img_metas" is exposed, which results in errors
+            model = build_data_parallel(model, cfg, distributed=False)
         model.train()
 
         if cfg.distributed:

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -470,19 +470,6 @@ class TestHierarchicalClassificationCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
-    def test_otx_train_cls_incr(self, template, tmp_dir_path):
-        tmp_dir_path = tmp_dir_path / "h_label_cls/test_cls_decr"
-        args0 = copy.deepcopy(args_h)
-        args0["--train-data-roots"] = "tests/assets/datumaro_h-label_class_decremental"
-        args0["--val-data-roots"] = "tests/assets/datumaro_h-label_class_decremental"
-        otx_train_testing(template, tmp_dir_path, otx_dir, args0)
-        template_work_dir = get_template_dir(template, tmp_dir_path)
-        args1 = copy.deepcopy(args_h)
-        args1["--load-weights"] = f"{template_work_dir}/trained_{template.model_template_id}/models/weights.pth"
-        otx_train_testing(template, tmp_dir_path, otx_dir, args1)
-
-    @e2e_pytest_component
-    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train_cls_decr(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "h_label_cls/test_cls_decr"
         otx_train_testing(template, tmp_dir_path, otx_dir, args_h)

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -470,6 +470,19 @@ class TestHierarchicalClassificationCLI:
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
+    def test_otx_train_cls_incr(self, template, tmp_dir_path):
+        tmp_dir_path = tmp_dir_path / "h_label_cls/test_cls_decr"
+        args0 = copy.deepcopy(args_h)
+        args0["--train-data-roots"] = "tests/assets/datumaro_h-label_class_decremental"
+        args0["--val-data-roots"] = "tests/assets/datumaro_h-label_class_decremental"
+        otx_train_testing(template, tmp_dir_path, otx_dir, args0)
+        template_work_dir = get_template_dir(template, tmp_dir_path)
+        args1 = copy.deepcopy(args_h)
+        args1["--load-weights"] = f"{template_work_dir}/trained_{template.model_template_id}/models/weights.pth"
+        otx_train_testing(template, tmp_dir_path, otx_dir, args1)
+
+    @e2e_pytest_component
+    @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_train_cls_decr(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "h_label_cls/test_cls_decr"
         otx_train_testing(template, tmp_dir_path, otx_dir, args_h)


### PR DESCRIPTION
### Summary

* Wrap multi-label and h-label classification models by `MMDataParallel` in case of CPU training.

### How to test

```bash

CUDA_VISIBLE_DEVICES= python src/otx/algorithms/classification/tools/classification_sample.py --multilabel src/otx/algorithms/classification/configs/efficientnet_b0_cls_incr/template.yaml

CUDA_VISIBLE_DEVICES= python src/otx/algorithms/classification/tools/classification_sample.py --hierarchical src/otx/algorithms/classification/configs/efficientnet_b0_cls_incr/template.yaml
```

Without this PR:
```bash
Traceback (most recent call last):
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/tools/classification_sample.py", line 366, in <module>
    sys.exit(main() or 0)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/tools/classification_sample.py", line 259, in main
    task.train(dataset, initial_model)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/task.py", line 215, in train
    results = self._train_model(dataset)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/adapters/mmcls/task.py", line 429, in _train_model
    train_model(
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/mmcls/apis/train.py", line 233, in train_model
    runner.run(data_loaders, cfg.workflow)
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/mmcv/runner/epoch_based_runner.py", line 136, in run
    epoch_runner(data_loaders[i], **kwargs)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/common/adapters/mmcv/runner.py", line 81, in train
    self.run_iter(data_batch, train_mode=True, **kwargs)
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/mmcv/runner/epoch_based_runner.py", line 31, in run_iter
    outputs = self.model.train_step(data_batch, self.optimizer,
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/adapters/mmcls/models/classifiers/mixin.py", line 29, in train_step
    return super().train_step(data, optimizer, **kwargs)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/adapters/mmcls/models/classifiers/mixin.py", line 105, in train_step
    return super().train_step(data, optimizer, **kwargs)
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/mmcls/models/classifiers/base.py", line 139, in train_step
    losses = self(**data)
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/mmcv/runner/fp16_utils.py", line 119, in new_func
    return old_func(*args, **kwargs)
  File "/mnt/sdb/workarea/otx/.tox/unittest-all-py310/lib/python3.10/site-packages/mmcls/models/classifiers/base.py", line 83, in forward
    return self.forward_train(img, **kwargs)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/adapters/mmcls/models/classifiers/sam_classifier.py", line 76, in forward_train
    loss = self.head.forward_train(x, gt_label, **kwargs)
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_linear_cls_head.py", line 124, in forward_train
    valid_label_mask = self.get_valid_label_mask(img_metas=img_metas)[
  File "/mnt/sdb/workarea/otx/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_linear_cls_head.py", line 176, in get_valid_label_mask
    for meta in img_metas:
TypeError: 'DataContainer' object is not iterable
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
