### PR TITLE
Unify mmX engine's export function

### DIFF
--- a/src/otx/v2/adapters/torch/lightning/anomalib/engine.py
+++ b/src/otx/v2/adapters/torch/lightning/anomalib/engine.py
@@ -20,6 +20,7 @@ from pytorch_lightning.loggers.logger import Logger
 from torch.utils.data import DataLoader
 
 from otx.v2.adapters.torch.lightning.engine import LightningEngine
+from otx.v2.api.entities.task_type import TaskType
 
 from .registry import AnomalibRegistry
 
@@ -38,16 +39,16 @@ class AnomalibEngine(LightningEngine):
 
     def __init__(
         self,
+        task: TaskType,
         work_dir: str | Path | None = None,
         config: str | dict | None = None,
-        task: str = "anomaly_classification",
     ) -> None:
         """Initialize the Anomalib engine.
 
         Args:
+            task (TaskType): The task to perform.
             work_dir (str | Path | None, optional): The working directory for the engine. Defaults to None.
             config (str | dict | None, optional): The configuration for the engine. Defaults to None.
-            task (str, optional): The task to perform. Defaults to "anomaly_classification".
         """
         super().__init__(work_dir=work_dir, config=config, task=task)
         self.registry = AnomalibRegistry()

--- a/src/otx/v2/adapters/torch/lightning/engine.py
+++ b/src/otx/v2/adapters/torch/lightning/engine.py
@@ -20,6 +20,7 @@ from torch.utils.data import DataLoader
 
 from otx.v2.adapters.torch.lightning.modules.models.base_model import BaseOTXLightningModel
 from otx.v2.api.core.engine import Engine
+from otx.v2.api.entities.task_type import TaskType
 from otx.v2.api.utils import set_tuple_constructor
 from otx.v2.api.utils.importing import get_all_args, get_default_args
 
@@ -42,9 +43,9 @@ class LightningEngine(Engine):
 
     def __init__(
         self,
+        task: TaskType,
         work_dir: str | Path | None = None,
         config: str | dict | None = None,
-        task: str = "visual_prompting",
     ) -> None:
         """Initialize the Lightning engine.
 
@@ -53,11 +54,10 @@ class LightningEngine(Engine):
             config (str | dict | None, optional): The configuration for the engine. Defaults to None.
             task (str, optional): The task to perform. Defaults to "visual_prompting".
         """
-        super().__init__(work_dir=work_dir)
+        super().__init__(work_dir=work_dir, task=task)
         self.trainer: Trainer
         self.trainer_config: dict = {}
         self.latest_model: dict[str, torch.nn.Module | str | None] = {"model": None, "checkpoint": None}
-        self.task = task
         self.config = self._initial_config(config)
         if hasattr(self, "work_dir"):
             self.config.default_root_dir = self.work_dir
