### PR TITLE
Refactor XAI data entities

### DIFF
--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -13,11 +13,7 @@ from torchvision import tv_tensors
 from torchvision.models import get_model, get_model_weights
 
 from otx.core.data.entity.base import OTXBatchLossEntity
-from otx.core.data.entity.classification import (
-    MulticlassClsBatchDataEntity,
-    MulticlassClsBatchPredEntity,
-    MulticlassClsBatchPredEntityWithXAI,
-)
+from otx.core.data.entity.classification import MulticlassClsBatchDataEntity, MulticlassClsBatchPredEntity
 from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.classification import OTXMulticlassClsModel
@@ -224,7 +220,7 @@ class OTXTVModel(OTXMulticlassClsModel):
         self,
         outputs: Any,  # noqa: ANN401
         inputs: MulticlassClsBatchDataEntity,
-    ) -> MulticlassClsBatchPredEntity | MulticlassClsBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> MulticlassClsBatchPredEntity | OTXBatchLossEntity:
         if self.training:
             return OTXBatchLossEntity(loss=outputs)
 
@@ -240,7 +236,7 @@ class OTXTVModel(OTXMulticlassClsModel):
 
             saliency_maps = outputs["saliency_map"].detach().cpu().numpy()
 
-            return MulticlassClsBatchPredEntityWithXAI(
+            return MulticlassClsBatchPredEntity(
                 batch_size=len(preds),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,

--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -862,12 +862,13 @@ class OTXZeroShotSegmentAnything(OTXZeroShotVisualPromptingModel):
 
     def transforms(self, entity: ZeroShotVisualPromptingBatchDataEntity) -> ZeroShotVisualPromptingBatchDataEntity:
         """Transforms for ZeroShotVisualPromptingBatchDataEntity."""
-        entity.images = [self.preprocess(self.apply_image(image)) for image in entity.images]
-        entity.prompts = [
-            self.apply_prompts(prompt, info.ori_shape, self.model.image_size)
-            for prompt, info in zip(entity.prompts, entity.imgs_info)
-        ]
-        return entity
+        return entity.wrap(
+            images=[self.preprocess(self.apply_image(image)) for image in entity.images],
+            prompts=[
+                self.apply_prompts(prompt, info.ori_shape, self.model.image_size)
+                for prompt, info in zip(entity.prompts, entity.imgs_info)
+            ],
+        )
 
     def initialize_reference_info(self) -> None:
         """Initialize reference information."""

--- a/src/otx/core/data/dataset/visual_prompting.py
+++ b/src/otx/core/data/dataset/visual_prompting.py
@@ -146,9 +146,12 @@ class OTXVisualPromptingDataset(OTXDataset[VisualPromptingDataEntity]):
         )
         transformed_entity = self._apply_transforms(entity)
 
+        if transformed_entity is None:
+            msg = "This is not allowed."
+            raise RuntimeError(msg)
+
         # insert masks to transformed_entity
-        transformed_entity.masks = masks  # type: ignore[union-attr]
-        return transformed_entity
+        return transformed_entity.wrap(masks=masks)
 
     @property
     def collate_fn(self) -> Callable:

--- a/src/otx/core/data/entity/action_classification.py
+++ b/src/otx/core/data/entity/action_classification.py
@@ -11,10 +11,8 @@ from typing import TYPE_CHECKING
 from otx.core.data.entity.base import (
     OTXBatchDataEntity,
     OTXBatchPredEntity,
-    OTXBatchPredEntityWithXAI,
     OTXDataEntity,
     OTXPredEntity,
-    OTXPredEntityWithXAI,
 )
 from otx.core.data.entity.utils import register_pytree_node
 from otx.core.types.task import OTXTaskType
@@ -51,13 +49,8 @@ class ActionClsDataEntity(OTXDataEntity):
 
 
 @dataclass
-class ActionClsPredEntity(ActionClsDataEntity, OTXPredEntity):
+class ActionClsPredEntity(OTXPredEntity, ActionClsDataEntity):
     """Data entity to represent the action classification model's output prediction."""
-
-
-@dataclass
-class ActionClsPredEntityWithXAI(ActionClsDataEntity, OTXPredEntityWithXAI):
-    """Data entity to represent the detection model output prediction with explanations."""
 
 
 @dataclass
@@ -92,16 +85,9 @@ class ActionClsBatchDataEntity(OTXBatchDataEntity[ActionClsDataEntity]):
 
     def pin_memory(self) -> ActionClsBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return super().pin_memory().wrap(labels=[label.pin_memory() for label in self.labels])
 
 
 @dataclass
-class ActionClsBatchPredEntity(ActionClsBatchDataEntity, OTXBatchPredEntity):
+class ActionClsBatchPredEntity(OTXBatchPredEntity, ActionClsBatchDataEntity):
     """Data entity to represent model output predictions for action classification task."""
-
-
-@dataclass
-class ActionClsBatchPredEntityWithXAI(ActionClsBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for multi-class classification task with explanations."""

--- a/src/otx/core/data/entity/action_detection.py
+++ b/src/otx/core/data/entity/action_detection.py
@@ -13,7 +13,6 @@ from torchvision import tv_tensors
 from otx.core.data.entity.base import (
     OTXBatchDataEntity,
     OTXBatchPredEntity,
-    OTXBatchPredEntityWithXAI,
     OTXDataEntity,
     OTXPredEntity,
 )
@@ -48,7 +47,7 @@ class ActionDetDataEntity(OTXDataEntity):
 
 
 @dataclass
-class ActionDetPredEntity(ActionDetDataEntity, OTXPredEntity):
+class ActionDetPredEntity(OTXPredEntity, ActionDetDataEntity):
     """Data entity to represent the action classification model's output prediction."""
 
 
@@ -89,18 +88,17 @@ class ActionDetBatchDataEntity(OTXBatchDataEntity[ActionDetDataEntity]):
 
     def pin_memory(self) -> ActionDetBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.bboxes = [tv_tensors.wrap(bbox.pin_memory(), like=bbox) for bbox in self.bboxes]
-        self.labels = [label.pin_memory() for label in self.labels]
-        self.proposals = [tv_tensors.wrap(proposal.pin_memory(), like=proposal) for proposal in self.proposals]
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                bboxes=[tv_tensors.wrap(bbox.pin_memory(), like=bbox) for bbox in self.bboxes],
+                labels=[label.pin_memory() for label in self.labels],
+                proposals=[tv_tensors.wrap(proposal.pin_memory(), like=proposal) for proposal in self.proposals],
+            )
+        )
 
 
 @dataclass
-class ActionDetBatchPredEntity(ActionDetBatchDataEntity, OTXBatchPredEntity):
+class ActionDetBatchPredEntity(OTXBatchPredEntity, ActionDetBatchDataEntity):
     """Data entity to represent model output predictions for action classification task."""
