### PR TITLE
Fix tile bug & add more tests

### DIFF
--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -644,7 +644,7 @@ class Engine:
 
         return cls(
             work_dir=instantiated_config.get("work_dir", work_dir),
-            datamodule=instantiated_config.get("datamodule"),
+            datamodule=instantiated_config.get("data"),
             model=instantiated_config.get("model"),
             optimizer=instantiated_config.get("optimizer"),
             scheduler=instantiated_config.get("scheduler"),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,10 +97,12 @@ def pytest_configure(config):
 
         target_recipe_list.extend(recipe_list)
         target_ov_recipe_list.extend(recipe_ov_list)
+    tile_recipe_list = [recipe for recipe in target_recipe_list if "tile" in recipe]
 
     pytest.TASK_LIST = task_list
     pytest.RECIPE_LIST = target_recipe_list
     pytest.RECIPE_OV_LIST = target_ov_recipe_list
+    pytest.TILE_RECIPE_LIST = tile_recipe_list
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_tiling.py
+++ b/tests/integration/test_tiling.py
@@ -4,17 +4,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from unittest.mock import MagicMock
-
 import numpy as np
 import pytest
 from datumaro import Dataset as DmDataset
-from datumaro import Image
-from datumaro.plugins.tiling.util import xywh_to_x1y1x2y2
 from omegaconf import DictConfig, OmegaConf
-from openvino.model_api.models import Model
-from openvino.model_api.tilers import DetectionTiler, InstanceSegmentationTiler, Tiler
 from otx.core.config.data import (
     DataModuleConfig,
     SubsetConfig,
@@ -25,10 +18,7 @@ from otx.core.data.dataset.tile import OTXTileTransform
 from otx.core.data.entity.detection import DetBatchDataEntity
 from otx.core.data.entity.tile import TileBatchDetDataEntity
 from otx.core.data.module import OTXDataModule
-from otx.core.model.entity.detection import OVDetectionModel
-from otx.core.model.entity.instance_segmentation import OVInstanceSegmentationModel
 from otx.core.types.task import OTXTaskType
-from otx.engine import Engine
 
 
 class TestOTXTiling:
@@ -94,32 +84,6 @@ class TestOTXTiling:
         num_tile_cols = (width + w_stride - 1) // w_stride
         assert len(tiled_dataset) == (num_tile_rows * num_tile_cols * len(dataset)), "Incorrect number of tiles"
 
-    def test_tiler_consistency(self, mocker):
-        # Test that the tiler and tile transform are consistent
-        rng = np.random.default_rng()
-        rnd_tile_size = rng.integers(low=100, high=500)
-        rnd_tile_overlap = rng.random()
-        image_size = rng.integers(low=1000, high=5000)
-        np_image = np.zeros((image_size, image_size, 3), dtype=np.uint8)
-        dm_image = Image.from_numpy(np_image)
-
-        mock_model = MagicMock(spec=Model)
-        mocker.patch("openvino.model_api.tilers.tiler.Tiler.__init__", return_value=None)
-        mocker.patch.multiple(Tiler, __abstractmethods__=set())
-
-        tiler = Tiler(model=mock_model)
-        tiler.tile_size = rnd_tile_size
-        tiler.tiles_overlap = rnd_tile_overlap
-
-        mocker.patch("otx.core.data.dataset.tile.OTXTileTransform.__init__", return_value=None)
-        tile_transform = OTXTileTransform()
-        tile_transform._tile_size = (rnd_tile_size, rnd_tile_size)
-        tile_transform._overlap = (rnd_tile_overlap, rnd_tile_overlap)
-
-        dm_rois = [xywh_to_x1y1x2y2(*roi) for roi in tile_transform._extract_rois(dm_image)]
-        # 0 index in tiler is the full image so we skip it
-        assert np.allclose(dm_rois, tiler._tile(np_image)[1:])
-
     def test_adaptive_tiling(self, fxt_det_data_config):
         # Enable tile adapter
         fxt_det_data_config.tile_config.enable_tiler = True
@@ -183,60 +147,3 @@ class TestOTXTiling:
 
     def test_tile_merge(self):
         pytest.skip("Not implemented yet")
-
-    def test_ov_det_tile_model(
-        self,
-        tmp_path: Path,
-        fxt_accelerator: str,
-        fxt_target_dataset_per_task: dict,
-    ):
-        tile_recipes = [recipe for recipe in pytest.RECIPE_LIST if "detection" in recipe and "tile" in recipe]
-        for tile_recipe in tile_recipes:
-            engine = Engine.from_config(
-                config_path=tile_recipe,
-                data_root=fxt_target_dataset_per_task[OTXTaskType.DETECTION.value.lower()],
-                work_dir=tmp_path / OTXTaskType.DETECTION,
-                device=fxt_accelerator,
-            )
-            engine.train(max_epochs=1)
-            exported_model_path = engine.export()
-            assert exported_model_path.exists()
-            engine.test(exported_model_path, accelerator="cpu")
-
-            ov_model = OVDetectionModel(model_name=exported_model_path, num_classes=3)
-
-            assert isinstance(ov_model.model, DetectionTiler), "Model should be an instance of DetectionTiler"
-            assert engine.datamodule.config.tile_config.tile_size[0] == ov_model.model.tile_size
-            assert engine.datamodule.config.tile_config.overlap == ov_model.model.tiles_overlap
-
-    def test_ov_inst_tile_model(
-        self,
-        tmp_path: Path,
-        fxt_accelerator: str,
-        fxt_target_dataset_per_task: dict,
-    ):
-        # Test that tiler is setup correctly for instance segmentation
-        tile_recipes = [
-            recipe for recipe in pytest.RECIPE_LIST if "instance_segmentation" in recipe and "tile" in recipe
-        ]
-
-        for tile_recipe in tile_recipes:
-            engine = Engine.from_config(
-                config_path=tile_recipe,
-                data_root=fxt_target_dataset_per_task[OTXTaskType.INSTANCE_SEGMENTATION.value.lower()],
-                work_dir=tmp_path / OTXTaskType.INSTANCE_SEGMENTATION,
-                device=fxt_accelerator,
-            )
-            engine.train(max_epochs=1)
-            exported_model_path = engine.export()
-            assert exported_model_path.exists()
-            engine.test(exported_model_path, accelerator="cpu")
-
-            ov_model = OVInstanceSegmentationModel(model_name=exported_model_path, num_classes=3)
-
-            assert isinstance(
-                ov_model.model,
-                InstanceSegmentationTiler,
-            ), "Model should be an instance of InstanceSegmentationTiler"
-            assert engine.datamodule.config.tile_config.tile_size[0] == ov_model.model.tile_size
-            assert engine.datamodule.config.tile_config.overlap == ov_model.model.tiles_overlap

--- a/tests/unit/core/utils/test_tile.py
+++ b/tests/unit/core/utils/test_tile.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from datumaro import Dataset as DmDataset
+from datumaro import Image
+from datumaro.plugins.tiling.util import xywh_to_x1y1x2y2
+from omegaconf import DictConfig, OmegaConf
+from openvino.model_api.models import Model
+from openvino.model_api.tilers import DetectionTiler, InstanceSegmentationTiler, Tiler
+from otx.core.config.data import (
+    DataModuleConfig,
+    SubsetConfig,
+    TileConfig,
+    VisualPromptingConfig,
+)
+from otx.core.data.dataset.tile import OTXTileTransform
+from otx.core.data.entity.detection import DetBatchDataEntity
+from otx.core.data.entity.tile import TileBatchDetDataEntity
+from otx.core.data.module import OTXDataModule
+from otx.core.model.entity.detection import OVDetectionModel
+from otx.core.model.entity.instance_segmentation import OVInstanceSegmentationModel
+from otx.core.types.task import OTXTaskType
+from otx.engine import Engine
+
+
+def test_tile_transform_consistency(mocker):
+    # Test that the tiler and tile transform are consistent
+    rng = np.random.default_rng()
+    rnd_tile_size = rng.integers(low=100, high=500)
+    rnd_tile_overlap = rng.random()
+    image_size = rng.integers(low=1000, high=5000)
+    np_image = np.zeros((image_size, image_size, 3), dtype=np.uint8)
+    dm_image = Image.from_numpy(np_image)
+
+    mock_model = MagicMock(spec=Model)
+    mocker.patch("openvino.model_api.tilers.tiler.Tiler.__init__", return_value=None)
+    mocker.patch.multiple(Tiler, __abstractmethods__=set())
+
+    tiler = Tiler(model=mock_model)
+    tiler.tile_size = rnd_tile_size
+    tiler.tiles_overlap = rnd_tile_overlap
+
+    mocker.patch("otx.core.data.dataset.tile.OTXTileTransform.__init__", return_value=None)
+    tile_transform = OTXTileTransform()
+    tile_transform._tile_size = (rnd_tile_size, rnd_tile_size)
+    tile_transform._overlap = (rnd_tile_overlap, rnd_tile_overlap)
+
+    dm_rois = [xywh_to_x1y1x2y2(*roi) for roi in tile_transform._extract_rois(dm_image)]
+    # 0 index in tiler is the full image so we skip it
+    assert np.allclose(dm_rois, tiler._tile(np_image)[1:])

--- a/tests/unit/core/utils/test_tile.py
+++ b/tests/unit/core/utils/test_tile.py
@@ -4,31 +4,14 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import numpy as np
-import pytest
-from datumaro import Dataset as DmDataset
 from datumaro import Image
 from datumaro.plugins.tiling.util import xywh_to_x1y1x2y2
-from omegaconf import DictConfig, OmegaConf
 from openvino.model_api.models import Model
-from openvino.model_api.tilers import DetectionTiler, InstanceSegmentationTiler, Tiler
-from otx.core.config.data import (
-    DataModuleConfig,
-    SubsetConfig,
-    TileConfig,
-    VisualPromptingConfig,
-)
+from openvino.model_api.tilers import Tiler
 from otx.core.data.dataset.tile import OTXTileTransform
-from otx.core.data.entity.detection import DetBatchDataEntity
-from otx.core.data.entity.tile import TileBatchDetDataEntity
-from otx.core.data.module import OTXDataModule
-from otx.core.model.entity.detection import OVDetectionModel
-from otx.core.model.entity.instance_segmentation import OVInstanceSegmentationModel
-from otx.core.types.task import OTXTaskType
-from otx.engine import Engine
 
 
 def test_tile_transform_consistency(mocker):


### PR DESCRIPTION
### Summary

Good news, OV model maintains its accuracy without too much drop (1-2% on inst-seg). Interestingly, it even outperforms PyTorch model in terms of accuracy on detection models. Probably will look into it in another PR, but I think the risk for Geti is low at the moment. 

OV Model | dataset | Image Size | Tile Size | Version | Torch Test/mAP50 | OV Test/mAP_50 | Inference Duration(s)
-- | -- | -- | -- | -- | -- | -- | --
MaskRCNN-Eff | Vitens Aeromonas | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.9168 | 0.9061 |  59.016 
MaskRCNN-R50 | Vitens Aeromonas | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.8979 | 0.9052 |  72.322
MaskRCNN-Eff | Vitens Coliform | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.5311 | 0.5134 | 48.878
MaskRCNN-R50 | Vitens Coliform | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.4854 | 0.5054 |  70.749
yolox_s | Vitens Aeromonas | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.6198 | 0.7948 | 37.497
yolox_s | Vitens Coliform | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.3721 | 0.42 | 23.833
yolox_tiny | Vitens Aeromonas | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.9354 | 0.9529 | 34.481
yolox_tiny | Vitens Coliform | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.5171 | 0.5943 | 21.262
yolox_l | Vitens Aeromonas | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.7258 | 0.7989 | 71.366
yolox_l | Vitens Coliform | 3500 x 3500 | 1663 x 1663 | 2.x (PR) | 0.43689 | 0.4206 | 51.628

</body></html></div>

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
