### PR TITLE
Fix to allow Scheduler to be configured as a list and fix a bug in the AdaptiveTrainingCallback

### DIFF
--- a/src/otx/algo/callbacks/adaptive_train_scheduling.py
+++ b/src/otx/algo/callbacks/adaptive_train_scheduling.py
@@ -104,9 +104,10 @@ class AdaptiveTrainScheduling(Callback):
             config.frequency = saved_frequency
 
         for config in lr_configs:
-            if hasattr(config, "frequency"):
+            if hasattr(config, "frequency") and hasattr(config, "interval") and config.interval == "epoch":
+                scheduler_name = config.scheduler.__class__.__name__
                 msg = (
-                    "The frequency of LRscheduler will be changed due to the effect of adaptive interval: "
+                    f"The frequency of {scheduler_name} will be changed due to the effect of adaptive interval: "
                     f"{config.frequency} --> {adaptive_interval}."
                 )
                 log.warning(msg)

--- a/src/otx/algo/callbacks/adaptive_train_scheduling.py
+++ b/src/otx/algo/callbacks/adaptive_train_scheduling.py
@@ -105,9 +105,8 @@ class AdaptiveTrainScheduling(Callback):
 
         for config in lr_configs:
             if hasattr(config, "frequency") and hasattr(config, "interval") and config.interval == "epoch":
-                scheduler_name = config.scheduler.__class__.__name__
                 msg = (
-                    f"The frequency of {scheduler_name} will be changed due to the effect of adaptive interval: "
+                    "The frequency of LRscheduler will be changed due to the effect of adaptive interval: "
                     f"{config.frequency} --> {adaptive_interval}."
                 )
                 log.warning(msg)

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 from warnings import warn
 
 import yaml
@@ -167,7 +167,7 @@ class OTXCLI:
             nested_key="optimizer",
             **optim_kwargs,
         )
