### PR TITLE
Fix otx_train

### DIFF
--- a/src/otx/cli/train.py
+++ b/src/otx/cli/train.py
@@ -13,10 +13,10 @@ from jsonargparse import ArgumentParser
 
 from otx.cli.utils.hydra import configure_hydra_outputs
 
+
 if TYPE_CHECKING:
     from jsonargparse._actions import _ActionSubCommands
     from pytorch_lightning import Trainer
-
 
 
 def add_train_parser(subcommands_action: _ActionSubCommands) -> None:
@@ -41,9 +41,11 @@ def otx_train(overrides: list[str]) -> tuple[Trainer, dict[str, Any]]:
     :param overrides: Override List values.
     :return: Optional[float] with optimized metric value.
     """
-    # apply extra utilities
-    # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
-    # utils.extras(cfg)
+    from otx.core.config import register_configs
+
+    # This should be in front of hydra.initialize()
+    register_configs()
+
     with initialize(config_path="../config", version_base="1.3", job_name="otx_train"):
         cfg = compose(
             config_name="train", overrides=overrides, return_hydra_config=True


### PR DESCRIPTION
### Summary

- Fix not working CLI train command train after merging https://github.com/openvinotoolkit/training_extensions/pull/2712

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
