### PR TITLE
Add unannotated_bg_ratio parameter to pre_filtering function

### DIFF
--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -103,6 +103,7 @@ class DataModuleConfig:
     stack_images: bool = True
 
     include_polygons: bool = False
+    unannotated_bg_ratio: float = 0.0
 
     auto_num_workers: bool = False
     device: DeviceType = DeviceType.auto

--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -103,7 +103,7 @@ class DataModuleConfig:
     stack_images: bool = True
 
     include_polygons: bool = False
-    unannotated_bg_ratio: float = 0.0
+    unannotated_items_ratio: float = 0.0
 
     auto_num_workers: bool = False
     device: DeviceType = DeviceType.auto

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -57,7 +57,7 @@ class OTXDataModule(LightningDataModule):
 
         dataset = DmDataset.import_from(self.config.data_root, format=self.config.data_format)
         if self.task != "H_LABEL_CLS":
-            dataset = pre_filtering(dataset, self.config.data_format, self.config.unannotated_bg_ratio)
+            dataset = pre_filtering(dataset, self.config.data_format, self.config.unannotated_items_ratio)
         if config.tile_config.enable_tiler and config.tile_config.enable_adaptive_tiling:
             adapt_tile_config(config.tile_config, dataset=dataset)
 

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -57,7 +57,7 @@ class OTXDataModule(LightningDataModule):
 
         dataset = DmDataset.import_from(self.config.data_root, format=self.config.data_format)
         if self.task != "H_LABEL_CLS":
-            dataset = pre_filtering(dataset, self.config.data_format)
+            dataset = pre_filtering(dataset, self.config.data_format, self.config.unannotated_bg_ratio)
         if config.tile_config.enable_tiler and config.tile_config.enable_adaptive_tiling:
             adapt_tile_config(config.tile_config, dataset=dataset)
 

