### PR TITLE
Use anomaly datamodule in CLI

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-
 from __future__ import annotations
 
 import dataclasses
@@ -348,7 +347,7 @@ class OTXCLI:
             # Instantiate the things that don't need to special handling
             self.config_init = self.parser.instantiate_classes(self.config)
             self.workspace = self.get_config_value(self.config_init, "workspace")
-            self.datamodule = self.get_config_value(self.config_init, "data")
+            self.datamodule = self._select_datamodule()  # type: ignore[no-untyped-call]
 
             # Instantiate the model and needed components
             self.model, self.optimizer, self.scheduler = self.instantiate_model(model_config=model_config)
@@ -579,3 +578,46 @@ class OTXCLI:
         else:
             msg = f"Unrecognized subcommand: {self.subcommand}"
             raise ValueError(msg)
+
+    def _select_datamodule(self):  # noqa: ANN202 # annotation is disabled as OTXDataModule is not imported
+        """Override the config with anomaly related configuration.
+
+        If the task is one of the anomaly detection tasks, the config is overridden with the anomaly related
+        configuration.
+
+        Note: (ashwinvaidya17)  This is temporary till OTX supports custom dataloader.
+
+        Returns:
+            OTXDataModule: The instantiated datamodule.
+        """
+        config = self.config[self.subcommand]
+        if config.engine.task in (
+            OTXTaskType.ANOMALY_CLASSIFICATION,
+            OTXTaskType.ANOMALY_DETECTION,
+            OTXTaskType.ANOMALY_SEGMENTATION,
+        ):
+            from otx.data.anomaly import AnomalyDataModule
+
+            datamodule = AnomalyDataModule(
+                task_type=config.engine.task,
+                data_dir=config.engine.data_root,
+                data_format="mvtec",
+                train_batch_size=config.data.config.train_subset.batch_size,
+                train_num_workers=config.data.config.train_subset.num_workers,
+                train_transforms=config.data.config.train_subset.transforms,
+                train_transform_lib_type=config.data.config.train_subset.transform_lib_type,
+                val_batch_size=config.data.config.val_subset.batch_size,
+                val_num_workers=config.data.config.val_subset.num_workers,
+                val_transforms=config.data.config.val_subset.transforms,
+                val_transform_lib_type=config.data.config.val_subset.transform_lib_type,
+                test_batch_size=config.data.config.test_subset.batch_size,
+                test_num_workers=config.data.config.test_subset.num_workers,
+                test_transforms=config.data.config.test_subset.transforms,
+                test_transform_lib_type=config.data.config.test_subset.transform_lib_type,
+                enable_tiler=config.data.config.tile_config.enable_tiler,
+                tile_size=config.data.config.tile_config.tile_size,
+                overlap=config.data.config.tile_config.overlap,
+            )
+        else:
+            datamodule = self.get_config_value(self.config_init, "data")
+        return datamodule

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -618,6 +618,8 @@ class OTXCLI:
                 tile_size=config.data.config.tile_config.tile_size,
                 overlap=config.data.config.tile_config.overlap,
             )
+            # update data in ``self.config_init``
+            self.config_init[self.subcommand].data = datamodule
         else:
             datamodule = self.get_config_value(self.config_init, "data")
         return datamodule

--- a/src/otx/recipe/anomaly_classification/draem.yaml
+++ b/src/otx/recipe/anomaly_classification/draem.yaml
@@ -34,7 +34,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -50,7 +50,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -66,7 +66,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_classification/draem.yaml
+++ b/src/otx/recipe/anomaly_classification/draem.yaml
@@ -10,16 +10,17 @@ engine:
   task: ANOMALY_CLASSIFICATION
   device: auto
 
-callback_monitor: train_loss_epoch # val loss is not available as there is no validation set from default dataloader
+callback_monitor: image_AUROC
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 700
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
+  num_sanity_val_steps: 0
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
         patience: 5
+        mode: max
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
@@ -31,11 +32,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -48,11 +48,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -65,11 +64,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_classification/padim.yaml
+++ b/src/otx/recipe/anomaly_classification/padim.yaml
@@ -28,7 +28,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -44,7 +44,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -60,7 +60,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_classification/padim.yaml
+++ b/src/otx/recipe/anomaly_classification/padim.yaml
@@ -10,33 +10,26 @@ engine:
   task: ANOMALY_CLASSIFICATION
   device: auto
 
