### PR TITLE
Fix reference info path for zero-shot learning

### DIFF
--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import logging as log
-import os
+import pickle
 from collections import defaultdict
 from copy import deepcopy
 from itertools import product
@@ -263,9 +263,9 @@ class ZeroShotSegmentAnything(SegmentAnything):
                 for input_prompt in input_prompts:
                     if isinstance(input_prompt, Mask):
                         # directly use annotation information as a mask
-                        ref_mask[
-                            input_prompt == 1
-                        ] += 1  # TODO (sungchul): check if the mask is bool or int # noqa: TD003
+                        ref_mask[input_prompt == 1] += (
+                            1  # TODO (sungchul): check if the mask is bool or int # noqa: TD003
+                        )
                     else:
                         if isinstance(input_prompt, BoundingBoxes):
                             point_coords = input_prompt.reshape(-1, 2, 2)
@@ -604,7 +604,8 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
         self,
         backbone: Literal["tiny_vit", "vit_b"],
         num_classes: int = 0,
-        root_reference_info: Path | str = "vpm_zsl_reference_infos",
+        reference_info_dir: Path | str = "reference_infos",
+        infer_reference_info_root: Path | str = "../.latest/train",
         save_outputs: bool = True,
         pixel_mean: list[float] | None = [123.675, 116.28, 103.53],  # noqa: B006
         pixel_std: list[float] | None = [58.395, 57.12, 57.375],  # noqa: B006
@@ -634,7 +635,8 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
         super().__init__(num_classes=num_classes)
 
         self.save_outputs = save_outputs
-        self.root_reference_info: Path = Path(root_reference_info)
+        self.reference_info_dir: Path = Path(reference_info_dir)
+        self.infer_reference_info_root: Path = Path(infer_reference_info_root)
 
         self.register_buffer("pixel_mean", Tensor(pixel_mean).view(-1, 1, 1), False)
         self.register_buffer("pixel_std", Tensor(pixel_std).view(-1, 1, 1), False)
@@ -841,29 +843,52 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
         self.register_buffer("reference_feats", torch.zeros(0, 1, self.model.embed_dim), False)
         self.register_buffer("used_indices", torch.tensor([], dtype=torch.int64), False)
 
-    def _find_latest_reference_info(self, root: Path) -> str | None:
-        """Find latest reference info to be used."""
-        if not Path.is_dir(root):
-            return None
-        if len(stamps := sorted(os.listdir(root), reverse=True)) > 0:
-            return stamps[0]
-        return None
+    def save_reference_info(self, default_root_dir: Path | str) -> None:
+        """Save reference info."""
+        reference_info = {
+            "reference_feats": self.reference_feats,
+            "used_indices": self.used_indices,
+        }
+        # save reference info
+        path_reference_info: Path = Path(default_root_dir) / self.reference_info_dir / "reference_info.pt"
+        Path.mkdir(Path(path_reference_info).parent, parents=True, exist_ok=True)
+        if isinstance(self, OTXVisualPromptingModel):
+            torch.save(reference_info, path_reference_info)
+            pickle.dump(
+                {k: v.numpy() for k, v in reference_info.items()},
+                Path.open(Path(str(path_reference_info).replace(".pt", ".pickle")), "wb"),
+            )
+        else:
+            torch.save({k: torch.as_tensor(v) for k, v in reference_info.items()}, path_reference_info)
+            pickle.dump(reference_info, Path.open(Path(str(path_reference_info).replace(".pt", ".pickle")), "wb"))
+        log.info(f"Saved reference info at {path_reference_info}.")
 
-    def load_latest_reference_info(self, device: str | torch.device = "cpu") -> bool:
+    def load_latest_reference_info(self, default_root_dir: Path | str, device: str | torch.device = "cpu") -> bool:
         """Load latest reference info to be used."""
