### PR TITLE
Fix h-label bug of missing parent labels in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fix h-label loss normalization issue w/ exclusive label group of singe label (<https://github.com/openvinotoolkit/training_extensions/pull/2604>)
 - Fix division by zero in class incremental learning for classification (<https://github.com/openvinotoolkit/training_extensions/pull/2606>)
 - Fix saliency maps calculation issue for detection models (<https://github.com/openvinotoolkit/training_extensions/pull/2609>)
+- Fix h-label bug of missing parent labels in output (<https://github.com/openvinotoolkit/training_extensions/pull/2626>)
 
 ## \[v1.4.3\]
 

--- a/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
@@ -300,6 +300,7 @@ class OTXHierarchicalClsDataset(OTXMultilabelClsDataset):
 
     def __init__(self, **kwargs):
         self.hierarchical_info = kwargs.pop("hierarchical_info", None)
+        self.label_schema = kwargs.pop("label_schema", None)
         super().__init__(**kwargs)
 
     def load_annotations(self):
@@ -308,6 +309,13 @@ class OTXHierarchicalClsDataset(OTXMultilabelClsDataset):
         for i, _ in enumerate(self.otx_dataset):
             class_indices = []
             item_labels = self.otx_dataset[i].get_roi_labels(self.labels, include_empty=include_empty)
+            if self.label_schema:
+                # NOTE: Parent labels might be missing in annotations.
+                # This code fills the gap just in case.
+                full_item_labels = set()
+                for label in item_labels:
+                    full_item_labels.update(self.label_schema.get_ancestors(label))
+                item_labels = full_item_labels
             ignored_labels = self.otx_dataset[i].ignored_labels
             if item_labels:
                 num_cls_heads = self.hierarchical_info["num_multiclass_heads"]

--- a/src/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/task.py
@@ -190,6 +190,7 @@ class MMClassificationTask(OTXClassificationTask):
         elif self._hierarchical:
             options_for_patch_datasets["type"] = "OTXHierarchicalClsDataset"
             options_for_patch_datasets["hierarchical_info"] = self._hierarchical_info
+            options_for_patch_datasets["label_schema"] = self._task_environment.label_schema
             options_for_patch_evaluation["task"] = "hierarchical"
         elif self._selfsl:
             options_for_patch_datasets["type"] = "SelfSLDataset"

--- a/tests/assets/datumaro_h-label/annotations/train.json
+++ b/tests/assets/datumaro_h-label/annotations/train.json
@@ -4,6 +4,11 @@
     "label": {
       "label_groups": [
         {
+          "name": "shape",
+          "group_type": "exclusive",
+          "labels": ["blue", "green"]
+        },
+        {
           "name": "blue",
           "group_type": "exclusive",
           "labels": ["blue_rectangle", "blue_circle", "blue_triangle"]

--- a/tests/assets/datumaro_h-label/annotations/valid.json
+++ b/tests/assets/datumaro_h-label/annotations/valid.json
@@ -4,6 +4,11 @@
     "label": {
       "label_groups": [
         {
+          "name": "shape",
+          "group_type": "exclusive",
+          "labels": ["blue", "green"]
+        },
+        {
           "name": "blue",
           "group_type": "exclusive",
           "labels": ["blue_rectangle", "blue_circle", "blue_triangle"]

--- a/tests/assets/datumaro_h-label_class_decremental/annotations/train.json
+++ b/tests/assets/datumaro_h-label_class_decremental/annotations/train.json
@@ -4,6 +4,11 @@
     "label": {
       "label_groups": [
         {
+          "name": "shape",
+          "group_type": "exclusive",
+          "labels": ["blue", "green"]
+        },
+        {
           "name": "blue",
           "group_type": "exclusive",
           "labels": ["blue_rectangle", "blue_circle", "blue_triangle"]

--- a/tests/assets/datumaro_h-label_class_decremental/annotations/valid.json
+++ b/tests/assets/datumaro_h-label_class_decremental/annotations/valid.json
@@ -4,6 +4,11 @@
     "label": {
       "label_groups": [
         {
+          "name": "shape",
+          "group_type": "exclusive",
+          "labels": ["blue", "green"]
+        },
+        {
           "name": "blue",
           "group_type": "exclusive",
           "labels": ["blue_rectangle", "blue_circle", "blue_triangle"]


### PR DESCRIPTION
### Summary

* In hierarchical classification, the parent labels might not be annotated explicitly.
In this case, the higher level classifier cannot learn how to classify the abstract semantic
so that the losses could be NaN, and the final leaf outputs are filtered out in post-processing.
(e.g. Datumaro dataset exported from Geti contains only leaf label annotations)
* This PR fills the parent label annotation if missing based on label schema.
As a result, the output would look like [ancestor(80%), ..., parent(60%), child(70%), ... other(60%)]. 
(No harm in case of full annotation)
* Additionally, added the top level label exclusive group for h-label test data.
Without this, models would not classify the highest level semantic.
* This PR would resolve: https://github.com/openvinotoolkit/training_extensions/issues/2579

### How to test

* E2e / Regression test
```bash
tox -e tests-all-py310 -- tests/e2e/cli/classification/test_classification.py::TestToolsHierarchicalClassification::test_otx_train[Custom_Image_Classification_EfficinetNet-B0]
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