--- a/src/otx/core/data/pre_filtering.py
+++ b/src/otx/core/data/pre_filtering.py
@@ -37,7 +37,9 @@ def pre_filtering(dataset: DmDataset, data_format: str, unannotated_items_ratio:
 
     dataset = DmDataset.filter(
         dataset,
-        lambda item: not (item.subset == "train" and len(item.annotations) == 0 and item not in used_background_items),
+        lambda item: not (
+            item.subset == "train" and len(item.annotations) == 0 and item.id not in used_background_items
+        ),
     )
     dataset = DmDataset.filter(dataset, is_valid_annot, filter_annotations=True)
 

--- a/src/otx/core/data/pre_filtering.py
+++ b/src/otx/core/data/pre_filtering.py
@@ -16,27 +16,24 @@ if TYPE_CHECKING:
     from datumaro.components.dataset_base import DatasetItem
 
 
-def pre_filtering(dataset: DmDataset, data_format: str, unannotated_bg_ratio: float) -> DmDataset:
+def pre_filtering(dataset: DmDataset, data_format: str, unannotated_items_ratio: float) -> DmDataset:
     """Pre-filtering function to filter the dataset based on certain criteria.
 
     Args:
         dataset (DmDataset): The input dataset to be filtered.
         data_format (str): The format of the dataset.
-        unannotated_bg_ratio (float): The ratio of background unannotated items to be used.
+        unannotated_items_ratio (float): The ratio of background unannotated items to be used.
             This must be a float between 0 and 1.
 
     Returns:
         DmDataset: The filtered dataset.
-
-    Raises:
-        None.
     """
-    used_background_items = []
-    msg = f"There are empty annotation items in train set, Of these, only {unannotated_bg_ratio*100}% are used."
+    used_background_items = set()
+    msg = f"There are empty annotation items in train set, Of these, only {unannotated_items_ratio*100}% are used."
     warnings.warn(msg, stacklevel=2)
-    if unannotated_bg_ratio > 0:
-        empty_items = [item for item in dataset if item.subset == "train" and len(item.annotations) == 0]
-        used_background_items = sample(empty_items, int(len(empty_items) * unannotated_bg_ratio))
+    if unannotated_items_ratio > 0:
+        empty_items = [item.id for item in dataset if item.subset == "train" and len(item.annotations) == 0]
+        used_background_items = set(sample(empty_items, int(len(empty_items) * unannotated_items_ratio)))
 
     dataset = DmDataset.filter(
         dataset,

--- a/src/otx/core/data/pre_filtering.py
+++ b/src/otx/core/data/pre_filtering.py
@@ -35,7 +35,7 @@ def pre_filtering(dataset: DmDataset, data_format: str, unannotated_bg_ratio: fl
     msg = f"There are empty annotation items in train set, Of these, only {unannotated_bg_ratio*100}% are used."
     warnings.warn(msg, stacklevel=2)
     if unannotated_bg_ratio > 0:
-        empty_items = [item for item in dataset if len(item.annotations) == 0]
+        empty_items = [item for item in dataset if item.subset == "train" and len(item.annotations) == 0]
         used_background_items = sample(empty_items, int(len(empty_items) * unannotated_bg_ratio))
 
     dataset = DmDataset.filter(

--- a/src/otx/core/data/pre_filtering.py
+++ b/src/otx/core/data/pre_filtering.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import warnings
+from random import sample
 from typing import TYPE_CHECKING
 
 from datumaro.components.annotation import Annotation, Bbox, Polygon
@@ -15,21 +16,35 @@ if TYPE_CHECKING:
     from datumaro.components.dataset_base import DatasetItem
 
 
-def pre_filtering(dataset: DmDataset, data_format: str) -> DmDataset:
-    """Filtering invalid data in datumaro dataset."""
-    dataset = DmDataset.filter(dataset, is_non_empty_item)
+def pre_filtering(dataset: DmDataset, data_format: str, unannotated_bg_ratio: float) -> DmDataset:
+    """Pre-filtering function to filter the dataset based on certain criteria.
+
+    Args:
+        dataset (DmDataset): The input dataset to be filtered.
+        data_format (str): The format of the dataset.
+        unannotated_bg_ratio (float): The ratio of background unannotated items to be used.
+            This must be a float between 0 and 1.
+
+    Returns:
+        DmDataset: The filtered dataset.
+
+    Raises:
+        None.
+    """
+    used_background_items = []
+    msg = f"There are empty annotation items in train set, Of these, only {unannotated_bg_ratio*100}% are used."
+    warnings.warn(msg, stacklevel=2)
+    if unannotated_bg_ratio > 0:
+        empty_items = [item for item in dataset if len(item.annotations) == 0]
+        used_background_items = sample(empty_items, int(len(empty_items) * unannotated_bg_ratio))
+
+    dataset = DmDataset.filter(
+        dataset,
+        lambda item: not (item.subset == "train" and len(item.annotations) == 0 and item not in used_background_items),
+    )
     dataset = DmDataset.filter(dataset, is_valid_annot, filter_annotations=True)
 
     return remove_unused_labels(dataset, data_format)
-
-
-def is_non_empty_item(item: DatasetItem) -> bool:
-    """Return whether DatasetItem's annotation is non-empty."""
-    if not (item.subset == "train" and len(item.annotations) == 0):
-        return True
-    msg = "There are empty annotation items in train set, they will be filtered out before training."
-    warnings.warn(msg, stacklevel=2)
-    return False
 
 
 def is_valid_annot(item: DatasetItem, annotation: Annotation) -> bool:  # noqa: ARG001

--- a/src/otx/recipe/_base_/data/mmaction_base.yaml
+++ b/src/otx/recipe/_base_/data/mmaction_base.yaml
@@ -6,7 +6,7 @@ config:
     - 500
     - 500
   image_color_channel: RGB
-  unannotated_bg_ratio: 0.0
+  unannotated_items_ratio: 0.0
   train_subset:
     subset_name: train
     transform_lib_type: MMACTION

--- a/src/otx/recipe/_base_/data/mmaction_base.yaml
+++ b/src/otx/recipe/_base_/data/mmaction_base.yaml
@@ -6,6 +6,7 @@ config:
     - 500
     - 500
   image_color_channel: RGB
+  unannotated_bg_ratio: 0.0
   train_subset:
     subset_name: train
     transform_lib_type: MMACTION

--- a/src/otx/recipe/_base_/data/mmdet_base.yaml
+++ b/src/otx/recipe/_base_/data/mmdet_base.yaml
@@ -5,6 +5,7 @@ config:
   image_color_channel: RGB
   data_format: coco_instances
   include_polygons: false
+  unannotated_bg_ratio: 0.0
   train_subset:
     subset_name: train
     batch_size: 8

--- a/src/otx/recipe/_base_/data/mmdet_base.yaml
+++ b/src/otx/recipe/_base_/data/mmdet_base.yaml
@@ -5,7 +5,7 @@ config:
   image_color_channel: RGB
   data_format: coco_instances
   include_polygons: false
-  unannotated_bg_ratio: 0.0
+  unannotated_items_ratio: 0.0
   train_subset:
     subset_name: train
     batch_size: 8

--- a/src/otx/recipe/_base_/data/mmpretrain_base.yaml
+++ b/src/otx/recipe/_base_/data/mmpretrain_base.yaml
@@ -7,6 +7,7 @@ config:
   mem_cache_size: 1GB
   image_color_channel: RGB
   include_polygons: false
+  unannotated_bg_ratio: 0.0
   train_subset:
     subset_name: train
     num_workers: 2

--- a/src/otx/recipe/_base_/data/mmpretrain_base.yaml
+++ b/src/otx/recipe/_base_/data/mmpretrain_base.yaml
@@ -7,7 +7,7 @@ config:
   mem_cache_size: 1GB
   image_color_channel: RGB
   include_polygons: false
-  unannotated_bg_ratio: 0.0
+  unannotated_items_ratio: 0.0
   train_subset:
     subset_name: train
     num_workers: 2

--- a/src/otx/recipe/_base_/data/mmseg_base.yaml
+++ b/src/otx/recipe/_base_/data/mmseg_base.yaml
@@ -5,6 +5,7 @@ config:
   image_color_channel: RGB
   data_format: common_semantic_segmentation_with_subset_dirs
   include_polygons: true
+  unannotated_bg_ratio: 0.0
   train_subset:
     subset_name: train
     batch_size: 8

--- a/src/otx/recipe/_base_/data/mmseg_base.yaml
+++ b/src/otx/recipe/_base_/data/mmseg_base.yaml
@@ -5,7 +5,7 @@ config:
   image_color_channel: RGB
   data_format: common_semantic_segmentation_with_subset_dirs
   include_polygons: true
-  unannotated_bg_ratio: 0.0
+  unannotated_items_ratio: 0.0
   train_subset:
     subset_name: train
     batch_size: 8

--- a/src/otx/recipe/_base_/data/torchvision_base.yaml
+++ b/src/otx/recipe/_base_/data/torchvision_base.yaml
@@ -5,7 +5,7 @@ config:
   image_color_channel: RGB
   stack_images: False
   data_format: imagenet_with_subset_dirs
-  unannotated_bg_ratio: 0.0
+  unannotated_items_ratio: 0.0
   train_subset:
     subset_name: train
     transform_lib_type: TORCHVISION

--- a/src/otx/recipe/_base_/data/torchvision_base.yaml
+++ b/src/otx/recipe/_base_/data/torchvision_base.yaml
@@ -5,6 +5,7 @@ config:
   image_color_channel: RGB
   stack_images: False
   data_format: imagenet_with_subset_dirs
+  unannotated_bg_ratio: 0.0
   train_subset:
     subset_name: train
     transform_lib_type: TORCHVISION

--- a/tests/unit/core/data/test_module.py
+++ b/tests/unit/core/data/test_module.py
@@ -19,8 +19,9 @@ from otx.core.data.module import (
 )
 
 
-def mock_data_filtering(dataset: DmDataset, data_format: str) -> DmDataset:
+def mock_data_filtering(dataset: DmDataset, data_format: str, unannotated_bg_ratio: float) -> DmDataset:
     del data_format
+    del unannotated_bg_ratio
     return dataset
 
 

--- a/tests/unit/core/data/test_module.py
+++ b/tests/unit/core/data/test_module.py
@@ -19,9 +19,9 @@ from otx.core.data.module import (
 )
 
 
-def mock_data_filtering(dataset: DmDataset, data_format: str, unannotated_bg_ratio: float) -> DmDataset:
+def mock_data_filtering(dataset: DmDataset, data_format: str, unannotated_items_ratio: float) -> DmDataset:
     del data_format
-    del unannotated_bg_ratio
+    del unannotated_items_ratio
     return dataset
 
 

--- a/tests/unit/core/data/test_pre_filtering.py
+++ b/tests/unit/core/data/test_pre_filtering.py
@@ -46,7 +46,9 @@ def test_pre_filtering(fxt_dm_dataset_with_unannotated: DmDataset, unannotated_b
     Returns:
         None
     """
-    empty_items = [item for item in fxt_dm_dataset_with_unannotated if len(item.annotations) == 0]
+    empty_items = [
+        item for item in fxt_dm_dataset_with_unannotated if item.subset == "train" and len(item.annotations) == 0
+    ]
     assert len(fxt_dm_dataset_with_unannotated) == 100
     assert len(empty_items) == 20
 

--- a/tests/unit/core/data/test_pre_filtering.py
+++ b/tests/unit/core/data/test_pre_filtering.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from datumaro.components.annotation import Label
+from datumaro.components.dataset import Dataset as DmDataset
+from datumaro.components.dataset_base import DatasetItem
+from otx.core.data.pre_filtering import pre_filtering
+
+
+@pytest.fixture()
+def fxt_dm_dataset_with_unannotated() -> DmDataset:
+    dataset_items = [
+        DatasetItem(
+            id=f"item00{i}_non_empty",
+            subset="train",
+            media=None,
+            annotations=[
+                Label(label=3 % i),
+            ],
+        )
+        for i in range(1, 81)
+    ]
+    dataset_items.extend(
+        [
+            DatasetItem(
+                id=f"item00{i}_empty",
+                subset="train",
+                media=None,
+                annotations=[],
+            )
+            for i in range(20)
+        ],
+    )
+    return DmDataset.from_iterable(dataset_items, categories=["0", "1", "2"])
+
+
+@pytest.mark.parametrize("unannotated_bg_ratio", [0.0, 0.1, 0.5, 1.0])
+def test_pre_filtering(fxt_dm_dataset_with_unannotated: DmDataset, unannotated_bg_ratio: float) -> None:
+    """Test function for pre_filtering.
+
+    Args:
+        fxt_dm_dataset_with_unannotated (DmDataset): The dataset to be filtered.
+        unannotated_bg_ratio (float): The ratio of unannotated background items to be added.
+
+    Returns:
+        None
+    """
+    empty_items = [item for item in fxt_dm_dataset_with_unannotated if len(item.annotations) == 0]
+    assert len(fxt_dm_dataset_with_unannotated) == 100
+    assert len(empty_items) == 20
+
+    filtered_dataset = pre_filtering(
+        dataset=fxt_dm_dataset_with_unannotated,
+        data_format="datumaro",
+        unannotated_bg_ratio=unannotated_bg_ratio,
+    )
+    assert len(filtered_dataset) == 80 + int(len(empty_items) * unannotated_bg_ratio)

--- a/tests/unit/core/data/test_pre_filtering.py
+++ b/tests/unit/core/data/test_pre_filtering.py
@@ -35,13 +35,13 @@ def fxt_dm_dataset_with_unannotated() -> DmDataset:
     return DmDataset.from_iterable(dataset_items, categories=["0", "1", "2"])
 
 
-@pytest.mark.parametrize("unannotated_bg_ratio", [0.0, 0.1, 0.5, 1.0])
-def test_pre_filtering(fxt_dm_dataset_with_unannotated: DmDataset, unannotated_bg_ratio: float) -> None:
+@pytest.mark.parametrize("unannotated_items_ratio", [0.0, 0.1, 0.5, 1.0])
+def test_pre_filtering(fxt_dm_dataset_with_unannotated: DmDataset, unannotated_items_ratio: float) -> None:
     """Test function for pre_filtering.
 
     Args:
         fxt_dm_dataset_with_unannotated (DmDataset): The dataset to be filtered.
-        unannotated_bg_ratio (float): The ratio of unannotated background items to be added.
+        unannotated_items_ratio (float): The ratio of unannotated background items to be added.
 
     Returns:
         None
@@ -55,6 +55,6 @@ def test_pre_filtering(fxt_dm_dataset_with_unannotated: DmDataset, unannotated_b
     filtered_dataset = pre_filtering(
         dataset=fxt_dm_dataset_with_unannotated,
         data_format="datumaro",
-        unannotated_bg_ratio=unannotated_bg_ratio,
+        unannotated_items_ratio=unannotated_items_ratio,
     )
-    assert len(filtered_dataset) == 80 + int(len(empty_items) * unannotated_bg_ratio)
+    assert len(filtered_dataset) == 80 + int(len(empty_items) * unannotated_items_ratio)


### PR DESCRIPTION
### Summary

Recent decisions have changed the data filtering flow.
It was argued that filtering without using unannotated items as background might not be suitable for some training, 
so making this configurable.

- Add `unannotated_bg_ratio` in `otx.core.config.data.DataModuleConfig`
- Sampling based on ratio (Default: 0.0) first, then filter.

How to use
`otx train --config src/otx/recipe/detection/atss_mobilenetv2.yaml --data_root detection/vitens_large --data.config.unannotated_items_ratio 0.1`

```
original dataset length: 2833
empty_item (train): 652
unannotated_items_ratio: 0.1
-> filtered dataset length: 2246 (2833 - (652 - int(652*0.1)))
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
