### PR TITLE
Update tools/expreiment.py

### DIFF
--- a/tests/unit/algorithms/segmentation/adapters/mmseg/datasets/pipelines/test_transforms.py
+++ b/tests/unit/algorithms/segmentation/adapters/mmseg/datasets/pipelines/test_transforms.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import pytest
@@ -110,11 +110,11 @@ class TestNormalize:
     @pytest.mark.parametrize(
         "mean,std,to_rgb,expected",
         [
-            (1.0, 1.0, True, np.array([[[1.0, 0.0, 0.0]]], dtype=np.float32)),
-            (1.0, 1.0, False, np.array([[[-1.0, 0.0, 0.0]]], dtype=np.float32)),
+            ([1.0 for _ in range(3)], [1.0 for _ in range(3)], True, np.array([[[1.0, 0.0, -1.0]]], dtype=np.float32)),
+            ([1.0 for _ in range(3)], [1.0 for _ in range(3)], False, np.array([[[-1.0, 0.0, 1.0]]], dtype=np.float32)),
         ],
     )
-    def test_call(self, mean: float, std: float, to_rgb: bool, expected: np.array) -> None:
+    def test_call(self, mean: List[float], std: List[float], to_rgb: bool, expected: np.array) -> None:
         """Test __call__."""
         normalize = Normalize(mean=mean, std=std, to_rgb=to_rgb)
         inputs = dict(img=np.arange(3).reshape(1, 1, 3))

--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -574,6 +574,7 @@ class ExpRecipeParser:
         if not found_keys:
             return []
 
+        found_keys = sorted(found_keys)
         values_of_found_key = []
         for key in found_keys:
             if isinstance(variable[key], list):

--- a/tools/experiment.py
+++ b/tools/experiment.py
@@ -74,6 +74,7 @@ class EvalResult:
     Each metric can be set or gotten by both dict-like(ins["metric"]) or class-like(ins.metric) way.
     "add" (only with a class having same metrics) and "true devide" are supported.
     """
+
     def __getitem__(self, key):
         """Support dict-like way to get attribute."""
         return getattr(self, key)


### PR DESCRIPTION
### Summary

This PR updates tools/expreiment.py as below.

- [x] Make experiment directory name same always
- [x] Parse all metric values in `otx eval` output file.
- [x] Fix minor unit test bug

### Details

#### Why is experiment name different in each run before?
When parsing variables in YAML recipe file, keys of variables are saved in a set.
Using the set, not only which values to use but also order of dict (python 3.6+ keeps order in default dict) is decided.
In contrast to my expectation, `set` doesn't have always same order.
So, I added a code to sort the set, which makes constant order in every runs.

#### How is `otx eval` ouptut parsed now?
After this PR is merged, all metrics in `otx eval` output file are parsed and saved in final experiment result file.
For example, if we assume that `eval` is executed after `train`, `export` and `optimize` in detection task,
metrics as below are saved

test_score => f-measure(train)
Recall(train) is newly added.
Precision(train) is newly added.
export_model_score => f-measure(export)
Recall(export) is newly added.
Precision(export) is newly added.
optimize_model_score => f-measure(optimize)
Recall(optimize) is newly added.
Precision(optimize) is newly added.
And other metrics are same as previous

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
