### PR TITLE
Add more backbone list for tv & fix exported_params

### DIFF
--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -292,6 +292,6 @@ class OTXTVModel(OTXMulticlassClsModel):
         if (head := getattr(self.model, "head", None)) is None:
             raise ValueError
 
-        if len(x.shape) == 4 and not self.use_layer_norm_2d:
+        if len(x.shape) == 4 and not self.model.use_layer_norm_2d:
             x = x.view(x.size(0), -1)
         return head(x)

--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -5,11 +5,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 import torch
 from torch import nn
-from torchvision import models, tv_tensors
+from torchvision import tv_tensors
+from torchvision.models import get_model, get_model_weights
 
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.classification import (
@@ -19,15 +20,66 @@ from otx.core.data.entity.classification import (
 )
 from otx.core.model.entity.classification import OTXMulticlassClsModel
 
-TV_WEIGHTS = {
-    "resnet50": models.ResNet50_Weights.IMAGENET1K_V2,
-    "efficientnet_b0": models.EfficientNet_B0_Weights.IMAGENET1K_V1,
-    "efficientnet_b1": models.EfficientNet_B1_Weights.IMAGENET1K_V2,
-    "efficientnet_b3": models.EfficientNet_B3_Weights.IMAGENET1K_V1,  # Balanced
-    "efficientnet_b4": models.EfficientNet_B4_Weights.IMAGENET1K_V1,
-    "efficientnet_v2_l": models.EfficientNet_V2_L_Weights.IMAGENET1K_V1,  # Accuracy
-    "mobilenet_v3_small": models.MobileNet_V3_Small_Weights.IMAGENET1K_V1,  # Speed
-}
+TVModelType = Literal[
+    "alexnet",
+    "convnext_base",
+    "convnext_large",
+    "convnext_small",
+    "convnext_tiny",
+    "efficientnet_b0",
+    "efficientnet_b1",
+    "efficientnet_b2",
+    "efficientnet_b3",
+    "efficientnet_b4",
+    "efficientnet_b5",
+    "efficientnet_b6",
+    "efficientnet_b7",
+    "efficientnet_v2_l",
+    "efficientnet_v2_m",
+    "efficientnet_v2_s",
+    "googlenet",
+    "mobilenet_v3_large",
+    "mobilenet_v3_small",
+    "regnet_x_16gf",
+    "regnet_x_1_6gf",
+    "regnet_x_32gf",
+    "regnet_x_3_2gf",
+    "regnet_x_400mf",
+    "regnet_x_800mf",
+    "regnet_x_8gf",
+    "regnet_y_128gf",
+    "regnet_y_16gf",
+    "regnet_y_1_6gf",
+    "regnet_y_32gf",
+    "regnet_y_3_2gf",
+    "regnet_y_400mf",
+    "regnet_y_800mf",
+    "regnet_y_8gf",
+    "resnet101",
+    "resnet152",
+    "resnet18",
+    "resnet34",
+    "resnet50",
+    "resnext101_32x8d",
+    "resnext101_64x4d",
+    "resnext50_32x4d",
+    "swin_b",
+    "swin_s",
+    "swin_t",
+    "swin_v2_b",
+    "swin_v2_s",
+    "swin_v2_t",
+    "vgg11",
+    "vgg11_bn",
+    "vgg13",
+    "vgg13_bn",
+    "vgg16",
+    "vgg16_bn",
+    "vgg19",
+    "vgg19_bn",
+    "wide_resnet101_2",
+    "wide_resnet50_2",
+]
 
 
 class TVModelWithLossComputation(nn.Module):
@@ -37,12 +89,10 @@ class TVModelWithLossComputation(nn.Module):
     It takes a backbone model, number of classes, and an optional loss function as input.
 
     Args:
-        backbone (
-            Literal["resnet50", "efficientnet_b0", "efficientnet_b1", "efficientnet_b3",
-            "efficientnet_b4", "efficientnet_v2_l", "mobilenet_v3_small"]):
-            The backbone model to use for feature extraction.
+        backbone (TVModelType): The backbone model to use for feature extraction.
         num_classes (int): The number of classes for the classification task.
-        loss (nn.Module | None, optional): The loss function to use.
+        loss (Callable | None, optional): The loss function to use.
+        freeze_backbone (bool, optional): Whether to freeze the backbone model. Defaults to False.
 
     Methods:
         forward(images: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
@@ -52,29 +102,28 @@ class TVModelWithLossComputation(nn.Module):
 
     def __init__(
         self,
-        backbone: Literal[
-            "resnet50",
-            "efficientnet_b0",
-            "efficientnet_b1",
-            "efficientnet_b3",
-            "efficientnet_b4",
-            "efficientnet_v2_l",
-            "mobilenet_v3_small",
-        ],
+        backbone: TVModelType,
         num_classes: int,
-        loss: nn.Module | None = None,
+        loss: Callable | None = None,
+        freeze_backbone: bool = False,
     ) -> None:
         super().__init__()
         self.num_classes = num_classes
-        net = getattr(models, backbone)(weights=TV_WEIGHTS[backbone])
+        net = get_model(name=backbone, weights=get_model_weights(backbone))
 
         self.backbone = nn.Sequential(*list(net.children())[:-1])
+        self.use_layer_norm_2d = False
+
+        if freeze_backbone:
+            for param in self.backbone.parameters():
+                param.requires_grad = False
 
         last_layer = list(net.children())[-1]
         classifier_len = len(list(last_layer.children()))
         if classifier_len >= 1:
             feature_channel = list(last_layer.children())[-1].in_features
             layers = list(last_layer.children())[:-1]
+            self.use_layer_norm_2d = layers[0].__class__.__name__ == "LayerNorm2d"
             self.head = nn.Sequential(*layers, nn.Linear(feature_channel, num_classes))
         else:
             feature_channel = last_layer.in_features
@@ -100,8 +149,8 @@ class TVModelWithLossComputation(nn.Module):
             torch.Tensor: The output logits or loss, depending on the training mode.
         """
         feats = self.backbone(images)
-        if len(feats.shape) == 4:  # If feats is a 4D tensor: (batch_size, channels, height, width)
-            feats = feats.view(feats.size(0), -1)  # Flatten the output of the backbone: (batch_size, features)
+        if len(feats.shape) == 4 and not self.use_layer_norm_2d:  # If feats is a 4D tensor: (b, c, h, w)
+            feats = feats.view(feats.size(0), -1)  # Flatten the output of the backbone: (b, f)
         logits = self.head(feats)
         if mode == "tensor":
             return logits
@@ -114,30 +163,22 @@ class OTXTVModel(OTXMulticlassClsModel):
     """OTXTVModel is that represents a TorchVision model for multiclass classification.
 
     Args:
-        backbone (
-            Literal["resnet50", "efficientnet_b0", "efficientnet_b1", "efficientnet_b3", "efficientnet_b4",
-            "efficientnet_v2_l", "mobilenet_v3_small"]):
-            The backbone architecture of the model.
+        backbone (TVModelType): The backbone architecture of the model.
         num_classes (int): The number of classes for classification.
-        loss (nn.Module | None, optional): The loss function to be used. Defaults to None.
+        loss (Callable | None, optional): The loss function to be used. Defaults to None.
+        freeze_backbone (bool, optional): Whether to freeze the backbone model. Defaults to False.
     """
 
     def __init__(
         self,
-        backbone: Literal[
-            "resnet50",
-            "efficientnet_b0",
-            "efficientnet_b1",
-            "efficientnet_b3",
-            "efficientnet_b4",
-            "efficientnet_v2_l",
-            "mobilenet_v3_small",
-        ],
+        backbone: TVModelType,
         num_classes: int,
-        loss: nn.Module | None = None,
+        loss: Callable | None = None,
+        freeze_backbone: bool = False,
     ) -> None:
         self.backbone = backbone
         self.loss = loss
+        self.freeze_backbone = freeze_backbone
 
         super().__init__(num_classes=num_classes)
 
@@ -146,6 +187,7 @@ class OTXTVModel(OTXMulticlassClsModel):
             backbone=self.backbone,
             num_classes=self.num_classes,
             loss=self.loss,
+            freeze_backbone=self.freeze_backbone,
         )
 
     def _customize_inputs(self, inputs: MulticlassClsBatchDataEntity) -> dict[str, Any]:
@@ -207,8 +249,8 @@ class OTXTVModel(OTXMulticlassClsModel):
         export_params["swap_rgb"] = False
         export_params["via_onnx"] = False
         export_params["onnx_export_configuration"] = None
-        export_params["mean"] = [0.485, 0.456, 0.406]
-        export_params["std"] = [0.229, 0.224, 0.225]
+        export_params["mean"] = [123.675, 116.28, 103.53]
+        export_params["std"] = [58.395, 57.12, 57.375]
 
         parameters = super()._export_parameters
         parameters.update(export_params)
@@ -227,7 +269,7 @@ class OTXTVModel(OTXMulticlassClsModel):
 
         saliency_map = self.explain_fn(backbone_feat)
 
-        if len(x.shape) == 4:
+        if len(x.shape) == 4 and not self.use_layer_norm_2d:
             x = x.view(x.size(0), -1)
 
         feature_vector = x
@@ -250,6 +292,6 @@ class OTXTVModel(OTXMulticlassClsModel):
         if (head := getattr(self.model, "head", None)) is None:
             raise ValueError
 
-        if len(x.shape) == 4:
+        if len(x.shape) == 4 and not self.use_layer_norm_2d:
             x = x.view(x.size(0), -1)
         return head(x)

--- a/tests/integration/cli/test_export_inference.py
+++ b/tests/integration/cli/test_export_inference.py
@@ -288,8 +288,5 @@ def test_otx_export_infer(
     if "h_label_cls/efficientnet_v2_light" in request.node.name:
         msg = f"h_label_cls/efficientnet_v2_light exceeds the following threshold = {threshold}"
         pytest.xfail(msg)
-    if "multi_class_cls/tv_" in request.node.name:
-        msg = "torchvision model for multi_class_cls exceeds the following threshold = 0.1"
-        pytest.xfail(msg)
 
     _check_relative_metric_diff(torch_acc, ov_acc, threshold)

--- a/tests/unit/algo/classification/test_torchvision_model.py
+++ b/tests/unit/algo/classification/test_torchvision_model.py
@@ -68,3 +68,8 @@ class TestOTXTVModel:
         x = torch.randn(16, 2048)
         output = fxt_tv_model.head_forward_fn(x)
         assert output.shape == (16, 10)
+
+    def test_freeze_backbone(self):
+        freezed_model = OTXTVModel(backbone="resnet50", num_classes=10, freeze_backbone=True)
+        for param in freezed_model.model.backbone.parameters():
+            assert not param.requires_grad


### PR DESCRIPTION
### Summary

- Add torchvision models
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/harimkan/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/harimkan/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link="#0563C1" vlink="#954F72">


TASK | model | Train
-- | -- | --
MULTI_CLASS_CLS | alexnet | O
  | convnext_base | O
  | convnext_large |  
  | convnext_small |  
  | efficientnet_b0 | O
  | efficientnet_b1 | O
  | efficientnet_b2 | O
  | efficientnet_b3 | O
  | efficientnet_b4 | O
  | efficientnet_b5 | O
  | efficientnet_b6 | O
  | efficientnet_b7 | O
  | efficientnet_v2_l | O
  | efficientnet_v2_m | O
  | efficientnet_v2_s | O
  | googlenet | O
  | mobilenet_v3_large | O
  | mobilenet_v3_small | O
  | regnet_x_16gf | O
  | regnet_x_1_6gf |  
  | regnet_x_32gf |  
  | regnet_x_3_2gf |  
  | regnet_x_400mf |  
  | regnet_x_800mf |  
  | regnet_x_8gf |  
  | regnet_y_128gf |  
  | regnet_y_16gf |  
  | regnet_y_1_6gf |  
  | regnet_y_32gf |  
  | regnet_y_3_2gf |  
  | regnet_y_400mf |  
  | regnet_y_800mf |  
  | regnet_y_8gf |  
  | resnet101 | O
  | resnet152 |  
  | resnet18 |  
  | resnet34 |  
  | resnet50 |  
  | resnext101_32x8d | O
  | resnext101_64x4d |  
  | resnext50_32x4d |  
  | swin_b | O
  | swin_s |  
  | swin_t |  
  | swin_v2_b | O
  | swin_v2_s |  
  | swin_v2_t |  
  | vgg11 | O
  | vgg11_bn | O
  | vgg13 |  
  | vgg13_bn |  
  | vgg16 |  
  | vgg16_bn |  
  | vgg19 |  
  | vgg19_bn |  
  | wide_resnet101_2 | O
  | wide_resnet50_2 |  

</body>

</html>

- Fix exported_params for tv_models
- Remove xfail for tv models

### How to test
```shell
otx train --model.help otx.algo.classification.torchvision_model.OTXTVModel

OTXTVModel is that represents a TorchVision model for multiclass classification:
  --model.init_args.backbone {alexnet,convnext_base,convnext_large,convnext_small,convnext_tiny,efficientnet_b0,efficientnet_b1,efficientnet_b2,efficientnet_b3,efficientnet_b4,efficientnet_b5,efficientnet_b6,efficientnet_b7,efficientnet_v2_l,efficientnet_v2_m,efficientnet_v2_s,googlenet,mobilenet_v3_large,mobilenet_v3_small,regnet_x_16gf,regnet_x_1_6gf,regnet_x_32gf,regnet_x_3_2gf,regnet_x_400mf,regnet_x_800mf,regnet_x_8gf,regnet_y_128gf,regnet_y_16gf,regnet_y_1_6gf,regnet_y_32gf,regnet_y_3_2gf,regnet_y_400mf,regnet_y_800mf,regnet_y_8gf,resnet101,resnet152,resnet18,resnet34,resnet50,resnext101_32x8d,resnext101_64x4d,resnext50_32x4d,swin_b,swin_s,swin_t,swin_v2_b,swin_v2_s,swin_v2_t,vgg11,vgg11_bn,vgg13,vgg13_bn,vgg16,vgg16_bn,vgg19,vgg19_bn,wide_resnet101_2,wide_resnet50_2}
                        The backbone architecture of the model. (required, type: Literal['alexnet', 'convnext_base', 'convnext_large', 'convnext_small', 'convnext_tiny', 'efficientnet_b0',
                        'efficientnet_b1', 'efficientnet_b2', 'efficientnet_b3', 'efficientnet_b4', 'efficientnet_b5', 'efficientnet_b6', 'efficientnet_b7', 'efficientnet_v2_l',
                        'efficientnet_v2_m', 'efficientnet_v2_s', 'googlenet', 'mobilenet_v3_large', 'mobilenet_v3_small', 'regnet_x_16gf', 'regnet_x_1_6gf', 'regnet_x_32gf', 'regnet_x_3_2gf',
                        'regnet_x_400mf', 'regnet_x_800mf', 'regnet_x_8gf', 'regnet_y_128gf', 'regnet_y_16gf', 'regnet_y_1_6gf', 'regnet_y_32gf', 'regnet_y_3_2gf', 'regnet_y_400mf',
                        'regnet_y_800mf', 'regnet_y_8gf', 'resnet101', 'resnet152', 'resnet18', 'resnet34', 'resnet50', 'resnext101_32x8d', 'resnext101_64x4d', 'resnext50_32x4d', 'swin_b',
                        'swin_s', 'swin_t', 'swin_v2_b', 'swin_v2_s', 'swin_v2_t', 'vgg11', 'vgg11_bn', 'vgg13', 'vgg13_bn', 'vgg16', 'vgg16_bn', 'vgg19', 'vgg19_bn', 'wide_resnet101_2',
                        'wide_resnet50_2'])
  --model.init_args.num_classes NUM_CLASSES
                        The number of classes for classification. (required, type: int)
  --model.init_args.loss LOSS
                        The loss function to be used. Defaults to None. (type: Optional[Callable], default: null)
  --model.init_args.freeze_backbone {true,false}
                        Whether to freeze the backbone model. Defaults to False. (type: bool, default: False)
```

```shell
otx train --config src/otx/recipe/classification/multi_class_cls/tv_mobilenet_v3_small.yaml --data_root /home/harimkan/workspace/repo/datasets/otx_v2_dataset/multiclass_classification/multiclass_CUB_medium --seed 0 --deterministic True --model.backbone convnext_base
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
