### PR TITLE
Fix a bug that a process tracking resource usage doesn't exit when main process raises an error

### DIFF
--- a/.github/workflows/perf-accuracy.yml
+++ b/.github/workflows/perf-accuracy.yml
@@ -7,17 +7,17 @@ on:
         type: choice
         description: Model type to run benchmark
         options:
-        - default  # speed, balance, accuracy models only
-        - all      # default + other models
+          - default # speed, balance, accuracy models only
+          - all # default + other models
         default: default
       data-size:
         type: choice
         description: Dataset size to run benchmark
         options:
-        - small
-        - medium
-        - large
-        - all
+          - small
+          - medium
+          - large
+          - all
         default: all
       num-repeat:
         description: Overrides default per-data-size number of repeat setting
@@ -29,9 +29,9 @@ on:
         type: choice
         description: The last operation to evaluate. 'optimize' means all.
         options:
-        - train
-        - export
-        - optimize
+          - train
+          - export
+          - optimize
         default: optimize
 
 jobs:

--- a/.github/workflows/perf-speed.yml
+++ b/.github/workflows/perf-speed.yml
@@ -7,17 +7,17 @@ on:
         type: choice
         description: Model type to run benchmark
         options:
-        - default  # speed, balance, accuracy models only
-        - all      # default + other models
+          - default # speed, balance, accuracy models only
+          - all # default + other models
         default: default
       data-size:
         type: choice
         description: Dataset size to run benchmark
         options:
-        - small
-        - medium
-        - large
-        - all
+          - small
+          - medium
+          - large
+          - all
         default: large
       num-repeat:
         description: Overrides default per-data-size number of repeat setting
@@ -29,9 +29,9 @@ on:
         type: choice
         description: The last operation to evaluate. 'optimize' means all.
         options:
-        - train
-        - export
-        - optimize
+          - train
+          - export
+          - optimize
         default: optimize
 
 jobs:

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -298,7 +298,7 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
         dataset, output_model, train_parameters=TrainParameters(), seed=args.seed, deterministic=args.deterministic
     )
 
-    if resource_tracker is not None:
+    if resource_tracker is not None and exit_stack is None:
         resource_tracker.stop()
 
     model_path = config_manager.output_path / "models"

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -19,7 +19,6 @@
 import datetime
 import time
 from contextlib import ExitStack
-from functools import partial
 from pathlib import Path
 from typing import Optional
 

--- a/src/otx/cli/tools/train.py
+++ b/src/otx/cli/tools/train.py
@@ -288,9 +288,7 @@ def train(exit_stack: Optional[ExitStack] = None):  # pylint: disable=too-many-b
     resource_tracker = None
     if args.track_resource_usage and not is_multigpu_child_process():
         resource_tracker = ResourceTracker(
-            config_manager.output_path / "resource_usage.yaml",
-            args.track_resource_usage,
-            args.gpus
+            config_manager.output_path / "resource_usage.yaml", args.track_resource_usage, args.gpus
         )
         resource_tracker.start()
         if exit_stack is not None:

--- a/src/otx/cli/utils/experiment.py
+++ b/src/otx/cli/utils/experiment.py
@@ -30,12 +30,16 @@ class ResourceTracker:
     """Class to track resources usage.
 
     Args:
+        output_path (Union[str, Path]): Output file path to save CPU & GPU utilization and max meory usage values.
         resource_type (str, optional): Which resource to track. Available values are cpu, gpu or all now.
                                         Defaults to "all".
         gpu_ids (Optional[str]): GPU indices to record.
     """
 
-    def __init__(self, resource_type: str = "all", gpu_ids: Optional[str] = None):
+    def __init__(self, output_path: Union[str, Path], resource_type: str = "all", gpu_ids: Optional[str] = None):
+        if isinstance(output_path, str):
+            output_path = Path(output_path)
+        self.output_path = output_path
         if resource_type == "all":
             self._resource_type = AVAILABLE_RESOURCE_TYPE
         else:
@@ -62,19 +66,12 @@ class ResourceTracker:
         )
         self._mem_check_proc.start()
 
-    def stop(self, output_path: Union[str, Path]):
-        """Terminate a process to record resources usage.
-
-        Args:
-            output_path (Union[str, Path]): Output file path to save CPU & GPU utilization and max meory usage values.
-        """
+    def stop(self):
+        """Terminate a process to record resources usage."""
         if self._mem_check_proc is None or not self._mem_check_proc.is_alive():
             return
 
-        if isinstance(output_path, str):
-            output_path = Path(output_path)
-
-        self._queue.put(output_path)
+        self._queue.put(self.output_path)
         self._mem_check_proc.join(10)
         if self._mem_check_proc.exitcode is None:
             self._mem_check_proc.terminate()


### PR DESCRIPTION
### Summary
This PR fixes a bug that a process tracking resource usage doesn't exit when main process raises an error.
I add a code to register a `ResourceTracker.stop` to ExitStack, which makes `stop` function be called automatically if the main process raises an error.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
