### PR TITLE
Update invalid configuration work_dir in CLI

### DIFF
--- a/docs/source/guide/tutorials/base/how_to_train/detection.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/detection.rst
@@ -172,7 +172,10 @@ Let's check the object detection configuration running the following command:
 .. code-block:: shell
 
     # or its config path
-    (otx) ...$ otx train --config  src/otx/recipe/detection/atss_mobilenetv2.yaml --data_root data/wgisd --print_config
+    (otx) ...$ otx train --config  src/otx/recipe/detection/atss_mobilenetv2.yaml \
+                         --data_root data/wgisd \
+                         --work_dir otx-workspace \
+                         --print_config
 
     ...
     data_root: data/wgisd

--- a/docs/source/guide/tutorials/base/how_to_train/instance_segmentation.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/instance_segmentation.rst
@@ -178,7 +178,10 @@ Let's check the object detection configuration running the following command:
 .. code-block:: shell
 
   # or its config path
-  (otx) ...$ otx train --config src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml --data_root data/wgisd --print_config
+  (otx) ...$ otx train --config  src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml \
+                       --data_root data/wgisd \
+                       --work_dir otx-workspace \
+                       --print_config
 
   ...
   data_root: data/wgisd

--- a/docs/source/guide/tutorials/base/how_to_train/visual_prompting.rst
+++ b/docs/source/guide/tutorials/base/how_to_train/visual_prompting.rst
@@ -164,7 +164,10 @@ Let's check the visual prompting configuration running the following command:
 .. code-block:: shell
 
     # or its config path
-    (otx) ...$ otx train --config src/otx/recipe/visual_prompting/sam_tiny_vit.yaml --data_root data/wgisd --print_config
+    (otx) ...$ otx train --config  src/otx/recipe/visual_prompting/sam_tiny_vit.yaml \
+                         --data_root data/wgisd \
+                         --work_dir otx-workspace \
+                         --print_config
 
     ...
     data_root: data/wgisd

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -514,6 +514,7 @@ class OTXCLI:
         The configuration is saved as a YAML file in the engine's working directory.
         """
         self.config[self.subcommand].pop("workspace", None)
+        self.config[self.subcommand]["work_dir"] = str(self.workspace.work_dir.parent)
         self.get_subcommand_parser(self.subcommand).save(
             cfg=self.config.get(str(self.subcommand), self.config),
             path=work_dir / "configs.yaml",


### PR DESCRIPTION
### Summary

I looked at the issue @sungmanc mentioned in that PR https://github.com/openvinotoolkit/training_extensions/pull/3225 and found that the configs.yaml doesn't show the correct work_dir, so I fix that.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