@@ -389,7 +389,7 @@ class LightningEngine(Engine):
         """
         dataloader = None
         # NOTE: It needs to be refactored in a more general way.
-        if self.task.lower() == "visual_prompting" and isinstance(img, (str, Path)):
+        if self.task.name.lower() == "visual_prompting" and isinstance(img, (str, Path)):
             from .modules.datasets.visual_prompting_dataset import VisualPromptInferenceDataset
 
             dataset_config = self.config.get("dataset", {})

--- a/src/otx/v2/adapters/torch/mmengine/engine.py
+++ b/src/otx/v2/adapters/torch/mmengine/engine.py
@@ -521,8 +521,6 @@ class MMXEngine(Engine):
                 Defaults to None.
             precision (Optional[str]): The precision to use for exporting.
                 Can be "float16", "fp16", "float32", or "fp32". Defaults to "float32".
-            task (Optional[str]): The task to use for exporting. Defaults to None.
-            codebase (Optional[str]): The codebase to use for exporting. Defaults to None.
             export_type (str): The type of export to perform. Can be "ONNX" or "OPENVINO". Defaults to "OPENVINO".
             deploy_config (Optional[str, dict]): The path to the deploy config to use for exporting. Defaults to None.
             device (str): The device to use for exporting. Defaults to "cpu".
@@ -653,7 +651,7 @@ class MMXEngine(Engine):
             TaskType.DETECTION: "ObjectDetection",
             TaskType.INSTANCE_SEGMENTATION: "InstanceSegmentation",
         }
-        codebase_config = {"type": codebase, "task": mmdeploy_task_dict[self.task]}
+        codebase_config: dict[str, str | dict] = {"type": codebase, "task": mmdeploy_task_dict[self.task]}
         if self.task == TaskType.DETECTION:
             # Detection task require post_processing config
             # This should be handled model api

--- a/src/otx/v2/adapters/torch/mmengine/mmpretrain/engine.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmpretrain/engine.py
@@ -13,6 +13,7 @@ import torch
 from otx.v2.adapters.torch.mmengine.engine import MMXEngine
 from otx.v2.adapters.torch.mmengine.mmpretrain.registry import MMPretrainRegistry
 from otx.v2.adapters.torch.mmengine.modules.utils.config_utils import CustomConfig as Config
+from otx.v2.api.entities.task_type import TaskType
 from otx.v2.api.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -24,16 +25,14 @@ logger = get_logger()
 class MMPTEngine(MMXEngine):
     """The MMPretrainEngine class is responsible for running inference on pre-trained models."""
 
-    def __init__(
-        self,
-        work_dir: str | Path | None = None,
-    ) -> None:
+    def __init__(self, task: TaskType, work_dir: str | Path | None = None) -> None:
         """Initialize a new instance of the MMPretrainEngine class.
 
         Args:
+            task (TaskType): Task type of engine.
             work_dir (Optional[Union[str, Path]], optional): The working directory for the engine. Defaults to None.
         """
-        super().__init__(work_dir=work_dir)
+        super().__init__(task=task, work_dir=work_dir)
         self.registry = MMPretrainRegistry()
 
     def _update_eval_config(self, evaluator_config: list | dict | None, num_classes: int) -> list | dict | None:
@@ -147,44 +146,3 @@ class MMPTEngine(MMXEngine):
         )
 
         return inferencer(img, batch_size, **kwargs)
-
-    def export(
-        self,
-        model: torch.nn.Module | (str | Config) | None = None,
-        checkpoint: str | Path | None = None,
-        precision: str | None = "float32",  # ["float16", "fp16", "float32", "fp32"]
-        task: str | None = "Classification",
-        codebase: str | None = "mmpretrain",
-        export_type: str = "OPENVINO",  # "ONNX" or "OPENVINO"
-        deploy_config: str | dict | None = None,
-        device: str = "cpu",
-        input_shape: tuple[int, int] | None = None,
-    ) -> dict:
-        """Export a PyTorch model to a specified format for deployment.
-
-        Args:
-            model (Optional[Union[torch.nn.Module, str, Config]]): The PyTorch model to export.
-            checkpoint (Optional[Union[str, Path]]): The path to the checkpoint file to use for exporting.
-            precision (Optional[str]): The precision to use for exporting.
-                Can be one of ["float16", "fp16", "float32", "fp32"].
-            task (Optional[str]): The task for which the model is being exported. Defaults to "Classification".
-            codebase (Optional[str]): The codebase for the model being exported. Defaults to "mmpretrain".
-            export_type (str): The type of export to perform. Can be one of "ONNX" or "OPENVINO". Defaults to "OPENVINO"
-            deploy_config (Optional[str, dict]): The path to the deploy config to use for exporting. Defaults to None.
-            device (str): The device to use for exporting. Defaults to "cpu".
-            input_shape (Optional[Tuple[int, int]]): The input shape of the model being exported.
-
-        Returns:
-            dict: A dictionary containing information about the exported model.
-        """
-        return super().export(
-            model=model,
-            checkpoint=checkpoint,
-            precision=precision,
-            task=task,
-            codebase=codebase,
-            export_type=export_type,
-            deploy_config=deploy_config,
-            device=device,
-            input_shape=input_shape,
-        )

--- a/src/otx/v2/adapters/torch/mmengine/mmseg/engine.py
+++ b/src/otx/v2/adapters/torch/mmengine/mmseg/engine.py
@@ -15,6 +15,7 @@ from mmseg.registry import VISUALIZERS
 from otx.v2.adapters.torch.mmengine.engine import MMXEngine
 from otx.v2.adapters.torch.mmengine.mmseg.registry import MMSegmentationRegistry
 from otx.v2.adapters.torch.mmengine.modules.utils.config_utils import CustomConfig as Config
+from otx.v2.api.entities.task_type import TaskType
 from otx.v2.api.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -26,14 +27,14 @@ logger = get_logger()
 class MMSegEngine(MMXEngine):
     """The MMSegmentation class is responsible for running inference on pre-trained models."""
 
-    def __init__(self, work_dir: str | Path | None = None) -> None:
+    def __init__(self, task: TaskType, work_dir: str | Path | None = None) -> None:
         """Initialize a new instance of the MMPretrainEngine class.
 
         Args:
