### PR TITLE
Remove unnecessary log while building a model

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/utils/builder.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/utils/builder.py
@@ -8,11 +8,11 @@ from typing import Optional, Union
 
 import torch
 from mmcv.runner import load_checkpoint
-from mmcv.utils import Config, ConfigDict
+from mmcv.utils import Config, ConfigDict, get_logger
 
-from otx.utils.logger import LEVEL, get_logger
+from otx.utils.logger import LEVEL
 
-logger = get_logger()
+mmcls_logger = get_logger("mmcls")
 
 
 def build_classifier(
@@ -35,9 +35,9 @@ def build_classifier(
 
     model_cfg = deepcopy(config.model)
     model = origin_build_classifier(model_cfg)
-    logger.setLevel("WARNING")
+    mmcls_logger.setLevel("WARNING")  # make logger less verbose temporally
     model.init_weights()
-    logger.setLevel(LEVEL)
+    mmcls_logger.setLevel(LEVEL)
     model = model.to(device)
 
     checkpoint = checkpoint if checkpoint else config.pop("load_from", None)

--- a/src/otx/algorithms/detection/adapters/mmdet/utils/builder.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/utils/builder.py
@@ -12,7 +12,7 @@ from mmcv.utils import Config, ConfigDict, get_logger
 
 from otx.utils.logger import LEVEL
 
-logger = get_logger("mmdet")
+mmdet_logger = get_logger("mmdet")
 
 
 def build_detector(
@@ -37,9 +37,9 @@ def build_detector(
 
     model_cfg = deepcopy(config.model)
     model = origin_build_detector(model_cfg, train_cfg=train_cfg, test_cfg=test_cfg)
-    logger.setLevel("WARNING")
+    mmdet_logger.setLevel("WARNING")  # make logger less verbose temporally
     model.init_weights()
-    logger.setLevel(LEVEL)
+    mmdet_logger.setLevel(LEVEL)
     model = model.to(device)
 
     checkpoint = checkpoint if checkpoint else config.pop("load_from", None)

--- a/src/otx/algorithms/detection/adapters/mmdet/utils/builder.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/utils/builder.py
@@ -8,11 +8,11 @@ from typing import Optional, Union
 
 import torch
 from mmcv.runner import load_checkpoint
-from mmcv.utils import Config, ConfigDict
+from mmcv.utils import Config, ConfigDict, get_logger
 
-from otx.utils.logger import LEVEL, get_logger
+from otx.utils.logger import LEVEL
 
-logger = get_logger()
+logger = get_logger("mmdet")
 
 
 def build_detector(


### PR DESCRIPTION
### Summary
Getting mmXX logger when building a model in cls and det task is for removing unnecessary log.
But when unifying all loggers to OTX's one, it's also changed to get OTX logger, which make logger verbose.
So, I reverted it.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
