### PR TITLE
Refactor label info

### DIFF
--- a/src/otx/__init__.py
+++ b/src/otx/__init__.py
@@ -5,6 +5,7 @@
 
 __version__ = "2.0.0"
 
+from otx.core.types import *  # noqa: F403
 
 OTX_LOGO: str = """
 

--- a/src/otx/algo/classification/deit_tiny.py
+++ b/src/otx/algo/classification/deit_tiny.py
@@ -21,6 +21,7 @@ from otx.core.model.classification import (
     MMPretrainMulticlassClsModel,
     MMPretrainMultilabelClsModel,
 )
+from otx.core.types.label import HLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -148,23 +149,16 @@ class DeitTinyForHLabelCls(ExplainableDeit, MMPretrainHlabelClsModel):
 
     def __init__(
         self,
-        num_classes: int,
-        num_multiclass_heads: int,
-        num_multilabel_classes: int,
+        hlabel_info: HLabelInfo,
         optimizer: list[OptimizerCallable] | OptimizerCallable = DefaultOptimizerCallable,
         scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
-        self.num_multiclass_heads = num_multiclass_heads
-        self.num_multilabel_classes = num_multilabel_classes
-
         config = read_mmconfig("deit_tiny", subdir_name="hlabel_classification")
-        config.head.num_multiclass_heads = num_multiclass_heads
-        config.head.num_multilabel_classes = num_multilabel_classes
 
         super().__init__(
-            num_classes=num_classes,
+            hlabel_info=hlabel_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/classification/efficientnet_b0.py
+++ b/src/otx/algo/classification/efficientnet_b0.py
@@ -15,6 +15,7 @@ from otx.core.model.classification import (
     MMPretrainMulticlassClsModel,
     MMPretrainMultilabelClsModel,
 )
+from otx.core.types.label import HLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -27,22 +28,16 @@ class EfficientNetB0ForHLabelCls(MMPretrainHlabelClsModel):
 
     def __init__(
         self,
-        num_classes: int,
-        num_multiclass_heads: int,
-        num_multilabel_classes: int,
+        hlabel_info: HLabelInfo,
         optimizer: list[OptimizerCallable] | OptimizerCallable = DefaultOptimizerCallable,
         scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
-        self.num_multiclass_heads = num_multiclass_heads
-        self.num_multilabel_classes = num_multilabel_classes
-
         config = read_mmconfig(model_name="efficientnet_b0_light", subdir_name="hlabel_classification")
-        config.head.num_multiclass_heads = num_multiclass_heads
-        config.head.num_multilabel_classes = num_multilabel_classes
+
         super().__init__(
-            num_classes=num_classes,
+            hlabel_info=hlabel_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/classification/efficientnet_v2.py
+++ b/src/otx/algo/classification/efficientnet_v2.py
@@ -15,6 +15,7 @@ from otx.core.model.classification import (
     MMPretrainMulticlassClsModel,
     MMPretrainMultilabelClsModel,
 )
+from otx.core.types.label import HLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -27,22 +28,16 @@ class EfficientNetV2ForHLabelCls(MMPretrainHlabelClsModel):
 
     def __init__(
         self,
-        num_classes: int,
-        num_multiclass_heads: int,
-        num_multilabel_classes: int,
+        hlabel_info: HLabelInfo,
         optimizer: list[OptimizerCallable] | OptimizerCallable = DefaultOptimizerCallable,
         scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
-        self.num_multiclass_heads = num_multiclass_heads
-        self.num_multilabel_classes = num_multilabel_classes
-
         config = read_mmconfig("efficientnet_v2_light", subdir_name="hlabel_classification")
-        config.head.num_multiclass_heads = num_multiclass_heads
-        config.head.num_multilabel_classes = num_multilabel_classes
+
         super().__init__(
-            num_classes=num_classes,
+            hlabel_info=hlabel_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/classification/heads/custom_hlabel_linear_cls_head.py
+++ b/src/otx/algo/classification/heads/custom_hlabel_linear_cls_head.py
@@ -14,7 +14,7 @@ from mmpretrain.structures import DataSample
 from torch import nn
 
 if TYPE_CHECKING:
-    from otx.core.data.dataset.classification import HLabelInfo
+    from otx.core.types.label import HLabelInfo
 
 
 @MODELS.register_module()

--- a/src/otx/algo/classification/heads/custom_hlabel_linear_cls_head.py
+++ b/src/otx/algo/classification/heads/custom_hlabel_linear_cls_head.py
@@ -5,16 +5,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import torch
 from mmengine.model import BaseModule, normal_init
 from mmpretrain.registry import MODELS
 from mmpretrain.structures import DataSample
 from torch import nn
-
-if TYPE_CHECKING:
-    from otx.core.types.label import HLabelInfo
 
 
 @MODELS.register_module()
@@ -24,6 +19,10 @@ class CustomHierarchicalLinearClsHead(BaseModule):
     Args:
         num_multiclass_heads (int): Number of multi-class heads.
         num_multilabel_classes (int): Number of multi-label classes.
+        head_idx_to_logits_range: the logit range of each heads
+        num_single_label_classes: the number of single label classes
+        empty_multiclass_head_indices: the index of head that doesn't include any label
+            due to the label removing
         in_channels (int): Number of channels in the input feature map.
         num_classes (int): Number of total classes.
         multiclass_loss (dict | None): Config of multi-class loss.
@@ -36,6 +35,9 @@ class CustomHierarchicalLinearClsHead(BaseModule):
         self,
         num_multiclass_heads: int,
         num_multilabel_classes: int,
+        head_idx_to_logits_range: dict[str, tuple[int, int]],
+        num_single_label_classes: int,
+        empty_multiclass_head_indices: list[int],
         in_channels: int,
         num_classes: int,
         multiclass_loss_cfg: dict | None = None,
@@ -46,6 +48,9 @@ class CustomHierarchicalLinearClsHead(BaseModule):
         super().__init__()
         self.num_multiclass_heads = num_multiclass_heads
         self.num_multilabel_classes = num_multilabel_classes
+        self.head_idx_to_logits_range = head_idx_to_logits_range
+        self.num_single_label_classes = num_single_label_classes
+        self.empty_multiclass_head_indices = empty_multiclass_head_indices
         self.in_channels = in_channels
         self.num_classes = num_classes
         self.thr = thr
@@ -74,19 +79,15 @@ class CustomHierarchicalLinearClsHead(BaseModule):
         pre_logits = self.pre_logits(feats)
         return self.fc(pre_logits)
 
-    def set_hlabel_info(self, hlabel_info: HLabelInfo) -> None:
-        """Set hlabel information."""
-        self.hlabel_info = hlabel_info
-
     def _get_gt_label(self, data_samples: list[DataSample]) -> torch.Tensor:
         """Get gt labels from data samples."""
         return torch.stack([data_sample.gt_label for data_sample in data_samples])
 
-    def _get_head_idx_to_logits_range(self, hlabel_info: HLabelInfo, idx: int) -> tuple[int, int]:
+    def _get_head_idx_to_logits_range(self, idx: int) -> tuple[int, int]:
         """Get head_idx_to_logits_range information from hlabel information."""
         return (
-            hlabel_info.head_idx_to_logits_range[str(idx)][0],
-            hlabel_info.head_idx_to_logits_range[str(idx)][1],
+            self.head_idx_to_logits_range[str(idx)][0],
+            self.head_idx_to_logits_range[str(idx)][1],
         )
 
     def loss(self, feats: tuple[torch.Tensor], data_samples: list[DataSample], **kwargs) -> dict:
@@ -113,9 +114,9 @@ class CustomHierarchicalLinearClsHead(BaseModule):
         # Multiclass loss
         num_effective_heads_in_batch = 0  # consider the label removal case
         for i in range(self.num_multiclass_heads):
-            if i not in self.hlabel_info.empty_multiclass_head_indices:
+            if i not in self.empty_multiclass_head_indices:
                 head_gt = gt_labels[:, i]
-                logit_range = self._get_head_idx_to_logits_range(self.hlabel_info, i)
+                logit_range = self._get_head_idx_to_logits_range(i)
                 head_logits = cls_scores[:, logit_range[0] : logit_range[1]]
                 valid_mask = head_gt >= 0
 
@@ -130,15 +131,15 @@ class CustomHierarchicalLinearClsHead(BaseModule):
 
         # Multilabel loss
         if self.num_multilabel_classes > 0:
-            head_gt = gt_labels[:, self.hlabel_info.num_multiclass_heads :]
-            head_logits = cls_scores[:, self.hlabel_info.num_single_label_classes :]
+            head_gt = gt_labels[:, self.num_multiclass_heads :]
+            head_logits = cls_scores[:, self.num_single_label_classes :]
             valid_mask = head_gt > 0
             head_gt = head_gt[valid_mask]
             if len(head_gt) > 0:
                 img_metas = [data_sample.metainfo for data_sample in data_samples]
                 head_logits = head_logits[valid_mask]
                 valid_label_mask = self.get_valid_label_mask(img_metas).to(head_logits.device)
-                valid_label_mask = valid_label_mask[:, self.hlabel_info.num_single_label_classes :]
+                valid_label_mask = valid_label_mask[:, self.num_single_label_classes :]
                 valid_label_mask = valid_label_mask[valid_mask]
                 losses["loss"] += self.multilabel_loss(head_logits, head_gt, valid_label_mask=valid_label_mask)
 
@@ -183,7 +184,7 @@ class CustomHierarchicalLinearClsHead(BaseModule):
         multiclass_pred_scores = []
         multiclass_pred_labels = []
         for i in range(self.num_multiclass_heads):
-            logit_range = self._get_head_idx_to_logits_range(self.hlabel_info, i)
+            logit_range = self._get_head_idx_to_logits_range(i)
             multiclass_logit = cls_scores[:, logit_range[0] : logit_range[1]]
             multiclass_pred = torch.softmax(multiclass_logit, dim=1)
             multiclass_pred_score, multiclass_pred_label = torch.max(multiclass_pred, dim=1)
@@ -195,7 +196,7 @@ class CustomHierarchicalLinearClsHead(BaseModule):
         multiclass_pred_labels = torch.cat(multiclass_pred_labels, dim=1)
 
         if self.num_multilabel_classes > 0:
-            multilabel_logits = cls_scores[:, self.hlabel_info.num_single_label_classes :]
+            multilabel_logits = cls_scores[:, self.num_single_label_classes :]
 
             multilabel_pred_scores = torch.sigmoid(multilabel_logits)
             multilabel_pred_labels = (multilabel_pred_scores >= self.thr).int()

--- a/src/otx/algo/classification/heads/custom_hlabel_non_linear_cls_head.py
+++ b/src/otx/algo/classification/heads/custom_hlabel_non_linear_cls_head.py
@@ -14,7 +14,7 @@ from mmpretrain.structures import DataSample
 from torch import nn
 
 if TYPE_CHECKING:
-    from otx.core.data.dataset.classification import HLabelInfo
+    from otx.core.types.label import HLabelInfo
 
 
 @MODELS.register_module()

--- a/src/otx/algo/classification/mobilenet_v3_large.py
+++ b/src/otx/algo/classification/mobilenet_v3_large.py
@@ -15,6 +15,7 @@ from otx.core.model.classification import (
     MMPretrainMulticlassClsModel,
     MMPretrainMultilabelClsModel,
 )
+from otx.core.types.label import HLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -27,22 +28,16 @@ class MobileNetV3ForHLabelCls(MMPretrainHlabelClsModel):
 
     def __init__(
         self,
-        num_classes: int,
-        num_multiclass_heads: int,
-        num_multilabel_classes: int,
+        hlabel_info: HLabelInfo,
         optimizer: list[OptimizerCallable] | OptimizerCallable = DefaultOptimizerCallable,
         scheduler: list[LRSchedulerCallable] | LRSchedulerCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
-        self.num_multiclass_heads = num_multiclass_heads
-        self.num_multilabel_classes = num_multilabel_classes
-
         config = read_mmconfig(model_name="mobilenet_v3_large_light", subdir_name="hlabel_classification")
-        config.head.num_multiclass_heads = num_multiclass_heads
-        config.head.num_multilabel_classes = num_multilabel_classes
+
         super().__init__(
-            num_classes=num_classes,
+            hlabel_info=hlabel_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -423,7 +423,7 @@ class OTXCLI:
                 model_config.init_args.num_classes = num_classes
 
             # Hlabel classification
-            from otx.core.data.dataset.classification import HLabelInfo
+            from otx.core.types.label import HLabelInfo
 
             if isinstance(self.datamodule.label_info, HLabelInfo):
                 hlabel_info = self.datamodule.label_info

--- a/src/otx/core/data/dataset/base.py
+++ b/src/otx/core/data/dataset/base.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Iterable
 from contextlib import contextmanager
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Generic, Iterator, List, Union
 
 import cv2
@@ -21,9 +20,10 @@ from torchvision.transforms.v2 import Compose
 from otx.core.data.entity.base import T_OTXDataEntity
 from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER
 from otx.core.types.image import ImageColorChannel
+from otx.core.types.label import LabelInfo
 
 if TYPE_CHECKING:
-    from datumaro import DatasetSubset, Image, LabelCategories
+    from datumaro import DatasetSubset, Image
 
     from otx.core.data.mem_cache import MemCacheHandlerBase
 
@@ -47,63 +47,6 @@ def image_decode_context() -> Iterator[None]:
 
     _IMAGE_BACKEND.set(ori_image_backend)
     IMAGE_COLOR_SCALE.set(ori_image_color_scale)
-
-
-@dataclass
-class LabelInfo:
-    """Object to represent label information."""
-
-    label_names: list[str]
-    label_groups: list[list[str]]
-
-    @property
-    def num_classes(self) -> int:
-        """Return number of labels."""
-        return len(self.label_names)
-
-    @classmethod
-    def from_num_classes(cls, num_classes: int) -> LabelInfo:
-        """Create this object from the number of classes.
-
-        Args:
-            num_classes: Number of classes
-
-        Returns:
-            LabelInfo(
-                label_names=["label_0", ...],
-                label_groups=[["label_0", ...]]
-            )
-        """
-        label_names = [f"label_{idx}" for idx in range(num_classes)]
-
-        return LabelInfo(
-            label_names=label_names,
-            label_groups=[label_names],
-        )
-
-    @classmethod
-    def from_dm_label_groups(cls, dm_label_categories: LabelCategories) -> LabelInfo:
-        """Create this object from the datumaro label groups.
-
-        Args:
-            dm_label_categories (LabelCategories): The label category information from Datumaro.
-
-        Returns:
-            LabelInfo(
-                label_names=["Heart_King", "Heart_Queen", "Spade_King", "Spade_Jack"]
-                label_groups=[["Heart_King", "Heart_Queen"], ["Spade_King", "Spade_Jack"]]
-            )
-
-        """
-        label_names = [item.name for item in dm_label_categories.items]
-        label_groups = [label_group.labels for label_group in dm_label_categories.label_groups]
-        if len(label_groups) == 0:  # Single-label classification
-            label_groups = [label_names]
-
-        return LabelInfo(
-            label_names=label_names,
-            label_groups=label_groups,
-        )
 
 
 class OTXDataset(Dataset, Generic[T_OTXDataEntity]):

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -5,16 +5,15 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Callable
 
 import torch
 from datumaro import Image, Label
 from datumaro.components.annotation import AnnotationType
 from torch.nn import functional
 
-from otx.core.data.dataset.base import LabelInfo, OTXDataset
+from otx.core.data.dataset.base import OTXDataset
 from otx.core.data.entity.base import ImageInfo
 from otx.core.data.entity.classification import (
     HlabelClsBatchDataEntity,
@@ -24,168 +23,7 @@ from otx.core.data.entity.classification import (
     MultilabelClsBatchDataEntity,
     MultilabelClsDataEntity,
 )
-
-if TYPE_CHECKING:
-    from datumaro import LabelCategories
-
-
-@dataclass
-class HLabelInfo(LabelInfo):
-    """The label information represents the hierarchy.
-
-    All params should be kept since they're also used at the Model API side.
-
-    :param num_multiclass_heads: the number of the multiclass heads
-    :param num_multilabel_classes: the number of multilabel classes
-    :param head_to_logits_range: the logit range of each heads
-    :param num_single_label_classes: the number of single label classes
-    :param class_to_group_idx: represents the head index and label index
-    :param all_groups: represents information of all groups
-    :param label_to_idx: index of each label
-    :param empty_multiclass_head_indices: the index of head that doesn't include any label
-                                          due to the label removing
-
-    i.e.
-    Single-selection group information (Multiclass, Exclusive)
-    {
-        "Shape": ["Rigid", "Non-Rigid"],
-        "Rigid": ["Rectangle", "Triangle"],
-        "Non-Rigid": ["Circle"]
-    }
-
-    Multi-selection group information (Multilabel)
-    {
-        "Animal": ["Lion", "Panda"]
-    }
-
-    In the case above, HlabelInfo will be generated as below.
-    NOTE, If there was only one label in the multiclass group, it will be handeled as multilabel(Circle).
-
-        num_multiclass_heads: 2  (Shape, Rigid)
-        num_multilabel_classes: 3 (Circle, Lion, Panda)
-        head_to_logits_range: {'0': (0, 2), '1': (2, 4)} (Each multiclass head have 2 labels)
-        num_single_label_classes: 4 (Rigid, Non-Rigid, Rectangle, Triangle)
-        class_to_group_idx: {
-            'Non-Rigid': (0, 0), 'Rigid': (0, 1),
-            'Rectangle': (1, 0), 'Triangle': (1, 1),
-            'Circle': (2, 0), 'Lion': (2,1), 'Panda': (2,2)
-        } (head index, label index for each head)
-        all_groups: [['Non-Rigid', 'Rigid'], ['Rectangle', 'Triangle'], ['Circle'], ['Lion'], ['Panda']]
-        label_to_idx: {
-            'Rigid': 0, 'Rectangle': 1,
-            'Triangle': 2, 'Non-Rigid': 3, 'Circle': 4
-            'Lion': 5, 'Panda': 6
-        }
-        label_tree_edges: [
-            ["Rectangle", "Rigid"], ["Triangle", "Rigid"], ["Circle", "Non-Rigid"],
-        ] # NOTE, label_tree_edges format could be changed.
-        empty_multiclass_head_indices: []
-
-    All of the member variables should be considered for the Model API.
-    https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/algorithms/classification/utils/cls_utils.py#L97
-    """
-
-    num_multiclass_heads: int
-    num_multilabel_classes: int
-    head_idx_to_logits_range: dict[str, tuple[int, int]]
-    num_single_label_classes: int
-    class_to_group_idx: dict[str, tuple[int, int]]
-    all_groups: list[list[str]]
-    label_to_idx: dict[str, int]
-    label_tree_edges: list[list[str]]
-    empty_multiclass_head_indices: list[int]
-
-    @classmethod
-    def from_dm_label_groups(cls, dm_label_categories: LabelCategories) -> HLabelInfo:
-        """Generate HLabelData from the Datumaro LabelCategories.
-
-        Args:
-            dm_label_categories (LabelCategories): the label categories of datumaro.
-        """
-
-        def get_exclusive_group_info(all_groups: list[Label | list[Label]]) -> dict[str, Any]:
-            """Get exclusive group information."""
-            exclusive_groups = [g for g in all_groups if len(g) > 1]
-
-            last_logits_pos = 0
-            num_single_label_classes = 0
-            head_idx_to_logits_range = {}
-            class_to_idx = {}
-
-            for i, group in enumerate(exclusive_groups):
-                head_idx_to_logits_range[str(i)] = (last_logits_pos, last_logits_pos + len(group))
-                last_logits_pos += len(group)
-                for j, c in enumerate(group):
-                    class_to_idx[c] = (i, j)
-                    num_single_label_classes += 1
-
-            return {
-                "num_multiclass_heads": len(exclusive_groups),
-                "head_idx_to_logits_range": head_idx_to_logits_range,
-                "class_to_idx": class_to_idx,
-                "num_single_label_classes": num_single_label_classes,
-            }
-
-        def get_single_label_group_info(
-            all_groups: list[Label | list[Label]],
-            num_exclusive_groups: int,
-        ) -> dict[str, Any]:
-            """Get single label group information."""
-            single_label_groups = [g for g in all_groups if len(g) == 1]
-
-            class_to_idx = {}
-
-            for i, group in enumerate(single_label_groups):
-                class_to_idx[group[0]] = (num_exclusive_groups, i)
-
-            return {
-                "num_multilabel_classes": len(single_label_groups),
-                "class_to_idx": class_to_idx,
-            }
-
-        def merge_class_to_idx(
-            exclusive_ctoi: dict[str, tuple[int, int]],
-            single_label_ctoi: dict[str, tuple[int, int]],
-        ) -> dict[str, tuple[int, int]]:
-            """Merge the class_to_idx information from exclusive and single_label groups."""
-
-            def put_key_values(src: dict, dst: dict) -> None:
-                """Put key and values from src to dst."""
-                for k, v in src.items():
-                    dst[k] = v
-
-            class_to_idx: dict[str, tuple[int, int]] = {}
-            put_key_values(exclusive_ctoi, class_to_idx)
-            put_key_values(single_label_ctoi, class_to_idx)
-            return class_to_idx
-
-        def get_label_tree_edges(dm_label_items: list[LabelCategories]) -> list[list[str]]:
-            """Get label tree edges information. Each edges represent [child, parent]."""
-            return [[item.name, item.parent] for item in dm_label_items if item.parent != ""]
-
-        all_groups = [label_group.labels for label_group in dm_label_categories.label_groups]
-
-        exclusive_group_info = get_exclusive_group_info(all_groups)
-        single_label_group_info = get_single_label_group_info(all_groups, exclusive_group_info["num_multiclass_heads"])
-
-        merged_class_to_idx = merge_class_to_idx(
-            exclusive_group_info["class_to_idx"],
-            single_label_group_info["class_to_idx"],
-        )
-
-        return HLabelInfo(
-            label_names=[item.name for item in dm_label_categories.items],
-            label_groups=all_groups,
-            num_multiclass_heads=exclusive_group_info["num_multiclass_heads"],
-            num_multilabel_classes=single_label_group_info["num_multilabel_classes"],
-            head_idx_to_logits_range=exclusive_group_info["head_idx_to_logits_range"],
-            num_single_label_classes=exclusive_group_info["num_single_label_classes"],
-            class_to_group_idx=merged_class_to_idx,
-            all_groups=all_groups,
-            label_to_idx=dm_label_categories._indices,  # noqa: SLF001
-            label_tree_edges=get_label_tree_edges(dm_label_categories.items),
-            empty_multiclass_head_indices=[],  # consider the label removing case
-        )
+from otx.core.types.label import HLabelInfo
 
 
 class OTXMulticlassClsDataset(OTXDataset[MulticlassClsDataEntity]):

--- a/src/otx/core/data/dataset/segmentation.py
+++ b/src/otx/core/data/dataset/segmentation.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import warnings
-from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Callable
 
@@ -20,28 +18,12 @@ from otx.core.data.entity.base import ImageInfo
 from otx.core.data.entity.segmentation import SegBatchDataEntity, SegDataEntity
 from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER, MemCacheHandlerBase
 from otx.core.types.image import ImageColorChannel
-from otx.core.types.label import LabelInfo
+from otx.core.types.label import SegLabelInfo
 
 from .base import OTXDataset
 
 if TYPE_CHECKING:
     from datumaro import DatasetSubset
-
-
-@dataclass
-class SegLabelInfo(LabelInfo):
-    """Meta information of Semantic Segmentation."""
-
-    def __init__(self, label_names: list[str], label_groups: list[list[str]]) -> None:
-        if not any(word.lower() == "background" for word in label_names):
-            msg = (
-                "Currently, no background label exists for `label_names`. "
-                "Segmentation requires a background label. "
-                "To do this, `Background` is added at index 0 of `label_names`."
-            )
-            warnings.warn(msg, stacklevel=2)
-            label_names.insert(0, "Background")
-        super().__init__(label_names, label_groups)
 
 
 class OTXSegmentationDataset(OTXDataset[SegDataEntity]):

--- a/src/otx/core/data/dataset/segmentation.py
+++ b/src/otx/core/data/dataset/segmentation.py
@@ -15,11 +15,12 @@ import torch
 from datumaro.components.annotation import Image, Mask
 from torchvision import tv_tensors
 
-from otx.core.data.dataset.base import LabelInfo, Transforms
+from otx.core.data.dataset.base import Transforms
 from otx.core.data.entity.base import ImageInfo
 from otx.core.data.entity.segmentation import SegBatchDataEntity, SegDataEntity
 from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER, MemCacheHandlerBase
 from otx.core.types.image import ImageColorChannel
+from otx.core.types.label import LabelInfo
 
 from .base import OTXDataset
 

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -13,7 +13,6 @@ from lightning import LightningDataModule
 from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import DataLoader, RandomSampler
 
-from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.dataset.tile import OTXTileDatasetFactory
 from otx.core.data.factory import OTXDatasetFactory
 from otx.core.data.mem_cache import (
@@ -23,6 +22,7 @@ from otx.core.data.mem_cache import (
 from otx.core.data.pre_filtering import pre_filtering
 from otx.core.data.tile_adaptor import adapt_tile_config
 from otx.core.types.device import DeviceType
+from otx.core.types.label import LabelInfo
 from otx.core.types.task import OTXTaskType
 from otx.core.utils.instantiators import instantiate_sampler
 from otx.core.utils.utils import get_adaptive_num_workers

--- a/src/otx/core/metrics/accuracy.py
+++ b/src/otx/core/metrics/accuracy.py
@@ -21,8 +21,7 @@ from otx.core.metrics.types import MetricCallable
 if TYPE_CHECKING:
     from torch import Tensor
 
-    from otx.core.data.dataset.base import LabelInfo
-    from otx.core.data.dataset.classification import HLabelInfo
+    from otx.core.types.label import HLabelInfo, LabelInfo
 
 
 class NamedConfusionMatrix(ConfusionMatrix):

--- a/src/otx/core/metrics/dice.py
+++ b/src/otx/core/metrics/dice.py
@@ -5,7 +5,7 @@
 from torchmetrics.classification.dice import Dice
 from torchmetrics.collections import MetricCollection
 
-from otx.core.data.dataset.base import LabelInfo
+from otx.core.types.label import LabelInfo
 
 
 def _dice_callable(label_info: LabelInfo) -> MetricCollection:

--- a/src/otx/core/metrics/mean_ap.py
+++ b/src/otx/core/metrics/mean_ap.py
@@ -11,7 +11,7 @@ import pycocotools.mask as mask_utils
 import torch
 from torchmetrics.detection.mean_ap import MeanAveragePrecision
 
-from otx.core.data.dataset.base import LabelInfo
+from otx.core.types.label import LabelInfo
 
 if TYPE_CHECKING:
     from torchmetrics import Metric

--- a/src/otx/core/metrics/types.py
+++ b/src/otx/core/metrics/types.py
@@ -8,7 +8,7 @@ from typing import Callable
 from torch import Tensor
 from torchmetrics import Metric, MetricCollection
 
-from otx.core.data.dataset.base import LabelInfo
+from otx.core.types.label import LabelInfo
 
 MetricCallable = Callable[[LabelInfo], Metric | MetricCollection]
 NullMetricCallable: MetricCallable = lambda label_info: Metric()  # noqa: ARG005

--- a/src/otx/core/metrics/visual_prompting.py
+++ b/src/otx/core/metrics/visual_prompting.py
@@ -8,7 +8,7 @@ from torchmetrics import MetricCollection
 from torchmetrics.classification import BinaryF1Score, BinaryJaccardIndex, Dice
 from torchmetrics.detection import MeanAveragePrecision
 
-from otx.core.data.dataset.base import LabelInfo
+from otx.core.types.label import LabelInfo
 
 
 def _visual_prompting_metric_callable(label_info: LabelInfo) -> MetricCollection:  # noqa: ARG001

--- a/src/otx/core/model/action_classification.py
+++ b/src/otx/core/model/action_classification.py
@@ -210,7 +210,6 @@ class OVActionClsModel(
 
     def __init__(
         self,
-        num_classes: int,
         model_name: str,
         model_type: str = "Action Classification",
         async_inference: bool = True,
@@ -221,7 +220,6 @@ class OVActionClsModel(
         **kwargs,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
             model_name=model_name,
             model_type=model_type,
             async_inference=async_inference,

--- a/src/otx/core/model/anomaly.py
+++ b/src/otx/core/model/anomaly.py
@@ -18,7 +18,6 @@ from anomalib.callbacks.post_processor import _PostProcessorCallback
 from anomalib.callbacks.thresholding import _ThresholdCallback
 from torch import nn
 
-from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.entity.anomaly import (
     AnomalyClassificationBatchPrediction,
     AnomalyClassificationDataBatch,
@@ -29,6 +28,7 @@ from otx.core.data.entity.anomaly import (
 )
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.types.export import OTXExportFormatType
+from otx.core.types.label import LabelInfo
 from otx.core.types.precision import OTXPrecisionType
 from otx.core.types.task import OTXTaskType
 

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -33,7 +33,7 @@ from otx.core.data.entity.tile import OTXTileBatchDataEntity, T_OTXTileBatchData
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.metrics import MetricInput, NullMetricCallable
 from otx.core.types.export import OTXExportFormatType
-from otx.core.types.label import LabelInfo
+from otx.core.types.label import LabelInfo, NullLabelInfo
 from otx.core.types.precision import OTXPrecisionType
 from otx.core.utils.build import get_default_num_async_infer_requests
 from otx.core.utils.utils import is_ckpt_for_finetuning, is_ckpt_from_otx_v1
@@ -80,7 +80,7 @@ class OTXModel(
     ) -> None:
         super().__init__()
 
-        self._label_info = LabelInfo.from_num_classes(num_classes)
+        self._label_info = LabelInfo.from_num_classes(num_classes) if num_classes > 0 else NullLabelInfo()
         self.classification_layers: dict[str, dict[str, Any]] = {}
         self.model = self._create_model()
         self.original_model_forward = None
@@ -369,6 +369,13 @@ class OTXModel(
     @label_info.setter
     def label_info(self, label_info: LabelInfo | list[str]) -> None:
         """Set this model label information."""
+        self._set_label_info(label_info)
+
+    def _set_label_info(self, label_info: LabelInfo | list[str]) -> None:
+        """Actual implementation for set this model label information.
+
+        Derived classes should override this function.
+        """
         if isinstance(label_info, list):
             label_info = LabelInfo(label_names=label_info, label_groups=[label_info])
 
@@ -596,6 +603,7 @@ class OTXModel(
             ("model_info", "labels"): all_labels.strip(),
             ("model_info", "label_ids"): all_label_ids.strip(),
             ("model_info", "optimization_config"): json.dumps(optimization_config),
+            ("model_info", "label_info"): self.label_info.to_json(),
         }
 
         return parameters
@@ -628,7 +636,6 @@ class OVModel(OTXModel, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity, T_OT
 
     def __init__(
         self,
-        num_classes: int,
         model_name: str,
         model_type: str,
         async_inference: bool = True,
@@ -643,7 +650,9 @@ class OVModel(OTXModel, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity, T_OT
         self.num_requests = max_num_requests if max_num_requests is not None else get_default_num_async_infer_requests()
         self.use_throughput_mode = use_throughput_mode
         self.model_api_configuration = model_api_configuration if model_api_configuration is not None else {}
-        super().__init__(num_classes=num_classes, metric=metric)
+        # NOTE: num_classes and label_info comes from the IR metadata
+        super().__init__(num_classes=-1, metric=metric)
+        self._label_info = self._create_label_info_from_ov_ir()
 
         tile_enabled = False
         with contextlib.suppress(RuntimeError):
@@ -807,71 +816,35 @@ class OVModel(OTXModel, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity, T_OT
         """Model parameters for export."""
         return {}
 
-    def _reset_prediction_layer(self, num_classes: int) -> None:
-        """Reset its prediction layer with a given number of classes.
+    def _set_label_info(self, label_info: LabelInfo | list[str]) -> None:
+        """Set this model label information."""
+        if isinstance(label_info, list):
+            label_info = LabelInfo(label_names=label_info, label_groups=[label_info])
 
