### PR TITLE
Pre-work for the design change: create own python class for every model

### DIFF
--- a/src/otx/algo/classification/otx_dino_v2.py
+++ b/src/otx/algo/classification/otx_dino_v2.py
@@ -65,9 +65,9 @@ class DINOv2(nn.Module):
 class DINOv2RegisterClassifier(OTXMulticlassClsModel):
     """DINO-v2 Classification Model with register."""
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
         self.config = config
-        super().__init__()  # create the model
+        super().__init__(num_classes=num_classes)  # create the model
 
     def _create_model(self) -> nn.Module:
         """Create the model."""

--- a/src/otx/config/model/default.yaml
+++ b/src/otx/config/model/default.yaml
@@ -10,3 +10,6 @@ scheduler:
   mode: min
   factor: 0.1
   patience: 10
+
+otx_model:
+  num_classes: ???

--- a/src/otx/config/model/mmdet_inst_seg.yaml
+++ b/src/otx/config/model/mmdet_inst_seg.yaml
@@ -1,3 +1,6 @@
+defaults:
+  - default
+
 _target_: otx.core.model.module.instance_segmentation.OTXInstanceSegLitModule
 
 optimizer:

--- a/src/otx/config/model/mmseg.yaml
+++ b/src/otx/config/model/mmseg.yaml
@@ -14,6 +14,7 @@ scheduler:
 otx_model:
   _target_: otx.core.model.entity.segmentation.MMSegCompatibleModel
   config: ???
+  num_classes: ???
 
 # compile model for faster training with pytorch 2.0
 torch_compile: false

--- a/src/otx/core/data/dataset/base.py
+++ b/src/otx/core/data/dataset/base.py
@@ -30,15 +30,27 @@ Transforms = Union[Compose, Callable, List[Callable]]
 
 
 @dataclass
-class DataMetaInfo:
-    """Meta information of each subset datasets."""
+class LabelInfo:
+    """Object to represent label information."""
 
-    class_names: list[str]
+    label_names: list[str]
 
     @property
     def num_classes(self) -> int:
-        """Return number of classes."""
-        return len(self.class_names)
+        """Return number of labels."""
+        return len(self.label_names)
+
+    @classmethod
+    def from_num_classes(cls, num_classes: int) -> LabelInfo:
+        """Create this object from the number of classes.
+
+        Args:
+            num_classes: Number of classes
+
+        Returns:
+            LabelInfo(label_names=["label_0", ...])
+        """
+        return LabelInfo(label_names=[f"label_{idx}" for idx in range(num_classes)])
 
 
 class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
@@ -59,8 +71,8 @@ class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
         self.mem_cache_img_max_size = mem_cache_img_max_size
         self.max_refetch = max_refetch
 
