### PR TITLE
Add ImageColorChannel to ImageInfo

### DIFF
--- a/src/otx/config/data/default.yaml
+++ b/src/otx/config/data/default.yaml
@@ -3,6 +3,7 @@ data_root: ${base.data_dir}
 
 mem_cache_size: 1GB
 mem_cache_img_max_size: null
+image_color_channel: RGB
 
 train_subset:
   subset_name: train

--- a/src/otx/config/data/openvino.yaml
+++ b/src/otx/config/data/openvino.yaml
@@ -1,6 +1,8 @@
 defaults:
   - default
 
+image_color_channel: BGR
+
 train_subset:
   transform_lib_type: TORCHVISION
   transforms:

--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -7,6 +7,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from otx.core.types.image import ImageColorChannel
 from otx.core.types.transformer_libs import TransformLibType
 
 
@@ -36,6 +37,7 @@ class DataModuleConfig:
 
     mem_cache_size: str = "1GB"
     mem_cache_img_max_size: Optional[Tuple[int, int]] = None
+    image_color_channel: ImageColorChannel = ImageColorChannel.RGB
 
 
 @dataclass

--- a/src/otx/core/data/dataset/action_classification.py
+++ b/src/otx/core/data/dataset/action_classification.py
@@ -30,6 +30,7 @@ class OTXActionClsDataset(OTXDataset[ActionClsDataEntity]):
                 img_idx=idx,
                 img_shape=(0, 0),
                 ori_shape=(0, 0),
+                image_color_channel=self.image_color_channel,
             ),
             labels=torch.as_tensor([ann.label for ann in label_anns]),
         )

--- a/src/otx/core/data/dataset/action_detection.py
+++ b/src/otx/core/data/dataset/action_detection.py
@@ -45,6 +45,7 @@ class OTXActionDetDataset(OTXDataset[ActionDetDataEntity]):
                 img_idx=idx,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             bboxes=tv_tensors.BoundingBoxes(
                 bboxes,

--- a/src/otx/core/data/dataset/base.py
+++ b/src/otx/core/data/dataset/base.py
@@ -20,6 +20,7 @@ from torchvision.transforms.v2 import Compose
 
 from otx.core.data.entity.base import T_OTXDataEntity
 from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER
+from otx.core.types.image import ImageColorChannel
 
 if TYPE_CHECKING:
     from datumaro import DatasetSubset, Image
@@ -63,6 +64,7 @@ class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
         mem_cache_handler: MemCacheHandlerBase = NULL_MEM_CACHE_HANDLER,
         mem_cache_img_max_size: tuple[int, int] | None = None,
         max_refetch: int = 1000,
+        image_color_channel: ImageColorChannel = ImageColorChannel.RGB,
     ) -> None:
         self.dm_subset = dm_subset
         self.ids = [item.id for item in dm_subset]
@@ -70,6 +72,7 @@ class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
         self.mem_cache_handler = mem_cache_handler
         self.mem_cache_img_max_size = mem_cache_img_max_size
         self.max_refetch = max_refetch