-        scheduler_type = (LRScheduler, ReduceLROnPlateau, list[LRScheduler | ReduceLROnPlateau])
+        scheduler_type = (LRScheduler, ReduceLROnPlateau, list[Union[LRScheduler, ReduceLROnPlateau]])
         parser.add_subclass_arguments(
             baseclass=scheduler_type,
             nested_key="scheduler",

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -347,11 +347,11 @@ class OTXCLI:
 
         optimizer_kwargs = self.get_config_value(self.config_init, "optimizer", Namespace())
         optimizer_kwargs = optimizer_kwargs if isinstance(optimizer_kwargs, list) else [optimizer_kwargs]
-        optimizers = [partial_instantiate_class(namespace_to_dict(_opt)) for _opt in optimizer_kwargs]
+        optimizers = partial_instantiate_class([namespace_to_dict(_opt) for _opt in optimizer_kwargs])
 
         scheduler_kwargs = self.get_config_value(self.config_init, "scheduler", Namespace())
         scheduler_kwargs = scheduler_kwargs if isinstance(scheduler_kwargs, list) else [scheduler_kwargs]
-        schedulers = [partial_instantiate_class(namespace_to_dict(_sch)) for _sch in scheduler_kwargs]
+        schedulers = partial_instantiate_class([namespace_to_dict(_sch) for _sch in scheduler_kwargs])
 
         return model, optimizers, schedulers
 

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -347,11 +347,11 @@ class OTXCLI:
 
         optimizer_kwargs = self.get_config_value(self.config_init, "optimizer", Namespace())
         optimizer_kwargs = optimizer_kwargs if isinstance(optimizer_kwargs, list) else [optimizer_kwargs]
-        optimizers = partial_instantiate_class([namespace_to_dict(_opt) for _opt in optimizer_kwargs])
+        optimizers = partial_instantiate_class([namespace_to_dict(_opt) for _opt in optimizer_kwargs if _opt])
 
         scheduler_kwargs = self.get_config_value(self.config_init, "scheduler", Namespace())
         scheduler_kwargs = scheduler_kwargs if isinstance(scheduler_kwargs, list) else [scheduler_kwargs]
-        schedulers = partial_instantiate_class([namespace_to_dict(_sch) for _sch in scheduler_kwargs])
+        schedulers = partial_instantiate_class([namespace_to_dict(_sch) for _sch in scheduler_kwargs if _sch])
 
         return model, optimizers, schedulers
 

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -178,7 +178,7 @@ def list_override(configs: Namespace, key: str, overrides: list) -> None:
         ...     ...
         ... ]
     """
-    if key not in configs:
+    if key not in configs or configs[key] is None:
         return
     for target in overrides:
         class_path = target.get("class_path", None)

--- a/src/otx/core/model/module/action_classification.py
+++ b/src/otx/core/model/module/action_classification.py
@@ -28,8 +28,8 @@ class OTXActionClsLitModule(OTXLitModule):
         self,
         otx_model: OTXActionClsModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/action_detection.py
+++ b/src/otx/core/model/module/action_detection.py
@@ -29,8 +29,8 @@ class OTXActionDetLitModule(OTXLitModule):
         self,
         otx_model: OTXActionDetModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/base.py
+++ b/src/otx/core/model/module/base.py
@@ -35,7 +35,7 @@ class LinearWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
         num_warmup_steps: int = 1000,
         interval: str = "step",
     ):
-        if num_warmup_steps > 0:
+        if not num_warmup_steps > 0:
             msg = f"num_warmup_steps should be > 0, got {num_warmup_steps}"
             raise ValueError(msg)
         self.num_warmup_steps = num_warmup_steps

--- a/src/otx/core/model/module/base.py
+++ b/src/otx/core/model/module/base.py
@@ -37,7 +37,7 @@ class LinearWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
     ):
         if num_warmup_steps > 0:
             msg = f"num_warmup_steps should be > 0, got {num_warmup_steps}"
-            ValueError(msg)
+            raise ValueError(msg)
         self.num_warmup_steps = num_warmup_steps
         self.interval = interval
         super().__init__(optimizer, lambda step: min(step / num_warmup_steps, 1.0))

--- a/src/otx/core/model/module/classification.py
+++ b/src/otx/core/model/module/classification.py
@@ -37,8 +37,8 @@ class OTXMulticlassClsLitModule(OTXLitModule):
         self,
         otx_model: OTXMulticlassClsModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,
@@ -130,8 +130,8 @@ class OTXMultilabelClsLitModule(OTXLitModule):
         self,
         otx_model: OTXMultilabelClsModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,
@@ -218,8 +218,8 @@ class OTXHlabelClsLitModule(OTXLitModule):
         self,
         otx_model: OTXHlabelClsModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/detection.py
+++ b/src/otx/core/model/module/detection.py
@@ -29,8 +29,8 @@ class OTXDetectionLitModule(OTXLitModule):
         self,
         otx_model: ExplainableOTXDetModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/instance_segmentation.py
+++ b/src/otx/core/model/module/instance_segmentation.py
@@ -32,8 +32,8 @@ class OTXInstanceSegLitModule(OTXLitModule):
         self,
         otx_model: ExplainableOTXInstanceSegModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/rotated_detection.py
+++ b/src/otx/core/model/module/rotated_detection.py
@@ -25,8 +25,8 @@ class OTXRotatedDetLitModule(OTXInstanceSegLitModule):
         self,
         otx_model: OTXRotatedDetModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/segmentation.py
+++ b/src/otx/core/model/module/segmentation.py
@@ -29,8 +29,8 @@ class OTXSegmentationLitModule(OTXLitModule):
         self,
         otx_model: OTXSegmentationModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/core/model/module/visual_prompting.py
+++ b/src/otx/core/model/module/visual_prompting.py
@@ -36,8 +36,8 @@ class OTXVisualPromptingLitModule(OTXLitModule):
         self,
         otx_model: OTXVisualPromptingModel,
         torch_compile: bool,
-        optimizer: OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
-        scheduler: LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
+        optimizer: list[OptimizerCallable] | OptimizerCallable = lambda p: torch.optim.SGD(p, lr=0.01),
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = torch.optim.lr_scheduler.ConstantLR,
     ):
         super().__init__(
             otx_model=otx_model,

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -97,9 +97,10 @@ class Engine:
             work_dir (PathLike, optional): Working directory for the engine. Defaults to "./otx-workspace".
             datamodule (OTXDataModule | None, optional): The data module for the engine. Defaults to None.
             model (OTXModel | str | None, optional): The model for the engine. Defaults to None.
-            optimizer (OptimizerCallable | None, optional): The optimizer for the engine. Defaults to None.
-            scheduler (LRSchedulerCallable | None, optional): The learning rate scheduler for the engine.
+            optimizer (list[OptimizerCallable] | OptimizerCallable | None, optional): The optimizer for the engine.
                 Defaults to None.
+            scheduler (list[LRSchedulerCallable] | LRSchedulerCallable | None, optional):
+                The learning rate scheduler for the engine. Defaults to None.
             checkpoint (PathLike | None, optional): Path to the checkpoint file. Defaults to None.
             device (DeviceType, optional): The device type to use. Defaults to DeviceType.auto.
             **kwargs: Additional keyword arguments for pl.Trainer.
@@ -675,8 +676,8 @@ class Engine:
 
         Args:
             model (OTXModel): The OTXModel instance.
-            optimizer (OptimizerCallable): The optimizer callable.
-            scheduler (LRSchedulerCallable): The learning rate scheduler callable.
+            optimizer (list[OptimizerCallable] | OptimizerCallable | None): The optimizer callable.
+            scheduler (list[LRSchedulerCallable] | LRSchedulerCallable | None): The learning rate scheduler callable.
 
         Returns:
             OTXLitModule: The built LightningModule instance.

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -83,8 +83,8 @@ class Engine:
         work_dir: PathLike = "./otx-workspace",
         datamodule: OTXDataModule | None = None,
         model: OTXModel | str | None = None,
-        optimizer: OptimizerCallable | None = None,
-        scheduler: LRSchedulerCallable | None = None,
+        optimizer: list[OptimizerCallable] | OptimizerCallable | None = None,
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable | None = None,
         checkpoint: PathLike | None = None,
         device: DeviceType = DeviceType.auto,
         **kwargs,
@@ -132,10 +132,10 @@ class Engine:
                 meta_info=self._datamodule.meta_info if self._datamodule is not None else None,
             )
         )
-        self.optimizer: OptimizerCallable | None = (
+        self.optimizer: list[OptimizerCallable] | OptimizerCallable | None = (
             optimizer if optimizer is not None else self._auto_configurator.get_optimizer()
         )
-        self.scheduler: LRSchedulerCallable | None = (
+        self.scheduler: list[LRSchedulerCallable] | LRSchedulerCallable | None = (
             scheduler if scheduler is not None else self._auto_configurator.get_scheduler()
         )
 
@@ -668,8 +668,8 @@ class Engine:
     def _build_lightning_module(
         self,
         model: OTXModel,
-        optimizer: OptimizerCallable,
-        scheduler: LRSchedulerCallable,
+        optimizer: list[OptimizerCallable] | OptimizerCallable | None,
+        scheduler: list[LRSchedulerCallable] | LRSchedulerCallable | None,
     ) -> OTXLitModule:
         """Builds a LightningModule for engine workflow.
 

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -249,7 +249,7 @@ class AutoConfigurator:
         logger.warning(f"Set Default Model: {self.config['model']}")
         return instantiate_class(args=(), init=self.config["model"])
 
