### PR TITLE
Merge pytest parser options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,107 @@ from otx.core.types.task import OTXTaskType
 from torchvision.tv_tensors import Image, Mask
 
 
+def pytest_addoption(parser: pytest.Parser):
+    """Add custom options for perf tests."""
+    parser.addoption(
+        "--model-category",
+        action="store",
+        default="all",
+        choices=("speed", "balance", "accuracy", "default", "other", "all"),
+        help="Choose speed|balcence|accuracy|default|other|all. Defaults to all.",
+    )
+    parser.addoption(
+        "--data-group",
+        action="store",
+        default="all",
+        choices=("small", "medium", "large", "all"),
+        help="Choose small|medium|large|all. Defaults to all.",
+    )
+    parser.addoption(
+        "--num-repeat",
+        action="store",
+        default=0,
+        help="Overrides default per-data-group number of repeat setting. "
+        "Random seeds are set to 0 ~ num_repeat-1 for the trials. "
+        "Defaults to 0 (small=3, medium=3, large=1).",
+    )
+    parser.addoption(
+        "--num-epoch",
+        action="store",
+        default=0,
+        help="Overrides default per-model number of epoch setting. "
+        "Defaults to 0 (per-model epoch & early-stopping).",
+    )
+    parser.addoption(
+        "--eval-upto",
+        action="store",
+        default="train",
+        choices=("train", "export", "optimize"),
+        help="Choose train|export|optimize. Defaults to train.",
+    )
+    parser.addoption(
+        "--data-root",
+        action="store",
+        default="data",
+        help="Dataset root directory.",
+    )
+    parser.addoption(
+        "--output-root",
+        action="store",
+        help="Output root directory. Defaults to temp directory.",
+    )
+    parser.addoption(
+        "--summary-csv",
+        action="store",
+        help="Path to output summary cvs file. Defaults to {output-root}/benchmark-summary.csv",
+    )
+    parser.addoption(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print OTX commands without execution.",
+    )
+    parser.addoption(
+        "--deterministic",
+        action="store_true",
+        default=False,
+        help="Turn on deterministic training.",
+    )
+    parser.addoption(
+        "--user-name",
+        type=str,
+        default="anonymous",
+        help='Sign-off the user name who launched the regression tests this time, e.g., `--user-name "John Doe"`.',
+    )
+    parser.addoption(
+        "--mlflow-tracking-uri",
+        type=str,
+        help="URI for MLFlow Tracking server to store the regression test results.",
+    )
+    parser.addoption(
+        "--otx-ref",
+        type=str,
+        default="__CURRENT_BRANCH_COMMIT__",
+        help="Target OTX ref (tag / branch name / commit hash) on main repo to test. Defaults to the current branch. "
+        "`pip install otx[full]@https://github.com/openvinotoolkit/training_extensions.git@{otx_ref}` will be executed before run, "
+        "and reverted after run. Works only for v2.x assuming CLI compatibility.",
+    )
+    parser.addoption(
+        "--open-subprocess",
+        action="store_true",
+        help="Open subprocess for each CLI test case. "
+        "This option can be used for easy memory management "
+        "while running consecutive multiple tests (default: false).",
+    )
+    parser.addoption(
+        "--task",
+        action="store",
+        default="all",
+        type=str,
+        help="Task type of OTX to use test.",
+    )
+
+
 @pytest.fixture(scope="session")
 def fxt_seg_data_entity() -> tuple[tuple, SegDataEntity, SegBatchDataEntity]:
     img_size = (32, 32)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,23 +14,6 @@ from otx.core.types.task import OTXTaskType
 from tests.test_helpers import find_folder
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--open-subprocess",
-        action="store_true",
-        help="Open subprocess for each CLI test case. "
-        "This option can be used for easy memory management "
-        "while running consecutive multiple tests (default: false).",
-    )
-    parser.addoption(
-        "--task",
-        action="store",
-        default="all",
-        type=str,
-        help="Task type of OTX to use test.",
-    )
-
-
 @pytest.fixture(scope="session")
 def fxt_ci_data_root() -> Path:
     data_root = Path(os.environ.get("CI_DATA_ROOT", "/home/validation/data/v2"))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,23 +12,6 @@ from mmengine.config import Config as MMConfig
 from otx.core.types.task import OTXTaskType
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--open-subprocess",
-        action="store_true",
-        help="Open subprocess for each CLI integration test case. "
-        "This option can be used for easy memory management "
-        "while running consecutive multiple tests (default: false).",
-    )
-    parser.addoption(
-        "--task",
-        action="store",
-        default="all",
-        type=str,
-        help="Task type of OTX to use integration test.",
-    )
-
-
 @pytest.fixture(scope="module", autouse=True)
 def fxt_open_subprocess(request: pytest.FixtureRequest) -> bool:
     """Open subprocess for each CLI integration test case.

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -14,98 +14,12 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 from cpuinfo import get_cpu_info
+
 from mlflow.client import MlflowClient
 
 from .benchmark import Benchmark
 
 log = logging.getLogger(__name__)
-
-
-def pytest_addoption(parser):
-    """Add custom options for perf tests."""
-    parser.addoption(
-        "--model-category",
-        action="store",
-        default="all",
-        choices=("speed", "balance", "accuracy", "default", "other", "all"),
-        help="Choose speed|balcence|accuracy|default|other|all. Defaults to all.",
-    )
-    parser.addoption(
-        "--data-group",
-        action="store",
-        default="all",
-        choices=("small", "medium", "large", "all"),
-        help="Choose small|medium|large|all. Defaults to all.",
-    )
-    parser.addoption(
-        "--num-repeat",
-        action="store",
-        default=0,
-        help="Overrides default per-data-group number of repeat setting. "
-        "Random seeds are set to 0 ~ num_repeat-1 for the trials. "
-        "Defaults to 0 (small=3, medium=3, large=1).",
-    )
-    parser.addoption(
-        "--num-epoch",
-        action="store",
-        default=0,
-        help="Overrides default per-model number of epoch setting. "
-        "Defaults to 0 (per-model epoch & early-stopping).",
-    )
-    parser.addoption(
-        "--eval-upto",
-        action="store",
-        default="train",
-        choices=("train", "export", "optimize"),
-        help="Choose train|export|optimize. Defaults to train.",
-    )
-    parser.addoption(
-        "--data-root",
-        action="store",
-        default="data",
-        help="Dataset root directory.",
-    )
-    parser.addoption(
-        "--output-root",
-        action="store",
-        help="Output root directory. Defaults to temp directory.",
-    )
-    parser.addoption(
-        "--summary-csv",
-        action="store",
-        help="Path to output summary cvs file. Defaults to {output-root}/benchmark-summary.csv",
-    )
-    parser.addoption(
-        "--dry-run",
-        action="store_true",
-        default=False,
-        help="Print OTX commands without execution.",
-    )
-    parser.addoption(
-        "--deterministic",
-        action="store_true",
-        default=False,
-        help="Turn on deterministic training.",
-    )
-    parser.addoption(
-        "--user-name",
-        type=str,
-        default="anonymous",
-        help='Sign-off the user name who launched the regression tests this time, e.g., `--user-name "John Doe"`.',
-    )
-    parser.addoption(
-        "--mlflow-tracking-uri",
-        type=str,
-        help="URI for MLFlow Tracking server to store the regression test results.",
-    )
-    parser.addoption(
-        "--otx-ref",
-        type=str,
-        default="__CURRENT_BRANCH_COMMIT__",
-        help="Target OTX ref (tag / branch name / commit hash) on main repo to test. Defaults to the current branch. "
-        "`pip install otx[full]@https://github.com/openvinotoolkit/training_extensions.git@{otx_ref}` will be executed before run, "
-        "and reverted after run. Works only for v2.x assuming CLI compatibility.",
-    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -14,7 +14,6 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 from cpuinfo import get_cpu_info
-
 from mlflow.client import MlflowClient
 
 from .benchmark import Benchmark

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -19,33 +19,6 @@ import mlflow
 log = logging.getLogger(__name__)
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--user-name",
-        type=str,
-        required=True,
-        help="Sign-off the user name who launched the regression tests this time, " 'e.g., `--user-name "John Doe"`.',
-    )
-    parser.addoption(
-        "--dataset-root-dir",
-        type=Path,
-        required=True,
-        help="Dataset root directory path for the regression tests",
-    )
-    parser.addoption(
-        "--mlflow-tracking-uri",
-        type=str,
-        required=True,
-        help="URI for MLFlow Tracking server to store the regression test results.",
-    )
-    parser.addoption(
-        "--num-repeat",
-        type=int,
-        default=1,
-        help="The number of repetitions for each test case with different seed (default=1).",
-    )
-
-
 @pytest.fixture(scope="module", autouse=True)
 def fxt_user_name(request: pytest.FixtureRequest) -> str:
     """User name to sign off the regression test execution.
