### PR TITLE
Resolve failed integration test w/ XPU

### DIFF
--- a/src/otx/algorithms/common/adapters/mmcv/ops/multi_scale_deformable_attn_pytorch.py
+++ b/src/otx/algorithms/common/adapters/mmcv/ops/multi_scale_deformable_attn_pytorch.py
@@ -66,6 +66,7 @@ def multi_scale_deformable_attn_pytorch(
 
 _warning_custom_grid_sample = False
 
+
 def _custom_grid_sample(im: torch.Tensor, grid: torch.Tensor, align_corners: bool = False) -> torch.Tensor:
     """Custom patch for mmcv.ops.point_sample.bilinear_grid_sample.
 
@@ -87,7 +88,7 @@ def _custom_grid_sample(im: torch.Tensor, grid: torch.Tensor, align_corners: boo
     ori_device = im.device
 
     if ori_device != "cpu":
-        global _warning_custom_grid_sample
+        global _warning_custom_grid_sample  # noqa: PLW0603
         if not _warning_custom_grid_sample:
             logger.warning(
                 "Sampling during 'multi_scale_deformable_attn_pytorch' is executed on CPU to avoid out of memory."

--- a/src/otx/algorithms/common/adapters/mmcv/utils/_builder_build_data_parallel.py
+++ b/src/otx/algorithms/common/adapters/mmcv/utils/_builder_build_data_parallel.py
@@ -102,7 +102,7 @@ class XPUDataParallel(MMDataParallel):
             elif isinstance(obj, tuple):
                 obj = tuple(map(change_tensor_device, obj))
             elif isinstance(obj, dict):
-                obj = {key : change_tensor_device(val) for key, val in obj.items()}
+                obj = {key: change_tensor_device(val) for key, val in obj.items()}
             elif isinstance(obj, torch.Tensor):
                 obj = obj.to(target_device)
             return obj

--- a/src/otx/algorithms/detection/adapters/mmdet/models/__init__.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/__init__.py
@@ -3,6 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from . import assigners, backbones, dense_heads, detectors, heads, layers, losses, necks, roi_heads
+from . import (
+    assigners,
+    backbones,
+    dense_heads,
+    detectors,
+    heads,
+    layers,
+    losses,
+    necks,
+    patch_mmdeploy,  # noqa: F401
+    roi_heads,
+)
 
 __all__ = ["assigners", "backbones", "dense_heads", "detectors", "heads", "layers", "losses", "necks", "roi_heads"]

--- a/src/otx/algorithms/detection/adapters/mmdet/models/patch_mmdeploy.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/patch_mmdeploy.py
@@ -1,0 +1,78 @@
+"""Patch mmdeploy code."""
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import torch
+from otx.algorithms.common.adapters.mmdeploy.utils import is_mmdeploy_enabled
+
+
+def _select_nms_index(scores: torch.Tensor,
+                    boxes: torch.Tensor,
+                    nms_index: torch.Tensor,
+                    batch_size: int,
+                    keep_top_k: int = -1):
+    """Transform NMS output.
+
+    Args:
+        scores (Tensor): The detection scores of shape
+            [N, num_classes, num_boxes].
+        boxes (Tensor): The bounding boxes of shape [N, num_boxes, 4].
+        nms_index (Tensor): NMS output of bounding boxes indexing.
+        batch_size (int): Batch size of the input image.
+        keep_top_k (int): Number of top K boxes to keep after nms.
+            Defaults to -1.
+
+    Returns:
+        tuple[Tensor, Tensor]: (dets, labels), `dets` of shape [N, num_det, 5]
+            and `labels` of shape [N, num_det].
+    """
+    batch_inds, cls_inds = nms_index[:, 0], nms_index[:, 1]
+    box_inds = nms_index[:, 2]
+
+    # index by nms output
+    scores = scores[batch_inds, cls_inds, box_inds].unsqueeze(1)
+    boxes = boxes[batch_inds, box_inds, ...]
+    dets = torch.cat([boxes, scores], dim=1)
+
+    # batch all
+    batched_dets = dets.unsqueeze(0).repeat(batch_size, 1, 1)
+    batch_template = torch.arange(
+        0, batch_size, dtype=batch_inds.dtype, device=batch_inds.device)
+    batched_dets = batched_dets.where(
+        (batch_inds == batch_template.unsqueeze(1)).unsqueeze(-1),
+        batched_dets.new_zeros(1))
+
+    batched_labels = cls_inds.unsqueeze(0).repeat(batch_size, 1)
+    batched_labels = batched_labels.where(
+        (batch_inds == batch_template.unsqueeze(1)),
+        batched_labels.new_ones(1, dtype=batched_labels.dtype) * -1)  # this line is only different line from original code
+
+    N = batched_dets.shape[0]
+
+    # expand tensor to eliminate [0, ...] tensor
+    batched_dets = torch.cat((batched_dets, batched_dets.new_zeros((N, 1, 5))),
+                            1)
+    batched_labels = torch.cat((batched_labels, batched_labels.new_zeros(
+        (N, 1))), 1)
+
+    # sort
+    is_use_topk = keep_top_k > 0 and \
+        (torch.onnx.is_in_onnx_export() or keep_top_k < batched_dets.shape[1])
+    if is_use_topk:
+        _, topk_inds = batched_dets[:, :, -1].topk(keep_top_k, dim=1)
+    else:
+        _, topk_inds = batched_dets[:, :, -1].sort(dim=1, descending=True)
+    topk_batch_inds = torch.arange(
+        batch_size, dtype=topk_inds.dtype,
+        device=topk_inds.device).view(-1, 1)
+    batched_dets = batched_dets[topk_batch_inds, topk_inds, ...]
+    batched_labels = batched_labels[topk_batch_inds, topk_inds, ...]
+
+    # slice and recover the tensor
+    return batched_dets, batched_labels
+
+if is_mmdeploy_enabled():
+
+    from mmdeploy.codebase.mmdet.core.post_processing import bbox_nms
+    bbox_nms.select_nms_index = _select_nms_index

--- a/src/otx/algorithms/detection/adapters/mmdet/models/patch_mmdeploy.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/patch_mmdeploy.py
@@ -4,14 +4,13 @@
 #
 
 import torch
+
 from otx.algorithms.common.adapters.mmdeploy.utils import is_mmdeploy_enabled
 
 
-def _select_nms_index(scores: torch.Tensor,
-                    boxes: torch.Tensor,
-                    nms_index: torch.Tensor,
-                    batch_size: int,
-                    keep_top_k: int = -1):
+def _select_nms_index(
+    scores: torch.Tensor, boxes: torch.Tensor, nms_index: torch.Tensor, batch_size: int, keep_top_k: int = -1
+):
     """Transform NMS output.
 
     Args:
@@ -37,42 +36,38 @@ def _select_nms_index(scores: torch.Tensor,
 
     # batch all
     batched_dets = dets.unsqueeze(0).repeat(batch_size, 1, 1)
-    batch_template = torch.arange(
-        0, batch_size, dtype=batch_inds.dtype, device=batch_inds.device)
+    batch_template = torch.arange(0, batch_size, dtype=batch_inds.dtype, device=batch_inds.device)
     batched_dets = batched_dets.where(
-        (batch_inds == batch_template.unsqueeze(1)).unsqueeze(-1),
-        batched_dets.new_zeros(1))
+        (batch_inds == batch_template.unsqueeze(1)).unsqueeze(-1), batched_dets.new_zeros(1)
+    )
 
     batched_labels = cls_inds.unsqueeze(0).repeat(batch_size, 1)
     batched_labels = batched_labels.where(
-        (batch_inds == batch_template.unsqueeze(1)),
-        batched_labels.new_ones(1, dtype=batched_labels.dtype) * -1)  # this line is only different line from original code
+        (batch_inds == batch_template.unsqueeze(1)), batched_labels.new_ones(1, dtype=batched_labels.dtype) * -1
+    )  # this line is only different line from original code
 
     N = batched_dets.shape[0]
 
     # expand tensor to eliminate [0, ...] tensor
