### PR TITLE
Add xfails in vpm e2e

### DIFF
--- a/tests/e2e/cli/visual_prompting/test_zero_shot.py
+++ b/tests/e2e/cli/visual_prompting/test_zero_shot.py
@@ -87,7 +87,7 @@ class TestToolsZeroShotVisualPrompting:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.xfail("This test is failing due to unexpected performance gap.")
+    @pytest.mark.xfail(reason="This test is failing due to unexpected performance gap.")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("half_precision", [True, False])
     def test_otx_eval_openvino(self, template, tmp_dir_path, half_precision):
@@ -118,7 +118,7 @@ class TestToolsZeroShotVisualPrompting:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.mark.xfail("This test is failing due to unexpected performance gap.")
+    @pytest.mark.xfail(reason="This test is failing due to unexpected performance gap.")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "zero_shot_visual_prompting"

--- a/tests/e2e/cli/visual_prompting/test_zero_shot.py
+++ b/tests/e2e/cli/visual_prompting/test_zero_shot.py
@@ -87,6 +87,7 @@ class TestToolsZeroShotVisualPrompting:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.xfail("This test is failing due to unexpected performance gap.")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("half_precision", [True, False])
     def test_otx_eval_openvino(self, template, tmp_dir_path, half_precision):
@@ -117,6 +118,7 @@ class TestToolsZeroShotVisualPrompting:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
+    @pytest.xfail("This test is failing due to unexpected performance gap.")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "zero_shot_visual_prompting"

--- a/tests/e2e/cli/visual_prompting/test_zero_shot.py
+++ b/tests/e2e/cli/visual_prompting/test_zero_shot.py
@@ -87,7 +87,7 @@ class TestToolsZeroShotVisualPrompting:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.xfail("This test is failing due to unexpected performance gap.")
+    @pytest.mark.xfail("This test is failing due to unexpected performance gap.")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     @pytest.mark.parametrize("half_precision", [True, False])
     def test_otx_eval_openvino(self, template, tmp_dir_path, half_precision):
@@ -118,7 +118,7 @@ class TestToolsZeroShotVisualPrompting:
 
     @e2e_pytest_component
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
-    @pytest.xfail("This test is failing due to unexpected performance gap.")
+    @pytest.mark.xfail("This test is failing due to unexpected performance gap.")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_ptq_eval(self, template, tmp_dir_path):
         tmp_dir_path = tmp_dir_path / "zero_shot_visual_prompting"


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
There are unexpected performance gaps between torch and ov models.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
