### PR TITLE
Accept a list of tvt_v2.Transform or tvt_v2.Compose Python object for data pipeline

### DIFF
--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -14,7 +14,7 @@ from otx.core.types.image import ImageColorChannel
 from otx.core.types.transformer_libs import TransformLibType
 
 if TYPE_CHECKING:
-    from torchvision.transforms.v2 import Transform
+    from torchvision.transforms.v2 import Compose, Transform
 
 
 @dataclass
@@ -26,17 +26,36 @@ class SubsetConfig:
         subset_name: Datumaro Dataset's subset name for this subset config.
             It can differ from the actual usage (e.g., 'val' for the validation subset config).
         transforms: List of actually used transforms.
-            It accepts `torchvision.transforms.v2.*` Python objects for `TransformLibType.TORCHVISION`.
+            It accepts a list of `torchvision.transforms.v2.*` Python objects
+            or `torchvision.transforms.v2.Compose` for `TransformLibType.TORCHVISION`.
             Otherwise, it takes a Python dictionary that fits the configuration style used in mmcv
             (`TransformLibType.MMCV`, `TransformLibType.MMPRETRAIN`, ...).
         transform_lib_type: Transform library type used by this subset.
         num_workers: Number of workers for the dataloader of this subset.
+
+    Example:
+        ```python
+        train_subset_config = SubsetConfig(
+            batch_size=64,
+            subset_name="train",
+            transforms=v2.Compose(
+                [
+                    v2.RandomResizedCrop(size=(224, 224), antialias=True),
+                    v2.RandomHorizontalFlip(p=0.5),
+                    v2.ToDtype(torch.float32, scale=True),
+                    v2.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+                ],
+            )
+            transform_lib_type=TransformLibType.TORCHVISION,
+            num_workers=2,
+        )
+        ```
     """
 
     batch_size: int
     subset_name: str
 
-    transforms: list[dict[str, Any] | Transform]
+    transforms: list[dict[str, Any] | Transform] | Compose
 
     transform_lib_type: TransformLibType = TransformLibType.TORCHVISION
     num_workers: int = 2

--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -4,23 +4,41 @@
 """Config data type objects for data."""
 # NOTE: omegaconf would fail to parse dataclass with `from __future__ import annotations` in Python 3.8, 3.9
 # ruff: noqa: FA100
+
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 from otx.core.types.image import ImageColorChannel
 from otx.core.types.transformer_libs import TransformLibType
 
+if TYPE_CHECKING:
+    from torchvision.transforms.v2 import Transform
+
 
 @dataclass
 class SubsetConfig:
-    """DTO for dataset subset configuration."""
+    """DTO for dataset subset configuration.
+
+    Attributes:
+        batch_size: Batch size produced.
+        subset_name: Datumaro Dataset's subset name for this subset config.
+            It can differ from the actual usage (e.g., 'val' for the validation subset config).
+        transforms: List of actually used transforms.
+            It accepts `torchvision.transforms.v2.*` Python objects for `TransformLibType.TORCHVISION`.
+            Otherwise, it takes a Python dictionary that fits the configuration style used in mmcv
+            (`TransformLibType.MMCV`, `TransformLibType.MMPRETRAIN`, ...).
+        transform_lib_type: Transform library type used by this subset.
+        num_workers: Number of workers for the dataloader of this subset.
+    """
 
     batch_size: int
     subset_name: str
 
-    transform_lib_type: TransformLibType
-    transforms: List[Dict[str, Any]]
+    transforms: list[dict[str, Any] | Transform]
 
+    transform_lib_type: TransformLibType = TransformLibType.TORCHVISION
     num_workers: int = 2
 
 
@@ -29,7 +47,7 @@ class TilerConfig:
     """DTO for tiler configuration."""
 
     enable_tiler: bool = False
-    grid_size: Tuple[int, int] = (2, 2)
+    grid_size: tuple[int, int] = (2, 2)
     overlap: float = 0.0
 
 
@@ -47,7 +65,7 @@ class DataModuleConfig:
     tile_config: TilerConfig
 
     mem_cache_size: str = "1GB"
-    mem_cache_img_max_size: Optional[Tuple[int, int]] = None
+    mem_cache_img_max_size: Optional[tuple[int, int]] = None
     image_color_channel: ImageColorChannel = ImageColorChannel.RGB
 
     include_polygons: bool = False

--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -8,13 +8,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 from otx.core.types.image import ImageColorChannel
 from otx.core.types.transformer_libs import TransformLibType
-
-if TYPE_CHECKING:
-    from torchvision.transforms.v2 import Compose, Transform
 
 
 @dataclass
@@ -22,16 +19,16 @@ class SubsetConfig:
     """DTO for dataset subset configuration.
 
     Attributes:
-        batch_size: Batch size produced.
-        subset_name: Datumaro Dataset's subset name for this subset config.
+        batch_size (int): Batch size produced.
+        subset_name (str): Datumaro Dataset's subset name for this subset config.
             It can differ from the actual usage (e.g., 'val' for the validation subset config).
-        transforms: List of actually used transforms.
+        transforms (list[dict[str, Any] | Transform] | Compose): List of actually used transforms.
             It accepts a list of `torchvision.transforms.v2.*` Python objects
             or `torchvision.transforms.v2.Compose` for `TransformLibType.TORCHVISION`.
             Otherwise, it takes a Python dictionary that fits the configuration style used in mmcv
             (`TransformLibType.MMCV`, `TransformLibType.MMPRETRAIN`, ...).
-        transform_lib_type: Transform library type used by this subset.
-        num_workers: Number of workers for the dataloader of this subset.
+        transform_lib_type (TransformLibType): Transform library type used by this subset.
+        num_workers (int): Number of workers for the dataloader of this subset.
 
     Example:
         ```python
@@ -55,7 +52,9 @@ class SubsetConfig:
     batch_size: int
     subset_name: str
 
-    transforms: list[dict[str, Any] | Transform] | Compose
+    # TODO (vinnamki): Revisit data configuration objects to support a union type in structured config # noqa: TD003
+    # Omegaconf does not allow to have a union type, https://github.com/omry/omegaconf/issues/144
+    transforms: list[dict[str, Any]]
 
     transform_lib_type: TransformLibType = TransformLibType.TORCHVISION
     num_workers: int = 2

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -117,7 +117,7 @@ class TorchVisionTransformLib:
 
         transforms = []
         for cfg_transform in config.transforms:
-            if isinstance(cfg_transform, dict | DictConfig):
+            if isinstance(cfg_transform, (DictConfig, dict)):
                 transform = instantiate_class(args=(), init=cfg_transform)
             elif isinstance(cfg_transform, tvt_v2.Transform):
                 transform = cfg_transform

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 import torchvision.transforms.v2 as tvt_v2
 from lightning.pytorch.cli import instantiate_class
+from omegaconf import DictConfig
 from torchvision import tv_tensors
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
@@ -115,8 +116,19 @@ class TorchVisionTransformLib:
         availables = set(cls.list_available_transforms())
 
         transforms = []
-        for cfg in config.transforms:
-            transform = instantiate_class(args=(), init=cfg)
+        for cfg_transform in config.transforms:
+            if isinstance(cfg_transform, dict | DictConfig):
+                transform = instantiate_class(args=(), init=cfg_transform)
+            elif isinstance(cfg_transform, tvt_v2.Transform):
+                transform = cfg_transform
+            else:
+                msg = (
+                    "TorchVisionTransformLib accepts only two types "
+                    "for config.transforms: dict | tvt_v2.Transform. "
+                    f"However, its type is {type(transform)}."
+                )
+                raise TypeError(msg)
+
             if type(transform) not in availables:
                 msg = f"transform={transform} is not a valid TorchVision V2 transform"
                 raise ValueError(msg)

--- a/tests/unit/core/data/test_transform_libs.py
+++ b/tests/unit/core/data/test_transform_libs.py
@@ -106,7 +106,7 @@ class TestResizetoLongestEdge:
 
 
 class TestTorchVisionTransformLib:
-    @pytest.fixture(params=[True, False], ids=["from_dict", "from_obj"])
+    @pytest.fixture(params=["from_dict", "from_obj"])
     def fxt_config(self, request) -> list[dict[str, Any]]:
         # >>> transforms = v2.Compose([
         # >>>     v2.RandomResizedCrop(size=(224, 224), antialias=True),
@@ -134,14 +134,13 @@ class TestTorchVisionTransformLib:
                 std: [0.229, 0.224, 0.225]
         """
         created = OmegaConf.create(cfg)
-        if request.param:
-            return created
-
-        return SubsetConfig(
-            batch_size=1,
-            subset_name="dummy",
-            transforms=[instantiate_class(args=(), init=transform) for transform in created.transforms],
-        )
+        if request.param == "from_obj":
+            return SubsetConfig(
+                batch_size=1,
+                subset_name="dummy",
+                transforms=[instantiate_class(args=(), init=transform) for transform in created.transforms],
+            )
+        return created
 
     def test_transform(
         self,

--- a/tests/unit/core/data/test_transform_libs.py
+++ b/tests/unit/core/data/test_transform_libs.py
@@ -7,7 +7,9 @@ from typing import Any
 
 import pytest
 import torch
+from lightning.pytorch.cli import instantiate_class
 from omegaconf import OmegaConf
+from otx.core.config.data import SubsetConfig
 from otx.core.data.transform_libs.torchvision import (
     PadtoSquare,
     PerturbBoundingBoxes,
@@ -104,8 +106,8 @@ class TestResizetoLongestEdge:
 
 
 class TestTorchVisionTransformLib:
-    @pytest.fixture()
-    def fxt_config(self) -> list[dict[str, Any]]:
+    @pytest.fixture(params=[True, False], ids=["from_dict", "from_obj"])
+    def fxt_config(self, request) -> list[dict[str, Any]]:
         # >>> transforms = v2.Compose([
         # >>>     v2.RandomResizedCrop(size=(224, 224), antialias=True),
         # >>>     v2.RandomHorizontalFlip(p=0.5),
@@ -131,7 +133,15 @@ class TestTorchVisionTransformLib:
                 mean: [0.485, 0.456, 0.406]
                 std: [0.229, 0.224, 0.225]
         """
-        return OmegaConf.create(cfg)
+        created = OmegaConf.create(cfg)
+        if request.param:
+            return created
+
+        return SubsetConfig(
+            batch_size=1,
+            subset_name="dummy",
+            transforms=[instantiate_class(args=(), init=transform) for transform in created.transforms],
+        )
 
     def test_transform(
         self,

--- a/tests/unit/core/data/test_transform_libs.py
+++ b/tests/unit/core/data/test_transform_libs.py
@@ -106,14 +106,17 @@ class TestResizetoLongestEdge:
 
 
 class TestTorchVisionTransformLib:
-    @pytest.fixture(params=["from_dict", "from_obj"])
+    @pytest.fixture(params=["from_dict", "from_list", "from_compose"])
     def fxt_config(self, request) -> list[dict[str, Any]]:
-        # >>> transforms = v2.Compose([
-        # >>>     v2.RandomResizedCrop(size=(224, 224), antialias=True),
-        # >>>     v2.RandomHorizontalFlip(p=0.5),
-        # >>>     v2.ToDtype(torch.float32, scale=True),
-        # >>>     v2.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        # >>> ])
+        if request.param == "from_compose":
+            return v2.Compose(
+                [
+                    v2.RandomResizedCrop(size=(224, 224), antialias=True),
+                    v2.RandomHorizontalFlip(p=0.5),
+                    v2.ToDtype(torch.float32, scale=True),
+                    v2.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+                ],
+            )
         prefix = "torchvision.transforms.v2"
         cfg = f"""
         transforms:


### PR DESCRIPTION
### Summary

- This is a request from @MarkByun. Now, Python API users can inject a list of `tvt_v2.Transform` Python objects or a `tvt_v2.Compose` Python object into `OTXDataModule` rather than MM-style configuration.

### How to test
Updated our existing tests for this change as well.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