-callback_monitor: step # this has no effect as Padim does not need to be trained
+callback_monitor: image_AUROC # this has no effect as Padim does not need to be trained
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   precision: 32
   max_epochs: 1
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
-  callbacks:
-    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
-      init_args:
-        max_interval: 1
+  val_check_interval: 1.0
+  num_sanity_val_steps: 0
   data:
     task: ANOMALY_CLASSIFICATION
     config:
       data_format: mvtec
-      vpm_config:
-        use_bbox: True
-        use_point: False
       train_subset:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -49,11 +42,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -66,11 +58,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_classification/stfpm.yaml
+++ b/src/otx/recipe/anomaly_classification/stfpm.yaml
@@ -16,16 +16,17 @@ engine:
   task: ANOMALY_CLASSIFICATION
   device: auto
 
-callback_monitor: train_loss_epoch # val loss is not available as there is no validation set from default dataloader
+callback_monitor: image_AUROC
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 100
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
+  num_sanity_val_steps: 0
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
         patience: 5
+        mode: max
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
@@ -37,11 +38,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -54,11 +54,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -71,11 +70,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_classification/stfpm.yaml
+++ b/src/otx/recipe/anomaly_classification/stfpm.yaml
@@ -40,7 +40,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -56,7 +56,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -72,7 +72,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_detection/draem.yaml
+++ b/src/otx/recipe/anomaly_detection/draem.yaml
@@ -34,7 +34,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -50,7 +50,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -66,7 +66,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_detection/draem.yaml
+++ b/src/otx/recipe/anomaly_detection/draem.yaml
@@ -10,16 +10,17 @@ engine:
   task: ANOMALY_DETECTION
   device: auto
 
-callback_monitor: train_loss_epoch # val loss is not available as there is no validation set from default dataloader
+callback_monitor: pixel_AUROC
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 700
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
+  num_sanity_val_steps: 0
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
         patience: 5
+        mode: max
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
@@ -31,11 +32,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -48,11 +48,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -65,11 +64,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_detection/padim.yaml
+++ b/src/otx/recipe/anomaly_detection/padim.yaml
@@ -28,7 +28,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -44,7 +44,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -60,7 +60,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_detection/padim.yaml
+++ b/src/otx/recipe/anomaly_detection/padim.yaml
@@ -10,33 +10,26 @@ engine:
   task: ANOMALY_DETECTION
   device: auto
 
-callback_monitor: step # this has no effect as Padim does not need to be trained
+callback_monitor: pixel_AUROC # this has no effect as Padim does not need to be trained
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   precision: 32
   max_epochs: 1
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
-  callbacks:
-    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
-      init_args:
-        max_interval: 1
+  val_check_interval: 1.0
+  num_sanity_val_steps: 0
   data:
     task: ANOMALY_DETECTION
     config:
       data_format: mvtec
-      vpm_config:
-        use_bbox: True
-        use_point: False
       train_subset:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -49,11 +42,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -66,11 +58,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_detection/stfpm.yaml
+++ b/src/otx/recipe/anomaly_detection/stfpm.yaml
@@ -40,7 +40,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -56,7 +56,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -72,7 +72,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_detection/stfpm.yaml
+++ b/src/otx/recipe/anomaly_detection/stfpm.yaml
@@ -16,16 +16,17 @@ engine:
   task: ANOMALY_DETECTION
   device: auto
 
-callback_monitor: train_loss_epoch # val loss is not available as there is no validation set from default dataloader
+callback_monitor: pixel_AUROC
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 100
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
+  num_sanity_val_steps: 0
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
         patience: 5
+        mode: max
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
@@ -37,11 +38,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -54,11 +54,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -71,11 +70,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_segmentation/draem.yaml
+++ b/src/otx/recipe/anomaly_segmentation/draem.yaml
@@ -34,7 +34,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -50,7 +50,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -66,7 +66,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_segmentation/draem.yaml
+++ b/src/otx/recipe/anomaly_segmentation/draem.yaml
@@ -10,16 +10,17 @@ engine:
   task: ANOMALY_SEGMENTATION
   device: auto
 