-
-
-@dataclass
-class ActionDetBatchPredEntityWithXAI(ActionDetBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for multi-class classification task with explanations."""

--- a/src/otx/core/data/entity/anomaly/classification.py
+++ b/src/otx/core/data/entity/anomaly/classification.py
@@ -63,18 +63,16 @@ class AnomalyClassificationDataBatch(OTXBatchDataEntity):
 
     def pin_memory(self) -> AnomalyClassificationDataBatch:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return super().pin_memory().wrap(labels=[label.pin_memory() for label in self.labels])
 
 
 @dataclass
-class AnomalyClassificationPrediction(AnomalyClassificationDataItem, OTXPredEntity):
+class AnomalyClassificationPrediction(OTXPredEntity, AnomalyClassificationDataItem):
     """Anomaly classification Prediction item."""
 
 
-@dataclass
-class AnomalyClassificationBatchPrediction(AnomalyClassificationDataBatch, OTXBatchPredEntity):
+@dataclass(kw_only=True)
+class AnomalyClassificationBatchPrediction(OTXBatchPredEntity, AnomalyClassificationDataBatch):
     """Anomaly classification batch prediction."""
 
     anomaly_maps: torch.Tensor

--- a/src/otx/core/data/entity/anomaly/detection.py
+++ b/src/otx/core/data/entity/anomaly/detection.py
@@ -68,20 +68,24 @@ class AnomalyDetectionDataBatch(OTXBatchDataEntity):
 
     def pin_memory(self) -> AnomalyDetectionDataBatch:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.labels = [label.pin_memory() for label in self.labels]
-        self.masks = self.masks.pin_memory()
-        self.boxes = [box.pin_memory() for box in self.boxes]
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                labels=[label.pin_memory() for label in self.labels],
+                masks=self.masks.pin_memory(),
+                boxes=[box.pin_memory() for box in self.boxes],
+            )
+        )
 
 
 @dataclass
-class AnomalyDetectionPrediction(AnomalyDetectionDataItem, OTXPredEntity):
+class AnomalyDetectionPrediction(OTXPredEntity, AnomalyDetectionDataItem):
     """Anomaly Detection Prediction item."""
 
 
-@dataclass
-class AnomalyDetectionBatchPrediction(AnomalyDetectionDataBatch, OTXBatchPredEntity):
+@dataclass(kw_only=True)
+class AnomalyDetectionBatchPrediction(OTXBatchPredEntity, AnomalyDetectionDataBatch):
     """Anomaly classification batch prediction."""
 
     anomaly_maps: torch.Tensor

--- a/src/otx/core/data/entity/anomaly/segmentation.py
+++ b/src/otx/core/data/entity/anomaly/segmentation.py
@@ -65,19 +65,23 @@ class AnomalySegmentationDataBatch(OTXBatchDataEntity):
 
     def pin_memory(self) -> AnomalySegmentationDataBatch:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.labels = [label.pin_memory() for label in self.labels]
-        self.masks = self.masks.pin_memory()
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                labels=[label.pin_memory() for label in self.labels],
+                masks=self.masks.pin_memory(),
+            )
+        )
 
 
 @dataclass
-class AnomalySegmentationPrediction(AnomalySegmentationDataItem, OTXPredEntity):
+class AnomalySegmentationPrediction(OTXPredEntity, AnomalySegmentationDataItem):
     """Anomaly Segmentation Prediction item."""
 
 
-@dataclass
-class AnomalySegmentationBatchPrediction(AnomalySegmentationDataBatch, OTXBatchPredEntity):
+@dataclass(kw_only=True)
+class AnomalySegmentationBatchPrediction(OTXBatchPredEntity, AnomalySegmentationDataBatch):
     """Anomaly classification batch prediction."""
 
     anomaly_maps: torch.Tensor

--- a/src/otx/core/data/entity/base.py
+++ b/src/otx/core/data/entity/base.py
@@ -684,7 +684,10 @@ class OTXBatchPredEntity(OTXBatchDataEntity):
     @property
     def has_xai_outputs(self) -> bool:
         """If the XAI related fields are fulfilled, return True."""
-        return len(self.saliency_maps) > 0 and len(self.feature_vectors) > 0
+        # NOTE: Don't know why but some of test cases in tests/integration/api/test_xai.py
+        # produce `len(self.saliency_maps) > 0` and `len(self.feature_vectors) == 0`
+        # return len(self.saliency_maps) > 0 and len(self.feature_vectors) > 0
+        return len(self.saliency_maps) > 0
 
 
 class OTXBatchLossEntity(Dict[str, Tensor]):

--- a/src/otx/core/data/entity/base.py
+++ b/src/otx/core/data/entity/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass, field, fields
 from typing import TYPE_CHECKING, Any, Dict, Generic, Iterator, TypeVar
 
 import torch
@@ -501,16 +501,20 @@ class OTXDataEntity(Mapping):
         return ImageType.get_image_type(self.image)
 
     def to_tv_image(self: T_OTXDataEntity) -> T_OTXDataEntity:
-        """Convert `self.image` to TorchVision Image if it is a Numpy array (inplace operation)."""
+        """Return a new instance with the `image` attribute converted to a TorchVision Image if it is a NumPy array.
+
+        Returns:
+            A new instance with the `image` attribute converted to a TorchVision Image, if applicable.
+            Otherwise, return this instance as is.
+        """
         if isinstance(self.image, tv_tensors.Image):
             return self
 
-        self.image = F.to_image(self.image)
-        return self
+        return self.wrap(image=F.to_image(self.image))
 
     def __iter__(self) -> Iterator[str]:
-        for field in fields(self):
-            yield field.name
+        for field_ in fields(self):
+            yield field_.name
 
     def __getitem__(self, key: str) -> Any:  # noqa: ANN401
         return getattr(self, key)
@@ -519,6 +523,18 @@ class OTXDataEntity(Mapping):
         """Get the number of fields in this data entity."""
         return len(fields(self))
 
+    def wrap(self: T_OTXDataEntity, **kwargs) -> T_OTXDataEntity:
+        """Wrap this dataclass with the given keyword arguments.
+
+        Args:
+            **kwargs: Keyword arguments to be overwritten on top of this dataclass
+        Returns:
+            Updated dataclass
+        """
+        updated_kwargs = asdict(self)
+        updated_kwargs.update(**kwargs)
+        return self.__class__(**updated_kwargs)
+
 
 @dataclass
 class OTXPredEntity(OTXDataEntity):
@@ -526,13 +542,8 @@ class OTXPredEntity(OTXDataEntity):
 
     score: np.ndarray | Tensor
 
-
-@dataclass
-class OTXPredEntityWithXAI(OTXPredEntity):
-    """Data entity to represent model output prediction with explanations."""
-
-    saliency_map: np.ndarray | Tensor
-    feature_vector: np.ndarray | list
+    saliency_map: np.ndarray | Tensor | None = None
+    feature_vector: np.ndarray | list | None = None
 
 
 T_OTXBatchDataEntity = TypeVar(
@@ -631,27 +642,49 @@ class OTXBatchDataEntity(Generic[T_OTXDataEntity]):
         """Pin memory for member tensor variables."""
         # TODO(vinnamki): Keep track this issue
         # https://github.com/pytorch/pytorch/issues/116403
-        self.images = (
-            [tv_tensors.wrap(image.pin_memory(), like=image) for image in self.images]
-            if isinstance(self.images, list)
-            else tv_tensors.wrap(self.images.pin_memory(), like=self.images)
+        return self.wrap(
+            images=(
+                [tv_tensors.wrap(image.pin_memory(), like=image) for image in self.images]
+                if isinstance(self.images, list)
+                else tv_tensors.wrap(self.images.pin_memory(), like=self.images)
+            ),
         )
-        return self
+
+    def wrap(self: T_OTXBatchDataEntity, **kwargs) -> T_OTXBatchDataEntity:
+        """Wrap this dataclass with the given keyword arguments.
+
+        Args:
+            **kwargs: Keyword arguments to be overwritten on top of this dataclass
+        Returns:
+            Updated dataclass
+        """
+        updated_kwargs = asdict(self)
+        updated_kwargs.update(**kwargs)
+        return self.__class__(**updated_kwargs)
 
 
 @dataclass
 class OTXBatchPredEntity(OTXBatchDataEntity):
-    """Data entity to represent model output predictions."""
+    """Data entity to represent model output predictions.
+
+    Attributes:
+        scores: List of probability scores representing model predictions.
+        saliency_maps: List of saliency maps used to explain model predictions.
+            This field is optional and will be an empty list for non-XAI pipelines.
+        feature_vectors: List of intermediate feature vectors used for model predictions.
+            This field is optional and will be an empty list for non-XAI pipelines.
+    """
 
     scores: list[np.ndarray] | list[Tensor]
 
+    # (Optional) XAI-related outputs
+    saliency_maps: list[np.ndarray] | list[Tensor] = field(default_factory=list)
+    feature_vectors: list[np.ndarray] | list[Tensor] = field(default_factory=list)
 
-@dataclass
-class OTXBatchPredEntityWithXAI(OTXBatchPredEntity):
-    """Data entity to represent model output predictions with explanations."""
-
-    saliency_maps: list[np.ndarray] | list[Tensor]
-    feature_vectors: list[np.ndarray] | list[Tensor]
+    @property
+    def has_xai_outputs(self) -> bool:
+        """If the XAI related fields are fulfilled, return True."""
+        return len(self.saliency_maps) > 0 and len(self.feature_vectors) > 0
 
 
 class OTXBatchLossEntity(Dict[str, Tensor]):
@@ -662,13 +695,6 @@ T_OTXBatchPredEntity = TypeVar(
     "T_OTXBatchPredEntity",
     bound=OTXBatchPredEntity,
 )
-
-
-T_OTXBatchPredEntityWithXAI = TypeVar(
-    "T_OTXBatchPredEntityWithXAI",
-    bound=OTXBatchPredEntityWithXAI,
-)
-
 
 T_OTXBatchLossEntity = TypeVar(
     "T_OTXBatchLossEntity",

--- a/src/otx/core/data/entity/classification.py
+++ b/src/otx/core/data/entity/classification.py
@@ -11,10 +11,8 @@ from typing import TYPE_CHECKING
 from otx.core.data.entity.base import (
     OTXBatchDataEntity,
     OTXBatchPredEntity,
-    OTXBatchPredEntityWithXAI,
     OTXDataEntity,
     OTXPredEntity,
-    OTXPredEntityWithXAI,
 )
 from otx.core.data.entity.utils import register_pytree_node
 from otx.core.types.task import OTXTaskType
@@ -40,13 +38,8 @@ class MulticlassClsDataEntity(OTXDataEntity):
 
 
 @dataclass
-class MulticlassClsPredEntity(MulticlassClsDataEntity, OTXPredEntity):
+class MulticlassClsPredEntity(OTXPredEntity, MulticlassClsDataEntity):
     """Data entity to represent the multi-class classification model output prediction."""
-
-
-@dataclass
-class MulticlassClsPredEntityWithXAI(MulticlassClsDataEntity, OTXPredEntityWithXAI):
-    """Data entity to represent the multi-class classification model output prediction with explanations."""
 
 
 @dataclass
@@ -80,19 +73,12 @@ class MulticlassClsBatchDataEntity(OTXBatchDataEntity[MulticlassClsDataEntity]):
 
     def pin_memory(self) -> MulticlassClsBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return super().pin_memory().wrap(labels=[label.pin_memory() for label in self.labels])
 
 
 @dataclass
-class MulticlassClsBatchPredEntity(MulticlassClsBatchDataEntity, OTXBatchPredEntity):
+class MulticlassClsBatchPredEntity(OTXBatchPredEntity, MulticlassClsBatchDataEntity):
     """Data entity to represent model output predictions for multi-class classification task."""
-
-
-@dataclass
-class MulticlassClsBatchPredEntityWithXAI(MulticlassClsBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for multi-class classification task with explanations."""
 
 
 @register_pytree_node
@@ -112,13 +98,8 @@ class MultilabelClsDataEntity(OTXDataEntity):
 
 
 @dataclass
-class MultilabelClsPredEntity(MultilabelClsDataEntity, OTXPredEntity):
+class MultilabelClsPredEntity(OTXPredEntity, MultilabelClsDataEntity):
     """Data entity to represent the multi-label classification model output prediction."""
-
-
-@dataclass
-class MultilabelClsPredEntityWithXAI(MultilabelClsDataEntity, OTXPredEntityWithXAI):
-    """Data entity to represent the multi-label classification model output prediction with explanations."""
 
 
 @dataclass
@@ -152,19 +133,12 @@ class MultilabelClsBatchDataEntity(OTXBatchDataEntity[MultilabelClsDataEntity]):
 
     def pin_memory(self) -> MultilabelClsBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return super().pin_memory().wrap(labels=[label.pin_memory() for label in self.labels])
 
 
 @dataclass
-class MultilabelClsBatchPredEntity(MultilabelClsBatchDataEntity, OTXBatchPredEntity):
+class MultilabelClsBatchPredEntity(OTXBatchPredEntity, MultilabelClsBatchDataEntity):
     """Data entity to represent model output predictions for multi-label classification task."""
-
-
-@dataclass
-class MultilabelClsBatchPredEntityWithXAI(MultilabelClsBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for multi-label classification task with explanations."""
 
 
 @register_pytree_node
@@ -185,13 +159,8 @@ class HlabelClsDataEntity(OTXDataEntity):
 
 
 @dataclass
-class HlabelClsPredEntity(HlabelClsDataEntity, OTXPredEntity):
+class HlabelClsPredEntity(OTXPredEntity, HlabelClsDataEntity):
     """Data entity to represent the H-label classification model output prediction."""
-
-
-@dataclass
-class HlabelClsPredEntityWithXAI(HlabelClsDataEntity, OTXPredEntityWithXAI):
-    """Data entity to represent the H-label classification model output prediction with explanation."""
 
 
 @dataclass
@@ -226,10 +195,5 @@ class HlabelClsBatchDataEntity(OTXBatchDataEntity[HlabelClsDataEntity]):
 
 
 @dataclass
-class HlabelClsBatchPredEntity(HlabelClsBatchDataEntity, OTXBatchPredEntity):
+class HlabelClsBatchPredEntity(OTXBatchPredEntity, HlabelClsBatchDataEntity):
     """Data entity to represent model output predictions for H-label classification task."""
-
-
-@dataclass
-class HlabelClsBatchPredEntityWithXAI(HlabelClsBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for H-label classification task with explanations."""

--- a/src/otx/core/data/entity/detection.py
+++ b/src/otx/core/data/entity/detection.py
@@ -13,10 +13,8 @@ from torchvision import tv_tensors
 from otx.core.data.entity.base import (
     OTXBatchDataEntity,
     OTXBatchPredEntity,
-    OTXBatchPredEntityWithXAI,
     OTXDataEntity,
     OTXPredEntity,
-    OTXPredEntityWithXAI,
 )
 from otx.core.data.entity.utils import register_pytree_node
 from otx.core.types.task import OTXTaskType
@@ -45,13 +43,8 @@ class DetDataEntity(OTXDataEntity):
 
 
 @dataclass
-class DetPredEntity(DetDataEntity, OTXPredEntity):
+class DetPredEntity(OTXPredEntity, DetDataEntity):
     """Data entity to represent the detection model output prediction."""
-
-
-@dataclass
-class DetPredEntityWithXAI(DetDataEntity, OTXPredEntityWithXAI):
-    """Data entity to represent the detection model output prediction with explanations."""
 
 
 @dataclass
@@ -98,17 +91,16 @@ class DetBatchDataEntity(OTXBatchDataEntity[DetDataEntity]):
 
     def pin_memory(self) -> DetBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.bboxes = [tv_tensors.wrap(bbox.pin_memory(), like=bbox) for bbox in self.bboxes]
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                bboxes=[tv_tensors.wrap(bbox.pin_memory(), like=bbox) for bbox in self.bboxes],
+                labels=[label.pin_memory() for label in self.labels],
+            )
+        )
 
 
 @dataclass