-        if (latest_stamp := self._find_latest_reference_info(self.root_reference_info)) is not None:
-            latest_reference_info = self.root_reference_info / latest_stamp / "reference_info.pt"
-            reference_info = torch.load(latest_reference_info)
-            self.register_buffer(
-                "reference_feats",
-                reference_info.get("reference_feats", torch.zeros(0, 1, self.model.embed_dim)).to(device),
-                False,
-            )
-            self.register_buffer(
-                "used_indices",
-                reference_info.get("used_indices", torch.tensor([], dtype=torch.int64)).to(device),
-                False,
-            )
-            log.info(f"reference info saved at {latest_reference_info} was successfully loaded.")
-            return True
-        return False
+        _infer_reference_info_root = (
+            self.infer_reference_info_root
+            if self.infer_reference_info_root == self.infer_reference_info_root.absolute()
+            else Path(default_root_dir) / self.infer_reference_info_root
+        )
+
+        if Path.is_file(
+            path_reference_info := _infer_reference_info_root / self.reference_info_dir / "reference_info.pt",
+        ):
+            reference_info = torch.load(path_reference_info)
+            retval = True
+            log.info(f"reference info saved at {path_reference_info} was successfully loaded.")
+        else:
+            reference_info = {}
+            retval = False
+
+        self.register_buffer(
+            "reference_feats",
+            reference_info.get("reference_feats", torch.zeros(0, 1, self.model.embed_dim)).to(device),
+            False,
+        )
+        self.register_buffer(
+            "used_indices",
+            reference_info.get("used_indices", torch.tensor([], dtype=torch.int64)).to(device),
+            False,
+        )
+        return retval

--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -863,7 +863,7 @@ class OTXZeroShotSegmentAnything(OTXVisualPromptingModel):
             pickle.dump(reference_info, Path.open(Path(str(path_reference_info).replace(".pt", ".pickle")), "wb"))
         log.info(f"Saved reference info at {path_reference_info}.")
 
