### PR TITLE
Select more proper model weight file according to commands run just before

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -59,7 +59,7 @@ Sample Experiment Recipe YAML File:
 
 Arguments for recipe
 
-- output*path (optional) : Output path where all experiment outputs are saved. Default is "./experiment*{executed_time}"
+- output_path (optional) : Output path where all experiment outputs are saved. Default is "./experiment\_{executed_time}"
 - constant (optional) :
   It's similar as constant or variable in programming languages.
   You can use it to replace duplicated string by using ${constant_name} in variables or commands.
@@ -82,7 +82,7 @@ Note that all commands within each case are executed within the same workspace,
 obviating the need to set a template path from the second command.
 When the "otx eval" or "otx optimize" command is executed, the model file (model weight or exported model, etc.)
 is automatically selected based on the preceding command.
-The output file of "otx eval" is then stored at "_workspace*path/outputs/XXXX*{train, export, optimize, etc.}/_"
+The output file of "otx eval" is then stored at "workspace_path/outputs/XXXX\_{train, export, optimize, etc.}/"
 under the name "performance.json".
 
 ### Feature 2 : organize experiment result from single workspace

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,7 +10,7 @@ The primary goal is to reduce the manual effort required in running experiments 
 ### Automated Experiment Execution
 
 - Given multiple variables, it automatically generates all combinations and runs the experiments.
-- Proper model files are selected automatically when the "otx eval" command is executed, based on the preceding command.
+- Proper model files are selected automatically when the "otx eval" or "otx optimize" command is executed, based on the preceding command.
 
 ### Fault Tolerance
 
@@ -80,9 +80,9 @@ If there are failed cases, variables and error logs are both printed and saved a
 
 Note that all commands within each case are executed within the same workspace,
 obviating the need to set a template path from the second command.
-When the "otx eval" command is executed, the model file (model weight or exported model, etc.)
+When the "otx eval" or "otx optimize" command is executed, the model file (model weight or exported model, etc.)
 is automatically selected based on the preceding command.
-The output file of "otx eval" is then stored at "workspace*path/outputs/XXXX*{train, export, optimize, etc.}/"
+The output file of "otx eval" is then stored at "_workspace*path/outputs/XXXX*{train, export, optimize, etc.}/_"
 under the name "performance.json".
 
 ### Feature 2 : organize experiment result from single workspace

--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -725,7 +725,7 @@ class OtxCommandRunner:
                 output_path = str(self._workspace / "outputs" / "latest_trained_model")
             self.set_arguments_to_cmd(command, "--output", output_path)
         elif cmd_entry == "optimize":
-            if previous_cmd == "export":
+            if previous_cmd == "export":  # execute PTQ. If not, execute QAT
                 file_path = self._find_model_path(previous_cmd)
                 if file_path is None:
                     return False


### PR DESCRIPTION
### Summary
Current experiment.py doesn't consider running "otx eval" right after `ptq`, which selects wrong model weight during 'otx eval'.
I updated code to use `ptq` optimized weight when running 'otx eval' after `ptq` and exported model file when running 'otx optimize' after 'otx export'.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
