### PR TITLE
Update visual prompting unit tests & documentations

### DIFF
--- a/docs/source/guide/explanation/algorithms/visual_prompting/fine_tuning.rst
+++ b/docs/source/guide/explanation/algorithms/visual_prompting/fine_tuning.rst
@@ -7,7 +7,7 @@ Using these useful prompts, the main purpose of this task is to obtain labels fr
 This section examines the solutions for visual prompting offered by the OpenVINO Training Extensions library.
 `Segment Anything (SAM) <https://arxiv.org/abs/2304.02643>`_, is one of the most famous visual prompting methods and this model will be used to adapt a new dataset domain.
 Because `SAM <https://arxiv.org/abs/2304.02643>`_ was trained by using web-scale dataset and has huge backbone network, fine-tuning the whole network is difficult and lots of resources are required.
-Therefore, in this section, we try to fine-tune only mask decoder only for several epochs to increase performance on the new dataset domain.
+Therefore, in this section, we try to fine-tune the mask decoder only for several epochs to increase performance on the new dataset domain.
 For fine-tuning `SAM <https://arxiv.org/abs/2304.02643>`_, we use following algorithms components:
 
 .. _visual_prompting_finetuning_pipeline:
@@ -24,8 +24,8 @@ For fine-tuning `SAM <https://arxiv.org/abs/2304.02643>`_, we use following algo
 
 .. note::
 
-    Currently, fine-tuning `SAM <https://arxiv.org/abs/2304.02643>`_ with bounding boxes in the OpenVINO Training Extensions is only supported.
-    We will support fine-tuning with other prompts (points and texts) and continuous fine-tuning with predicted mask information in the near future.
+    In OTX 2.0, fine-tuning using either bounding boxes or points is available.
+    Given both bounding boxes and points prompts at the same time, bounding boxes have priority because using bounding boxes as prompts is more accurate.
 
 .. note::
 
@@ -39,7 +39,7 @@ Dataset Format
 
 For the dataset handling inside OpenVINO™ Training Extensions, we use `Dataset Management Framework (Datumaro) <https://github.com/openvinotoolkit/datumaro>`_.
 
-We support three dataset formats for visual prompting:
+We support four dataset formats for visual prompting:
 
 - `Common Semantic Segmentation <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/common_semantic_segmentation.html>`_ for semantic segmentation
 
@@ -47,11 +47,7 @@ We support three dataset formats for visual prompting:
 
 - `Pascal VOC <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/pascal_voc.html>`_ for instance segmentation and semantic segmentation
 
-.. note::
-
-    During training, mDice for binary mask without label information is used for train/validation metric.
-    After training, if using ``otx test`` to evaluate performance, mDice for binary or multi-class masks with label information will be used.
-    As you can expect, performance will be different between ``otx train`` and ``otx test``, but if unlabeled mask performance is high, labeld mask performance is high as well.
+- `Datumaro <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/datumaro.html>`_ for custom format dataset
 
 
 ******
@@ -64,13 +60,13 @@ We support the following model templates in experimental phase:
 +------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------------------+-----------------+
 |                                                                                        Template ID                                                         |     Name     | Complexity (GFLOPs) | Model size (MB) |
 +============================================================================================================================================================+==============+=====================+=================+
-| `Visual_Prompting_SAM_Tiny_ViT <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml>`_   | SAM_Tiny_ViT | 38.95               | 47              |
+| `Visual_Prompting_SAM_Tiny_ViT <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml>`_   | SAM_Tiny_ViT | 38.55               | 47              |
 +------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------------------+-----------------+
-| `Visual_Prompting_SAM_ViT_B <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/visual_prompting/sam_vit_b.yaml>`_         | SAM_ViT_B    | 483.71              | 362             |
+| `Visual_Prompting_SAM_ViT_B <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/visual_prompting/sam_vit_b.yaml>`_         | SAM_ViT_B    | 454.76              | 363             |
 +------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+---------------------+-----------------+
 
-To check feasibility of `SAM <https://arxiv.org/abs/2304.02643>`_, we did experiments using three public datasets with each other domains: `WGISD <https://github.com/thsant/wgisd>`_, `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_, and `FLARE22 <https://flare22.grand-challenge.org/>`_, and checked `Dice score <https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient>`_.
-We used sampled training data from `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_ and `FLARE22 <https://flare22.grand-challenge.org/>`_, and full training data (=110) from `WGISD <https://github.com/thsant/wgisd>`_.
+To check feasibility of `SAM <https://arxiv.org/abs/2304.02643>`_, we did experiments using three public datasets with each other domains: `WGISD <https://github.com/thsant/wgisd>`_ and `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_, and checked `F1-score <https://en.wikipedia.org/wiki/F-score>`_.
+We used sampled training data from `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_ and full training data (=110) from `WGISD <https://github.com/thsant/wgisd>`_.
 
 +---------------------------------------------------------------+--------------------+
 |                            Dataset                            |      #samples      |
@@ -79,24 +75,23 @@ We used sampled training data from `Trashcan <https://conservancy.umn.edu/handle
 +---------------------------------------------------------------+--------------------+
 | `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_ | 500                |
 +---------------------------------------------------------------+--------------------+
-| `FLARE22 <https://flare22.grand-challenge.org/>`_             | 1 CT (=100 slices) |
-+---------------------------------------------------------------+--------------------+
 
 The below table shows performance improvement after fine-tuning.
 
-+------------+--------------------------------------------+---------------------------------------------------------------+---------------------------------------------------+
-| Model name | `WGISD <https://github.com/thsant/wgisd>`_ | `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_ | `FLARE22 <https://flare22.grand-challenge.org/>`_ |
-+============+============================================+===============================================================+===================================================+
-| Tiny_ViT   | 90.32 → 92.29 (+1.97)                      | 82.38 → 85.01 (+2.63)                                         | 89.69 → 93.05 (+3.36)                             |
-+------------+--------------------------------------------+---------------------------------------------------------------+---------------------------------------------------+
-| ViT_B      | 92.32 → 92.46 (+0.14)                      | 79.61 → 81.50 (+1.89)                                         | 91.48 → 91.68 (+0.20)                             |
-+------------+--------------------------------------------+---------------------------------------------------------------+---------------------------------------------------+
++--------------+--------------------------------------------+---------------------------------------------------------------+
+|  Model name  | `WGISD <https://github.com/thsant/wgisd>`_ | `Trashcan <https://conservancy.umn.edu/handle/11299/214865>`_ |
++==============+============================================+===============================================================+
+| SAM_Tiny_ViT | 90.32 → 92.10 (+1.78)                      | 82.38 → 85.35 (+2.97)                                         |
++--------------+--------------------------------------------+---------------------------------------------------------------+
+| SAM_ViT_B    | 92.32 → 93.16 (+0.84)                      | 79.61 → 86.40 (+6.79)                                         |
++--------------+--------------------------------------------+---------------------------------------------------------------+
 
 According to datasets, ``learning rate`` and ``batch size`` can be adjusted like below:
 
 .. code-block:: shell
 
-    (otx) ...$ otx train --config <model_config_path> \
-                         --data_root <path_to_data_root> \
-                         --data.config.train_subset.batch_size <batch_size_to_be_updated> \
-                         --optimizer.lr <learning_rate_to_be_updated>
+    (otx) ...$ otx train \
+        --config <model_config_path> \
+        --data_root <path_to_data_root> \
+        --data.config.train_subset.batch_size <batch_size_to_be_updated> \
+        --optimizer.lr <learning_rate_to_be_updated>

--- a/docs/source/guide/explanation/algorithms/visual_prompting/zero_shot.rst
+++ b/docs/source/guide/explanation/algorithms/visual_prompting/zero_shot.rst
@@ -10,15 +10,15 @@ Especially, in this section, we try to automatically predict given images withou
 Unlike fine-tuning, zero-shot learning needs only pre-processing component.
 
 
-.. _visual_prompting_zeroshot_pipeline:
+.. _zero_shot_visual_prompting_pipeline:
 
-- ``Pre-processing``: Resize an image according to the longest axis and pad the rest with zero.
+- ``Pre-processing``: Resize an image according to the longest axis and pad the rest with zero. This pre-processing step is internalized in the model for standalone usecases unlike other models.
 
 
 .. note::
 
-    Currently, zero-shot learning with `SAM <https://arxiv.org/abs/2304.02643>`_ with bounding boxes in the OpenVINO Training Extensions is only supported.
-    We will support zero-shot learning with other prompts (points and texts) in the near future.
+    In OTX 2.0, zero-shot learning supports various types of prompts, such as bounding boxes, points, and masks. (Polygon will be available soon.)
+    Regardless of the prompt types, prediction will be made in the order prompts come in.
 
 .. note::
 
@@ -28,11 +28,11 @@ Unlike fine-tuning, zero-shot learning needs only pre-processing component.
 **************
 Dataset Format
 **************
-.. _visual_prompting_dataset:
+.. _zero_shot_visual_prompting_dataset:
 
 For the dataset handling inside OpenVINO™ Training Extensions, we use `Dataset Management Framework (Datumaro) <https://github.com/openvinotoolkit/datumaro>`_.
 
-We support three dataset formats for visual prompting:
+We support four dataset formats for zero-shot visual prompting:
 
 - `Common Semantic Segmentation <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/common_semantic_segmentation.html>`_ for semantic segmentation
 
@@ -40,40 +40,46 @@ We support three dataset formats for visual prompting:
 
 - `Pascal VOC <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/pascal_voc.html>`_ for instance segmentation and semantic segmentation
 
+- `Datumaro <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/datumaro.html>`_ for custom format dataset
+
 
 ******
 Models
 ******
-.. _visual_prompting_zero_shot_model:
+.. _zero_shot_visual_prompting_model:
 
 We support the following model templates in experimental phase:
 
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------------------+-----------------+
-|                                                                                          Template ID                                                          |          Name          | Complexity (GFLOPs) | Model size (MB) |
-+===============================================================================================================================================================+========================+=====================+=================+
-| `Zero_Shot_SAM_Tiny_ViT <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/zeto_shot_visual_prompting/sam_tiny_vit.yaml>`_   | Zero_Shot_SAM_Tiny_ViT | 38.18               | 25              |
-+---------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------------------+-----------------+
++-------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------------------+-----------------+
+|                                                                         Template ID                                                                         |          Name          | Complexity (GFLOPs) | Model size (MB) |
++=============================================================================================================================================================+========================+=====================+=================+
+| `Zero_Shot_SAM_Tiny_ViT <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml>`_ | Zero_Shot_SAM_Tiny_ViT | 38.54               | 47              |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------------------+-----------------+
+| `Zero_Shot_SAM_ViT_B <https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml>`_       | Zero_Shot_SAM_ViT_B    | 454.76              | 363             |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------------------+-----------------+
 
 ***************
 Simple tutorial
 ***************