-        Args:
-            num_classes: Number of classes
-        """
-        # TODO(vinnamki): See the following link
-        # https://github.com/openvinotoolkit/training_extensions/actions/runs/8339199693/job/22821020564?pr=3155#step:5:3966
-        # This is because this test is trying to launch the test pipeline with giving 80 num_classes to OV model
-        # which is really trained for 21 classes.
-        # Indeed, it should be failed at initialization but the current code allows it.
-        # Without this function overriding, it fails at label_info injection
-        #
-        # ╭───────────────────── Traceback (most recent call last) ──────────────────────╮
-        # │ /home/vinnamki/otx/training_extensions/src/otx/cli/cli.py:586 in run         │
-        # │                                                                              │
-        # │   583 │   │   │   fn_kwargs = self.prepare_subcommand_kwargs(self.subcommand │
-        # │   584 │   │   │   fn = getattr(self.engine, self.subcommand)                 │
-        # │   585 │   │   │   try:                                                       │
-        # │ ❱ 586 │   │   │   │   fn(**fn_kwargs)                                        │
-        # │   587 │   │   │   except Exception:                                          │
-        # │   588 │   │   │   │   self.console.print_exception(width=self.console.width) │
-        # │   589 │   │   │   self.save_config(work_dir=Path(self.engine.work_dir))      │
-        # │                                                                              │
-        # │ /home/vinnamki/otx/training_extensions/src/otx/engine/engine.py:338 in test  │
-        # │                                                                              │
-        # │   335 │   │   │   │   f"It will be overriden: {self.model.label_info} => {se │
-        # │   336 │   │   │   )                                                          │
-        # │   337 │   │   │   logging.warning(msg)                                       │
-        # │ ❱ 338 │   │   │   self.model.label_info = self.datamodule.label_info         │
-        # │   339 │   │   │                                                              │
-        # │   340 │   │   │   # TODO (vinnamki): This should be changed to raise an erro │
-        # │   341 │   │   │   # raise ValueError()                                       │
-        # │                                                                              │
-        # │ /home/vinnamki/miniconda3/envs/otx-v2/lib/python3.11/site-packages/torch/nn/ │
-        # │ modules/module.py:1754 in __setattr__                                        │
-        # │                                                                              │
-        # │   1751 │   │   │   │   │   │   │   value = output                            │
-        # │   1752 │   │   │   │   │   buffers[name] = value                             │
-        # │   1753 │   │   │   │   else:                                                 │
-        # │ ❱ 1754 │   │   │   │   │   super().__setattr__(name, value)                  │
-        # │   1755 │                                                                     │
-        # │   1756 │   def __delattr__(self, name):                                      │
-        # │   1757 │   │   if name in self._parameters:                                  │
-        # │                                                                              │
-        # │ /home/vinnamki/otx/training_extensions/src/otx/core/model/base.py:386 in     │
-        # │ label_info                                                                   │
-        # │                                                                              │
-        # │   383 │   │   │   │   f"(={new_num_classes})."                               │
-        # │   384 │   │   │   )                                                          │
-        # │   385 │   │   │   warnings.warn(msg, stacklevel=0)                           │
-        # │ ❱ 386 │   │   │   self._reset_prediction_layer(num_classes=label_info.num_cl │
-        # │   387 │   │                                                                  │
-        # │   388 │   │   self._label_info = label_info                                  │
-        # │   389                                                                        │
-        # │                                                                              │
-        # │ /home/vinnamki/otx/training_extensions/src/otx/core/model/base.py:609 in     │
-        # │ _reset_prediction_layer                                                      │
-        # │                                                                              │
-        # │   606 │   │   Args:                                                          │
-        # │   607 │   │   │   num_classes: Number of classes                             │
-        # │   608 │   │   """                                                            │
-        # │ ❱ 609 │   │   raise NotImplementedError                                      │
-        # │   610 │                                                                      │
-        # │   611 │   @property                                                          │
-        # │   612 │   def _optimization_config(self) -> dict[str, str]:                  │
-        # ╰──────────────────────────────────────────────────────────────────────────────╯
-        # NotImplementedError
+        if self._label_info != label_info:
+            msg = "OVModel strictly does not allow overwrite label_info if they are different each other."
+            raise ValueError(msg)
+
+        self._label_info = label_info
+
+    def _create_label_info_from_ov_ir(self) -> LabelInfo:
+        ov_model = self.model.get_model()
+
+        if ov_model.has_rt_info(["model_info", "label_info"]):
+            serialized = ov_model.get_rt_info(["model_info", "label_info"]).value
+            return LabelInfo.from_json(serialized)
+
+        mapi_model: Model = self.model
+
+        if label_names := getattr(mapi_model, "labels", None):
+            msg = (
+                'Cannot find "label_info" from OpenVINO IR. '
+                "However, we found labels attributes from ModelAPI. "
+                "Construct LabelInfo from it."
+            )
+
+            logger.warning(msg)
+            return LabelInfo(label_names=label_names, label_groups=[label_names])
+
+        msg = "Cannot construct LabelInfo from OpenVINO IR. Please check this model is trained by OTX."
+        raise ValueError(msg)

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -23,7 +23,6 @@ from torch.optim.lr_scheduler import ConstantLR
 from torch.optim.sgd import SGD
 from torchmetrics import Metric, MetricCollection
 
