### PR TITLE
Update .latest cache directory with subcommand links

### DIFF
--- a/for_developers/cli_guide.md
+++ b/for_developers/cli_guide.md
@@ -320,7 +320,10 @@ If we run a typical Training example, we'll have a folder like the one below as 
 
 ```console
 otx-workspace/
-    .latest/                       # As of the last training, we have a .latest with path information for config and checkpoint.
+    .latest/                      # Gather the most recent information.
+        train/                    # Link to the output_dir where the most recent train was performed.
+        export/                   # Link to the output_dir where the most recent export was performed.
+        .../
     20240000_000000/              # Deliverables from OTX CLI
     20240000_000001/              # Deliverables from OTX CLI Second-Trial
 ```

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -223,7 +223,7 @@ class OTXCLI:
         for subcommand in self.engine_subcommands():
             # If already have a workspace or run it from the root of a workspace, utilize config and checkpoint in cache
             root_dir = Path(sys.argv[sys.argv.index("--work_dir") + 1]) if "--work_dir" in sys.argv else Path.cwd()
-            self.cache_dir = root_dir / ".latest"
+            self.cache_dir = root_dir / ".latest" / "train"  # The config and checkpoint used in the latest training.
 
             parser_kwargs = self._set_default_config()
             sub_parser = self.engine_subcommand_parser(**parser_kwargs)
@@ -487,8 +487,7 @@ class OTXCLI:
             skip_check=True,
         )
         # if train -> Update `.latest` folder
-        if self.subcommand == "train":
-            self.update_latest(work_dir=work_dir)
+        self.update_latest(work_dir=work_dir)
 
     def update_latest(self, work_dir: Path) -> None:
         """Update the latest cache directory with the latest configurations and checkpoint file.
@@ -496,7 +495,9 @@ class OTXCLI:
         Args:
             work_dir (Path): The working directory where the configurations and checkpoint files are located.
         """
-        cache_dir = work_dir.parent / ".latest"
+        latest_dir = work_dir.parent / ".latest"
+        latest_dir.mkdir(exist_ok=True)
+        cache_dir = latest_dir / self.subcommand
         if cache_dir.exists():
             cache_dir.unlink()
         cache_dir.symlink_to(work_dir)


### PR DESCRIPTION
### Summary

Based on some feedback. Modifying the `.latest` folder to link to the most recent output folder for each subcommand.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
