### PR TITLE
Resolve issue where the model configuration was missing in output configuration file

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -336,6 +336,9 @@ class OTXCLI:
         model_parser.add_subclass_arguments(OTXModel, "model", required=False, fail_untyped=False)
         model = model_parser.instantiate_classes(Namespace(model=model_config)).get("model")
 
+        # Update self.config with model
+        self.config[self.subcommand].update(Namespace(model=model_config))
+
         optimizer_kwargs = namespace_to_dict(self.get_config_value(self.config_init, "optimizer", Namespace()))
         scheduler_kwargs = namespace_to_dict(self.get_config_value(self.config_init, "scheduler", Namespace()))
         from otx.core.utils.instantiators import partial_instantiate_class

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 from otx.cli import main
 
 # This assumes have OTX installed in environment.
@@ -73,6 +74,12 @@ def test_otx_e2e(
     # Currently, a simple output check
     assert (tmp_path_train / "outputs").exists()
     assert (tmp_path_train / "outputs" / "configs.yaml").exists()
+    # Check Configs file
+    with (tmp_path_train / "outputs" / "configs.yaml").open() as file:
+        train_output_config = yaml.safe_load(file)
+    assert "model" in train_output_config
+    assert "data" in train_output_config
+    assert "engine" in train_output_config
     assert (tmp_path_train / "outputs" / "csv").exists()
     assert (tmp_path_train / "outputs" / "checkpoints").exists()
     ckpt_files = list((tmp_path_train / "outputs" / "checkpoints").glob(pattern="epoch_*.ckpt"))


### PR DESCRIPTION
### Summary

@eugene123tw reported an issue where the model configuration was missing from the `configs.yaml` resulting in train output because the PR(https://github.com/openvinotoolkit/training_extensions/pull/2861) popped the model configuration from the config and didn't add it back in, so fixing that.
also add an assert statement that checks for key in the train output result.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
