### PR TITLE
Fix a bug where scheduler overrides didn't work correctly

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -166,19 +166,19 @@ class OTXCLI:
             sub_configs=True,
         )
         # Optimizer & Scheduler Settings
-        from lightning.pytorch.cli import ReduceLROnPlateau
+        from lightning.pytorch.cli import LRSchedulerTypeUnion, ReduceLROnPlateau
         from torch.optim import Optimizer
         from torch.optim.lr_scheduler import LRScheduler
 
         optim_kwargs = {"instantiate": False, "fail_untyped": False, "skip": {"params"}}
         scheduler_kwargs = {"instantiate": False, "fail_untyped": False, "skip": {"optimizer"}}
         parser.add_subclass_arguments(
-            baseclass=(Optimizer, list),
+            baseclass=(Optimizer, list[Optimizer]),
             nested_key="optimizer",
             **optim_kwargs,
         )
         parser.add_subclass_arguments(
-            baseclass=(LRScheduler, ReduceLROnPlateau, list),
+            baseclass=(LRScheduler, ReduceLROnPlateau, list[LRSchedulerTypeUnion]),
             nested_key="scheduler",
             **scheduler_kwargs,
         )

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from otx import OTX_LOGO, __version__
 from otx.cli.utils import absolute_path
 from otx.cli.utils.help_formatter import CustomHelpFormatter
-from otx.cli.utils.jsonargparse import get_short_docstring, patch_update_configs
+from otx.cli.utils.jsonargparse import add_list_type_arguments, get_short_docstring, patch_update_configs
 from otx.cli.utils.workspace import Workspace
 from otx.core.types.task import OTXTaskType
 from otx.core.utils.imports import get_otx_root_path
@@ -170,17 +170,17 @@ class OTXCLI:
         from torch.optim import Optimizer
         from torch.optim.lr_scheduler import LRScheduler
 