-class DetBatchPredEntity(DetBatchDataEntity, OTXBatchPredEntity):
+class DetBatchPredEntity(OTXBatchPredEntity, DetBatchDataEntity):
     """Data entity to represent model output predictions for detection task."""
-
-
-@dataclass
-class DetBatchPredEntityWithXAI(DetBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for detection task with explanations."""

--- a/src/otx/core/data/entity/instance_segmentation.py
+++ b/src/otx/core/data/entity/instance_segmentation.py
@@ -12,7 +12,7 @@ from torchvision import tv_tensors
 
 from otx.core.types.task import OTXTaskType
 
-from .base import OTXBatchDataEntity, OTXBatchPredEntity, OTXBatchPredEntityWithXAI, OTXDataEntity, OTXPredEntity
+from .base import OTXBatchDataEntity, OTXBatchPredEntity, OTXDataEntity, OTXPredEntity
 
 if TYPE_CHECKING:
     from datumaro import Polygon
@@ -42,13 +42,8 @@ class InstanceSegDataEntity(OTXDataEntity):
 
 
 @dataclass
-class InstanceSegPredEntity(InstanceSegDataEntity, OTXPredEntity):
+class InstanceSegPredEntity(OTXPredEntity, InstanceSegDataEntity):
     """Data entity to represent the detection model output prediction."""
-
-
-@dataclass
-class InstanceSegPredEntityWithXAI(InstanceSegDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent the detection model output prediction with explanation."""
 
 
 @dataclass
@@ -101,18 +96,17 @@ class InstanceSegBatchDataEntity(OTXBatchDataEntity[InstanceSegDataEntity]):
 
     def pin_memory(self) -> InstanceSegBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.bboxes = [tv_tensors.wrap(bbox.pin_memory(), like=bbox) for bbox in self.bboxes]
-        self.masks = [tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks]
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                bboxes=[tv_tensors.wrap(bbox.pin_memory(), like=bbox) for bbox in self.bboxes],
+                masks=[tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks],
+                labels=[label.pin_memory() for label in self.labels],
+            )
+        )
 
 
 @dataclass