-    batched_dets = torch.cat((batched_dets, batched_dets.new_zeros((N, 1, 5))),
-                            1)
-    batched_labels = torch.cat((batched_labels, batched_labels.new_zeros(
-        (N, 1))), 1)
+    batched_dets = torch.cat((batched_dets, batched_dets.new_zeros((N, 1, 5))), 1)
+    batched_labels = torch.cat((batched_labels, batched_labels.new_zeros((N, 1))), 1)
 
     # sort
-    is_use_topk = keep_top_k > 0 and \
-        (torch.onnx.is_in_onnx_export() or keep_top_k < batched_dets.shape[1])
+    is_use_topk = keep_top_k > 0 and (torch.onnx.is_in_onnx_export() or keep_top_k < batched_dets.shape[1])
     if is_use_topk:
         _, topk_inds = batched_dets[:, :, -1].topk(keep_top_k, dim=1)
     else:
         _, topk_inds = batched_dets[:, :, -1].sort(dim=1, descending=True)
-    topk_batch_inds = torch.arange(
-        batch_size, dtype=topk_inds.dtype,
-        device=topk_inds.device).view(-1, 1)
+    topk_batch_inds = torch.arange(batch_size, dtype=topk_inds.dtype, device=topk_inds.device).view(-1, 1)
     batched_dets = batched_dets[topk_batch_inds, topk_inds, ...]
     batched_labels = batched_labels[topk_batch_inds, topk_inds, ...]
 
     # slice and recover the tensor
     return batched_dets, batched_labels
 
+
 if is_mmdeploy_enabled():
 
     from mmdeploy.codebase.mmdet.core.post_processing import bbox_nms
+
     bbox_nms.select_nms_index = _select_nms_index

--- a/tests/test_suite/run_test_command.py
+++ b/tests/test_suite/run_test_command.py
@@ -23,6 +23,11 @@ from otx.cli.tools.find import SUPPORTED_TASKS as find_supported_tasks
 from otx.cli.utils.nncf import get_number_of_fakequantizers_in_xml
 from tests.test_suite.e2e_test_system import e2e_pytest_component
 
+try:
+    import intel_extension_for_pytorch
+except ImportError:
+    pass
+
 
 def get_template_rel_dir(template):
     return os.path.dirname(os.path.relpath(template.model_template_path))


### PR DESCRIPTION
### Summary
I resolved all failed integration test w/ XPU including tests/integration/cli/detection/test_tiling_detection.py::TestTilingDetectionCLI::test_otx_export tests.
Currently, tiling integration test tests only ATSS model so I just checked that error is raised w/ ATSS but it need to be checked that same  error occurs w/ other models.

![image](https://github.com/openvinotoolkit/training_extensions/assets/92974184/0b2e1d8a-ea40-414f-bca2-7963ba9e0734)
The image above is some part of 'mmdeploy/codebase/mmdet/core/post_processing/bbox_nms.py'.

The reason why error is raised is that OpenVINO checks that `batched_labels` and `batched_labels.new_ones(1) * -1` have different data type, but they have same data type when I checked by pdb.
Workaround is to change code `batched_labels.new_ones(1)` to `batched_labels.new_ones(1, dtype=torch.int64)`, but that code besides in `mmdeploy`, so I patched that code.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
