### PR TITLE
Disable mixed precision training on XPU

### DIFF
--- a/src/otx/algorithms/common/adapters/mmcv/configurer.py
+++ b/src/otx/algorithms/common/adapters/mmcv/configurer.py
@@ -264,18 +264,11 @@ class BaseConfigurer:
                 opts["type"] = "HPUOptimizerHook"
                 cfg.optimizer_config.update(opts)
             elif is_xpu_available():
-                opts.update({"distributed": distributed, **fp16_config})
                 if optim_type == "SAMOptimizerHook":
                     logger.warning("SAMOptimizerHook is not supported on XPU yet, changed to OptimizerHook.")
                     opts["type"] = "OptimizerHook"
-                if optim_type == "OptimizerHook":
-                    opts["type"] = "BFp16XPUOptimizerHook"
-                else:
-                    # does not support optimizerhook type
-                    # let mm library handle it
-                    cfg.fp16 = fp16_config
-                    opts = dict()
                 cfg.optimizer_config.update(opts)
+                logger.warning("XPU doesn't support mixed precision training currently.")
             elif torch.cuda.is_available():
                 opts.update({"distributed": distributed, **fp16_config})
                 if optim_type == "SAMOptimizerHook":

--- a/src/otx/algorithms/common/adapters/mmcv/nncf/utils.py
+++ b/src/otx/algorithms/common/adapters/mmcv/nncf/utils.py
@@ -56,6 +56,8 @@ def get_fake_input(
         data = scatter(collate([data], samples_per_gpu=1), [-1])[0]
     elif device.type == "cuda":
         data = scatter(collate([data], samples_per_gpu=1), [device.index])[0]
+    elif device.type == "xpu":
+        data = scatter(collate([data], samples_per_gpu=1), [-1])[0]
     else:
         raise NotImplementedError()
     return data

--- a/src/otx/algorithms/common/adapters/mmcv/utils/_builder_build_data_parallel.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/_builder_build_data_parallel.py
@@ -92,10 +92,6 @@ def build_data_parallel(
 
 
 class XPUDataParallel(MMDataParallel):
-    def __init__(self, *args, enable_autocast: bool = False, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.enable_autocast = enable_autocast
-
     def scatter(self, inputs, kwargs, device_ids):
         inputs, kwargs = super().scatter(inputs, kwargs, [-1])
         target_device = torch.device(f"xpu:{device_ids[0]}")
@@ -123,20 +119,6 @@ class XPUDataParallel(MMDataParallel):
                                 x[k][i] = item.to(target_device)
 
         return inputs, kwargs
-
-    def forward(self, *inputs, **kwargs):
-        # we have to apply autocast here, because the original mmcv's fp16 decorator is hard to override.
-        # Perhaps, one global autocast is not as accurate as original mmcv's approach
-        with torch.autocast(device_type="xpu", dtype=torch.bfloat16, enabled=self.enable_autocast):
-            return super().forward(*inputs, **kwargs)
-
-    def train_step(self, *inputs, **kwargs):
-        with torch.autocast(device_type="xpu", dtype=torch.bfloat16, enabled=self.enable_autocast):
-            return super().train_step(*inputs, **kwargs)
-
-    def val_step(self, *inputs, **kwargs):
-        with torch.autocast(device_type="xpu", dtype=torch.bfloat16, enabled=self.enable_autocast):
-            return super().val_step(*inputs, **kwargs)
 
 
 class HPUDataParallel(MMDataParallel):

--- a/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
@@ -51,6 +51,9 @@ def train_segmentor(model, dataset, cfg, distributed=False, validate=False, time
     train_loader_cfg = {**loader_cfg, **cfg.data.get("train_dataloader", {})}
     data_loaders = [build_dataloader(ds, **train_loader_cfg) for ds in dataset]
 
+    if cfg.device == "xpu":
+        model.to(f"xpu:{cfg.gpu_ids[0]}")
+
     # put model on devices
     if distributed:
         find_unused_parameters = cfg.get("find_unused_parameters", False)
@@ -68,11 +71,6 @@ def train_segmentor(model, dataset, cfg, distributed=False, validate=False, time
             assert digit_version(mmcv.__version__) >= digit_version(
                 "1.4.4"
             ), "Please use MMCV >= 1.4.4 for CPU training!"
-
-        if cfg.device == "xpu":
-            use_autocast = bool(cfg.get("fp16_", False))
-            model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids, enable_autocast=use_autocast)
-            model.to(f"xpu:{cfg.gpu_ids[0]}")
         elif cfg.device == "hpu":
             use_autocast = bool(cfg.get("fp16_", False))
             model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids, enable_autocast=use_autocast)
@@ -92,7 +90,9 @@ def train_segmentor(model, dataset, cfg, distributed=False, validate=False, time
     optimizer = build_optimizer(model, cfg.optimizer)
 
     if cfg.device == "xpu":
-        dtype = torch.bfloat16 if cfg.optimizer_config.get("bf16_training", False) else torch.float32
+        if cfg.optimizer_config.get("bf16_training", False):
+            logger.warning("XPU supports fp32 training only currently.")
+        dtype = torch.float32
         model.train()
         model, optimizer = torch.xpu.optimize(model, optimizer=optimizer, dtype=dtype)
 

--- a/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
@@ -71,7 +71,8 @@ def train_segmentor(model, dataset, cfg, distributed=False, validate=False, time
             assert digit_version(mmcv.__version__) >= digit_version(
                 "1.4.4"
             ), "Please use MMCV >= 1.4.4 for CPU training!"
-        elif cfg.device == "hpu":
+
+        if cfg.device == "hpu":
             use_autocast = bool(cfg.get("fp16_", False))
             model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids, enable_autocast=use_autocast)
             model.to(model.src_device_obj)

--- a/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
+++ b/src/otx/algorithms/segmentation/adapters/mmseg/apis/train.py
@@ -67,7 +67,7 @@ def train_segmentor(model, dataset, cfg, distributed=False, validate=False, time
             find_unused_parameters=find_unused_parameters,
         )
     else:
-        if not torch.cuda.is_available():
+        if not torch.cuda.is_available():  # noqa
             assert digit_version(mmcv.__version__) >= digit_version(
                 "1.4.4"
             ), "Please use MMCV >= 1.4.4 for CPU training!"

--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -21,9 +21,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from otx.cli.tools.cli import main as otx_cli
 from rich.console import Console
 from rich.table import Table
+
+from otx.cli.tools.cli import main as otx_cli
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -21,10 +21,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
+from otx.cli.tools.cli import main as otx_cli
 from rich.console import Console
 from rich.table import Table
-
-from otx.cli.tools.cli import main as otx_cli
 
 
 def get_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
### Summary
As @sungchul2 said, Current IPEX doesn't have GradScaler implementation for XPU.
For this reason, this PR disables mixed precision and bfp16 training on XPU.
And current `XPUDataParallel` class is using `torch.autocast` but it's duplication because `auto_fp16` is already using it.
So, I remove it in the class.
And I updated minor one related to 'otx optimize'
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