-class InstanceSegBatchPredEntity(InstanceSegBatchDataEntity, OTXBatchPredEntity):
+class InstanceSegBatchPredEntity(OTXBatchPredEntity, InstanceSegBatchDataEntity):
     """Data entity to represent model output predictions for instance segmentation task."""
-
-
-@dataclass
-class InstanceSegBatchPredEntityWithXAI(InstanceSegBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for instance segmentation task with explanations."""

--- a/src/otx/core/data/entity/segmentation.py
+++ b/src/otx/core/data/entity/segmentation.py
@@ -12,10 +12,8 @@ from torchvision import tv_tensors
 from otx.core.data.entity.base import (
     OTXBatchDataEntity,
     OTXBatchPredEntity,
-    OTXBatchPredEntityWithXAI,
     OTXDataEntity,
     OTXPredEntity,
-    OTXPredEntityWithXAI,
 )
 from otx.core.data.entity.utils import register_pytree_node
 from otx.core.types.task import OTXTaskType
@@ -38,13 +36,8 @@ class SegDataEntity(OTXDataEntity):
 
 
 @dataclass
-class SegPredEntity(SegDataEntity, OTXPredEntity):
+class SegPredEntity(OTXPredEntity, SegDataEntity):
     """Data entity to represent the segmentation model output prediction."""
-
-
-@dataclass
-class SegPredEntityWithXAI(SegDataEntity, OTXPredEntityWithXAI):
-    """Data entity to represent the segmentation model output prediction with explanation."""
 
 
 @dataclass
@@ -78,16 +71,9 @@ class SegBatchDataEntity(OTXBatchDataEntity[SegDataEntity]):
 
     def pin_memory(self) -> SegBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.masks = [tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks]
-        return self
+        return super().pin_memory().wrap(masks=[tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks])
 
 
 @dataclass
-class SegBatchPredEntity(SegBatchDataEntity, OTXBatchPredEntity):
+class SegBatchPredEntity(OTXBatchPredEntity, SegBatchDataEntity):
     """Data entity to represent model output predictions for segmentation task."""
-
-
-@dataclass
-class SegBatchPredEntityWithXAI(SegBatchDataEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for segmentation task with explanations."""

--- a/src/otx/core/data/entity/visual_prompting.py
+++ b/src/otx/core/data/entity/visual_prompting.py
@@ -13,7 +13,6 @@ from torchvision import tv_tensors
 from otx.core.data.entity.base import (
     OTXBatchDataEntity,
     OTXBatchPredEntity,
-    OTXBatchPredEntityWithXAI,
     OTXDataEntity,
     OTXPredEntity,
     Points,
@@ -52,7 +51,7 @@ class VisualPromptingDataEntity(OTXDataEntity):
 
 
 @dataclass
-class VisualPromptingPredEntity(VisualPromptingDataEntity, OTXPredEntity):
+class VisualPromptingPredEntity(OTXPredEntity, VisualPromptingDataEntity):
     """Data entity to represent the visual prompting model output prediction."""
 
 
@@ -107,27 +106,28 @@ class VisualPromptingBatchDataEntity(OTXBatchDataEntity[VisualPromptingDataEntit
 
     def pin_memory(self) -> VisualPromptingBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.points = [
-            tv_tensors.wrap(point.pin_memory(), like=point) if point is not None else point for point in self.points
-        ]
-        self.bboxes = [
-            tv_tensors.wrap(bbox.pin_memory(), like=bbox) if bbox is not None else bbox for bbox in self.bboxes
-        ]
-        self.masks = [tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks]
-        self.labels = [
-            {prompt_type: values.pin_memory() for prompt_type, values in labels.items()} for labels in self.labels
-        ]
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                points=[
+                    tv_tensors.wrap(point.pin_memory(), like=point) if point is not None else point
+                    for point in self.points
+                ],
+                bboxes=[
+                    tv_tensors.wrap(bbox.pin_memory(), like=bbox) if bbox is not None else bbox for bbox in self.bboxes
+                ],
+                masks=[tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks],
+                labels=[
+                    {prompt_type: values.pin_memory() for prompt_type, values in labels.items()}
+                    for labels in self.labels
+                ],
+            )
+        )
 
 
 @dataclass
-class VisualPromptingBatchPredEntity(VisualPromptingBatchDataEntity, OTXBatchPredEntity):
-    """Data entity to represent model output predictions for visual prompting task."""
-
-
-@dataclass
-class VisualPromptingBatchPredEntityWithXAI(VisualPromptingBatchPredEntity, OTXBatchPredEntityWithXAI):
+class VisualPromptingBatchPredEntity(OTXBatchPredEntity, VisualPromptingBatchDataEntity):
     """Data entity to represent model output predictions for visual prompting task."""
 
 
@@ -202,22 +202,22 @@ class ZeroShotVisualPromptingBatchDataEntity(OTXBatchDataEntity[ZeroShotVisualPr
 
     def pin_memory(self) -> ZeroShotVisualPromptingBatchDataEntity:
         """Pin memory for member tensor variables."""
-        super().pin_memory()
-        self.prompts = [
-            [tv_tensors.wrap(prompt.pin_memory(), like=prompt) for prompt in prompts] for prompts in self.prompts
-        ]
-        self.masks = [tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks]
-        self.labels = [label.pin_memory() for label in self.labels]
-        return self
+        return (
+            super()
+            .pin_memory()
+            .wrap(
+                prompts=[
+                    [tv_tensors.wrap(prompt.pin_memory(), like=prompt) for prompt in prompts]
+                    for prompts in self.prompts
+                ],
+                masks=[tv_tensors.wrap(mask.pin_memory(), like=mask) for mask in self.masks],
+                labels=[label.pin_memory() for label in self.labels],
+            )
+        )
 
 
 @dataclass
-class ZeroShotVisualPromptingBatchPredEntity(ZeroShotVisualPromptingBatchDataEntity, OTXBatchPredEntity):
+class ZeroShotVisualPromptingBatchPredEntity(OTXBatchPredEntity, ZeroShotVisualPromptingBatchDataEntity):
     """Data entity to represent model output predictions for zero-shot visual prompting task."""
 
     prompts: list[Points]  # type: ignore[assignment]
-
-
-@dataclass
-class ZeroShotVisualPromptingBatchPredEntityWithXAI(ZeroShotVisualPromptingBatchPredEntity, OTXBatchPredEntityWithXAI):
-    """Data entity to represent model output predictions for visual prompting task."""

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -48,7 +48,8 @@ def custom_query_size(flat_inputs: list[Any]) -> tuple[int, int]:  # noqa: D103
     if not sizes:
         raise TypeError("No image, video, mask, bounding box, or point was found in the sample")  # noqa: EM101, TRY003
     elif len(sizes) > 1:  # noqa: RET506
-        raise ValueError(f"Found multiple HxW dimensions in the sample: {sequence_to_str(sorted(sizes))}")  # noqa: EM102, TRY003
+        msg = f"Found multiple HxW dimensions in the sample: {sequence_to_str(sorted(sizes))}"
+        raise ValueError(msg)
     h, w = sizes.pop()
     return h, w
 
@@ -275,10 +276,7 @@ class PackVideo(tvt_v2.Transform):
 
     def forward(self, *inputs: ActionClsDataEntity) -> ActionClsDataEntity:
         """Replace ActionClsDataEntity's image to ActionClsDataEntity's video."""
-        inputs[0].image = inputs[0].video
-        inputs[0].video = []
-
-        return inputs[0]
+        return inputs[0].wrap(image=inputs[0].video, video=[])
 
 
 tvt_v2.PerturbBoundingBoxes = PerturbBoundingBoxes

--- a/src/otx/core/model/action_classification.py
+++ b/src/otx/core/model/action_classification.py
@@ -10,11 +10,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch
 
-from otx.core.data.entity.action_classification import (
-    ActionClsBatchDataEntity,
-    ActionClsBatchPredEntity,
-    ActionClsBatchPredEntityWithXAI,
-)
+from otx.core.data.entity.action_classification import ActionClsBatchDataEntity, ActionClsBatchPredEntity
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.tile import T_OTXTileBatchDataEntity
 from otx.core.exporter.native import OTXNativeModelExporter
@@ -38,7 +34,6 @@ class OTXActionClsModel(
     OTXModel[
         ActionClsBatchDataEntity,
         ActionClsBatchPredEntity,
-        ActionClsBatchPredEntityWithXAI,
         T_OTXTileBatchDataEntity,
     ],
 ):
@@ -74,7 +69,7 @@ class OTXActionClsModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: ActionClsBatchPredEntity | ActionClsBatchPredEntityWithXAI,
+        preds: ActionClsBatchPredEntity,
         inputs: ActionClsBatchDataEntity,
     ) -> MetricInput:
         pred = torch.tensor(preds.labels)
@@ -200,7 +195,7 @@ class MMActionCompatibleModel(OTXActionClsModel):
 
 
 class OVActionClsModel(
-    OVModel[ActionClsBatchDataEntity, ActionClsBatchPredEntity, ActionClsBatchPredEntityWithXAI],
+    OVModel[ActionClsBatchDataEntity, ActionClsBatchPredEntity],
 ):
     """Action Classification model compatible for OpenVINO IR inference.
 

--- a/src/otx/core/model/action_detection.py
+++ b/src/otx/core/model/action_detection.py
@@ -9,11 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from torchvision import tv_tensors
 
-from otx.core.data.entity.action_detection import (
-    ActionDetBatchDataEntity,
-    ActionDetBatchPredEntity,
-    ActionDetBatchPredEntityWithXAI,
-)
+from otx.core.data.entity.action_detection import ActionDetBatchDataEntity, ActionDetBatchPredEntity
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.tile import T_OTXTileBatchDataEntity
 from otx.core.metrics import MetricInput
@@ -33,7 +29,6 @@ class OTXActionDetModel(
     OTXModel[
         ActionDetBatchDataEntity,
         ActionDetBatchPredEntity,
-        ActionDetBatchPredEntityWithXAI,
         T_OTXTileBatchDataEntity,
     ],
 ):
@@ -57,7 +52,7 @@ class OTXActionDetModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: ActionDetBatchPredEntity | ActionDetBatchPredEntityWithXAI,
+        preds: ActionDetBatchPredEntity,
         inputs: ActionDetBatchDataEntity,
     ) -> MetricInput:
         return {

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -17,7 +17,7 @@ from torchvision import tv_tensors
 
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
-from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity, DetBatchPredEntityWithXAI
+from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
 from otx.core.data.entity.tile import TileBatchDetDataEntity
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.metrics import MetricInput
@@ -40,9 +40,7 @@ if TYPE_CHECKING:
     from otx.core.metrics import MetricCallable
 
 
-class OTXDetectionModel(
-    OTXModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchPredEntityWithXAI, TileBatchDetDataEntity],
-):
+class OTXDetectionModel(OTXModel[DetBatchDataEntity, DetBatchPredEntity, TileBatchDetDataEntity]):
     """Base class for the detection models used in OTX."""
 
     def __init__(
@@ -62,7 +60,7 @@ class OTXDetectionModel(
         )
         self.tile_config = TileConfig()
 
-    def forward_tiles(self, inputs: TileBatchDetDataEntity) -> DetBatchPredEntity | DetBatchPredEntityWithXAI:
+    def forward_tiles(self, inputs: TileBatchDetDataEntity) -> DetBatchPredEntity:
         """Unpack detection tiles.
 
         Args:
@@ -71,7 +69,7 @@ class OTXDetectionModel(
         Returns:
             DetBatchPredEntity: Merged detection prediction.
         """
-        tile_preds: list[DetBatchPredEntity | DetBatchPredEntityWithXAI] = []
+        tile_preds: list[DetBatchPredEntity] = []
         tile_attrs: list[list[dict[str, int | str]]] = []
         merger = DetectionTileMerge(
             inputs.imgs_info,
@@ -123,7 +121,7 @@ class OTXDetectionModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: DetBatchPredEntity | DetBatchPredEntityWithXAI,
+        preds: DetBatchPredEntity,
         inputs: DetBatchDataEntity,
     ) -> MetricInput:
         return {
@@ -189,7 +187,7 @@ class ExplainableOTXDetModel(OTXDetectionModel):
     def forward_explain(
         self,
         inputs: DetBatchDataEntity,
-    ) -> DetBatchPredEntityWithXAI:
+    ) -> DetBatchPredEntity:
         """Model forward function."""
         from otx.algo.hooks.recording_forward_hook import feature_vector_fn
 
@@ -412,7 +410,7 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
         self,
         outputs: dict[str, Any],
         inputs: DetBatchDataEntity,
-    ) -> DetBatchPredEntity | DetBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> DetBatchPredEntity | OTXBatchLossEntity:
         from mmdet.structures import DetDataSample
 
         if self.training:
@@ -464,7 +462,7 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
             saliency_maps = outputs["saliency_map"].detach().cpu().numpy()
             feature_vectors = outputs["feature_vector"].detach().cpu().numpy()
 
-            return DetBatchPredEntityWithXAI(
+            return DetBatchPredEntity(
                 batch_size=len(predictions),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,
@@ -492,7 +490,7 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
         return MMdeployExporter(**self._export_parameters)
 
 
-class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchPredEntityWithXAI]):
+class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity]):
     """Object detection model compatible for OpenVINO IR inference.
 
     It can consume OpenVINO IR model path or model name from Intel OMZ repository
@@ -566,7 +564,7 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchP
         self,
         outputs: list[DetectionResult],
         inputs: DetBatchDataEntity,
-    ) -> DetBatchPredEntity | DetBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> DetBatchPredEntity | OTXBatchLossEntity:
         # add label index
         bboxes = []
         scores = []
@@ -605,7 +603,7 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchP
 
             # Squeeze dim 2D => 1D, (1, internal_dim) => (internal_dim)
             predicted_f_vectors = [out.feature_vector[0] for out in outputs]
-            return DetBatchPredEntityWithXAI(
+            return DetBatchPredEntity(
                 batch_size=len(outputs),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,
@@ -627,7 +625,7 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity, DetBatchP
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: DetBatchPredEntity | DetBatchPredEntityWithXAI,
+        preds: DetBatchPredEntity,
         inputs: DetBatchDataEntity,
     ) -> MetricInput:
         return {

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -19,14 +19,8 @@ from torchvision import tv_tensors
 
 from otx.algo.hooks.recording_forward_hook import MaskRCNNRecordingForwardHook, feature_vector_fn
 from otx.core.config.data import TileConfig
-from otx.core.data.entity.base import (
-    OTXBatchLossEntity,
-)
-from otx.core.data.entity.instance_segmentation import (
-    InstanceSegBatchDataEntity,
-    InstanceSegBatchPredEntity,
-    InstanceSegBatchPredEntityWithXAI,
-)
+from otx.core.data.entity.base import OTXBatchLossEntity
+from otx.core.data.entity.instance_segmentation import InstanceSegBatchDataEntity, InstanceSegBatchPredEntity
 from otx.core.data.entity.tile import TileBatchInstSegDataEntity
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.metrics import MetricInput
@@ -54,7 +48,6 @@ class OTXInstanceSegModel(
     OTXModel[
         InstanceSegBatchDataEntity,
         InstanceSegBatchPredEntity,
-        InstanceSegBatchPredEntityWithXAI,
         TileBatchInstSegDataEntity,
     ],
 ):
@@ -86,7 +79,7 @@ class OTXInstanceSegModel(
         Returns:
             InstanceSegBatchPredEntity: Merged instance segmentation prediction.
         """
-        tile_preds: list[InstanceSegBatchPredEntity | InstanceSegBatchPredEntityWithXAI] = []
+        tile_preds: list[InstanceSegBatchPredEntity] = []
         tile_attrs: list[list[dict[str, int | str]]] = []
         merger = InstanceSegTileMerge(
             inputs.imgs_info,
@@ -185,7 +178,7 @@ class OTXInstanceSegModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: InstanceSegBatchPredEntity | InstanceSegBatchPredEntityWithXAI,
+        preds: InstanceSegBatchPredEntity,
         inputs: InstanceSegBatchDataEntity,
     ) -> MetricInput:
         """Convert the prediction entity to the format that the metric can compute and cache the ground truth.
@@ -245,7 +238,7 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
     def forward_explain(
         self,
         inputs: InstanceSegBatchDataEntity,
-    ) -> InstanceSegBatchPredEntityWithXAI:
+    ) -> InstanceSegBatchPredEntity:
         """Model forward function."""
         self.model.feature_vector_fn = feature_vector_fn
         self.model.explain_fn = self.get_explain_fn()
@@ -454,7 +447,7 @@ class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
         self,
         outputs: dict[str, Any],
         inputs: InstanceSegBatchDataEntity,
-    ) -> InstanceSegBatchPredEntity | InstanceSegBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> InstanceSegBatchPredEntity | OTXBatchLossEntity:
         from mmdet.structures import DetDataSample
 
         if self.training:
@@ -510,7 +503,7 @@ class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
             saliency_maps = outputs["saliency_map"].detach().cpu().numpy()
             feature_vectors = outputs["feature_vector"].detach().cpu().numpy()
 
-            return InstanceSegBatchPredEntityWithXAI(
+            return InstanceSegBatchPredEntity(
                 batch_size=len(predictions),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,
@@ -543,7 +536,7 @@ class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
 
 
 class OVInstanceSegmentationModel(
-    OVModel[InstanceSegBatchDataEntity, InstanceSegBatchPredEntity, InstanceSegBatchPredEntityWithXAI],
+    OVModel[InstanceSegBatchDataEntity, InstanceSegBatchPredEntity],
 ):
     """Instance segmentation model compatible for OpenVINO IR inference.
 
@@ -618,7 +611,7 @@ class OVInstanceSegmentationModel(
         self,
         outputs: list[InstanceSegmentationResult],
         inputs: InstanceSegBatchDataEntity,
-    ) -> InstanceSegBatchPredEntity | InstanceSegBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> InstanceSegBatchPredEntity | OTXBatchLossEntity:
         # add label index
         bboxes = []
         scores = []
@@ -653,7 +646,7 @@ class OVInstanceSegmentationModel(
 
             # Squeeze dim 2D => 1D, (1, internal_dim) => (internal_dim)
             predicted_f_vectors = [out.feature_vector[0] for out in outputs]
-            return InstanceSegBatchPredEntityWithXAI(
+            return InstanceSegBatchPredEntity(
                 batch_size=len(outputs),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,
@@ -679,7 +672,7 @@ class OVInstanceSegmentationModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: InstanceSegBatchPredEntity | InstanceSegBatchPredEntityWithXAI,
+        preds: InstanceSegBatchPredEntity,
         inputs: InstanceSegBatchDataEntity,
     ) -> MetricInput:
         """Convert the prediction entity to the format that the metric can compute and cache the ground truth.

--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from torchvision import tv_tensors
 
 from otx.core.data.entity.base import OTXBatchLossEntity
-from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity, SegBatchPredEntityWithXAI
+from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity
 from otx.core.data.entity.tile import T_OTXTileBatchDataEntity
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.exporter.native import OTXNativeModelExporter
@@ -33,9 +33,7 @@ if TYPE_CHECKING:
     from otx.core.metrics import MetricCallable
 
 
-class OTXSegmentationModel(
-    OTXModel[SegBatchDataEntity, SegBatchPredEntity, SegBatchPredEntityWithXAI, T_OTXTileBatchDataEntity],
-):
+class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity, T_OTXTileBatchDataEntity]):
     """Base class for the detection models used in OTX."""
 
     def __init__(
@@ -75,7 +73,7 @@ class OTXSegmentationModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: SegBatchPredEntity | SegBatchPredEntityWithXAI,
+        preds: SegBatchPredEntity,
         inputs: SegBatchDataEntity,
     ) -> MetricInput:
         return [
@@ -157,7 +155,7 @@ class MMSegCompatibleModel(OTXSegmentationModel):
         self,
         outputs: Any,  # noqa: ANN401
         inputs: SegBatchDataEntity,
-    ) -> SegBatchPredEntity | SegBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> SegBatchPredEntity | OTXBatchLossEntity:
         from mmseg.structures import SegDataSample
 
         if self.training:
@@ -181,7 +179,7 @@ class MMSegCompatibleModel(OTXSegmentationModel):
             hook_records = self.explain_hook.records
             explain_results = copy.deepcopy(hook_records[-len(outputs) :])
 
-            return SegBatchPredEntityWithXAI(
+            return SegBatchPredEntity(
                 batch_size=len(outputs),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,
@@ -219,7 +217,7 @@ class MMSegCompatibleModel(OTXSegmentationModel):
         return OTXNativeModelExporter(**self._export_parameters)
 
 
-class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity, SegBatchPredEntityWithXAI]):
+class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity]):
     """Semantic segmentation model compatible for OpenVINO IR inference.
 
     It can consume OpenVINO IR model path or model name from Intel OMZ repository
@@ -251,11 +249,11 @@ class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity, SegBat
         self,
         outputs: list[ImageResultWithSoftPrediction],
         inputs: SegBatchDataEntity,
-    ) -> SegBatchPredEntity | SegBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> SegBatchPredEntity | OTXBatchLossEntity:
         if outputs and outputs[0].saliency_map.size != 1:
             predicted_s_maps = [out.saliency_map for out in outputs]
             predicted_f_vectors = [out.feature_vector for out in outputs]
-            return SegBatchPredEntityWithXAI(
+            return SegBatchPredEntity(
                 batch_size=len(outputs),
                 images=inputs.images,
                 imgs_info=inputs.imgs_info,
@@ -275,7 +273,7 @@ class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity, SegBat
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: SegBatchPredEntity | SegBatchPredEntityWithXAI,
+        preds: SegBatchPredEntity,
         inputs: SegBatchDataEntity,
     ) -> MetricInput:
         return [

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -25,15 +25,13 @@ import torch
 from torch import Tensor
 from torchvision import tv_tensors
 
-from otx.core.data.entity.base import OTXBatchLossEntity, Points, T_OTXBatchPredEntityWithXAI
+from otx.core.data.entity.base import OTXBatchLossEntity, Points
 from otx.core.data.entity.tile import T_OTXTileBatchDataEntity
 from otx.core.data.entity.visual_prompting import (
     VisualPromptingBatchDataEntity,
     VisualPromptingBatchPredEntity,
-    VisualPromptingBatchPredEntityWithXAI,
     ZeroShotVisualPromptingBatchDataEntity,
     ZeroShotVisualPromptingBatchPredEntity,
-    ZeroShotVisualPromptingBatchPredEntityWithXAI,
 )
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.exporter.visual_prompting import OTXVisualPromptingModelExporter
@@ -170,12 +168,7 @@ def _inference_step_for_zero_shot(
 
 
 class OTXVisualPromptingModel(
-    OTXModel[
-        VisualPromptingBatchDataEntity,
-        VisualPromptingBatchPredEntity,
-        VisualPromptingBatchPredEntityWithXAI,
-        T_OTXTileBatchDataEntity,
-    ],
+    OTXModel[VisualPromptingBatchDataEntity, VisualPromptingBatchPredEntity, T_OTXTileBatchDataEntity],
 ):
     """Base class for the visual prompting models used in OTX."""
 
@@ -269,7 +262,7 @@ class OTXVisualPromptingModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: VisualPromptingBatchPredEntity | VisualPromptingBatchPredEntityWithXAI,
+        preds: VisualPromptingBatchPredEntity,
         inputs: VisualPromptingBatchDataEntity,
     ) -> MetricInput:
         """Convert the prediction entity to the format required by the compute metric function."""
@@ -284,7 +277,6 @@ class OTXZeroShotVisualPromptingModel(
     OTXModel[
         ZeroShotVisualPromptingBatchDataEntity,
         ZeroShotVisualPromptingBatchPredEntity,
-        ZeroShotVisualPromptingBatchPredEntityWithXAI,
         T_OTXTileBatchDataEntity,
     ],
 ):
@@ -445,7 +437,7 @@ class OTXZeroShotVisualPromptingModel(
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: ZeroShotVisualPromptingBatchPredEntity | ZeroShotVisualPromptingBatchPredEntityWithXAI,
+        preds: ZeroShotVisualPromptingBatchPredEntity,
         inputs: ZeroShotVisualPromptingBatchDataEntity,
     ) -> MetricInput:
         """Convert the prediction entity to the format required by the compute metric function."""
@@ -460,7 +452,6 @@ class OVVisualPromptingModel(
     OVModel[
         VisualPromptingBatchDataEntity,
         VisualPromptingBatchPredEntity,
-        VisualPromptingBatchPredEntityWithXAI,
     ],
 ):
     """Visual prompting model compatible for OpenVINO IR inference.
@@ -596,7 +587,7 @@ class OVVisualPromptingModel(
         self,
         outputs: Any,  # noqa: ANN401
         inputs: VisualPromptingBatchDataEntity,  # type: ignore[override]
-    ) -> VisualPromptingBatchPredEntity | T_OTXBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> VisualPromptingBatchPredEntity | OTXBatchLossEntity:
         """Customize OTX output batch data entity if needed for model."""
         masks: list[tv_tensors.Mask] = []
         scores: list[torch.Tensor] = []
@@ -920,7 +911,7 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
     def forward(  # type: ignore[override]
         self,
         inputs: ZeroShotVisualPromptingBatchDataEntity,  # type: ignore[override]
-    ) -> ZeroShotVisualPromptingBatchPredEntity | T_OTXBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> ZeroShotVisualPromptingBatchPredEntity | OTXBatchLossEntity:
         """Model forward function."""
         kwargs: dict[str, Any] = {}
         fn = self.learn if self.training else self.infer
@@ -991,7 +982,7 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
         self,
         outputs: Any,  # noqa: ANN401
         inputs: ZeroShotVisualPromptingBatchDataEntity,  # type: ignore[override]
-    ) -> ZeroShotVisualPromptingBatchPredEntity | T_OTXBatchPredEntityWithXAI | OTXBatchLossEntity:
+    ) -> ZeroShotVisualPromptingBatchPredEntity | OTXBatchLossEntity:
         """Customize OTX output batch data entity if needed for model."""
         if self.training:
             return outputs
