### PR TITLE
Refine parsing final score of training in experiment.py

### DIFF
--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -236,7 +236,7 @@ class BaseExpParser(ABC):
         with file_path.open("r") as f:
             lines = f.readlines()
 
-        val_score_pattern = re.compile(r"score: Performance\(score: ([-+]?\d+(\.\d*)?|\.\d+)")
+        val_score_pattern = re.compile(r"score:.*Performance\(score: ([-+]?\d+(\.\d*)?|\.\d+)")
         e2e_time_pattern = re.compile(r"time elapsed: '(\d+:\d+:\d+(\.\d*)?)'")
         for line in lines:
             if save_val_score:


### PR DESCRIPTION
### Summary
Current experiment.py assumes that final score format is as below in "cli_report.log".
```
score: Performance(score: 0.4651162790697673, dashboard: (17 metric groups))
```
So, it can't parse format below (instance segmentation format)
```
score: MultiScorePerformance(score: 0.5384615384615383, primary_metric: ScoreMetric(name=`f-measure`, score=`0.5384615384615383`), additional_metrics: (2 metrics), dashboard: (18 metric groups))
```
This PR refines code to parse both format.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