@@ -64,7 +37,7 @@ def fxt_dataset_root_dir(request: pytest.FixtureRequest) -> Path:
 
     This should be given by the PyTest CLI option.
     """
-    dataset_root_dir = request.config.getoption("--dataset-root-dir")
+    dataset_root_dir = request.config.getoption("--data-root")
     msg = f"dataset_root_dir: {dataset_root_dir}"
     log.info(msg)
     return dataset_root_dir


### PR DESCRIPTION
### Summary

- There are many pytest parser option duplicated in `tests`
- This makes test collection harder (VSCode's testing feature is affected). Thus, the developer experience got bad.
```console
2024-04-04 17:40:11.037 [info] ResultResolver EOT received for discovery.
2024-04-04 17:40:11.038 [info] ==================================== ERRORS ====================================
________________________ ERROR collecting test session _________________________
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/main.py:741: in collect
    for x in self._collectfile(pkginit):
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/main.py:588: in _collectfile
    ihook = self.gethookproxy(fspath)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/main.py:555: in gethookproxy
    my_conftestmodules = pm._getconftestmodules(
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/config/__init__.py:609: in _getconftestmodules
    mod = self._importconftest(conftestpath, importmode, rootpath)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/config/__init__.py:657: in _importconftest
    self.consider_conftest(mod)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/config/__init__.py:739: in consider_conftest
    self.register(conftestmodule, name=conftestmodule.__file__)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/config/__init__.py:491: in register
    ret: Optional[str] = super().register(plugin, name)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/pluggy/_manager.py:164: in register
    hook._maybe_apply_history(hookimpl)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/pluggy/_hooks.py:559: in _maybe_apply_history
    res = self._hookexec(self.name, [method], kwargs, False)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/pluggy/_manager.py:115: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
tests/integration/conftest.py:16: in pytest_addoption
    parser.addoption(
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/config/argparsing.py:104: in addoption
    self._anonymous.addoption(*opts, **attrs)
../../miniconda3/envs/otx-v2/lib/python3.11/site-packages/_pytest/config/argparsing.py:385: in addoption
    raise ValueError("option names %s already added" % conflict)
E   ValueError: option names {'--open-subprocess'} already added
=========================== short test summary info ============================
ERROR  - ValueError: option names {'--open-subprocess'} already added
```
- Merge them into one

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
