### PR TITLE
Revert inference batch size to 1 for instance segmentation

### DIFF
--- a/src/otx/algorithms/detection/configs/instance_segmentation/convnext_maskrcnn/template_experimental.yaml
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/convnext_maskrcnn/template_experimental.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 2
         auto_hpo_state: POSSIBLE
       inference_batch_size:
-        default_value: 2
+        default_value: 1
       learning_rate:
         default_value: 0.001
         auto_hpo_state: POSSIBLE

--- a/src/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -29,7 +29,7 @@ hyper_parameters:
         default_value: 4
         auto_hpo_state: POSSIBLE
       inference_batch_size:
-        default_value: 4
+        default_value: 1
       learning_rate:
         default_value: 0.015
         auto_hpo_state: POSSIBLE


### PR DESCRIPTION
### Summary

* Resolves https://github.com/openvinotoolkit/training_extensions/issues/2597
* Revert inference batch size which had been mistakenly increased back to 1 for instance segmentation due to QAT errors
* Will be able to fixed after QAT is disabled for all existing models

### How to test

```bash
$ CI_DATA_ROOT=/mnt/hdd1/data/ci_datasets/ tox -vvv -e tests-iseg-py310-pt1 -- tests/regression/instance_segmentation/test_instance_segmentation.py::TestRegressionInstanceSegmentation -k Custom_Counting_Instance_Segmentation_MaskRCNN_EfficientNetB2B
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
