### PR TITLE
Add help verbosity with export & explain

### DIFF
--- a/src/otx/cli/utils/help_formatter.py
+++ b/src/otx/cli/utils/help_formatter.py
@@ -21,17 +21,40 @@ if TYPE_CHECKING:
 
 
 BASE_ARGUMENTS = {"config", "print_config", "help", "engine", "model", "model.help", "task"}
-ENGINE_ARGUMENTS = {"data_root", "engine.help", "engine.device", "engine.checkpoint", "engine.work_dir"}
+ENGINE_ARGUMENTS = {"data_root", "engine.help", "engine.device", "engine.work_dir"}
 REQUIRED_ARGUMENTS = {
     "train": {
         "data",
         "optimizer",
         "scheduler",
+        "engine.checkpoint",
         *BASE_ARGUMENTS,
         *ENGINE_ARGUMENTS,
     },
     "test": {
         "data",
+        "checkpoint",
+        *BASE_ARGUMENTS,
+        *ENGINE_ARGUMENTS,
+    },
+    "predict": {
+        "data",
+        "checkpoint",
+        "return_predictions",
+        *BASE_ARGUMENTS,
+        *ENGINE_ARGUMENTS,
+    },
+    "export": {
+        "checkpoint",
+        "export_format",
+        "export_precision",
+        *BASE_ARGUMENTS,
+        *ENGINE_ARGUMENTS,
+    },
+    "explain": {
+        "data",
+        "checkpoint",
+        "explain_config",
         *BASE_ARGUMENTS,
         *ENGINE_ARGUMENTS,
     },

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -327,7 +327,7 @@ class Engine:
             1. you can pick a model.
                 ```python
                 otx predict
-                    --model <CONFIG | CLASS_PATH_OR_NAME> --data_root <DATASET_PATH, str>
+                    --config <CONFIG_PATH> --data_root <DATASET_PATH, str>
                     --checkpoint <CKPT_PATH, str>
                 ```
             2. If you have a ready configuration file, run it like this.
@@ -377,8 +377,14 @@ class Engine:
             1. To export a model, run
                 ```python
                 otx export
-                    --model <CONFIG | CLASS_PATH_OR_NAME> --data_root <DATASET_PATH, str>
-                    --checkpoint <CKPT_PATH, str> --export_precision FP32 --export_format ONNX
+                    --config <CONFIG_PATH> --data_root <DATASET_PATH, str>
+                    --checkpoint <CKPT_PATH, str>
+                ```
+            2. To export a model with precison FP16 and format ONNX, run
+                ```python
+                otx export
+                    --config <CONFIG_PATH> --data_root <DATASET_PATH, str>
+                    --checkpoint <CKPT_PATH, str> --export_precision FP16 --export_format ONNX
                 ```
         """
         ckpt_path = str(checkpoint) if checkpoint is not None else self.checkpoint
@@ -429,6 +435,14 @@ class Engine:
             ...     checkpoint=<checkpoint/path>,
             ...     explain_config=ExplainConfig(),
             ... )
+
+        CLI Usage:
+            1. To run XAI using the specified model, run
+                ```python
+                otx explain
+                    --config <CONFIG_PATH> --data_root <DATASET_PATH, str>
+                    --checkpoint <CKPT_PATH, str>
+                ```
         """
         import cv2
 


### PR DESCRIPTION
### Summary

- Set Verbosity-Help Formatter with `otx export` & `explain`

Before
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/4045afb9-3085-4c5f-adde-85dc19429064)

After
- Verbosity Level 0
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/a379974a-dab5-4c94-aadb-55e493ffd8f0)
- Verbosity Level 1
<img width="931" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/38045080/0f0902dd-8b97-4690-9662-21219b949c55">

- Verbosity Level 2 == before

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