@@ -1425,7 +1416,7 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
 
     def _convert_pred_entity_to_compute_metric(
         self,
-        preds: ZeroShotVisualPromptingBatchPredEntity | ZeroShotVisualPromptingBatchPredEntityWithXAI,
+        preds: ZeroShotVisualPromptingBatchPredEntity,
         inputs: ZeroShotVisualPromptingBatchDataEntity,
     ) -> MetricInput:
         """Convert the prediction entity to the format required by the compute metric function."""

--- a/src/otx/core/utils/tile_merge.py
+++ b/src/otx/core/utils/tile_merge.py
@@ -14,12 +14,8 @@ from torchvision import tv_tensors
 from torchvision.ops import batched_nms
 
 from otx.core.data.entity.base import ImageInfo, T_OTXBatchPredEntity, T_OTXDataEntity
-from otx.core.data.entity.detection import DetBatchPredEntity, DetBatchPredEntityWithXAI, DetPredEntity
-from otx.core.data.entity.instance_segmentation import (
-    InstanceSegBatchPredEntity,
-    InstanceSegBatchPredEntityWithXAI,
-    InstanceSegPredEntity,
-)
+from otx.core.data.entity.detection import DetBatchPredEntity, DetPredEntity
+from otx.core.data.entity.instance_segmentation import InstanceSegBatchPredEntity, InstanceSegPredEntity
 
 
 class TileMerge(Generic[T_OTXDataEntity, T_OTXBatchPredEntity]):
