### PR TITLE
Add GPU marker to the regression test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -287,3 +287,8 @@ max-returns = 10
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.pytest.ini_options]
+markers = [
+    "gpu: mark tests which require NVIDIA GPU device"
+]

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -24,8 +24,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         "--user-name",
         type=str,
         required=True,
-        help="Sign-off the user name who launched the regression tests this time, "
-        'e.g., `--user-name "John Doe"`.',
+        help="Sign-off the user name who launched the regression tests this time, " 'e.g., `--user-name "John Doe"`.',
     )
     parser.addoption(
         "--dataset-root-dir",
@@ -154,3 +153,8 @@ def fxt_recipe_dir() -> Path:
     import otx.recipe as otx_recipe
 
     return Path(otx_recipe.__file__).parent
+
+
+@pytest.fixture(params=[pytest.param("gpu", marks=pytest.mark.gpu)])
+def fxt_accelerator(request: pytest.FixtureRequest) -> str:
+    return request.param

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -43,6 +43,7 @@ class BaseTest:
         fxt_dataset_root_dir: Path,
         fxt_tags: dict,
         fxt_num_repeat: int,
+        fxt_accelerator: str,
         tmpdir: pytest.TempdirFactory,
     ) -> None:
         for seed in range(fxt_num_repeat):
@@ -73,6 +74,7 @@ class BaseTest:
                     f"data.data_format={test_case.dataset.data_format}",
                     f"base.output_dir={test_case.output_dir}",
                     f"seed={seed}",
+                    f"trainer={fxt_accelerator}",
                     "test=true",
                 ] + [
                     f"{key}={value}"
@@ -122,6 +124,7 @@ class TestMultiClassCls(BaseTest):
         fxt_dataset_root_dir: Path,
         fxt_tags: dict,
         fxt_num_repeat: int,
+        fxt_accelerator: str,
         tmpdir: pytest.TempdirFactory,
     ) -> None:
         self._test_regression(
@@ -130,6 +133,7 @@ class TestMultiClassCls(BaseTest):
             fxt_dataset_root_dir=fxt_dataset_root_dir,
             fxt_tags=fxt_tags,
             fxt_num_repeat=fxt_num_repeat,
+            fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
         )
 
@@ -170,6 +174,7 @@ class TestMultilabelCls(BaseTest):
         fxt_dataset_root_dir: Path,
         fxt_tags: dict,
         fxt_num_repeat: int,
+        fxt_accelerator: str,
         tmpdir: pytest.TempdirFactory,
     ) -> None:
         self._test_regression(
@@ -178,5 +183,6 @@ class TestMultilabelCls(BaseTest):
             fxt_dataset_root_dir=fxt_dataset_root_dir,
             fxt_tags=fxt_tags,
             fxt_num_repeat=fxt_num_repeat,
+            fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
         )


### PR DESCRIPTION
### Summary

- Fix revealed in https://github.com/openvinotoolkit/training_extensions/pull/2724#discussion_r1424738570
- Add the GPU pytest marker and set it as the default for the regression test.

### How to test
Manually tested it

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
