### PR TITLE
Make `max_num_detections` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Update ModelAPI configuration(<https://github.com/openvinotoolkit/training_extensions/pull/2564>)
 - Add Anomaly modelAPI changes (<https://github.com/openvinotoolkit/training_extensions/pull/2563>)
 - Update Image numpy access (<https://github.com/openvinotoolkit/training_extensions/pull/2586>)
+- Make max_num_detections configurable (<https://github.com/openvinotoolkit/training_extensions/pull/2647>)
 
 ### Bug fixes
 

--- a/src/otx/algorithms/common/configs/training_base.py
+++ b/src/otx/algorithms/common/configs/training_base.py
@@ -1,18 +1,7 @@
 """Base Configuration of OTX Common Algorithms."""
 
-# Copyright (C) 2022 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 from sys import maxsize
 
@@ -224,6 +213,16 @@ class BaseConfig(ConfigurableParameters):
             max_value=1,
             header="Confidence threshold",
             description="This threshold only takes effect if the threshold is not set based on the result.",
+            affects_outcome_of=ModelLifecycle.INFERENCE,
+        )
+
+        max_num_detections = configurable_integer(
+            header="Maximum number of detection per image",
+            description="Extra detection outputs will be discared in non-maximum suppression process. "
+            "Defaults to 0, which means per-model default value.",
+            default_value=0,
+            min_value=0,
+            max_value=10000,
             affects_outcome_of=ModelLifecycle.INFERENCE,
         )
 

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -114,7 +114,7 @@ class DetectionConfigurer:
             new_classes = np.setdiff1d(data_classes, model_classes).tolist()
             train_data_cfg["new_classes"] = new_classes
 
-    def configure_model(self, cfg, ir_options, max_num_detections):  # noqa: C901
+    def configure_model(self, cfg, ir_options, max_num_detections=0):  # noqa: C901
         """Patch config's model.
 
         Change model type to super type

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -158,10 +158,14 @@ class DetectionConfigurer:
             test_cfg.nms_pre = max_num_detections * 10
             # Special cases for 2-stage detectors (e.g. MaskRCNN)
             if hasattr(test_cfg, "rpn"):
-                test_cfg.rpn.nms_pre = max_num_detections * 10
+                test_cfg.rpn.nms_pre = max_num_detections * 20
                 test_cfg.rpn.max_per_img = max_num_detections * 10
             if hasattr(test_cfg, "rcnn"):
                 test_cfg.rcnn.max_per_img = max_num_detections
+            train_cfg = cfg.model.train_cfg
+            if hasattr(train_cfg, "rpn_proposal"):
+                train_cfg.rpn_proposal.nms_pre = max_num_detections * 20
+                train_cfg.rpn_proposal.max_per_img = max_num_detections * 10
 
     def configure_data(self, cfg, training, data_cfg):  # noqa: C901
         """Patch cfg.data.

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -156,6 +156,12 @@ class DetectionConfigurer:
             test_cfg = cfg.model.test_cfg
             test_cfg.max_per_img = max_num_detections
             test_cfg.nms_pre = max_num_detections * 10
+            # Special cases for 2-stage detectors (e.g. MaskRCNN)
+            if hasattr(test_cfg, "rpn"):
+                test_cfg.rpn.nms_pre = max_num_detections * 10
+                test_cfg.rpn.max_per_img = max_num_detections * 10
+            if hasattr(test_cfg, "rcnn"):
+                test_cfg.rcnn.max_per_img = max_num_detections
 
     def configure_data(self, cfg, training, data_cfg):  # noqa: C901
         """Patch cfg.data.

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -64,13 +64,14 @@ class DetectionConfigurer:
         ir_options=None,
         data_classes=None,
         model_classes=None,
+        max_num_detections=0,
     ):
         """Create MMCV-consumable config from given inputs."""
         logger.info(f"configure!: training={training}")
 
         self.configure_base(cfg, data_cfg, data_classes, model_classes)
         self.configure_device(cfg, training)
-        self.configure_model(cfg, ir_options)
+        self.configure_model(cfg, ir_options, max_num_detections)
         self.configure_ckpt(cfg, model_ckpt)
         self.configure_data(cfg, training, data_cfg)
         self.configure_regularization(cfg, training)
@@ -113,7 +114,7 @@ class DetectionConfigurer:
             new_classes = np.setdiff1d(data_classes, model_classes).tolist()
             train_data_cfg["new_classes"] = new_classes
 
-    def configure_model(self, cfg, ir_options):  # noqa: C901
+    def configure_model(self, cfg, ir_options, max_num_detections):  # noqa: C901
         """Patch config's model.
 
         Change model type to super type
@@ -148,6 +149,13 @@ class DetectionConfigurer:
                 is_mmov_model,
                 {"model_path": ir_model_path, "weight_path": ir_weight_path, "init_weight": ir_weight_init},
             )
+
+        # Test config
+        if max_num_detections > 0:
+            logger.info(f"Model max_num_detections: {max_num_detections}")
+            test_cfg = cfg.model.test_cfg
+            test_cfg.max_per_img = max_num_detections
+            test_cfg.nms_pre = max_num_detections * 10
 
     def configure_data(self, cfg, training, data_cfg):  # noqa: C901
         """Patch cfg.data.

--- a/src/otx/algorithms/detection/adapters/mmdet/task.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/task.py
@@ -1,18 +1,7 @@
 """Task of OTX Detection using mmdetection training backend."""
 
 # Copyright (C) 2023 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 import glob
 import io
@@ -206,6 +195,7 @@ class MMDetectionTask(OTXDetectionTask):
             ir_options,
             data_classes,
             model_classes,
+            self.max_num_detections,
         )
         if should_cluster_anchors(self._recipe_cfg):
             if train_dataset is not None:
@@ -513,6 +503,12 @@ class MMDetectionTask(OTXDetectionTask):
         assert len(self._precision) == 1
         export_options["precision"] = str(self._precision[0])
         export_options["type"] = str(export_format)
+        if self.max_num_detections > 0:
+            logger.info(f"Export max_num_detections: {self.max_num_detections}")
+            post_proc_cfg = export_options["deploy_cfg"]["codebase_config"]["post_processing"]
+            post_proc_cfg["max_output_boxes_per_class"] = self.max_num_detections
+            post_proc_cfg["keep_top_k"] = self.max_num_detections
+            post_proc_cfg["pre_top_k"] = self.max_num_detections * 10
 
         export_options["deploy_cfg"]["dump_features"] = dump_features
         if dump_features:

--- a/src/otx/algorithms/detection/adapters/openvino/task.py
+++ b/src/otx/algorithms/detection/adapters/openvino/task.py
@@ -1,18 +1,7 @@
 """Openvino Task of Detection."""
 
-# Copyright (C) 2021 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# Copyright (C) 2021-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 import copy
 import io

--- a/src/otx/algorithms/detection/configs/base/configuration.py
+++ b/src/otx/algorithms/detection/configs/base/configuration.py
@@ -1,18 +1,7 @@
 """Configuration file of OTX Detection."""
 
-# Copyright (C) 2022 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 from attr import attrs
 

--- a/src/otx/algorithms/detection/configs/detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/detection/configuration.yaml
@@ -258,6 +258,25 @@ postprocessing:
     value: 0.01
     visible_in_ui: true
     warning: null
+  max_num_detections:
+    affects_outcome_of: INFERENCE
+    default_value: 0
+    description:
+      Extra detection outputs will be discared in non-maximum suppression process.
+      Defaults to 0, which means per-model default values.
+    editable: true
+    header: Maximum number of detections per image
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
   use_ellipse_shapes:
     affects_outcome_of: INFERENCE
     default_value: false

--- a/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -258,6 +258,25 @@ postprocessing:
     value: 0.01
     visible_in_ui: true
     warning: null
+  max_num_detections:
+    affects_outcome_of: INFERENCE
+    default_value: 0
+    description:
+      Extra detection outputs will be discared in non-maximum suppression process.
+      Defaults to 0, which means per-model default values.
+    editable: true
+    header: Maximum number of detections per image
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
   use_ellipse_shapes:
     affects_outcome_of: INFERENCE
     default_value: false

--- a/src/otx/algorithms/detection/configs/instance_segmentation/convnext_maskrcnn/model.py
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/convnext_maskrcnn/model.py
@@ -115,9 +115,7 @@ model = dict(
             nms=dict(type="nms", iou_threshold=0.7),
             min_bbox_size=0,
         ),
-        rcnn=dict(
-            score_thr=0.05, nms=dict(type="nms", iou_threshold=0.5, max_num=100), max_per_img=100, mask_thr_binary=0.5
-        ),
+        rcnn=dict(score_thr=0.05, nms=dict(type="nms", iou_threshold=0.5), max_per_img=100, mask_thr_binary=0.5),
     ),
 )
 

--- a/src/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/model.py
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/resnet50_maskrcnn/model.py
@@ -1,18 +1,7 @@
 """Model configuration of Resnet50-MaskRCNN model for Instance-Seg Task."""
 
-# Copyright (C) 2022 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# Copyright (C) 2022-2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=invalid-name
 
@@ -149,7 +138,7 @@ model = dict(
         ),
         rcnn=dict(
             score_thr=0.05,
-            nms=dict(type="nms", iou_threshold=0.5, max_num=100),
+            nms=dict(type="nms", iou_threshold=0.5),
             max_per_img=100,
             mask_thr_binary=0.5,
         ),

--- a/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
@@ -277,6 +277,25 @@ postprocessing:
     warning: null
   type: PARAMETER_GROUP
   visible_in_ui: true
+  max_num_detections:
+    affects_outcome_of: INFERENCE
+    default_value: 0
+    description:
+      Extra detection outputs will be discared in non-maximum suppression process.
+      Defaults to 0, which means per-model default values.
+    editable: true
+    header: Maximum number of detections per image
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
 algo_backend:
   description: parameters for algo backend
   header: Algo backend parameters

--- a/src/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/model.py
+++ b/src/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/model.py
@@ -139,7 +139,7 @@ model = dict(
         ),
         rcnn=dict(
             score_thr=0.05,
-            nms=dict(type="nms", iou_threshold=0.5, max_num=100),
+            nms=dict(type="nms", iou_threshold=0.5),
             max_per_img=100,
             mask_thr_binary=0.5,
         ),

--- a/tests/integration/cli/detection/test_detection.py
+++ b/tests/integration/cli/detection/test_detection.py
@@ -36,7 +36,15 @@ args = {
     "--val-data-roots": "tests/assets/car_tree_bug",
     "--test-data-roots": "tests/assets/car_tree_bug",
     "--input": "tests/assets/car_tree_bug/images/train",
-    "train_params": ["params", "--learning_parameters.num_iters", "1", "--learning_parameters.batch_size", "4"],
+    "train_params": [
+        "params",
+        "--learning_parameters.num_iters",
+        "1",
+        "--learning_parameters.batch_size",
+        "4",
+        "--postprocessing.max_num_detections",
+        "200",
+    ],
 }
 
 args_semisl = {

--- a/tests/integration/cli/detection/test_tiling_detection.py
+++ b/tests/integration/cli/detection/test_tiling_detection.py
@@ -1,5 +1,5 @@
 """Tests for MPA Class-Incremental Learning for object detection with OTX CLI"""
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import os
@@ -36,6 +36,8 @@ args = {
         "1",
         "--tiling_parameters.enable_adaptive_params",
         "1",
+        "--postprocessing.max_num_detections",
+        "200",
     ],
 }
 

--- a/tests/integration/cli/instance_segmentation/test_instance_segmentation.py
+++ b/tests/integration/cli/instance_segmentation/test_instance_segmentation.py
@@ -32,7 +32,15 @@ args = {
     "--val-data-roots": "tests/assets/car_tree_bug",
     "--test-data-roots": "tests/assets/car_tree_bug",
     "--input": "tests/assets/car_tree_bug/images/train",
-    "train_params": ["params", "--learning_parameters.num_iters", "1", "--learning_parameters.batch_size", "2"],
+    "train_params": [
+        "params",
+        "--learning_parameters.num_iters",
+        "1",
+        "--learning_parameters.batch_size",
+        "2",
+        "--postprocessing.max_num_detections",
+        "200",
+    ],
 }
 
 # Training params for resume, num_iters*2

--- a/tests/integration/cli/instance_segmentation/test_tiling_instseg.py
+++ b/tests/integration/cli/instance_segmentation/test_tiling_instseg.py
@@ -1,5 +1,5 @@
 """Tests for MPA Class-Incremental Learning for instance segmentation with OTX CLI"""
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 import copy
@@ -41,6 +41,8 @@ args = {
         "1",
         "--tiling_parameters.enable_adaptive_params",
         "1",
+        "--postprocessing.max_num_detections",
+        "200",
     ],
 }
 

--- a/tests/unit/algorithms/detection/adapters/mmdet/test_configurer.py
+++ b/tests/unit/algorithms/detection/adapters/mmdet/test_configurer.py
@@ -43,10 +43,12 @@ class TestDetectionConfigurer:
 
         model_cfg = copy.deepcopy(self.model_cfg)
         data_cfg = copy.deepcopy(self.data_cfg)
-        returned_value = self.configurer.configure(model_cfg, self.det_dataset, "", data_cfg, True)
+        returned_value = self.configurer.configure(
+            model_cfg, self.det_dataset, "", data_cfg, True, max_num_detections=100
+        )
         mock_cfg_base.assert_called_once_with(model_cfg, data_cfg, None, None)
         mock_cfg_device.assert_called_once_with(model_cfg, True)
-        mock_cfg_model.assert_called_once_with(model_cfg, None)
+        mock_cfg_model.assert_called_once_with(model_cfg, None, 100)
         mock_cfg_ckpt.assert_called_once_with(model_cfg, "")
         mock_cfg_regularization.assert_called_once_with(model_cfg, True)
         mock_cfg_task.assert_called_once_with(model_cfg, self.det_dataset, True)


### PR DESCRIPTION
### Summary

* Fix hard-coded maximum number of detections regarding NMS threshold both for torch & OpenVINO models
* Add a configurable parameter: `postprocessing.max_num_detections` for detection, instance segmenatation, rotated_detection tasks.
* Defaults to 0, which means using the per-model default (hard-coded) setting

![image](https://github.com/openvinotoolkit/training_extensions/assets/4629606/b581ba5d-9452-4b57-a7ad-780a3cabaedf)

### How to test

```bash
otx train MobileNetV2-ATSS --train-data-roots /path/to/dataset params --postprocessing.max_num_detections 500
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
