### PR TITLE
Set default wf permission to read-all

### DIFF
--- a/.github/workflows/code_scan.yml
+++ b/.github/workflows/code_scan.yml
@@ -6,6 +6,9 @@ on:
     # every UTC 6PM from Mon to Fri
     - cron: "0 18 * * 1-5"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   Trivy-scan:
     runs-on: ubuntu-20.04

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,6 +6,9 @@ on:
     # every UTC 7PM from Mon to Fri
     - cron: "0 19 * * 1-5"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   E2E-tests:
     strategy:

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch: # run on request (no need for PR)
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   Code-Quality-Checks:
     # This is what will cancel the job concurrency

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build_wheels:
     name: Build wheels

--- a/.github/workflows/publish_internal.yml
+++ b/.github/workflows/publish_internal.yml
@@ -3,6 +3,9 @@ name: Build and upload to internal PyPI
 on:
   workflow_dispatch: # run on request (no need for PR)
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build_wheels:
     name: Build wheels

--- a/.github/workflows/run_tests_in_tox.yml
+++ b/.github/workflows/run_tests_in_tox.yml
@@ -33,6 +33,10 @@ on:
       toxenv-ptver:
         type: string
         default: "pt1"
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   run_tests_in_tox:
     # tricky workaround to pass list from the string input type

--- a/.github/workflows/stale_marker.yml
+++ b/.github/workflows/stale_marker.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -6,6 +6,9 @@ on:
     # every 12AM on Sunday
     - cron: "0 0 * * 0"
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   Regression-Tests:
     strategy:


### PR DESCRIPTION
### Summary

To remedy token-permission issues from the OSSF scorecard scanning, set the "read-all" permission to the default workflow permissions.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