-    def get_optimizer(self) -> OptimizerCallable | None:
+    def get_optimizer(self) -> list[OptimizerCallable] | OptimizerCallable | None:
         """Returns the optimizer callable based on the configuration.
 
         Returns:
@@ -257,9 +257,12 @@ class AutoConfigurator:
         """
         optimizer_config = self.config.get("optimizer", None)
         logger.warning(f"Set Default Optimizer: {optimizer_config}")
+        if isinstance(optimizer_config, list):
+            optimizers = [partial_instantiate_class(init=_opt) for _opt in optimizer_config]
+            return [opt for opt in optimizers if opt is not None]
         return partial_instantiate_class(init=optimizer_config)
 
-    def get_scheduler(self) -> LRSchedulerCallable | None:
+    def get_scheduler(self) -> list[LRSchedulerCallable] | LRSchedulerCallable | None:
         """Returns the instantiated scheduler based on the configuration.
 
         Returns:
@@ -267,6 +270,9 @@ class AutoConfigurator:
         """
         scheduler_config = self.config.get("scheduler", None)
         logger.warning(f"Set Default Scheduler: {scheduler_config}")
+        if isinstance(scheduler_config, list):
+            schedulers = [partial_instantiate_class(init=scheduler) for scheduler in scheduler_config]
+            return [scheduler for scheduler in schedulers if scheduler is not None]
         return partial_instantiate_class(init=scheduler_config)
 
     def get_ov_model(self, model_name: str, meta_info: LabelInfo) -> OVModel:

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -249,30 +249,24 @@ class AutoConfigurator:
         logger.warning(f"Set Default Model: {self.config['model']}")
         return instantiate_class(args=(), init=self.config["model"])
 
