### PR TITLE
Fix CPU training issue on non-CUDA system

### DIFF
--- a/src/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/automatic_bs.py
@@ -8,6 +8,7 @@ from math import sqrt
 from typing import Callable, Dict, List
 
 import numpy as np
+from torch.cuda import is_available as cuda_available
 
 from otx.algorithms.common.adapters.torch.utils import BsSearchAlgo
 from otx.algorithms.common.utils.logger import get_logger
@@ -52,6 +53,10 @@ def adapt_batch_size(train_func: Callable, cfg, datasets: List, validate: bool =
         validate (bool): Whether do vlidation or not.
         not_increase (bool) : Whether adapting batch size to larger value than default value or not.
     """
+
+    if not cuda_available():
+        logger.warning("Skip Auto-adaptive batch size: CUDA should be available, but it isn't.")
+        return
 
     def train_func_single_iter(batch_size):
         copied_cfg = deepcopy(cfg)

--- a/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
+++ b/tests/unit/algorithms/common/adapters/mmcv/utils/test_automatic_bs.py
@@ -109,6 +109,19 @@ def test_adapt_batch_size(
     assert len(mock_train_func.call_args_list[0].kwargs["cfg"].custom_hooks) == 1
 
 
+def test_adapt_batch_size_no_gpu(mocker, common_cfg, mock_dataset):
+    # prepare
+    mock_train_func = mocker.MagicMock()
+    mock_config = set_mock_cfg_not_action(common_cfg)
+    mocker.patch.object(automatic_bs, "cuda_available", return_value=False)
+
+    # execute
+    adapt_batch_size(mock_train_func, mock_config, mock_dataset, False, True)
+
+    # check train function ins't called.
+    mock_train_func.assert_not_called()
+
+
 class TestSubDataset:
     @pytest.fixture(autouse=True)
     def set_up(self, mocker):


### PR DESCRIPTION
### Summary

* Applying https://github.com/openvinotoolkit/training_extensions/pull/2410 to releases/1.4.0

### How to test

* CI test

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