-callback_monitor: train_loss_epoch # val loss is not available as there is no validation set from default dataloader
+callback_monitor: pixel_AUROC
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 700
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
+  num_sanity_val_steps: 0
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
         patience: 5
+        mode: max
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
@@ -31,11 +32,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -48,11 +48,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -65,11 +64,10 @@ overrides:
         batch_size: 8
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_segmentation/padim.yaml
+++ b/src/otx/recipe/anomaly_segmentation/padim.yaml
@@ -28,7 +28,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -44,7 +44,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -60,7 +60,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/src/otx/recipe/anomaly_segmentation/padim.yaml
+++ b/src/otx/recipe/anomaly_segmentation/padim.yaml
@@ -10,33 +10,26 @@ engine:
   task: ANOMALY_SEGMENTATION
   device: auto
 
-callback_monitor: step # this has no effect as Padim does not need to be trained
+callback_monitor: pixel_AUROC # this has no effect as Padim does not need to be trained
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   precision: 32
   max_epochs: 1
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
-  callbacks:
-    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
-      init_args:
-        max_interval: 1
+  val_check_interval: 1.0
+  num_sanity_val_steps: 0
   data:
     task: ANOMALY_SEGMENTATION
     config:
       data_format: mvtec
-      vpm_config:
-        use_bbox: True
-        use_point: False
       train_subset:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -49,11 +42,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -66,11 +58,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_segmentation/stfpm.yaml
+++ b/src/otx/recipe/anomaly_segmentation/stfpm.yaml
@@ -16,16 +16,18 @@ engine:
   task: ANOMALY_SEGMENTATION
   device: auto
 
-callback_monitor: train_loss_epoch # val loss is not available as there is no validation set from default dataloader
+callback_monitor: pixel_AUROC
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
   max_epochs: 100
-  limit_val_batches: 0 # this is set to 0 as the default dataloader does not have validation set. But this also means that the model will not give correct performance numbers
+
+  num_sanity_val_steps: 0
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
         patience: 5
+        mode: max
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
@@ -37,11 +39,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -54,11 +55,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}
@@ -71,11 +71,10 @@ overrides:
         batch_size: 32
         num_workers: 4
         transforms:
-          - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+          - class_path: torchvision.transforms.v2.Resize
             init_args:
               size: 256
               antialias: True
-          - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
               dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/anomaly_segmentation/stfpm.yaml
+++ b/src/otx/recipe/anomaly_segmentation/stfpm.yaml
@@ -41,7 +41,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -57,7 +57,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:
@@ -73,7 +73,7 @@ overrides:
         transforms:
           - class_path: torchvision.transforms.v2.Resize
             init_args:
-              size: 256
+              size: [256, 256]
               antialias: True
           - class_path: torchvision.transforms.v2.ToDtype
             init_args:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 from mmengine.config import Config as MMConfig
+
 from otx.core.types.task import OTXTaskType
 
 
@@ -157,7 +158,7 @@ def fxt_cli_override_command_per_task() -> dict:
         ],
         "visual_prompting": [],
         "zero_shot_visual_prompting": [],
-        "anomaly_classification": ["--limit_val_batches", "0"],
-        "anomaly_detection": ["--limit_val_batches", "0"],
-        "anomaly_segmentation": ["--limit_val_batches", "0"],
+        "anomaly_classification": [],
+        "anomaly_detection": [],
+        "anomaly_segmentation": [],
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 from mmengine.config import Config as MMConfig
-
 from otx.core.types.task import OTXTaskType
 
 


### PR DESCRIPTION
### Summary

Addresses: https://github.com/openvinotoolkit/training_extensions/issues/3219

```bash
otx train --config src/otx/recipe/anomaly_classification/padim.yaml --data_root ~/datasets/MVTec/bottle --work_dir otx-workspace
otx test --config src/otx/recipe/anomaly_classification/padim.yaml --data_root ~/datasets/MVTec/bottle --work_dir otx-workspace 
```

### Padim
<img width="491" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/17232914/9308aa8b-4ae7-4b9e-8b82-eb47fbf31613">

### Stfpm
<img width="495" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/17232914/d9b5d46d-08d7-4077-aba6-90f6f8916871">

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