@@ -94,7 +90,7 @@ class DetectionTileMerge(TileMerge):
 
     def merge(
         self,
-        batch_tile_preds: list[DetBatchPredEntity | DetBatchPredEntityWithXAI],
+        batch_tile_preds: list[DetBatchPredEntity],
         batch_tile_attrs: list[list[dict]],
     ) -> list[DetPredEntity]:
         """Merge batch tile predictions to a list of full-size prediction data entities.
@@ -187,7 +183,7 @@ class InstanceSegTileMerge(TileMerge):
 
     def merge(
         self,
-        batch_tile_preds: list[InstanceSegBatchPredEntity | InstanceSegBatchPredEntityWithXAI],
+        batch_tile_preds: list[InstanceSegBatchPredEntity],
         batch_tile_attrs: list[list[dict]],
     ) -> list[InstanceSegPredEntity]:
         """Merge inst-seg tile predictions to one single prediction.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,19 +17,23 @@ def fxt_seg_data_entity() -> tuple[tuple, SegDataEntity, SegBatchDataEntity]:
     fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
     fake_masks = Mask(torch.randint(low=0, high=255, size=img_size, dtype=torch.uint8))
     # define data entity
-    single_data_entity = SegDataEntity(fake_image, fake_image_info, fake_masks)
+    single_data_entity = SegDataEntity(
+        image=fake_image,
+        img_info=fake_image_info,
+        gt_seg_map=fake_masks,
+    )
     batch_data_entity = SegBatchDataEntity(
-        1,
-        [Image(data=torch.from_numpy(fake_image))],
-        [fake_image_info],
-        [fake_masks],
+        batch_size=1,
+        images=[Image(data=torch.from_numpy(fake_image))],
+        imgs_info=[fake_image_info],
+        masks=[fake_masks],
     )
     batch_pred_data_entity = SegBatchPredEntity(
-        1,
-        [Image(data=torch.from_numpy(fake_image))],
-        [fake_image_info],
-        [],
-        [fake_masks],
+        batch_size=1,
+        images=[Image(data=torch.from_numpy(fake_image))],
+        imgs_info=[fake_image_info],
+        masks=[fake_masks],
+        scores=[],
     )
 
     return single_data_entity, batch_pred_data_entity, batch_data_entity

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import openvino.runtime as ov
 import pytest
