### PR TITLE
[Release 1.5] Fix label order for h-cls

### DIFF
--- a/src/otx/algorithms/classification/adapters/openvino/task.py
+++ b/src/otx/algorithms/classification/adapters/openvino/task.py
@@ -127,7 +127,11 @@ class ClassificationOpenVINOInferencer(IInferencer):
 
         self.model = Model.create_model(model_adapter, "Classification", self.configuration, preload=True)
 
-        self.converter = ClassificationToAnnotationConverter(self.label_schema)
+        if self.model.hierarchical:
+            hierarchical_cls_heads_info = self.model.hierarchical_info["cls_heads_info"]
+        else:
+            hierarchical_cls_heads_info = None
+        self.converter = ClassificationToAnnotationConverter(self.label_schema, hierarchical_cls_heads_info)
         self.callback_exceptions: List[Exception] = []
         self.model.inference_adapter.set_callback(self._async_callback)
 

--- a/src/otx/algorithms/classification/utils/cls_utils.py
+++ b/src/otx/algorithms/classification/utils/cls_utils.py
@@ -18,8 +18,9 @@
 
 import json
 from operator import itemgetter
-from typing import Any, Dict
+from typing import Any, Dict, List
 
+from otx.api.entities.label import LabelEntity
 from otx.api.entities.label_schema import LabelSchemaEntity
 from otx.api.serialization.label_mapper import LabelSchemaMapper
 
@@ -51,8 +52,8 @@ def get_multihead_class_info(label_schema: LabelSchemaEntity):  # pylint: disabl
     for j, group in enumerate(single_label_groups):
         class_to_idx[group[0]] = (len(exclusive_groups), j)
 