-        self.meta_info = DataMetaInfo(
-            class_names=[category.name for category in self.dm_subset.categories()[AnnotationType.label]],
+        self.meta_info = LabelInfo(
+            label_names=[category.name for category in self.dm_subset.categories()[AnnotationType.label]],
         )
 
     def __len__(self) -> int:

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -13,7 +13,7 @@ from datumaro import Image, Label
 from datumaro.components.annotation import AnnotationType
 from torch.nn import functional
 
-from otx.core.data.dataset.base import DataMetaInfo, OTXDataset
+from otx.core.data.dataset.base import LabelInfo, OTXDataset
 from otx.core.data.entity.base import ImageInfo
 from otx.core.data.entity.classification import (
     HlabelClsBatchDataEntity,
@@ -27,7 +27,7 @@ from otx.core.data.entity.classification import (
 
 
 @dataclass
-class HLabelMetaInfo(DataMetaInfo):
+class HLabelMetaInfo(LabelInfo):
     """Meta information of hlabel classification."""
 
     hlabel_info: HLabelInfo
@@ -110,7 +110,7 @@ class OTXHlabelClsDataset(OTXDataset[HlabelClsDataEntity]):
 
         # Hlabel classification used HLabelMetaInfo to insert the HLabelInfo.
         self.meta_info = HLabelMetaInfo(
-            class_names=[category.name for category in self.dm_categories],
+            label_names=[category.name for category in self.dm_categories],
             hlabel_info=HLabelInfo.from_dm_label_groups(self.dm_categories),
         )
 

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -12,7 +12,7 @@ from lightning import LightningDataModule
 from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import DataLoader
 
-from otx.core.data.dataset.base import DataMetaInfo
+from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.factory import OTXDatasetFactory
 from otx.core.data.mem_cache import (
     MemCacheHandlerSingleton,
@@ -68,7 +68,7 @@ class OTXDataModule(LightningDataModule):
             mem_size=mem_size,
         )
 
-        meta_infos: list[DataMetaInfo] = []
+        meta_infos: list[LabelInfo] = []
         for name, dm_subset in dataset.subsets().items():
             if name not in config_mapping:
                 log.warning(f"{name} is not available. Skip it")
@@ -91,7 +91,7 @@ class OTXDataModule(LightningDataModule):
 
         self.meta_info = next(iter(meta_infos))
 
-    def _is_meta_info_valid(self, meta_infos: list[DataMetaInfo]) -> bool:
+    def _is_meta_info_valid(self, meta_infos: list[LabelInfo]) -> bool:
         """Check whether there are mismatches in the metainfo for the all subsets."""
         if all(meta_info == meta_infos[0] for meta_info in meta_infos):
             return True

--- a/src/otx/core/model/entity/action_classification.py
+++ b/src/otx/core/model/entity/action_classification.py
@@ -14,6 +14,7 @@ from otx.core.data.entity.action_classification import (
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.model.entity.base import OTXModel
 from otx.core.utils.build import build_mm_model, get_classification_layers
+from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -32,10 +33,11 @@ class MMActionCompatibleModel(OTXActionClsModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from mmaction.models.data_preprocessors import (

--- a/src/otx/core/model/entity/action_detection.py
+++ b/src/otx/core/model/entity/action_detection.py
@@ -13,6 +13,7 @@ from otx.core.data.entity.action_detection import ActionDetBatchDataEntity, Acti
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.model.entity.base import OTXModel
 from otx.core.utils.build import build_mm_model, get_classification_layers
+from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -31,10 +32,11 @@ class MMActionCompatibleModel(OTXActionDetModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from mmaction.models.data_preprocessors import (

--- a/src/otx/core/model/entity/base.py
+++ b/src/otx/core/model/entity/base.py
@@ -15,8 +15,11 @@ from otx.core.data.entity.base import (
     T_OTXBatchDataEntity,
     T_OTXBatchPredEntity,
 )
+from otx.core.types.export import OTXExportFormat
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import torch
 
 
@@ -116,3 +119,48 @@ class OTXModel(nn.Module, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity]):
             else:
                 src2dst.append(-1)
         return src2dst
+
+    def export(self, output_dir: Path, export_format: OTXExportFormat) -> None:
+        """Export this model to the specified output directory.
+
+        Args:
+            output_dir: Directory path to save exported binary files.
+            export_format: Format in which this `OTXModel` is exported.
+        """
+        if export_format == OTXExportFormat.OPENVINO:
+            self._export_to_openvino(output_dir)
+        if export_format == OTXExportFormat.ONNX:
+            self._export_to_onnx()
+        if export_format == OTXExportFormat.EXPORTABLE_CODE:
+            self._export_to_exportable_code()
+
+    def _export_to_openvino(self, output_dir: Path) -> None:
+        """Export to OpenVINO Intermediate Representation format.
+
+        Args:
+            output_dir: Directory path to save exported binary files
+        """
+        raise NotImplementedError
+
+    def _export_to_onnx(self) -> None:
+        """Export to ONNX format.
+
+        Args:
+            output_dir: Directory path to save exported binary files
+        """
+        raise NotImplementedError
+
+    def _export_to_exportable_code(self) -> None:
+        """Export to exportable code format.
+
+        Args:
+            output_dir: Directory path to save exported binary files
+        """
+        raise NotImplementedError
+
+    def register_explain_hook(self) -> None:
+        """Register explain hook.
+
+        TBD
+        """
+        raise NotImplementedError

--- a/src/otx/core/model/entity/base.py
+++ b/src/otx/core/model/entity/base.py
@@ -5,11 +5,13 @@
 
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Generic
 
 from torch import nn
 
+from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.entity.base import (
     OTXBatchLossEntity,
     T_OTXBatchDataEntity,
@@ -24,12 +26,44 @@ if TYPE_CHECKING:
 
 
 class OTXModel(nn.Module, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity]):
-    """Base class for the models used in OTX."""
+    """Base class for the models used in OTX.
 
-    def __init__(self) -> None:
+    Args:
+        num_classes: Number of classes this model can predict.
+    """
+
+    def __init__(self, num_classes: int) -> None:
         super().__init__()
+
+        self._label_info = LabelInfo.from_num_classes(num_classes)
         self.classification_layers: dict[str, dict[str, Any]] = {}
         self.model = self._create_model()
+
+    @property
+    def label_info(self) -> LabelInfo:
+        """Get this model label information."""
+        return self._label_info
+
+    @label_info.setter
+    def label_info(self, label_info: LabelInfo | list[str]) -> None:
+        """Set this model label information."""
+        if isinstance(label_info, list):
+            label_info = LabelInfo(label_names=label_info)
+
+        old_num_classes = self._label_info.num_classes
+        new_num_classes = label_info.num_classes
+
+        if old_num_classes != new_num_classes:
+            msg = (
+                f"Given LabelInfo has the different number of classes "
+                f"({old_num_classes}!={new_num_classes}). "
+                "The model prediction layer is reset to the new number of classes "
+                f"(={new_num_classes})."
+            )
+            warnings.warn(msg, stacklevel=0)
+            self._reset_prediction_layer(num_classes=label_info.num_classes)
+
+        self._label_info = label_info
 
     @abstractmethod
     def _create_model(self) -> nn.Module:
@@ -162,5 +196,13 @@ class OTXModel(nn.Module, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity]):
         """Register explain hook.
 
         TBD
+        """
+        raise NotImplementedError
+
+    def _reset_prediction_layer(self, num_classes: int) -> None:
+        """Reset its prediction layer with a given number of classes.
+
+        Args:
+            num_classes: Number of classes
         """
         raise NotImplementedError

--- a/src/otx/core/model/entity/classification.py
+++ b/src/otx/core/model/entity/classification.py
@@ -21,6 +21,7 @@ from otx.core.data.entity.classification import (
 )
 from otx.core.model.entity.base import OTXModel
 from otx.core.utils.build import build_mm_model, get_classification_layers
+from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
     from mmpretrain.models.utils import ClsDataPreprocessor
@@ -63,10 +64,11 @@ class MMPretrainMulticlassClsModel(OTXMulticlassClsModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         model, classification_layers = _create_mmpretrain_model(self.config, self.load_from)
@@ -155,10 +157,11 @@ class MMPretrainMultilabelClsModel(OTXMultilabelClsModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         model, classification_layers = _create_mmpretrain_model(self.config, self.load_from)
@@ -241,10 +244,11 @@ class MMPretrainHlabelClsModel(OTXHlabelClsModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         model, classification_layers = _create_mmpretrain_model(self.config, self.load_from)
@@ -322,10 +326,11 @@ class OVClassificationCompatibleModel(OTXMulticlassClsModel):
     and create the OTX classification model compatible for OTX testing pipeline.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
         self.model_name = config.pop("model_name")
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from openvino.model_api.models import ClassificationModel

--- a/src/otx/core/model/entity/detection.py
+++ b/src/otx/core/model/entity/detection.py
@@ -16,6 +16,7 @@ from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
 from otx.core.model.entity.base import OTXModel
 from otx.core.utils.build import build_mm_model, get_classification_layers
+from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
     from mmdet.models.data_preprocessors import DetDataPreprocessor
@@ -35,10 +36,11 @@ class MMDetCompatibleModel(OTXDetectionModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from mmdet.models.data_preprocessors import (
@@ -154,10 +156,10 @@ class OVDetectionCompatibleModel(OTXDetectionModel):
     and create the OTX detection model compatible for OTX testing pipeline.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
         self.model_name = config.pop("model_name")
         self.config = config
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from openvino.model_api.models import DetectionModel

--- a/src/otx/core/model/entity/instance_segmentation.py
+++ b/src/otx/core/model/entity/instance_segmentation.py
@@ -18,6 +18,7 @@ from otx.core.data.entity.instance_segmentation import (
 )
 from otx.core.model.entity.base import OTXModel
 from otx.core.utils.build import build_mm_model, get_classification_layers
+from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
     from mmdet.models.data_preprocessors import DetDataPreprocessor
@@ -34,10 +35,11 @@ class OTXInstanceSegModel(
 class MMDetInstanceSegCompatibleModel(OTXInstanceSegModel):
     """Instance Segmentation model compatible for MMDet."""
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = self.config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from mmdet.models.data_preprocessors import (
@@ -176,11 +178,12 @@ class OVInstanceSegCompatibleModel(OTXInstanceSegModel):
     and create the OTX detection model compatible for OTX testing pipeline.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
         self.model_name = config.pop("model_name")
         self.model_type = config.pop("model_type")
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from openvino.model_api.models import Model

--- a/src/otx/core/model/entity/segmentation.py
+++ b/src/otx/core/model/entity/segmentation.py
@@ -14,6 +14,7 @@ from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity
 from otx.core.model.entity.base import OTXModel
 from otx.core.utils.build import build_mm_model, get_classification_layers
+from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
     from mmseg.models.data_preprocessor import SegDataPreProcessor
@@ -33,10 +34,11 @@ class MMSegCompatibleModel(OTXSegmentationModel):
     compatible for OTX pipelines.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
         self.load_from = self.config.pop("load_from", None)
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from mmengine.registry import MODELS as MMENGINE_MODELS
@@ -130,10 +132,11 @@ class OVSegmentationCompatibleModel(OTXSegmentationModel):
     and create the OTX segmentation model compatible for OTX testing pipeline.
     """
 
-    def __init__(self, config: DictConfig) -> None:
+    def __init__(self, num_classes: int, config: DictConfig) -> None:
         self.model_name = config.pop("model_name")
+        config = inplace_num_classes(cfg=config, num_classes=num_classes)
         self.config = config
-        super().__init__()
+        super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:
         from openvino.model_api.models import SegmentationModel

--- a/src/otx/core/model/module/base.py
+++ b/src/otx/core/model/module/base.py
@@ -19,7 +19,7 @@ from otx.core.types.export import OTXExportFormat
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from otx.core.data.dataset.base import DataMetaInfo
+    from otx.core.data.dataset.base import LabelInfo
 
 
 class OTXLitModule(LightningModule):
@@ -151,10 +151,10 @@ class OTXLitModule(LightningModule):
             logger = logging.getLogger()
             logger.info(
                 f"Data classes from checkpoint: {ckpt_meta_info.class_names} -> "
-                f"Data classes from training data: {self.meta_info.class_names}",
+                f"Data classes from training data: {self.meta_info.label_names}",
             )
             self.register_load_state_dict_pre_hook(
-                self.meta_info.class_names,
+                self.meta_info.label_names,
                 ckpt_meta_info.class_names,
             )
         return super().load_state_dict(state_dict, *args, **kwargs)
@@ -165,16 +165,14 @@ class OTXLitModule(LightningModule):
         return "val/loss"
 
     @property
-    def meta_info(self) -> DataMetaInfo:
-        """Meta information of OTXLitModule."""
-        if self._meta_info is None:
-            err_msg = "meta_info is referenced before assignment"
-            raise ValueError(err_msg)
-        return self._meta_info
+    def label_info(self) -> LabelInfo:
+        """Get the member `OTXModel` label information."""
+        return self.model.label_info
 
-    @meta_info.setter
-    def meta_info(self, meta_info: DataMetaInfo) -> None:
-        self._meta_info = meta_info
+    @label_info.setter
+    def label_info(self, label_info: LabelInfo | list[str]) -> None:
+        """Set the member `OTXModel` label information."""
+        self.model.label_info = label_info  # type: ignore[assignment]
 
     def export(self, output_dir: Path, export_format: OTXExportFormat) -> None:
         """Export the member `OTXModel` of this module to the specified output directory.

--- a/src/otx/core/model/module/base.py
+++ b/src/otx/core/model/module/base.py
@@ -14,8 +14,11 @@ from torch import Tensor
 
 from otx.core.data.entity.base import OTXBatchDataEntity
 from otx.core.model.entity.base import OTXModel
+from otx.core.types.export import OTXExportFormat
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from otx.core.data.dataset.base import DataMetaInfo
 
 
@@ -172,3 +175,12 @@ class OTXLitModule(LightningModule):
     @meta_info.setter
     def meta_info(self, meta_info: DataMetaInfo) -> None:
         self._meta_info = meta_info
+
+    def export(self, output_dir: Path, export_format: OTXExportFormat) -> None:
+        """Export the member `OTXModel` of this module to the specified output directory.
+
+        Args:
+            output_dir: Directory path to save exported binary files.
+            export_format: Format in which this `OTXModel` is exported.
+        """
+        self.model.export(output_dir, export_format)

--- a/src/otx/core/model/module/classification.py
+++ b/src/otx/core/model/module/classification.py
@@ -25,7 +25,7 @@ from otx.core.model.entity.classification import OTXHlabelClsModel, OTXMulticlas
 from otx.core.model.module.base import OTXLitModule
 
 if TYPE_CHECKING:
-    from otx.core.data.dataset.base import DataMetaInfo
+    from otx.core.data.dataset.base import LabelInfo
 
 
 class OTXMulticlassClsLitModule(OTXLitModule):
@@ -220,7 +220,7 @@ class OTXHlabelClsLitModule(OTXLitModule):
         self.model.model.head.set_hlabel_info(self.hlabel_info)
 
         # Set the OTXHlabelClsLitModule params.
-        self.num_labels = len(self.meta_info.class_names)
+        self.num_labels = len(self.meta_info.label_names)
         self.num_multiclass_heads = self.hlabel_info.num_multiclass_heads
         self.num_multilabel_classes = self.hlabel_info.num_multilabel_classes
         self.num_singlelabel_classes = self.num_labels - self.num_multilabel_classes
@@ -310,7 +310,7 @@ class OTXHlabelClsLitModule(OTXLitModule):
         return "train/loss"
 
     @property
-    def meta_info(self) -> DataMetaInfo:
+    def meta_info(self) -> LabelInfo:
         """Meta information of OTXLitModule."""
         if self._meta_info is None:
             err_msg = "meta_info is referenced before assignment"
@@ -318,6 +318,6 @@ class OTXHlabelClsLitModule(OTXLitModule):
         return self._meta_info
 
     @meta_info.setter
-    def meta_info(self, meta_info: DataMetaInfo) -> None:
+    def meta_info(self, meta_info: LabelInfo) -> None:
         self._meta_info = meta_info
         self._set_hlabel_setup()

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""OTX export type definition."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class OTXExportFormat(str, Enum):
+    """OTX export type definition."""
+
+    OPENVINO = "OPENVINO"
+    ONNX = "ONNX"
+    EXPORTABLE_CODE = "EXPORTABLE_CODE"

--- a/src/otx/core/utils/build.py
+++ b/src/otx/core/utils/build.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-from mmengine.logging import MMLogger
 from omegaconf import DictConfig
 
 from otx.core.utils.config import convert_conf_to_mmconfig_dict
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
 
 def build_mm_model(config: DictConfig, model_registry: Registry, load_from: str | None = None) -> nn.Module:
     """Build a model by using the registry."""
+    from mmengine.logging import MMLogger
     from mmengine.runner import load_checkpoint
 
     from otx import algo  # noqa: F401

--- a/src/otx/recipe/detection/openvino_model.yaml
+++ b/src/otx/recipe/detection/openvino_model.yaml
@@ -13,3 +13,4 @@ model:
     _target_: otx.core.model.entity.detection.OVDetectionCompatibleModel
     config:
       model_name: ssd300
+    num_classes: 20

--- a/src/otx/recipe/instance_segmentation/openvino_model.yaml
+++ b/src/otx/recipe/instance_segmentation/openvino_model.yaml
@@ -14,3 +14,4 @@ model:
     config:
       model_name: yolact-resnet50-fpn-pytorch
       model_type: YOLACT
+    num_classes: 80

--- a/src/otx/recipe/multiclass_classification/openvino_model.yaml
+++ b/src/otx/recipe/multiclass_classification/openvino_model.yaml
@@ -15,3 +15,4 @@ model:
       model_name: efficientnet-b0-pytorch
       head:
         num_classes: 1000
+    num_classes: 1000

--- a/src/otx/recipe/segmentation/openvino_model.yaml
+++ b/src/otx/recipe/segmentation/openvino_model.yaml
@@ -15,3 +15,4 @@ model:
       model_name: drn-d-38
       decode_head:
         num_classes: 19
+    num_classes: 19

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -22,46 +22,45 @@ DATASET = {
     "multiclass_classification": {
         "data_dir": "tests/assets/classification_dataset",
         "overrides": [
-            "model.otx_model.config.head.num_classes=2",
+            "model.otx_model.num_classes=2",
         ],
     },
     "multilabel_classification": {
         "data_dir": "tests/assets/multilabel_classification",
         "overrides": [
-            "model.otx_model.config.head.num_classes=2",
+            "model.otx_model.num_classes=2",
         ],
     },
     "hlabel_classification": {
         "data_dir": "tests/assets/hlabel_classification",
         "overrides": [
-            "model.otx_model.config.head.num_classes=7",
+            "model.otx_model.num_classes=7",
             "model.otx_model.config.head.num_multiclass_heads=2",
             "model.otx_model.config.head.num_multilabel_classes=3",
         ],
     },
     "detection": {
         "data_dir": "tests/assets/car_tree_bug",
-        "overrides": ["model.otx_model.config.bbox_head.num_classes=3"],
+        "overrides": ["model.otx_model.num_classes=3"],
     },
     "instance_segmentation": {
         "data_dir": "tests/assets/car_tree_bug",
         "overrides": [
-            "model.otx_model.config.roi_head.bbox_head.num_classes=3",
-            "model.otx_model.config.roi_head.mask_head.num_classes=3",
+            "model.otx_model.num_classes=3",
         ],
     },
     "segmentation": {
         "data_dir": "tests/assets/common_semantic_segmentation_dataset/supervised",
-        "overrides": ["model.otx_model.config.decode_head.num_classes=2"],
+        "overrides": ["model.otx_model.num_classes=2"],
     },
     "action_classification": {
         "data_dir": "tests/assets/action_classification_dataset/",
-        "overrides": ["model.otx_model.config.cls_head.num_classes=2"],
+        "overrides": ["model.otx_model.num_classes=2"],
     },
     "action_detection": {
         "data_dir": "tests/assets/action_detection_dataset/",
         "overrides": [
-            "model.otx_model.config.roi_head.bbox_head.num_classes=5",
+            "model.otx_model.num_classes=5",
             "+model.otx_model.config.roi_head.bbox_head.topk=3",
         ],
     },

--- a/tests/integration/detection/test_model.py
+++ b/tests/integration/detection/test_model.py
@@ -15,7 +15,7 @@ class TestOTXModel:
 
     @pytest.fixture()
     def fxt_model(self, fxt_rtmdet_tiny_model_config) -> MMDetCompatibleModel:
-        return MMDetCompatibleModel(config=fxt_rtmdet_tiny_model_config)
+        return MMDetCompatibleModel(num_classes=3, config=fxt_rtmdet_tiny_model_config)
 
     def test_forward_train(
         self,

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -45,7 +45,6 @@ class BaseTest:
         fxt_num_repeat: int,
         fxt_accelerator: str,
         tmpdir: pytest.TempdirFactory,
-        head_name: str,
     ) -> None:
         for seed in range(fxt_num_repeat):
             test_case = RegressionTestCase(
@@ -70,7 +69,7 @@ class BaseTest:
             with mlflow.start_run(tags=tags, run_name=run_name):
                 overrides = [
                     f"+recipe={test_case.model.task}/{test_case.model.name}",
-                    f"model.otx_model.config.{head_name}.num_classes={test_case.dataset.num_classes}",
+                    f"model.otx_model.num_classes={test_case.dataset.num_classes}",
                     f"data.data_root={data_root}",
                     f"data.data_format={test_case.dataset.data_format}",
                     f"base.output_dir={test_case.output_dir}",
@@ -152,7 +151,6 @@ class TestMultiClassCls(BaseTest):
             fxt_num_repeat=fxt_num_repeat,
             fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
-            head_name="head",
         )
 
 
@@ -219,7 +217,6 @@ class TestMultilabelCls(BaseTest):
             fxt_num_repeat=fxt_num_repeat,
             fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
-            head_name="head",
         )
 
 
@@ -271,7 +268,6 @@ class TestHlabelCls(BaseTest):
             fxt_num_repeat=fxt_num_repeat,
             fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
-            head_name="head",
         )
 
 class TestObjectDetection(BaseTest):
@@ -338,5 +334,4 @@ class TestObjectDetection(BaseTest):
             fxt_tags=fxt_tags,
             fxt_num_repeat=fxt_num_repeat,
             tmpdir=tmpdir,
-            head_name="bbox_head",
         )

--- a/tests/unit/core/model/entity/test_base.py
+++ b/tests/unit/core/model/entity/test_base.py
@@ -12,10 +12,10 @@ class MockNNModule(torch.nn.Module):
 class TestOTXModel:
     def test_smart_weight_loading(self, mocker) -> None:
         mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(2))
-        prev_model = OTXModel()
+        prev_model = OTXModel(num_classes=2)
 
         mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(3))
-        current_model = OTXModel()
+        current_model = OTXModel(num_classes=3)
         current_model.classification_layers = ["model.head.weight", "model.head.bias"]
         current_model.classification_layers = {
             "model.head.weight": {"stride": 1, "num_extra_classes": 0},

--- a/tests/unit/core/model/entity/test_segmentation.py
+++ b/tests/unit/core/model/entity/test_segmentation.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 class TestOTXSegmentationModel:
     @pytest.fixture()
     def config(self) -> DictConfig:
-        return OmegaConf.load("src/otx/recipe/segmentation/segnext_s.yaml")
+        return OmegaConf.load("src/otx/recipe/segmentation/segnext_s.yaml").model.otx_model.config
 
     @pytest.fixture()
     def model(self, config) -> MMSegCompatibleModel:
-        return MMSegCompatibleModel(config.model.otx_model.config)
+        return MMSegCompatibleModel(num_classes=1, config=config)
 
     def test_create_model(self, model) -> None:
         mmseg_model = model._create_model()


### PR DESCRIPTION
### Summary

- This is the pre-work, so that we will actually introduce own python class for every model in the next PR.
- Enrich `OTXModel` to have `export()`, `register_explain_hook()`, and `label_info` property.
- `label_info` will be automatically constructed by the input integer argument, `num_classes`.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