-from otx.core.data.entity.base import OTXBatchPredEntity, OTXBatchPredEntityWithXAI
+from otx.core.data.entity.base import OTXBatchPredEntity
 from otx.engine import Engine
 
 RECIPE_LIST_ALL = pytest.RECIPE_LIST
@@ -57,7 +57,8 @@ def test_forward_explain(
     assert isinstance(predict_result[0], OTXBatchPredEntity)
 
     predict_result_explain = engine.predict(explain=True)
-    assert isinstance(predict_result_explain[0], OTXBatchPredEntityWithXAI)
+    assert isinstance(predict_result_explain[0], OTXBatchPredEntity)
+    assert predict_result_explain[0].has_xai_outputs
 
     batch_size = len(predict_result[0].scores)
     for i in range(batch_size):
@@ -106,7 +107,8 @@ def test_predict_with_explain(
 
     # Predict with explain torch & process maps
     predict_result_explain_torch = engine.predict(explain=True)
-    assert isinstance(predict_result_explain_torch[0], OTXBatchPredEntityWithXAI)
+    assert isinstance(predict_result_explain_torch[0], OTXBatchPredEntity)
+    assert predict_result_explain_torch[0].has_xai_outputs
     assert predict_result_explain_torch[0].saliency_maps is not None
     assert isinstance(predict_result_explain_torch[0].saliency_maps[0], dict)
 
@@ -134,7 +136,8 @@ def test_predict_with_explain(
 
     # Predict OV model with xai & process maps
     predict_result_explain_ov = engine.predict(checkpoint=exported_model_path, explain=True)
-    assert isinstance(predict_result_explain_ov[0], OTXBatchPredEntityWithXAI)
+    assert isinstance(predict_result_explain_ov[0], OTXBatchPredEntity)
+    assert predict_result_explain_ov[0].has_xai_outputs
     assert predict_result_explain_ov[0].saliency_maps is not None
     assert isinstance(predict_result_explain_ov[0].saliency_maps[0], dict)
     assert predict_result_explain_ov[0].feature_vectors is not None

--- a/tests/unit/algo/hooks/test_saliency_map_dumping.py
+++ b/tests/unit/algo/hooks/test_saliency_map_dumping.py
@@ -8,7 +8,7 @@ import numpy as np
 from otx.algo.utils.xai_utils import dump_saliency_maps
 from otx.core.config.explain import ExplainConfig
 from otx.core.data.entity.base import ImageInfo
-from otx.core.data.entity.classification import MulticlassClsBatchPredEntityWithXAI
+from otx.core.data.entity.classification import MulticlassClsBatchPredEntity
 from otx.core.types.task import OTXTaskType
 from otx.engine.utils.auto_configurator import AutoConfigurator
 
@@ -30,7 +30,7 @@ def test_sal_map_dump(
     datamodule = auto_configurator.get_datamodule()
 
     predict_result = [
-        MulticlassClsBatchPredEntityWithXAI(
+        MulticlassClsBatchPredEntity(
             batch_size=BATCH_SIZE,
             images=None,
             imgs_info=IMGS_INFO,

--- a/tests/unit/algo/hooks/test_saliency_map_processing.py
+++ b/tests/unit/algo/hooks/test_saliency_map_processing.py
@@ -6,7 +6,7 @@ import torch
 from otx.algo.utils.xai_utils import process_saliency_maps, process_saliency_maps_in_pred_entity
 from otx.core.config.explain import ExplainConfig
 from otx.core.data.entity.base import ImageInfo
-from otx.core.data.entity.classification import MulticlassClsBatchPredEntityWithXAI, MultilabelClsBatchPredEntityWithXAI
+from otx.core.data.entity.classification import MulticlassClsBatchPredEntity, MultilabelClsBatchPredEntity
 from otx.core.types.explain import TargetExplainGroup
 
 NUM_CLASSES = 5
@@ -100,8 +100,8 @@ def test_process_image(postprocess) -> None:
         assert all(s_map_dict["map_per_image"].shape == (RAW_SIZE, RAW_SIZE) for s_map_dict in processed_saliency_maps)
 
 
-def _get_pred_result_multiclass(pred_labels) -> MulticlassClsBatchPredEntityWithXAI:
-    return MulticlassClsBatchPredEntityWithXAI(
+def _get_pred_result_multiclass(pred_labels) -> MulticlassClsBatchPredEntity:
+    return MulticlassClsBatchPredEntity(
         batch_size=BATCH_SIZE,
         images=None,
         imgs_info=IMGS_INFO,
@@ -112,8 +112,8 @@ def _get_pred_result_multiclass(pred_labels) -> MulticlassClsBatchPredEntityWith
     )
 
 
-def _get_pred_result_multilabel(pred_labels) -> MultilabelClsBatchPredEntityWithXAI:
-    return MultilabelClsBatchPredEntityWithXAI(
+def _get_pred_result_multilabel(pred_labels) -> MultilabelClsBatchPredEntity:
+    return MultilabelClsBatchPredEntity(
         batch_size=BATCH_SIZE,
         images=None,
         imgs_info=IMGS_INFO,


### PR DESCRIPTION
### Summary

- Ticket no. 135930
- This PR aims to remove `*PredEntityWithXAI` and merge the fields owned by it into `*PredEntity`.
- It is because it doubles the number of entities in the data entity codebase and makes OTXModel’s generic typing too complicated.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
