### PR TITLE
Refactor the datumaro adapter

### DIFF
--- a/src/otx/v2/adapters/datumaro/adapter/action_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/action_dataset_adapter.py
@@ -118,9 +118,8 @@ class ActionClassificationDatasetAdapter(ActionBaseDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Acion Classification."""
-        label_information = self._prepare_label_information(self.dataset)
-        self.label_entities = label_information["label_entities"]
-
+        if not hasattr(self, "label_entities"):
+            super().get_label_schema()
         dataset_items: List[DatasetItemEntity] = []
         for subset, subset_data in self.dataset.items():
             for _, datumaro_items in subset_data.subsets().items():
@@ -156,9 +155,8 @@ class ActionDetectionDatasetAdapter(ActionBaseDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Acion Detection."""
-        label_information = self._prepare_label_information(self.dataset)
-        self.label_entities = label_information["label_entities"]
-
+        if not hasattr(self, "label_entities"):
+            super().get_label_schema()
         # Detection use index 0 as a background category
         for label_entity in self.label_entities:
             label_entity.id = ID(int(label_entity.id) + 1)

--- a/src/otx/v2/adapters/datumaro/adapter/action_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/action_dataset_adapter.py
@@ -153,8 +153,6 @@ class ActionDetectionDatasetAdapter(ActionBaseDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Acion Detection."""
-        if not hasattr(self, "label_entities"):
-            super().get_label_schema()
         # Detection use index 0 as a background category
         for label_entity in self.label_entities:
             label_entity.id = ID(int(label_entity.id) + 1)

--- a/src/otx/v2/adapters/datumaro/adapter/action_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/action_dataset_adapter.py
@@ -118,8 +118,6 @@ class ActionClassificationDatasetAdapter(ActionBaseDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Acion Classification."""
-        if not hasattr(self, "label_entities"):
-            super().get_label_schema()
         dataset_items: List[DatasetItemEntity] = []
         for subset, subset_data in self.dataset.items():
             for _, datumaro_items in subset_data.subsets().items():

--- a/src/otx/v2/adapters/datumaro/adapter/anomaly_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/anomaly_dataset_adapter.py
@@ -23,9 +23,7 @@ from otx.v2.api.entities.label import LabelEntity
 from otx.v2.api.entities.label_schema import LabelSchemaEntity
 from otx.v2.api.entities.subset import Subset
 
-from .datumaro_dataset_adapter import DatumaroDatasetAdapter
-
-LabelInformationType = Dict[str, Union[List[LabelEntity], List[DatumCategories]]]
+from .datumaro_dataset_adapter import DatumaroDatasetAdapter, LabelInformationType
 
 class AnomalyBaseDatasetAdapter(DatumaroDatasetAdapter):
     """BaseDataset Adpater for Anomaly tasks inherited from DatumaroDatasetAdapter."""

--- a/src/otx/v2/adapters/datumaro/adapter/anomaly_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/anomaly_dataset_adapter.py
@@ -72,7 +72,7 @@ class AnomalyBaseDatasetAdapter(DatumaroDatasetAdapter):
             dataset[Subset.TESTING] = DatumDataset.import_from(test_data_roots, format="image_dir")
         return dataset
 
-    def _prepare_label_information(self) -> LabelInformationType:
+    def _prepare_label_information(self, datumaro_dataset: dict[Subset, DatumDataset]) -> LabelInformationType:
         """Prepare LabelEntity List."""
         normal_label = LabelEntity(id=ID(0), name="Normal", domain=self.domain)
         abnormal_label = LabelEntity(

--- a/src/otx/v2/adapters/datumaro/adapter/datumaro_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/datumaro_dataset_adapter.py
@@ -413,7 +413,7 @@ class DatumaroDatasetAdapter(BaseDatasetAdapter):
         for item in copy_dataset:
             if item.id not in file_list:
                 unlabeled_dataset.remove(item.id, item.subset)
-    
+
     @staticmethod
     def datum_media_2_otx_media(datumaro_media: DatumMediaElement) -> IMediaEntity:
         """Convert Datumaro media to OTX media."""

--- a/src/otx/v2/adapters/datumaro/adapter/datumaro_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/datumaro_dataset_adapter.py
@@ -219,6 +219,8 @@ class DatumaroDatasetAdapter(BaseDatasetAdapter):
 
     def get_label_schema(self) -> LabelSchemaEntity:
         """Get Label Schema."""
+        label_information = self._prepare_label_information(self.dataset)
+        self.label_entities = label_information["label_entities"]
         return self._generate_default_label_schema(self.label_entities)
 
     def _get_subset_data(self, subset: str, dataset: DatumDataset) -> DatumDatasetSubset:

--- a/src/otx/v2/adapters/datumaro/adapter/detection_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/detection_dataset_adapter.py
@@ -24,8 +24,6 @@ class DetectionDatasetAdapter(DatumaroDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Detection."""
-        if not hasattr(self, "label_entities"):
-            super().get_label_schema()
         dataset_items: List[DatasetItemEntityWithID] = []
         used_labels: List[int] = []
         for subset, subset_data in self.dataset.items():

--- a/src/otx/v2/adapters/datumaro/adapter/detection_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/detection_dataset_adapter.py
@@ -24,9 +24,8 @@ class DetectionDatasetAdapter(DatumaroDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Detection."""
-        # Prepare label information
-        label_information = self._prepare_label_information(self.dataset)
-        self.label_entities = label_information["label_entities"]
+        if not hasattr(self, "label_entities"):
+            super().get_label_schema()
         dataset_items: List[DatasetItemEntityWithID] = []
         used_labels: List[int] = []
         for subset, subset_data in self.dataset.items():
@@ -59,5 +58,6 @@ class DetectionDatasetAdapter(DatumaroDatasetAdapter):
                             id_=datumaro_item.id,
                         )
                         dataset_items.append(dataset_item)
+        
         self.remove_unused_label_entities(used_labels)
         return DatasetEntity(items=dataset_items)

--- a/src/otx/v2/adapters/datumaro/adapter/segmentation_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/segmentation_dataset_adapter.py
@@ -76,8 +76,6 @@ class SegmentationDatasetAdapter(DatumaroDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Segmentation."""
-        if not hasattr(self, "label_entities"):
-            super().get_label_schema()
         dataset_items: List[DatasetItemEntity] = []
         used_labels: List[int] = []
         self.updated_label_id: Dict[int, int] = {}

--- a/src/otx/v2/adapters/datumaro/adapter/segmentation_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/segmentation_dataset_adapter.py
@@ -76,10 +76,8 @@ class SegmentationDatasetAdapter(DatumaroDatasetAdapter):
 
     def get_otx_dataset(self) -> DatasetEntity:
         """Convert DatumaroDataset to DatasetEntity for Segmentation."""
-        # Prepare label information
-        label_information = self._prepare_label_information(self.dataset)
-        self.label_entities = label_information["label_entities"]
-
+        if not hasattr(self, "label_entities"):
+            super().get_label_schema()
         dataset_items: List[DatasetItemEntity] = []
         used_labels: List[int] = []
         self.updated_label_id: Dict[int, int] = {}

--- a/src/otx/v2/adapters/datumaro/adapter/visual_prompting_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/visual_prompting_dataset_adapter.py
@@ -68,6 +68,8 @@ class VisualPromptingDatasetAdapter(SegmentationDatasetAdapter):
 
     def get_otx_dataset(self) -> dict[Subset, DatumDataset]:
         """Convert DatumaroDataset to DatasetEntity for Visual Prompting."""
+        if not hasattr(self, "label_entities"):
+            self.get_label_schema()
         used_labels: List[int] = []
         self.updated_label_id: Dict[int, int] = {}
 

--- a/src/otx/v2/adapters/datumaro/adapter/visual_prompting_dataset_adapter.py
+++ b/src/otx/v2/adapters/datumaro/adapter/visual_prompting_dataset_adapter.py
@@ -59,17 +59,8 @@ class VisualPromptingDatasetAdapter(SegmentationDatasetAdapter):
             **kwargs,
         )
 
-    def get_label_schema(self) -> LabelSchemaEntity:
-        """Get Label Schema."""
-        label_information = self._prepare_label_information(self.dataset)
-        self.label_entities = label_information["label_entities"]
-
-        return super()._generate_default_label_schema(self.label_entities)
-
     def get_otx_dataset(self) -> dict[Subset, DatumDataset]:
         """Convert DatumaroDataset to DatasetEntity for Visual Prompting."""
-        if not hasattr(self, "label_entities"):
-            self.get_label_schema()
         used_labels: List[int] = []
         self.updated_label_id: Dict[int, int] = {}
 

--- a/tests/v2/unit/adapters/datumaro/adapter/test_action_adapter.py
+++ b/tests/v2/unit/adapters/datumaro/adapter/test_action_adapter.py
@@ -11,6 +11,7 @@ from otx.v2.adapters.datumaro.adapter.action_dataset_adapter import (
 )
 from otx.v2.api.entities.datasets import DatasetEntity
 from otx.v2.api.entities.subset import Subset
+from otx.v2.api.entities.label_schema import LabelSchemaEntity
 
 from tests.v2.unit.adapters.datumaro.test_helpers import (
     TASK_NAME_TO_DATA_ROOT,
@@ -50,6 +51,9 @@ class TestOTXActionClassificationDatasetAdapter:
         assert Subset.TESTING in self.test_dataset_adapter.dataset
 
     def test_get_otx_dataset(self) -> None:
+        assert isinstance(self.train_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        assert isinstance(self.test_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        
         assert isinstance(self.train_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(self.test_dataset_adapter.get_otx_dataset(), DatasetEntity)
 
@@ -83,5 +87,8 @@ class TestOTXActionDetectionDatasetAdapter:
         assert Subset.TESTING in self.test_dataset_adapter.dataset
 
     def test_get_otx_dataset(self) -> None:
+        assert isinstance(self.train_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        assert isinstance(self.test_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        
         assert isinstance(self.train_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(self.test_dataset_adapter.get_otx_dataset(), DatasetEntity)

--- a/tests/v2/unit/adapters/datumaro/adapter/test_detection_adapter.py
+++ b/tests/v2/unit/adapters/datumaro/adapter/test_detection_adapter.py
@@ -62,8 +62,8 @@ class TestOTXDetectionDatasetAdapter:
         )
 
         assert Subset.TESTING in det_test_dataset_adapter.dataset
-        assert isinstance(det_test_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(det_test_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        assert isinstance(det_test_dataset_adapter.get_otx_dataset(), DatasetEntity)
 
     def test_get_subset_data(self) -> None:
         class MockDataset:
@@ -169,5 +169,5 @@ class TestOTXDetectionDatasetAdapter:
         )
 
         assert Subset.TESTING in instance_seg_test_dataset_adapter.dataset
-        assert isinstance(instance_seg_test_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(instance_seg_test_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        assert isinstance(instance_seg_test_dataset_adapter.get_otx_dataset(), DatasetEntity)

--- a/tests/v2/unit/adapters/datumaro/adapter/test_segmentation_adapter.py
+++ b/tests/v2/unit/adapters/datumaro/adapter/test_segmentation_adapter.py
@@ -15,6 +15,7 @@ from otx.v2.adapters.datumaro.adapter.segmentation_dataset_adapter import (
 )
 from otx.v2.api.entities.datasets import DatasetEntity
 from otx.v2.api.entities.subset import Subset
+from otx.v2.api.entities.label_schema import LabelSchemaEntity
 from pytest_mock.plugin import MockerFixture
 
 from tests.v2.unit.adapters.datumaro.test_helpers import (
@@ -62,6 +63,9 @@ class TestOTXSegmentationDatasetAdapter:
         assert Subset.TESTING in self.test_dataset_adapter.dataset
 
     def test_get_otx_dataset(self) -> None:
+        assert isinstance(self.train_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        assert isinstance(self.test_dataset_adapter.get_label_schema(), LabelSchemaEntity)
+        
         assert isinstance(self.train_dataset_adapter.get_otx_dataset(), DatasetEntity)
         assert isinstance(self.test_dataset_adapter.get_otx_dataset(), DatasetEntity)
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
After this PR, `self.label_entities` will be generated at the `get_label_schema()` function instead of `get_otx_dataset()`.
So, the only function we should inherit is the `get_otx_dataset()` at each child class. 

Recommended step is `get_label_schema()` --> `get_otx_dataset()`. However, if there is a counter-example, it raises an error since it couldn't find the `self.label_entities`. That's the reason why I added the codes below.
```python
def get_otx_dataset(self) -> DatasetEntity:
        if not hasattr(self, "label_entities"):
            super().get_label_schema()
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