+            task (TaskType): Task type of engine.
             work_dir (Optional[Union[str, Path]], optional): The working directory for the engine. Defaults to None.
-            config (Optional[Union[Dict, Config, str]], optional): The configuration for the engine. Defaults to None.
         """
-        super().__init__(work_dir=work_dir)
+        super().__init__(task=task, work_dir=work_dir)
         self.registry = MMSegmentationRegistry()
         self.visualizer_cfg = {"name": "visualizer", "type": "SegLocalVisualizer"}
         self.evaluator_cfg = {"type": "IoUMetric", "iou_metrics": ["mDice"]}
@@ -114,47 +115,3 @@ class MMSegEngine(MMXEngine):
         inferencer = MMSegInferencer(model=config, weights=checkpoint, device=device)
 
         return inferencer(img, batch_size=batch_size, **kwargs)
-
-    def export(
-        self,
-        model: torch.nn.Module | (str | Config) | None = None,
-        checkpoint: str | Path | None = None,
-        precision: str | None = "float32",  # ["float16", "fp16", "float32", "fp32"]
-        task: str | None = "Segmentation",
-        codebase: str | None = "mmseg",
-        export_type: str = "OPENVINO",  # "ONNX" or "OPENVINO"
-        deploy_config: str | dict | None = None,
-        device: str = "cpu",
-        input_shape: tuple[int, int] | None = None,
-        **kwargs,
-    ) -> dict:
-        """Export a PyTorch model to a specified format for deployment.
-
-        Args:
-            model (torch.nn.Module | str | Config | None): The PyTorch model to export.
-            checkpoint (str | Path | None): The path to the checkpoint file to use for exporting.
-            precision (str | None): The precision to use for exporting.
-            task (str | None): The task for which the model is being exported. Defaults to "Segmentation".
-            codebase (str | None): The codebase for the model being exported. Defaults to "mmseg".
-            export_type (str): The type of export to perform. Can be one of "ONNX" or "OPENVINO". Defaults to "OPENVINO"
-            deploy_config (str | None): The path to the deployment configuration file to use for exporting.
-                File path only.
-            device (str): The device to use for exporting. Defaults to "cpu".
-            input_shape (tuple[int, int] | None): The input shape of the model being exported.
-            **kwargs: Additional keyword arguments to pass to the export function.
-
-        Returns:
-            dict: A dictionary containing information about the exported model.
-        """
-        return super().export(
-            model=model,
-            checkpoint=checkpoint,
-            precision=precision,
-            task=task,
-            codebase=codebase,
-            export_type=export_type,
-            deploy_config=deploy_config,
-            device=device,
-            input_shape=input_shape,
-            **kwargs,
-        )

--- a/src/otx/v2/api/core/auto_runner.py
+++ b/src/otx/v2/api/core/auto_runner.py
@@ -346,7 +346,7 @@ class AutoRunner:
 
     def build_framework_engine(self) -> None:
         """Create the selected framework Engine."""
-        self.engine = self.framework_engine(work_dir=self.work_dir)
+        self.engine = self.framework_engine(work_dir=self.work_dir, task=self.task)
 
     def subset_dataloader(  # noqa: ANN201
         self,

--- a/src/otx/v2/api/core/engine.py
+++ b/src/otx/v2/api/core/engine.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from otx.v2.api.core.registry import BaseRegistry
+from otx.v2.api.entities.task_type import TaskType
 
 
 class Engine:
@@ -23,15 +24,17 @@ class Engine:
     )
     """
 
