### PR TITLE
Add meta_info update in segmentation dataset class

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -317,11 +317,10 @@ class OTXCLI:
             tuple: The model and optimizer and scheduler.
         """
         from otx.core.model.entity.base import OTXModel
-        from otx.engine.utils.auto_configurator import get_num_classes_from_meta_info
 
         # Update num_classes
         if not self.get_config_value(self.config_init, "disable_infer_num_classes", False):
-            num_classes = get_num_classes_from_meta_info(task=self.datamodule.task, meta_info=self.datamodule.meta_info)
+            num_classes = self.datamodule.meta_info.num_classes
             if num_classes != model_config.init_args.num_classes:
                 warning_msg = (
                     f"The `num_classes` in dataset is {num_classes} "

--- a/src/otx/core/data/dataset/segmentation.py
+++ b/src/otx/core/data/dataset/segmentation.py
@@ -5,21 +5,62 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 import torch
 from datumaro.components.annotation import Image, Mask
 from torchvision import tv_tensors
 
+from otx.core.data.dataset.base import Transforms
 from otx.core.data.entity.base import ImageInfo
 from otx.core.data.entity.segmentation import SegBatchDataEntity, SegDataEntity
+from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER, MemCacheHandlerBase
+from otx.core.types.image import ImageColorChannel
 
 from .base import OTXDataset
+
+if TYPE_CHECKING:
+    from datumaro import DatasetSubset
 
 
 class OTXSegmentationDataset(OTXDataset[SegDataEntity]):
     """OTXDataset class for segmentation task."""
+
+    def __init__(
+        self,
+        dm_subset: DatasetSubset,
+        transforms: Transforms,
+        mem_cache_handler: MemCacheHandlerBase = NULL_MEM_CACHE_HANDLER,
+        mem_cache_img_max_size: tuple[int, int] | None = None,
+        max_refetch: int = 1000,
+        image_color_channel: ImageColorChannel = ImageColorChannel.RGB,
+        stack_images: bool = True,
+    ) -> None:
+        super().__init__(
+            dm_subset,
+            transforms,
+            mem_cache_handler,
+            mem_cache_img_max_size,
+            max_refetch,
+            image_color_channel,
+            stack_images,
+        )
+        # Check & Update background label in LabelInfo
+        self._update_meta_info()
+
+    def _update_meta_info(self) -> None:
+        """Updates the meta information of the dataset.
+
+        This method checks if the label names contain the word "background" and inserts
+        "Background" at the beginning of the label names list if it is not found.
+
+        Currently, this is a workaround method to update the num_classes of multiple models in train-test-export etc.
+        to be the same. This should be addressed in another workaround or in datumaro.
+        """
+        label_names = self.meta_info.label_names
+        if not any(word.lower() == "background" for word in label_names):
+            label_names.insert(0, "Background")
 
     def _get_item_impl(self, index: int) -> SegDataEntity | None:
         item = self.dm_subset.get(id=self.ids[index], subset=self.dm_subset.name)

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -23,7 +23,7 @@ from otx.core.types.precision import OTXPrecisionType
 from otx.core.types.task import OTXTaskType
 from otx.core.utils.cache import TrainerArgumentsCache
 
-from .utils.auto_configurator import AutoConfigurator, PathLike, get_num_classes_from_meta_info
+from .utils.auto_configurator import AutoConfigurator, PathLike
 
 if TYPE_CHECKING:
     from lightning import Callback
@@ -571,7 +571,7 @@ class Engine:
             ),
         )
         # Model
-        num_classes = get_num_classes_from_meta_info(data_config["task"], datamodule.meta_info)
+        num_classes = datamodule.meta_info.num_classes
         config["model"]["init_args"]["num_classes"] = num_classes
         model = instantiate_class(args=(), init=config.pop("model"))
         optimizer = partial_instantiate_class(init=config.pop("optimizer", None))

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -93,29 +93,6 @@ def configure_task(data_root: PathLike) -> OTXTaskType:
     return TASK_PER_DATA_FORMAT[data_format][0]
 
 
-def get_num_classes_from_meta_info(task: OTXTaskType, meta_info: LabelInfo) -> int:
-    """Get the number of classes from the meta information.
-
-    Args:
-        task (OTXTaskType): The current task type.
-        meta_info (LabelInfo): The meta information about the labels.
-
-    Returns:
-        int: The number of classes.
-    """
-    num_classes = len(meta_info.label_names)
-    # Check background class
-    if task in (OTXTaskType.SEMANTIC_SEGMENTATION):
-        has_background = False
-        for label in meta_info.label_names:
-            if label.lower() == "background":
-                has_background = True
-                break
-        if not has_background:
-            num_classes += 1
-    return num_classes
-
-
 class AutoConfigurator:
     """This Class is used to configure the OTXDataModule, OTXModel, Optimizer, and Scheduler with OTX Default.
 
