### PR TITLE
Update regression test metric of object detection and instance segmentation

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -371,7 +371,7 @@ class OTXCLI:
         from otx.core.utils.instantiators import partial_instantiate_class
 
         if metric_config and self.subcommand in ["train", "test"]:
-            metric_kwargs = self.get_config_value(metric_config, "metric")
+            metric_kwargs = self.get_config_value(metric_config, "metric", namespace_to_dict(metric_config))
             metric = partial_instantiate_class(metric_kwargs)
             return metric[0] if isinstance(metric, list) else metric
 

--- a/src/otx/core/model/module/classification.py
+++ b/src/otx/core/model/module/classification.py
@@ -215,27 +215,14 @@ class OTXHlabelClsLitModule(OTXLitModule):
             metric=metric,
         )
 
-        if metric:
-            sig = inspect.signature(metric)
-            param_dict = {}
-            for name, param in sig.parameters.items():
-                if name in ["num_multiclass_heads", "num_multilabel_classes"]:
-                    param_dict[name] = self.model.get(name)
-                else:
-                    param_dict[name] = param.default
-            param_dict.pop("kwargs")
-
-            metric = metric(**param_dict)  # type: ignore[call-arg]
-
         # Temporary, TODO (sungmanc)
         # OTX can't support the auto-configuration for the H-label classification
         # Therefore, default metric can be None and it cause the error
         # This is the workaround
-        else:
-            self.metric = HLabelAccuracy(
-                num_multiclass_heads=self.model.num_multiclass_heads,
-                num_multilabel_classes=self.model.num_multilabel_classes,
-            )
+        self.metric = HLabelAccuracy(
+            num_multiclass_heads=self.model.num_multiclass_heads,
+            num_multilabel_classes=self.model.num_multilabel_classes,
+        )
 
     def _set_hlabel_setup(self) -> None:
         if not isinstance(self.meta_info, HLabelMetaInfo):

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -264,7 +264,7 @@ class TestHlabelCls(BaseTest):
                 "model.num_multilabel_classes": "0",
             },
         )
-        
+
     ]
 
     @pytest.mark.parametrize(
@@ -316,7 +316,12 @@ class TestObjectDetection(BaseTest):
             data_root=Path("detection/pothole_small") / f"{idx}",
             data_format="coco",
             num_classes=1,
-            extra_overrides={"deterministic": "True"},
+            extra_overrides={
+                "deterministic": "True",
+                "metric": "otx.algo.metrices.fmeasure.FMeasure",
+                "callback_monitor": "val/f1-score",
+                "scheduler.monitor": "val/f1-score",
+            },
         )
         for idx in range(1, 4)
     ] + [
@@ -325,14 +330,24 @@ class TestObjectDetection(BaseTest):
             data_root=Path("detection/pothole_medium"),
             data_format="coco",
             num_classes=1,
-            extra_overrides={"deterministic": "True"}
+            extra_overrides={
+                "deterministic": "True",
+                "metric": "otx.algo.metrices.fmeasure.FMeasure",
+                "callback_monitor": "val/f1-score",
+                "scheduler.monitor": "val/f1-score",
+            },
         ),
         DatasetTestCase(
             name="vitens_large",
             data_root=Path("detection/vitens_large"),
             data_format="coco",
             num_classes=1,
-            extra_overrides={"deterministic": "True"}
+            extra_overrides={
+                "deterministic": "True",
+                "metric": "otx.algo.metrices.fmeasure.FMeasure",
+                "callback_monitor": "val/f1-score",
+                "scheduler.monitor": "val/f1-score",
+            },
         )
     ]
 
@@ -448,7 +463,12 @@ class TestInstanceSegmentation(BaseTest):
             data_root=Path("instance_seg/wgisd_small") / f"{idx}",
             data_format="coco",
             num_classes=5,
-            extra_overrides={"deterministic": "True"},
+            extra_overrides={
+                "deterministic": "True",
+                "metric": "otx.algo.metrices.fmeasure.FMeasure",
+                "callback_monitor": "val/f1-score",
+                "scheduler.monitor": "val/f1-score",
+            },
         )
         for idx in range(1, 4)
     ] + [
@@ -457,14 +477,24 @@ class TestInstanceSegmentation(BaseTest):
             data_root=Path("instance_seg/coco_car_person_medium"),
             data_format="coco",
             num_classes=2,
-            extra_overrides={"deterministic": "True"}
+            extra_overrides={
+                "deterministic": "True",
+                "metric": "otx.algo.metrices.fmeasure.FMeasure",
+                "callback_monitor": "val/f1-score",
+                "scheduler.monitor": "val/f1-score",
+            },
         ),
         DatasetTestCase(
             name="vitens_coliform",
             data_root=Path("instance_seg/Vitens-Coliform-coco"),
             data_format="coco",
             num_classes=1,
-            extra_overrides={"deterministic": "True"}
+            extra_overrides={
+                "deterministic": "True",
+                "metric": "otx.algo.metrices.fmeasure.FMeasure",
+                "callback_monitor": "val/f1-score",
+                "scheduler.monitor": "val/f1-score",
+            },
         )
     ]
 
@@ -560,8 +590,8 @@ class TestVisualPrompting(BaseTest):
             fxt_accelerator=fxt_accelerator,
             tmpdir=tmpdir,
         )
-        
-        
+
+
 class TestZeroShotVisualPrompting(BaseTest):
     # Test case parametrization for model
     MODEL_TEST_CASES = [  # noqa: RUF012


### PR DESCRIPTION
### Summary
Update test metric of object detection and instance segmentation for regresson test from mAP to f1
I tested this on my local machine
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
