### PR TITLE
Fix bug on visual prompting

### DIFF
--- a/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/models/visual_prompters/zero_shot_segment_anything.py
+++ b/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/models/visual_prompters/zero_shot_segment_anything.py
@@ -272,10 +272,7 @@ class ZeroShotSegmentAnything(SegmentAnything):
 
     @torch.no_grad()
     def learn(
-        self,
-        batch: List[Dict[str, Any]],
-        reset_feat: bool = False,
-        is_cascade: bool = False
+        self, batch: List[Dict[str, Any]], reset_feat: bool = False, is_cascade: bool = False
     ) -> Union[None, Tuple[ParameterDict, Tensor]]:
         """Get reference features.
 

--- a/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/models/visual_prompters/zero_shot_segment_anything.py
+++ b/src/otx/algorithms/visual_prompting/adapters/pytorch_lightning/models/visual_prompters/zero_shot_segment_anything.py
@@ -724,7 +724,7 @@ class ZeroShotSegmentAnything(SegmentAnything):
                 # all predicted masks were zero masks, ignore them.
                 return None, torch.zeros(masks.shape[-2:], device="cpu")
 
-            best_idx = int(torch.argmax(scores[0]))
+            best_idx = torch.argmax(scores[0])
         return logits[:, [best_idx]], masks[0, best_idx]
 
     def set_metrics(self) -> None:


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
This PR includes:
- [x] Fix bug in cascade inference that used logits with 3 dim, not 4 dim
- [x] Update default value of `is_cascade` for `infer` to True

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2023 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