@@ -256,7 +233,7 @@ class AutoConfigurator:
         if model_name is not None:
             self._config = self._load_default_config(self.model_name)
         if meta_info is not None:
-            num_classes = get_num_classes_from_meta_info(self.task, meta_info)
+            num_classes = meta_info.num_classes
             self.config["model"]["init_args"]["num_classes"] = num_classes
         logger.warning(f"Set Default Model: {self.config['model']}")
         return instantiate_class(args=(), init=self.config["model"])

--- a/tests/integration/api/test_auto_configuration.py
+++ b/tests/integration/api/test_auto_configuration.py
@@ -8,7 +8,7 @@ from otx.core.data.module import OTXDataModule
 from otx.core.model.entity.base import OTXModel
 from otx.core.types.task import OTXTaskType
 from otx.engine import Engine
-from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK, get_num_classes_from_meta_info
+from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
 
 @pytest.mark.parametrize("task", [task.value.lower() for task in DEFAULT_CONFIG_PER_TASK])
@@ -43,7 +43,7 @@ def test_auto_configuration(task: str, tmp_path: Path, fxt_accelerator: str, fxt
 
     default_config = get_configuration(DEFAULT_CONFIG_PER_TASK[task_type])
     default_config["data"]["config"]["data_root"] = data_root
-    num_classes = get_num_classes_from_meta_info(task=task_type, meta_info=engine.datamodule.meta_info)
+    num_classes = engine.datamodule.meta_info.num_classes
 
     default_config["model"]["init_args"]["num_classes"] = num_classes
 

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -13,7 +13,6 @@ from otx.engine.utils.auto_configurator import (
     DEFAULT_CONFIG_PER_TASK,
     AutoConfigurator,
     configure_task,
-    get_num_classes_from_meta_info,
 )
 
 
@@ -45,30 +44,6 @@ def test_configure_task_with_unsupported_data_format(tmp_path: Path) -> None:
     # Test the configure_task function with an unsupported data format
     with pytest.raises(ValueError, match="Can't find proper task."):
         configure_task(data_root)
-
-
-@pytest.mark.parametrize(
-    "task",
-    [task for task in DEFAULT_CONFIG_PER_TASK if task != OTXTaskType.SEMANTIC_SEGMENTATION],
-)
-def test_get_num_classes_from_meta_info(task: OTXTaskType) -> None:
-    # Test the get_num_classes_from_meta_info function
-    label_names = ["class1", "class2", "class3"]
-    meta_info = LabelInfo(label_names=label_names, label_groups=[label_names])
-    num_classes = get_num_classes_from_meta_info(task, meta_info)
-    assert num_classes == 3
-
-
-@pytest.mark.parametrize("has_background", [True, False])
-def test_get_num_classes_from_meta_info_with_no_background(has_background: bool) -> None:
-    # Test the get_num_classes_from_meta_info function with no background class
-    task = OTXTaskType.SEMANTIC_SEGMENTATION
-    label_names = ["class1", "class2", "class3"]
-    if has_background:
-        label_names = ["background", *label_names]
-    meta_info = LabelInfo(label_names=label_names, label_groups=[label_names])
-    num_classes = get_num_classes_from_meta_info(task, meta_info)
-    assert num_classes == 4
 
 
 class TestAutoConfigurator:


### PR DESCRIPTION
### Summary

Currently, the logic within auto-configuration to +1 num_classes in segmentation is not being reflected in post-export operations that use `checkpoint.meta_info`, so i've fixed this to add a `background` to the label list of `meta_info` if it doesn't have one. and remove `num_classes` update function in auto-configuration. (Request by @sovrasov)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