-    def get_optimizer(self) -> list[OptimizerCallable] | OptimizerCallable | None:
+    def get_optimizer(self) -> list[OptimizerCallable] | None:
         """Returns the optimizer callable based on the configuration.
 
         Returns:
-            OptimizerCallable | None: The optimizer callable.
+            list[OptimizerCallable] | None: The optimizer callable.
         """
         optimizer_config = self.config.get("optimizer", None)
         logger.warning(f"Set Default Optimizer: {optimizer_config}")
-        if isinstance(optimizer_config, list):
-            optimizers = [partial_instantiate_class(init=_opt) for _opt in optimizer_config]
-            return [opt for opt in optimizers if opt is not None]
         return partial_instantiate_class(init=optimizer_config)
 
-    def get_scheduler(self) -> list[LRSchedulerCallable] | LRSchedulerCallable | None:
+    def get_scheduler(self) -> list[LRSchedulerCallable] | None:
         """Returns the instantiated scheduler based on the configuration.
 
         Returns:
-            LRSchedulerCallable | None: The instantiated scheduler.
+            list[LRSchedulerCallable] | None: The instantiated scheduler.
         """
         scheduler_config = self.config.get("scheduler", None)
         logger.warning(f"Set Default Scheduler: {scheduler_config}")
-        if isinstance(scheduler_config, list):
-            schedulers = [partial_instantiate_class(init=scheduler) for scheduler in scheduler_config]
-            return [scheduler for scheduler in schedulers if scheduler is not None]
         return partial_instantiate_class(init=scheduler_config)
 
     def get_ov_model(self, model_name: str, meta_info: LabelInfo) -> OVModel:

--- a/src/otx/recipe/action/action_classification/x3d.yaml
+++ b/src/otx/recipe/action/action_classification/x3d.yaml
@@ -10,13 +10,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 2
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 2
+      monitor: val/accuracy
 
 engine:
   task: ACTION_CLASSIFICATION

--- a/src/otx/recipe/action/action_detection/x3d_fastrcnn.yaml
+++ b/src/otx/recipe/action/action_detection/x3d_fastrcnn.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.00001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 2
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 2
+      monitor: val/map_50
 
 engine:
   task: ACTION_DETECTION

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
@@ -11,13 +11,15 @@ optimizer:
     lr: 0.0049
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 0
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: H_LABEL_CLS

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
@@ -11,15 +11,12 @@ optimizer:
     lr: 0.0049
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: H_LABEL_CLS

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
@@ -29,6 +29,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
@@ -13,15 +13,12 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: H_LABEL_CLS

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
@@ -13,13 +13,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 0
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: H_LABEL_CLS

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
@@ -13,13 +13,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 10
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: H_LABEL_CLS

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
@@ -29,6 +29,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.05
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 10
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: H_LABEL_CLS

--- a/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
@@ -28,6 +28,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: H_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 0
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
@@ -12,15 +12,12 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
@@ -27,3 +27,10 @@ engine:
 callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