-    def __init__(self, work_dir: str | Path | None) -> None:
+    def __init__(self, task: TaskType, work_dir: str | Path | None = None) -> None:
         """Initialize a new instance of the Engine class.
 
         Args:
+            task (TaskType): Task type of engine.
             work_dir (Optional[Union[str, Path]]): The working directory for the engine.
 
         Returns:
             None
         """
+        self.task = task
         if work_dir is not None:
             self.work_dir: Path = Path(work_dir).resolve()
             self.work_dir.mkdir(exist_ok=True, parents=True)

--- a/src/otx/v2/cli/cli.py
+++ b/src/otx/v2/cli/cli.py
@@ -360,6 +360,7 @@ class OTXCLIv2:
         self.workspace = Workspace(work_dir=work_dir, task=str(self.auto_runner.task.name).lower())
         self.engine = self.framework_engine(
             work_dir=str(self.workspace.work_dir),
+            task=self.auto_runner.task,
         )
         self.workspace.add_config(workspace_config)
 

--- a/tests/v2/integration/api/anomaly/test_anomaly_classification.py
+++ b/tests/v2/integration/api/anomaly/test_anomaly_classification.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import torch
 from otx.v2.adapters.torch.lightning.anomalib import Dataset, Engine, get_model
+from otx.v2.api.entities.task_type import TaskType
 
 from tests.v2.integration.test_helper import TASK_CONFIGURATION
 
@@ -57,7 +58,7 @@ class TestAnomalibClassificationAPI:
             None
         """
         # Setup Engine
-        engine = Engine(work_dir=tmp_dir_path)
+        engine = Engine(work_dir=tmp_dir_path, task=TaskType.ANOMALY_CLASSIFICATION)
         built_model = get_model(model=model)
 
         # Train (1 epochs)

--- a/tests/v2/integration/api/auto_runner/test_auto_runner.py
+++ b/tests/v2/integration/api/auto_runner/test_auto_runner.py
@@ -5,12 +5,23 @@ from pathlib import Path
 
 import pytest
 from otx.v2.api.core import AutoRunner
+from otx.v2.api.entities.task_type import TaskType
 
 from tests.v2.integration.test_helper import TASK_CONFIGURATION
 
 # NOTE: This test currently only checks the basic pipeline and doesn't do much checking on the result, which will be fixed in the future.
 
 class TestAutoRunnerAPI:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.task_type_dict = {
+            "classification": TaskType.CLASSIFICATION,
+            "anomaly_classification": TaskType.ANOMALY_CLASSIFICATION,
+            "visual_prompting": TaskType.VISUAL_PROMPTING,
+            "segmentation": TaskType.SEGMENTATION,
+            "detection": TaskType.DETECTION,
+        }
+
     @pytest.mark.parametrize("task", TASK_CONFIGURATION.keys())
     def test_auto_training_api(self, task: str, tmp_dir_path: Path) -> None:
         """
