### PR TITLE
Remove dtype argument in torch.xpu.optimize

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/apis/train.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/apis/train.py
@@ -98,7 +98,7 @@ def train_model(model, dataset, cfg, distributed=False, validate=False, timestam
         else:
             dtype = torch.float32
         model.train()
-        model, optimizer = torch.xpu.optimize(model, optimizer=optimizer, dtype=dtype)
+        model, optimizer = torch.xpu.optimize(model, optimizer=optimizer)
 
     if cfg.get("runner") is None:
         cfg.runner = {"type": "EpochBasedRunner", "max_epochs": cfg.total_epochs}

--- a/src/otx/algorithms/detection/adapters/mmdet/apis/train.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/apis/train.py
@@ -147,7 +147,7 @@ def train_detector(model, dataset, cfg, distributed=False, validate=False, times
         else:
             dtype = torch.float32
         model.train()
-        model, optimizer = torch.xpu.optimize(model, optimizer=optimizer, dtype=dtype)
+        model, optimizer = torch.xpu.optimize(model, optimizer=optimizer)
 
     runner = build_runner(
         cfg.runner, default_args=dict(model=model, optimizer=optimizer, work_dir=cfg.work_dir, logger=logger, meta=meta)

--- a/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
@@ -98,7 +98,7 @@ def train_segmentor(model, dataset, cfg, distributed=False, validate=False, time
         else:
             dtype = torch.float32
         model.train()
-        model, optimizer = torch.xpu.optimize(model, optimizer=optimizer, dtype=dtype)
+        model, optimizer = torch.xpu.optimize(model, optimizer=optimizer)
 
     if cfg.get("runner") is None:
         cfg.runner = {"type": "IterBasedRunner", "max_iters": cfg.total_iters}


### PR DESCRIPTION
### Summary
@sungchul2  found that If `dtype` argument is set, model is trained with that `dtype` not mixed precision.
So, I removed it from argument.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