-        optim_kwargs = {"instantiate": False, "fail_untyped": False, "skip": {"params"}}
-        scheduler_kwargs = {"instantiate": False, "fail_untyped": False, "skip": {"optimizer"}}
-        parser.add_subclass_arguments(
+        add_list_type_arguments(
+            parser,
             baseclass=(Optimizer, list[Optimizer]),
             nested_key="optimizer",
-            **optim_kwargs,
+            skip={"params"},
         )
-        parser.add_subclass_arguments(
+        add_list_type_arguments(
+            parser,
             baseclass=(LRScheduler, ReduceLROnPlateau, list[LRSchedulerTypeUnion]),
             nested_key="scheduler",
-            **scheduler_kwargs,
+            skip={"optimizer"},
         )
 
         return parser

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -264,6 +264,7 @@ def get_defaults_with_overrides(self: ArgumentParser, skip_check: bool = False) 
     return cfg
 
 
+# Workaround for https://github.com/omni-us/jsonargparse/issues/456
 def add_list_type_arguments(
     parser: ArgumentParser,
     baseclass: tuple[type, ...],

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -9,7 +9,7 @@ import ast
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator, TypeVar
+from typing import Any, Iterator, TypeVar, Union
 
 import docstring_parser
 from jsonargparse import ActionConfigFile, ArgumentParser, Namespace, dict_to_namespace, namespace_to_dict
@@ -262,6 +262,62 @@ def get_defaults_with_overrides(self: ArgumentParser, skip_check: bool = False) 
     ActionTypeHint.add_sub_defaults(self, cfg)
 
     return cfg
+
+
+def add_list_type_arguments(
+    parser: ArgumentParser,
+    baseclass: tuple[type, ...],
+    nested_key: str,
+    skip: set[str] | None = None,
+) -> None:
+    """Add list type arguments to the given ArgumentParser.
+
+    From python >= 3.11, add_subclass_arguments no longer allows adding arguments of the form list[Class].
+    Modify it to bypass class checking, allowing you to use the list argument.
+    Copy from jsonargparse._signatures.SignatureArguments.add_subclass_arguments.
+
+    Args:
+        parser (ArgumentParser): The ArgumentParser to add the arguments to.
+        baseclass (tuple[type, ...]): A tuple of base classes for the subclasses.
+        nested_key (str): The nested key for the arguments.
+        skip (set[str] | None, optional): A set of arguments to skip. Defaults to None.
+    """
+    from argparse import SUPPRESS
+
+    from jsonargparse._parameter_resolvers import ParamData
+    from jsonargparse._util import get_import_path, iter_to_set_str
+
+    group = parser._create_group_if_requested(  # noqa: SLF001
+        baseclass,
+        nested_key,
+        True,
+        None,
+        config_load=False,
+        required=False,
+        instantiate=False,
+    )
+    added_args: list[str] = []
+    if skip is not None:
+        skip = {f"{nested_key}.init_args." + s for s in skip}
+    param = ParamData(name=nested_key, annotation=Union[baseclass], component=baseclass)
+    str_baseclass = iter_to_set_str(get_import_path(x) for x in baseclass)
+    kwargs = {
+        "metavar": "CONFIG | CLASS_PATH_OR_NAME | .INIT_ARG_NAME VALUE",
+        "help": (
+            f"One or more arguments specifying 'class_path' and 'init_args' for any subclass of {str_baseclass}s."
+        ),
+    }
+    kwargs["default"] = SUPPRESS
+    parser._add_signature_parameter(  # noqa: SLF001
+        group,
+        None,
+        param,
+        added_args,
+        skip,
+        sub_configs=True,
+        instantiate=False,
+        fail_untyped=False,
+    )
 
 
 @contextmanager

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 
 import pytest
+import yaml
 from otx.cli import OTXCLI, main
 
 
@@ -111,3 +112,46 @@ class TestOTXCLI:
 
         assert cli.datamodule == cli.engine.datamodule
         assert cli.model == cli.engine.model
+
+    @pytest.fixture()
+    def fxt_print_config_scheduler_override_command(self, monkeypatch) -> None:
+        argv = [
+            "otx",
+            "train",
+            "--config",
+            "src/otx/recipe/detection/atss_mobilenetv2.yaml",
+            "--data_root",
+            "tests/assets/car_tree_bug",
+            "--scheduler.monitor",
+            "val/test_f1",
+            "--print_config",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+    def test_print_config_scheduler_override_command(self, fxt_print_config_scheduler_override_command, capfd) -> None:
+        # Test that main function runs with help -> return 0
+        with pytest.raises(SystemExit, match="0"):
+            OTXCLI()
+        out, _ = capfd.readouterr()
+        result_config = yaml.safe_load(out)
+        expected_str = """
+        scheduler:
+        - class_path: otx.algo.schedulers.LinearWarmupScheduler
+          init_args:
+              num_warmup_steps: 3
+              interval: step
+        - class_path: lightning.pytorch.cli.ReduceLROnPlateau
+          init_args:
+              monitor: val/test_f1
+              mode: max
+              factor: 0.5
+              patience: 5
+              threshold: 0.0001
+              threshold_mode: rel
+              cooldown: 0
+              min_lr: 0.0
+              eps: 1.0e-08
+              verbose: false
+        """
+        expected_config = yaml.safe_load(expected_str)
+        assert expected_config["scheduler"] == result_config["scheduler"]


### PR DESCRIPTION
### Summary

When scheduler overriding, found that this didn't work as intended.
`otx train --config src/otx/recipe/detection/atss_mobilenetv2.yaml --scheduler.monitor val/test_f1 --print_config`
```yaml
scheduler:
- monitor
- val/test_f1
```

Identify and fix the unclear type of optimizer and scheduler, which is preventing them from mapping properly.
After fix
```yaml
scheduler:
- class_path: otx.algo.schedulers.LinearWarmupScheduler
  init_args:
    num_warmup_steps: 3
    interval: step
- class_path: lightning.pytorch.cli.ReduceLROnPlateau
  init_args:
    monitor: val/test_f1
    mode: max
    factor: 0.5
    patience: 5
    threshold: 0.0001
    threshold_mode: rel
    cooldown: 0
    min_lr: 0.0
    eps: 1.0e-08
    verbose: false
```

In python 3.11, i found jsonargparse is not working properly with `list[Optimizer]`, `list[Scheduler]`
https://github.com/omni-us/jsonargparse/issues/456 --> So I wrote the `add_list_type_arguments()` function as a workaround for this.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. 

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