@@ -37,7 +48,7 @@ class TestAutoRunnerAPI:
         task_configuration = TASK_CONFIGURATION[task]
         auto_runner = AutoRunner(
             work_dir=tmp_dir_path,
-            task=task,
+            task=self.task_type_dict[task],
             train_data_roots=task_configuration["train_data_roots"],
             val_data_roots=task_configuration["val_data_roots"],
             test_data_roots=task_configuration["test_data_roots"],

--- a/tests/v2/integration/api/classification/test_mmpretrain.py
+++ b/tests/v2/integration/api/classification/test_mmpretrain.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 import torch
 from otx.v2.adapters.torch.mmengine.mmpretrain import Dataset, Engine, get_model, list_models
+from otx.v2.api.entities.task_type import TaskType
 
 from tests.v2.integration.api.test_helper import assert_torch_dataset_api_is_working
 from tests.v2.integration.test_helper import TASK_CONFIGURATION
@@ -88,7 +89,7 @@ class TestMMPretrainAPI:
             None
         """
         # Setup Engine
-        engine = Engine(work_dir=tmp_dir_path)
+        engine = Engine(work_dir=tmp_dir_path, task=TaskType.CLASSIFICATION)
         built_model = get_model(model=model, num_classes=dataset.num_classes)
 
         # Train (1 epochs)

--- a/tests/v2/integration/api/detection/test_mmdet.py
+++ b/tests/v2/integration/api/detection/test_mmdet.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import torch
 from otx.v2.adapters.torch.mmengine.mmdet import Dataset, Engine, get_model, list_models
+from otx.v2.api.entities.task_type import TaskType
 
 from tests.v2.integration.api.test_helper import assert_torch_dataset_api_is_working
 from tests.v2.integration.test_helper import TASK_CONFIGURATION
@@ -90,7 +91,7 @@ class TestMMDetAPI:
             None
         """
         # Setup Engine
-        engine = Engine(work_dir=tmp_dir_path)
+        engine = Engine(work_dir=tmp_dir_path, task=TaskType.DETECTION)
         built_model = get_model(model=model, num_classes=dataset.num_classes)
 
         # Train (1 epoch)

--- a/tests/v2/integration/api/segmentation/test_mmseg.py
+++ b/tests/v2/integration/api/segmentation/test_mmseg.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 import torch
 from otx.v2.adapters.torch.mmengine.mmseg import Engine, get_model, list_models, Dataset
+from otx.v2.api.entities.task_type import TaskType
 
 from tests.v2.integration.api.test_helper import assert_torch_dataset_api_is_working
 from tests.v2.integration.test_helper import TASK_CONFIGURATION
@@ -90,7 +91,7 @@ class TestMMSegAPI:
             None
         """
         # Setup Engine
-        engine = Engine(work_dir=tmp_dir_path)
+        engine = Engine(work_dir=tmp_dir_path, task=TaskType.SEGMENTATION)
         built_model = get_model(model=model, num_classes=dataset.num_classes)
 
         # Train (1 epochs)

--- a/tests/v2/integration/api/visual_prompt/test_visual_prompt.py
+++ b/tests/v2/integration/api/visual_prompt/test_visual_prompt.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import torch
 from otx.v2.adapters.torch.lightning import Dataset, Engine, get_model, list_models
+from otx.v2.api.entities.task_type import TaskType
 
 from tests.v2.integration.test_helper import TASK_CONFIGURATION
 
@@ -57,7 +58,7 @@ class TestVisaulPromptAPI:
             None
         """
         # Setup Engine
-        engine = Engine(work_dir=tmp_dir_path, task="visual_prompting")
+        engine = Engine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         built_model = get_model(model=model)
 
         # Train (1 epochs)

--- a/tests/v2/unit/adapters/torch/lightning/test_engine.py
+++ b/tests/v2/unit/adapters/torch/lightning/test_engine.py
@@ -8,6 +8,7 @@ import pytorch_lightning as pl
 import torch
 from omegaconf import DictConfig
 from otx.v2.adapters.torch.lightning.engine import LightningEngine
+from otx.v2.api.entities.task_type import TaskType
 from pytest_mock.plugin import MockerFixture
 
 
@@ -19,30 +20,30 @@ class MockModel(torch.nn.Module):
 
 class TestLightningEngine:
     def test_init(self, tmp_dir_path: Path) -> None:
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         assert engine.work_dir == tmp_dir_path
         assert engine.registry.name == "lightning"
         assert engine.timestamp is not None
 
     def test_initial_config(self, tmp_dir_path: Path) -> None:
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         assert isinstance(engine.config, DictConfig)
 
         config = {"foo": "bar"}
-        engine = LightningEngine(work_dir=tmp_dir_path, config=config)
+        engine = LightningEngine(work_dir=tmp_dir_path, config=config, task=TaskType.VISUAL_PROMPTING)
         assert isinstance(engine.config, DictConfig)
         assert hasattr(engine.config, "foo")
         assert engine.config.foo == "bar"
 
         config_file = tmp_dir_path / "config.yaml"
         config_file.write_text("foo : 'bar'")
-        engine = LightningEngine(work_dir=tmp_dir_path, config=str(config_file))
+        engine = LightningEngine(work_dir=tmp_dir_path, config=str(config_file), task=TaskType.VISUAL_PROMPTING)
         assert isinstance(engine.config, DictConfig)
         assert hasattr(engine.config, "foo")
         assert engine.config.foo == "bar"
 
     def test_update_config(self, mocker: MockerFixture, tmp_dir_path: Path) -> None:
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
 
         # Test with invalid argument
         engine._update_config({}, invalid="test")
@@ -77,7 +78,7 @@ class TestLightningEngine:
         mock_trainer = mocker.patch("otx.v2.adapters.torch.lightning.engine.Trainer")
         mock_trainer.return_value.fit.return_value = None
         mock_trainer.return_value.save_checkpoint.return_value = None
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         mock_model = mocker.Mock()
         mock_model.callbacks = []
         mock_dataloader = mocker.Mock()
@@ -94,7 +95,7 @@ class TestLightningEngine:
         mock_trainer = mocker.patch("otx.v2.adapters.torch.lightning.engine.Trainer")
         mock_trainer.return_value.validate.return_value = {}
         mock_trainer.return_value.save_checkpoint.return_value = None
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         mock_model = mocker.Mock()
         mock_dataloader = mocker.Mock()
         mock_model.callbacks = []
@@ -107,7 +108,7 @@ class TestLightningEngine:
         mock_trainer = mocker.patch("otx.v2.adapters.torch.lightning.engine.Trainer")
         mock_trainer.return_value.test.return_value = {}
         mock_trainer.return_value.save_checkpoint.return_value = None
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         mock_model = mocker.Mock()
         mock_model.callbacks = []
         mock_dataloader = mocker.Mock()
@@ -123,7 +124,7 @@ class TestLightningEngine:
         mock_trainer = mocker.patch("otx.v2.adapters.torch.lightning.engine.Trainer")
         mock_trainer.return_value.predict.return_value = []
         mock_trainer.return_value.save_checkpoint.return_value = None
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
         mock_model = mocker.Mock()
         img = mocker.Mock()
         mock_model.callbacks = []
@@ -134,7 +135,7 @@ class TestLightningEngine:
         mock_trainer.return_value.predict.assert_called_with(model=None, dataloaders=[img], ckpt_path="test.pth")
 
     def test_export(self, mocker: MockerFixture, tmp_dir_path: Path) -> None:
-        engine = LightningEngine(work_dir=tmp_dir_path)
+        engine = LightningEngine(work_dir=tmp_dir_path, task=TaskType.VISUAL_PROMPTING)
 
         mock_model = mocker.Mock()
         mock_model.__class__.return_value = pl.LightningModule

--- a/tests/v2/unit/adapters/torch/mmengine/mmpretrain/test_engine.py
+++ b/tests/v2/unit/adapters/torch/mmengine/mmpretrain/test_engine.py
@@ -8,12 +8,13 @@ import torch
 from mmengine.model import BaseModel
 from otx.v2.adapters.torch.mmengine.mmpretrain.engine import MMPTEngine
 from otx.v2.adapters.torch.mmengine.modules.utils.config_utils import CustomConfig as Config
+from otx.v2.api.entities.task_type import TaskType
 from pytest_mock.plugin import MockerFixture
 
 
 class TestMMPTEngine:
     def test_init(self, tmp_dir_path: Path) -> None:
-        engine = MMPTEngine(work_dir=tmp_dir_path)
+        engine = MMPTEngine(work_dir=tmp_dir_path, task=TaskType.CLASSIFICATION)
         assert engine.work_dir == tmp_dir_path
 
     def test_predict(self, mocker: MockerFixture, tmp_dir_path: Path) -> None:
@@ -21,7 +22,7 @@ class TestMMPTEngine:
         mock_result = mocker.MagicMock()
         mock_api = mocker.patch("mmpretrain.inference_model", return_value=mock_result)
         mock_inferencer = mocker.patch("mmpretrain.ImageClassificationInferencer")
-        engine = MMPTEngine(work_dir=tmp_dir_path)
+        engine = MMPTEngine(work_dir=tmp_dir_path, task=TaskType.CLASSIFICATION)
 
         class MockModule(torch.nn.Module):
             def __init__(self) -> None:
@@ -49,10 +50,7 @@ class TestMMPTEngine:
     def test_export(self, mocker: MockerFixture, tmp_dir_path: Path) -> None:
         mock_super_export = mocker.patch("otx.v2.adapters.torch.mmengine.mmpretrain.engine.MMXEngine.export")
         mock_super_export.return_value = {"outputs": {"bin": "test.bin", "xml": "test.xml"}}
-        engine = MMPTEngine(work_dir=tmp_dir_path)
+        engine = MMPTEngine(work_dir=tmp_dir_path, task=TaskType.CLASSIFICATION)
 
         result = engine.export(model="model", checkpoint="checkpoint")
         assert result == {"outputs": {"bin": "test.bin", "xml": "test.xml"}}
-        mock_super_export.assert_called_once_with(
-            model="model", checkpoint="checkpoint", precision="float32", task="Classification", codebase="mmpretrain", export_type="OPENVINO", deploy_config=None, device="cpu", input_shape=None,
-        )

--- a/tests/v2/unit/api/core/test_engine.py
+++ b/tests/v2/unit/api/core/test_engine.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 
 from otx.v2.api.core.engine import Engine
+from otx.v2.api.entities.task_type import TaskType
 from pytest_mock.plugin import MockerFixture
 
 
@@ -27,7 +28,7 @@ class TestEngine:
         -------
             None
         """
-        engine = Engine(work_dir=tmp_dir_path)
+        engine = Engine(work_dir=tmp_dir_path, task=TaskType.CLASSIFICATION)
 
         assert engine.work_dir == tmp_dir_path
         assert engine.registry.name == "base"
@@ -50,7 +51,7 @@ class TestEngine:
         -------
             None
         """
-        engine = Engine(work_dir=None)
+        engine = Engine(work_dir=None, task=TaskType.CLASSIFICATION)
         mock_train = mocker.spy(Engine, "train")
         engine.train(None, None)
 
@@ -74,7 +75,7 @@ class TestEngine:
         -------
             None
         """
-        engine = Engine(work_dir=None)
+        engine = Engine(work_dir=None, task=TaskType.CLASSIFICATION)
         mock_validate = mocker.spy(Engine, "validate")
         engine.validate(None, None)
 
@@ -98,7 +99,7 @@ class TestEngine:
         -------
             None
         """
-        engine = Engine(work_dir=None)
+        engine = Engine(work_dir=None, task=TaskType.CLASSIFICATION)
         mock_test = mocker.spy(Engine, "test")
         engine.test(None, None)
 
@@ -122,7 +123,7 @@ class TestEngine:
         -------
             None
         """
-        engine = Engine(work_dir=None)
+        engine = Engine(work_dir=None, task=TaskType.CLASSIFICATION)
         mock_predict = mocker.spy(Engine, "predict")
         engine.predict(None, None)
 
@@ -146,7 +147,7 @@ class TestEngine:
         -------
             None
         """
-        engine = Engine(work_dir=None)
+        engine = Engine(work_dir=None, task=TaskType.CLASSIFICATION)
         mock_export = mocker.spy(Engine, "export")
         engine.export()
 


### PR DESCRIPTION
### Summary
In this phase, we want to integrate each algo frameworks' engine.py into a single engine.py
The first step of it is integrate adapters/torch/mmengine/***/engine.py into adapters/torch/mmengine/engine.py

Currently each adapters/torch/mmengine/mmX/engine.py have __init__, _update_config, predict and export function.
Therefore we need to migrate all of these function into adapters/torch/mmengine/engine.py
This PR is going to migrate export function of each adapters/torch/mmengine/mmX/engine.py
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
