### PR TITLE
Update usage of save_model

### DIFF
--- a/src/otx/algorithms/action/adapters/openvino/task.py
+++ b/src/otx/algorithms/action/adapters/openvino/task.py
@@ -315,7 +315,7 @@ class ActionOpenVINOTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IOpti
 
         with tempfile.TemporaryDirectory() as tempdir:
             xml_path = os.path.join(tempdir, "model.xml")
-            ov.serialize(compressed_model, xml_path)
+            ov.save_model(compressed_model, xml_path)
             with open(xml_path, "rb") as f:
                 output_model.set_data("openvino.xml", f.read())
             with open(os.path.join(tempdir, "model.bin"), "rb") as f:

--- a/src/otx/algorithms/anomaly/tasks/openvino.py
+++ b/src/otx/algorithms/anomaly/tasks/openvino.py
@@ -355,7 +355,7 @@ class OpenVINOTask(IInferenceTask, IEvaluationTask, IOptimizationTask, IDeployme
 
         with tempfile.TemporaryDirectory() as tempdir:
             xml_path = os.path.join(tempdir, "model.xml")
-            ov.serialize(compressed_model, xml_path)
+            ov.save_model(compressed_model, xml_path)
             self.__load_weights(path=xml_path, output_model=output_model, key="openvino.xml")
             self.__load_weights(path=os.path.join(tempdir, "model.bin"), output_model=output_model, key="openvino.bin")
 

--- a/src/otx/algorithms/classification/adapters/openvino/task.py
+++ b/src/otx/algorithms/classification/adapters/openvino/task.py
@@ -425,7 +425,7 @@ class ClassificationOpenVINOTask(IDeploymentTask, IInferenceTask, IEvaluationTas
 
         with tempfile.TemporaryDirectory() as tempdir:
             xml_path = os.path.join(tempdir, "model.xml")
-            ov.serialize(compressed_model, xml_path)
+            ov.save_model(compressed_model, xml_path)
             with open(xml_path, "rb") as f:
                 output_model.set_data("openvino.xml", f.read())
             with open(os.path.join(tempdir, "model.bin"), "rb") as f:

--- a/src/otx/algorithms/common/utils/ir.py
+++ b/src/otx/algorithms/common/utils/ir.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
-from openvino.runtime import Core, serialize
+from openvino.runtime import Core, save_model
 
 
 def check_if_quantized(model: Any) -> bool:
@@ -34,6 +34,6 @@ def embed_ir_model_data(xml_file: str, data_items: Dict[Tuple[str, str], Any]) -
 
     # workaround for CVS-110054
     tmp_xml_path = Path(Path(xml_file).parent) / "tmp.xml"
-    serialize(model, str(tmp_xml_path))
+    save_model(model, str(tmp_xml_path), compress_to_fp16=False)
     tmp_xml_path.rename(xml_file)
     Path(str(tmp_xml_path.parent / tmp_xml_path.stem) + ".bin").unlink()

--- a/src/otx/algorithms/detection/adapters/openvino/task.py
+++ b/src/otx/algorithms/detection/adapters/openvino/task.py
@@ -722,7 +722,7 @@ class OpenVINODetectionTask(IDeploymentTask, IInferenceTask, IEvaluationTask, IO
 
         with tempfile.TemporaryDirectory() as tempdir:
             xml_path = os.path.join(tempdir, "model.xml")
-            ov.serialize(compressed_model, xml_path)
+            ov.save_model(compressed_model, xml_path)
             with open(xml_path, "rb") as f:
                 output_model.set_data("openvino.xml", f.read())
             with open(os.path.join(tempdir, "model.bin"), "rb") as f:

--- a/src/otx/algorithms/segmentation/adapters/openvino/task.py
+++ b/src/otx/algorithms/segmentation/adapters/openvino/task.py
@@ -367,7 +367,7 @@ class OpenVINOSegmentationTask(IDeploymentTask, IInferenceTask, IEvaluationTask,
 
         with tempfile.TemporaryDirectory() as tempdir:
             xml_path = os.path.join(tempdir, "model.xml")
-            ov.serialize(compressed_model, xml_path)
+            ov.save_model(compressed_model, xml_path)
             with open(xml_path, "rb") as f:
                 output_model.set_data("openvino.xml", f.read())
             with open(os.path.join(tempdir, "model.bin"), "rb") as f:

--- a/src/otx/algorithms/visual_prompting/tasks/openvino.py
+++ b/src/otx/algorithms/visual_prompting/tasks/openvino.py
@@ -815,7 +815,7 @@ class OpenVINOVisualPromptingTask(IInferenceTask, IEvaluationTask, IOptimization
             with tempfile.TemporaryDirectory() as tempdir:
                 xml_path = os.path.join(tempdir, f"visual_prompting_{module_name}.xml")
                 bin_path = os.path.join(tempdir, f"visual_prompting_{module_name}.bin")
-                ov.serialize(compressed_model, xml_path)
+                ov.save_model(compressed_model, xml_path)
                 with open(xml_path, "rb") as f:
                     output_model.set_data(f"visual_prompting_{module_name}.xml", f.read())
                 with open(bin_path, "rb") as f:

--- a/tests/unit/algorithms/action/adapters/openvino/test_task.py
+++ b/tests/unit/algorithms/action/adapters/openvino/test_task.py
@@ -347,7 +347,7 @@ class TestActionOVTask:
                 f.write(np.ndarray(1).tobytes())
 
         mocker.patch("otx.algorithms.action.adapters.openvino.task.ov.Core.read_model", autospec=True)
-        mocker.patch("otx.algorithms.action.adapters.openvino.task.ov.serialize", new=mock_save_model)
+        mocker.patch("otx.algorithms.action.adapters.openvino.task.ov.save_model", new=mock_save_model)
         fake_quantize = mocker.patch("otx.algorithms.action.adapters.openvino.task.nncf.quantize", autospec=True)
 
         mocker.patch(

--- a/tests/unit/algorithms/classification/tasks/test_classification_openvino_task.py
+++ b/tests/unit/algorithms/classification/tasks/test_classification_openvino_task.py
@@ -231,7 +231,7 @@ class TestOpenVINOClassificationTask:
         self.cls_ov_task.model.set_data("openvino.bin", b"foo")
         self.cls_ov_task.model.set_data("openvino.xml", b"bar")
         mocker.patch("otx.algorithms.classification.adapters.openvino.task.ov.Core.read_model", autospec=True)
-        mocker.patch("otx.algorithms.classification.adapters.openvino.task.ov.serialize", new=patch_save_model)
+        mocker.patch("otx.algorithms.classification.adapters.openvino.task.ov.save_model", new=patch_save_model)
         fake_quantize = mocker.patch(
             "otx.algorithms.classification.adapters.openvino.task.nncf.quantize", autospec=True
         )

--- a/tests/unit/algorithms/detection/adapters/openvino/test_task.py
+++ b/tests/unit/algorithms/detection/adapters/openvino/test_task.py
@@ -235,7 +235,7 @@ class TestOpenVINODetectionTask:
         self.ov_task.model.set_data("openvino.bin", b"foo")
         self.ov_task.model.set_data("openvino.xml", b"bar")
         mocker.patch("otx.algorithms.detection.adapters.openvino.task.ov.Core.read_model", autospec=True)
-        mocker.patch("otx.algorithms.detection.adapters.openvino.task.ov.serialize", new=patch_save_model)
+        mocker.patch("otx.algorithms.detection.adapters.openvino.task.ov.save_model", new=patch_save_model)
         fake_quantize = mocker.patch("otx.algorithms.detection.adapters.openvino.task.nncf.quantize", autospec=True)
         self.ov_task.optimize(OptimizationType.POT, dataset=dataset, output_model=output_model)
 

--- a/tests/unit/algorithms/segmentation/adapters/openvino/test_openvino_task.py
+++ b/tests/unit/algorithms/segmentation/adapters/openvino/test_openvino_task.py
@@ -184,7 +184,7 @@ class TestOpenVINOSegmentationTask:
         self.seg_ov_task.model.set_data("openvino.xml", b"bar")
 
         mocker.patch("otx.algorithms.segmentation.adapters.openvino.task.ov.Core.read_model", autospec=True)
-        mocker.patch("otx.algorithms.segmentation.adapters.openvino.task.ov.serialize", new=patch_save_model)
+        mocker.patch("otx.algorithms.segmentation.adapters.openvino.task.ov.save_model", new=patch_save_model)
         fake_quantize = mocker.patch("otx.algorithms.segmentation.adapters.openvino.task.nncf.quantize", autospec=True)
         self.seg_ov_task.optimize(OptimizationType.POT, dataset=dataset, output_model=output_model)
 

--- a/tests/unit/algorithms/visual_prompting/tasks/test_openvino.py
+++ b/tests/unit/algorithms/visual_prompting/tasks/test_openvino.py
@@ -530,7 +530,7 @@ class TestOpenVINOVisualPromptingTask:
         self.visual_prompting_ov_task.model.set_data("visual_prompting_decoder.xml", b"decoder_xml")
         self.visual_prompting_ov_task.model.set_data("visual_prompting_decoder.bin", b"decoder_bin")
         mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.Core.read_model", autospec=True)
-        mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.serialize", new=patch_save_model)
+        mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.save_model", new=patch_save_model)
         mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.Core.compile_model")
         fake_quantize = mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.nncf.quantize", autospec=True)
 
@@ -608,7 +608,7 @@ class TestOpenVINOZeroShotVisualPromptingTask:
         self.visual_prompting_ov_task.model.set_data("visual_prompting_decoder.xml", b"decoder_xml")
         self.visual_prompting_ov_task.model.set_data("visual_prompting_decoder.bin", b"decoder_bin")
         mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.Core.read_model", autospec=True)
-        mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.serialize", new=patch_save_model)
+        mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.save_model", new=patch_save_model)
         mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.ov.Core.compile_model")
         fake_quantize = mocker.patch("otx.algorithms.visual_prompting.tasks.openvino.nncf.quantize", autospec=True)
 


### PR DESCRIPTION
### Summary

Models were always saved to FP16, because default saving mode was changed since OV 2023.2

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
