### PR TITLE
Fix visual prompting e2e test

### DIFF
--- a/tests/e2e/cli/visual_prompting/test_visual_prompting.py
+++ b/tests/e2e/cli/visual_prompting/test_visual_prompting.py
@@ -60,11 +60,13 @@ if TT_STABILITY_TESTS:
     templates_ids = [template.model_template_id + f"-{i+1}" for i, template in enumerate(templates)]
 
 else:
-    templates = (
-        Registry("src/otx/algorithms/visual_prompting", experimental=True)
+    templates = [
+        template
+        for template in Registry("src/otx/algorithms/visual_prompting", experimental=True)
         .filter(task_type="VISUAL_PROMPTING")
         .templates
-    )
+        if "Zero_Shot" not in template.name
+    ]
     templates_ids = [template.model_template_id for template in templates]
 
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

e2e have included recently merged PR (https://github.com/openvinotoolkit/training_extensions/pull/2616), but it doesn't support export yet.
Fix to ignore zero-shot related template.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```python
$ tox -vv -e tests-visprompt-py310-pt1 -- tests/e2e/cli/visual_prompting
=================================================== 14 passed, 6 skipped, 1 warning in 354.07s (0:05:54) ===================================================
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