-from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.entity.base import (
     OTXBatchLossEntity,
     T_OTXBatchDataEntity,
@@ -34,6 +33,7 @@ from otx.core.data.entity.tile import OTXTileBatchDataEntity, T_OTXTileBatchData
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.metrics import MetricInput, NullMetricCallable
 from otx.core.types.export import OTXExportFormatType
+from otx.core.types.label import LabelInfo
 from otx.core.types.precision import OTXPrecisionType
 from otx.core.utils.build import get_default_num_async_infer_requests
 from otx.core.utils.utils import is_ckpt_for_finetuning, is_ckpt_from_otx_v1

--- a/src/otx/core/model/classification.py
+++ b/src/otx/core/model/classification.py
@@ -14,7 +14,6 @@ import torch
 from torchmetrics import Accuracy
 
 from otx.algo.hooks.recording_forward_hook import feature_vector_fn
-from otx.core.data.dataset.classification import HLabelInfo
 from otx.core.data.entity.base import (
     OTXBatchLossEntity,
     T_OTXBatchDataEntity,
@@ -42,6 +41,7 @@ from otx.core.metrics.accuracy import (
     MultiLabelClsMetricCallable,
 )
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
+from otx.core.types.label import HLabelInfo
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -494,7 +494,6 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchP
 
     def __init__(
         self,
-        num_classes: int,
         model_name: str,
         model_type: str = "SSD",
         async_inference: bool = True,
@@ -506,7 +505,6 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchP
     ) -> None:
         self.test_meta_info: dict[str, Any] = {}
         super().__init__(
-            num_classes=num_classes,
             model_name=model_name,
             model_type=model_type,
             async_inference=async_inference,

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -540,7 +540,6 @@ class OVInstanceSegmentationModel(
 
     def __init__(
         self,
-        num_classes: int,
         model_name: str,
         model_type: str = "MaskRCNN",
         async_inference: bool = True,
@@ -552,7 +551,6 @@ class OVInstanceSegmentationModel(
     ) -> None:
         self.test_meta_info: dict[str, Any] = {}
         super().__init__(
-            num_classes=num_classes,
             model_name=model_name,
             model_type=model_type,
             async_inference=async_inference,

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -40,6 +40,7 @@ from otx.core.exporter.visual_prompting import OTXVisualPromptingModelExporter
 from otx.core.metrics import MetricInput
 from otx.core.metrics.visual_prompting import VisualPromptingMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
+from otx.core.types.label import LabelInfo, NullLabelInfo
 from otx.core.utils.mask_util import polygon_to_bitmap
 
 if TYPE_CHECKING:
@@ -274,6 +275,10 @@ class OTXVisualPromptingModel(
         """Convert the prediction entity to the format required by the compute metric function."""
         return _convert_pred_entity_to_compute_metric(preds=preds, inputs=inputs)
 
+    def _set_label_info(self, _: LabelInfo | list[str]) -> None:
+        msg = f"Reconfiguring label_info has no effect on {self.__class__.__name__}."
+        log.warning(msg)
+
 
 class OTXZeroShotVisualPromptingModel(
     OTXModel[
@@ -446,6 +451,10 @@ class OTXZeroShotVisualPromptingModel(
         """Convert the prediction entity to the format required by the compute metric function."""
         return _convert_pred_entity_to_compute_metric(preds=preds, inputs=inputs)
 
+    def _set_label_info(self, _: LabelInfo | list[str]) -> None:
+        msg = f"Reconfiguring label_info has no effect on {self.__class__.__name__}."
+        log.warning(msg)
+
 
 class OVVisualPromptingModel(
     OVModel[
@@ -462,7 +471,6 @@ class OVVisualPromptingModel(
 
     def __init__(
         self,
-        num_classes: int,
         model_name: str,
         model_type: str = "Visual_Prompting",
         async_inference: bool = False,
@@ -485,7 +493,6 @@ class OVVisualPromptingModel(
             for module in ["image_encoder", "decoder"]
         }
         super().__init__(
-            num_classes=num_classes,
             model_name=model_name,
             model_type=model_type,
             async_inference=async_inference,
@@ -728,6 +735,10 @@ class OVVisualPromptingModel(
         """Convert the prediction entity to the format required by the compute metric function."""
         return _convert_pred_entity_to_compute_metric(preds=preds, inputs=inputs)
 
+    def _create_label_info_from_ov_ir(self) -> LabelInfo:
+        """Create NullLabelInfo since Visual Prompting tasks has no use of label information."""
+        return NullLabelInfo()
+
 
 class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
     """Zero-shot visual prompting model compatible for OpenVINO IR inference.
@@ -738,7 +749,6 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
 
     def __init__(
         self,
-        num_classes: int,
         model_name: str,
         model_type: str = "Zero_Shot_Visual_Prompting",
         async_inference: bool = False,
@@ -751,7 +761,6 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
         **kwargs,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
             model_name=model_name,
             model_type=model_type,
             async_inference=async_inference,
@@ -1412,3 +1421,7 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
     ) -> MetricInput:
         """Convert the prediction entity to the format required by the compute metric function."""
         return _convert_pred_entity_to_compute_metric(preds=preds, inputs=inputs)
+
+    def _create_label_info_from_ov_ir(self) -> LabelInfo:
+        """Create NullLabelInfo since Visual Prompting tasks has no use of label information."""
+        return NullLabelInfo()

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -739,6 +739,13 @@ class OVVisualPromptingModel(
         """Create NullLabelInfo since Visual Prompting tasks has no use of label information."""
         return NullLabelInfo()
 
+    def _set_label_info(self, label_info: LabelInfo | list[str]) -> None:
+        """Visual prompting task does not check label_info equivalance.
+
+        This is because it always has NullLabelInfo.
+        """
+        return
+
 
 class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
     """Zero-shot visual prompting model compatible for OpenVINO IR inference.
@@ -1425,3 +1432,10 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
     def _create_label_info_from_ov_ir(self) -> LabelInfo:
         """Create NullLabelInfo since Visual Prompting tasks has no use of label information."""
         return NullLabelInfo()
+
+    def _set_label_info(self, label_info: LabelInfo | list[str]) -> None:
+        """Visual prompting task does not check label_info equivalance.
+
+        This is because it always has NullLabelInfo.
+        """
+        return

--- a/src/otx/core/types/__init__.py
+++ b/src/otx/core/types/__init__.py
@@ -9,4 +9,17 @@ from typing import Union
 
 from typing_extensions import TypeAlias
 
+from otx.core.types.label import HLabelInfo, LabelInfo, NullLabelInfo, SegLabelInfo
+from otx.core.types.task import OTXTaskType
+
+__all__ = [
+    # label_info
+    "LabelInfo",
+    "HLabelInfo",
+    "SegLabelInfo",
+    "NullLabelInfo",
+    # task_type
+    "OTXTaskType",
+]
+
 PathLike: TypeAlias = Union[str, Path, os.PathLike]

--- a/src/otx/core/types/label.py
+++ b/src/otx/core/types/label.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from datumaro import Label, LabelCategories
 
-__all__ = ["LabelInfo", "HLabelInfo"]
+__all__ = ["LabelInfo", "HLabelInfo", "SegLabelInfo", "NullLabelInfo"]
 
 
 @dataclass

--- a/src/otx/core/types/label.py
+++ b/src/otx/core/types/label.py
@@ -289,3 +289,8 @@ class NullLabelInfo(LabelInfo):
 
     def __init__(self) -> None:
         super().__init__(label_names=[], label_groups=[[]])
+
+    @classmethod
+    def from_json(cls, _: str) -> LabelInfo:
+        """Reconstruct it from the JSON serialized string."""
+        return cls()

--- a/src/otx/core/types/label.py
+++ b/src/otx/core/types/label.py
@@ -1,0 +1,291 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Dataclasses for label information."""
+
+from __future__ import annotations
+
+import json
+import warnings
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datumaro import Label, LabelCategories
+
+__all__ = ["LabelInfo", "HLabelInfo"]
+
+
+@dataclass
+class LabelInfo:
+    """Object to represent label information."""
+
+    label_names: list[str]
+    label_groups: list[list[str]]
+
+    @property
+    def num_classes(self) -> int:
+        """Return number of labels."""
+        return len(self.label_names)
+
+    @classmethod
+    def from_num_classes(cls, num_classes: int) -> LabelInfo:
+        """Create this object from the number of classes.
+
+        Args:
+            num_classes: Number of classes
+
+        Returns:
+            LabelInfo(
+                label_names=["label_0", ...],
+                label_groups=[["label_0", ...]]
+            )
+        """
+        label_names = [f"label_{idx}" for idx in range(num_classes)]
+
+        return LabelInfo(
+            label_names=label_names,
+            label_groups=[label_names],
+        )
+
+    @classmethod
+    def from_dm_label_groups(cls, dm_label_categories: LabelCategories) -> LabelInfo:
+        """Create this object from the datumaro label groups.
+
+        Args:
+            dm_label_categories (LabelCategories): The label category information from Datumaro.
+
+        Returns:
+            LabelInfo(
+                label_names=["Heart_King", "Heart_Queen", "Spade_King", "Spade_Jack"]
+                label_groups=[["Heart_King", "Heart_Queen"], ["Spade_King", "Spade_Jack"]]
+            )
+
+        """
+        label_names = [item.name for item in dm_label_categories.items]
+        label_groups = [label_group.labels for label_group in dm_label_categories.label_groups]
+        if len(label_groups) == 0:  # Single-label classification
+            label_groups = [label_names]
+
+        return LabelInfo(
+            label_names=label_names,
+            label_groups=label_groups,
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dictionary including all params."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Return JSON serialized string."""
+        return json.dumps(self.as_dict())
+
+    @classmethod
+    def from_json(cls, serialized: str) -> LabelInfo:
+        """Reconstruct it from the JSON serialized string."""
+        return cls(**json.loads(serialized))
+
+
+@dataclass
+class HLabelInfo(LabelInfo):
+    """The label information represents the hierarchy.
+
+    All params should be kept since they're also used at the Model API side.
+
+    :param num_multiclass_heads: the number of the multiclass heads
+    :param num_multilabel_classes: the number of multilabel classes
+    :param head_to_logits_range: the logit range of each heads
+    :param num_single_label_classes: the number of single label classes
+    :param class_to_group_idx: represents the head index and label index
+    :param all_groups: represents information of all groups
+    :param label_to_idx: index of each label
+    :param empty_multiclass_head_indices: the index of head that doesn't include any label
+                                          due to the label removing
+
+    i.e.
+    Single-selection group information (Multiclass, Exclusive)
+    {
+        "Shape": ["Rigid", "Non-Rigid"],
+        "Rigid": ["Rectangle", "Triangle"],
+        "Non-Rigid": ["Circle"]
+    }
+
+    Multi-selection group information (Multilabel)
+    {
+        "Animal": ["Lion", "Panda"]
+    }
+
+    In the case above, HlabelInfo will be generated as below.
+    NOTE, If there was only one label in the multiclass group, it will be handeled as multilabel(Circle).
+
+        num_multiclass_heads: 2  (Shape, Rigid)
+        num_multilabel_classes: 3 (Circle, Lion, Panda)
+        head_to_logits_range: {'0': (0, 2), '1': (2, 4)} (Each multiclass head have 2 labels)
+        num_single_label_classes: 4 (Rigid, Non-Rigid, Rectangle, Triangle)
+        class_to_group_idx: {
+            'Non-Rigid': (0, 0), 'Rigid': (0, 1),
+            'Rectangle': (1, 0), 'Triangle': (1, 1),
+            'Circle': (2, 0), 'Lion': (2,1), 'Panda': (2,2)
+        } (head index, label index for each head)
+        all_groups: [['Non-Rigid', 'Rigid'], ['Rectangle', 'Triangle'], ['Circle'], ['Lion'], ['Panda']]
+        label_to_idx: {
+            'Rigid': 0, 'Rectangle': 1,
+            'Triangle': 2, 'Non-Rigid': 3, 'Circle': 4
+            'Lion': 5, 'Panda': 6
+        }
+        label_tree_edges: [
+            ["Rectangle", "Rigid"], ["Triangle", "Rigid"], ["Circle", "Non-Rigid"],
+        ] # NOTE, label_tree_edges format could be changed.
+        empty_multiclass_head_indices: []
+
+    All of the member variables should be considered for the Model API.
+    https://github.com/openvinotoolkit/training_extensions/blob/develop/src/otx/algorithms/classification/utils/cls_utils.py#L97
+    """
+
+    num_multiclass_heads: int
+    num_multilabel_classes: int
+    head_idx_to_logits_range: dict[str, tuple[int, int]]
+    num_single_label_classes: int
+    class_to_group_idx: dict[str, tuple[int, int]]
+    all_groups: list[list[str]]
+    label_to_idx: dict[str, int]
+    label_tree_edges: list[list[str]]
+    empty_multiclass_head_indices: list[int]
+
+    @classmethod
+    def from_dm_label_groups(cls, dm_label_categories: LabelCategories) -> HLabelInfo:
+        """Generate HLabelData from the Datumaro LabelCategories.
+
+        Args:
+            dm_label_categories (LabelCategories): the label categories of datumaro.
+        """
+
+        def get_exclusive_group_info(all_groups: list[Label | list[Label]]) -> dict[str, Any]:
+            """Get exclusive group information."""
+            exclusive_groups = [g for g in all_groups if len(g) > 1]
+
+            last_logits_pos = 0
+            num_single_label_classes = 0
+            head_idx_to_logits_range = {}
+            class_to_idx = {}
+
+            for i, group in enumerate(exclusive_groups):
+                head_idx_to_logits_range[str(i)] = (last_logits_pos, last_logits_pos + len(group))
+                last_logits_pos += len(group)
+                for j, c in enumerate(group):
+                    class_to_idx[c] = (i, j)
+                    num_single_label_classes += 1
+
+            return {
+                "num_multiclass_heads": len(exclusive_groups),
+                "head_idx_to_logits_range": head_idx_to_logits_range,
+                "class_to_idx": class_to_idx,
+                "num_single_label_classes": num_single_label_classes,
+            }
+
+        def get_single_label_group_info(
+            all_groups: list[Label | list[Label]],
+            num_exclusive_groups: int,
+        ) -> dict[str, Any]:
+            """Get single label group information."""
+            single_label_groups = [g for g in all_groups if len(g) == 1]
+
+            class_to_idx = {}
+
+            for i, group in enumerate(single_label_groups):
+                class_to_idx[group[0]] = (num_exclusive_groups, i)
+
+            return {
+                "num_multilabel_classes": len(single_label_groups),
+                "class_to_idx": class_to_idx,
+            }
+
+        def merge_class_to_idx(
+            exclusive_ctoi: dict[str, tuple[int, int]],
+            single_label_ctoi: dict[str, tuple[int, int]],
+        ) -> dict[str, tuple[int, int]]:
+            """Merge the class_to_idx information from exclusive and single_label groups."""
+
+            def put_key_values(src: dict, dst: dict) -> None:
+                """Put key and values from src to dst."""
+                for k, v in src.items():
+                    dst[k] = v
+
+            class_to_idx: dict[str, tuple[int, int]] = {}
+            put_key_values(exclusive_ctoi, class_to_idx)
+            put_key_values(single_label_ctoi, class_to_idx)
+            return class_to_idx
+
+        def get_label_tree_edges(dm_label_items: list[LabelCategories]) -> list[list[str]]:
+            """Get label tree edges information. Each edges represent [child, parent]."""
+            return [[item.name, item.parent] for item in dm_label_items if item.parent != ""]
+
+        all_groups = [label_group.labels for label_group in dm_label_categories.label_groups]
+
+        exclusive_group_info = get_exclusive_group_info(all_groups)
+        single_label_group_info = get_single_label_group_info(all_groups, exclusive_group_info["num_multiclass_heads"])
+
+        merged_class_to_idx = merge_class_to_idx(
+            exclusive_group_info["class_to_idx"],
+            single_label_group_info["class_to_idx"],
+        )
+
+        return HLabelInfo(
+            label_names=[item.name for item in dm_label_categories.items],
+            label_groups=all_groups,
+            num_multiclass_heads=exclusive_group_info["num_multiclass_heads"],
+            num_multilabel_classes=single_label_group_info["num_multilabel_classes"],
+            head_idx_to_logits_range=exclusive_group_info["head_idx_to_logits_range"],
+            num_single_label_classes=exclusive_group_info["num_single_label_classes"],
+            class_to_group_idx=merged_class_to_idx,
+            all_groups=all_groups,
+            label_to_idx=dm_label_categories._indices,  # noqa: SLF001
+            label_tree_edges=get_label_tree_edges(dm_label_categories.items),
+            empty_multiclass_head_indices=[],  # consider the label removing case
+        )
+
+    def as_head_config_dict(self) -> dict[str, Any]:
+        """Return a dictionary including params needed to configure the HLabel MMPretrained head network."""
+        return {
+            "num_classes": self.num_classes,
+            "num_multiclass_heads": self.num_multiclass_heads,
+            "num_multilabel_classes": self.num_multilabel_classes,
+            "head_idx_to_logits_range": self.head_idx_to_logits_range,
+            "num_single_label_classes": self.num_single_label_classes,
+            "empty_multiclass_head_indices": self.empty_multiclass_head_indices,
+        }
+
+    @classmethod
+    def from_json(cls, serialized: str) -> HLabelInfo:
+        """Reconstruct it from the JSON serialized string."""
+        loaded = json.loads(serialized)
+        # List to tuple
+        loaded["head_idx_to_logits_range"] = {
+            key: tuple(value) for key, value in loaded["head_idx_to_logits_range"].items()
+        }
+        loaded["class_to_group_idx"] = {key: tuple(value) for key, value in loaded["class_to_group_idx"].items()}
+        return cls(**loaded)
+
+
+@dataclass
+class SegLabelInfo(LabelInfo):
+    """Meta information of Semantic Segmentation."""
+
+    def __init__(self, label_names: list[str], label_groups: list[list[str]]) -> None:
+        if not any(word.lower() == "background" for word in label_names):
+            msg = (
+                "Currently, no background label exists for `label_names`. "
+                "Segmentation requires a background label. "
+                "To do this, `Background` is added at index 0 of `label_names`."
+            )
+            warnings.warn(msg, stacklevel=2)
+            label_names.insert(0, "Background")
+        super().__init__(label_names, label_groups)
+
+
+@dataclass
+class NullLabelInfo(LabelInfo):
+    """Represent no label information. It is used for Visual Prompting tasks."""
+
+    def __init__(self) -> None:
+        super().__init__(label_names=[], label_groups=[[]])

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -15,10 +15,10 @@ import datumaro
 from lightning.pytorch.cli import instantiate_class
 
 from otx.core.config.data import DataModuleConfig, SamplerConfig, SubsetConfig, TileConfig
-from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.module import OTXDataModule
 from otx.core.model.base import OVModel
 from otx.core.types import PathLike
+from otx.core.types.label import LabelInfo
 from otx.core.types.task import OTXTaskType
 from otx.core.utils.imports import get_otx_root_path
 from otx.core.utils.instantiators import partial_instantiate_class
@@ -262,7 +262,7 @@ class AutoConfigurator:
             num_classes = label_info.num_classes
             self.config["model"]["init_args"]["num_classes"] = num_classes
 
-            from otx.core.data.dataset.classification import HLabelInfo
+            from otx.core.types.label import HLabelInfo
 
             if isinstance(label_info, HLabelInfo):
                 init_args = self.config["model"]["init_args"]

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0_light.yaml
@@ -1,9 +1,5 @@
 model:
   class_path: otx.algo.classification.efficientnet_b0.EfficientNetB0ForHLabelCls
-  init_args:
-    num_classes: 1000
-    num_multiclass_heads: 0
-    num_multilabel_classes: 0
 
 optimizer:
   class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2_light.yaml
@@ -1,9 +1,5 @@
 model:
   class_path: otx.algo.classification.efficientnet_v2.EfficientNetV2ForHLabelCls
-  init_args:
-    num_classes: 1000
-    num_multiclass_heads: 0
-    num_multilabel_classes: 0
 
 optimizer:
   class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large_light.yaml
@@ -1,9 +1,5 @@
 model:
   class_path: otx.algo.classification.mobilenet_v3_large.MobileNetV3ForHLabelCls
-  init_args:
-    num_classes: 1000
-    num_multiclass_heads: 0
-    num_multilabel_classes: 0
 
 optimizer:
   class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/h_label_cls/openvino_model.yaml
+++ b/src/otx/recipe/classification/h_label_cls/openvino_model.yaml
@@ -6,9 +6,6 @@ model:
     async_inference: True
     use_throughput_mode: False
     model_type: Classification
-    num_classes: 7
-    num_multiclass_heads: 0
-    num_multilabel_classes: 0
 
 optimizer:
   class_path: torch.optim.Adam

--- a/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/otx_deit_tiny.yaml
@@ -1,9 +1,5 @@
 model:
   class_path: otx.algo.classification.deit_tiny.DeitTinyForHLabelCls
-  init_args:
-    num_classes: 1000
-    num_multiclass_heads: 0
-    num_multilabel_classes: 0
 
 optimizer:
   class_path: torch.optim.AdamW

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -295,8 +295,6 @@ def test_otx_explain_e2e(
         "explain",
         "--config",
         recipe,
-        "--model.num_classes",
-        "1000",
         "--data_root",
         fxt_target_dataset_per_task[task],
         "--work_dir",

--- a/tests/unit/algo/classification/conftest.py
+++ b/tests/unit/algo/classification/conftest.py
@@ -7,8 +7,9 @@ import pytest
 import torch
 from mmpretrain.structures import DataSample
 from omegaconf import DictConfig
-from otx.core.data.dataset.classification import HLabelInfo, MulticlassClsBatchDataEntity
+from otx.core.data.dataset.classification import MulticlassClsBatchDataEntity
 from otx.core.data.entity.base import ImageInfo
+from otx.core.types.label import HLabelInfo
 from torchvision import tv_tensors
 
 

--- a/tests/unit/algo/classification/conftest.py
+++ b/tests/unit/algo/classification/conftest.py
@@ -98,7 +98,7 @@ def fxt_hlabel_multilabel_info() -> HLabelInfo:
         num_multiclass_heads=3,
         num_multilabel_classes=3,
         head_idx_to_logits_range={"0": (0, 2), "1": (2, 4), "2": (4, 6)},
-        num_single_label_classes=3,
+        num_single_label_classes=6,
         empty_multiclass_head_indices=[],
         class_to_group_idx={
             "Heart": (0, 0),

--- a/tests/unit/algo/classification/test_deit_tiny.py
+++ b/tests/unit/algo/classification/test_deit_tiny.py
@@ -17,21 +17,23 @@ class TestDeitTiny:
         "model_cls",
         [DeitTinyForMulticlassCls, DeitTinyForMultilabelCls, DeitTinyForHLabelCls],
     )
-    def test_deit_tiny(self, model_cls, mocker):
+    def test_deit_tiny(self, model_cls, mocker, fxt_hlabel_data):
+        num_classes = fxt_hlabel_data.num_classes
+
         if model_cls == DeitTinyForHLabelCls:
-            model = model_cls(num_classes=10, num_multiclass_heads=2, num_multilabel_classes=5)
+            model = model_cls(hlabel_info=fxt_hlabel_data)
         else:
-            model = model_cls(num_classes=10)
+            model = model_cls(num_classes=num_classes)
         model.model.explain_fn = model.get_explain_fn()
 
         assert model._optimization_config["model_type"] == "transformer"
 
-        assert model.head_forward_fn(torch.randn([1, 24, 192])).shape == torch.Size([1, 10])
+        assert model.head_forward_fn(torch.randn([1, 24, 192])).shape == torch.Size([1, num_classes])
 
         out = model._forward_explain_image_classifier(model.model, torch.randn(1, 3, 24, 24))
-        assert out["logits"].shape == torch.Size([1, 10])
+        assert out["logits"].shape == torch.Size([1, num_classes])
         assert out["feature_vector"].shape == torch.Size([1, 192])
-        assert out["saliency_map"].shape == torch.Size([1, 10, 2, 2])
+        assert out["saliency_map"].shape == torch.Size([1, num_classes, 2, 2])
 
         mock_load_ckpt = mocker.patch.object(OTXv1Helper, "load_cls_effnet_b0_ckpt")
         model.load_from_otx_v1_ckpt({})

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -19,13 +19,30 @@ from otx.core.data.entity.visual_prompting import (
     ZeroShotVisualPromptingBatchPredEntity,
     ZeroShotVisualPromptingDataEntity,
 )
-from otx.core.types.label import HLabelInfo, LabelInfo
+from otx.core.types.label import HLabelInfo, LabelInfo, NullLabelInfo, SegLabelInfo
 from torchvision import tv_tensors
 
 
 @pytest.fixture(scope="session", autouse=True)
 def fxt_register_configs() -> None:
     register_configs()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fxt_null_label_info() -> LabelInfo:
+    return NullLabelInfo()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fxt_seg_label_info() -> SegLabelInfo:
+    label_names = ["class1", "class2", "class3"]
+    return SegLabelInfo(
+        label_names=label_names,
+        label_groups=[
+            label_names,
+            ["class2", "class3"],
+        ],
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -10,8 +10,6 @@ from datumaro.components.annotation import AnnotationType, LabelCategories
 from datumaro.components.dataset import Dataset, DatasetItem
 from datumaro.components.media import Image
 from otx.core.config import register_configs
-from otx.core.data.dataset.base import LabelInfo
-from otx.core.data.dataset.classification import HLabelInfo
 from otx.core.data.entity.base import ImageInfo, Points
 from otx.core.data.entity.visual_prompting import (
     VisualPromptingBatchDataEntity,
@@ -21,6 +19,7 @@ from otx.core.data.entity.visual_prompting import (
     ZeroShotVisualPromptingBatchPredEntity,
     ZeroShotVisualPromptingDataEntity,
 )
+from otx.core.types.label import HLabelInfo, LabelInfo
 from torchvision import tv_tensors
 
 

--- a/tests/unit/core/metrics/test_accuracy.py
+++ b/tests/unit/core/metrics/test_accuracy.py
@@ -5,14 +5,13 @@
 
 import pytest
 import torch
-from otx.core.data.dataset.base import LabelInfo
-from otx.core.data.dataset.classification import HLabelInfo
 from otx.core.metrics.accuracy import (
     HlabelAccuracy,
     MixedHLabelAccuracy,
     MulticlassAccuracywithLabelGroup,
     MultilabelAccuracywithLabelGroup,
 )
+from otx.core.types.label import HLabelInfo, LabelInfo
 
 
 class TestAccuracy:

--- a/tests/unit/core/model/test_base.py
+++ b/tests/unit/core/model/test_base.py
@@ -55,7 +55,7 @@ class TestOVModel:
 
     @pytest.fixture()
     def model(self) -> OVModel:
-        return OVModel(num_classes=2, model_name="efficientnet-b0-pytorch", model_type="Classification")
+        return OVModel(model_name="efficientnet-b0-pytorch", model_type="Classification")
 
     def test_customize_inputs(self, model, input_batch) -> None:
         inputs = model._customize_inputs(input_batch)

--- a/tests/unit/core/types/__init__.py
+++ b/tests/unit/core/types/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/core/types/test_label.py
+++ b/tests/unit/core/types/test_label.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from otx.core.types.label import LabelInfo
+
+
+@pytest.fixture(
+    params=[
+        "fxt_multiclass_labelinfo",
+        "fxt_hlabel_multilabel_info",
+        "fxt_null_label_info",
+        "fxt_seg_label_info",
+    ],
+)
+def fxt_label_info(request: pytest.FixtureRequest) -> LabelInfo:
+    return request.getfixturevalue(request.param)
+
+
+def test_as_json(fxt_label_info):
+    serialized = fxt_label_info.to_json()
+    deserialized = fxt_label_info.__class__.from_json(serialized)
+    assert fxt_label_info == deserialized

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -5,9 +5,9 @@
 from pathlib import Path
 
 import pytest
-from otx.core.data.dataset.base import LabelInfo
 from otx.core.data.module import OTXDataModule
 from otx.core.model.base import OTXModel
+from otx.core.types.label import LabelInfo
 from otx.core.types.task import OTXTaskType
 from otx.core.types.transformer_libs import TransformLibType
 from otx.engine.utils.auto_configurator import (


### PR DESCRIPTION
### Summary
This ticket (136313) about refactoring LabelInfo in OTX 2.0. The scope is

1. Move LabelInfo from `otx/core/data/dataset.py` to the dedicated source file at `otx/core/types/label.py`
2. Prevent label_info from being over-written for OVModel. It will be serialized into a JSON string which is stored in OpenVINO IR's rt_info fields, and deserialized when OVModel is initialized.
3. Remove runtime patching for HLabel head and the HLabelInfo object can be propagated at the model initialization

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
