### PR TITLE
Add more convenient way to override callbacks and loggers per configuration file

### DIFF
--- a/for_developers/cli_guide.md
+++ b/for_developers/cli_guide.md
@@ -202,3 +202,96 @@ Override Parameters
 ```console
 otx train ... --model.num_classes <num-classes> --max_epochs <max-epochs>
 ```
+
+## How to write OTX Configuration (recipe)
+
+### Configuration
+
+Example of `recipe/classification/multi_class_cls`
+
+```yaml
+model:
+  class_path: otx.algo.classification.mobilenet_v3_large.MobileNetV3ForMulticlassCls
+  init_args:
+    num_classes: 1000
+    light: True
+
+optimizer:
+  class_path: torch.optim.SGD
+  init_args:
+    lr: 0.0058
+    momentum: 0.9
+    weight_decay: 0.0001
+
+scheduler:
+  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
+  init_args:
+    warmup_steps: 10
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
+
+engine:
+  task: MULTI_CLASS_CLS
+  device: auto
+
+callback_monitor: val/accuracy
+data: ../../_base_/data/mmpretrain_base.yaml
+```
+
+We can use the `~.yaml` with the above values configured.
+
+- `engine`
+- `model`, `optimizer`, `scheduler`
+- `data`
+- `callback_monitor`
+  The basic configuration is the same as the configuration configuration format for jsonargparse.
+  [Jsonargparse Documentation](https://jsonargparse.readthedocs.io/en/v4.27.4/#configuration-files)
+
+### Configuration overrides
+
+Here we provide a feature called `overrides`.
+
+```yaml
+...
+
+overrides:
+  data:
+    config:
+      train_subset:
+        transforms:
+          - type: LoadImageFromFile
+          - backend: cv2
+            scale: 224
+            type: RandomResizedCrop
+          - direction: horizontal
+            prob: 0.5
+            type: RandomFlip
+          - type: PackInputs
+  ...
+```
+
+This feature allows you to override the values need from the default configuration.
+You can see the final configuration with the command below.
+
+```console
+otx train --config <config-file-path> --print_config
+```
+
+### Callbacks & Logger overrides
+
+`callbacks` and `logger` can currently be provided as a list of different callbacks and loggers. The way to override this is as follows.
+
+For example, if you want to change the patience of EarlyStopping, you can configure the overrides like this
+
+```yaml
+...
+
+overrides:
+  ...
+  callbacks:
+    - class_path: ligthning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
+```

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -188,7 +188,7 @@ def list_override(configs: Namespace, key: str, overrides: list) -> None:
 
         item = next((item for item in configs[key] if item["class_path"] == class_path), None)
         if item is not None:
-            item.update(target)
+            Namespace(item).update(target)
         else:
             configs[key].append(dict_to_namespace(target))
 
@@ -232,7 +232,9 @@ def get_defaults_with_overrides(self: ArgumentParser, skip_check: bool = False) 
         with change_to_path_dir(default_config_file), parser_context(parent_parser=self):
             cfg_file = self._load_config_parser_mode(default_config_file.get_content(), key=key)
             cfg = self.merge_config(cfg_file, cfg)
-            overrides = cfg.__dict__.pop("overrides", None)
+            overrides = cfg.__dict__.pop("overrides", {})
+            list_override(configs=cfg, key="callbacks", overrides=overrides.pop("callbacks", []))
+            list_override(configs=cfg, key="logger", overrides=overrides.pop("logger", []))
             if overrides is not None:
                 cfg.update(overrides)
             try:

--- a/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml
+++ b/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml
@@ -29,47 +29,14 @@ engine:
 
 callback_monitor: val/Dice
 
-# tmp: currently getting all callbacks is required to override specific component
-callbacks:
-  - class_path: lightning.pytorch.callbacks.EarlyStopping
-    init_args:
-      monitor: val/Dice # updated
-      mode: max
-      patience: 3 # updated
-      check_on_train_epoch_end: false
-  - class_path: lightning.pytorch.callbacks.RichProgressBar
-    init_args:
-      refresh_rate: 1
-      leave: false
-  - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-    init_args:
-      dirpath: null
-      monitor: null
-      mode: max
-      save_top_k: 1
-      save_last: true
-      auto_insert_metric_name: false
-      filename: "checkpoints/epoch_{epoch:03d}"
-  - class_path: otx.algo.callbacks.iteration_timer.IterationTimer
-    init_args:
-      prog_bar: true
-      on_step: false
-      on_epoch: true
-  - class_path: lightning.pytorch.callbacks.RichModelSummary
-    init_args:
-      max_depth: 1
-  - class_path: lightning.pytorch.callbacks.LearningRateMonitor
-    init_args:
-      logging_interval: epoch
-      log_momentum: true
-  - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
-    init_args:
-      max_interval: 5
-      decay: -0.025
-
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: val/Dice
+        patience: 3
   data:
     task: VISUAL_PROMPTING
     config:

--- a/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml
+++ b/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml
@@ -35,7 +35,6 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        monitor: val/Dice
         patience: 3
   data:
     task: VISUAL_PROMPTING

--- a/src/otx/recipe/visual_prompting/sam_vit_b.yaml
+++ b/src/otx/recipe/visual_prompting/sam_vit_b.yaml
@@ -29,47 +29,14 @@ engine:
 
 callback_monitor: val/Dice
 
-# tmp: currently getting all callbacks is required to override specific component
-callbacks:
-  - class_path: lightning.pytorch.callbacks.EarlyStopping
-    init_args:
-      monitor: val/Dice # updated
-      mode: max
-      patience: 3 # updated
-      check_on_train_epoch_end: false
-  - class_path: lightning.pytorch.callbacks.RichProgressBar
-    init_args:
-      refresh_rate: 1
-      leave: false
-  - class_path: lightning.pytorch.callbacks.ModelCheckpoint
-    init_args:
-      dirpath: null
-      monitor: null
-      mode: max
-      save_top_k: 1
-      save_last: true
-      auto_insert_metric_name: false
-      filename: "checkpoints/epoch_{epoch:03d}"
-  - class_path: otx.algo.callbacks.iteration_timer.IterationTimer
-    init_args:
-      prog_bar: true
-      on_step: false
-      on_epoch: true
-  - class_path: lightning.pytorch.callbacks.RichModelSummary
-    init_args:
-      max_depth: 1
-  - class_path: lightning.pytorch.callbacks.LearningRateMonitor
-    init_args:
-      logging_interval: epoch
-      log_momentum: true
-  - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
-    init_args:
-      max_interval: 5
-      decay: -0.025
-
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 100
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: val/Dice
+        patience: 3
   data:
     task: VISUAL_PROMPTING
     config:

--- a/src/otx/recipe/visual_prompting/sam_vit_b.yaml
+++ b/src/otx/recipe/visual_prompting/sam_vit_b.yaml
@@ -35,7 +35,6 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        monitor: val/Dice
         patience: 3
   data:
     task: VISUAL_PROMPTING

--- a/tests/unit/cli/utils/test_jsonargparse.py
+++ b/tests/unit/cli/utils/test_jsonargparse.py
@@ -1,0 +1,247 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from jsonargparse import Namespace
+from otx.cli.utils.jsonargparse import (
+    flatten_dict,
+    get_configuration,
+    get_short_docstring,
+    list_override,
+    patch_update_configs,
+)
+
+
+@pytest.fixture()
+def fxt_configs() -> Namespace:
+    return Namespace(
+        data=Namespace(batch_size=32, num_workers=4),
+        callbacks=[
+            Namespace(
+                class_path="otx.algo.callbacks.iteration_timer.IterationTimer",
+                init_args=Namespace(prog_bar=True),
+            ),
+            Namespace(
+                class_path="lightning.pytorch.callbacks.EarlyStopping",
+                init_args=Namespace(patience=10),
+            ),
+            Namespace(
+                class_path="lightning.pytorch.callbacks.RichModelSummary",
+                init_args=Namespace(max_depth=1),
+            ),
+        ],
+        logger=[
+            Namespace(
+                class_path="lightning.pytorch.loggers.csv_logs.CSVLogger",
+                init_args=Namespace(name="csv/"),
+            ),
+            Namespace(
+                class_path="lightning.pytorch.loggers.tensorboard.TensorBoardLogger",
+                init_args=Namespace(name="tensorboard/"),
+            ),
+        ],
+    )
+
+
+def test_list_override(fxt_configs) -> None:
+    with patch_update_configs():
+        list_override(fxt_configs, "callbacks", [])
+        assert fxt_configs.callbacks[0].init_args.prog_bar
+        assert fxt_configs.callbacks[1].init_args.patience == 10
+        assert fxt_configs.callbacks[2].init_args.max_depth == 1
+
+        # Wrong Config overriding
+        wrong_override = [
+            {
+                "init_args": {"patience": 3},
+            },
+        ]
+        with pytest.raises(ValueError, match="class_path is required in the override list."):
+            list_override(fxt_configs, "callbacks", wrong_override)
+
+        callbacks_override = [
+            {
+                "class_path": "lightning.pytorch.callbacks.EarlyStopping",
+                "init_args": {"patience": 3},
+            },
+        ]
+        list_override(fxt_configs, "callbacks", callbacks_override)
+        assert fxt_configs.callbacks[1].init_args.patience == 3
+
+        logger_override = [
+            {
+                "class_path": "lightning.pytorch.loggers.tensorboard.TensorBoardLogger",
+                "init_args": {"name": "workspace/"},
+            },
+        ]
+        list_override(fxt_configs, "logger", logger_override)
+        assert fxt_configs.logger[1].init_args.name == "workspace/"
+
+        new_callbacks_override = [
+            {
+                "class_path": "lightning.pytorch.callbacks.NewCallBack",
+                "init_args": {"patience": 100},
+            },
+        ]
+        list_override(fxt_configs, "callbacks", new_callbacks_override)
+        assert len(fxt_configs.callbacks) == 4
+        assert fxt_configs.callbacks[3].class_path == "lightning.pytorch.callbacks.NewCallBack"
+        assert fxt_configs.callbacks[3].init_args.patience == 100
+
+
+def test_update(fxt_configs) -> None:
+    with patch_update_configs():
+        # Test KeyError
+        with pytest.raises(KeyError):
+            fxt_configs.update(value=8, key=None)
+
+        # Test updating a single key
+        updated_configs = fxt_configs.update(8, "data.batch_size")
+        assert updated_configs.data.batch_size == 8
+
+        updated_configs = fxt_configs.update("8", "data.batch_size")
+        assert updated_configs.data.batch_size == 8
+
+        updated_configs = fxt_configs.update(None, "data.num_workers")
+        assert "num_workers" not in updated_configs.data
+
+        # Test updating multiple values using a namespace
+        new_values = Namespace(
+            callbacks=[
+                Namespace(
+                    class_path="new_callback",
+                    init_args=Namespace(prog_bar=False),
+                ),
+            ],
+            logger=[
+                Namespace(
+                    class_path="new_logger",
+                    init_args=Namespace(name="new_name"),
+                ),
+            ],
+        )
+        updated_configs = fxt_configs.update(new_values)
+        assert updated_configs.callbacks[0].class_path == "new_callback"
+        assert updated_configs.callbacks[0].init_args.prog_bar is False
+        assert updated_configs.logger[0].class_path == "new_logger"
+        assert updated_configs.logger[0].init_args.name == "new_name"
+
+        # Test updating multiple values using a dictionary
+        new_values_dict = {
+            "callbacks": [
+                {
+                    "class_path": "updated_callback",
+                    "init_args": {"prog_bar": True},
+                },
+            ],
+            "logger": [
+                {
+                    "class_path": "updated_logger",
+                    "init_args": {"name": "updated_name"},
+                },
+            ],
+        }
+        updated_configs = fxt_configs.update(new_values_dict)
+        assert updated_configs.callbacks[0].class_path == "updated_callback"
+        assert updated_configs.callbacks[0].init_args.prog_bar is True
+        assert updated_configs.logger[0].class_path == "updated_logger"
+        assert updated_configs.logger[0].init_args.name == "updated_name"
+
+
+def test_get_short_docstring() -> None:
+    class Component:
+        """This is a component."""
+
+        def method(self) -> None:
+            """This is a method."""
+
+    class WithoutDocstring:
+        pass
+
+    assert get_short_docstring(Component) == "This is a component."
+    assert get_short_docstring(Component.method) == "This is a method."
+    assert get_short_docstring(WithoutDocstring) == ""
+
+
+def test_flatten_dict() -> None:
+    # Test case 1: Flattening an empty dictionary
+    config: dict = {}
+    flattened = flatten_dict(config)
+    assert flattened == {}
+
+    # Test case 2: Flattening a dictionary with nested keys
+    config_1 = {
+        "a": {
+            "b": {
+                "c": 1,
+                "d": 2,
+            },
+            "e": 3,
+        },
+        "f": 4,
+    }
+    flattened = flatten_dict(config_1)
+    expected_1 = {
+        "a.b.c": 1,
+        "a.b.d": 2,
+        "a.e": 3,
+        "f": 4,
+    }
+    assert flattened == expected_1
+
+    # Test case 3: Flattening a dictionary with custom separator
+    config_2 = {
+        "a": {
+            "b": {
+                "c": 1,
+                "d": 2,
+            },
+            "e": 3,
+        },
+        "f": 4,
+    }
+    flattened = flatten_dict(config_2, sep="-")
+    expected_2 = {
+        "a-b-c": 1,
+        "a-b-d": 2,
+        "a-e": 3,
+        "f": 4,
+    }
+    assert flattened == expected_2
+
+    # Test case 4: Flattening a dictionary with non-string keys
+    config_3 = {
+        1: {
+            2: {
+                3: "value",
+            },
+        },
+    }
+    flattened = flatten_dict(config_3)
+    expected_3 = {
+        "1.2.3": "value",
+    }
+    assert flattened == expected_3
+
+
+def test_get_configuration(tmp_path):
+    # Create a temporary configuration file
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+        data:
+            task: SEMANTIC_SEGMENTATION
+        """,
+    )
+
+    # Call the get_configuration function
+    config = get_configuration(config_file)
+    assert "config" in config
+    assert config["config"] == [config_file]
+    assert "engine" in config
+    assert "data" in config
+    assert config["data"]["task"] == "SEMANTIC_SEGMENTATION"
+
+    cli_args = ["verbose", "data_root", "task", "seed", "callback_monitor", "resume", "disable_infer_num_classes"]
+    for arg in cli_args:
+        assert arg not in config


### PR DESCRIPTION
### Summary

In the old way, callbacks and loggers have a list type, so to override the value of some callbacks in the configuration file, we have to copy all the callbacks and override them from `train.yaml`.
I heard that this was an inconvenience (reported by @sungmanc @sungchul2),
so I looked into it to improve it.

For `callbacks` and `logger` overrides, i've fixed it to check for the same `class_path` in the list and update it accordingly.
+ Add unit tests for `otx/cli/utils/jsonargparse.py`
+ Add 'How to write configuration file' example in `cli_guide.md`

How to use:
```yaml
...

overrides:
  ...
  callbacks:
    - class_path: ligthning.pytorch.callbacks.EarlyStopping
      init_args:
        patience: 3
```
This is how to update the patience of EarlyStopping in an existing configuration, which has been modified to retain all existing callback values.

```console
otx train --config <config-file-path> --print_config
```
The final configuration can be verified by running the above command.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