-.. _visual_prompting_zero_shot_tutorial:
+.. _zero_shot_visual_prompting_tutorial:
 
 There are two steps for zero-shot inference: ``learn`` and ``infer``.
-``Learn`` is to extracet reference features from given reference images and prompts. These extracted reference features will be used to get point candidates on given target images.
-Extracted reference features will be saved in the model checkpoint (such as `weight.pth`) with the model.
+``Learn`` is to extract reference features from given reference images and prompts. These extracted reference features will be used to get point candidates on given target images.
+Extracted reference features will be returned as outputs and saved at a given path for OTX standalone usecase.
 You can do ``learn`` with the following source code:
 
 .. code-block:: shell
 
-    (otx) ...$ otx train --config <model_config_path> \
+    (otx) ...$ otx train \
+        --config <model_config_path> \
         --data_root <path_to_data_root>
 
 ``Infer`` is to get predicted masks on given target images. Unlike ``learn``, this stage doesn't need any prompt information.
 
 .. code-block::
 
-    (otx) ...$ otx test --config <model_config_path> \
+    (otx) ...$ otx test 
+        --config <model_config_path> \
         --data_root <path_to_data_root> \
         --checkpoint <path_to_weights_from_learn>
 

--- a/docs/source/guide/tutorials/base/how_to_train/classification.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/classification.rst
@@ -294,7 +294,7 @@ while training logs can be found in the ``{work_dir}/{timestamp}`` dir.
 
 The training time highly relies on the hardware characteristics, for example on 1 NVIDIA GeForce RTX 3090 the training took about 3 minutes.
 
-After that, we have the PyTorch multi-class classification model trained with OpenVINO™ Training Extensions, which we can use for evaliation, export, optimization and deployment.
+After that, we have the PyTorch multi-class classification model trained with OpenVINO™ Training Extensions, which we can use for evaluation, export, optimization and deployment.
 
 ***********
 Evaluation
@@ -357,7 +357,7 @@ Export
 
 1. ``otx export`` exports a trained Pytorch `.pth` model to the OpenVINO™ Intermediate Representation (IR) format.
 It allows to efficiently run it on Intel hardware, especially on CPU, using OpenVINO™ runtime.
-Also, the resulting IR model is required to run PTQ optimization in the section below. IR model contains 2 files: ``exported_model.xml`` for weights and ``exported_model.bin`` for architecture.
+Also, the resulting IR model is required to run PTQ optimization in the section below. IR model contains 2 files: ``exported_model.xml`` for architecture and ``exported_model.bin`` for weights.
 
 2. That's how we can export the trained model ``{work_dir}/{timestamp}/checkpoints/epoch_*.ckpt``
 from the previous section and save the exported model to the ``{work_dir}/{timestamp}/`` folder.
@@ -505,7 +505,7 @@ with OpenVINO™ PTQ.
             engine.optimize(checkpoint=ckpt_path)
 
 
-The optimization time highly relies on the hardware characteristics, for example on 1 NVIDIA GeForce RTX 3090 it took about 10 minutes.
+The optimization time highly relies on the hardware characteristics, for example on Intel(R) Core(TM) i9-10980XE it took about 9 seconds.
 Please note, that PTQ will take some time without logging to optimize the model.
 
 3. Finally, we can also evaluate the optimized model by passing

--- a/docs/source/guide/tutorials/base/how_to_train/detection.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/detection.rst
@@ -306,7 +306,7 @@ while training logs can be found in the ``{work_dir}/{timestamp}`` dir.
 
 The training time highly relies on the hardware characteristics, for example on 1 NVIDIA GeForce RTX 3090 the training took about 3 minutes.
 
-After that, we have the PyTorch object detection model trained with OpenVINO™ Training Extensions, which we can use for evaliation, export, optimization and deployment.
+After that, we have the PyTorch object detection model trained with OpenVINO™ Training Extensions, which we can use for evaluation, export, optimization and deployment.
 
 ***********
 Evaluation
@@ -369,7 +369,7 @@ Export
 
 1. ``otx export`` exports a trained Pytorch `.pth` model to the OpenVINO™ Intermediate Representation (IR) format.
 It allows to efficiently run it on Intel hardware, especially on CPU, using OpenVINO™ runtime.
-Also, the resulting IR model is required to run PTQ optimization in the section below. IR model contains 2 files: ``exported_model.xml`` for weights and ``exported_model.bin`` for architecture.
+Also, the resulting IR model is required to run PTQ optimization in the section below. IR model contains 2 files: ``exported_model.xml`` for architecture and ``exported_model.bin`` for weights.
 
 2. That's how we can export the trained model ``{work_dir}/{timestamp}/checkpoints/epoch_*.ckpt``
 from the previous section and save the exported model to the ``{work_dir}/{timestamp}/`` folder.
@@ -539,7 +539,7 @@ with OpenVINO™ PTQ.
             engine.optimize(checkpoint=ckpt_path)
 
 
-The optimization time highly relies on the hardware characteristics, for example on 1 NVIDIA GeForce RTX 3090 it took about 10 minutes.
+The optimization time highly relies on the hardware characteristics, for example on Intel(R) Core(TM) i9-11900 it took about 25 seconds.
 Please note, that PTQ will take some time without logging to optimize the model.
 
 3. Finally, we can also evaluate the optimized model by passing

--- a/docs/source/guide/tutorials/base/how_to_train/index.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/index.rst
@@ -41,6 +41,8 @@ How to train, validate, export and optimize the model
       :text-align: center
 
    .. grid-item-card:: Visual Prompting
+      :link: visual_prompting
+      :link-type: doc
       :text-align: center
 
 .. toctree::
@@ -54,3 +56,4 @@ How to train, validate, export and optimize the model
    anomaly_detection
    action_classification
    action_detection
+   visual_prompting

--- a/docs/source/guide/tutorials/base/how_to_train/instance_segmentation.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/instance_segmentation.rst
@@ -382,7 +382,7 @@ Export
 1. ``otx export`` exports a trained Pytorch `.pth` model to the
 OpenVINO™ Intermediate Representation (IR) format.
 
-It allows running the model on the Intel hardware much more efficient, especially on the CPU. Also, the resulting IR model is required to run PTQ optimization. IR model consists of 2 files: ``exported_model.xml`` for weights and ``exported_model.bin`` for architecture.
+It allows running the model on the Intel hardware much more efficient, especially on the CPU. Also, the resulting IR model is required to run PTQ optimization. IR model consists of 2 files: ``exported_model.xml`` for architecture and ``exported_model.bin`` for weights.
 
 2. We can run the below command line to export the trained model
 and save the exported model to the ``{work_dir}/{timestamp}/`` folder.

