### PR TITLE
Separate integration tests by task

### DIFF
--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -94,4 +94,4 @@ jobs:
       - name: Install tox
         run: python -m pip install tox
       - name: Run Integration Test
-        run: TASK=${{ matrix.task }} tox -vv -e integration-test
+        run: tox -vv -e integration-test-${{ matrix.task }}

--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -82,7 +82,7 @@ jobs:
     name: Integration-Test-${{ matrix.task }}-py310
     # This is what will cancel the job concurrency
     concurrency:
-      group: ${{ github.workflow }}-Integration-${{ github.event.pull_request.number || github.ref }}
+      group: ${{ github.workflow }}-Integration-${{ github.event.pull_request.number || github.ref }}-${{ matrix.task }}
       cancel-in-progress: true
     steps:
       - name: Checkout repository

--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -68,17 +68,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - task: "MULTI_CLASS_CLS"
-          - task: "MULTI_LABEL_CLS"
-          - task: "H_LABEL_CLS"
-          - task: "DETECTION"
-          - task: "ROTATED_DETECTION"
-          - task: "INSTANCE_SEGMENTATION"
-          - task: "SEMANTIC_SEGMENTATION"
-          - task: "ACTION_CLASSIFICATION"
-          - task: "ACTION_DETECTION"
-          - task: "VISUAL_PROMPTING"
-          - task: "ZERO_SHOT_VISUAL_PROMPTING"
+          - task: "action"
+          - task: "classification"
+          - task: "detection"
+          - task: "instance_segmentation"
+          - task: "semantic_segmentation"
+          - task: "visual_prompting"
     name: Integration-Test-${{ matrix.task }}-py310
     # This is what will cancel the job concurrency
     concurrency:

--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - task: "MULTI_CLASS_CLS"
-          - task: "MULTI_LABLE_CLS"
+          - task: "MULTI_LABEL_CLS"
           - task: "H_LABEL_CLS"
           - task: "DETECTION"
           - task: "ROTATED_DETECTION"

--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -68,9 +68,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.10"
-            tox-env: "py310"
-    name: Integration-Test-Py${{ matrix.python-version }}
+          - task: "MULTI_CLASS_CLS"
+          - task: "MULTI_LABLE_CLS"
+          - task: "H_LABEL_CLS"
+          - task: "DETECTION"
+          - task: "ROTATED_DETECTION"
+          - task: "INSTANCE_SEGMENTATION"
+          - task: "SEMANTIC_SEGMENTATION"
+          - task: "ACTION_CLASSIFICATION"
+          - task: "ACTION_DETECTION"
+          - task: "VISUAL_PROMPTING"
+          - task: "ZERO_SHOT_VISUAL_PROMPTING"
+    name: Integration-Test-${{ matrix.task }}-py310
     # This is what will cancel the job concurrency
     concurrency:
       group: ${{ github.workflow }}-Integration-${{ github.event.pull_request.number || github.ref }}
@@ -81,8 +90,8 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
       - name: Install tox
         run: python -m pip install tox
       - name: Run Integration Test
-        run: tox -vv -e integration-test
+        run: TASK=${{ matrix.task }} tox -vv -e integration-test

--- a/tests/integration/api/test_auto_configuration.py
+++ b/tests/integration/api/test_auto_configuration.py
@@ -11,6 +11,7 @@ from otx.engine import Engine
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
 
