### PR TITLE
Fix h-label loss normalization issue w/ exclusive label group of singe label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix IBLoss enablement with DeiT-Tiny when class incremental training (<https://github.com/openvinotoolkit/training_extensions/pull/2595>)
 - Fix mmcls bug not wrapping model in DataParallel on CPUs (<https://github.com/openvinotoolkit/training_extensions/pull/2601>)
+- Fix h-label loss normalization issue w/ exclusive label group of singe label (<https://github.com/openvinotoolkit/training_extensions/pull/2604>)
 
 ## \[v1.4.3\]
 

--- a/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_linear_cls_head.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_linear_cls_head.py
@@ -105,7 +105,7 @@ class CustomHierarchicalLinearClsHead(OTXHeadMixin, MultiLabelClsHead):
                     losses["loss"] += multiclass_loss
                     num_effective_heads_in_batch += 1
 
-        if self.hierarchical_info["num_multiclass_heads"] > 1:
+        if num_effective_heads_in_batch > 0:
             losses["loss"] /= num_effective_heads_in_batch
 
         if self.compute_multilabel_loss:

--- a/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_non_linear_cls_head.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/models/heads/custom_hierarchical_non_linear_cls_head.py
@@ -135,7 +135,7 @@ class CustomHierarchicalNonLinearClsHead(
                     losses["loss"] += multiclass_loss
                     num_effective_heads_in_batch += 1
 
-        if self.hierarchical_info["num_multiclass_heads"] > 1:
+        if num_effective_heads_in_batch > 0:
             losses["loss"] /= num_effective_heads_in_batch
 
         if self.compute_multilabel_loss:


### PR DESCRIPTION
### Summary

* Exclusive label groups are expected to have more than 1 labels. If it has just 1 label,
the group is regarded as single label group which corresponds to a label in multi-label classification.
![image](https://github.com/openvinotoolkit/training_extensions/assets/4629606/e355f807-a013-41b6-bed9-10a596fbdc29)
* In case that a batch has samples with that label only, the `num_effective_heads_in_batch` below
could be 0 even if the `num_multiclass_heads` > 0.
![image](https://github.com/openvinotoolkit/training_extensions/assets/4629606/23c2a89e-58f2-4006-ab16-1dbba8b30c37)
* This fix is an workaround in OTX side; not to divide by 0. "Exclusive group with single label" should be prevented by UX or other user frontend because it's not correct by definition.

### How to test

* Hard to reproduce on OTX side

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