+        self.image_color_channel = image_color_channel
 
         self.meta_info = LabelInfo(
             label_names=[category.name for category in self.dm_subset.categories()[AnnotationType.label]],
@@ -128,9 +131,7 @@ class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
         # There is an upcoming Datumaro patch here for this
         # https://github.com/openvinotoolkit/datumaro/pull/1194
         img_data = (
-            np.asarray(PILImage.open(BytesIO(img_bytes)).convert("RGB"))
-            if (img_bytes := img.bytes) is not None
-            else self._convert_to_rgb(img.data)
+            self._read_from_bytes(img_bytes) if (img_bytes := img.bytes) is not None else self._read_from_data(img.data)
         )
 
         if img_data is None:
@@ -141,17 +142,35 @@ class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
 
         return img_data, img_data.shape[:2]
 
-    @staticmethod
-    def _convert_to_rgb(img_data: np.ndarray | None) -> np.ndarray | None:
+    def _read_from_bytes(self, img_bytes: bytes) -> np.ndarray:
+        """Read an image from `img.bytes`."""
+        img_data = np.asarray(PILImage.open(BytesIO(img_bytes)).convert("RGB"))
+
+        if self.image_color_channel == ImageColorChannel.BGR:
+            return cv2.cvtColor(img_data, cv2.COLOR_RGB2BGR)
+
+        return img_data
+
+    def _read_from_data(self, img_data: np.ndarray | None) -> np.ndarray | None:
         """This function is required for `img.data` (not read by PIL)."""
         if img_data is None:
             return None
-        if img_data.shape[-1] == 4:
-            return cv2.cvtColor(img_data, cv2.COLOR_BGRA2RGB)
-        if len(img_data.shape) == 2:
-            return cv2.cvtColor(img_data, cv2.COLOR_GRAY2BGR)
 
-        return cv2.cvtColor(img_data, cv2.COLOR_BGR2RGB)
+        # TODO(vinnamki): dm.ImageFromData forces `img_data` to have `np.float32` type. #noqa: TD003
+        # This behavior will be removed in the Datumaro side.
+        if img_data.dtype == np.float32:
+            img_data = img_data.astype(np.uint8)
+
+        if img_data.shape[-1] == 4:
+            conversion = cv2.COLOR_BGRA2RGB if self.image_color_channel == ImageColorChannel.RGB else cv2.COLOR_BGRA2BGR
+            return cv2.cvtColor(img_data, conversion)
+        if len(img_data.shape) == 2:
+            conversion = cv2.COLOR_GRAY2RGB if self.image_color_channel == ImageColorChannel.RGB else cv2.COLOR_GRAY2BGR
+            return cv2.cvtColor(img_data, conversion)
+        if self.image_color_channel == ImageColorChannel.RGB:
+            return cv2.cvtColor(img_data, cv2.COLOR_BGR2RGB)
+
+        return img_data
 
     def _cache_img(self, key: str | int, img_data: np.ndarray) -> np.ndarray:
         """Cache an image after resizing.

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -52,6 +52,7 @@ class OTXMulticlassClsDataset(OTXDataset[MulticlassClsDataEntity]):
                 img_idx=index,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             labels=torch.as_tensor([ann.label for ann in label_anns]),
         )
@@ -85,6 +86,7 @@ class OTXMultilabelClsDataset(OTXDataset[MultilabelClsDataEntity]):
                 img_idx=index,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             labels=self._convert_to_onehot(labels),
         )
@@ -132,6 +134,7 @@ class OTXHlabelClsDataset(OTXDataset[HlabelClsDataEntity]):
                 img_idx=index,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             labels=torch.as_tensor(hlabel_labels),
         )

--- a/src/otx/core/data/dataset/detection.py
+++ b/src/otx/core/data/dataset/detection.py
@@ -40,6 +40,7 @@ class OTXDetectionDataset(OTXDataset[DetDataEntity]):
                 img_idx=index,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             bboxes=tv_tensors.BoundingBoxes(
                 bboxes,

--- a/src/otx/core/data/dataset/instance_segmentation.py
+++ b/src/otx/core/data/dataset/instance_segmentation.py
@@ -65,6 +65,7 @@ class OTXInstanceSegDataset(OTXDataset[InstanceSegDataEntity]):
                 img_idx=index,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             bboxes=tv_tensors.BoundingBoxes(
                 bboxes,

--- a/src/otx/core/data/dataset/segmentation.py
+++ b/src/otx/core/data/dataset/segmentation.py
@@ -39,6 +39,7 @@ class OTXSegmentationDataset(OTXDataset[SegDataEntity]):
                 img_idx=index,
                 img_shape=img_shape,
                 ori_shape=img_shape,
+                image_color_channel=self.image_color_channel,
             ),
             gt_seg_map=tv_tensors.Mask(
                 torch.as_tensor(mask_anns, dtype=torch.long),

--- a/src/otx/core/data/factory.py
+++ b/src/otx/core/data/factory.py
@@ -75,85 +75,52 @@ class OTXDatasetFactory:
     ) -> OTXDataset:
         """Create OTXDataset."""
         transforms = TransformLibFactory.generate(cfg_subset)
+        common_kwargs = {
+            "dm_subset": dm_subset,
+            "transforms": transforms,
+            "mem_cache_handler": mem_cache_handler,
+            "mem_cache_img_max_size": cfg_data_module.mem_cache_img_max_size,
+            "image_color_channel": cfg_data_module.image_color_channel,
+        }
         if task == OTXTaskType.MULTI_CLASS_CLS:
             from .dataset.classification import OTXMulticlassClsDataset
 
-            return OTXMulticlassClsDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXMulticlassClsDataset(**common_kwargs)
 
         if task == OTXTaskType.MULTI_LABEL_CLS:
             from .dataset.classification import OTXMultilabelClsDataset
 
-            return OTXMultilabelClsDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXMultilabelClsDataset(**common_kwargs)
 
         if task == OTXTaskType.H_LABEL_CLS:
             from .dataset.classification import OTXHlabelClsDataset
 
-            return OTXHlabelClsDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXHlabelClsDataset(**common_kwargs)
 
         if task == OTXTaskType.DETECTION:
             from .dataset.detection import OTXDetectionDataset
 
-            return OTXDetectionDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXDetectionDataset(**common_kwargs)
 
         if task == OTXTaskType.INSTANCE_SEGMENTATION:
             from .dataset.instance_segmentation import OTXInstanceSegDataset
 
             # NOTE: DataModuleConfig does not have include_polygons attribute
             include_polygons = getattr(cfg_data_module, "include_polygons", False)
-            return OTXInstanceSegDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-                include_polygons=include_polygons,
-            )
+            return OTXInstanceSegDataset(include_polygons=include_polygons, **common_kwargs)
 
         if task == OTXTaskType.SEMANTIC_SEGMENTATION:
             from .dataset.segmentation import OTXSegmentationDataset
 
-            return OTXSegmentationDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXSegmentationDataset(**common_kwargs)
 
         if task == OTXTaskType.ACTION_CLASSIFICATION:
             from .dataset.action_classification import OTXActionClsDataset
 
-            return OTXActionClsDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXActionClsDataset(**common_kwargs)
 
         if task == OTXTaskType.ACTION_DETECTION:
             from .dataset.action_detection import OTXActionDetDataset
 
-            return OTXActionDetDataset(
-                dm_subset=dm_subset,
-                transforms=transforms,
-                mem_cache_handler=mem_cache_handler,
-                mem_cache_img_max_size=cfg_data_module.mem_cache_img_max_size,
-            )
+            return OTXActionDetDataset(**common_kwargs)
         raise NotImplementedError(task)

--- a/src/otx/core/data/transform_libs/mmaction.py
+++ b/src/otx/core/data/transform_libs/mmaction.py
@@ -20,7 +20,6 @@ from torchvision import tv_tensors
 
 from otx.core.data.entity.action_classification import ActionClsDataEntity
 from otx.core.data.entity.action_detection import ActionDetDataEntity
-from otx.core.data.entity.base import ImageInfo
 from otx.core.utils.config import convert_conf_to_mmconfig_dict
 
 if TYPE_CHECKING:
@@ -182,15 +181,15 @@ class PackActionInputs(MMPackActionInputs):
         img_shape = data_samples.img_shape
         pad_shape = data_samples.metainfo.get("pad_shape", img_shape)
         scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
-        image_info = ImageInfo(
-            img_idx=0,
-            img_shape=img_shape,
-            ori_shape=ori_shape,
-            scale_factor=scale_factor,
-        )
-        image_info.pad_shape = pad_shape
 
         data_entity: ActionClsDataEntity | ActionDetDataEntity = results["__otx__"]
+
+        image_info = deepcopy(data_entity.img_info)
+        image_info.img_shape = img_shape
+        image_info.ori_shape = ori_shape
+        image_info.scale_factor = scale_factor
+        image_info.pad_shape = pad_shape
+
         labels = data_entity.labels
 
         if "gt_bboxes" in results:
@@ -220,8 +219,6 @@ class PackActionInputs(MMPackActionInputs):
             img_info=image_info,
             labels=labels,
         )
-
-        return data_entity
 
 
 class MMActionTransformLib:

--- a/src/otx/core/data/transform_libs/mmdet.py
+++ b/src/otx/core/data/transform_libs/mmdet.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Callable
 
 import numpy as np
@@ -102,14 +103,14 @@ class PackDetInputs(MMDetPackDetInputs):
         """Pack MMDet data entity into DetDataEntity."""
         transformed = super().transform(results)
         data_samples = transformed["data_samples"]
-        img_shape, ori_shape, pad_shape, scale_factor = self.extract_metadata(data_samples)
+        image_info = self.create_image_info(src_image_info=results["__otx__"].img_info, data_samples=data_samples)
 
-        bboxes = self.convert_bboxes(data_samples.gt_instances.bboxes, img_shape)
+        bboxes = self.convert_bboxes(data_samples.gt_instances.bboxes, image_info.img_shape)
         labels = data_samples.gt_instances.labels
 
         return DetDataEntity(
             image=tv_tensors.Image(transformed.get("inputs")),
-            img_info=self.create_image_info(0, img_shape, ori_shape, pad_shape, scale_factor),
+            img_info=image_info,
             bboxes=bboxes,
             labels=labels,
         )
@@ -118,11 +119,10 @@ class PackDetInputs(MMDetPackDetInputs):
         """Pack MMDet data entity into InstanceSegDataEntity."""
         transformed = super().transform(results)
         data_samples = transformed["data_samples"]
-        img_shape, ori_shape, pad_shape, scale_factor = self.extract_metadata(data_samples)
+        image_info = self.create_image_info(src_image_info=results["__otx__"].img_info, data_samples=data_samples)
 
-        bboxes = self.convert_bboxes(data_samples.gt_instances.bboxes, img_shape)
+        bboxes = self.convert_bboxes(data_samples.gt_instances.bboxes, image_info.img_shape)
         labels = data_samples.gt_instances.labels
-        image_info = self.create_image_info(0, img_shape, ori_shape, pad_shape, scale_factor)
 
         masks, polygons = self.convert_masks_and_polygons(data_samples.gt_instances.masks)
 
@@ -135,11 +135,12 @@ class PackDetInputs(MMDetPackDetInputs):
             polygons=polygons,
         )
 
-    def extract_metadata(
+    def create_image_info(
         self,
+        src_image_info: ImageInfo,
         data_samples: DetDataSample,
-    ) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int], tuple[float, float]]:
-        """Extract metadata from data_samples."""
+    ) -> ImageInfo:
+        """Create ImageInfo instance from data_samples."""
         # Some MM* transforms return (H, W, C), not (H, W)
         img_shape = data_samples.img_shape if len(data_samples.img_shape) == 2 else data_samples.img_shape[:2]
         ori_shape = data_samples.ori_shape if len(data_samples.ori_shape) == 2 else data_samples.ori_shape[:2]
@@ -147,7 +148,14 @@ class PackDetInputs(MMDetPackDetInputs):
         if len(pad_shape) == 3:
             pad_shape = pad_shape[:2]
         scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
-        return img_shape, ori_shape, pad_shape, scale_factor
+
+        image_info = deepcopy(src_image_info)
+        image_info.img_shape = img_shape
+        image_info.ori_shape = ori_shape
+        image_info.scale_factor = scale_factor
+        image_info.pad_shape = pad_shape
+
+        return image_info
 
     def convert_bboxes(self, original_bboxes: torch.Tensor, img_shape: tuple[int, int]) -> tv_tensors.BoundingBoxes:
         """Convert bounding boxes to tv_tensors.BoundingBoxes format."""
@@ -156,24 +164,6 @@ class PackDetInputs(MMDetPackDetInputs):
             format=tv_tensors.BoundingBoxFormat.XYXY,
             canvas_size=img_shape,
         )
-
-    def create_image_info(
-        self,
-        img_idx: int,
-        img_shape: tuple[int, int],
-        ori_shape: tuple[int, int],
-        pad_shape: tuple[int, int],
-        scale_factor: tuple[float, float],
-    ) -> ImageInfo:
-        """Create ImageInfo instance."""
-        image_info = ImageInfo(
-            img_idx=img_idx,
-            img_shape=img_shape,
-            ori_shape=ori_shape,
-            scale_factor=scale_factor,
-        )
-        image_info.pad_shape = pad_shape
-        return image_info
 
     def convert_masks_and_polygons(self, masks: BitmapMasks | PolygonMasks) -> tuple[tv_tensors.Mask, list[Polygon]]:
         """Convert masks and polygons to the desired format."""

--- a/src/otx/core/data/transform_libs/mmseg.py
+++ b/src/otx/core/data/transform_libs/mmseg.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Callable
 
 from mmseg.datasets.transforms import (
@@ -16,7 +17,6 @@ from mmseg.datasets.transforms import (
 from mmseg.registry import TRANSFORMS
 from torchvision import tv_tensors
 
-from otx.core.data.entity.base import ImageInfo
 from otx.core.data.entity.segmentation import SegDataEntity
 
 from .mmcv import MMCVTransformLib
@@ -59,16 +59,18 @@ class PackSegInputs(MMSegPackInputs):
         ori_shape = data_samples.ori_shape
         pad_shape = data_samples.metainfo.get("pad_shape", img_shape)
         scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
+
+        image_info = deepcopy(results["__otx__"].img_info)
+        image_info.img_shape = img_shape
+        image_info.ori_shape = ori_shape
+        image_info.scale_factor = scale_factor
+        image_info.pad_shape = pad_shape
+
         masks = data_samples.gt_sem_seg.data
 
         data_entity = SegDataEntity(
             image=image,
-            img_info=ImageInfo(
-                img_idx=0,
-                img_shape=img_shape,
-                ori_shape=ori_shape,
-                scale_factor=scale_factor,
-            ),
+            img_info=image_info,
             gt_seg_map=masks,
         )
         data_entity.img_info.pad_shape = pad_shape

--- a/src/otx/core/types/image.py
+++ b/src/otx/core/types/image.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""OTX image type definition."""
+
+from __future__ import annotations
+
+from enum import Enum, IntEnum, auto
+
+import numpy as np
+from torchvision import tv_tensors
+
+
+class ImageColorChannel(str, Enum):
+    """ImageColorChannel definition."""
+
+    RGB = "RGB"
+    BGR = "BGR"
+
+
+class ImageType(IntEnum):
+    """Enum to indicate the image type in `ImageInfo` class."""
+
+    NUMPY = auto()
+    TV_IMAGE = auto()
+    NUMPY_LIST = auto()
+    TV_IMAGE_LIST = auto()
+
+    @classmethod
+    def get_image_type(
+        cls,
+        image: np.ndarray | tv_tensors.Image | list[np.ndarray] | list[tv_tensors.Image],
+    ) -> ImageType:
+        """Infer the image type from the given image object."""
+        if isinstance(image, np.ndarray):
+            return ImageType.NUMPY
+        if isinstance(image, tv_tensors.Image):
+            return ImageType.TV_IMAGE
+        if isinstance(image, list):
+            image = next(iter(image))
+            if isinstance(image, np.ndarray):
+                return ImageType.NUMPY_LIST
+            if isinstance(image, tv_tensors.Image):
+                return ImageType.TV_IMAGE_LIST
+        raise TypeError(image)

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -42,6 +42,9 @@ def fxt_mem_cache_handler() -> MemCacheHandlerBase:
 @pytest.fixture(params=["bytes", "numpy"])
 def fxt_dm_item(request) -> DatasetItem:
     np_img = np.zeros(shape=(10, 10, 3), dtype=np.uint8)
+    np_img[:, :, 0] = 0  # Set 0 for B channel
+    np_img[:, :, 1] = 1  # Set 1 for G channel
+    np_img[:, :, 2] = 2  # Set 2 for R channel
 
     if request.param == "bytes":
         _, np_bytes = cv2.imencode(".png", np_img)

--- a/tests/unit/core/data/test_transform_libs.py
+++ b/tests/unit/core/data/test_transform_libs.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+import torch
 from omegaconf import OmegaConf
 from otx.core.data.transform_libs.torchvision import TorchVisionTransformLib
+from otx.core.types.image import ImageColorChannel
 from torchvision.transforms import v2
 
 
@@ -56,11 +58,16 @@ class TestTorchVisionTransformLib:
         item = dataset[0]
         assert isinstance(item, data_entity_cls)
 
+    @pytest.fixture(params=["RGB", "BGR"])
+    def fxt_image_color_channel(self, request) -> ImageColorChannel:
+        return ImageColorChannel(request.param)
+
     def test_image_info(
         self,
         fxt_config,
         fxt_dataset_and_data_entity_cls,
         fxt_mock_dm_subset,
+        fxt_image_color_channel,
     ) -> None:
         transform = TorchVisionTransformLib.generate(fxt_config)
         assert isinstance(transform, v2.Compose)
@@ -70,7 +77,21 @@ class TestTorchVisionTransformLib:
             dm_subset=fxt_mock_dm_subset,
             transforms=transform,
             mem_cache_img_max_size=None,
+            image_color_channel=fxt_image_color_channel,
         )
 
         item = dataset[0]
         assert item.img_info.img_shape == item.image.shape[1:]
+
+        if fxt_image_color_channel == ImageColorChannel.RGB:
+            r_pixel = 255.0 * (0.229 * item.image[0, 0, 0] + 0.485)
+            g_pixel = 255.0 * (0.224 * item.image[1, 0, 0] + 0.456)
+            b_pixel = 255.0 * (0.225 * item.image[2, 0, 0] + 0.406)
+        else:
+            b_pixel = 255.0 * (0.229 * item.image[0, 0, 0] + 0.485)
+            g_pixel = 255.0 * (0.224 * item.image[1, 0, 0] + 0.456)
+            r_pixel = 255.0 * (0.225 * item.image[2, 0, 0] + 0.406)
+
+        assert torch.allclose(r_pixel, torch.tensor(2.0))
+        assert torch.allclose(g_pixel, torch.tensor(1.0))
+        assert torch.allclose(b_pixel, torch.tensor(0.0))


### PR DESCRIPTION
### Summary

- Same as title
- By default, the OpenVINO data pipeline (`src/otx/config/data/openvino.yaml`) will use BGR color channel.

### How to test
Added an unit test for this change.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