-    def load_latest_reference_info(self, default_root_dir: Path | str, device: str | torch.device = "cpu") -> bool:
+    def load_reference_info(self, default_root_dir: Path | str, device: str | torch.device = "cpu") -> bool:
         """Load latest reference info to be used."""
         _infer_reference_info_root = (
             self.infer_reference_info_root

--- a/src/otx/core/model/entity/visual_prompting.py
+++ b/src/otx/core/model/entity/visual_prompting.py
@@ -798,7 +798,7 @@ class OVZeroShotVisualPromptingModel(OVVisualPromptingModel):
     ######################################
     #               Infer                #
     ######################################
-    def load_latest_reference_info(self, default_root_dir: Path | str, *args, **kwargs) -> bool:
+    def load_reference_info(self, default_root_dir: Path | str, *args, **kwargs) -> bool:
         """Load latest reference info to be used."""
         _infer_reference_info_root = (
             self.infer_reference_info_root

--- a/src/otx/core/model/module/visual_prompting.py
+++ b/src/otx/core/model/module/visual_prompting.py
@@ -263,7 +263,7 @@ class OTXZeroShotVisualPromptingLitModule(OTXVisualPromptingLitModule):
     def on_test_start(self) -> None:
         """Load previously saved reference info."""
         super().on_test_start()
-        if not self.model.load_latest_reference_info(self.trainer.default_root_dir, self.device):
+        if not self.model.load_reference_info(self.trainer.default_root_dir, self.device):
             log.warning("No reference info found. `Learn` will be automatically executed first.")
             self.trainer.lightning_module.automatic_optimization = False
             self.trainer.fit_loop.run()
@@ -273,11 +273,11 @@ class OTXZeroShotVisualPromptingLitModule(OTXVisualPromptingLitModule):
             # to set _combined_loader
             self.trainer._evaluation_loop.setup_data()  # noqa: SLF001
             self.trainer._evaluation_loop.reset()  # noqa: SLF001
-            self.model.load_latest_reference_info(self.trainer.default_root_dir, self.device)
+            self.model.load_reference_info(self.trainer.default_root_dir, self.device)
 
     def on_predict_start(self) -> None:
         """Load previously saved reference info."""
-        if not self.model.load_latest_reference_info(self.trainer.default_root_dir, self.device):
+        if not self.model.load_reference_info(self.trainer.default_root_dir, self.device):
             log.warning("No reference info found. `Learn` will be automatically executed first.")
             self.trainer.lightning_module.automatic_optimization = False
             self.trainer.fit_loop.run()
@@ -287,7 +287,7 @@ class OTXZeroShotVisualPromptingLitModule(OTXVisualPromptingLitModule):
             # to set _combined_loader
             self.trainer._evaluation_loop.setup_data()  # noqa: SLF001
             self.trainer._evaluation_loop.reset()  # noqa: SLF001
-            self.model.load_latest_reference_info(self.trainer.default_root_dir, self.device)
+            self.model.load_reference_info(self.trainer.default_root_dir, self.device)
 
     def on_train_epoch_start(self) -> None:
         """Skip on_train_epoch_start unused in zero-shot visual prompting."""

--- a/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
@@ -6,7 +6,8 @@ model:
     model_type: Zero_Shot_Visual_Prompting
     async_inference: False
     use_throughput_mode: True
-    root_reference_info: vpm_zsl_reference_infos
+    reference_info_dir: reference_infos
+    infer_reference_info_root: ../.latest/train # set absolute path for using reference_info saved in other location
     save_outputs: True
 
 engine:

--- a/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml
@@ -9,7 +9,8 @@ model:
     default_threshold_reference: 0.3
     default_threshold_target: 0.65
     save_outputs: True
-    root_reference_info: vpm_zsl_reference_infos
+    reference_info_dir: reference_infos
+    infer_reference_info_root: ../.latest/train # set absolute path for using reference_info saved in other location
     # options
     use_stability_score: False
     return_single_mask: False

--- a/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml
@@ -9,7 +9,8 @@ model:
     default_threshold_reference: 0.3
     default_threshold_target: 0.65
     save_outputs: True
-    root_reference_info: vpm_zsl_reference_infos
+    reference_info_dir: reference_infos
+    infer_reference_info_root: ../.latest/train # set absolute path for using reference_info saved in other location
     # options
     use_stability_score: False
     return_single_mask: False

--- a/tests/integration/api/test_auto_configuration.py
+++ b/tests/integration/api/test_auto_configuration.py
@@ -43,6 +43,8 @@ def test_auto_configuration(
         work_dir=tmp_path_train,
         device=fxt_accelerator,
     )
+    if task.lower() == "zero_shot_visual_prompting":
+        engine.model.infer_reference_info_root = Path()
 
     # Check OTXModel & OTXDataModule
     assert isinstance(engine.model, OTXModel)

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -45,6 +45,8 @@ def test_engine_from_config(
         work_dir=tmp_path_train,
         device=fxt_accelerator,
     )
+    if task.lower() == "zero_shot_visual_prompting":
+        engine.model.infer_reference_info_root = Path()
 
     # Check OTXModel & OTXDataModule
     assert isinstance(engine.model, OTXModel)
@@ -87,6 +89,11 @@ def test_engine_from_config(
     # Test with IR Model
     if task in OVMODEL_PER_TASK:
         if task.lower() in ["visual_prompting", "zero_shot_visual_prompting"]:
+            engine.model = engine._auto_configurator.get_ov_model(
+                model_name=str(exported_model_path["decoder"]),
+                label_info=engine.datamodule.label_info,
+            )
+            engine.model.infer_reference_info_root = Path()
             test_metric_from_ov_model = engine.test(checkpoint=exported_model_path["decoder"], accelerator="cpu")
         else:
             test_metric_from_ov_model = engine.test(checkpoint=exported_model_path, accelerator="cpu")

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -99,6 +99,15 @@ def test_otx_e2e(
         "--checkpoint",
         str(ckpt_files[-1]),
     ]
+    # Zero-shot visual prompting needs to specify `infer_reference_info_root`
+    if task in ["zero_shot_visual_prompting"]:
+        idx_task = str(ckpt_files[-1]).split("/").index(f"otx_train_{model_name}")
+        command_cfg.extend(
+            [
+                "--model.init_args.infer_reference_info_root",
+                str(ckpt_files[-1].parents[-idx_task] / f"otx_train_{model_name}/outputs/.latest/train"),
+            ],
+        )
 
     run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 
@@ -174,7 +183,11 @@ def test_otx_e2e(
         (p for p in ov_output_dir.iterdir() if p.is_dir() and p.name != ".latest"),
         key=lambda p: p.stat().st_mtime,
     )
-    exported_model_path = str(ov_latest_dir / "exported_model.xml")
+    if task in ("visual_prompting", "zero_shot_visual_prompting"):
+        exported_model_path = str(ov_latest_dir / "exported_model_decoder.xml")
+        recipe = str(Path(recipe).parents[0] / "openvino_model.yaml")
+    else:
+        exported_model_path = str(ov_latest_dir / "exported_model.xml")
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:
@@ -195,6 +208,15 @@ def test_otx_e2e(
         "--checkpoint",
         exported_model_path,
     ]
+    # Zero-shot visual prompting needs to specify `infer_reference_info_root`
+    if task in ["zero_shot_visual_prompting"]:
+        idx_task = str(ckpt_files[-1]).split("/").index(f"otx_train_{model_name}")
+        command_cfg.extend(
+            [
+                "--model.init_args.infer_reference_info_root",
+                str(ckpt_files[-1].parents[-idx_task] / f"otx_train_{model_name}/outputs/.latest/train"),
+            ],
+        )
 
     run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 

--- a/tests/integration/cli/test_export_inference.py
+++ b/tests/integration/cli/test_export_inference.py
@@ -151,6 +151,21 @@ def test_otx_export_infer(
         if task in ("h_label_cls") and not test_recipe.endswith("openvino_model.yaml"):
             command_cfg.extend(["--metric.num_multiclass_heads", "2"])
             command_cfg.extend(["--metric.num_multilabel_classes", "3"])
+
+        # Zero-shot visual prompting needs to specify `infer_reference_info_root`
+        if task in ["zero_shot_visual_prompting"]:
+            try:
+                idx_task = checkpoint_path.split("/").index(f"otx_train_{model_name}")
+            except ValueError:
+                idx_task = checkpoint_path.split("/").index(f"otx_test_{model_name}")
+
+            command_cfg.extend(
+                [
+                    "--model.init_args.infer_reference_info_root",
+                    str(Path(checkpoint_path).parents[-idx_task] / f"otx_train_{model_name}/outputs/.latest/train"),
+                ],
+            )
+
         run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 
         return tmp_path_test

--- a/tests/unit/algo/visual_prompting/test_zero_shot_segment_anything.py
+++ b/tests/unit/algo/visual_prompting/test_zero_shot_segment_anything.py
@@ -710,8 +710,8 @@ class TestOTXZeroShotSegmentAnything:
         mocker_torch_save.assert_called_once()
         mocker_pickle_dump.assert_called_once()
 
-    def test_load_latest_reference_info(self, mocker, model) -> None:
-        """Test load_latest_reference_info."""
+    def test_load_reference_info(self, mocker, model) -> None:
+        """Test load_reference_info."""
         # get previously saved reference info
         mocker.patch(
             "otx.algo.visual_prompting.zero_shot_segment_anything.torch.load",
@@ -719,7 +719,7 @@ class TestOTXZeroShotSegmentAnything:
         )
         mocker.patch("pathlib.Path.is_file", return_value=True)
 
-        model.load_latest_reference_info(".")
+        model.load_reference_info(".")
         assert model.reference_feats.shape == (1, 1, 256)
         assert model.used_indices.shape == (1,)
 
@@ -727,7 +727,7 @@ class TestOTXZeroShotSegmentAnything:
         mocker.patch("pathlib.Path.is_file", return_value=False)
 
         model.initialize_reference_info()
-        model.load_latest_reference_info(".")
+        model.load_reference_info(".")
 
         assert model.reference_feats.shape == (0, 1, 256)
         assert model.used_indices.shape == (0,)

--- a/tests/unit/algo/visual_prompting/test_zero_shot_segment_anything.py
+++ b/tests/unit/algo/visual_prompting/test_zero_shot_segment_anything.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Callable
 
 import pytest
@@ -695,54 +694,40 @@ class TestOTXZeroShotSegmentAnything:
         assert model.reference_feats.shape == (0, 1, 256)
         assert model.used_indices.shape == (0,)
 
-    def test_find_latest_reference_info(self, mocker, model) -> None:
-        """Test _find_latest_reference_info."""
-        mocker.patch(
-            "otx.algo.visual_prompting.zero_shot_segment_anything.os.path.isdir",
-            return_value=True,
-        )
+    def test_save_reference_info(self, mocker, tmpdir, model) -> None:
+        """Test save_reference_info."""
+        model.root_reference_info = tmpdir
+        model.reference_feats = torch.tensor(1)
+        model.used_indices = torch.tensor(1)
+        mocker_mkdir = mocker.patch("pathlib.Path.mkdir")
+        mocker.patch("pathlib.Path.open")
+        mocker_torch_save = mocker.patch("torch.save")
+        mocker_pickle_dump = mocker.patch("pickle.dump")
 
-        # there are some saved reference info
-        mocker.patch(
-            "otx.algo.visual_prompting.zero_shot_segment_anything.os.listdir",
-            return_value=["1", "2"],
-        )
-        results = model._find_latest_reference_info(Path())
-        assert results == "2"
+        model.save_reference_info(".")
 
-        # there are no saved reference info
-        mocker.patch(
-            "otx.algo.visual_prompting.zero_shot_segment_anything.os.listdir",
-            return_value=[],
-        )
-        results = model._find_latest_reference_info(Path())
-        assert results is None
+        mocker_mkdir.assert_called_once()
+        mocker_torch_save.assert_called_once()
+        mocker_pickle_dump.assert_called_once()
 
     def test_load_latest_reference_info(self, mocker, model) -> None:
         """Test load_latest_reference_info."""
         # get previously saved reference info
         mocker.patch(
-            "otx.algo.visual_prompting.zero_shot_segment_anything.OTXZeroShotSegmentAnything._find_latest_reference_info",
-            return_value="1",
-        )
-        mocker.patch(
             "otx.algo.visual_prompting.zero_shot_segment_anything.torch.load",
             return_value={"reference_feats": torch.zeros((1, 1, 256)), "used_indices": torch.tensor([0.0])},
         )
-        mocker.patch("builtins.open", return_value="Mocked data")
+        mocker.patch("pathlib.Path.is_file", return_value=True)
 
-        model.load_latest_reference_info()
+        model.load_latest_reference_info(".")
         assert model.reference_feats.shape == (1, 1, 256)
         assert model.used_indices.shape == (1,)
 
         # no saved reference info
-        mocker.patch(
-            "otx.algo.visual_prompting.zero_shot_segment_anything.OTXZeroShotSegmentAnything._find_latest_reference_info",
-            return_value=None,
-        )
+        mocker.patch("pathlib.Path.is_file", return_value=False)
 
         model.initialize_reference_info()
-        model.load_latest_reference_info()
+        model.load_latest_reference_info(".")
 
         assert model.reference_feats.shape == (0, 1, 256)
         assert model.used_indices.shape == (0,)

--- a/tests/unit/core/model/entity/test_visual_prompting.py
+++ b/tests/unit/core/model/entity/test_visual_prompting.py
@@ -432,8 +432,8 @@ class TestOVZeroShotVisualPromptingModel:
         assert result[8:, :8].sum() == 0
         assert result[8:, 8:].sum() == 0
 
-    def test_load_latest_reference_info(self, mocker, ov_zero_shot_visual_prompting_model) -> None:
-        """Test load_latest_reference_info."""
+    def test_load_reference_info(self, mocker, ov_zero_shot_visual_prompting_model) -> None:
+        """Test load_reference_info."""
         ov_zero_shot_visual_prompting_model.model["decoder"].embed_dim = 256
 
         # get previously saved reference info
@@ -444,7 +444,7 @@ class TestOVZeroShotVisualPromptingModel:
         mocker.patch("pathlib.Path.is_file", return_value=True)
         mocker.patch("pathlib.Path.open", return_value="Mocked data")
 
-        ov_zero_shot_visual_prompting_model.load_latest_reference_info(".")
+        ov_zero_shot_visual_prompting_model.load_reference_info(".")
         assert ov_zero_shot_visual_prompting_model.reference_feats.shape == (1, 1, 256)
         assert ov_zero_shot_visual_prompting_model.used_indices.shape == (1,)
 
@@ -453,7 +453,7 @@ class TestOVZeroShotVisualPromptingModel:
 
         ov_zero_shot_visual_prompting_model.reference_feats = np.zeros((0, 1, 256), dtype=np.float32)
         ov_zero_shot_visual_prompting_model.used_indices = np.array([], dtype=np.int64)
-        ov_zero_shot_visual_prompting_model.load_latest_reference_info(".")
+        ov_zero_shot_visual_prompting_model.load_reference_info(".")
 
         assert ov_zero_shot_visual_prompting_model.reference_feats.shape == (0, 1, 256)
         assert ov_zero_shot_visual_prompting_model.used_indices.shape == (0,)

--- a/tests/unit/core/model/entity/test_visual_prompting.py
+++ b/tests/unit/core/model/entity/test_visual_prompting.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import Mock
 
 import numpy as np
@@ -433,51 +432,28 @@ class TestOVZeroShotVisualPromptingModel:
         assert result[8:, :8].sum() == 0
         assert result[8:, 8:].sum() == 0
 
-    def test_find_latest_reference_info(self, mocker, ov_zero_shot_visual_prompting_model) -> None:
-        """Test _find_latest_reference_info."""
-        mocker.patch(
-            "otx.core.model.entity.visual_prompting.os.path.isdir",
-            return_value=True,
-        )
-
-        # there are some saved reference info
-        mocker.patch(
-            "otx.core.model.entity.visual_prompting.os.listdir",
-            return_value=["1", "2"],
-        )
-        results = ov_zero_shot_visual_prompting_model._find_latest_reference_info(Path())
-        assert results == "2"
-
-        # there are no saved reference info
-        mocker.patch(
-            "otx.core.model.entity.visual_prompting.os.listdir",
-            return_value=[],
-        )
-        results = ov_zero_shot_visual_prompting_model._find_latest_reference_info(Path())
-        assert results is None
-
     def test_load_latest_reference_info(self, mocker, ov_zero_shot_visual_prompting_model) -> None:
         """Test load_latest_reference_info."""
         ov_zero_shot_visual_prompting_model.model["decoder"].embed_dim = 256
 
         # get previously saved reference info
-        mocker.patch.object(ov_zero_shot_visual_prompting_model, "_find_latest_reference_info", return_value="1")
         mocker.patch(
             "otx.core.model.entity.visual_prompting.pickle.load",
             return_value={"reference_feats": np.zeros((1, 1, 256)), "used_indices": np.array([0])},
         )
-        mocker.patch("otx.core.model.entity.visual_prompting.Path.open", return_value="Mocked data")
+        mocker.patch("pathlib.Path.is_file", return_value=True)
+        mocker.patch("pathlib.Path.open", return_value="Mocked data")
 
-        ov_zero_shot_visual_prompting_model.load_latest_reference_info()
+        ov_zero_shot_visual_prompting_model.load_latest_reference_info(".")
         assert ov_zero_shot_visual_prompting_model.reference_feats.shape == (1, 1, 256)
         assert ov_zero_shot_visual_prompting_model.used_indices.shape == (1,)
 
         # no saved reference info
-        mocker.patch.object(ov_zero_shot_visual_prompting_model, "_find_latest_reference_info", return_value=None)
+        mocker.patch("pathlib.Path.is_file", return_value=False)
 
         ov_zero_shot_visual_prompting_model.reference_feats = np.zeros((0, 1, 256), dtype=np.float32)
         ov_zero_shot_visual_prompting_model.used_indices = np.array([], dtype=np.int64)
-        ov_zero_shot_visual_prompting_model.load_latest_reference_info()
+        ov_zero_shot_visual_prompting_model.load_latest_reference_info(".")
 
         assert ov_zero_shot_visual_prompting_model.reference_feats.shape == (0, 1, 256)
         assert ov_zero_shot_visual_prompting_model.used_indices.shape == (0,)

--- a/tests/unit/core/model/module/test_visual_prompting.py
+++ b/tests/unit/core/model/module/test_visual_prompting.py
@@ -111,22 +111,14 @@ class TestOTXZeroShotVisualPromptingLitModule:
         mocker_setup_data.assert_called_once()
         mocker_reset.assert_called_once()
 
-    def test_on_train_epoch_end(self, mocker, tmpdir, otx_zero_shot_visual_prompting_lit_module) -> None:
+    def test_on_train_epoch_end(self, mocker, otx_zero_shot_visual_prompting_lit_module) -> None:
         """Test on_train_epoch_end."""
         otx_zero_shot_visual_prompting_lit_module.model.save_outputs = True
-        otx_zero_shot_visual_prompting_lit_module.model.root_reference_info = tmpdir
-        otx_zero_shot_visual_prompting_lit_module.model.reference_feats = torch.tensor(1)
-        otx_zero_shot_visual_prompting_lit_module.model.used_indices = torch.tensor(1)
-        mocker_mkdir = mocker.patch("otx.core.model.module.visual_prompting.Path.mkdir")
-        mocker.patch("otx.core.model.module.visual_prompting.Path.open")
-        mocker_torch_save = mocker.patch("otx.core.model.module.visual_prompting.torch.save")
-        mocker_pickle_dump = mocker.patch("otx.core.model.module.visual_prompting.pickle.dump")
+        otx_zero_shot_visual_prompting_lit_module.model.save_reference_info = Mock()
+        otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
+        mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer, "default_root_dir")
 
         otx_zero_shot_visual_prompting_lit_module.on_train_epoch_end()
-
-        mocker_mkdir.assert_called_once()
-        mocker_torch_save.assert_called_once()
-        mocker_pickle_dump.assert_called_once()
 
     def test_inference_step(
         self,

--- a/tests/unit/core/model/module/test_visual_prompting.py
+++ b/tests/unit/core/model/module/test_visual_prompting.py
@@ -79,7 +79,7 @@ class TestOTXZeroShotVisualPromptingLitModule:
 
     def test_on_test_start(self, mocker, otx_zero_shot_visual_prompting_lit_module) -> None:
         """Test on_test_start."""
-        otx_zero_shot_visual_prompting_lit_module.model.load_latest_reference_info = Mock(return_value=False)
+        otx_zero_shot_visual_prompting_lit_module.model.load_reference_info = Mock(return_value=False)
         otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
         mocker_run = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer.fit_loop, "run")
         mocker_setup_data = mocker.patch.object(
@@ -96,7 +96,7 @@ class TestOTXZeroShotVisualPromptingLitModule:
 
     def test_on_predict_start(self, mocker, otx_zero_shot_visual_prompting_lit_module) -> None:
         """Test on_predict_start."""
-        otx_zero_shot_visual_prompting_lit_module.model.load_latest_reference_info = Mock(return_value=False)
+        otx_zero_shot_visual_prompting_lit_module.model.load_reference_info = Mock(return_value=False)
         otx_zero_shot_visual_prompting_lit_module.trainer = Mock()
         mocker_run = mocker.patch.object(otx_zero_shot_visual_prompting_lit_module.trainer.fit_loop, "run")
         mocker_setup_data = mocker.patch.object(


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
Fixed the issue about stacking reference info files in the specific path.
- Updated the path to `work_dir`, the files will be saved in tmp dir during test.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
