### PR TITLE
Make mean teacher algorithm consider distributed training

### DIFF
--- a/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
@@ -10,11 +10,11 @@ import cv2
 import mmcv
 import numpy as np
 import torch
-from torch import distributed as dist
 from mmdet.core import bbox2result, bbox2roi
 from mmdet.core.mask.structures import BitmapMasks
 from mmdet.models import DETECTORS, build_detector
 from mmdet.models.detectors import BaseDetector
+from torch import distributed as dist
 
 from otx.utils.logger import get_logger
 

--- a/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
@@ -193,19 +193,19 @@ class MeanTeacher(SAMDetectorMixin, BaseDetector):
                 get_unlabeled_loss = True
                 non_empty[0] = True
 
-        if self.filter_empty_annotations:
-            pseudo_bboxes = [pb for i, pb in enumerate(pseudo_bboxes) if non_empty[i]]
-            pseudo_labels = [pl for i, pl in enumerate(pseudo_labels) if non_empty[i]]
-            pseudo_masks = [pm for i, pm in enumerate(pseudo_masks) if non_empty[i]]
-            ul_img_metas = [im for i, im in enumerate(ul_img_metas) if non_empty[i]]
-            ul_img = ul_img[non_empty]
-        if self.visualize:
-            self._visual_online(ul_img, pseudo_bboxes, pseudo_labels)
         losses.update(ps_ratio=torch.tensor([pseudo_ratio], device=current_device))
 
         # Unsupervised loss
         # Compute only if min_pseudo_label_ratio is reached
         if get_unlabeled_loss:
+            if self.filter_empty_annotations:
+                pseudo_bboxes = [pb for i, pb in enumerate(pseudo_bboxes) if non_empty[i]]
+                pseudo_labels = [pl for i, pl in enumerate(pseudo_labels) if non_empty[i]]
+                pseudo_masks = [pm for i, pm in enumerate(pseudo_masks) if non_empty[i]]
+                ul_img_metas = [im for i, im in enumerate(ul_img_metas) if non_empty[i]]
+                ul_img = ul_img[non_empty]
+                if self.visualize:
+                    self._visual_online(ul_img, pseudo_bboxes, pseudo_labels)
             if self.bg_loss_weight >= 0.0:
                 self.model_s.bbox_head.bg_loss_weight = self.bg_loss_weight
             if self.model_t.with_mask:

--- a/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
@@ -10,6 +10,7 @@ import cv2
 import mmcv
 import numpy as np
 import torch
+from torch import distributed as dist
 from mmdet.core import bbox2result, bbox2roi
 from mmdet.core.mask.structures import BitmapMasks
 from mmdet.models import DETECTORS, build_detector
@@ -182,22 +183,29 @@ class MeanTeacher(SAMDetectorMixin, BaseDetector):
         pseudo_bboxes, pseudo_labels, pseudo_masks, pseudo_ratio = self.generate_pseudo_labels(
             teacher_outputs, device=current_device, img_meta=ul_img_metas, **kwargs
         )
+        non_empty = [bool(len(i)) for i in pseudo_labels] if self.filter_empty_annotations else [True]
+        get_unlabeled_loss = pseudo_ratio >= self.min_pseudo_label_ratio and any(non_empty)
+
+        if dist.is_initialized():
+            reduced_get_unlabeled_loss = torch.tensor(int(get_unlabeled_loss)).cuda()
+            dist.all_reduce(reduced_get_unlabeled_loss)
+            if dont_have_to_train := not get_unlabeled_loss and reduced_get_unlabeled_loss > 0:
+                get_unlabeled_loss = True
+                non_empty[0] = True
+
         if self.filter_empty_annotations:
-            non_empty = [bool(len(i)) for i in pseudo_labels]
             pseudo_bboxes = [pb for i, pb in enumerate(pseudo_bboxes) if non_empty[i]]
             pseudo_labels = [pl for i, pl in enumerate(pseudo_labels) if non_empty[i]]
             pseudo_masks = [pm for i, pm in enumerate(pseudo_masks) if non_empty[i]]
             ul_img_metas = [im for i, im in enumerate(ul_img_metas) if non_empty[i]]
             ul_img = ul_img[non_empty]
-        else:
-            non_empty = [True]
         if self.visualize:
             self._visual_online(ul_img, pseudo_bboxes, pseudo_labels)
         losses.update(ps_ratio=torch.tensor([pseudo_ratio], device=current_device))
 
         # Unsupervised loss
         # Compute only if min_pseudo_label_ratio is reached
-        if pseudo_ratio >= self.min_pseudo_label_ratio and any(non_empty):
+        if get_unlabeled_loss:
             if self.bg_loss_weight >= 0.0:
                 self.model_s.bbox_head.bg_loss_weight = self.bg_loss_weight
             if self.model_t.with_mask:
@@ -214,7 +222,10 @@ class MeanTeacher(SAMDetectorMixin, BaseDetector):
                 if ul_loss_name.startswith("loss_"):
                     ul_loss = ul_losses[ul_loss_name]
                     target_loss = ul_loss_name.split("_")[-1]
-                    if self.unlabeled_loss_weights[target_loss] == 0:
+                    if dist.is_initialized():
+                        if dont_have_to_train:
+                            self.unlabeled_loss_weights[target_loss] = 0
+                    elif self.unlabeled_loss_weights[target_loss] == 0:
                         continue
                     self._update_unlabeled_loss(losses, ul_loss, ul_loss_name, self.unlabeled_loss_weights[target_loss])
         return losses

--- a/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/detectors/mean_teacher.py
@@ -187,7 +187,7 @@ class MeanTeacher(SAMDetectorMixin, BaseDetector):
         get_unlabeled_loss = pseudo_ratio >= self.min_pseudo_label_ratio and any(non_empty)
 
         if dist.is_initialized():
-            reduced_get_unlabeled_loss = torch.tensor(int(get_unlabeled_loss)).cuda()
+            reduced_get_unlabeled_loss = torch.tensor(int(get_unlabeled_loss)).to(current_device)
             dist.all_reduce(reduced_get_unlabeled_loss)
             if dont_have_to_train := not get_unlabeled_loss and reduced_get_unlabeled_loss > 0:
                 get_unlabeled_loss = True

--- a/tests/e2e/cli/detection/test_detection.py
+++ b/tests/e2e/cli/detection/test_detection.py
@@ -348,8 +348,6 @@ class TestToolsOTXSemiSLDetection:
     def test_otx_multi_gpu_train_semisl(self, template, tmp_dir_path):
         if not (Path(template.model_template_path).parent / "semisl").is_dir():
             pytest.skip(f"Semi-SL training type isn't available for {template.name}")
-        if template.name == "ResNeXt101-ATSS":
-            pytest.skip(f"Issue#2705: multi-gpu training e2e test failure for {template.name}")
         tmp_dir_path = tmp_dir_path / "detection/test_multi_gpu_semisl"
         args_semisl_multigpu = copy.deepcopy(args_semisl)
         args_semisl_multigpu["--gpus"] = "0,1"


### PR DESCRIPTION
### Summary
This PR fixes #2705 
The reason of bug is that when distributed training, one process may train a model w/ pseudo label but other processes doesn't  in some case. In this case, each process executes different code flow, which makes the error.
This PR changes code as below

-  If any process will train a model w/ pseudo label, then all process train a model w/ pseudo label.
- Not to affect backprop, process, which doesn't have to train w/ pseudo label, get 0 loss from pseudo label.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
