### PR TITLE
[release 1.5.0] DeiT: enable tests + add ViTFeatureVectorHook

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/task.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/task.py
@@ -19,7 +19,6 @@ from mmcls.utils import collect_env
 from mmcv.runner import wrap_fp16_model
 from mmcv.utils import Config, ConfigDict
 
-from otx.algorithms import TRANSFORMER_BACKBONES
 from otx.algorithms.classification.adapters.mmcls.utils.exporter import (
     ClassificationExporter,
 )
@@ -31,6 +30,7 @@ from otx.algorithms.common.adapters.mmcv.hooks.recording_forward_hook import (
     EigenCamHook,
     FeatureVectorHook,
     ReciproCAMHook,
+    ViTFeatureVectorHook,
     ViTReciproCAMHook,
 )
 from otx.algorithms.common.adapters.mmcv.utils import (
@@ -225,7 +225,6 @@ class MMClassificationTask(OTXClassificationTask):
             )
         )
 
-        dump_features = True
         dump_saliency_map = not inference_parameters.is_evaluation if inference_parameters else True
 
         self._init_task()
@@ -274,16 +273,16 @@ class MMClassificationTask(OTXClassificationTask):
         forward_explainer_hook: Union[nullcontext, BaseRecordingForwardHook]
         if model_type == "VisionTransformer":
             forward_explainer_hook = ViTReciproCAMHook(feature_model)
-        elif (
-            not dump_saliency_map or model_type in TRANSFORMER_BACKBONES
-        ):  # TODO: remove latter "or" condition after resolving Issue#2098
+        elif not dump_saliency_map:
             forward_explainer_hook = nullcontext()
         else:
             forward_explainer_hook = ReciproCAMHook(feature_model)
-        if (
-            not dump_features or model_type in TRANSFORMER_BACKBONES
-        ):  # TODO: remove latter "or" condition after resolving Issue#2098
-            feature_vector_hook: Union[nullcontext, BaseRecordingForwardHook] = nullcontext()
+
+        feature_vector_hook: Union[nullcontext, BaseRecordingForwardHook]
+        if model_type == "VisionTransformer":
+            feature_vector_hook = ViTFeatureVectorHook(feature_model)
+        elif not dump_saliency_map:
+            feature_vector_hook = nullcontext()
         else:
             feature_vector_hook = FeatureVectorHook(feature_model)
 
@@ -532,11 +531,6 @@ class MMClassificationTask(OTXClassificationTask):
 
         export_options["precision"] = str(precision)
         export_options["type"] = str(export_format)
-
-        # [TODO] Enable dump_features for ViT backbones
-        model_type = cfg.model.backbone.type.split(".")[-1]  # mmcls.VisionTransformer => VisionTransformer
-        if model_type in TRANSFORMER_BACKBONES:
-            dump_features = False
 
         export_options["deploy_cfg"]["dump_features"] = dump_features
         if dump_features:

--- a/src/otx/algorithms/common/adapters/mmcv/hooks/recording_forward_hook.py
+++ b/src/otx/algorithms/common/adapters/mmcv/hooks/recording_forward_hook.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -170,6 +170,16 @@ class FeatureVectorHook(BaseRecordingForwardHook):
         else:
             feature_vector = torch.nn.functional.adaptive_avg_pool2d(feature_map, (1, 1))
         return feature_vector
+
+
+class ViTFeatureVectorHook(BaseRecordingForwardHook):
+    """FeatureVectorHook for transformer-based classifiers."""
+
+    @staticmethod
+    def func(features: Tuple[List[torch.Tensor]], fpn_idx: int = -1) -> torch.Tensor:
+        """Generate the feature vector for transformer-based classifiers by returning the cls token."""
+        _, cls_token = features[0]
+        return cls_token
 
 
 class ReciproCAMHook(BaseRecordingForwardHook):

--- a/tests/e2e/cli/classification/test_classification.py
+++ b/tests/e2e/cli/classification/test_classification.py
@@ -137,8 +137,6 @@ class TestToolsMultiClassClassification:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("dump_features", [True, False])
     def test_otx_export(self, template, tmp_dir_path, dump_features):
