### PR TITLE
Add list_models function to return a list of OTX available models & 'otx find' CLI command

### DIFF
--- a/src/otx/engine/utils/api.py
+++ b/src/otx/engine/utils/api.py
@@ -1,0 +1,71 @@
+"""OTX APIs for User-friendliness."""
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+from otx.core.utils.imports import get_otx_root_path
+
+RECIPE_PATH = get_otx_root_path() / "recipe"
+
+
+def list_models(task: str | None = None, pattern: str | None = None, print_table: bool = False) -> list[str]:
+    """Returns a list of available models for training.
+
+    Args:
+        task (str | None, optional): Recipe Filter by Task.
+        pattern (Optional[str], optional): A string pattern to filter the list of available models. Defaults to None.
+        print_table (bool, optional): Output the recipe information as a Rich.Table.
+            This is primarily used for `otx find` in the CLI.
+
+    Returns:
+        list[str]: A list of available models for pretraining.
+
+    Example:
+        # Return all available model list.
+        >>> models = list_models()
+        >>> models
+        ['atss_mobilenetv2', 'atss_r50_fpn', ...]
+
+        # Return INSTANCE_SEGMENTATION model list.
+        >>> models = list_models(task="INSTANCE_SEGMENTATION")
+        >>> models
+        ['maskrcnn_efficientnetb2b', 'maskrcnn_r50', 'maskrcnn_swint', 'openvino_model']
+
+        # Return all available model list that matches the pattern.
+        >>> models = list_models(task="MULTI_CLASS_CLS", pattern="*efficient")
+        >>> models
+        ['otx_efficientnet_b0', 'efficientnet_v2_light', 'efficientnet_b0_light', ...]
+
+        # Print the recipe information as a Rich.Table (include task, model name, recipe path)
+        >>> models = list_models(task="MULTI_CLASS_CLS", pattern="*efficient", print_table=True)
+    """
+    task = task.lower() if task is not None else "**"
+    recipe_list = [str(recipe) for recipe in RECIPE_PATH.glob(f"**/{task}/*.yaml") if "_base_" not in recipe.parts]
+
+    if pattern is not None:
+        # Always match keys with any postfix.
+        recipe_list = list(set(fnmatch.filter(recipe_list, f"*{pattern}*")))
+
+    if print_table:
+        from rich.console import Console
+        from rich.table import Table
+
+        console = Console()
+        table = Table(title="OTX Recipes", show_header=True, header_style="bold magenta")
+        table.add_column("Task")
+        table.add_column("Model Name")
+        table.add_column("Recipe Path")
+        for recipe in recipe_list:
+            table.add_row(
+                recipe.split("/")[-2].upper(),
+                Path(recipe).stem,
+                recipe,
+            )
+        console.print(table)
+
+    return list({Path(recipe).stem for recipe in recipe_list})

