### PR TITLE
Add `--dryrun` option to tools/experiment.py

### DIFF
--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -594,9 +594,11 @@ class ExpRecipeParser:
             for key, val in variable.items():
                 target = target.replace(f"${{{key}}}", val)
         elif isinstance(target, list):
+            target = target.copy()
             for i in range(len(target)):
                 target[i] = self._replace_var_in_target(variable, target[i])
         elif isinstance(target, dict):
+            target = target.copy()
             for key in target.keys():
                 target[key] = self._replace_var_in_target(variable, target[key])
         else:

--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -767,7 +767,7 @@ def run_experiment_recipe(recipe_file: Union[str, Path], dryrun: bool = False):
 
     Args:
         recipe_file (Union[str, Path]): Recipe file to run.
-        dry_run (bool, optional): Whether to only print experiment commands. Defaults to False.
+        dryrun (bool, optional): Whether to only print experiment commands. Defaults to False.
     """
     exp_recipe = ExpRecipeParser(recipe_file)
     output_path = exp_recipe.output_path


### PR DESCRIPTION
### Summary

* Fix a bug that variables are overwritten by the first one due to template corruption.
* Add `--dryrun` / `-d` option to see the experiment list before run long test

### How to test

```bash
python tools/experiment.py -d -f promising_experiments.yaml
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
