### PR TITLE
Update e2e tests for XAI Detection

### DIFF
--- a/tests/e2e/cli/detection/test_api_xai_sanity_detection.py
+++ b/tests/e2e/cli/detection/test_api_xai_sanity_detection.py
@@ -32,7 +32,7 @@ assert_text_explain_predicted = "The number of saliency maps should be equal to 
 
 class TestOVDetXAIAPI(DetectionTaskAPIBase):
     ref_raw_saliency_shapes = {
-        "MobileNetV2-ATSS": (4, 4),  # Need to be adapted to configurable or adaptive input size
+        "MobileNetV2-ATSS": (16, 16),  # Need to be adapted to configurable or adaptive input size
     }
 
     @e2e_pytest_api


### PR DESCRIPTION
### Summary
- Update reference values for e2e tests after latest XAI update [PR#2617](https://github.com/openvinotoolkit/training_extensions/pull/2617)

```
pytest /home/gzalessk/code/training_extensions/tests/e2e/cli/detection/test_api_xai_sanity_detection.py

...

2023-11-14 17:20:45,765 | INFO : 0.08116712899936829 secs
2023-11-14 17:20:45,908 | INFO : Avg time per image: 0.07109713680001732 secs
2023-11-14 17:20:45,908 | INFO : Total time: 0.7109713680001732 secs
2023-11-14 17:20:45,908 | INFO : OpenVINO inference completed
PASSED
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