--- a/docs/source/guide/tutorials/base/how_to_train/visual_prompting.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/visual_prompting.rst
@@ -1,0 +1,623 @@
+Visual Prompting model
+======================
+
+This tutorial reveals end-to-end solution from installation to model export and optimization for visual prompting task on a specific example.
+On this page, we show how to train, validate, export and optimize SegmentAnything model on a toy dataset.
+
+To learn more about Visual Prompting task, refer to :doc:`../../../explanation/algorithms/visual_prompting/index`.
+
+.. note::
+
+  To learn deeper how to manage training process of the model including additional parameters and its modification.
+
+The process has been tested on the following configuration.
+
+- Ubuntu 18.04
+- NVIDIA GeForce RTX 3090
+- Intel(R) Core(TM) i9-11900
+- CUDA Toolkit 11.8
+
+*************************
+Setup virtual environment
+*************************
+
+1. You can follow the installation process from a :doc:`quick start guide <../../../get_started/installation>`
+to create a universal virtual environment for OpenVINO™ Training Extensions.
+
+2. Activate your virtual
+environment:
+
+.. code-block:: shell
+
+  .otx/bin/activate
+  # or by this line, if you created an environment, using tox
+  . venv/otx/bin/activate
+
+
+***************************
+Dataset preparation
+***************************
+
+..  note::
+
+  Currently, we support the following visual prompting dataset formats:
+
+  - `Common Semantic Segmentation <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/common_semantic_segmentation.html>`_
+  - `COCO <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/coco.html>`_
+  - `Pascal VOC <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/pascal_voc.html>`_
+  - `Datumaro <https://openvinotoolkit.github.io/datumaro/stable/docs/data-formats/formats/datumaro.html>`_
+
+1. Clone a repository with
+`WGISD dataset <https://github.com/thsant/wgisd>`_.
+
+.. code-block:: shell
+
+    mkdir data ; cd data
+    git clone https://github.com/thsant/wgisd.git
+    cd wgisd
+    git checkout 6910edc5ae3aae8c20062941b1641821f0c30127
+
+
+This dataset contains images of grapevines with the annotation for different varieties of grapes.
+
+- ``CDY`` - Chardonnay
+- ``CFR`` - Cabernet Franc
+- ``CSV`` - Cabernet Sauvignon
+- ``SVB`` - Sauvignon Blanc
+- ``SYH`` - Syrah
+
+It's a great example to start with. The model achieves high accuracy right from the beginning of the training due to relatively large and focused objects. Also, these objects are distinguished by a person, so we can check inference results just by looking at images.
+
+|
+
+.. image:: ../../../../../utils/images/wgisd_gt_sample.jpg
+  :width: 600
+  :alt: this image uploaded from this `source <https://github.com/thsant/wgisd/blob/master/data/CDY_2015.jpg>`_
+
+|
+
+2. To run the training using :doc:`auto-configuration feature <../../../explanation/additional_features/auto_configuration>`,
+we need to reformat the dataset according to this structure:
+
+.. code-block:: shell
+
+    wgisd
+    ├── annotations/
+        ├── instances_train.json
+        ├── instances_val.json
+        (Optional)
+        └── instances_test.json
+    ├──images/
+        (The split on folders is optional)
+        ├── train
+        ├── val
+        └── test
+    (There may be more extra unrelated folders)
+
+We can do that by running these commands:
+
+.. code-block:: shell
+
+    # format images folder
+    mv data images
+
+    # format annotations folder
+    mv coco_annotations annotations
+
+    # rename annotations to meet *_train.json pattern
+    mv annotations/train_bbox_instances.json annotations/instances_train.json
+    mv annotations/test_bbox_instances.json annotations/instances_val.json
+    cp annotations/instances_val.json annotations/instances_test.json
+
+    cd ../..
+
+*********
+Training
+*********
+
+1. First of all, you need to choose which visual prompting model you want to train.
+The list of supported templates for visual prompting is available with the command line below.
+
+.. note::
+
+    The characteristics and detailed comparison of the models could be found in :doc:`Explanation section <../../../explanation/algorithms/visual_prompting/index>`.
+
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx find --task VISUAL_PROMPTING
+            ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+            ┃ Task             ┃ Model Name     ┃ Recipe Path                                              ┃
+            ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+            │ VISUAL_PROMPTING │ sam_tiny_vit   │ src/otx/recipe/visual_prompting/sam_tiny_vit.yaml        │
+            │ VISUAL_PROMPTING │ openvino_model │ src/otx/recipe/visual_prompting/openvino_model.yaml      │
+            │ VISUAL_PROMPTING │ sam_vit_b      │ src/otx/recipe/visual_prompting/sam_vit_b.yaml           │
+            └──────────────────┴────────────────┴──────────────────────────────────────────────────────────┘
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            from otx.engine.utils.api import list_models
+
+            model_lists = list_models(task="VISUAL_PROMPTING")
+            print(model_lists)
+            '''
+            ['sam_tiny_vit', 'sam_vit_b', 'openvino_model']
+            '''
+
+2. On this step we will configure configuration
+with:
+
+- all necessary configs for sam_tiny_vit
+- train/validation sets, based on provided annotation.
+
+It may be counterintuitive, but for ``--data_root`` we need to pass the path to the dataset folder root (in our case it's ``data/wgisd``) instead of the folder with validation images.
+This is because the function automatically detects annotations and images according to the expected folder structure we achieved above.
+
+Let's check the visual prompting configuration running the following command:
+
+.. code-block:: shell
+
+    # or its config path
+    (otx) ...$ otx train --config src/otx/recipe/visual_prompting/sam_tiny_vit.yaml --data_root data/wgisd --print_config
+
+    ...
+    data_root: data/wgisd
+    work_dir: otx-workspace
+    callback_monitor: val/f1-score
+    disable_infer_num_classes: false
+    engine:
+      task: VISUAL_PROMPTING
+      device: auto
+    data:
+    ...
+
+.. note::
+
+    If you want to get configuration as yaml file, please use ``--print_config`` parameter and ``> configs.yaml``.
+
+    .. code-block:: shell
+
+        (otx) ...$ otx train --config  src/otx/recipe/visual_prompting/sam_tiny_vit.yaml --data_root data/wgisd --print_config > configs.yaml
+        # Update configs.yaml & Train configs.yaml
+        (otx) ...$ otx train --config configs.yaml
+
+3. ``otx train`` trains a model (a particular model template)
+on a dataset and results:
+
+Here are the main outputs can expect with CLI:
+- ``{work_dir}/{timestamp}/checkpoints/epoch_*.ckpt`` - a model checkpoint file.
+- ``{work_dir}/{timestamp}/configs.yaml`` - The configuration file used in the training can be reused to reproduce the training.
+- ``{work_dir}/.latest`` - The results of each of the most recently executed subcommands are soft-linked. This allows you to skip checkpoints and config file entry as a workspace.
+
+.. tab-set::
+
+    .. tab-item:: CLI (auto-config)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train --data_root data/wgisd --task VISUAL_PROMPTING
+
+    .. tab-item:: CLI (with config)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train --config src/otx/recipe/visual_prompting/sam_tiny_vit.yaml --data_root data/wgisd
+
+    .. tab-item:: API (from_config)
+
+        .. code-block:: python
+
+            from otx.engine import Engine
+
+            data_root = "data/wgisd"
+            recipe = "src/otx/recipe/visual_prompting/sam_tiny_vit.yaml"
+
+            engine = Engine.from_config(
+                      config_path=recipe,
+                      data_root=data_root,
+                      work_dir="otx-workspace",
+                    )
+
+            engine.train(...)
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            from otx.engine import Engine
+
+            data_root = "data/wgisd"
+
+            engine = Engine(
+                      model="sam_tiny_vit",
+                      task="VISUAL_PROMPTING",
+                      data_root=data_root,
+                      work_dir="otx-workspace",
+                    )
+
+            engine.train(...)
+
+.. note::
+
+  Because the dataset structure is mostly the same as detection, VISUAL_PROMPTING requires the task type to be specified to enable auto-configuration.
+
+4. ``(Optional)`` Additionally, we can tune training parameters such as batch size, learning rate, patience epochs or warm-up iterations.
+Learn more about template-specific parameters using ``otx train params --help``.
+
+It can be done by manually updating parameters in the ``template.yaml`` file in your workplace or via the command line.
+
+For example, to increase the batch size to 4, fix the number of epochs to 100, extend the command line above with the following line.
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train ... --data.config.train_subset.batch_size 4 \
+                                     --max_epochs 100
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            from otx.core.config.data import DataModuleConfig, SubsetConfig
+            from otx.core.data.module import OTXDataModule
+            from otx.engine import Engine
+
+            data_config = DataModuleConfig(..., train_subset=SubsetConfig(..., batch_size=4))
+            datamodule = OTXDataModule(..., config=data_config)
+
+            engine = Engine(..., datamodule=datamodule)
+
+            engine.train(max_epochs=100)
+
+5. The training result ``checkpoints/*.ckpt`` file is located in ``{work_dir}`` folder,
+while training logs can be found in the ``{work_dir}/{timestamp}`` dir.
+
+.. note::
+    We also can visualize the training using ``Tensorboard`` as these logs are located in ``{work_dir}/{timestamp}/tensorboard``.
+
+.. code-block::
+
+    otx-workspace
+    ├── outputs/
+        ├── 20240403_134256/
+            ├── csv/
+            ├── checkpoints/
+            |   └── epoch_*.pth
+            ├── tensorboard/
+            └── configs.yaml
+        └── .latest
+            └── train/
+    ...
+
+The training time highly relies on the hardware characteristics, for example on 1 NVIDIA GeForce RTX 3090 the training took about 4 minutes.
+
+After that, we have the PyTorch visual prompting model trained with OpenVINO™ Training Extensions, which we can use for evaluation, export, optimization and deployment.
+
+***********
+Evaluation
+***********
+
+1. ``otx test`` runs evaluation of a
+trained model on a particular dataset.
+
+Test function receives test annotation information and model snapshot, trained in previous step.
+
+The default metric is f1-score measure.
+
+2. That's how we can evaluate the snapshot in ``otx-workspace``
+folder on WGISD dataset and save results to ``otx-workspace``:
+
+.. tab-set::
+
+    .. tab-item:: CLI (with work_dir)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx test --work_dir otx-workspace
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+            ┃        Test metric        ┃       DataLoader 0        ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+            │      test/data_time       │   0.0009265312692150474   │
+            │         test/dice         │    0.9201090335845947     │
+            │       test/f1-score       │    0.9201071262359619     │
+            │         test/iou          │    0.8520355224609375     │
+            │      test/iter_time       │    0.3015514016151428     │
+            │         test/map          │    0.5886790156364441     │
+            │        test/map_50        │    0.9061686396598816     │
+            │        test/map_75        │    0.6716098785400391     │
+            │      test/map_large       │    0.7401198148727417     │
+            │      test/map_medium      │    0.5705212950706482     │
+            │    test/map_per_class     │           -1.0            │
+            │      test/map_small       │    0.21598181128501892    │
+            │        test/mar_1         │    0.03824029490351677    │
+            │        test/mar_10        │    0.3468073010444641     │
+            │       test/mar_100        │     0.614170253276825     │
+            │  test/mar_100_per_class   │           -1.0            │
+            │      test/mar_large       │     0.766523003578186     │
+            │      test/mar_medium      │     0.599896252155304     │
+            │      test/mar_small       │    0.2501521706581116     │
+            └───────────────────────────┴───────────────────────────┘
+
+    .. tab-item:: CLI (with config)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx test --config src/otx/recipe/visual_prompting/sam_tiny_vit.yaml \
+                                --data_root data/wgisd \
+                                --checkpoint otx-workspace/.latest/train/checkpoints/epoch_009.ckpt
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+            ┃        Test metric        ┃       DataLoader 0        ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+            │      test/data_time       │   0.0009342798730358481   │
+            │         test/dice         │    0.9201090335845947     │
+            │       test/f1-score       │    0.9201071262359619     │
+            │         test/iou          │    0.8520355224609375     │
+            │      test/iter_time       │    0.31654438376426697    │
+            │         test/map          │    0.5886790156364441     │
+            │        test/map_50        │    0.9061686396598816     │
+            │        test/map_75        │    0.6716098785400391     │
+            │      test/map_large       │    0.7401198148727417     │
+            │      test/map_medium      │    0.5705212950706482     │
+            │    test/map_per_class     │           -1.0            │
+            │      test/map_small       │    0.21598181128501892    │
+            │        test/mar_1         │    0.03824029490351677    │
+            │        test/mar_10        │    0.3468073010444641     │
+            │       test/mar_100        │     0.614170253276825     │
+            │  test/mar_100_per_class   │           -1.0            │
+            │      test/mar_large       │     0.766523003578186     │
+            │      test/mar_medium      │     0.599896252155304     │
+            │      test/mar_small       │    0.2501521706581116     │
+            └───────────────────────────┴───────────────────────────┘
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            engine.test()
+
+
+3. The output of ``{work_dir}/{timestamp}/csv/version_0/metrics.csv`` consists of
+a dict with target metric name and its value.
+
+
+*********
+Export
+*********
+
+1. ``otx export`` exports a trained Pytorch `.pth` model to the OpenVINO™ Intermediate Representation (IR) format.
+It allows to efficiently run it on Intel hardware, especially on CPU, using OpenVINO™ runtime.
+Also, the resulting IR model is required to run PTQ optimization in the section below. IR model contains 4 files: ``exported_model_image_encoder.xml`` and ``exported_model_decoder.xml`` for architecture and ``exported_model_image_encoder.bin`` and ``exported_model_decoder.bin`` for weights.
+
+2. That's how we can export the trained model ``{work_dir}/{timestamp}/checkpoints/epoch_*.ckpt``
+from the previous section and save the exported model to the ``{work_dir}/{timestamp}/`` folder.
+
+.. tab-set::
+
+    .. tab-item:: CLI (with work_dir)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx export --work_dir otx-workspace
+            ...
+            Elapsed time: 0:00:05.396129
+
+    .. tab-item:: CLI (with config)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx export ... --checkpoint otx-workspace/.latest/train/checkpoints/epoch_009.ckpt
+            ...
+            Elapsed time: 0:00:05.313879
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            engine.export()
+
+
+3. We can check the accuracy of the IR model and the consistency between the exported model and the PyTorch model,
+using ``otx test`` and passing the IR model path to the ``--checkpoint`` parameter.
+
+.. tab-set::
+
+    .. tab-item:: CLI (with work_dir)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx test --work_dir otx-workspace \
+                                --checkpoint otx-workspace/.latest/export/exported_model_decoder.xml \
+                                --engine.device cpu
+            ...
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+            ┃        Test metric        ┃       DataLoader 0        ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+            │      test/data_time       │   0.0007283412269316614   │
+            │         test/dice         │    0.9990837574005127     │
+            │       test/f1-score       │    0.9169966578483582     │
+            │         test/iou          │    0.8467163443565369     │
+            │      test/iter_time       │    3.1121630668640137     │
+            │         test/map          │    0.47309553623199463    │
+            │        test/map_50        │    0.8371172547340393     │
+            │        test/map_75        │    0.5044668912887573     │
+            │      test/map_large       │    0.6876431107521057     │
+            │      test/map_medium      │    0.5046071410179138     │
+            │    test/map_per_class     │           -1.0            │
+            │      test/map_small       │    0.11672457307577133    │
+            │        test/mar_1         │    0.02601064182817936    │
+            │        test/mar_10        │    0.26142847537994385    │
+            │       test/mar_100        │    0.6027402281761169     │
+            │  test/mar_100_per_class   │           -1.0            │
+            │      test/mar_large       │    0.7594292163848877     │
+            │      test/mar_medium      │    0.5897444486618042     │
+            │      test/mar_small       │    0.22268414497375488    │
+            └───────────────────────────┴───────────────────────────┘
+
+    .. tab-item:: CLI (with config)
+
+        .. code-block:: shell
+
+            (otx) ...$ otx test --config src/otx/recipe/visual_prompting/sam_tiny_vit.yaml \
+                                --data_root data/wgisd \
+                                --checkpoint otx-workspace/.latest/export/exported_model_decoder.xml \
+                                --engine.device cpu
+            ...
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+            ┃        Test metric        ┃       DataLoader 0        ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+            │      test/data_time       │   0.0007516053738072515   │
+            │         test/dice         │    0.9990837574005127     │
+            │       test/f1-score       │    0.9169966578483582     │
+            │         test/iou          │    0.8467163443565369     │
+            │      test/iter_time       │     3.09753680229187      │
+            │         test/map          │    0.47309553623199463    │
+            │        test/map_50        │    0.8371172547340393     │
+            │        test/map_75        │    0.5044668912887573     │
+            │      test/map_large       │    0.6876431107521057     │
+            │      test/map_medium      │    0.5046071410179138     │
+            │    test/map_per_class     │           -1.0            │
+            │      test/map_small       │    0.11672457307577133    │
+            │        test/mar_1         │    0.02601064182817936    │
+            │        test/mar_10        │    0.26142847537994385    │
+            │       test/mar_100        │    0.6027402281761169     │
+            │  test/mar_100_per_class   │           -1.0            │
+            │      test/mar_large       │    0.7594292163848877     │
+            │      test/mar_medium      │    0.5897444486618042     │
+            │      test/mar_small       │    0.22268414497375488    │
+            └───────────────────────────┴───────────────────────────┘
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            exported_model = engine.export()
+            engine.test(checkpoint=exported_model)
+
+.. note::
+    Visual prompting task has two IR models unlike other tasks. 
+    But it doesn't matter which one to be inserted to ``--checkpoint`` for testing because OTX will automatically load both IR models.
+
+
+4. ``Optional`` Additionally, we can tune confidence threshold via the command line.
+Learn more about template-specific parameters using ``otx export --help``.
+
+For example, If you want to get the ONNX model format you can run it like below.
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx export ... --checkpoint otx-workspace/.latest/train/checkpoints/epoch_009.ckpt --export_format ONNX
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            engine.export(..., export_format="ONNX")
+
+
+*************
+Optimization
+*************
+
+1. We can further optimize the model with ``otx optimize``.
+It uses PTQ depending on the model and transforms it to ``INT8`` format.
+
+``PTQ`` optimization is used for models exported in the OpenVINO™ IR format. It decreases the floating-point precision to integer precision of the exported model by performing the post-training optimization.
+
+To learn more about optimization, refer to `NNCF repository <https://github.com/openvinotoolkit/nncf>`_.
+
+2.  Command example for optimizing OpenVINO™ model (.xml)
+with OpenVINO™ PTQ.
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx optimize  --work_dir otx-workspace \ 
+                                     --checkpoint otx-workspace/.latest/export/exported_model_decoder.xml \
+                                     --data.config.train_subset.num_workers 0
+
+            ...
+            Statistics collection ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 55/55 • 0:00:35 • 0:00:00
+            Applying Fast Bias correction ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 50/50 • 0:00:01 • 0:00:00
+            Elapsed time: 0:04:28.609954
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            ckpt_path = "otx-workspace/.latest/export/exported_model_decoder.xml"
+            engine.optimize(checkpoint=ckpt_path)
+
+The optimization time highly relies on the hardware characteristics, for example on Intel(R) Core(TM) i9-11900 it took about 10 minutes.
+Please note, that PTQ will take some time without logging to optimize the model.
+
+.. note::
+    Optimization is performed in the following order: image encoder  then decoder. 
+    Because the optimized image encoder is used for decoder optimization, segmentation fault error can occur when releasing threads and memories after optimization step.
+    It doesn't affect optimization results, but it's recommended to set ``--data.config.train_subset.num_workers 0`` to avoid this error.
+
+3. Finally, we can also evaluate the optimized model by passing
+it to the ``otx test`` function.
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx test --work_dir otx-workspace \ 
+                                --checkpoint otx-workspace/.latest/optimize/optimized_model_decoder.xml \
+                                --engine.device cpu
+
+            ...
+            ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+            ┃        Test metric        ┃       DataLoader 0        ┃
+            ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+            │      test/data_time       │   0.0007440951885655522   │
+            │         test/dice         │     0.998199462890625     │
+            │       test/f1-score       │     0.853766918182373     │
+            │         test/iou          │    0.7448458075523376     │
+            │      test/iter_time       │    2.8865625858306885     │
+            │         test/map          │    0.23295165598392487    │
+            │        test/map_50        │    0.5494663119316101     │
+            │        test/map_75        │    0.15102604031562805    │
+            │      test/map_large       │    0.45290130376815796    │
+            │      test/map_medium      │    0.16153287887573242    │
+            │    test/map_per_class     │           -1.0            │
+            │      test/map_small       │   0.012729672715067863    │
+            │        test/mar_1         │   0.014449129812419415    │
+            │        test/mar_10        │    0.15996699035167694    │
+            │       test/mar_100        │    0.3901452422142029     │
+            │  test/mar_100_per_class   │           -1.0            │
+            │      test/mar_large       │    0.5868775844573975     │
+            │      test/mar_medium      │    0.30925533175468445    │
+            │      test/mar_small       │   0.027198636904358864    │
+            └───────────────────────────┴───────────────────────────┘
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            ckpt_path = "otx-workspace/.latest/optimize/optimized_model_decoder.xml"
+            engine.test(checkpoint=ckpt_path)
+
+.. note::
+    Visual prompting task has two IR models unlike other tasks. 
+    But it doesn't matter which one to be inserted to ``--checkpoint`` for testing because OTX will automatically load both IR models.
+
+Now we have fully trained, optimized and exported an efficient model representation ready-to-use visual prompting model.

--- a/src/otx/algo/visual_prompting/segment_anything.py
+++ b/src/otx/algo/visual_prompting/segment_anything.py
@@ -481,8 +481,29 @@ class SegmentAnything(nn.Module):
 class OTXSegmentAnything(OTXVisualPromptingModel):
     """Visual Prompting model."""
 
-    def __init__(self, backbone: Literal["tiny_vit", "vit_b"], num_classes: int = 0, **kwargs):
-        self.config = {"backbone": backbone, **DEFAULT_CONFIG_SEGMENT_ANYTHING[backbone], **kwargs}
+    def __init__(
+        self,
+        backbone: Literal["tiny_vit", "vit_b"],
+        num_classes: int = 0,
+        freeze_image_encoder: bool = True,
+        freeze_prompt_encoder: bool = True,
+        freeze_mask_decoder: bool = False,
+        use_stability_score: bool = False,
+        return_single_mask: bool = True,
+        return_extra_metrics: bool = False,
+        stability_score_offset: float = 1.0,
+    ) -> None:
+        self.config = {
+            "backbone": backbone,
+            "freeze_image_encoder": freeze_image_encoder,
+            "freeze_prompt_encoder": freeze_prompt_encoder,
+            "freeze_mask_decoder": freeze_mask_decoder,
+            "use_stability_score": use_stability_score,
+            "return_single_mask": return_single_mask,
+            "return_extra_metrics": return_extra_metrics,
+            "stability_score_offset": stability_score_offset,
+            **DEFAULT_CONFIG_SEGMENT_ANYTHING[backbone],
+        }
         super().__init__(num_classes=num_classes)
 
     def _create_model(self) -> nn.Module:

--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -19,12 +19,9 @@ from datumaro import Polygon as dmPolygon
 from torch import LongTensor, Tensor, nn
 from torch.nn import functional as F  # noqa: N812
 from torchvision import tv_tensors
-from torchvision.tv_tensors import BoundingBoxes, Image
+from torchvision.tv_tensors import BoundingBoxes, Image, Mask, TVTensor
 
-from otx.algo.visual_prompting.segment_anything import (
-    DEFAULT_CONFIG_SEGMENT_ANYTHING,
-    SegmentAnything,
-)
+from otx.algo.visual_prompting.segment_anything import DEFAULT_CONFIG_SEGMENT_ANYTHING, SegmentAnything
 from otx.core.data.entity.base import OTXBatchLossEntity, Points
 from otx.core.data.entity.visual_prompting import (
     ZeroShotVisualPromptingBatchDataEntity,
@@ -225,8 +222,8 @@ class ZeroShotSegmentAnything(SegmentAnything):
     @torch.no_grad()
     def learn(
         self,
-        images: list[tv_tensors.Image],
-        processed_prompts: list[dict[int, list[tv_tensors.TVTensor]]],
+        images: list[Image],
+        processed_prompts: list[dict[int, list[TVTensor]]],
         reference_feats: Tensor,
         used_indices: Tensor,
         ori_shapes: list[Tensor],
@@ -239,8 +236,8 @@ class ZeroShotSegmentAnything(SegmentAnything):
         Currently, single batch is only supported.
 
         Args:
-            images (list[tv_tensors.Image]): List of given images for reference features.
-            processed_prompts (dict[int, list[tv_tensors.TVTensor]]): The class-wise prompts
+            images (list[Image]): List of given images for reference features.
+            processed_prompts (dict[int, list[TVTensor]]): The class-wise prompts
                 processed at OTXZeroShotSegmentAnything._gather_prompts_with_labels.
             reference_feats (Tensor): Reference features for target prediction.
             used_indices (Tensor): To check which indices of reference features are validate.
@@ -264,7 +261,7 @@ class ZeroShotSegmentAnything(SegmentAnything):
                 # TODO (sungchul): ensemble multi reference features (current : use merged masks) # noqa: TD003
                 ref_mask = torch.zeros(*map(int, ori_shape), dtype=torch.uint8, device=image.device)
                 for input_prompt in input_prompts:
-                    if isinstance(input_prompt, tv_tensors.Mask):
+                    if isinstance(input_prompt, Mask):
                         # directly use annotation information as a mask
                         ref_mask[
                             input_prompt == 1
@@ -318,7 +315,7 @@ class ZeroShotSegmentAnything(SegmentAnything):
     @torch.no_grad()
     def infer(
         self,
-        images: list[tv_tensors.Image],
+        images: list[Image],
         reference_feats: Tensor,
         used_indices: Tensor,
         ori_shapes: list[Tensor],
@@ -331,7 +328,7 @@ class ZeroShotSegmentAnything(SegmentAnything):
         Get target results by using reference features and target images' features.
 
         Args:
-            images (list[tv_tensors.Image]): Given images for target results.
+            images (list[Image]): Given images for target results.
             reference_feats (Tensor): Reference features for target prediction.
             used_indices (Tensor): To check which indices of reference features are validate.
             ori_shapes (list[Tensor]): Original image size.
@@ -703,7 +700,7 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
             self.used_indices = outputs[0].get("used_indices")
             return outputs
 
-        masks: list[tv_tensors.Mask] = []
+        masks: list[Mask] = []
         prompts: list[Points] = []
         scores: list[Tensor] = []
         labels: list[LongTensor] = []
@@ -711,7 +708,7 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
             for label, predicted_mask in predicted_masks.items():
                 if len(predicted_mask) == 0:
                     continue
-                masks.append(tv_tensors.Mask(torch.stack(predicted_mask, dim=0), dtype=torch.float32))
+                masks.append(Mask(torch.stack(predicted_mask, dim=0), dtype=torch.float32))
                 prompts.append(
                     Points(
                         torch.stack([p[:2] for p in used_points[label]], dim=0),
@@ -735,11 +732,11 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
 
     def _gather_prompts_with_labels(
         self,
-        prompts: list[list[tv_tensors.TVTensor]],
+        prompts: list[list[TVTensor]],
         labels: list[Tensor],
-    ) -> list[dict[int, list[tv_tensors.TVTensor]]]:
+    ) -> list[dict[int, list[TVTensor]]]:
         """Gather prompts according to labels."""
-        total_processed_prompts: list[dict[int, list[tv_tensors.TVTensor]]] = []
+        total_processed_prompts: list[dict[int, list[TVTensor]]] = []
         for prompt, label in zip(prompts, labels):
             processed_prompts = defaultdict(list)
             for _prompt, _label in zip(prompt, label):  # type: ignore[arg-type]
@@ -748,7 +745,7 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
             total_processed_prompts.append(sorted_processed_prompts)
         return total_processed_prompts
 
-    def apply_image(self, image: tv_tensors.Image | np.ndarray, target_length: int = 1024) -> tv_tensors.Image:
+    def apply_image(self, image: Image | np.ndarray, target_length: int = 1024) -> Image:
         """Preprocess image to be used in the model."""
         h, w = image.shape[-2:]
         target_size = self.get_preprocess_shape(h, w, target_length)

--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -608,9 +608,29 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
         save_outputs: bool = True,
         pixel_mean: list[float] | None = [123.675, 116.28, 103.53],  # noqa: B006
         pixel_std: list[float] | None = [58.395, 57.12, 57.375],  # noqa: B006
-        **kwargs,
-    ):
-        self.config = {"backbone": backbone, **DEFAULT_CONFIG_SEGMENT_ANYTHING[backbone], **kwargs}
+        freeze_image_encoder: bool = True,
+        freeze_prompt_encoder: bool = True,
+        freeze_mask_decoder: bool = True,
+        default_threshold_reference: float = 0.3,
+        default_threshold_target: float = 0.65,
+        use_stability_score: bool = False,
+        return_single_mask: bool = False,
+        return_extra_metrics: bool = False,
+        stability_score_offset: float = 1.0,
+    ) -> None:
+        self.config = {
+            "backbone": backbone,
+            "freeze_image_encoder": freeze_image_encoder,
+            "freeze_prompt_encoder": freeze_prompt_encoder,
+            "freeze_mask_decoder": freeze_mask_decoder,
+            "default_threshold_reference": default_threshold_reference,
+            "default_threshold_target": default_threshold_target,
+            "use_stability_score": use_stability_score,
+            "return_single_mask": return_single_mask,
+            "return_extra_metrics": return_extra_metrics,
+            "stability_score_offset": stability_score_offset,
+            **DEFAULT_CONFIG_SEGMENT_ANYTHING[backbone],
+        }
         super().__init__(num_classes=num_classes)
 
         self.save_outputs = save_outputs

--- a/src/otx/core/model/module/visual_prompting.py
+++ b/src/otx/core/model/module/visual_prompting.py
@@ -250,12 +250,13 @@ class OTXZeroShotVisualPromptingLitModule(OTXVisualPromptingLitModule):
         """Configure metrics."""
         self.test_metric = MetricCollection(
             {
-                "iou": BinaryJaccardIndex().to(self.device),
-                "f1-score": BinaryF1Score().to(self.device),
-                "dice": Dice().to(self.device),
-                "mAP": MeanAveragePrecision(iou_type="segm").to(self.device),
+                "iou": BinaryJaccardIndex(),
+                "f1-score": BinaryF1Score(),
+                "dice": Dice(),
+                "mAP": MeanAveragePrecision(iou_type="segm"),
             },
         )
+        self.test_metric.to(self.device)
 
     def on_train_start(self) -> None:
         """Initialize reference infos before learn."""

--- a/src/otx/recipe/visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/visual_prompting/openvino_model.yaml
@@ -22,7 +22,7 @@ engine:
   task: VISUAL_PROMPTING
   device: cpu
 
-callback_monitor: val/Dice
+callback_monitor: val/f1-score
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:

--- a/tests/unit/algo/visual_prompting/encoders/test_sam_image_encoder.py
+++ b/tests/unit/algo/visual_prompting/encoders/test_sam_image_encoder.py
@@ -10,6 +10,7 @@ class TestSAMImageEncoder:
         ("backbone", "expected"),
         [
             ("tiny_vit", "TinyViT"),
+            ("vit_b", "ViT"),
         ],
     )
     def test_new(self, backbone: str, expected: str) -> None:
@@ -17,3 +18,8 @@ class TestSAMImageEncoder:
         sam_image_encoder = SAMImageEncoder(backbone=backbone)
 
         assert sam_image_encoder.__class__.__name__ == expected
+
+    def test_new_unsupported_backbone(self) -> None:
+        """Test __new__ for unsupported backbone."""
+        with pytest.raises(ValueError):  # noqa: PT011
+            SAMImageEncoder(backbone="unsupported_backbone")

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -177,7 +177,7 @@ def fxt_vpm_data_entity() -> (
     tuple[VisualPromptingDataEntity, VisualPromptingBatchDataEntity, VisualPromptingBatchPredEntity]
 ):
     img_size = (1024, 1024)
-    fake_image = tv_tensors.Image(torch.rand(img_size))
+    fake_image = tv_tensors.Image(torch.ones(img_size))
     fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
     fake_bboxes = tv_tensors.BoundingBoxes(
         [[0, 0, 1, 1]],
@@ -186,9 +186,10 @@ def fxt_vpm_data_entity() -> (
         dtype=torch.float32,
     )
     fake_points = Points([[2, 2]], canvas_size=img_size, dtype=torch.float32)
-    fake_masks = tv_tensors.Mask(torch.rand(img_size))
+    fake_masks = tv_tensors.Mask(torch.ones(1, *img_size))
     fake_labels = {"bboxes": torch.as_tensor([1], dtype=torch.int64)}
     fake_polygons = [None]
+    fake_scores = torch.tensor([[1.0]])
     # define data entity
     single_data_entity = VisualPromptingDataEntity(
         image=fake_image,
@@ -218,7 +219,7 @@ def fxt_vpm_data_entity() -> (
         polygons=[fake_polygons],
         bboxes=[fake_bboxes],
         points=[fake_points],
-        scores=[],
+        scores=[fake_scores],
     )
 
     return single_data_entity, batch_data_entity, batch_pred_data_entity
@@ -233,7 +234,7 @@ def fxt_zero_shot_vpm_data_entity() -> (
     ]
 ):
     img_size = (1024, 1024)
-    fake_image = tv_tensors.Image(torch.rand(img_size))
+    fake_image = tv_tensors.Image(torch.ones(img_size))
     fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
     fake_bboxes = tv_tensors.BoundingBoxes(
         [[0, 0, 1, 1]],
@@ -242,9 +243,10 @@ def fxt_zero_shot_vpm_data_entity() -> (
         dtype=torch.float32,
     )
     fake_points = Points([[2, 2]], canvas_size=img_size, dtype=torch.float32)
-    fake_masks = tv_tensors.Mask(torch.rand(img_size))
-    fake_labels = torch.as_tensor([1], dtype=torch.int64)
+    fake_masks = tv_tensors.Mask(torch.ones(1, *img_size))
+    fake_labels = torch.as_tensor([[1]], dtype=torch.int64)
     fake_polygons = [None]
+    fake_scores = torch.tensor([[1.0]])
     # define data entity
     single_data_entity = ZeroShotVisualPromptingDataEntity(
         image=fake_image,
@@ -271,7 +273,7 @@ def fxt_zero_shot_vpm_data_entity() -> (
         labels=[fake_labels],
         polygons=[fake_polygons],
         prompts=[[fake_bboxes, fake_points]],
-        scores=[],
+        scores=[fake_scores],
     )
 
     return single_data_entity, batch_data_entity, batch_pred_data_entity

--- a/tests/unit/core/exporter/__init__.py
+++ b/tests/unit/core/exporter/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/core/exporter/test_visual_prompting.py
+++ b/tests/unit/core/exporter/test_visual_prompting.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests of visual prompting exporter."""
+
+import pytest
+from otx.core.exporter.visual_prompting import OTXVisualPromptingModelExporter
+from otx.core.types.export import OTXExportFormatType
+from torch import nn
+
+
+class MockModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.image_encoder = nn.Identity()
+        self.embed_dim = 2
+        self.image_embedding_size = 4
+
+    def forward(self, x):
+        return x
+
+
+class TestOTXVisualPromptingModelExporter:
+    @pytest.fixture()
+    def otx_visual_prompting_model_exporter(self) -> OTXVisualPromptingModelExporter:
+        return OTXVisualPromptingModelExporter(input_size=(10, 10), via_onnx=True)
+
+    def test_export_openvino(self, mocker, tmpdir, otx_visual_prompting_model_exporter) -> None:
+        """Test export for OPENVINO."""
+        mocker_torch_onnx_export = mocker.patch("torch.onnx.export")
+        mocker_onnx_load = mocker.patch("onnx.load")
+        mocker_onnx_save = mocker.patch("onnx.save")
+        mocker_postprocess_onnx_model = mocker.patch.object(otx_visual_prompting_model_exporter, "_postprocess_onnx_model")
+        mocker_openvino_convert_model = mocker.patch("openvino.convert_model")
+        mocker_postprocess_openvino_model = mocker.patch.object(otx_visual_prompting_model_exporter, "_postprocess_openvino_model")
+        mocker_openvino_save_model = mocker.patch("openvino.save_model")
+        
+        otx_visual_prompting_model_exporter.export(model=MockModel(), output_dir=tmpdir, export_format=OTXExportFormatType.OPENVINO)
+        
+        mocker_torch_onnx_export.assert_called()
+        mocker_onnx_load.assert_called()
+        mocker_onnx_save.assert_called()
+        mocker_postprocess_onnx_model.assert_called()
+        mocker_openvino_convert_model.assert_called()
+        mocker_postprocess_openvino_model.assert_called()
+        mocker_openvino_save_model.assert_called()
+        
+    def test_export_onnx(self, mocker, tmpdir, otx_visual_prompting_model_exporter) -> None:
+        """Test export for ONNX."""
+        mocker_torch_onnx_export = mocker.patch("torch.onnx.export")
+        mocker_onnx_load = mocker.patch("onnx.load")
+        mocker_onnx_save = mocker.patch("onnx.save")
+        mocker_postprocess_onnx_model = mocker.patch.object(otx_visual_prompting_model_exporter, "_postprocess_onnx_model")
+        
+        otx_visual_prompting_model_exporter.export(model=MockModel(), output_dir=tmpdir, export_format=OTXExportFormatType.ONNX)
+        
+        mocker_torch_onnx_export.assert_called()
+        mocker_onnx_load.assert_called()
+        mocker_onnx_save.assert_called()
+        mocker_postprocess_onnx_model.assert_called()
+        
+    def test_export_exportable_code(self, tmpdir, otx_visual_prompting_model_exporter) -> None:
+        """Test export for EXPORTABLE_CODE."""
+        with pytest.raises(NotImplementedError):
+            otx_visual_prompting_model_exporter.export(model=MockModel(), output_dir=tmpdir, export_format=OTXExportFormatType.EXPORTABLE_CODE)
+        

--- a/tests/unit/core/exporter/test_visual_prompting.py
+++ b/tests/unit/core/exporter/test_visual_prompting.py
@@ -29,13 +29,23 @@ class TestOTXVisualPromptingModelExporter:
         mocker_torch_onnx_export = mocker.patch("torch.onnx.export")
         mocker_onnx_load = mocker.patch("onnx.load")
         mocker_onnx_save = mocker.patch("onnx.save")
-        mocker_postprocess_onnx_model = mocker.patch.object(otx_visual_prompting_model_exporter, "_postprocess_onnx_model")
+        mocker_postprocess_onnx_model = mocker.patch.object(
+            otx_visual_prompting_model_exporter,
+            "_postprocess_onnx_model",
+        )
         mocker_openvino_convert_model = mocker.patch("openvino.convert_model")
-        mocker_postprocess_openvino_model = mocker.patch.object(otx_visual_prompting_model_exporter, "_postprocess_openvino_model")
+        mocker_postprocess_openvino_model = mocker.patch.object(
+            otx_visual_prompting_model_exporter,
+            "_postprocess_openvino_model",
+        )
         mocker_openvino_save_model = mocker.patch("openvino.save_model")
-        
-        otx_visual_prompting_model_exporter.export(model=MockModel(), output_dir=tmpdir, export_format=OTXExportFormatType.OPENVINO)
-        
+
+        otx_visual_prompting_model_exporter.export(
+            model=MockModel(),
+            output_dir=tmpdir,
+            export_format=OTXExportFormatType.OPENVINO,
+        )
+
         mocker_torch_onnx_export.assert_called()
         mocker_onnx_load.assert_called()
         mocker_onnx_save.assert_called()
@@ -43,23 +53,33 @@ class TestOTXVisualPromptingModelExporter:
         mocker_openvino_convert_model.assert_called()
         mocker_postprocess_openvino_model.assert_called()
         mocker_openvino_save_model.assert_called()
-        
+
     def test_export_onnx(self, mocker, tmpdir, otx_visual_prompting_model_exporter) -> None:
         """Test export for ONNX."""
         mocker_torch_onnx_export = mocker.patch("torch.onnx.export")
         mocker_onnx_load = mocker.patch("onnx.load")
         mocker_onnx_save = mocker.patch("onnx.save")
-        mocker_postprocess_onnx_model = mocker.patch.object(otx_visual_prompting_model_exporter, "_postprocess_onnx_model")
-        
-        otx_visual_prompting_model_exporter.export(model=MockModel(), output_dir=tmpdir, export_format=OTXExportFormatType.ONNX)
-        
+        mocker_postprocess_onnx_model = mocker.patch.object(
+            otx_visual_prompting_model_exporter,
+            "_postprocess_onnx_model",
+        )
+
+        otx_visual_prompting_model_exporter.export(
+            model=MockModel(),
+            output_dir=tmpdir,
+            export_format=OTXExportFormatType.ONNX,
+        )
+
         mocker_torch_onnx_export.assert_called()
         mocker_onnx_load.assert_called()
         mocker_onnx_save.assert_called()
         mocker_postprocess_onnx_model.assert_called()
-        
+
     def test_export_exportable_code(self, tmpdir, otx_visual_prompting_model_exporter) -> None:
         """Test export for EXPORTABLE_CODE."""
         with pytest.raises(NotImplementedError):
-            otx_visual_prompting_model_exporter.export(model=MockModel(), output_dir=tmpdir, export_format=OTXExportFormatType.EXPORTABLE_CODE)
-        
+            otx_visual_prompting_model_exporter.export(
+                model=MockModel(),
+                output_dir=tmpdir,
+                export_format=OTXExportFormatType.EXPORTABLE_CODE,
+            )

--- a/tests/unit/core/model/entity/test_visual_prompting.py
+++ b/tests/unit/core/model/entity/test_visual_prompting.py
@@ -11,7 +11,8 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 import torch
-from otx.core.data.entity.visual_prompting import VisualPromptingBatchPredEntity
+from otx.core.data.entity.base import Points
+from otx.core.data.entity.visual_prompting import VisualPromptingBatchPredEntity, ZeroShotVisualPromptingBatchPredEntity
 from otx.core.exporter.visual_prompting import OTXVisualPromptingModelExporter
 from otx.core.model.entity.visual_prompting import (
     OTXVisualPromptingModel,
@@ -172,6 +173,26 @@ class TestOVZeroShotVisualPromptingModel:
         mocker.patch.object(OVZeroShotVisualPromptingModel, "initialize_reference_info")
         return OVZeroShotVisualPromptingModel(num_classes=0, model_name="exported_model_decoder.xml")
 
+    @pytest.mark.parametrize("training", [True, False])
+    def test_forward(
+        self,
+        mocker,
+        ov_zero_shot_visual_prompting_model,
+        fxt_zero_shot_vpm_data_entity,
+        training: bool,
+    ) -> None:
+        """Test forward."""
+        ov_zero_shot_visual_prompting_model.training = training
+        ov_zero_shot_visual_prompting_model.reference_feats = "reference_feats"
+        ov_zero_shot_visual_prompting_model.used_indices = "used_indices"
+        mocker_fn = mocker.patch.object(ov_zero_shot_visual_prompting_model, "learn" if training else "infer")
+        mocker_customize_outputs = mocker.patch.object(ov_zero_shot_visual_prompting_model, "_customize_outputs")
+
+        ov_zero_shot_visual_prompting_model.forward(fxt_zero_shot_vpm_data_entity[1])
+
+        mocker_fn.assert_called_once()
+        mocker_customize_outputs.assert_called_once()
+
     def test_learn(self, mocker, ov_zero_shot_visual_prompting_model, fxt_zero_shot_vpm_data_entity) -> None:
         """Test learn."""
         ov_zero_shot_visual_prompting_model.reference_feats = np.zeros((0, 1, 256), dtype=np.float32)
@@ -303,6 +324,52 @@ class TestOVZeroShotVisualPromptingModel:
             for label, predicted_mask in predicted_masks.items():
                 for pm, _ in zip(predicted_mask, used_points[label]):
                     assert pm.shape == (1024, 1024)
+
+    def test_customize_outputs_training(
+        self,
+        ov_zero_shot_visual_prompting_model,
+        fxt_zero_shot_vpm_data_entity,
+    ) -> None:
+        ov_zero_shot_visual_prompting_model.training = True
+
+        outputs = [torch.tensor([1, 2, 3]), torch.tensor([4, 5, 6])]
+
+        result = ov_zero_shot_visual_prompting_model._customize_outputs(outputs, fxt_zero_shot_vpm_data_entity[1])
+
+        assert result == outputs
+
+    def test_customize_outputs_inference(
+        self,
+        ov_zero_shot_visual_prompting_model,
+        fxt_zero_shot_vpm_data_entity,
+    ) -> None:
+        ov_zero_shot_visual_prompting_model.training = False
+
+        outputs = [
+            ({1: [[1, 2, 3], [4, 5, 6]]}, {1: [[7, 8, 9], [10, 11, 12]]}),
+            ({2: [[13, 14, 15], [16, 17, 18]]}, {2: [[19, 20, 21], [22, 23, 24]]}),
+        ]
+
+        result = ov_zero_shot_visual_prompting_model._customize_outputs(outputs, fxt_zero_shot_vpm_data_entity[1])
+
+        assert isinstance(result, ZeroShotVisualPromptingBatchPredEntity)
+        assert result.batch_size == len(outputs)
+        assert result.images == fxt_zero_shot_vpm_data_entity[1].images
+        assert result.imgs_info == fxt_zero_shot_vpm_data_entity[1].imgs_info
+
+        assert isinstance(result.masks, list)
+        assert all(isinstance(mask, tv_tensors.Mask) for mask in result.masks)
+
+        assert isinstance(result.prompts, list)
+        assert all(isinstance(prompt, Points) for prompt in result.prompts)
+
+        assert isinstance(result.scores, list)
+        assert all(isinstance(score, torch.Tensor) for score in result.scores)
+
+        assert isinstance(result.labels, list)
+        assert all(isinstance(label, torch.LongTensor) for label in result.labels)
+
+        assert result.polygons == []
 
     def test_gather_prompts_with_labels(self, ov_zero_shot_visual_prompting_model) -> None:
         """Test _gather_prompts_with_labels."""

--- a/tests/unit/core/model/module/test_visual_prompting.py
+++ b/tests/unit/core/model/module/test_visual_prompting.py
@@ -1,0 +1,170 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for visual prompting module."""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+from otx.core.data.entity.visual_prompting import (
+    ZeroShotVisualPromptingBatchDataEntity,
+    ZeroShotVisualPromptingBatchPredEntity,
+)
+from otx.core.model.module.visual_prompting import OTXVisualPromptingLitModule, OTXZeroShotVisualPromptingLitModule
+from torch import nn
+from torchmetrics.aggregation import MeanMetric
+from torchmetrics.collections import MetricCollection
+
+
+class TestOTXVisualPromptingLitModule:
+    @pytest.fixture()
+    def otx_visual_prompting_lit_module(self) -> OTXVisualPromptingLitModule:
+        return OTXVisualPromptingLitModule(otx_model=Mock(spec=nn.Module), torch_compile=False)
+
+    def test_configure_metric(self, otx_visual_prompting_lit_module) -> None:
+        """Test configure_metric."""
+        otx_visual_prompting_lit_module.configure_metric()
+
+        assert isinstance(otx_visual_prompting_lit_module.val_metric, MetricCollection)
+        assert isinstance(otx_visual_prompting_lit_module.test_metric, MetricCollection)
+
+    def test_log_metrics(self, mocker, otx_visual_prompting_lit_module) -> None:
+        """Test _log_metrics."""
+        mocker_log = mocker.patch.object(otx_visual_prompting_lit_module, "log")
+        meter = MetricCollection({"mean": MeanMetric()})
+        meter["mean"].update(torch.tensor(1))
+
+        otx_visual_prompting_lit_module._log_metrics(meter, "test")
+
+        mocker_log.assert_called()
+
+    def test_training_step(self, mocker, otx_visual_prompting_lit_module) -> None:
+        """Test training_step."""
+        otx_visual_prompting_lit_module.model.return_value = {"loss": torch.tensor(1.)}
+        mocker_log_metrics = mocker.patch.object(otx_visual_prompting_lit_module, "_log_metrics")
+
+        _ = otx_visual_prompting_lit_module.training_step({"loss": torch.tensor(1.)}, 0)
+
+        mocker_log_metrics.assert_called_once()
+
+    def test_inference_step(self, mocker, otx_visual_prompting_lit_module, fxt_vpm_data_entity) -> None:
+        """Test _inference_step."""
+        otx_visual_prompting_lit_module.configure_metric()
+        otx_visual_prompting_lit_module.model.return_value = fxt_vpm_data_entity[2]
+        mocker_updates = {}
+        for k, v in otx_visual_prompting_lit_module.test_metric.items():
+            mocker_updates[k] = mocker.patch.object(v, "update")
+
+        otx_visual_prompting_lit_module._inference_step(otx_visual_prompting_lit_module.test_metric, fxt_vpm_data_entity[1], 0)
+
+        for v in mocker_updates.values():
+            v.assert_called_once()
+
+
+class TestOTXZeroShotVisualPromptingLitModule:
+    @pytest.fixture()
+    def otx_zero_shot_visual_prompting_lit_module(self) -> OTXZeroShotVisualPromptingLitModule:
+        return OTXZeroShotVisualPromptingLitModule(otx_model=Mock(spec=nn.Module), torch_compile=False)
+
+    def test_configure_metric(self, otx_zero_shot_visual_prompting_lit_module) -> None:
+        """Test configure_metric."""
+        otx_zero_shot_visual_prompting_lit_module.configure_metric()
+
+        assert not hasattr(otx_zero_shot_visual_prompting_lit_module, "val_metric")
+        assert isinstance(otx_zero_shot_visual_prompting_lit_module.test_metric, MetricCollection)
+
+    def test_on_test_start(self, mocker, otx_zero_shot_visual_prompting_lit_module) -> None:
+        """Test on_test_start."""
+        otx_zero_shot_visual_prompting_lit_module.model.load_latest_reference_info = Mock(return_value=False)
+        otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
+        mocker_run = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer.fit_loop, "run")
+        mocker_setup_data = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "setup_data")
+        mocker_reset = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "reset")
+
+        otx_zero_shot_visual_prompting_lit_module.on_test_start()
+
+        mocker_run.assert_called_once()
+        mocker_setup_data.assert_called_once()
+        mocker_reset.assert_called_once()
+
+    def test_on_predict_start(self, mocker, otx_zero_shot_visual_prompting_lit_module) -> None:
+        """Test on_predict_start."""
+        otx_zero_shot_visual_prompting_lit_module.model.load_latest_reference_info = Mock(return_value=False)
+        otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
+        mocker_run = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer.fit_loop, "run")
+        mocker_setup_data = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "setup_data")
+        mocker_reset = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "reset")
+
+        otx_zero_shot_visual_prompting_lit_module.on_predict_start()
+
+        mocker_run.assert_called_once()
+        mocker_setup_data.assert_called_once()
+        mocker_reset.assert_called_once()
+
+    def test_on_train_epoch_end(self, mocker, tmpdir, otx_zero_shot_visual_prompting_lit_module) -> None:
+        """Test on_train_epoch_end."""
+        otx_zero_shot_visual_prompting_lit_module.model.save_outputs = True
+        otx_zero_shot_visual_prompting_lit_module.model.root_reference_info = tmpdir
+        otx_zero_shot_visual_prompting_lit_module.model.reference_feats = torch.tensor(1)
+        otx_zero_shot_visual_prompting_lit_module.model.used_indices = torch.tensor(1)
+        mocker_mkdir = mocker.patch("otx.core.model.module.visual_prompting.Path.mkdir")
+        mocker.patch("otx.core.model.module.visual_prompting.Path.open")
+        mocker_torch_save = mocker.patch("otx.core.model.module.visual_prompting.torch.save")
+        mocker_pickle_dump = mocker.patch("otx.core.model.module.visual_prompting.pickle.dump")
+
+        otx_zero_shot_visual_prompting_lit_module.on_train_epoch_end()
+
+        mocker_mkdir.assert_called_once()
+        mocker_torch_save.assert_called_once()
+        mocker_pickle_dump.assert_called_once()
+
+    def test_inference_step(self, mocker, otx_zero_shot_visual_prompting_lit_module, fxt_zero_shot_vpm_data_entity) -> None:
+        """Test _inference_step."""
+        otx_zero_shot_visual_prompting_lit_module.configure_metric()
+        otx_zero_shot_visual_prompting_lit_module.model.return_value = fxt_zero_shot_vpm_data_entity[2]
+        mocker_updates = {}
+        for k, v in otx_zero_shot_visual_prompting_lit_module.test_metric.items():
+            mocker_updates[k] = mocker.patch.object(v, "update")
+
+        otx_zero_shot_visual_prompting_lit_module._inference_step(otx_zero_shot_visual_prompting_lit_module.test_metric, fxt_zero_shot_vpm_data_entity[1], 0)
+
+        for v in mocker_updates.values():
+            v.assert_called_once()
+
+    def test_inference_step_with_more_preds(self, mocker, otx_zero_shot_visual_prompting_lit_module, fxt_zero_shot_vpm_data_entity) -> None:
+        """Test _inference_step with more predictions."""
+        otx_zero_shot_visual_prompting_lit_module.configure_metric()
+        preds = {}
+        for k, v in fxt_zero_shot_vpm_data_entity[2].__dict__.items():
+            if k in ["batch_size", "polygons"]:
+                preds[k] = v
+            else:
+                preds[k] = v * 2
+        otx_zero_shot_visual_prompting_lit_module.model.return_value = ZeroShotVisualPromptingBatchPredEntity(**preds)
+        mocker_updates = {}
+        for k, v in otx_zero_shot_visual_prompting_lit_module.test_metric.items():
+            mocker_updates[k] = mocker.patch.object(v, "update")
+
+        otx_zero_shot_visual_prompting_lit_module._inference_step(otx_zero_shot_visual_prompting_lit_module.test_metric, fxt_zero_shot_vpm_data_entity[1], 0)
+
+        for v in mocker_updates.values():
+            v.assert_called_once()
+
+    def test_inference_step_with_more_target(self, mocker, otx_zero_shot_visual_prompting_lit_module, fxt_zero_shot_vpm_data_entity) -> None:
+        """Test _inference_step with more targets."""
+        otx_zero_shot_visual_prompting_lit_module.configure_metric()
+        otx_zero_shot_visual_prompting_lit_module.model.return_value = fxt_zero_shot_vpm_data_entity[2]
+        mocker_updates = {}
+        for k, v in otx_zero_shot_visual_prompting_lit_module.test_metric.items():
+            mocker_updates[k] = mocker.patch.object(v, "update")
+
+        target = {}
+        for k, v in fxt_zero_shot_vpm_data_entity[1].__dict__.items():
+            if k in ["batch_size"]:
+                target[k] = v
+            else:
+                target[k] = v * 2
+        otx_zero_shot_visual_prompting_lit_module._inference_step(otx_zero_shot_visual_prompting_lit_module.test_metric, ZeroShotVisualPromptingBatchDataEntity(**target), 0)
+
+        for v in mocker_updates.values():
+            v.assert_called_once()

--- a/tests/unit/core/model/module/test_visual_prompting.py
+++ b/tests/unit/core/model/module/test_visual_prompting.py
@@ -40,10 +40,10 @@ class TestOTXVisualPromptingLitModule:
 
     def test_training_step(self, mocker, otx_visual_prompting_lit_module) -> None:
         """Test training_step."""
-        otx_visual_prompting_lit_module.model.return_value = {"loss": torch.tensor(1.)}
+        otx_visual_prompting_lit_module.model.return_value = {"loss": torch.tensor(1.0)}
         mocker_log_metrics = mocker.patch.object(otx_visual_prompting_lit_module, "_log_metrics")
 
-        _ = otx_visual_prompting_lit_module.training_step({"loss": torch.tensor(1.)}, 0)
+        _ = otx_visual_prompting_lit_module.training_step({"loss": torch.tensor(1.0)}, 0)
 
         mocker_log_metrics.assert_called_once()
 
@@ -55,7 +55,11 @@ class TestOTXVisualPromptingLitModule:
         for k, v in otx_visual_prompting_lit_module.test_metric.items():
             mocker_updates[k] = mocker.patch.object(v, "update")
 
-        otx_visual_prompting_lit_module._inference_step(otx_visual_prompting_lit_module.test_metric, fxt_vpm_data_entity[1], 0)
+        otx_visual_prompting_lit_module._inference_step(
+            otx_visual_prompting_lit_module.test_metric,
+            fxt_vpm_data_entity[1],
+            0,
+        )
 
         for v in mocker_updates.values():
             v.assert_called_once()
@@ -78,7 +82,10 @@ class TestOTXZeroShotVisualPromptingLitModule:
         otx_zero_shot_visual_prompting_lit_module.model.load_latest_reference_info = Mock(return_value=False)
         otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
         mocker_run = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer.fit_loop, "run")
-        mocker_setup_data = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "setup_data")
+        mocker_setup_data = mocker.patch.object(
+            otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop,
+            "setup_data",
+        )
         mocker_reset = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "reset")
 
         otx_zero_shot_visual_prompting_lit_module.on_test_start()
@@ -92,7 +99,10 @@ class TestOTXZeroShotVisualPromptingLitModule:
         otx_zero_shot_visual_prompting_lit_module.model.load_latest_reference_info = Mock(return_value=False)
         otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
         mocker_run = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer.fit_loop, "run")
-        mocker_setup_data = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "setup_data")
+        mocker_setup_data = mocker.patch.object(
+            otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop,
+            "setup_data",
+        )
         mocker_reset = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer._evaluation_loop, "reset")
 
         otx_zero_shot_visual_prompting_lit_module.on_predict_start()
@@ -118,7 +128,12 @@ class TestOTXZeroShotVisualPromptingLitModule:
         mocker_torch_save.assert_called_once()
         mocker_pickle_dump.assert_called_once()
 
-    def test_inference_step(self, mocker, otx_zero_shot_visual_prompting_lit_module, fxt_zero_shot_vpm_data_entity) -> None:
+    def test_inference_step(
+        self,
+        mocker,
+        otx_zero_shot_visual_prompting_lit_module,
+        fxt_zero_shot_vpm_data_entity,
+    ) -> None:
         """Test _inference_step."""
         otx_zero_shot_visual_prompting_lit_module.configure_metric()
         otx_zero_shot_visual_prompting_lit_module.model.return_value = fxt_zero_shot_vpm_data_entity[2]
@@ -126,12 +141,21 @@ class TestOTXZeroShotVisualPromptingLitModule:
         for k, v in otx_zero_shot_visual_prompting_lit_module.test_metric.items():
             mocker_updates[k] = mocker.patch.object(v, "update")
 
-        otx_zero_shot_visual_prompting_lit_module._inference_step(otx_zero_shot_visual_prompting_lit_module.test_metric, fxt_zero_shot_vpm_data_entity[1], 0)
+        otx_zero_shot_visual_prompting_lit_module._inference_step(
+            otx_zero_shot_visual_prompting_lit_module.test_metric,
+            fxt_zero_shot_vpm_data_entity[1],
+            0,
+        )
 
         for v in mocker_updates.values():
             v.assert_called_once()
 
-    def test_inference_step_with_more_preds(self, mocker, otx_zero_shot_visual_prompting_lit_module, fxt_zero_shot_vpm_data_entity) -> None:
+    def test_inference_step_with_more_preds(
+        self,
+        mocker,
+        otx_zero_shot_visual_prompting_lit_module,
+        fxt_zero_shot_vpm_data_entity,
+    ) -> None:
         """Test _inference_step with more predictions."""
         otx_zero_shot_visual_prompting_lit_module.configure_metric()
         preds = {}
@@ -145,12 +169,21 @@ class TestOTXZeroShotVisualPromptingLitModule:
         for k, v in otx_zero_shot_visual_prompting_lit_module.test_metric.items():
             mocker_updates[k] = mocker.patch.object(v, "update")
 
-        otx_zero_shot_visual_prompting_lit_module._inference_step(otx_zero_shot_visual_prompting_lit_module.test_metric, fxt_zero_shot_vpm_data_entity[1], 0)
+        otx_zero_shot_visual_prompting_lit_module._inference_step(
+            otx_zero_shot_visual_prompting_lit_module.test_metric,
+            fxt_zero_shot_vpm_data_entity[1],
+            0,
+        )
 
         for v in mocker_updates.values():
             v.assert_called_once()
 
-    def test_inference_step_with_more_target(self, mocker, otx_zero_shot_visual_prompting_lit_module, fxt_zero_shot_vpm_data_entity) -> None:
+    def test_inference_step_with_more_target(
+        self,
+        mocker,
+        otx_zero_shot_visual_prompting_lit_module,
+        fxt_zero_shot_vpm_data_entity,
+    ) -> None:
         """Test _inference_step with more targets."""
         otx_zero_shot_visual_prompting_lit_module.configure_metric()
         otx_zero_shot_visual_prompting_lit_module.model.return_value = fxt_zero_shot_vpm_data_entity[2]
@@ -164,7 +197,11 @@ class TestOTXZeroShotVisualPromptingLitModule:
                 target[k] = v
             else:
                 target[k] = v * 2
-        otx_zero_shot_visual_prompting_lit_module._inference_step(otx_zero_shot_visual_prompting_lit_module.test_metric, ZeroShotVisualPromptingBatchDataEntity(**target), 0)
+        otx_zero_shot_visual_prompting_lit_module._inference_step(
+            otx_zero_shot_visual_prompting_lit_module.test_metric,
+            ZeroShotVisualPromptingBatchDataEntity(**target),
+            0,
+        )
 
         for v in mocker_updates.values():
             v.assert_called_once()


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR includes:

- [x] Update unwritten unit tests
- [x] Write documentations
- [x] Fix typos in other documentations
- [x] Refactoring
    - [x] Unwrap args in OTX models to use `--print_config`
    - [x] Types
    - [x] Metric


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```python
$ tox -vv -e unit-test-py310
Name                                                                                                                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------------------------------------------------------------------------------------
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/backbones/tiny_vit.py                                   300      7    98%   281-285, 368, 405, 624
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/backbones/vit.py                                        114      6    95%   185-186, 191, 252, 280, 307
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/decoders/sam_mask_decoder.py                            149      1    99%   188
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/encoders/sam_image_encoder.py                            15      0   100%
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/encoders/sam_prompt_encoder.py                           95      0   100%
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/openvino_models.py                                       75      1    99%   125
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/segment_anything.py                                     182      7    96%   143, 189, 196, 201-207, 244
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/utils/layer_norm_2d.py                                   14      0   100%
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/utils/mlp_block.py                                       11      0   100%
.tox/unit-test-py310/lib/python3.10/site-packages/otx/algo/visual_prompting/zero_shot_segment_anything.py                           371     21    94%   266, 276-284, 345, 368-369, 371, 405, 425-429, 468, 476, 552, 730, 809-810, 847
.tox/unit-test-py310/lib/python3.10/site-packages/otx/core/data/dataset/visual_prompting.py                                         109      4    96%   80, 156, 202, 256
.tox/unit-test-py310/lib/python3.10/site-packages/otx/core/data/entity/visual_prompting.py                                           76     11    86%   103-114, 193-199
.tox/unit-test-py310/lib/python3.10/site-packages/otx/core/exporter/visual_prompting.py                                              54      3    94%   58-59, 78
.tox/unit-test-py310/lib/python3.10/site-packages/otx/core/model/entity/visual_prompting.py                                         441     46    90%   97, 124-127, 174, 278-310, 318-319, 415-416, 480, 486-488, 490, 529, 565-567, 600, 671, 679, 723, 729, 739-740, 777, 803, 944, 963-967, 994
.tox/unit-test-py310/lib/python3.10/site-packages/otx/core/model/module/visual_prompting.py                                         156     23    85%   88, 92, 96, 100-101, 105-106, 110-111, 117-118, 120-121, 139, 147, 166, 178, 228, 263, 310-311, 335, 354
...
========================================================================================================================== 848 passed, 140 warnings in 75.03s (0:01:15) ==========================================================================================================================
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
