### PR TITLE
Update object detection regression

### DIFF
--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -288,7 +288,7 @@ class TestObjectDetection(BaseTest):
             data_root=Path("pothole_small") / f"{idx}",
             data_format="coco",
             num_classes=1,
-            extra_overrides={"trainer.max_epochs": "10"},
+            extra_overrides={"trainer.max_epochs": "40", "trainer.deterministic": "True"},
         )
         for idx in range(1, 4)
     ] + [
@@ -297,14 +297,14 @@ class TestObjectDetection(BaseTest):
             data_root="pothole_medium",
             data_format="coco",
             num_classes=1,
-            extra_overrides={"trainer.max_epochs": "10"}
+            extra_overrides={"trainer.max_epochs": "40", "trainer.deterministic": "True"}
         ),
         DatasetTestCase(
             name="vitens_large",
             data_root="vitens_large",
             data_format="coco",
             num_classes=1,
-            extra_overrides={"trainer.max_epochs": "10"}
+            extra_overrides={"trainer.max_epochs": "40", "trainer.deterministic": "True"}
         )
     ]
 
@@ -325,6 +325,7 @@ class TestObjectDetection(BaseTest):
         fxt_dataset_root_dir: Path,
         fxt_tags: dict,
         fxt_num_repeat: int,
+        fxt_accelerator: str,
         tmpdir: pytest.TempdirFactory,
     ) -> None:
         self._test_regression(
@@ -333,5 +334,6 @@ class TestObjectDetection(BaseTest):
             fxt_dataset_root_dir=fxt_dataset_root_dir,
             fxt_tags=fxt_tags,
             fxt_num_repeat=fxt_num_repeat,
+            fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
         )


### PR DESCRIPTION
### Summary
Update for object detection regression test

1. Update total epoch 10 -> 40: This is average epochs of OTX1.x
2. Add deterministic
3. Add fxt_accelerator

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
