### PR TITLE
Update export, export for reflecting the latest MMXFrameworks

### DIFF
--- a/src/otx/v2/adapters/torch/mmengine/engine.py
+++ b/src/otx/v2/adapters/torch/mmengine/engine.py
@@ -505,7 +505,7 @@ class MMXEngine(Engine):
         task: str | None = None,
         codebase: str | None = None,
         export_type: str = "OPENVINO",  # "ONNX" or "OPENVINO"
-        deploy_config: str | dict | None = None, 
+        deploy_config: str | dict | None = None,
         device: str = "cpu",
         input_shape: tuple[int, int] | None = None,
     ) -> dict:
@@ -522,7 +522,7 @@ class MMXEngine(Engine):
             task (Optional[str]): The task to use for exporting. Defaults to None.
             codebase (Optional[str]): The codebase to use for exporting. Defaults to None.
             export_type (str): The type of export to perform. Can be "ONNX" or "OPENVINO". Defaults to "OPENVINO".
-            deploy_config (Optional[str, dict]): The path to the deploy config file to use for exporting. Defaults to None.
+            deploy_config (Optional[str, dict]): The path to the deploy config to use for exporting. Defaults to None.
             device (str): The device to use for exporting. Defaults to "cpu".
             input_shape (Optional[Tuple[int, int]]): The input shape to use for exporting. Defaults to None.
 
@@ -602,9 +602,9 @@ class MMXEngine(Engine):
         # BACKEND_CONFIG Update
         if "backend_config" not in deploy_config_dict:
             backend_config = {
-                "type": "openvino", 
+                "type": "openvino",
                 "model_inputs": [{"opt_shapes": {"input": [1, 3, 224, 224]}}],
-                "input_metas": {"mode": "predict"}
+                "input_metas": {"mode": "predict"},
             }
             deploy_config_dict["backend_config"] = backend_config
 

--- a/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
@@ -85,7 +85,8 @@ class Exporter:
         """Prepare torch model's input and input_metas."""
         input_shape = self.deploy_cfg.backend_config.model_inputs[0]["opt_shapes"]["input"]
         input_tensor = torch.randn(input_shape)
-        input_metas = None
+        input_metas = self.deploy_cfg.backend_config.get("input_metas", None)
+        input_metas["data_samples"] = input_tensor
         return input_tensor, input_metas
 
     def export(self) -> dict[str, dict[str, str]]:

--- a/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
@@ -85,7 +85,8 @@ class Exporter:
         """Prepare torch model's input and input_metas."""
         input_shape = self.deploy_cfg.backend_config.model_inputs[0]["opt_shapes"]["input"]
         input_tensor = torch.randn(input_shape)
-        input_metas = self.deploy_cfg.backend_config.get("input_metas", None)
+        input_metas = self.deploy_cfg.backend_config.get("input_metas", {})
+        input_metas["mode"] = "predict"
         input_metas["data_samples"] = input_tensor
         return input_tensor, input_metas
 

--- a/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
@@ -13,6 +13,7 @@ from mmdeploy.apis.core.pipeline_manager import no_mp
 from mmdeploy.apis.onnx import export
 from mmdeploy.backend.openvino.onnx2openvino import from_onnx
 from mmdeploy.backend.openvino.utils import ModelOptimizerOptions
+from mmengine.structures import BaseDataElement
 
 from otx.v2.api.utils.logger import get_logger
 

--- a/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmdeploy/exporter.py
@@ -85,9 +85,9 @@ class Exporter:
         """Prepare torch model's input and input_metas."""
         input_shape = self.deploy_cfg.backend_config.model_inputs[0]["opt_shapes"]["input"]
         input_tensor = torch.randn(input_shape)
-        input_metas = self.deploy_cfg.backend_config.get("input_metas", {})
-        input_metas["mode"] = "predict"
-        input_metas["data_samples"] = input_tensor
+        input_metas = self.deploy_cfg.backend_config.get("input_metas", None)
+        if input_metas is None:
+            input_metas = {"data_samples": [BaseDataElement()] * input_shape[0], "mode": "predict"}
         return input_tensor, input_metas
 
     def export(self) -> dict[str, dict[str, str]]:

--- a/src/otx/v2/adapters/torch/mmengine/mmpretrain/engine.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmpretrain/engine.py
@@ -156,10 +156,9 @@ class MMPTEngine(MMXEngine):
         task: str | None = "Classification",
         codebase: str | None = "mmpretrain",
         export_type: str = "OPENVINO",  # "ONNX" or "OPENVINO"
-        deploy_config: str | None = None,  # File path only?
+        deploy_config: str | dict | None = None,
         device: str = "cpu",
         input_shape: tuple[int, int] | None = None,
-        **kwargs,
     ) -> dict:
         """Export a PyTorch model to a specified format for deployment.
 
@@ -171,11 +170,9 @@ class MMPTEngine(MMXEngine):
             task (Optional[str]): The task for which the model is being exported. Defaults to "Classification".
             codebase (Optional[str]): The codebase for the model being exported. Defaults to "mmpretrain".
             export_type (str): The type of export to perform. Can be one of "ONNX" or "OPENVINO". Defaults to "OPENVINO"
-            deploy_config (Optional[str]): The path to the deployment configuration file to use for exporting.
-                File path only.
+            deploy_config (Optional[str, dict]): The path to the deploy config to use for exporting. Defaults to None.
             device (str): The device to use for exporting. Defaults to "cpu".
             input_shape (Optional[Tuple[int, int]]): The input shape of the model being exported.
-            **kwargs: Additional keyword arguments to pass to the export function.
 
         Returns:
             dict: A dictionary containing information about the exported model.
@@ -190,5 +187,4 @@ class MMPTEngine(MMXEngine):
             deploy_config=deploy_config,
             device=device,
             input_shape=input_shape,
-            **kwargs,
         )


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

The current `export` function couldn't reflect the latest `mmdeploy` version especially for the `input_metas`. As latest mmXframework wanted the `input_metas={'data_samples', 'mode'='predict'}` for some models. So, I added this `input_metas` as a default. The hardest thing is it could be different with the different frameworks, let's fix it if it occurs a further error

So, I partially changed the flow of the export function.

After this PR, we could transfer the `deploy_config` from the subengine.export() function. (i.e. `MMActionEngine.export()).
All frameworks want slightly different configurations, so they should be modified at the level of each framework engine.

This is the example of the MMAction Engine.
```python
class MMActionEngine(MMXEngine):
    def export(...):
        mmaction_backend_config = {
                "type": "openvino",
                "model_inputs": [
                    {
                        "opt_shapes":{
                            "input": [1, 1, 3, 32, 224, 224],
                        },
                    },
                ],
                "input_metas": {"mode": "predict"},
                "mo_options":{
                    "args":{
                        "--source_layout": "?bctwh",
                    },
                },
            }
        mmaction_deploy_config_dict["backend_config"] = mmaction_backend_config
        super().export(
            ...
            deploy_config_dict=mmaction_deploy_config_dict
        )
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
