### PR TITLE
Change logger in otx.api to default logger

### DIFF
--- a/src/otx/api/entities/dataset_item.py
+++ b/src/otx/api/entities/dataset_item.py
@@ -7,14 +7,14 @@
 
 import abc
 import copy
-from inspect import signature
 import itertools
+import logging
+from inspect import signature
 from threading import Lock
 from typing import List, Optional, Sequence, Set, Tuple, TypeVar, Union
 from bson import ObjectId
 import numpy as np
 
-from otx.utils.logger import get_logger
 from otx.api.entities.annotation import Annotation, AnnotationSceneEntity
 from otx.api.entities.id import ID
 from otx.api.entities.label import LabelEntity
@@ -26,7 +26,7 @@ from otx.api.entities.shapes.rectangle import Rectangle
 from otx.api.entities.subset import Subset
 from otx.api.utils.shape_factory import ShapeFactory
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 T = TypeVar("T", bound="DatasetItemEntity")

--- a/src/otx/api/entities/datasets.py
+++ b/src/otx/api/entities/datasets.py
@@ -14,14 +14,13 @@ from typing import Generic, Iterator, List, Optional, TypeVar, Union, cast, over
 
 from bson.objectid import ObjectId
 
-from otx.utils.logger import get_logger
 from otx.api.entities.annotation import AnnotationSceneEntity, AnnotationSceneKind
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.id import ID
 from otx.api.entities.label import LabelEntity
 from otx.api.entities.subset import Subset
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 class DatasetPurpose(Enum):

--- a/src/otx/api/entities/label_schema.py
+++ b/src/otx/api/entities/label_schema.py
@@ -5,8 +5,7 @@
 #
 
 import copy
-from otx.utils.logger import get_logger
-import re
+import logging
 from enum import Enum
 from typing import Dict, List, Optional, Sequence, Union
 
@@ -18,7 +17,7 @@ from otx.api.entities.id import ID
 from otx.api.entities.label import LabelEntity
 from otx.api.entities.scored_label import ScoredLabel
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 def natural_sort_label_id(target: Union[ID, LabelEntity, ScoredLabel]) -> List[Union[int, str]]:

--- a/src/otx/api/entities/metrics.py
+++ b/src/otx/api/entities/metrics.py
@@ -7,15 +7,15 @@
 import abc
 import datetime
 import math
+import logging
 from enum import Enum
 from typing import Generic, List, Optional, Sequence, TypeVar, Union
-from otx.utils.logger import get_logger
 
 import numpy as np
 
 from otx.api.utils.time_utils import now
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 class MetricEntity(metaclass=abc.ABCMeta):

--- a/src/otx/api/usecases/evaluation/accuracy.py
+++ b/src/otx/api/usecases/evaluation/accuracy.py
@@ -6,12 +6,12 @@
 
 
 import copy
+import logging
 from typing import List, Set, Tuple
 
 import numpy as np
 from sklearn.metrics import confusion_matrix as sklearn_confusion_matrix
 
-from otx.utils.logger import get_logger
 from otx.api.entities.dataset_item import DatasetItemEntity
 from otx.api.entities.datasets import DatasetEntity
 from otx.api.entities.label import LabelEntity
@@ -37,7 +37,7 @@ from otx.api.usecases.evaluation.performance_provider_interface import (
     IPerformanceProvider,
 )
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 class Accuracy(IPerformanceProvider):

--- a/src/otx/api/usecases/evaluation/f_measure.py
+++ b/src/otx/api/usecases/evaluation/f_measure.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import logging
 from typing import Dict, List, Optional, Tuple
-from otx.utils.logger import get_logger
 
 import numpy as np
 
@@ -32,7 +32,7 @@ from otx.api.usecases.evaluation.performance_provider_interface import (
 )
 from otx.api.utils.shape_factory import ShapeFactory
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 ALL_CLASSES_NAME = "All Classes"
 
 

--- a/src/otx/api/usecases/reporting/time_monitor_callback.py
+++ b/src/otx/api/usecases/reporting/time_monitor_callback.py
@@ -7,8 +7,8 @@
 # pylint: disable=too-many-instance-attributes,too-many-arguments
 
 import math
-from otx.utils.logger import get_logger
 import time
+import logging
 from copy import deepcopy
 from typing import List
 
@@ -20,7 +20,7 @@ from otx.api.entities.train_parameters import (
 )
 from otx.api.usecases.reporting.callback import Callback
 
-logger = get_logger()
+logger = logging.getLogger(__name__)
 
 
 class TimeMonitorCallback(Callback):


### PR DESCRIPTION
### Summary
Change logger in otx.api to default logger like OTX 1.5 for Geti.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