--- a/src/otx/engine/utils/api.py
+++ b/src/otx/engine/utils/api.py
@@ -46,7 +46,7 @@ def list_models(task: OTXTaskType | None = None, pattern: str | None = None, pri
         # Print the recipe information as a Rich.Table (include task, model name, recipe path)
         >>> models = list_models(task="MULTI_CLASS_CLS", pattern="*efficient", print_table=True)
     """
-    task_type = task.name.lower() if task is not None else "**"
+    task_type = OTXTaskType(task).name.lower() if task is not None else "**"
     recipe_list = [str(recipe) for recipe in RECIPE_PATH.glob(f"**/{task_type}/*.yaml") if "_base_" not in recipe.parts]
 
     if pattern is not None:

--- a/src/otx/engine/utils/api.py
+++ b/src/otx/engine/utils/api.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import fnmatch
+import textwrap
 from pathlib import Path
 
 from otx.core.utils.imports import get_otx_root_path
@@ -61,11 +62,14 @@ def list_models(task: str | None = None, pattern: str | None = None, print_table
         table.add_column("Model Name")
         table.add_column("Recipe Path")
         for recipe in recipe_list:
+            recipe_path = (
+                textwrap.fill(recipe, width=int(console.width / 2)) if len(recipe) > console.width / 2 else recipe
+            )
             table.add_row(
                 recipe.split("/")[-2].upper(),
                 Path(recipe).stem,
-                recipe,
+                recipe_path,
             )
-        console.print(table)
+        console.print(table, width=console.width, justify="center")
 
     return list({Path(recipe).stem for recipe in recipe_list})

--- a/src/otx/engine/utils/api.py
+++ b/src/otx/engine/utils/api.py
@@ -9,16 +9,17 @@ import fnmatch
 import textwrap
 from pathlib import Path
 
+from otx.core.types.task import OTXTaskType
 from otx.core.utils.imports import get_otx_root_path
 
 RECIPE_PATH = get_otx_root_path() / "recipe"
 
 
-def list_models(task: str | None = None, pattern: str | None = None, print_table: bool = False) -> list[str]:
+def list_models(task: OTXTaskType | None = None, pattern: str | None = None, print_table: bool = False) -> list[str]:
     """Returns a list of available models for training.
 
     Args:
-        task (str | None, optional): Recipe Filter by Task.
+        task (OTXTaskType | None, optional): Recipe Filter by Task.
         pattern (Optional[str], optional): A string pattern to filter the list of available models. Defaults to None.
         print_table (bool, optional): Output the recipe information as a Rich.Table.
             This is primarily used for `otx find` in the CLI.
@@ -45,8 +46,8 @@ def list_models(task: str | None = None, pattern: str | None = None, print_table
         # Print the recipe information as a Rich.Table (include task, model name, recipe path)
         >>> models = list_models(task="MULTI_CLASS_CLS", pattern="*efficient", print_table=True)
     """
-    task = task.lower() if task is not None else "**"
-    recipe_list = [str(recipe) for recipe in RECIPE_PATH.glob(f"**/{task}/*.yaml") if "_base_" not in recipe.parts]
+    task_type = task.name.lower() if task is not None else "**"
+    recipe_list = [str(recipe) for recipe in RECIPE_PATH.glob(f"**/{task_type}/*.yaml") if "_base_" not in recipe.parts]
 
     if pattern is not None:
         # Always match keys with any postfix.

--- a/tests/unit/engine/utils/test_api.py
+++ b/tests/unit/engine/utils/test_api.py
@@ -13,11 +13,12 @@ def test_list_models() -> None:
 
 @pytest.mark.parametrize("task", [task.value for task in OTXTaskType])
 def test_list_models_per_task(task: str) -> None:
-    if task.endswith("CLS"):
-        task = "classification/" + task
-    elif task.startswith("ACTION"):
-        task = "action/" + task
-    target_dir = RECIPE_PATH / task.lower()
+    task_dir = task
+    if task_dir.endswith("CLS"):
+        task_dir = "classification/" + task_dir
+    elif task_dir.startswith("ACTION"):
+        task_dir = "action/" + task_dir
+    target_dir = RECIPE_PATH / task_dir.lower()
     target_recipes = [str(recipe.stem) for recipe in target_dir.glob("**/*.yaml")]
 
     models = list_models(task=task)

--- a/tests/unit/engine/utils/test_api.py
+++ b/tests/unit/engine/utils/test_api.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from otx.core.types.task import OTXTaskType
+from otx.engine.utils.api import RECIPE_PATH, list_models
+
+
+def test_list_models() -> None:
+    models = list_models()
+    assert len(models) >= 32
+
+
+@pytest.mark.parametrize("task", [task.value for task in OTXTaskType])
+def test_list_models_per_task(task: str) -> None:
+    if task.endswith("CLS"):
+        task = "classification/" + task
+    elif task.startswith("ACTION"):
+        task = "action/" + task
+    target_dir = RECIPE_PATH / task.lower()
+    target_recipes = [str(recipe.stem) for recipe in target_dir.glob("**/*.yaml")]
+
+    models = list_models(task=task)
+    assert sorted(models) == sorted(target_recipes)
+
+
+def test_list_models_pattern() -> None:
+    models = list_models(pattern="efficient")
+
+    target = [
+        "efficientnet_v2_light",
+        "efficientnet_b0_light",
+        "maskrcnn_efficientnetb2b",
+        "otx_efficientnet_v2",
+        "otx_efficientnet_b0",
+    ]
+    assert sorted(models) == sorted(target)
+
+
+def test_list_models_print_table(capfd: pytest.CaptureFixture) -> None:
+    list_models(pattern="otx_efficient", print_table=True)
+
+    out, _ = capfd.readouterr()
+    assert "Task" in out
+    assert "Model Name" in out
+    assert "Recipe Path" in out
+    assert "otx_efficientnet_b0" in out
+    assert "otx_efficientnet_v2" in out


### PR DESCRIPTION
### Summary

- Add `list_models()` for showing available OTX models.
This allows API users to use the model provided by auto-configuration by selecting a different recipe provided by OTX.
- Add `otx find` to use list_models and print Recipe tables.
This allows CLI users to get information about the location of available configuration files provided by OTX.



### Use-Case
1. list_models() & Training with Engine API
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/4eff8668-8e18-4c62-a210-84768b22b886)

2. `otx find` CLI commands
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/235260cc-90e3-4927-b95e-295a810547cf)
*Refer: Training from model name in CLI is not working for now.

### How to test

`python -m pytest tests/unit/engine/utils/test_api.py`
`otx find`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
