### PR TITLE
Provide iter_time, data_time from anomaly task

### DIFF
--- a/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/__init__.py
+++ b/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/__init__.py
@@ -16,5 +16,6 @@
 
 from .inference import AnomalyInferenceCallback
 from .progress import ProgressCallback
+from .iteration_timer import IterationTimer
 
 __all__ = ["AnomalyInferenceCallback", "ProgressCallback"]

--- a/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/__init__.py
+++ b/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/__init__.py
@@ -15,7 +15,7 @@
 # and limitations under the License.
 
 from .inference import AnomalyInferenceCallback
-from .progress import ProgressCallback
 from .iteration_timer import IterationTimer
+from .progress import ProgressCallback
 
-__all__ = ["AnomalyInferenceCallback", "ProgressCallback"]
+__all__ = ["AnomalyInferenceCallback", "IterationTimer", "ProgressCallback"]

--- a/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/iteration_timer.py
+++ b/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/iteration_timer.py
@@ -1,0 +1,183 @@
+"""Timer for logging iteration time for train, val, and test phases."""
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from collections import defaultdict
+from time import time
+from typing import Dict, Any
+
+from pytorch_lightning import Callback, LightningModule, Trainer
+from pytorch_lightning.utilities.types import STEP_OUTPUT
+
+
+class IterationTimer(Callback):
+    """Timer for logging iteration time for train, val, and test phases."""
+
+    def __init__(
+        self,
+        prog_bar: bool = True,
+        on_step: bool = True,
+        on_epoch: bool = True,
+    ) -> None:
+        super().__init__()
+        self.prog_bar = prog_bar
+        self.on_step = on_step
+        self.on_epoch = on_epoch
+
+        self.start_time: Dict[str, float] = defaultdict(float)
+        self.end_time: Dict[str, float] = defaultdict(float)
+
+    def on_train_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset timer before every train epoch starts."""
+        self.start_time.clear()
+        self.end_time.clear()
+
+    def on_validation_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset timer before every validation epoch starts."""
+        self.start_time.clear()
+        self.end_time.clear()
+
+    def on_test_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        """Reset timer before every test epoch starts."""
+        self.start_time.clear()
+        self.end_time.clear()
+
+    def _on_batch_start(
+        self,
+        pl_module: LightningModule,
+        phase: str,
+        batch_size: int,
+    ) -> None:
+        self.start_time[phase] = time()
+
+        if not self.end_time[phase]:
+            return
+
+        name = f"{phase}/data_time"
+
+        data_time = self.start_time[phase] - self.end_time[phase]
+
+        pl_module.log(
+            name=name,
+            value=data_time,
+            prog_bar=self.prog_bar,
+            on_step=self.on_step,
+            on_epoch=self.on_epoch,
+            batch_size=batch_size,
+        )
+
+    def _on_batch_end(
+        self,
+        pl_module: LightningModule,
+        phase: str,
+        batch_size: int,
+    ) -> None:
+        if not self.end_time[phase]:
+            self.end_time[phase] = time()
+            return
+
+        name = f"{phase}/iter_time"
+        curr_end_time = time()
+        iter_time = curr_end_time - self.end_time[phase]
+        self.end_time[phase] = curr_end_time
+
+        pl_module.log(
+            name=name,
+            value=iter_time,
+            prog_bar=self.prog_bar,
+            on_step=self.on_step,
+            on_epoch=self.on_epoch,
+            batch_size=batch_size,
+        )
+
+    def on_train_batch_start(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+    ) -> None:
+        """Log iteration data time on the training batch start."""
+        self._on_batch_start(
+            pl_module=pl_module,
+            phase="train",
+            batch_size=batch["image"].shape[0],
+        )
+
+    def on_train_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+    ) -> None:
+        """Log iteration time on the training batch end."""
+        self._on_batch_end(
+            pl_module=pl_module,
+            phase="train",
+            batch_size=batch["image"].shape[0],
+        )
+
+    def on_validation_batch_start(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Log iteration data time on the validation batch start."""
+        self._on_batch_start(
+            pl_module=pl_module,
+            phase="validation",
+            batch_size=batch["image"].shape[0],
+        )
+
+    def on_validation_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Log iteration time on the validation batch end."""
+        self._on_batch_end(
+            pl_module=pl_module,
+            phase="validation",
+            batch_size=batch["image"].shape[0],
+        )
+
+    def on_test_batch_start(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Log iteration data time on the test batch start."""
+        self._on_batch_start(
+            pl_module=pl_module,
+            phase="test",
+            batch_size=batch["image"].shape[0],
+        )
+
+    def on_test_batch_end(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Log iteration time on the test batch end."""
+        self._on_batch_end(
+            pl_module=pl_module,
+            phase="test",
+            batch_size=batch["image"].shape[0],
+        )

--- a/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/iteration_timer.py
+++ b/src/otx/algorithms/anomaly/adapters/anomalib/callbacks/iteration_timer.py
@@ -5,7 +5,7 @@
 
 from collections import defaultdict
 from time import time
-from typing import Dict, Any
+from typing import Any, Dict
 
 from pytorch_lightning import Callback, LightningModule, Trainer
 from pytorch_lightning.utilities.types import STEP_OUTPUT

--- a/src/otx/algorithms/anomaly/tasks/train.py
+++ b/src/otx/algorithms/anomaly/tasks/train.py
@@ -26,8 +26,9 @@ from anomalib.utils.callbacks import (
     PostProcessingConfigurationCallback,
 )
 from pytorch_lightning import Trainer, seed_everything
+from pytorch_lightning.loggers.csv_logs import CSVLogger
 
-from otx.algorithms.anomaly.adapters.anomalib.callbacks import ProgressCallback
+from otx.algorithms.anomaly.adapters.anomalib.callbacks import ProgressCallback, IterationTimer
 from otx.algorithms.anomaly.adapters.anomalib.data import OTXAnomalyDataModule
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.model import ModelEntity
@@ -86,9 +87,10 @@ class TrainingTask(InferenceTask, ITrainingTask):
                 manual_image_threshold=config.metrics.threshold.manual_image,
                 manual_pixel_threshold=config.metrics.threshold.manual_pixel,
             ),
+            IterationTimer(on_step=False),
         ]
 
-        self.trainer = Trainer(**config.trainer, logger=False, callbacks=callbacks)
+        self.trainer = Trainer(**config.trainer, logger=CSVLogger(self.project_path, name=""), callbacks=callbacks)
         self.trainer.fit(model=self.model, datamodule=datamodule)
 
         self.save_model(output_model)

--- a/src/otx/algorithms/anomaly/tasks/train.py
+++ b/src/otx/algorithms/anomaly/tasks/train.py
@@ -28,7 +28,7 @@ from anomalib.utils.callbacks import (
 from pytorch_lightning import Trainer, seed_everything
 from pytorch_lightning.loggers.csv_logs import CSVLogger
 
-from otx.algorithms.anomaly.adapters.anomalib.callbacks import ProgressCallback, IterationTimer
+from otx.algorithms.anomaly.adapters.anomalib.callbacks import IterationTimer, ProgressCallback
 from otx.algorithms.anomaly.adapters.anomalib.data import OTXAnomalyDataModule
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.model import ModelEntity


### PR DESCRIPTION
### Summary
This PR makes anomaly task provide iter_time and data_time during training and save it in 'logs' directory.
'iteration_timer.py' is copy of OTX 2.0's.
'experiment.py' is also updated to parse this information.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
