### PR TITLE
Hotfix default memcache size to 100MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[v1.5.1\]
+
+### Bug fixes
+
+- Remove polygon clipping code (<https://github.com/openvinotoolkit/training_extensions/pull/2926>)
+- Hotfix default memcache size to 100MB (<https://github.com/openvinotoolkit/training_extensions/pull/2990>)
+
 ## \[v1.5.0\]
 
 ### New features

--- a/src/otx/algorithms/action/configs/classification/configuration.yaml
+++ b/src/otx/algorithms/action/configs/classification/configuration.yaml
@@ -290,7 +290,7 @@ algo_backend:
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:

--- a/src/otx/algorithms/action/configs/detection/configuration.yaml
+++ b/src/otx/algorithms/action/configs/detection/configuration.yaml
@@ -290,7 +290,7 @@ algo_backend:
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:

--- a/src/otx/algorithms/classification/configs/configuration.yaml
+++ b/src/otx/algorithms/classification/configs/configuration.yaml
@@ -445,7 +445,7 @@ algo_backend:
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:

--- a/src/otx/algorithms/detection/configs/detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/detection/configuration.yaml
@@ -371,11 +371,11 @@ algo_backend:
     warning: null
   mem_cache_size:
     affects_outcome_of: TRAINING
-    default_value: 1000000000
+    default_value: 100000000
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:

--- a/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -371,11 +371,11 @@ algo_backend:
     warning: null
   mem_cache_size:
     affects_outcome_of: TRAINING
-    default_value: 1000000000
+    default_value: 100000000
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:

--- a/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
@@ -356,11 +356,11 @@ algo_backend:
     warning: null
   mem_cache_size:
     affects_outcome_of: TRAINING
-    default_value: 1000000000
+    default_value: 100000000
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:

--- a/src/otx/algorithms/segmentation/configs/configuration.yaml
+++ b/src/otx/algorithms/segmentation/configs/configuration.yaml
@@ -323,11 +323,11 @@ algo_backend:
     warning: null
   mem_cache_size:
     affects_outcome_of: TRAINING
-    default_value: 1000000000
+    default_value: 100000000
     description: Size of memory pool for caching decoded data to load data faster (bytes).
     editable: true
     header: Size of memory pool
-    max_value: 9223372036854775807
+    max_value: 10000000000
     min_value: 0
     type: INTEGER
     ui_rules:


### PR DESCRIPTION
### Summary

* Hotfix per-task mem_cache size override (missing in #2960)
* Fix max limit to 10GB

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