-    all_labels = label_schema.get_labels(include_empty=False)
-    label_to_idx = {lbl.name: i for i, lbl in enumerate(all_labels)}
+    # Idx of label corresponds to model output
+    label_to_idx = {lbl: i for i, lbl in enumerate(class_to_idx.keys())}
 
     mixed_cls_heads_info = {
         "num_multiclass_heads": len(exclusive_groups),
@@ -104,9 +105,13 @@ def get_cls_model_api_configuration(label_schema: LabelSchemaEntity, inference_c
     mapi_config[("model_info", "hierarchical")] = str(inference_config["hierarchical"])
     mapi_config[("model_info", "output_raw_scores")] = str(True)
 
+    label_entities = label_schema.get_labels(include_empty=False)
+    if inference_config["hierarchical"]:
+        label_entities = get_hierarchical_label_list(inference_config["multihead_class_info"], label_entities)
+
     all_labels = ""
     all_label_ids = ""
-    for lbl in label_schema.get_labels(include_empty=False):
+    for lbl in label_entities:
         all_labels += lbl.name.replace(" ", "_") + " "
         all_label_ids += f"{lbl.id_} "
 
@@ -123,22 +128,16 @@ def get_cls_model_api_configuration(label_schema: LabelSchemaEntity, inference_c
     return mapi_config
 
 
-def get_hierarchical_label_list(hierarchical_info, labels):
+def get_hierarchical_label_list(hierarchical_cls_heads_info: Dict, labels: List) -> List[LabelEntity]:
     """Return hierarchical labels list which is adjusted to model outputs classes."""
-    hierarchical_labels = []
-    for head_idx in range(hierarchical_info["num_multiclass_heads"]):
-        logits_begin, logits_end = hierarchical_info["head_idx_to_logits_range"][str(head_idx)]
-        for logit in range(0, logits_end - logits_begin):
-            label_str = hierarchical_info["all_groups"][head_idx][logit]
-            label_idx = hierarchical_info["label_to_idx"][label_str]
-            hierarchical_labels.append(labels[label_idx])
 
-    if hierarchical_info["num_multilabel_classes"]:
-        logits_begin = hierarchical_info["num_single_label_classes"]
-        logits_end = len(labels)
-        for logit_idx, logit in enumerate(range(0, logits_end - logits_begin)):
-            label_str_idx = hierarchical_info["num_multiclass_heads"] + logit_idx
-            label_str = hierarchical_info["all_groups"][label_str_idx][0]
-            label_idx = hierarchical_info["label_to_idx"][label_str]
-            hierarchical_labels.append(labels[label_idx])
+    # Create the list of Label Entities (took from "labels")
+    # corresponding to names and order in "label_to_idx"
+    label_to_idx = hierarchical_cls_heads_info["label_to_idx"]
+    hierarchical_labels = []
+    for label_str, _ in label_to_idx.items():
+        for label_entity in labels:
+            if label_entity.name == label_str:
+                hierarchical_labels.append(label_entity)
+                break
     return hierarchical_labels

--- a/src/otx/api/usecases/exportable_code/prediction_to_annotation_converter.py
+++ b/src/otx/api/usecases/exportable_code/prediction_to_annotation_converter.py
@@ -18,6 +18,7 @@ from openvino.model_api.models.utils import (
     InstanceSegmentationResult,
 )
 
+from otx.algorithms.classification.utils import get_hierarchical_label_list
 from otx.api.entities.annotation import (
     Annotation,
     AnnotationSceneEntity,
@@ -182,7 +183,11 @@ def create_converter(
     elif converter_type == Domain.SEGMENTATION:
         converter = SegmentationToAnnotationConverter(labels)
     elif converter_type == Domain.CLASSIFICATION:
-        converter = ClassificationToAnnotationConverter(labels)
+        if configuration is not None and configuration.get("hierarchical", False):
+            hierarchical_cls_heads_info = configuration["multihead_class_info"]
+        else:
+            hierarchical_cls_heads_info = None
+        converter = ClassificationToAnnotationConverter(labels, hierarchical_cls_heads_info)
     elif converter_type == Domain.ANOMALY_CLASSIFICATION:
         converter = AnomalyClassificationToAnnotationConverter(labels)
     elif converter_type == Domain.ANOMALY_DETECTION:
@@ -280,9 +285,10 @@ class ClassificationToAnnotationConverter(IPredictionToAnnotationConverter):
 
     Args:
         labels (LabelSchemaEntity): Label Schema containing the label info of the task
+        hierarchical_cls_heads_info (Dict): Info from model.hierarchical_info["cls_heads_info"]
     """
 
-    def __init__(self, label_schema: LabelSchemaEntity):
+    def __init__(self, label_schema: LabelSchemaEntity, hierarchical_cls_heads_info: Optional[Dict] = None):
         if len(label_schema.get_labels(False)) == 1:
             self.labels = label_schema.get_labels(include_empty=True)
         else:
@@ -295,6 +301,9 @@ class ClassificationToAnnotationConverter(IPredictionToAnnotationConverter):
         self.hierarchical = not multilabel and len(label_schema.get_groups(False)) > 1
 
         self.label_schema = label_schema
+
+        if self.hierarchical:
+            self.labels = get_hierarchical_label_list(hierarchical_cls_heads_info, self.labels)
 
     def convert_to_annotation(
         self, predictions: ClassificationResult, metadata: Optional[Dict] = None

--- a/tests/unit/algorithms/classification/tasks/test_classification_openvino_task.py
+++ b/tests/unit/algorithms/classification/tasks/test_classification_openvino_task.py
@@ -101,8 +101,8 @@ class TestOpenVINOClassificationTask:
             "cls_heads_info": {
                 "num_multiclass_heads": 2,
                 "head_idx_to_logits_range": {"0": (0, 1), "1": (1, 2)},
-                "all_groups": [["a"], ["b"]],
-                "label_to_idx": {"a": 0, "b": 1},
+                "all_groups": [["b"], ["g"]],
+                "label_to_idx": {"b": 0, "g": 1},
                 "num_multilabel_classes": 0,
             }
         }
@@ -134,6 +134,7 @@ class TestOpenVINOClassificationTask:
             ),
         )
         mocker.patch.object(ShapeFactory, "shape_produces_valid_crop", return_value=True)
+        self.cls_ov_task.inferencer.model.hierarchical = True
         self.cls_ov_task.inferencer.model.hierarchical_info = self.fake_hierarchical_info
         updated_dataset = self.cls_ov_task.infer(
             self.dataset, InferenceParameters(enable_async_inference=False, is_evaluation=False)
@@ -188,6 +189,7 @@ class TestOpenVINOClassificationTask:
             ),
         )
         self.cls_ov_task.inferencer.model.hierarchical_info = self.fake_hierarchical_info
+        self.cls_ov_task.inferencer.model.hierarchical = True
         updpated_dataset = self.cls_ov_task.explain(self.dataset)
 
         assert updpated_dataset is not None

--- a/tests/unit/api/usecases/exportable_code/test_prediction_to_annotation_converter.py
+++ b/tests/unit/api/usecases/exportable_code/test_prediction_to_annotation_converter.py
@@ -758,7 +758,10 @@ class TestSegmentationToAnnotation:
                 labels=other_non_empty_labels,
             )
             label_schema = LabelSchemaEntity(label_groups=[label_group, other_label_group])
-            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            hierarchical_cls_heads_info = {"label_to_idx": {label_0_1.name: 0, label_0_1_1.name: 1, label_0_2.name: 2}}
+            converter = ClassificationToAnnotationConverter(
+                label_schema=label_schema, hierarchical_cls_heads_info=hierarchical_cls_heads_info
+            )
             assert not converter.empty_label
             assert converter.label_schema == label_schema
             assert converter.hierarchical
@@ -849,7 +852,10 @@ class TestSegmentationToAnnotation:
             label_schema = LabelSchemaEntity(label_groups=[label_group, other_label_group])
 
             label_schema.add_child(parent=label_0_1, child=label_0_1_1)
-            converter = ClassificationToAnnotationConverter(label_schema=label_schema)
+            hierarchical_cls_heads_info = {"label_to_idx": {label_0_1.name: 0, label_0_1_1.name: 1, label_0_2.name: 2}}
+            converter = ClassificationToAnnotationConverter(
+                label_schema=label_schema, hierarchical_cls_heads_info=hierarchical_cls_heads_info
+            )
             predictions = ClassificationResult([(2, 0.9), (1, 0.8)], None, None, None)
             predictions_to_annotations = converter.convert_to_annotation(predictions)
             check_annotation_scene(annotation_scene=predictions_to_annotations, expected_length=1)


### PR DESCRIPTION
### Summary
Duplicate of [PR#2906](https://github.com/openvinotoolkit/training_extensions/pull/2906) targeting to release 1.5

Fixing label order to pick correct saliency maps in Geti

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
