### PR TITLE
Fix semantic seg ground truth mask extraction

### DIFF
--- a/src/otx/core/config/data.py
+++ b/src/otx/core/config/data.py
@@ -104,6 +104,7 @@ class DataModuleConfig:
     stack_images: bool = True
 
     include_polygons: bool = False
+    ignore_index: int = 255
     unannotated_items_ratio: float = 0.0
 
     auto_num_workers: bool = False

--- a/src/otx/core/data/dataset/segmentation.py
+++ b/src/otx/core/data/dataset/segmentation.py
@@ -110,7 +110,7 @@ def _extract_class_mask(item: DatasetItem, img_shape: tuple[int, int], ignore_in
             raise ValueError(msg)
 
         if index > 255:
-            msg = "It is not currently support a label index which is more than 255."
+            msg = "Mask's label index should not be more than 255."
             raise ValueError(msg, index)
 
         this_class_mask = _make_index_mask(

--- a/src/otx/core/data/factory.py
+++ b/src/otx/core/data/factory.py
@@ -123,7 +123,7 @@ class OTXDatasetFactory:
         if task == OTXTaskType.SEMANTIC_SEGMENTATION:
             from .dataset.segmentation import OTXSegmentationDataset
 
-            return OTXSegmentationDataset(**common_kwargs)
+            return OTXSegmentationDataset(**common_kwargs, ignore_index=cfg_data_module.ignore_index)
 
         if task == OTXTaskType.ACTION_CLASSIFICATION:
             from .dataset.action_classification import OTXActionClsDataset

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -87,7 +87,7 @@ def fxt_dm_item(request) -> DatasetItem:
         annotations=[
             Label(label=0),
             Bbox(x=0, y=0, w=1, h=1, label=0),
-            Mask(label=0, image=np.zeros(shape=(10, 10), dtype=np.uint8)),
+            Mask(label=0, image=np.eye(10, dtype=np.uint8)),
             Polygon(points=[399.0, 570.0, 397.0, 572.0, 397.0, 573.0, 394.0, 576.0], label=0),
         ],
     )

--- a/tests/unit/core/data/test_dataset.py
+++ b/tests/unit/core/data/test_dataset.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from otx.core.data.dataset.action_classification import OTXActionClsDataset
 from otx.core.data.dataset.classification import HLabelInfo
+from otx.core.data.dataset.segmentation import OTXSegmentationDataset
 
 
 class TestDataset:
@@ -87,3 +88,19 @@ class TestDataset:
 
             assert item.image.shape[:2] == (h_expected, w_expected)
             assert item.img_info.img_shape == (h_expected, w_expected)
+
+
+class TestOTXSegmentationDataset:
+    def test_ignore_index(self, fxt_mock_dm_subset):
+        dataset = OTXSegmentationDataset(
+            dm_subset=fxt_mock_dm_subset,
+            transforms=lambda x: x,
+            mem_cache_img_max_size=None,
+            ignore_index=100,
+        )
+
+        # The mask is np.eye(10) with label_id = 0,
+        # so that the diagonal is filled with zero
+        # and others are filled with ignore_index.
+        gt_seg_map = next(iter(dataset)).gt_seg_map
+        assert gt_seg_map.sum() == (10 * 10 - 10) * 100


### PR DESCRIPTION
### Summary

- Let `ignore_index` working correctly.
- Merge individual masks into a class mask (semantic mask) correctly.

### How to test
Added an unit test to validate `ignore_index`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
