### PR TITLE
Fix a bug that error is raised when training a model after HPO on multi XPU environment

### DIFF
--- a/src/otx/hpo/resource_manager.py
+++ b/src/otx/hpo/resource_manager.py
@@ -180,6 +180,10 @@ class GPUResourceManager(AcceleratorManager):
 class XPUResourceManager(AcceleratorManager):
     """Resource manager class for XPU."""
 
+    def __init__(self, num_devices_per_trial: int = 1, available_devices: Optional[str] = None):
+        super().__init__(num_devices_per_trial, available_devices)
+        torch.xpu.init()  # Avoid default_generators index error in multi XPU environment
+
     def _set_available_devices(self, available_devices: Optional[str] = None) -> List[int]:
         if available_devices is None:
             visible_devices = os.getenv("ONEAPI_DEVICE_SELECTOR", "").split(":")


### PR DESCRIPTION
### Summary
When running HPO on multi XPU environment, `default_generators` index error occurs.
It can be fixed by initializing `torch.xpu` explicitly before running HPO.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
