### PR TITLE
Fix configuration max_epochs & early-stop patience for classification

### DIFF
--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
@@ -29,6 +29,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
@@ -29,6 +29,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
@@ -28,6 +28,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
@@ -27,3 +27,10 @@ engine:
 callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
+
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
@@ -28,6 +28,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large_light.yaml
@@ -28,6 +28,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
@@ -25,3 +25,10 @@ engine:
 callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
+
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8

--- a/src/otx/recipe/classification/multi_class_cls/otx_dino_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_dino_v2.yaml
@@ -34,6 +34,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_dino_v2_linear_probe.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_dino_v2_linear_probe.yaml
@@ -36,6 +36,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
@@ -26,3 +26,10 @@ engine:
 callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
+
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_mobilenet_v3_large.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -25,6 +25,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -26,6 +26,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
@@ -29,3 +29,8 @@ engine:
 callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
+overrides:
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8

--- a/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
@@ -29,3 +29,8 @@ engine:
 callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
+overrides:
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8

--- a/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
@@ -29,3 +29,8 @@ engine:
 callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
+overrides:
+  callbacks:
+    - class_path: otx.algo.callbacks.EarlyStopping
+      init_args:
+        patience: 8


### PR DESCRIPTION
### Summary

Adjust the patience and max_epochs for classification and segmentation that were not being overridden by this PR (https://github.com/openvinotoolkit/training_extensions/pull/2884).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
