### PR TITLE
Fix warning from batch_size auto-inference failure

### DIFF
--- a/src/otx/algo/callbacks/iteration_timer.py
+++ b/src/otx/algo/callbacks/iteration_timer.py
@@ -33,7 +33,9 @@ class IterationTimer(Callback):
         self.start_time: dict[str, float] = defaultdict(float)
         self.end_time: dict[str, float] = defaultdict(float)
 
-    def _on_batch_start(self, pl_module: LightningModule, phase: str) -> None:
+    def _on_batch_start(
+        self, pl_module: LightningModule, phase: str, batch_size: int,
+    ) -> None:
         self.start_time[phase] = time()
 
         if not self.end_time[phase]:
@@ -49,9 +51,12 @@ class IterationTimer(Callback):
             prog_bar=self.prog_bar,
             on_step=self.on_step,
             on_epoch=self.on_epoch,
+            batch_size=batch_size,
         )
 
-    def _on_batch_end(self, pl_module: LightningModule, phase: str) -> None:
+    def _on_batch_end(
+        self, pl_module: LightningModule, phase: str, batch_size: int,
+    ) -> None:
         if not self.end_time[phase]:
             self.end_time[phase] = time()
             return
@@ -67,6 +72,7 @@ class IterationTimer(Callback):
             prog_bar=self.prog_bar,
             on_step=self.on_step,
             on_epoch=self.on_epoch,
+            batch_size=batch_size,
         )
 
     def on_train_batch_start(
@@ -77,7 +83,9 @@ class IterationTimer(Callback):
         batch_idx: int,
     ) -> None:
         """Log iteration data time on the training batch start."""
-        self._on_batch_start(pl_module=pl_module, phase="train")
+        self._on_batch_start(
+            pl_module=pl_module, phase="train", batch_size=batch.batch_size,
+        )
 
     def on_train_batch_end(
         self,
@@ -88,7 +96,9 @@ class IterationTimer(Callback):
         batch_idx: int,
     ) -> None:
         """Log iteration time on the training batch end."""
-        self._on_batch_end(pl_module=pl_module, phase="train")
+        self._on_batch_end(
+            pl_module=pl_module, phase="train", batch_size=batch.batch_size,
+        )
 
     def on_validation_batch_start(
         self,
@@ -99,7 +109,9 @@ class IterationTimer(Callback):
         dataloader_idx: int = 0,
     ) -> None:
         """Log iteration data time on the validation batch start."""
-        self._on_batch_start(pl_module=pl_module, phase="validation")
+        self._on_batch_start(
+            pl_module=pl_module, phase="validation", batch_size=batch.batch_size,
+        )
 
     def on_validation_batch_end(
         self,
@@ -111,7 +123,9 @@ class IterationTimer(Callback):
         dataloader_idx: int = 0,
     ) -> None:
         """Log iteration time on the validation batch end."""
-        self._on_batch_end(pl_module=pl_module, phase="validation")
+        self._on_batch_end(
+            pl_module=pl_module, phase="validation", batch_size=batch.batch_size,
+        )
 
     def on_test_batch_start(
         self,
@@ -122,7 +136,9 @@ class IterationTimer(Callback):
         dataloader_idx: int = 0,
     ) -> None:
         """Log iteration data time on the test batch start."""
-        self._on_batch_start(pl_module=pl_module, phase="test")
+        self._on_batch_start(
+            pl_module=pl_module, phase="test", batch_size=batch.batch_size,
+        )
 
     def on_test_batch_end(
         self,
@@ -134,4 +150,6 @@ class IterationTimer(Callback):
         dataloader_idx: int = 0,
     ) -> None:
         """Log iteration time on the test batch end."""
-        self._on_batch_end(pl_module=pl_module, phase="test")
+        self._on_batch_end(
+            pl_module=pl_module, phase="test", batch_size=batch.batch_size,
+        )

--- a/tests/unit/algo/callbacks/test_iteration_timer.py
+++ b/tests/unit/algo/callbacks/test_iteration_timer.py
@@ -14,6 +14,8 @@ class TestIterationTimer:
         mock_trainer = MagicMock()
         mock_pl_module = MagicMock()
         mock_batch = MagicMock()
+        batch_size = 64
+        mock_batch.batch_size = batch_size
         mock_outputs = MagicMock()
 
         timer = IterationTimer()
@@ -46,6 +48,7 @@ class TestIterationTimer:
                     prog_bar=timer.prog_bar,
                     on_step=timer.on_step,
                     on_epoch=timer.on_epoch,
+                    batch_size=batch_size,
                 )
 
             getattr(timer, f"on_{phase}_batch_end")(
@@ -70,4 +73,5 @@ class TestIterationTimer:
                     prog_bar=timer.prog_bar,
                     on_step=timer.on_step,
                     on_epoch=timer.on_epoch,
+                    batch_size=batch_size,
                 )


### PR DESCRIPTION
### Summary

- Fix the following Pytorch Lightning Trainer's warning
```console
Epoch 0:   1%|█▎                                                                                                      | 1/82 [00:01<01:21,  0.99it/s, v_num=0, train/loss=6.910]
/home/vinnamki/miniconda3/envs/otx-v2/lib/python3.11/site-packages/lightning/pytorch/utilities/data.py:77: Trying to infer the `batch_size` from an ambiguous collection. The batch size we found is 3. To avoid any miscalculations, use `self.log(..., batch_size=batch_size)`.
```
### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
