### PR TITLE
Enable auto_num_workers

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -217,6 +217,7 @@ class OTXCLI:
 
             sub_parser.link_arguments("data_root", "engine.data_root")
             sub_parser.link_arguments("data_root", "data.config.data_root")
+            sub_parser.link_arguments("engine.device", "data.config.device")
 
             fn = getattr(Engine, subcommand)
             description = get_short_docstring(fn)

--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from otx.core.types.device import DeviceType
 from otx.core.types.image import ImageColorChannel
 from otx.core.types.transformer_libs import TransformLibType
 
@@ -102,3 +103,6 @@ class DataModuleConfig:
     stack_images: bool = True
 
     include_polygons: bool = False
+
+    auto_num_workers: bool = False
+    device: DeviceType = DeviceType.auto

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -74,7 +74,11 @@ class OTXDataModule(LightningDataModule):
                     f"Current deveice type is {self.config.device!s}. auto_num_workers is skipped.",
                 )
             elif (num_workers := get_adaptive_num_workers()) is not None:
-                for subset_config in config_mapping.values():
+                for subset_name, subset_config in config_mapping.items():
+                    log.info(
+                        f"num_workers of {subset_name} subset is changed : "
+                        f"{subset_config.num_workers} -> {num_workers}",
+                    )
                     subset_config.num_workers = num_workers
 
         mem_size = parse_mem_cache_size_to_int(config.mem_cache_size)

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -22,7 +22,9 @@ from otx.core.data.mem_cache import (
 )
 from otx.core.data.pre_filtering import pre_filtering
 from otx.core.data.tile_adaptor import adapt_tile_config
+from otx.core.types.device import DeviceType
 from otx.core.types.task import OTXTaskType
+from otx.core.utils.utils import get_adaptive_num_workers
 
 if TYPE_CHECKING:
     from lightning.pytorch.utilities.parsing import AttributeDict
@@ -64,6 +66,16 @@ class OTXDataModule(LightningDataModule):
             self.config.val_subset.subset_name: self.config.val_subset,
             self.config.test_subset.subset_name: self.config.test_subset,
         }
+
+        if self.config.auto_num_workers:
+            if self.config.device not in [DeviceType.gpu, DeviceType.auto]:
+                log.warning(
+                    "Only GPU device type support auto_num_workers. "
+                    f"Current deveice type is {self.config.device!s}. auto_num_workers is skipped.",
+                )
+            elif (num_workers := get_adaptive_num_workers()) is not None:
+                for subset_config in config_mapping.values():
+                    subset_config.num_workers = num_workers
 
         mem_size = parse_mem_cache_size_to_int(config.mem_cache_size)
         mem_cache_mode = (

--- a/src/otx/core/utils/utils.py
+++ b/src/otx/core/utils/utils.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+from multiprocessing import cpu_count
 from typing import TYPE_CHECKING, Any
+
+import torch
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -48,3 +51,11 @@ def get_mean_std_from_data_processing(config: DictConfig) -> dict[str, Any]:
         "mean": config["data_preprocessor"]["mean"],
         "std": config["data_preprocessor"]["std"],
     }
+
+
+def get_adaptive_num_workers(num_dataloader: int = 1) -> int | None:
+    """Measure appropriate num_workers value and return it."""
+    num_gpus = torch.cuda.device_count()
+    if num_gpus == 0:
+        return None
+    return min(cpu_count() // (num_dataloader * num_gpus), 8)  # max available num_workers is 8

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -362,4 +362,3 @@ def test_otx_hpo_e2e(
     hpo_work_dor = tmp_path_hpo / "hpo"
     assert hpo_work_dor.exists()
     assert len([val for val in hpo_work_dor.rglob("*.json") if str(val.stem).isdigit()]) == 2
-    assert len(list(hpo_work_dor.rglob("*.ckpt"))) == 1

--- a/tests/unit/core/data/test_module.py
+++ b/tests/unit/core/data/test_module.py
@@ -92,6 +92,8 @@ class TestModule:
         cfg.mem_cache_size = "1GB"
         cfg.tile_config = {}
         cfg.tile_config.enable_tiler = False
+        cfg.auto_num_workers = False
+        cfg.device = "auto"
         return cfg
 
     @patch("otx.core.data.module.OTXDatasetFactory")

--- a/tests/unit/core/utils/test_utils.py
+++ b/tests/unit/core/utils/test_utils.py
@@ -1,0 +1,26 @@
+import pytest
+from otx.core.utils import utils as target_file
+from otx.core.utils.utils import get_adaptive_num_workers
+
+
+@pytest.mark.parametrize("num_dataloader", [1, 2, 4])
+def test_get_adaptive_num_workers(mocker, num_dataloader):
+    num_gpu = 5
+    mock_torch = mocker.patch.object(target_file, "torch")
+    mock_torch.cuda.device_count.return_value = num_gpu
+
+    num_cpu = 20
+    mocker.patch.object(target_file, "cpu_count", return_value=num_cpu)
+
+    assert get_adaptive_num_workers(num_dataloader) == num_cpu // (num_gpu * num_dataloader)
+
+
+def test_get_adaptive_num_workers_no_gpu(mocker):
+    num_gpu = 0
+    mock_torch = mocker.patch.object(target_file, "torch")
+    mock_torch.cuda.device_count.return_value = num_gpu
+
+    num_cpu = 20
+    mocker.patch.object(target_file, "cpu_count", return_value=num_cpu)
+
+    assert get_adaptive_num_workers() is None


### PR DESCRIPTION
### Summary
Implement auto_num_workers.
It simply decides proper num_workers values based on number of GPU and number of CPU cores.
Additionally, I change HPO test code to check all ckpt files are removed except best wegith.
It's because model weights of last trials tried right before HPO is done can be left if HPO algo is finished before trials is finalized.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