+
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 0
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
@@ -12,15 +12,12 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
@@ -28,6 +28,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large_light.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 10
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large_light.yaml
@@ -28,6 +28,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
@@ -10,13 +10,15 @@ optimizer:
     weight_decay: 0.05
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 10
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
@@ -25,3 +25,10 @@ engine:
 callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
+
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3

--- a/src/otx/recipe/classification/multi_class_cls/otx_dino_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_dino_v2.yaml
@@ -34,6 +34,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_dino_v2_linear_probe.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_dino_v2_linear_probe.yaml
@@ -36,6 +36,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
@@ -12,15 +12,12 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
@@ -12,12 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: lightning.pytorch.cli.ReduceLROnPlateau
-  init_args:
-    mode: min
-    factor: 0.5
-    patience: 1
-    monitor: train/loss
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
@@ -26,3 +26,10 @@ engine:
 callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
+
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
@@ -12,15 +12,12 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
@@ -12,12 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: lightning.pytorch.cli.ReduceLROnPlateau
-  init_args:
-    mode: min
-    factor: 0.5
-    patience: 1
-    monitor: train/loss
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_class_cls/otx_mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_mobilenet_v3_large.yaml
@@ -12,12 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: lightning.pytorch.cli.ReduceLROnPlateau
-  init_args:
-    mode: min
-    factor: 0.5
-    patience: 1
-    monitor: train/loss
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_CLASS_CLS

--- a/src/otx/recipe/classification/multi_class_cls/otx_mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_mobilenet_v3_large.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     config:
       train_subset:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -9,15 +9,12 @@ optimizer:
     lr: 0.0049
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: MULTI_LABEL_CLS

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -25,6 +25,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -9,13 +9,15 @@ optimizer:
     lr: 0.0049
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 0
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_LABEL_CLS

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -11,13 +11,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 0
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_LABEL_CLS

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -11,15 +11,12 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  - class_path: otx.core.model.module.base.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 0
-  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
-    init_args:
-      mode: max
-      factor: 0.5
-      patience: 1
-      monitor: val/accuracy
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: max
+    factor: 0.5
+    patience: 1
+    monitor: val/accuracy
 
 engine:
   task: MULTI_LABEL_CLS

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
@@ -27,6 +27,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
@@ -11,13 +11,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 10
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_LABEL_CLS

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -10,13 +10,15 @@ optimizer:
     weight_decay: 0.05
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 10
-    mode: max
-    factor: 0.5
-    patience: 1
-    monitor: val/accuracy
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 10
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 1
+      monitor: val/accuracy
 
 engine:
   task: MULTI_LABEL_CLS

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -26,6 +26,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        patience: 3
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/detection/atss_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/atss_r50_fpn.yaml
+++ b/src/otx/recipe/detection/atss_r50_fpn.yaml
@@ -10,13 +10,15 @@ optimizer:
     weight_decay: 0.0
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/atss_resnext101.yaml
+++ b/src/otx/recipe/detection/atss_resnext101.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/ssd_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -11,13 +11,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.0001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 3
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 3
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: DETECTION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 0
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -28,6 +28,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   data:
     task: INSTANCE_SEGMENTATION
     config:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -14,7 +14,7 @@ optimizer:
 scheduler:
   - class_path: otx.core.model.module.base.LinearWarmupScheduler
     init_args:
-      num_warmup_steps: 0
+      num_warmup_steps: 100
   - class_path: lightning.pytorch.cli.ReduceLROnPlateau
     init_args:
       mode: max

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -28,6 +28,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   gradient_clip_val: 35.0
   data:
     task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
@@ -28,6 +28,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   gradient_clip_val: 35.0
   data:
     task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -12,13 +12,15 @@ optimizer:
     weight_decay: 0.001
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -28,6 +28,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   gradient_clip_val: 35.0
   data:
     task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
@@ -26,6 +26,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   data:
     task: INSTANCE_SEGMENTATION
     config:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
@@ -10,13 +10,15 @@ optimizer:
     weight_decay: 0.05
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/map_50
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/map_50
 
 engine:
   task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
@@ -12,12 +12,15 @@ optimizer:
     weight_decay: 0.001
 
 scheduler:
