### PR TITLE
Add auto-config num_classes in CLI side

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -119,8 +119,11 @@ class OTXCLI:
             help="The metric to monitor the model performance during training callbacks.",
         )
         parser.add_argument(
-            "--no-update-num-classes",
-            help="This disables the ability to update the model with the num_classes in the dataset.",
+            "--disable-infer-num-classes",
+            help="OTX automatically infers num_classes from the given dataset "
+            "and applies it to the model initialization."
+            "Consequently, there might be a mismatch with the provided model configuration during runtime. "
+            "Setting this option to true will disable this behavior.",
             action="store_true",
         )
         engine_skip = {"model", "datamodule", "optimizer", "scheduler"}
@@ -316,7 +319,7 @@ class OTXCLI:
         from otx.engine.utils.auto_configurator import get_num_classes_from_meta_info
 
         # Update num_classes
-        if not self.get_config_value(self.config_init, "no_update_num_classes", False):
+        if not self.get_config_value(self.config_init, "disable_infer_num_classes", False):
             num_classes = get_num_classes_from_meta_info(task=self.datamodule.task, meta_info=self.datamodule.meta_info)
             if num_classes != model_config.init_args.num_classes:
                 warning_msg = (

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -245,7 +245,7 @@ def get_configuration(config_path: str | Path) -> dict:
     logger.info(f"{config_path} is loaded.")
 
     # Remove unnecessary cli arguments for API usage
-    cli_args = ["verbose", "data_root", "task", "seed", "callback_monitor", "resume"]
+    cli_args = ["verbose", "data_root", "task", "seed", "callback_monitor", "resume", "no_update_num_classes"]
     logger.warning(f"The corresponding keys in config are not used.: {cli_args}")
     for arg in cli_args:
         config.pop(arg, None)

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -245,7 +245,7 @@ def get_configuration(config_path: str | Path) -> dict:
     logger.info(f"{config_path} is loaded.")
 
     # Remove unnecessary cli arguments for API usage
-    cli_args = ["verbose", "data_root", "task", "seed", "callback_monitor", "resume", "no_update_num_classes"]
+    cli_args = ["verbose", "data_root", "task", "seed", "callback_monitor", "resume", "disable_infer_num_classes"]
     logger.warning(f"The corresponding keys in config are not used.: {cli_args}")
     for arg in cli_args:
         config.pop(arg, None)

--- a/tests/integration/cli/test_auto_configuration.py
+++ b/tests/integration/cli/test_auto_configuration.py
@@ -10,27 +10,6 @@ from otx.cli import main
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
 
-# [TODO]: Please Remove this with auto num_classes update feature in CLI
-@pytest.fixture()
-def fxt_cli_override_command_per_task() -> dict:
-    return {
-        "multi_class_cls": ["--model.num_classes", "2"],
-        "multi_label_cls": ["--model.num_classes", "2"],
-        "detection": ["--model.num_classes", "3"],
-        "instance_segmentation": ["--model.num_classes", "3"],
-        "semantic_segmentation": ["--model.num_classes", "2"],
-        "action_classification": ["--model.num_classes", "2"],
-        "action_detection": [
-            "--model.num_classes",
-            "5",
-            "--model.topk",
-            "3",
-        ],
-        "visual_prompting": [],
-        "zero_shot_visual_prompting": ["--max_epochs", "1"],
-    }
-
-
 @pytest.mark.parametrize("task", [task.value.lower() for task in DEFAULT_CONFIG_PER_TASK])
 def test_otx_cli_auto_configuration(
     task: str,

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -258,6 +258,7 @@ def test_otx_ov_test(recipe: str, tmp_path: Path, fxt_target_dataset_per_task: d
         str(tmp_path_test / "outputs"),
         "--engine.device",
         "cpu",
+        "--no-update-num-classes",
     ]
 
     with patch("sys.argv", command_cfg):

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -258,7 +258,7 @@ def test_otx_ov_test(recipe: str, tmp_path: Path, fxt_target_dataset_per_task: d
         str(tmp_path_test / "outputs"),
         "--engine.device",
         "cpu",
-        "--no-update-num-classes",
+        "--disable-infer-num-classes",
     ]
 
     with patch("sys.argv", command_cfg):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -60,6 +60,6 @@ def fxt_cli_override_command_per_task() -> dict:
         "zero_shot_visual_prompting": [
             "--max_epochs",
             "1",
-            "--no-update-num-classes",
+            "--disable-infer-num-classes",
         ],
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -57,5 +57,9 @@ def fxt_cli_override_command_per_task() -> dict:
             "3",
         ],
         "visual_prompting": [],
-        "zero_shot_visual_prompting": [],
+        "zero_shot_visual_prompting": [
+            "--max_epochs",
+            "1",
+            "--no-update-num-classes",
+        ],
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -40,23 +40,19 @@ def fxt_target_dataset_per_task() -> dict:
 @pytest.fixture()
 def fxt_cli_override_command_per_task() -> dict:
     return {
-        "multi_class_cls": ["--model.num_classes", "2"],
-        "multi_label_cls": ["--model.num_classes", "2"],
+        "multi_class_cls": [],
+        "multi_label_cls": [],
         "h_label_cls": [
-            "--model.num_classes",
-            "7",
             "--model.num_multiclass_heads",
             "2",
             "--model.num_multilabel_classes",
             "3",
         ],
-        "detection": ["--model.num_classes", "3"],
-        "instance_segmentation": ["--model.num_classes", "3"],
-        "semantic_segmentation": ["--model.num_classes", "2"],
-        "action_classification": ["--model.num_classes", "2"],
+        "detection": [],
+        "instance_segmentation": [],
+        "semantic_segmentation": [],
+        "action_classification": [],
         "action_detection": [
-            "--model.num_classes",
-            "5",
             "--model.topk",
             "3",
         ],


### PR DESCRIPTION
### Summary

- Add the ability to automatically update the `model.num_classes` in the CLI to match the `datamodule`.
- Instantiate the model separately in the CLI.
- Add the `--no-update-num-classes` argument to disable the feature if needed.

Before: `model.num_classes` was a required element.
```shell
otx train --config <CONFIG> --data_root <DATASET> --model.num_classes <NUM_CLASSES>
```
After: don't need to update `model.num_classes` separately.
```shell
otx train --config <CONFIG> --data_root <DATASET>
>>> UserWarning: The `num_classes` in dataset is 2 but, the `num_classes` of model is 1000. So, Update `model.num_classes` to 2.
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
