### PR TITLE
Fix multilabel classification class index

### DIFF
--- a/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
+++ b/src/otx/algorithms/classification/adapters/mmcls/datasets/otx_datasets.py
@@ -264,7 +264,7 @@ class OTXMultilabelClsDataset(OTXClsDataset):
 
             confusion_matrices = []
             for cls_idx in cls_index:
-                group_labels_idx = set([cls_idx - 1])
+                group_labels_idx = set([cls_idx])
                 y_true = [int(not group_labels_idx.issubset(true_labels)) for true_labels in true_label_idx]
                 y_pred = [int(not group_labels_idx.issubset(pred_labels)) for pred_labels in pred_label_idx]
                 matrix_data = sklearn_confusion_matrix(y_true, y_pred, labels=list(range(len([0, 1]))))


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Since `cls_idx` starts with 1, we don't need to -1. 
Currently, the accuracy of first-class is always set to 1.00 since there is no `0` class.

```python3
confusion_matrices = []
    for cls_idx in cls_index:
        group_labels_idx = set([cls_idx])
        # Since there is no 0 class in the `ture_label_idx` and `pred_label_idx`, `group_labels_idx` should starts with 1.
        y_true = [int(not group_labels_idx.issubset(true_labels)) for true_labels in true_label_idx]
        y_pred = [int(not group_labels_idx.issubset(pred_labels)) for pred_labels in pred_label_idx]
        matrix_data = sklearn_confusion_matrix(y_true, y_pred, labels=list(range(len([0, 1]))))
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