-        if template.name == "DeiT-Tiny" and dump_features:
-            pytest.skip(reason="Issue#2098 ViT template does not support dump_features.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_export_testing(template, tmp_dir_path, dump_features)
 
@@ -160,8 +158,6 @@ class TestToolsMultiClassClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args)
 
@@ -169,8 +165,6 @@ class TestToolsMultiClassClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_openvino_testing(template, tmp_dir_path, otx_dir, args)
 
@@ -383,8 +377,6 @@ class TestToolsMultilabelClassification:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("dump_features", [True, False])
     def test_otx_export(self, template, tmp_dir_path, dump_features):
-        if template.name == "DeiT-Tiny" and dump_features:
-            pytest.skip(reason="Issue#2098 ViT template does not support dump_features.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_export_testing(template, tmp_dir_path, dump_features)
 
@@ -399,8 +391,6 @@ class TestToolsMultilabelClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args_m)
 
@@ -546,8 +536,6 @@ class TestToolsHierarchicalClassification:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("dump_features", [True, False])
     def test_otx_export(self, template, tmp_dir_path, dump_features):
-        if template.name == "DeiT-Tiny" and dump_features:
-            pytest.skip(reason="Issue#2098 ViT template does not support dump_features.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_export_testing(template, tmp_dir_path, dump_features)
 
@@ -562,8 +550,6 @@ class TestToolsHierarchicalClassification:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args_h)
 

--- a/tests/integration/cli/classification/test_classification.py
+++ b/tests/integration/cli/classification/test_classification.py
@@ -124,8 +124,6 @@ class TestMultiClassClassificationCLI:
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("dump_features", [True, False])
     def test_otx_export(self, template, tmp_dir_path, dump_features):
-        if template.name == "DeiT-Tiny" and dump_features:
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_export_testing(template, tmp_dir_path, dump_features, check_ir_meta=True)
 
@@ -150,48 +148,36 @@ class TestMultiClassClassificationCLI:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain_all_classes(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_testing_all_classes(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain_process_saliency_maps(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_testing_process_saliency_maps(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_openvino_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain_all_classes_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_all_classes_openvino_testing(template, tmp_dir_path, otx_dir, args)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_otx_explain_process_saliency_maps_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_class_cls"
         otx_explain_process_saliency_maps_openvino_testing(template, tmp_dir_path, otx_dir, args)
 
@@ -365,48 +351,36 @@ class TestMultilabelClassificationCLI:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_all_classes(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_testing_all_classes(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_process_saliency_maps(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_testing_process_saliency_maps(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_openvino_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_all_classes_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_all_classes_openvino_testing(template, tmp_dir_path, otx_dir, args_m)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_process_saliency_maps_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "multi_label_cls"
         otx_explain_process_saliency_maps_openvino_testing(template, tmp_dir_path, otx_dir, args_m)
 
@@ -502,48 +476,36 @@ class TestHierarchicalClassificationCLI:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_all_classes(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_testing_all_classes(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_process_saliency_maps(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_testing_process_saliency_maps(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_openvino_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_all_classes_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_all_classes_openvino_testing(template, tmp_dir_path, otx_dir, args_h)
 
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_otx_explain_process_saliency_maps_openvino(self, template, tmp_dir_path):
-        if template.name == "DeiT-Tiny":
-            pytest.skip(reason="Issue#2098 ViT inference does not work by FeatureVectorHook.")
         tmp_dir_path = tmp_dir_path / "h_label_cls"
         otx_explain_process_saliency_maps_openvino_testing(template, tmp_dir_path, otx_dir, args_h)
 


### PR DESCRIPTION
### Summary

- Add ViTFeatureVectorHook for transformer-base classifications
- Enable ViT tests after merging saliency hook for ViT ([PR#2403](https://github.com/openvinotoolkit/training_extensions/pull/2403))  
- Re-enable feature dumping for IR export after merging saliency hook for ViT ([PR#2403](https://github.com/openvinotoolkit/training_extensions/pull/2403))  

The PR duplicates [PR#2536](https://github.com/openvinotoolkit/training_extensions/pull/2536) to release/1.5.0
Reverts changes from [PR#2282](https://github.com/openvinotoolkit/training_extensions/pull/2282), [PR#2093](https://github.com/openvinotoolkit/training_extensions/pull/2093)
Adds  ViTFeatureVectorHook.


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
