### PR TITLE
Add config_dict attribute to mmengine based model

### DIFF
--- a/src/otx/v2/adapters/torch/mmengine/mmpretrain/model.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmpretrain/model.py
@@ -150,6 +150,7 @@ def get_model(
 
     torch_model = get_mmpretrain_model(model, pretrained=pretrained, **kwargs)
 
+    # Config modification below should not affect original model config.
     source_config = deepcopy(torch_model._config.model)  # noqa: SLF001
     source_config.name = model_name
     torch_model.config_dict = Config.to_dict(source_config)

--- a/src/otx/v2/adapters/torch/mmengine/modules/utils/config_utils.py
+++ b/src/otx/v2/adapters/torch/mmengine/modules/utils/config_utils.py
@@ -149,6 +149,25 @@ class CustomConfig(Config):
             import_modules_from_strings(**cfg_dict["custom_imports"])
         return CustomConfig(cfg_dict, cfg_text=cfg_text, filename=filename)
 
+    @staticmethod
+    def to_dict(config: Config | ConfigDict) -> dict:
+        """Converts a Config object to a dictionary.
+
+        Args:
+            config(Config): The Config object to convert.
+
+        Return:
+            dict: The resulting dictionary.
+        """
+        output_dict = {}
+        for key, value in config.items():
+            if isinstance(value, (Config, ConfigDict)):
+                output_dict[key] = CustomConfig.to_dict(value)
+            else:
+                output_dict[key] = value
+
+        return output_dict
+
     @property
     def pretty_text(self) -> str:
         """Make python file human-readable.

--- a/src/otx/v2/cli/cli.py
+++ b/src/otx/v2/cli/cli.py
@@ -349,8 +349,8 @@ class OTXCLIv2:
         self.model = self.auto_runner.get_model(model={**model_cfg}, num_classes=num_classes)
         # For prediction class
         # NOTE: We'll need to move this somewhere other than here in the next phase.
-        if num_classes is not None and "num_classes" in model_cfg.get("head", {}):
-            model_cfg["head"]["num_classes"] = num_classes
+        if getattr(self.model, "config_dict", None):
+            model_cfg = self.model.config_dict
         workspace_config["model"] = {**model_cfg}
 
         work_dir = self._pop(self.config_init, "work_dir")

--- a/src/otx/v2/cli/cli.py
+++ b/src/otx/v2/cli/cli.py
@@ -347,10 +347,8 @@ class OTXCLIv2:
             msg = "There is a problem with model configuration. Please check it again."
             raise TypeError(msg)
         self.model = self.auto_runner.get_model(model={**model_cfg}, num_classes=num_classes)
-        # For prediction class
         # NOTE: We'll need to move this somewhere other than here in the next phase.
-        if getattr(self.model, "config_dict", None):
-            model_cfg = self.model.config_dict
+        model_cfg = self.model.config_dict if hasattr(self.model, 'config_dict') else model_cfg
         workspace_config["model"] = {**model_cfg}
 
         work_dir = self._pop(self.config_init, "work_dir")

--- a/src/otx/v2/cli/cli.py
+++ b/src/otx/v2/cli/cli.py
@@ -348,7 +348,8 @@ class OTXCLIv2:
             raise TypeError(msg)
         self.model = self.auto_runner.get_model(model={**model_cfg}, num_classes=num_classes)
         # NOTE: We'll need to move this somewhere other than here in the next phase.
-        model_cfg = self.model.config_dict if hasattr(self.model, 'config_dict') else model_cfg
+        if getattr(self.model, "config_dict", None):
+            model_cfg = self.model.config_dict
         workspace_config["model"] = {**model_cfg}
 
         work_dir = self._pop(self.config_init, "work_dir")

--- a/tests/v2/unit/adapters/torch/mmengine/mmpretrain/test_model.py
+++ b/tests/v2/unit/adapters/torch/mmengine/mmpretrain/test_model.py
@@ -88,11 +88,28 @@ def test_get_model(mocker: MockerFixture, monkeypatch: MonkeyPatch) -> None:
     configure_in_channels_mock = mocker.patch("otx.v2.adapters.torch.mmengine.mmpretrain.model.configure_in_channels")
     configure_in_channels_mock.return_value = mocker.MagicMock()
 
+    model_dict = {
+        "model": {
+            "name": "test1",
+            "backbone": "resnet50",
+            "neck": {
+                "type": "FPN",
+                "in_channels": -1,
+            },
+            "head": {
+                "type": "ClsHead",
+                "in_channels": -1,
+                "num_classes": 10,
+            },
+        },
+    }
+
     # Mock the get_mmpretrain_model function
     class MockModel(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()
             self.shape = (1, 256, 14, 14)
+            self._config = Config(model_dict)
 
         def forward(self, *args, **kwargs) -> list:
             _, _ = args, kwargs
@@ -113,21 +130,6 @@ def test_get_model(mocker: MockerFixture, monkeypatch: MonkeyPatch) -> None:
         pretrained=True,
     )
 
-    model_dict = {
-        "model": {
-            "name": "test1",
-            "backbone": "resnet50",
-            "neck": {
-                "type": "FPN",
-                "in_channels": -1,
-            },
-            "head": {
-                "type": "ClsHead",
-                "in_channels": -1,
-                "num_classes": 10,
-            },
-        },
-    }
     model = get_model(model_dict, pretrained=True, num_classes=10, channel_last=True)
     configure_in_channels_mock.assert_called_once()
     assert isinstance(model, torch.nn.Module)


### PR DESCRIPTION
### Summary
Unlike current visual prompting and anomaly models, mmengine based models need some patch to model config during building model with the model config. 
Therefore, cli need to get patched config from model api. 
This PR is for adding config_dict attribute to mmengine based model so that mmengine based model api can give proper model config to cli for re-building same model.

Since model api should be refactored in near future, this PR only patch mmengine based model api.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