-  class_path: lightning.pytorch.cli.ReduceLROnPlateau
-  init_args:
-    mode: min
-    factor: 0.1
-    patience: 10
-    monitor: train/loss
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.1
+      patience: 10
+      monitor: val/map_50
 
 engine:
   task: ROTATED_DETECTION

--- a/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
@@ -27,6 +27,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   data:
     task: ROTATED_DETECTION
     config:

--- a/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
@@ -12,12 +12,15 @@ optimizer:
     weight_decay: 0.001
 
 scheduler:
-  class_path: lightning.pytorch.cli.ReduceLROnPlateau
-  init_args:
-    mode: min
-    factor: 0.1
-    patience: 10
-    monitor: train/loss
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.1
+      patience: 10
+      monitor: val/map_50
 
 engine:
   task: ROTATED_DETECTION

--- a/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
@@ -27,6 +27,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/mmdet_base.yaml
 overrides:
+  max_epochs: 100
   data:
     task: ROTATED_DETECTION
     config:

--- a/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
@@ -29,3 +29,6 @@ engine:
 callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
+
+overrides:
+  max_epochs: 300

--- a/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
@@ -14,13 +14,15 @@ optimizer:
     weight_decay: 0.0
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/mIoU
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/mIoU
 
 engine:
   task: SEMANTIC_SEGMENTATION

--- a/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
@@ -29,3 +29,6 @@ engine:
 callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
+
+overrides:
+  max_epochs: 300

--- a/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
@@ -14,13 +14,15 @@ optimizer:
     weight_decay: 0.0
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/mIoU
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/mIoU
 
 engine:
   task: SEMANTIC_SEGMENTATION

--- a/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
@@ -29,3 +29,6 @@ engine:
 callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
+
+overrides:
+  max_epochs: 300

--- a/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
@@ -14,13 +14,15 @@ optimizer:
     weight_decay: 0.0
 
 scheduler:
-  class_path: otx.algo.schedulers.WarmupReduceLROnPlateau
-  init_args:
-    warmup_steps: 100
-    mode: max
-    factor: 0.5
-    patience: 5
-    monitor: val/mIoU
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 100
+  - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+    init_args:
+      mode: max
+      factor: 0.5
+      patience: 5
+      monitor: val/mIoU
 
 engine:
   task: SEMANTIC_SEGMENTATION

--- a/src/otx/recipe/semantic_segmentation/segnext_b.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_b.yaml
@@ -14,12 +14,14 @@ optimizer:
     weight_decay: 0.01
 
 scheduler:
-  class_path: otx.algo.schedulers.warmup_schedulers.WarmupPolynomialLR
-  init_args:
-    warmup_steps: 20
-    total_iters: 100
-    power: 0.9
-    last_epoch: -1
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 20
+  - class_path: torch.optim.lr_scheduler.PolynomialLR
+    init_args:
+      total_iters: 100
+      power: 0.9
+      last_epoch: -1
 
 engine:
   task: SEMANTIC_SEGMENTATION
@@ -29,7 +31,7 @@ callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
 overrides:
-  max_epochs: 150
+  max_epochs: 170
   data:
     config:
       train_subset:

--- a/src/otx/recipe/semantic_segmentation/segnext_b.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_b.yaml
@@ -29,6 +29,7 @@ callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
 overrides:
+  max_epochs: 150
   data:
     config:
       train_subset:

--- a/src/otx/recipe/semantic_segmentation/segnext_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_s.yaml
@@ -14,12 +14,14 @@ optimizer:
     weight_decay: 0.01
 
 scheduler:
-  class_path: otx.algo.schedulers.warmup_schedulers.WarmupPolynomialLR
-  init_args:
-    warmup_steps: 20
-    total_iters: 100
-    power: 0.9
-    last_epoch: -1
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 20
+  - class_path: torch.optim.lr_scheduler.PolynomialLR
+    init_args:
+      total_iters: 100
+      power: 0.9
+      last_epoch: -1
 
 engine:
   task: SEMANTIC_SEGMENTATION
