### PR TITLE
Update perf logging workflow to get branch+sha from gh context

### DIFF
--- a/.github/workflows/run_tests_in_tox.yml
+++ b/.github/workflows/run_tests_in_tox.yml
@@ -52,6 +52,8 @@ jobs:
         env:
           MLFLOW_TRACKING_SERVER_URI: ${{ vars.MLFLOW_TRACKING_SERVER_URI }}
           BENCHMARK_RESULTS_CLEAR: ${{ vars.BENCHMARK_RESULTS_CLEAR }}
+          GH_CTX_REF_NAME: ${{ github.ref_name }}
+          GH_CTX_SHA: ${{ github.sha  }}
         run: tox -vv -e tests-${{ inputs.toxenv-task }}-${{ inputs.toxenv-pyver }}-${{ inputs.toxenv-ptver }} -- ${{ inputs.tests-dir }}
       - name: Upload test results
         uses: actions/upload-artifact@v3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,13 +98,14 @@ def manage_tm_config_for_testing():
 
 @pytest.fixture(autouse=True, scope="session")
 def init_mlflow_tracking():
-    uri = os.environ.get("MLFLOW_TRACKING_SERVER_URI", "http://localhost:8080")
-    mlflow.set_tracking_uri(uri=uri)
+    uri = os.environ.get("MLFLOW_TRACKING_SERVER_URI")
+    if uri is not None:
+        mlflow.set_tracking_uri(uri=uri)
 
     yield
 
 
 @pytest.fixture(scope="session")
 def fxt_mlflow_client():
-    uri = os.environ.get("MLFLOW_TRACKING_SERVER_URI", "http://localhost:8080")
-    return mlflow.MlflowClient(uri)
+    uri = os.environ.get("MLFLOW_TRACKING_SERVER_URI")
+    return mlflow.MlflowClient(uri) if uri is not None else None

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,8 @@ passenv =
     {[testenv]passenv}
     MLFLOW_TRACKING_SERVER_URI
     BENCHMARK_RESULTS_CLEAR
+    GH_CTX_REF_NAME
+    GH_CTX_SHA
 commands =
     python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv {posargs:tests/integration/{[testenv]test_dir}}
 


### PR DESCRIPTION
### Summary

* removed "git" dependency for perf testing
* skipped perf results logging when server uri is not configured

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
