### PR TITLE
Fix multilabel training on non-trivial data

### DIFF
--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -93,7 +93,7 @@ class OTXMultilabelClsDataset(OTXDataset[MultilabelClsDataEntity]):
 
     def _convert_to_onehot(self, labels: torch.tensor) -> torch.tensor:
         """Convert label to one-hot vector format."""
-        return functional.one_hot(labels, self.num_classes).sum(0)
+        return functional.one_hot(labels, self.num_classes).sum(0).clamp_max_(1)
 
     @property
     def collate_fn(self) -> Callable:

--- a/src/otx/recipe/multilabel_classification/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/multilabel_classification/efficientnet_b0_light.yaml
@@ -11,29 +11,23 @@ data:
       - type: LoadImageFromFile
       - backend: cv2
         scale: 224
-        type: RandomResizedCrop
+        type: Resize
       - type: PackInputs
   val_subset:
     batch_size: 64
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
   test_subset:
     batch_size: 64
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
 model:
   otx_model:

--- a/src/otx/recipe/multilabel_classification/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/multilabel_classification/efficientnet_v2_light.yaml
@@ -11,7 +11,7 @@ data:
       - type: LoadImageFromFile
       - backend: cv2
         scale: 224
-        type: RandomResizedCrop
+        type: Resize
       - direction: horizontal
         prob: 0.5
         type: RandomFlip
@@ -21,22 +21,16 @@ data:
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
   test_subset:
     batch_size: 64
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
 model:
   otx_model:

--- a/src/otx/recipe/multilabel_classification/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/multilabel_classification/mobilenet_v3_large_light.yaml
@@ -11,7 +11,7 @@ data:
       - type: LoadImageFromFile
       - backend: cv2
         scale: 224
-        type: RandomResizedCrop
+        type: Resize
       - direction: horizontal
         prob: 0.5
         type: RandomFlip
@@ -21,22 +21,16 @@ data:
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
   test_subset:
     batch_size: 64
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
 model:
   otx_model:

--- a/src/otx/recipe/multilabel_classification/otx_deit_tiny.yaml
+++ b/src/otx/recipe/multilabel_classification/otx_deit_tiny.yaml
@@ -11,29 +11,23 @@ data:
       - type: LoadImageFromFile
       - backend: cv2
         scale: 224
-        type: RandomResizedCrop
+        type: Resize
       - type: PackInputs
   val_subset:
     batch_size: 64
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
   test_subset:
     batch_size: 64
     transforms:
       - type: LoadImageFromFile
       - backend: cv2
-        edge: short
-        scale: 256
-        type: ResizeEdge
-      - crop_size: 224
-        type: CenterCrop
+        scale: 224
+        type: Resize
       - type: PackInputs
 model:
   otx_model:


### PR DESCRIPTION
### Summary
- Fix one-hot preparation: .sum(0) gives number of instances for each class instead of 0/1 values
- In ml-cls we suppose multiple objects to be located anywhere on an input image, therefore center crop augmentation is not suitable for test -> therefore we have also delete this on training to preserve objects scale


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
