### PR TITLE
Fix bug by resetting timer every epoch begins

### DIFF
--- a/src/otx/algo/callbacks/iteration_timer.py
+++ b/src/otx/algo/callbacks/iteration_timer.py
@@ -9,10 +9,9 @@ from collections import defaultdict
 from time import time
 from typing import TYPE_CHECKING, Any
 
-from lightning import Callback
+from lightning import Callback, LightningModule, Trainer
 
 if TYPE_CHECKING:
-    from lightning import LightningModule, Trainer
     from lightning.pytorch.utilities.types import STEP_OUTPUT
 
 
@@ -32,6 +31,21 @@ class IterationTimer(Callback):
 
         self.start_time: dict[str, float] = defaultdict(float)
         self.end_time: dict[str, float] = defaultdict(float)
+
+    def on_train_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset timer before every train epoch starts."""
+        self.start_time.clear()
+        self.end_time.clear()
+
+    def on_validation_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset timer before every validation epoch starts."""
+        self.start_time.clear()
+        self.end_time.clear()
+
+    def on_test_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset timer before every test epoch starts."""
+        self.start_time.clear()
+        self.end_time.clear()
 
     def _on_batch_start(
         self,

--- a/tests/unit/algo/callbacks/test_iteration_timer.py
+++ b/tests/unit/algo/callbacks/test_iteration_timer.py
@@ -12,7 +12,6 @@ class TestIterationTimer:
     @patch("otx.algo.callbacks.iteration_timer.time")
     def test_all_phases(self, mock_time, phase) -> None:
         mock_trainer = MagicMock()
-        mock_pl_module = MagicMock()
         mock_batch = MagicMock()
         batch_size = 64
         mock_batch.batch_size = batch_size
@@ -20,54 +19,66 @@ class TestIterationTimer:
 
         timer = IterationTimer()
 
+        epoch_len = 3
+        time_span = 10
         batch_len = 2
 
-        # Timestamp
-        # 0, batch_start
-        # 1, batch_end
-        # 2, ...
-        # 3,
-        mock_time.side_effect = range(2 * batch_len)
+        for epoch_idx in range(epoch_len):
+            # Timestamp
+            # 0 + time_span * epoch_idx, batch_start
+            # 1 + time_span * epoch_idx, batch_end
+            # 2 + time_span * epoch_idx, ...
+            # 3 + time_span * epoch_idx,
+            mock_time.side_effect = [time + time_span * epoch_idx for time in range(2 * batch_len)]
 
-        for batch_idx in range(batch_len):
-            getattr(timer, f"on_{phase}_batch_start")(
+            mock_pl_module = MagicMock()
+
+            # Timer member variables should be reset.
+            # Without this, test should be failed.
+            getattr(timer, f"on_{phase}_epoch_start")(
                 trainer=mock_trainer,
                 pl_module=mock_pl_module,
-                batch=mock_batch,
-                batch_idx=batch_idx,
             )
 
-            if batch_idx == 0:
-                assert not mock_pl_module.log.called, "Cannot log data and iter time at the first batch step"
-            else:
-                mock_pl_module.log.assert_called_with(
-                    name=f"{phase}/data_time",
-                    value=1,
-                    prog_bar=timer.prog_bar,
-                    on_step=timer.on_step,
-                    on_epoch=timer.on_epoch,
-                    batch_size=batch_size,
+            for batch_idx in range(batch_len):
+                getattr(timer, f"on_{phase}_batch_start")(
+                    trainer=mock_trainer,
+                    pl_module=mock_pl_module,
+                    batch=mock_batch,
+                    batch_idx=batch_idx,
                 )
 
-            getattr(timer, f"on_{phase}_batch_end")(
-                trainer=mock_trainer,
-                pl_module=mock_pl_module,
-                outputs=mock_outputs,
-                batch=mock_batch,
-                batch_idx=batch_idx,
-            )
+                if batch_idx == 0:
+                    assert not mock_pl_module.log.called, "Cannot log data and iter time at the first batch step"
+                else:
+                    mock_pl_module.log.assert_called_with(
+                        name=f"{phase}/data_time",
+                        value=1,
+                        prog_bar=timer.prog_bar,
+                        on_step=timer.on_step,
+                        on_epoch=timer.on_epoch,
+                        batch_size=batch_size,
+                    )
 
-            assert timer.start_time[phase] == 2 * batch_idx
-            assert timer.end_time[phase] == 2 * batch_idx + 1
-
-            if batch_idx == 0:
-                assert not mock_pl_module.log.called, "Cannot log data and iter time at the first batch step"
-            else:
-                mock_pl_module.log.assert_called_with(
-                    name=f"{phase}/iter_time",
-                    value=2,
-                    prog_bar=timer.prog_bar,
-                    on_step=timer.on_step,
-                    on_epoch=timer.on_epoch,
-                    batch_size=batch_size,
+                getattr(timer, f"on_{phase}_batch_end")(
+                    trainer=mock_trainer,
+                    pl_module=mock_pl_module,
+                    outputs=mock_outputs,
+                    batch=mock_batch,
+                    batch_idx=batch_idx,
                 )
+
+                assert timer.start_time[phase] == time_span * epoch_idx + 2 * batch_idx
+                assert timer.end_time[phase] == time_span * epoch_idx + 2 * batch_idx + 1
+
+                if batch_idx == 0:
+                    assert not mock_pl_module.log.called, "Cannot log data and iter time at the first batch step"
+                else:
+                    mock_pl_module.log.assert_called_with(
+                        name=f"{phase}/iter_time",
+                        value=2,
+                        prog_bar=timer.prog_bar,
+                        on_step=timer.on_step,
+                        on_epoch=timer.on_epoch,
+                        batch_size=batch_size,
+                    )


### PR DESCRIPTION
### Summary

- Please see this. There has been no timer reset every epoch begins. It results in the incorrect very long iter/data time at every first batch. This patch fixes it.
![image](https://github.com/openvinotoolkit/training_extensions/assets/26541465/9c6a43e4-a8bd-41e7-b967-6533700152f7)

### How to test
I updated our unit test as well to test this behavior.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