+@pytest.mark.parametrize("task", pytest.TASK_LIST)
 def test_auto_configuration(
     task: OTXTaskType,
     tmp_path: Path,
@@ -54,7 +55,8 @@ def test_auto_configuration(
 
     assert engine._auto_configurator.config == default_config
 
-    train_metric = engine.train(max_epochs=default_config.get("max_epochs", 2))
+    max_epochs = 2 if task.lower() != "zero_shot_visual_prompting" else 1
+    train_metric = engine.train(max_epochs=max_epochs)
     if task.lower() != "zero_shot_visual_prompting":
         assert len(train_metric) > 0
 

--- a/tests/integration/api/test_auto_configuration.py
+++ b/tests/integration/api/test_auto_configuration.py
@@ -55,7 +55,7 @@ def test_auto_configuration(
     assert engine._auto_configurator.config == default_config
 
     train_metric = engine.train(max_epochs=default_config.get("max_epochs", 2))
-    if task != "zero_shot_visual_prompting":
+    if task.lower() != "zero_shot_visual_prompting":
         assert len(train_metric) > 0
 
     test_metric = engine.test()

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -25,6 +25,8 @@ def test_engine_from_config(
         fxt_accelerator (str): The accelerator used for training.
         fxt_target_dataset_per_task (dict): A dictionary mapping tasks to target datasets.
     """
+    if task not in DEFAULT_CONFIG_PER_TASK:
+        pytest.skip("Only the Task has Default config is tested to reduce unnecessary resources.")
     if task.lower() in ("action_classification"):
         pytest.xfail(reason="xFail until this root cause is resolved on the Datumaro side.")
 

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -11,6 +11,7 @@ from otx.engine import Engine
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK, OVMODEL_PER_TASK
 
 
+@pytest.mark.parametrize("task", pytest.TASK_LIST)
 def test_engine_from_config(
     task: OTXTaskType,
     tmp_path: Path,

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -11,7 +11,6 @@ from otx.engine import Engine
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK, OVMODEL_PER_TASK
 
 
-@pytest.mark.parametrize("task", list(DEFAULT_CONFIG_PER_TASK))
 def test_engine_from_config(
     task: OTXTaskType,
     tmp_path: Path,

--- a/tests/integration/cli/test_auto_configuration.py
+++ b/tests/integration/cli/test_auto_configuration.py
@@ -11,6 +11,7 @@ from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 from tests.integration.cli.utils import run_main
 
 
+@pytest.mark.parametrize("task", pytest.TASK_LIST)
 def test_otx_cli_auto_configuration(
     task: OTXTaskType,
     tmp_path: Path,

--- a/tests/integration/cli/test_auto_configuration.py
+++ b/tests/integration/cli/test_auto_configuration.py
@@ -5,14 +5,14 @@
 from pathlib import Path
 
 import pytest
+from otx.core.types.task import OTXTaskType
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
 from tests.integration.cli.utils import run_main
 
 
-@pytest.mark.parametrize("task", [task.value.lower() for task in DEFAULT_CONFIG_PER_TASK])
 def test_otx_cli_auto_configuration(
-    task: str,
+    task: OTXTaskType,
     tmp_path: Path,
     fxt_accelerator: str,
     fxt_target_dataset_per_task: dict,
@@ -22,7 +22,7 @@ def test_otx_cli_auto_configuration(
     """Test the OTX auto configuration with CLI.
 
     Args:
-        task (str): The task to be performed.
+        task (OTXTaskType): The task to be performed.
         tmp_path (Path): The temporary path for storing outputs.
         fxt_accelerator (str): The accelerator to be used.
         fxt_target_dataset_per_task (dict): The target dataset per task.
@@ -30,14 +30,16 @@ def test_otx_cli_auto_configuration(
     Returns:
         None
     """
-    if task in ("action_classification"):
+    if task not in DEFAULT_CONFIG_PER_TASK:
+        pytest.skip(f"Task {task} is not supported in the auto-configuration.")
+    if task.lower() in ("action_classification"):
         pytest.xfail(reason="xFail until this root cause is resolved on the Datumaro side.")
     tmp_path_train = tmp_path / f"otx_auto_train_{task}"
     command_cfg = [
         "otx",
         "train",
         "--data_root",
-        fxt_target_dataset_per_task[task],
+        fxt_target_dataset_per_task[task.lower()],
         "--task",
         task.upper(),
         "--engine.work_dir",
@@ -46,7 +48,7 @@ def test_otx_cli_auto_configuration(
         fxt_accelerator,
         "--max_epochs",
         "2",
-        *fxt_cli_override_command_per_task[task],
+        *fxt_cli_override_command_per_task[task.lower()],
     ]
 
     run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import importlib
-import inspect
 from pathlib import Path
 
 import pytest
@@ -11,15 +9,7 @@ import yaml
 
 from tests.integration.cli.utils import run_main
 
-# This assumes have OTX installed in environment.
-otx_module = importlib.import_module("otx")
-RECIPE_PATH = Path(inspect.getfile(otx_module)).parent / "recipe"
-RECIPE_LIST = [str(p) for p in RECIPE_PATH.glob("**/*.yaml") if "_base_" not in p.parts]
-RECIPE_OV_LIST = [str(p) for p in RECIPE_PATH.glob("**/openvino_model.yaml") if "_base_" not in p.parts]
-RECIPE_LIST = set(RECIPE_LIST) - set(RECIPE_OV_LIST)
 
-
-@pytest.mark.parametrize("recipe", RECIPE_LIST)
 def test_otx_e2e(
     recipe: str,
     tmp_path: Path,
@@ -177,7 +167,6 @@ def test_otx_e2e(
     assert (tmp_path_test / "outputs").exists()
 
 
-@pytest.mark.parametrize("recipe", RECIPE_LIST)
 def test_otx_explain_e2e(
     recipe: str,
     tmp_path: Path,
@@ -249,9 +238,8 @@ def test_otx_explain_e2e(
         assert np.max(np.abs(actual_sal_vals - ref_sal_vals) <= 3)
 
 
-@pytest.mark.parametrize("recipe", RECIPE_OV_LIST)
 def test_otx_ov_test(
-    recipe: str,
+    ov_recipe: str,
     tmp_path: Path,
     fxt_target_dataset_per_task: dict,
     fxt_open_subprocess: bool,
@@ -268,8 +256,8 @@ def test_otx_ov_test(
     Returns:
         None
     """
-    task = recipe.split("/")[-2]
-    model_name = recipe.split("/")[-1].split(".")[0]
+    task = ov_recipe.split("/")[-2]
+    model_name = ov_recipe.split("/")[-1].split(".")[0]
 
     if task in ["multi_label_cls", "instance_segmentation", "h_label_cls"]:
         # OMZ doesn't have proper model for Pytorch MaskRCNN interface
@@ -282,7 +270,7 @@ def test_otx_ov_test(
         "otx",
         "test",
         "--config",
-        recipe,
+        ov_recipe,
         "--data_root",
         fxt_target_dataset_per_task[task],
         "--engine.work_dir",

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -10,6 +10,11 @@ import yaml
 from tests.integration.cli.utils import run_main
 
 
+@pytest.mark.parametrize(
+    "recipe",
+    pytest.RECIPE_LIST,
+    ids=lambda x: "/".join(Path(x).parts[-2:]),
+)
 def test_otx_e2e(
     recipe: str,
     tmp_path: Path,
@@ -167,6 +172,11 @@ def test_otx_e2e(
     assert (tmp_path_test / "outputs").exists()
 
 
+@pytest.mark.parametrize(
+    "recipe",
+    pytest.RECIPE_LIST,
+    ids=lambda x: "/".join(Path(x).parts[-2:]),
+)
 def test_otx_explain_e2e(
     recipe: str,
     tmp_path: Path,
@@ -238,6 +248,11 @@ def test_otx_explain_e2e(
         assert np.max(np.abs(actual_sal_vals - ref_sal_vals) <= 3)
 
 
+# @pytest.mark.skipif(len(pytest.RECIPE_OV_LIST) < 1, reason="No OV recipe found.")
+@pytest.mark.parametrize(
+    "ov_recipe",
+    pytest.RECIPE_OV_LIST,
+)
 def test_otx_ov_test(
     ov_recipe: str,
     tmp_path: Path,

--- a/tests/integration/cli/test_export_inference.py
+++ b/tests/integration/cli/test_export_inference.py
@@ -46,6 +46,11 @@ TASK_NAME_TO_MAIN_METRIC_NAME = {
 }
 
 
+@pytest.mark.parametrize(
+    "recipe",
+    pytest.RECIPE_LIST,
+    ids=lambda x: "/".join(Path(x).parts[-2:]),
+)
 def test_otx_export_infer(
     recipe: str,
     tmp_path: Path,

--- a/tests/integration/cli/test_export_inference.py
+++ b/tests/integration/cli/test_export_inference.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import importlib
-import inspect
 import logging
 from pathlib import Path
 
@@ -13,13 +11,6 @@ import pytest
 from tests.integration.cli.utils import run_main
 
 log = logging.getLogger(__name__)
-
-# This assumes have OTX installed in environment.
-otx_module = importlib.import_module("otx")
-RECIPE_PATH = Path(inspect.getfile(otx_module)).parent / "recipe"
-RECIPE_LIST = [str(p) for p in RECIPE_PATH.glob("**/*.yaml") if "_base_" not in p.parts]
-RECIPE_OV_LIST = [str(p) for p in RECIPE_PATH.glob("**/openvino_model.yaml") if "_base_" not in p.parts]
-RECIPE_LIST = set(RECIPE_LIST) - set(RECIPE_OV_LIST)
 
 
 def _check_relative_metric_diff(ref: float, value: float, eps: float) -> None:
@@ -55,7 +46,6 @@ TASK_NAME_TO_MAIN_METRIC_NAME = {
 }
 
 
-@pytest.mark.parametrize("recipe", RECIPE_LIST, ids=lambda x: "/".join(Path(x).parts[-2:]))
 def test_otx_export_infer(
     recipe: str,
     tmp_path: Path,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -109,12 +109,15 @@ def pytest_generate_tests(metafunc):
             ids=lambda x: "/".join(Path(x).parts[-2:]),
         )
     if "ov_recipe" in metafunc.fixturenames:
-        metafunc.parametrize(
-            "ov_recipe",
-            metafunc.config.RECIPE_OV_LIST,
-            scope="session",
-            ids=lambda x: "/".join(Path(x).parts[-2:]),
-        )
+        if metafunc.config.RECIPE_OV_LIST:
+            metafunc.parametrize(
+                "ov_recipe",
+                metafunc.config.RECIPE_OV_LIST,
+                scope="session",
+                ids=lambda x: "/".join(Path(x).parts[-2:]),
+            )
+        else:
+            pytest.skip("No OpenVINO recipe found for the task.")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -76,7 +76,7 @@ def pytest_configure(config):
         recipe_path = find_recipe_folder(recipe_path, task.value.lower())
         task_list = [task]
     else:
-        task_list = list(OTXTaskType)
+        task_list = [task_type for task_type in OTXTaskType if task_type != OTXTaskType.DETECTION_SEMI_SL]
 
     # Update RECIPE_LIST
     recipe_list = [str(p) for p in recipe_path.glob("**/*.yaml") if "_base_" not in p.parts]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,11 +1,15 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+from __future__ import annotations
 
+import importlib
+import inspect
 from pathlib import Path
 
 import pytest
 from mmengine.config import Config as MMConfig
+from otx.core.types.task import OTXTaskType
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -15,6 +19,13 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Open subprocess for each CLI integration test case. "
         "This option can be used for easy memory management "
         "while running consecutive multiple tests (default: false).",
+    )
+    parser.addoption(
+        "--task",
+        action="store",
+        default=None,
+        type=OTXTaskType,
+        help="Task type of OTX to use integration test.",
     )
 
 
@@ -26,6 +37,84 @@ def fxt_open_subprocess(request: pytest.FixtureRequest) -> bool:
     while running consecutive multiple tests (default: false).
     """
     return request.config.getoption("--open-subprocess")
+
+
+def find_recipe_folder(base_path: Path, folder_name: str) -> Path:
+    """
+    Find the folder with the given name within the specified base path.
+
+    Args:
+        base_path (Path): The base path to search within.
+        folder_name (str): The name of the folder to find.
+
+    Returns:
+        Path: The path to the folder.
+    """
+    for folder_path in base_path.rglob(folder_name):
+        if folder_path.is_dir():
+            return folder_path
+    msg = f"Folder {folder_name} not found in {base_path}."
+    raise FileNotFoundError(msg)
+
+
+def pytest_configure(config):
+    """Configure pytest options and set task, recipe, and recipe_ov lists.
+
+    Args:
+        config (pytest.Config): The pytest configuration object.
+
+    Returns:
+        None
+    """
+    task = config.getoption("--task")
+
+    # This assumes have OTX installed in environment.
+    otx_module = importlib.import_module("otx")
+    # Modify RECIPE_PATH based on the task
+    recipe_path = Path(inspect.getfile(otx_module)).parent / "recipe"
+    if task is not None:
+        recipe_path = find_recipe_folder(recipe_path, task.value.lower())
+        task_list = [task]
+    else:
+        task_list = list(OTXTaskType)
+
+    # Update RECIPE_LIST
+    recipe_list = [str(p) for p in recipe_path.glob("**/*.yaml") if "_base_" not in p.parts]
+    recipe_ov_list = [str(p) for p in recipe_path.glob("**/openvino_model.yaml") if "_base_" not in p.parts]
+    recipe_list = set(recipe_list) - set(recipe_ov_list)
+
+    config.TASK_LIST = task_list
+    config.RECIPE_LIST = recipe_list
+    config.RECIPE_OV_LIST = recipe_ov_list
+
+
+def pytest_generate_tests(metafunc):
+    """Generate test cases for pytest based on the provided fixtures.
+
+    This is to ensure that they behave separately per task.
+
+    Args:
+        metafunc: The metafunc object containing information about the test function.
+
+    Returns:
+        None
+    """
+    if "task" in metafunc.fixturenames:
+        metafunc.parametrize("task", metafunc.config.TASK_LIST, scope="session")
+    if "recipe" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "recipe",
+            metafunc.config.RECIPE_LIST,
+            scope="session",
+            ids=lambda x: "/".join(Path(x).parts[-2:]),
+        )
+    if "ov_recipe" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "ov_recipe",
+            metafunc.config.RECIPE_OV_LIST,
+            scope="session",
+            ids=lambda x: "/".join(Path(x).parts[-2:]),
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -42,13 +42,14 @@ commands =
 [testenv:integration-test]
 setenv =
     CUBLAS_WORKSPACE_CONFIG=:4096:8
+    TASK={env:TASK}
 deps =
     .[dev]
 commands_pre =
     ; [TODO]: Needs to be fixed so that this is not duplicated for each test run
     otx install -v
 commands =
-    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --open-subprocess {posargs:tests/integration}
+    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {env:TASK} --open-subprocess {posargs:tests/integration}
 
 
 [testenv:performance-test]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 isolated_build = true
 skip_missing_interpreters = true
+envlist = integration-test-{MULTI_CLASS_CLS,MULTI_LABEL_CLS,H_LABEL_CLS,DETECTION,ROTATED_DETECTION,INSTANCE_SEGMENTATION,SEMANTIC_SEGMENTATION,ACTION_CLASSIFICATION,ACTION_DETECTION,VISUAL_PROMPTING,ZERO_SHOT_VISUAL_PROMPTING}
 
 [pytest]
 addopts = --csv=.tox/tests-{env:TOXENV_TASK}-{env:TOXENV_PYVER}.csv
@@ -39,7 +40,7 @@ commands =
         {posargs}
 
 
-[testenv:integration-test]
+[testenv:integration-test-{MULTI_CLASS_CLS,MULTI_LABEL_CLS,H_LABEL_CLS,DETECTION,ROTATED_DETECTION,INSTANCE_SEGMENTATION,SEMANTIC_SEGMENTATION,ACTION_CLASSIFICATION,ACTION_DETECTION,VISUAL_PROMPTING,ZERO_SHOT_VISUAL_PROMPTING}]
 setenv =
     CUBLAS_WORKSPACE_CONFIG=:4096:8
     TASK={env:TASK}
@@ -49,7 +50,7 @@ commands_pre =
     ; [TODO]: Needs to be fixed so that this is not duplicated for each test run
     otx install -v
 commands =
-    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {env:TASK} --open-subprocess {posargs:tests/integration}
+    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {envname} --open-subprocess {posargs:tests/integration}
 
 
 [testenv:performance-test]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 isolated_build = true
 skip_missing_interpreters = true
-envlist = integration-test-{MULTI_CLASS_CLS,MULTI_LABEL_CLS,H_LABEL_CLS,DETECTION,ROTATED_DETECTION,INSTANCE_SEGMENTATION,SEMANTIC_SEGMENTATION,ACTION_CLASSIFICATION,ACTION_DETECTION,VISUAL_PROMPTING,ZERO_SHOT_VISUAL_PROMPTING}
 
 [pytest]
 addopts = --csv=.tox/tests-{env:TOXENV_TASK}-{env:TOXENV_PYVER}.csv
@@ -9,6 +8,18 @@ addopts = --csv=.tox/tests-{env:TOXENV_TASK}-{env:TOXENV_PYVER}.csv
 [testenv]
 setenv =
     TOX_WORK_DIR={toxworkdir}
+task =
+    MULTI_CLASS_CLS: "MULTI_CLASS_CLS"
+    MULTI_LABEL_CLS: "MULTI_LABEL_CLS"
+    H_LABEL_CLS: "H_LABEL_CLS"
+    DETECTION: "DETECTION"
+    ROTATED_DETECTION: "ROTATED_DETECTION"
+    INSTANCE_SEGMENTATION: "INSTANCE_SEGMENTATION"
+    SEMANTIC_SEGMENTATION: "SEMANTIC_SEGMENTATION"
+    ACTION_CLASSIFICATION: "ACTION_CLASSIFICATION"
+    ACTION_DETECTION: "ACTION_DETECTION"
+    VISUAL_PROMPTING: "VISUAL_PROMPTING"
+    ZERO_SHOT_VISUAL_PROMPTING: "ZERO_SHOT_VISUAL_PROMPTING"
 passenv =
     ftp_proxy
     HTTP_PROXY
@@ -43,15 +54,13 @@ commands =
 [testenv:integration-test-{MULTI_CLASS_CLS,MULTI_LABEL_CLS,H_LABEL_CLS,DETECTION,ROTATED_DETECTION,INSTANCE_SEGMENTATION,SEMANTIC_SEGMENTATION,ACTION_CLASSIFICATION,ACTION_DETECTION,VISUAL_PROMPTING,ZERO_SHOT_VISUAL_PROMPTING}]
 setenv =
     CUBLAS_WORKSPACE_CONFIG=:4096:8
-    TASK={envname:19}
 deps =
     .[dev]
 commands_pre =
     ; [TODO]: Needs to be fixed so that this is not duplicated for each test run
     otx install -v
 commands =
-    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {env:TASK} --open-subprocess {posargs:tests/integration}
-
+    python -m pytest tests/integration -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {[testenv]task} --open-subprocess {posargs}
 
 [testenv:performance-test]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -9,17 +9,14 @@ addopts = --csv=.tox/tests-{env:TOXENV_TASK}-{env:TOXENV_PYVER}.csv
 setenv =
     TOX_WORK_DIR={toxworkdir}
 task =
-    MULTI_CLASS_CLS: "MULTI_CLASS_CLS"
-    MULTI_LABEL_CLS: "MULTI_LABEL_CLS"
-    H_LABEL_CLS: "H_LABEL_CLS"
-    DETECTION: "DETECTION"
-    ROTATED_DETECTION: "ROTATED_DETECTION"
-    INSTANCE_SEGMENTATION: "INSTANCE_SEGMENTATION"
-    SEMANTIC_SEGMENTATION: "SEMANTIC_SEGMENTATION"
-    ACTION_CLASSIFICATION: "ACTION_CLASSIFICATION"
-    ACTION_DETECTION: "ACTION_DETECTION"
-    VISUAL_PROMPTING: "VISUAL_PROMPTING"
-    ZERO_SHOT_VISUAL_PROMPTING: "ZERO_SHOT_VISUAL_PROMPTING"
+    all: "all"
+    action: "action"
+    classification: "classification"
+    detection: "detection"
+    rotated_detection: "rotated_detection"
+    instance_segmentation: "instance_segmentation"
+    semantic_segmentation: "semantic_segmentation"
+    visual_prompting: "visual_prompting"
 passenv =
     ftp_proxy
     HTTP_PROXY
@@ -51,7 +48,7 @@ commands =
         {posargs}
 
 
-[testenv:integration-test-{MULTI_CLASS_CLS,MULTI_LABEL_CLS,H_LABEL_CLS,DETECTION,ROTATED_DETECTION,INSTANCE_SEGMENTATION,SEMANTIC_SEGMENTATION,ACTION_CLASSIFICATION,ACTION_DETECTION,VISUAL_PROMPTING,ZERO_SHOT_VISUAL_PROMPTING}]
+[testenv:integration-test-{all, action, classification, detection, rotated_detection, instance_segmentation, semantic_segmentation, visual_prompting}]
 setenv =
     CUBLAS_WORKSPACE_CONFIG=:4096:8
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands_pre =
     ; [TODO]: Needs to be fixed so that this is not duplicated for each test run
     otx install -v
 commands =
-    python -m pytest tests/integration -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {[testenv]task} --open-subprocess {posargs}
+    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {[testenv]task} --open-subprocess {posargs:tests/integration}
 
 [testenv:performance-test]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -43,14 +43,14 @@ commands =
 [testenv:integration-test-{MULTI_CLASS_CLS,MULTI_LABEL_CLS,H_LABEL_CLS,DETECTION,ROTATED_DETECTION,INSTANCE_SEGMENTATION,SEMANTIC_SEGMENTATION,ACTION_CLASSIFICATION,ACTION_DETECTION,VISUAL_PROMPTING,ZERO_SHOT_VISUAL_PROMPTING}]
 setenv =
     CUBLAS_WORKSPACE_CONFIG=:4096:8
-    TASK={env:TASK}
+    TASK={envname:19}
 deps =
     .[dev]
 commands_pre =
     ; [TODO]: Needs to be fixed so that this is not duplicated for each test run
     otx install -v
 commands =
-    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {envname} --open-subprocess {posargs:tests/integration}
+    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {env:TASK} --open-subprocess {posargs:tests/integration}
 
 
 [testenv:performance-test]

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands_pre =
     ; [TODO]: Needs to be fixed so that this is not duplicated for each test run
     otx install -v
 commands =
-    python -m pytest -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {[testenv]task} --open-subprocess {posargs:tests/integration}
+    python -m pytest tests/integration -ra --showlocals --csv={toxworkdir}/{envname}.csv --task {[testenv]task} --open-subprocess {posargs}
 
 [testenv:performance-test]
 deps =


### PR DESCRIPTION
### Summary

As integration tests exceed 50 minutes, development efficiency decreases.
So I modified it to run the test separately by Task.
This is a similar configuration to OTX `develop (1.6)`.

### How to test

Locally, you can run tests per task with the command below.
`python -m pytest tests/integration --task detection`
`tox -vv -e integration-test-detection`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