@@ -29,7 +31,7 @@ callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
 overrides:
-  max_epochs: 150
+  max_epochs: 170
   data:
     config:
       train_subset:

--- a/src/otx/recipe/semantic_segmentation/segnext_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_s.yaml
@@ -29,6 +29,7 @@ callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
 overrides:
+  max_epochs: 150
   data:
     config:
       train_subset:

--- a/src/otx/recipe/semantic_segmentation/segnext_t.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_t.yaml
@@ -14,12 +14,14 @@ optimizer:
     weight_decay: 0.01
 
 scheduler:
-  class_path: otx.algo.schedulers.warmup_schedulers.WarmupPolynomialLR
-  init_args:
-    warmup_steps: 20
-    total_iters: 100
-    power: 0.9
-    last_epoch: -1
+  - class_path: otx.core.model.module.base.LinearWarmupScheduler
+    init_args:
+      num_warmup_steps: 20
+  - class_path: torch.optim.lr_scheduler.PolynomialLR
+    init_args:
+      total_iters: 100
+      power: 0.9
+      last_epoch: -1
 
 engine:
   task: SEMANTIC_SEGMENTATION
@@ -29,7 +31,7 @@ callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
 overrides:
-  max_epochs: 150
+  max_epochs: 170
   data:
     config:
       train_subset:

--- a/src/otx/recipe/semantic_segmentation/segnext_t.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_t.yaml
@@ -29,6 +29,7 @@ callback_monitor: val/mIoU
 
 data: ../_base_/data/mmseg_base.yaml
 overrides:
+  max_epochs: 150
   data:
     config:
       train_subset:

--- a/tests/unit/algo/callbacks/test_adaptive_train_scheduling.py
+++ b/tests/unit/algo/callbacks/test_adaptive_train_scheduling.py
@@ -32,6 +32,7 @@ class TestAdaptiveTrainScheduling:
 
         mock_lr_scheduler_config = MagicMock(spec=LRSchedulerConfig)
         mock_lr_scheduler_config.frequency = 1
+        mock_lr_scheduler_config.interval = "epoch"
         mock_trainer.lr_scheduler_configs = [mock_lr_scheduler_config]
 
         with caplog.at_level(log.WARNING):

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -124,9 +124,19 @@ class TestAutoConfigurator:
     def test_get_optimizer(self) -> None:
         task = OTXTaskType.SEMANTIC_SEGMENTATION
         auto_configurator = AutoConfigurator(task=task)
-        assert callable(auto_configurator.get_optimizer())
+        optimizer = auto_configurator.get_optimizer()
+        if isinstance(optimizer, list):
+            for opt in optimizer:
+                assert callable(opt)
+        else:
+            assert callable(optimizer)
 
     def test_get_scheduler(self) -> None:
         task = OTXTaskType.INSTANCE_SEGMENTATION
         auto_configurator = AutoConfigurator(task=task)
-        assert callable(auto_configurator.get_scheduler())
+        scheduler = auto_configurator.get_scheduler()
+        if isinstance(scheduler, list):
+            for sch in scheduler:
+                assert callable(sch)
+        else:
+            assert callable(scheduler)


### PR DESCRIPTION
### Summary

- Fix wrong update the frequency of the warmup-scheduler (This is the cause of a bug from `AdaptiveTrainingCallback`. -> Longer warmup times in small-dataset)

| Model            | Dataset         | Before (map_50) | After (map_50) | seed |
|------------------|-----------------|-----------------|----------------|------|
| ATSS_MobilenetV2 | Pothole_small_0 |             0.0 |           0.46 |    0 |

- Fixes an issue where `overrides` would throw an error if `configs.callbacks` came in as `None`.
- Modify the optimizer and scheduler to receive them as a list.
- `WarmupReduceLROnPlateau` -> `LinearWarmupScheduler + ReduceLROnPlateau`.
- `WarmupPolynomialLR` -> `LinearWarmupScheduler + PolynomialLR`.
- It also modifies it to match the configuration based on OTX1.6 (develop).
    - `max_epochs`, `warmup_iters`, `early-stopping patience`

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
