### PR TITLE
Update ignored scope for hrent_18_mod2

### DIFF
--- a/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/compression_config.json
+++ b/src/otx/algorithms/segmentation/configs/ocr_lite_hrnet_18_mod2/compression_config.json
@@ -35,8 +35,8 @@
             }
           },
           "ignored_scopes": [
-            "{re}.*cross_resolution_weighting.*__mul__.*",
-            "{re}.*spatial_weighting.*__mul__.*"
+            "{re}.*backbone*",
+            "{re}.*aggregator*"
           ]
         }
       ],


### PR DESCRIPTION
### Summary

Set full ignored scope to hrnet_18_mod2 NNCF Accuracy Aware Training config. 

This is done because at the moment it's not possible to precisely control the resulting accuracy of the returned quantized model: the validation function provided for early stopping to NNCF AAT is not aligned with the evaluation function used for obtaining the final model score. That's why even if the resulting model is within 1% accuracy drop based on validation metric, it doesn't necessarily mean that it will be within 1% accuracy drop based on evaluation metric.

Ticket 129044.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
