### PR TITLE
Refactor export part 1 - export parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # minimum target version
 target-version = "py38"
 
+# Enumerate all fixed violations.
+show-fixes = true
+
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 20

--- a/src/otx/algo/classification/mobilenet_v3_large.py
+++ b/src/otx/algo/classification/mobilenet_v3_large.py
@@ -62,9 +62,9 @@ class MobileNetV3ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlabelC
             resize_mode="standard",
             pad_value=0,
             swap_rgb=False,
-            via_onnx=True,  # NOTE: This should be done via onnx
+            via_onnx=True,  # TODO(someone): Check if this model can be exported directly with OV > 2024.0
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
@@ -109,7 +109,7 @@ class MobileNetV3ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrainMul
             swap_rgb=False,
             via_onnx=True,  # NOTE: This should be done via onnx
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
@@ -152,7 +152,7 @@ class MobileNetV3ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrainMul
             swap_rgb=False,
             via_onnx=True,  # NOTE: This should be done via onnx
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:

--- a/src/otx/algo/classification/mobilenet_v3_large.py
+++ b/src/otx/algo/classification/mobilenet_v3_large.py
@@ -4,10 +4,12 @@
 """MobileNetV3 model implementation."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics.accuracy import HLabelClsMetricCallble, MultiClassClsMetricCallable, MultiLabelClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.classification import (
@@ -18,6 +20,7 @@ from otx.core.model.classification import (
 from otx.core.model.utils.mmpretrain import ExplainableMixInMMPretrainModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.label import HLabelInfo
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -48,11 +51,21 @@ class MobileNetV3ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlabelC
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parent_parameters = super()._export_parameters
-        parent_parameters.update({"via_onnx": True})
-        return parent_parameters
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        mean, std = get_mean_std_from_data_processing(self.config)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=True,  # NOTE: This should be done via onnx
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
@@ -83,11 +96,21 @@ class MobileNetV3ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrainMul
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parent_parameters = super()._export_parameters
-        parent_parameters.update({"via_onnx": True})
-        return parent_parameters
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        mean, std = get_mean_std_from_data_processing(self.config)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=True,  # NOTE: This should be done via onnx
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
@@ -116,11 +139,21 @@ class MobileNetV3ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrainMul
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parent_parameters = super()._export_parameters
-        parent_parameters.update({"via_onnx": True})
-        return parent_parameters
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        mean, std = get_mean_std_from_data_processing(self.config)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=True,  # NOTE: This should be done via onnx
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""

--- a/src/otx/algo/classification/mobilenet_v3_large.py
+++ b/src/otx/algo/classification/mobilenet_v3_large.py
@@ -64,7 +64,7 @@ class MobileNetV3ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlabelC
             swap_rgb=False,
             via_onnx=True,  # TODO(someone): Check if this model can be exported directly with OV > 2024.0
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
@@ -109,7 +109,7 @@ class MobileNetV3ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrainMul
             swap_rgb=False,
             via_onnx=True,  # NOTE: This should be done via onnx
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
@@ -152,7 +152,7 @@ class MobileNetV3ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrainMul
             swap_rgb=False,
             via_onnx=True,  # NOTE: This should be done via onnx
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:

--- a/src/otx/algo/classification/otx_dino_v2.py
+++ b/src/otx/algo/classification/otx_dino_v2.py
@@ -155,7 +155,7 @@ class DINOv2RegisterClassifier(OTXMulticlassClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     @property

--- a/src/otx/algo/classification/otx_dino_v2.py
+++ b/src/otx/algo/classification/otx_dino_v2.py
@@ -143,28 +143,20 @@ class DINOv2RegisterClassifier(OTXMulticlassClsModel):
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params: dict[str, Any] = {}
-
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["input_size"] = (1, 3, 224, 224)
-        export_params["onnx_export_configuration"] = None
-        export_params["mean"] = [123.675, 116.28, 103.53]
-        export_params["std"] = [58.395, 57.12, 57.375]
-
-        parent_parameters = super()._export_parameters
-        parent_parameters.update(export_params)
-
-        return parent_parameters
-
-    @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=(1, 3, 224, 224),
+            mean=(123.675, 116.28, 103.53),
+            std=(58.395, 57.12, 57.375),
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     @property
     def _optimization_config(self) -> dict[str, Any]:

--- a/src/otx/algo/classification/otx_dino_v2.py
+++ b/src/otx/algo/classification/otx_dino_v2.py
@@ -155,7 +155,7 @@ class DINOv2RegisterClassifier(OTXMulticlassClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
     @property

--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -295,7 +295,7 @@ class OTXTVModel(OTXMulticlassClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
     def forward_explain(self, inputs: MulticlassClsBatchDataEntity) -> MulticlassClsBatchPredEntity:

--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -285,25 +285,18 @@ class OTXTVModel(OTXMulticlassClsModel):
     @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params: dict[str, Any] = {}
-        export_params["input_size"] = (1, 3, 224, 224)
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["onnx_export_configuration"] = None
-        export_params["mean"] = [123.675, 116.28, 103.53]
-        export_params["std"] = [58.395, 57.12, 57.375]
-
-        parameters = super()._export_parameters
-        parameters.update(export_params)
-
-        return parameters
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=(1, 3, 224, 224),
+            mean=(123.675, 116.28, 103.53),
+            std=(58.395, 57.12, 57.375),
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def forward_explain(self, inputs: MulticlassClsBatchDataEntity) -> MulticlassClsBatchPredEntity:
         """Model forward explain function."""

--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -295,7 +295,7 @@ class OTXTVModel(OTXMulticlassClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def forward_explain(self, inputs: MulticlassClsBatchDataEntity) -> MulticlassClsBatchPredEntity:

--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from copy import deepcopy
+from typing import TYPE_CHECKING, Literal
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.mmdeploy import MMdeployExporter
 from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
@@ -46,16 +49,23 @@ class ATSS(MMDetCompatibleModel):
         self.tile_image_size = self.image_size
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["deploy_cfg"] = "otx.algo.detection.mmdeploy.atss"
-        export_params["input_size"] = self.image_size
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.detection.mmdeploy.atss",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""

--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -54,6 +55,8 @@ class ATSS(MMDetCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -61,6 +64,8 @@ class ATSS(MMDetCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="standard",
             pad_value=0,
             swap_rgb=False,

--- a/src/otx/algo/detection/rtmdet.py
+++ b/src/otx/algo/detection/rtmdet.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -54,6 +55,8 @@ class RTMDet(MMDetCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -61,6 +64,8 @@ class RTMDet(MMDetCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="fit_to_window_letterbox",
             pad_value=114,
             swap_rgb=False,

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -21,6 +21,7 @@ from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallab
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.utils.build import build_mm_model, modify_num_classes
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     import torch
@@ -269,6 +270,8 @@ class SSD(MMDetCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -276,6 +279,8 @@ class SSD(MMDetCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="standard",
             pad_value=0,
             swap_rgb=False,

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -14,6 +14,8 @@ from datumaro.components.annotation import Bbox
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.mmdeploy import MMdeployExporter
 from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
@@ -262,16 +264,23 @@ class SSD(MMDetCompatibleModel):
             state_dict[prefix + param_name] = model_param
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["deploy_cfg"] = "otx.algo.detection.mmdeploy.ssd_mobilenetv2"
-        export_params["input_size"] = self.image_size
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.detection.mmdeploy.ssd_mobilenetv2",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def _set_anchors_hook(self, state_dict: dict[str, Any], *args, **kwargs) -> None:
         """Pre hook for pop anchor statistics from checkpoint state_dict."""

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from copy import deepcopy
+from typing import TYPE_CHECKING, Literal
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.mmdeploy import MMdeployExporter
 from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
@@ -46,16 +49,23 @@ class YoloX(MMDetCompatibleModel):
         self.tile_image_size = self.image_size
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["resize_mode"] = "fit_to_window_letterbox"
-        export_params["pad_value"] = 114
-        export_params["swap_rgb"] = True
-        export_params["input_size"] = self.image_size
-        export_params["deploy_cfg"] = "otx.algo.detection.mmdeploy.yolox"
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.detection.mmdeploy.yolox",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="fit_to_window_letterbox",
+            pad_value=114,
+            swap_rgb=True,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
@@ -87,13 +97,20 @@ class YoloXTiny(MMDetCompatibleModel):
         self.tile_image_size = self.image_size
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["resize_mode"] = "fit_to_window_letterbox"
-        export_params["pad_value"] = 114
-        export_params["swap_rgb"] = False
-        export_params["input_size"] = self.image_size
-        export_params["deploy_cfg"] = "otx.algo.detection.mmdeploy.yolox_tiny"
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.detection.mmdeploy.yolox_tiny",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="fit_to_window_letterbox",
+            pad_value=114,
+            swap_rgb=False,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -54,6 +55,8 @@ class YoloX(MMDetCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -61,6 +64,8 @@ class YoloX(MMDetCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="fit_to_window_letterbox",
             pad_value=114,
             swap_rgb=True,
@@ -102,6 +107,8 @@ class YoloXTiny(MMDetCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -109,6 +116,8 @@ class YoloXTiny(MMDetCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="fit_to_window_letterbox",
             pad_value=114,
             swap_rgb=False,

--- a/src/otx/algo/instance_segmentation/maskrcnn.py
+++ b/src/otx/algo/instance_segmentation/maskrcnn.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.instance_segmentation import MMDetInstanceSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -54,6 +55,8 @@ class MaskRCNN(MMDetInstanceSegCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -61,6 +64,8 @@ class MaskRCNN(MMDetInstanceSegCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="standard",  # [TODO](@Eunwoo): need to revert it to fit_to_window after resolving
             pad_value=0,
             swap_rgb=False,
@@ -102,6 +107,8 @@ class MaskRCNNSwinT(MMDetInstanceSegCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -109,6 +116,8 @@ class MaskRCNNSwinT(MMDetInstanceSegCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="standard",  # [TODO](@Eunwoo): need to revert it to fit_to_window after resolving
             pad_value=0,
             swap_rgb=False,

--- a/src/otx/algo/instance_segmentation/maskrcnn.py
+++ b/src/otx/algo/instance_segmentation/maskrcnn.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from copy import deepcopy
+from typing import TYPE_CHECKING, Literal
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.mmdeploy import MMdeployExporter
 from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.instance_segmentation import MMDetInstanceSegCompatibleModel
@@ -46,16 +49,23 @@ class MaskRCNN(MMDetInstanceSegCompatibleModel):
         self.tile_image_size = (1, 3, 512, 512)
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["deploy_cfg"] = "otx.algo.instance_segmentation.mmdeploy.maskrcnn"
-        export_params["input_size"] = self.image_size
-        export_params["resize_mode"] = "standard"  # [TODO](@Eunwoo): need to revert it to fit_to_window after resolving
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.instance_segmentation.mmdeploy.maskrcnn",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="standard",  # [TODO](@Eunwoo): need to revert it to fit_to_window after resolving
+            pad_value=0,
+            swap_rgb=False,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
@@ -87,13 +97,20 @@ class MaskRCNNSwinT(MMDetInstanceSegCompatibleModel):
         self.tile_image_size = (1, 3, 512, 512)
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["deploy_cfg"] = "otx.algo.instance_segmentation.mmdeploy.maskrcnn_swint"
-        export_params["input_size"] = self.image_size
-        export_params["resize_mode"] = "standard"  # [TODO](@Eunwoo): need to revert it to fit_to_window after resolving
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.instance_segmentation.mmdeploy.maskrcnn_swint",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="standard",  # [TODO](@Eunwoo): need to revert it to fit_to_window after resolving
+            pad_value=0,
+            swap_rgb=False,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )

--- a/src/otx/algo/instance_segmentation/rtmdet_inst.py
+++ b/src/otx/algo/instance_segmentation/rtmdet_inst.py
@@ -15,6 +15,7 @@ from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.instance_segmentation import MMDetInstanceSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -53,6 +54,8 @@ class RTMDetInst(MMDetInstanceSegCompatibleModel):
         if self.image_size is None:
             raise ValueError(self.image_size)
 
+        mean, std = get_mean_std_from_data_processing(self.config)
+
         return MMdeployExporter(
             model_builder=self._create_model,
             model_cfg=deepcopy(self.config),
@@ -60,6 +63,8 @@ class RTMDetInst(MMDetInstanceSegCompatibleModel):
             test_pipeline=self._make_fake_test_pipeline(),
             task_level_export_parameters=self._export_parameters,
             input_size=self.image_size,
+            mean=mean,
+            std=std,
             resize_mode="fit_to_window_letterbox",
             pad_value=114,
             swap_rgb=False,

--- a/src/otx/algo/instance_segmentation/rtmdet_inst.py
+++ b/src/otx/algo/instance_segmentation/rtmdet_inst.py
@@ -5,9 +5,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from copy import deepcopy
+from typing import TYPE_CHECKING, Literal
 
 from otx.algo.utils.mmconfig import read_mmconfig
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.mmdeploy import MMdeployExporter
 from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.instance_segmentation import MMDetInstanceSegCompatibleModel
@@ -45,13 +48,20 @@ class RTMDetInst(MMDetInstanceSegCompatibleModel):
         self.tile_image_size = self.image_size
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        export_params = super()._export_parameters
-        export_params["deploy_cfg"] = "otx.algo.instance_segmentation.mmdeploy.rtmdet_inst"
-        export_params["input_size"] = self.image_size
-        export_params["resize_mode"] = "fit_to_window_letterbox"
-        export_params["pad_value"] = 114
-        export_params["swap_rgb"] = False
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        if self.image_size is None:
+            raise ValueError(self.image_size)
 
-        return export_params
+        return MMdeployExporter(
+            model_builder=self._create_model,
+            model_cfg=deepcopy(self.config),
+            deploy_cfg="otx.algo.instance_segmentation.mmdeploy.rtmdet_inst",
+            test_pipeline=self._make_fake_test_pipeline(),
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            resize_mode="fit_to_window_letterbox",
+            pad_value=114,
+            swap_rgb=False,
+            output_names=["feature_vector", "saliency_map"] if self.explain_mode else None,
+        )

--- a/src/otx/algo/segmentation/dino_v2_seg.py
+++ b/src/otx/algo/segmentation/dino_v2_seg.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from otx.algo.utils.mmconfig import read_mmconfig
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics.dice import DiceCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.segmentation import MMSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -39,13 +42,25 @@ class DinoV2Seg(MMSegCompatibleModel):
             metric=metric,
             torch_compile=torch_compile,
         )
+        self.image_size = (1, 3, 560, 560)
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parent_parameters = super()._export_parameters
-        parent_parameters["input_size"] = (1, 3, 560, 560)
-        return parent_parameters
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        mean, std = get_mean_std_from_data_processing(self.config)
+
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=None,
+        )
 
     @property
     def _optimization_config(self) -> dict[str, Any]:

--- a/src/otx/algo/segmentation/litehrnet.py
+++ b/src/otx/algo/segmentation/litehrnet.py
@@ -11,10 +11,13 @@ from torch.onnx import OperatorExportTypes
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics.dice import DiceCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.segmentation import MMSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -46,17 +49,22 @@ class LiteHRNet(MMSegCompatibleModel):
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parent_parameters = super()._export_parameters
-        parent_parameters.update(
-            {
-                "onnx_export_configuration": {"operator_export_type": OperatorExportTypes.ONNX_ATEN_FALLBACK},
-                "via_onnx": True,
-            },
-        )
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        mean, std = get_mean_std_from_data_processing(self.config)
 
-        return parent_parameters
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=True,
+            onnx_export_configuration={"operator_export_type": OperatorExportTypes.ONNX_ATEN_FALLBACK},
+            output_names=None,
+        )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""

--- a/src/otx/algo/segmentation/segnext.py
+++ b/src/otx/algo/segmentation/segnext.py
@@ -8,10 +8,13 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics.dice import DiceCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.segmentation import MMSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -40,6 +43,24 @@ class SegNext(MMSegCompatibleModel):
             scheduler=scheduler,
             metric=metric,
             torch_compile=torch_compile,
+        )
+
+    @property
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        mean, std = get_mean_std_from_data_processing(self.config)
+
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=None,
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:

--- a/src/otx/core/exporter/base.py
+++ b/src/otx/core/exporter/base.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from zipfile import ZipFile
 
 from otx.core.exporter.exportable_code import demo
-from otx.core.types.export import OTXExportFormatType
+from otx.core.types.export import OTXExportFormatType, TaskLevelExportParameters
 from otx.core.types.precision import OTXPrecisionType
 
 if TYPE_CHECKING:
@@ -27,6 +27,8 @@ class OTXModelExporter:
     """Base class for the model exporters used in OTX.
 
     Args:
+        task_level_export_parameters (TaskLevelExportParameters): Collection of export parameters
+            which can be defined at a task level.
         input_size (tuple[int, ...]): Input shape.
         mean (tuple[float, float, float], optional): Mean values of 3 channels. Defaults to (0.0, 0.0, 0.0).
         std (tuple[float, float, float], optional): Std values of 3 channels. Defaults to (1.0, 1.0, 1.0).
@@ -36,20 +38,19 @@ class OTXModelExporter:
             "fit_to_window_letterbox" resizes images and pads images to fit the size. Defaults to "standard".
         pad_value (int, optional): Padding value. Defaults to 0.
         swap_rgb (bool, optional): Whether to convert the image from BGR to RGB Defaults to False.
-        metadata (dict[tuple[str, str],str] | None, optional): metadata to embed to the exported model.
         output_names (list[str] | None, optional): Names for model's outputs, which would be
         embedded into resulting model.
     """
 
     def __init__(
         self,
+        task_level_export_parameters: TaskLevelExportParameters,
         input_size: tuple[int, ...],
         mean: tuple[float, float, float] = (0.0, 0.0, 0.0),
         std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         resize_mode: Literal["crop", "standard", "fit_to_window", "fit_to_window_letterbox"] = "standard",
         pad_value: int = 0,
         swap_rgb: bool = False,
-        metadata: dict[tuple[str, str], str] | None = None,
         output_names: list[str] | None = None,
     ) -> None:
         self.input_size = input_size
@@ -58,8 +59,16 @@ class OTXModelExporter:
         self.resize_mode = resize_mode
         self.pad_value = pad_value
         self.swap_rgb = swap_rgb
-        self.metadata = metadata
+        self.task_level_export_parameters = task_level_export_parameters
         self.output_names = output_names
+
+    @property
+    def metadata(self) -> dict[tuple[str, str], str]:
+        """Collection of metadata to be stored in OpenVINO Intermediate Representation or ONNX.
+
+        This metadata is mainly used to support ModelAPI.
+        """
+        return self.task_level_export_parameters.to_metadata()
 
     def export(
         self,

--- a/src/otx/core/exporter/mmdeploy.py
+++ b/src/otx/core/exporter/mmdeploy.py
@@ -21,6 +21,7 @@ from mmengine.config import Config as MMConfig
 from mmengine.registry.default_scope import DefaultScope
 
 from otx.core.exporter.base import OTXModelExporter
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.types.precision import OTXPrecisionType
 from otx.core.utils.config import convert_conf_to_mmconfig_dict, to_tuple
 
@@ -38,6 +39,8 @@ class MMdeployExporter(OTXModelExporter):
         model_cfg (DictConfig): Model config for mm framework.
         deploy_cfg (str | MMConfig): Deployment config module path or MMEngine Config object.
         test_pipeline (list[dict]): A pipeline for test dataset.
+        task_level_export_parameters (TaskLevelExportParameters): Collection of export parameters
+            which can be defined at a task level.
         input_size (tuple[int, ...]): Input shape.
         mean (tuple[float, float, float], optional): Mean values of 3 channels. Defaults to (0.0, 0.0, 0.0).
         std (tuple[float, float, float], optional): Std values of 3 channels. Defaults to (1.0, 1.0, 1.0).
@@ -57,17 +60,26 @@ class MMdeployExporter(OTXModelExporter):
         model_cfg: DictConfig,
         deploy_cfg: str | MMConfig,
         test_pipeline: list[dict],
+        task_level_export_parameters: TaskLevelExportParameters,
         input_size: tuple[int, ...],
         mean: tuple[float, float, float] = (0.0, 0.0, 0.0),
         std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         resize_mode: Literal["crop", "standard", "fit_to_window", "fit_to_window_letterbox"] = "standard",
         pad_value: int = 0,
         swap_rgb: bool = False,
-        metadata: dict[tuple[str, str], str] | None = None,
         max_num_detections: int = 0,
         output_names: list[str] | None = None,
     ) -> None:
-        super().__init__(input_size, mean, std, resize_mode, pad_value, swap_rgb, metadata, output_names)
+        super().__init__(
+            task_level_export_parameters=task_level_export_parameters,
+            input_size=input_size,
+            mean=mean,
+            std=std,
+            resize_mode=resize_mode,
+            pad_value=pad_value,
+            swap_rgb=swap_rgb,
+            output_names=output_names,
+        )
         self._model_builder = model_builder
         model_cfg = convert_conf_to_mmconfig_dict(model_cfg, "list")
         self._model_cfg = MMConfig({"model": model_cfg, "test_pipeline": list(map(to_tuple, test_pipeline))})

--- a/src/otx/core/exporter/native.py
+++ b/src/otx/core/exporter/native.py
@@ -15,6 +15,7 @@ import openvino
 import torch
 
 from otx.core.exporter.base import OTXModelExporter
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.types.precision import OTXPrecisionType
 
 
@@ -23,18 +24,27 @@ class OTXNativeModelExporter(OTXModelExporter):
 
     def __init__(
         self,
+        task_level_export_parameters: TaskLevelExportParameters,
         input_size: tuple[int, ...],
         mean: tuple[float, float, float] = (0.0, 0.0, 0.0),
         std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         resize_mode: Literal["crop", "standard", "fit_to_window", "fit_to_window_letterbox"] = "standard",
         pad_value: int = 0,
         swap_rgb: bool = False,
-        metadata: dict[tuple[str, str], str] | None = None,
         via_onnx: bool = False,
         onnx_export_configuration: dict[str, Any] | None = None,
         output_names: list[str] | None = None,
     ) -> None:
-        super().__init__(input_size, mean, std, resize_mode, pad_value, swap_rgb, metadata, output_names)
+        super().__init__(
+            task_level_export_parameters=task_level_export_parameters,
+            input_size=input_size,
+            mean=mean,
+            std=std,
+            resize_mode=resize_mode,
+            pad_value=pad_value,
+            swap_rgb=swap_rgb,
+            output_names=output_names,
+        )
         self.via_onnx = via_onnx
         self.onnx_export_configuration = onnx_export_configuration if onnx_export_configuration is not None else {}
         if output_names is not None:

--- a/src/otx/core/model/action_classification.py
+++ b/src/otx/core/model/action_classification.py
@@ -64,13 +64,6 @@ class OTXActionClsModel(
             model_type="Action Classification",
             task_type="action classification",
         )
-        # parameters["metadata"].update(
-        #     {
-        #         ("model_info", "model_type"): "Action Classification",
-        #         ("model_info", "task_type"): "action classification",
-        #     },
-        # )
-        # return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,

--- a/src/otx/core/model/action_classification.py
+++ b/src/otx/core/model/action_classification.py
@@ -18,6 +18,7 @@ from otx.core.metrics import MetricInput
 from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
@@ -57,16 +58,19 @@ class OTXActionClsModel(
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "Action Classification",
-                ("model_info", "task_type"): "action classification",
-            },
+        return super()._export_parameters.wrap(
+            model_type="Action Classification",
+            task_type="action classification",
         )
-        return parameters
+        # parameters["metadata"].update(
+        #     {
+        #         ("model_info", "model_type"): "Action Classification",
+        #         ("model_info", "task_type"): "action classification",
+        #     },
+        # )
+        # return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,
@@ -176,23 +180,22 @@ class MMActionCompatibleModel(OTXActionClsModel):
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["input_size"] = self.image_size
-        export_params["onnx_export_configuration"] = None
-
-        return export_params
-
-    @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
+        mean, std = get_mean_std_from_data_processing(self.config)
+
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=None,
+        )
 
 
 class OVActionClsModel(

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -602,14 +602,33 @@ class OTXModel(LightningModule, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEnti
 
     @property
     def _export_parameters(self) -> TaskLevelExportParameters:
-        """Defines parameters required to export a particular model implementation.
+        """Defines export parameters sharable at a task level.
 
-        To export OTXModel, you should define an appropriate parameters."
-        "This is used in the constructor of `self._exporter`. "
-        "For example, `self._exporter = SomeExporter(**self.export_parameters)`. "
-        "Please refer to `otx.core.exporter.*` for detailed examples."
+        To export OTXModel which is compatible with ModelAPI,
+        you should define an appropriate export parameters for each task.
+        This property is usually defined at the task level classes defined in `otx.core.model.*`.
+        Please refer to `TaskLevelExportParameters` for more details.
+
         Returns:
             Collection of exporter parameters that can be defined at a task level.
+
+        Examples:
+            This example shows how this property is used at the new model development
+
+            ```python
+
+            class MyDetectionModel(OTXDetectionModel):
+                ...
+
+                @property
+                def _exporter(self) -> OTXModelExporter:
+                    # `self._export_parameters` defined at `OTXDetectionModel`
+                    # You can redefine it `MyDetectionModel` if you need
+                    return OTXModelExporter(
+                        task_level_export_parameters=self._export_parameters,
+                        ...
+                    )
+            ```
         """
         return TaskLevelExportParameters(
             model_type="null",
@@ -617,24 +636,6 @@ class OTXModel(LightningModule, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEnti
             label_info=self.label_info,
             optimization_config=self._optimization_config,
         )
-        # all_labels = ""
-        # all_label_ids = ""
-        # for lbl in self.label_info.label_names:
-        #     all_labels += lbl.replace(" ", "_") + " "
-        #     all_label_ids += lbl.replace(" ", "_") + " "
-
-        # # not every model requires ptq_config
-        # optimization_config = self._optimization_config
-
-        # return TaskLevelExportParameters(
-        #     metadata={
-        #         ("model_info", "labels"): all_labels.strip(),
-        #         ("model_info", "label_ids"): all_label_ids.strip(),
-        #         ("model_info", "optimization_config"): json.dumps(optimization_config),
-        #         ("model_info", "label_info"): self.label_info.to_json(),
-        #     },
-        #     output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
-        # )
 
     def _reset_prediction_layer(self, num_classes: int) -> None:
         """Reset its prediction layer with a given number of classes.

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -3,6 +3,8 @@
 #
 """Class definition for base model entity used in OTX."""
 
+# mypy: disable-error-code="arg-type"
+
 from __future__ import annotations
 
 import contextlib

--- a/src/otx/core/model/classification.py
+++ b/src/otx/core/model/classification.py
@@ -233,7 +233,7 @@ class MMPretrainMulticlassClsModel(OTXMulticlassClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
 
@@ -429,7 +429,7 @@ class MMPretrainMultilabelClsModel(OTXMultilabelClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
 
@@ -638,7 +638,7 @@ class MMPretrainHlabelClsModel(OTXHlabelClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
 

--- a/src/otx/core/model/classification.py
+++ b/src/otx/core/model/classification.py
@@ -233,7 +233,7 @@ class MMPretrainMulticlassClsModel(OTXMulticlassClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
 
@@ -429,7 +429,7 @@ class MMPretrainMultilabelClsModel(OTXMultilabelClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
 
@@ -638,7 +638,7 @@ class MMPretrainHlabelClsModel(OTXHlabelClsModel):
             swap_rgb=False,
             via_onnx=False,
             onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else ["logits"],
         )
 
 

--- a/src/otx/core/model/classification.py
+++ b/src/otx/core/model/classification.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -32,6 +31,7 @@ from otx.core.metrics.accuracy import (
 )
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.types.label import HLabelInfo
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.utils import get_mean_std_from_data_processing
@@ -72,18 +72,14 @@ class OTXMulticlassClsModel(
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "Classification",
-                ("model_info", "task_type"): "classification",
-                ("model_info", "multilabel"): str(False),
-                ("model_info", "hierarchical"): str(False),
-            },
+        return super()._export_parameters.wrap(
+            model_type="Classification",
+            task_type="classification",
+            multilabel=False,
+            hierarchical=False,
         )
-        return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,
@@ -226,21 +222,19 @@ class MMPretrainMulticlassClsModel(OTXMulticlassClsModel):
     @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["input_size"] = self.image_size
-        export_params["onnx_export_configuration"] = None
-
-        return export_params
+        mean, std = get_mean_std_from_data_processing(self.config)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
 
 ### NOTE, currently, although we've made the separate Multi-cls, Multi-label classes
@@ -273,19 +267,15 @@ class OTXMultilabelClsModel(
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "Classification",
-                ("model_info", "task_type"): "classification",
-                ("model_info", "multilabel"): str(True),
-                ("model_info", "hierarchical"): str(False),
-                ("model_info", "confidence_threshold"): str(0.5),
-            },
+        return super()._export_parameters.wrap(
+            model_type="Classification",
+            task_type="classification",
+            multilabel=True,
+            hierarchical=False,
+            confidence_threshold=0.5,
         )
-        return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,
@@ -428,21 +418,19 @@ class MMPretrainMultilabelClsModel(OTXMultilabelClsModel):
     @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["input_size"] = self.image_size
-        export_params["onnx_export_configuration"] = None
-
-        return export_params
+        mean, std = get_mean_std_from_data_processing(self.config)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
 
 class OTXHlabelClsModel(
@@ -473,29 +461,15 @@ class OTXHlabelClsModel(
         self._label_info = hlabel_info
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        hierarchical_config: dict = {}
-
-        label_info: HLabelInfo = self.label_info  # type: ignore[assignment]
-        hierarchical_config["cls_heads_info"] = label_info.as_dict()
-        hierarchical_config["label_tree_edges"] = label_info.label_tree_edges
-
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "Classification",
-                ("model_info", "task_type"): "classification",
-                ("model_info", "multilabel"): str(False),
-                ("model_info", "hierarchical"): str(True),
-                ("model_info", "confidence_threshold"): str(0.5),
-                ("model_info", "hierarchical_config"): json.dumps(hierarchical_config),
-                # NOTE: There is currently too many channels for label related metadata.
-                # This should be clean up afterwards in ModelAPI side.
-                ("model_info", "label_info"): json.dumps(label_info.as_dict()),
-            },
+        return super()._export_parameters.wrap(
+            model_type="Classification",
+            task_type="classification",
+            multilabel=False,
+            hierarchical=True,
+            confidence_threshold=0.5,
         )
-        return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,
@@ -653,21 +627,19 @@ class MMPretrainHlabelClsModel(OTXHlabelClsModel):
     @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["input_size"] = self.image_size
-        export_params["onnx_export_configuration"] = None
-
-        return export_params
+        mean, std = get_mean_std_from_data_processing(self.config)
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=self.image_size,
+            mean=mean,
+            std=std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
 
 
 class OVMulticlassClassificationModel(

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -286,13 +286,6 @@ class ExplainableOTXDetModel(OTXDetectionModel):
 
         return [1] * 10
 
-    # @property
-    # def _export_parameters(self) -> dict[str, Any]:
-    #     """Defines parameters required to export a particular model implementation."""
-    #     parameters = super()._export_parameters
-    #     parameters["output_names"] = ["feature_vector", "saliency_map"] if self.explain_mode else None
-    #     return parameters
-
 
 class MMDetCompatibleModel(ExplainableOTXDetModel):
     """Detection model compatible for MMDet.
@@ -451,21 +444,6 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
             bboxes=bboxes,
             labels=labels,
         )
-
-    # @property
-    # def _export_parameters(self) -> dict[str, Any]:
-    #     """Parameters for an exporter."""
-    #     if self.image_size is None:
-    #         error_msg = "self.image_size shouldn't be None to use mmdeploy."
-    #         raise ValueError(error_msg)
-
-    #     export_params = super()._export_parameters
-    #     export_params.update(get_mean_std_from_data_processing(self.config))
-    #     export_params["model_builder"] = self._create_model
-    #     export_params["model_cfg"] = copy.copy(self.config)
-    #     export_params["test_pipeline"] = self._make_fake_test_pipeline()
-
-    #     return export_params
 
 
 class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity]):

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import copy
 import logging as log
 import types
 from typing import TYPE_CHECKING, Any, Callable, Literal
@@ -19,14 +18,13 @@ from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
 from otx.core.data.entity.tile import TileBatchDetDataEntity
-from otx.core.exporter.base import OTXModelExporter
 from otx.core.metrics import MetricInput
 from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.tile_merge import DetectionTileMerge
-from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -96,29 +94,15 @@ class OTXDetectionModel(OTXModel[DetBatchDataEntity, DetBatchPredEntity, TileBat
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "ssd",
-                ("model_info", "task_type"): "detection",
-                ("model_info", "confidence_threshold"): str(
-                    self.hparams.get("best_confidence_threshold", 0.0),
-                ),  # it was able to be set in OTX 1.X
-                ("model_info", "iou_threshold"): str(0.5),
-            },
+        return super()._export_parameters.wrap(
+            model_type="ssd",
+            task_type="detection",
+            confidence_threshold=self.hparams.get("best_confidence_threshold", 0.0),
+            iou_threshold=0.5,
+            tile_config=self.tile_config if self.tile_config.enable_tiler else None,
         )
-        if self.tile_config.enable_tiler:
-            parameters["metadata"].update(
-                {
-                    ("model_info", "tile_size"): str(self.tile_config.tile_size[0]),
-                    ("model_info", "tiles_overlap"): str(self.tile_config.overlap),
-                    ("model_info", "max_pred_number"): str(self.tile_config.max_num_instances),
-                },
-            )
-
-        return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,
@@ -302,12 +286,12 @@ class ExplainableOTXDetModel(OTXDetectionModel):
 
         return [1] * 10
 
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["output_names"] = ["feature_vector", "saliency_map"] if self.explain_mode else None
-        return parameters
+    # @property
+    # def _export_parameters(self) -> dict[str, Any]:
+    #     """Defines parameters required to export a particular model implementation."""
+    #     parameters = super()._export_parameters
+    #     parameters["output_names"] = ["feature_vector", "saliency_map"] if self.explain_mode else None
+    #     return parameters
 
 
 class MMDetCompatibleModel(ExplainableOTXDetModel):
@@ -338,21 +322,6 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
             metric=metric,
             torch_compile=torch_compile,
         )
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        if self.image_size is None:
-            error_msg = "self.image_size shouldn't be None to use mmdeploy."
-            raise ValueError(error_msg)
-
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["model_builder"] = self._create_model
-        export_params["model_cfg"] = copy.copy(self.config)
-        export_params["test_pipeline"] = self._make_fake_test_pipeline()
-
-        return export_params
 
     def _create_model(self) -> nn.Module:
         from .utils.mmdet import create_model
@@ -483,12 +452,20 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
             labels=labels,
         )
 
-    @property
-    def _exporter(self) -> OTXModelExporter:
-        """Creates OTXModelExporter object that can export the model."""
-        from otx.core.exporter.mmdeploy import MMdeployExporter
+    # @property
+    # def _export_parameters(self) -> dict[str, Any]:
+    #     """Parameters for an exporter."""
+    #     if self.image_size is None:
+    #         error_msg = "self.image_size shouldn't be None to use mmdeploy."
+    #         raise ValueError(error_msg)
 
-        return MMdeployExporter(**self._export_parameters)
+    #     export_params = super()._export_parameters
+    #     export_params.update(get_mean_std_from_data_processing(self.config))
+    #     export_params["model_builder"] = self._create_model
+    #     export_params["model_cfg"] = copy.copy(self.config)
+    #     export_params["test_pipeline"] = self._make_fake_test_pipeline()
+
+    #     return export_params
 
 
 class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity]):

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -303,13 +303,6 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
         self.model.forward = func_type(self.original_model_forward, self.model)
         self.original_model_forward = None
 
-    # @property
-    # def _export_parameters(self) -> dict[str, Any]:
-    #     """Defines parameters required to export a particular model implementation."""
-    #     parameters = super()._export_parameters
-    #     parameters["output_names"] = ["feature_vector", "saliency_map"] if self.explain_mode else None
-    #     return parameters
-
 
 class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
     """Instance Segmentation model compatible for MMDet."""

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging as log
 import types
-from copy import copy
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import numpy as np
@@ -21,15 +20,14 @@ from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.instance_segmentation import InstanceSegBatchDataEntity, InstanceSegBatchPredEntity
 from otx.core.data.entity.tile import TileBatchInstSegDataEntity
-from otx.core.exporter.base import OTXModelExporter
 from otx.core.metrics import MetricInput
 from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.mask_util import encode_rle, polygon_to_rle
 from otx.core.utils.tile_merge import InstanceSegTileMerge
-from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -107,40 +105,15 @@ class OTXInstanceSegModel(
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "MaskRCNN",
-                ("model_info", "task_type"): "instance_segmentation",
-                ("model_info", "confidence_threshold"): str(
-                    self.hparams.get("best_confidence_threshold", 0.0),
-                ),  # it was able to be set in OTX 1.X
-                ("model_info", "iou_threshold"): str(0.5),
-            },
+        return super()._export_parameters.wrap(
+            model_type="MaskRCNN",
+            task_type="instance_segmentation",
+            confidence_threshold=self.hparams.get("best_confidence_threshold", 0.0),
+            iou_threshold=0.5,
+            tile_config=self.tile_config if self.tile_config.enable_tiler else None,
         )
-
-        # Instance segmentation needs to add empty label
-        all_labels = "otx_empty_lbl "
-        all_label_ids = "None "
-        for lbl in self.label_info.label_names:
-            all_labels += lbl.replace(" ", "_") + " "
-            all_label_ids += lbl.replace(" ", "_") + " "
-
-        parameters["metadata"][("model_info", "labels")] = all_labels.strip()
-        parameters["metadata"][("model_info", "label_ids")] = all_label_ids.strip()
-
-        if self.tile_config.enable_tiler:
-            parameters["metadata"].update(
-                {
-                    ("model_info", "tile_size"): str(self.tile_config.tile_size[0]),
-                    ("model_info", "tiles_overlap"): str(self.tile_config.overlap),
-                    ("model_info", "max_pred_number"): str(self.tile_config.max_num_instances),
-                },
-            )
-
-        return parameters
 
     def load_state_dict(self, ckpt: dict[str, Any], *args, **kwargs) -> None:
         """Load state_dict from checkpoint.
@@ -330,12 +303,12 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
         self.model.forward = func_type(self.original_model_forward, self.model)
         self.original_model_forward = None
 
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        parameters["output_names"] = ["feature_vector", "saliency_map"] if self.explain_mode else None
-        return parameters
+    # @property
+    # def _export_parameters(self) -> dict[str, Any]:
+    #     """Defines parameters required to export a particular model implementation."""
+    #     parameters = super()._export_parameters
+    #     parameters["output_names"] = ["feature_vector", "saliency_map"] if self.explain_mode else None
+    #     return parameters
 
 
 class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
@@ -361,21 +334,6 @@ class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
             metric=metric,
             torch_compile=torch_compile,
         )
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Parameters for an exporter."""
-        if self.image_size is None:
-            error_msg = "self.image_size shouldn't be None to use mmdeploy."
-            raise ValueError(error_msg)
-
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["model_builder"] = self._create_model
-        export_params["model_cfg"] = copy(self.config)
-        export_params["test_pipeline"] = self._make_fake_test_pipeline()
-
-        return export_params
 
     def _create_model(self) -> nn.Module:
         from .utils.mmdet import create_model
@@ -530,13 +488,6 @@ class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
             polygons=[],
             labels=labels,
         )
-
-    @property
-    def _exporter(self) -> OTXModelExporter:
-        """Creates OTXModelExporter object that can export the model."""
-        from otx.core.exporter.mmdeploy import MMdeployExporter
-
-        return MMdeployExporter(**self._export_parameters)
 
 
 class OVInstanceSegmentationModel(

--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -14,15 +14,13 @@ from torchvision import tv_tensors
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity
 from otx.core.data.entity.tile import T_OTXTileBatchDataEntity
-from otx.core.exporter.base import OTXModelExporter
-from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics import MetricInput
 from otx.core.metrics.dice import DiceCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.types.label import SegLabelInfo
 from otx.core.utils.config import inplace_num_classes
-from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -54,23 +52,15 @@ class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity, T_OT
         )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        parameters = super()._export_parameters
-        hierarchical_config: dict = {}
-        hierarchical_config["cls_heads_info"] = {}
-        hierarchical_config["label_tree_edges"] = []
-
-        parameters["metadata"].update(
-            {
-                ("model_info", "model_type"): "Segmentation",
-                ("model_info", "task_type"): "segmentation",
-                ("model_info", "return_soft_prediction"): str(True),
-                ("model_info", "soft_threshold"): str(0.5),
-                ("model_info", "blur_strength"): str(-1),
-            },
+        return super()._export_parameters.wrap(
+            model_type="Segmentation",
+            task_type="segmentation",
+            return_soft_prediction=True,
+            soft_threshold=0.5,
+            blur_strength=-1,
         )
-        return parameters
 
     def _convert_pred_entity_to_compute_metric(
         self,
@@ -197,25 +187,6 @@ class MMSegCompatibleModel(OTXSegmentationModel):
             scores=[],
             masks=masks,
         )
-
-    @property
-    def _export_parameters(self) -> dict[str, Any]:
-        """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params.update(get_mean_std_from_data_processing(self.config))
-        export_params["resize_mode"] = "standard"
-        export_params["pad_value"] = 0
-        export_params["swap_rgb"] = False
-        export_params["via_onnx"] = False
-        export_params["input_size"] = self.image_size
-        export_params["onnx_export_configuration"] = None
-
-        return export_params
-
-    @property
-    def _exporter(self) -> OTXModelExporter:
-        """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(**self._export_parameters)
 
 
 class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity]):

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -39,6 +39,7 @@ from otx.core.metrics import MetricInput
 from otx.core.metrics.visual_prompting import VisualPromptingMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
 from otx.core.types.label import LabelInfo, NullLabelInfo
 from otx.core.utils.mask_util import polygon_to_bitmap
 
@@ -192,23 +193,22 @@ class OTXVisualPromptingModel(
     @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXVisualPromptingModelExporter(via_onnx=True, **self._export_parameters)
+        return OTXVisualPromptingModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=(1, 3, self.model.image_size, self.model.image_size),
+            mean=(123.675, 116.28, 103.53),
+            std=(58.395, 57.12, 57.375),
+            resize_mode="fit_to_window",
+            via_onnx=True,
+        )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params["metadata"].update(
-            {
-                ("model_info", "model_type"): "Visual_Prompting",
-                ("model_info", "task_type"): "visual_prompting",
-            },
+        return super()._export_parameters.wrap(
+            model_type="Visual_Prompting",
+            task_type="visual_prompting",
         )
-        export_params["input_size"] = (1, 3, self.model.image_size, self.model.image_size)
-        export_params["resize_mode"] = "fit_to_window"
-        export_params["mean"] = (123.675, 116.28, 103.53)
-        export_params["std"] = (58.395, 57.12, 57.375)
-        return export_params
 
     @property
     def _optimization_config(self) -> dict[str, Any]:
@@ -302,23 +302,22 @@ class OTXZeroShotVisualPromptingModel(
     @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
-        return OTXVisualPromptingModelExporter(via_onnx=True, **self._export_parameters)
+        return OTXVisualPromptingModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=(1, 3, self.model.image_size, self.model.image_size),
+            mean=(123.675, 116.28, 103.53),
+            std=(58.395, 57.12, 57.375),
+            resize_mode="fit_to_window",
+            via_onnx=True,
+        )
 
     @property
-    def _export_parameters(self) -> dict[str, Any]:
+    def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
-        export_params = super()._export_parameters
-        export_params["metadata"].update(
-            {
-                ("model_info", "model_type"): "Visual_Prompting",
-                ("model_info", "task_type"): "visual_prompting",
-            },
+        return super()._export_parameters.wrap(
+            model_type="Visual_Prompting",
+            task_type="visual_prompting",
         )
-        export_params["input_size"] = (1, 3, self.model.image_size, self.model.image_size)
-        export_params["resize_mode"] = "fit_to_window"
-        export_params["mean"] = (123.675, 116.28, 103.53)
-        export_params["std"] = (58.395, 57.12, 57.375)
-        return export_params
 
     @property
     def _optimization_config(self) -> dict[str, Any]:

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -5,7 +5,12 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass, fields
 from enum import Enum
+
+from otx.core.config.data import TileConfig
+from otx.core.types.label import HLabelInfo, LabelInfo
 
 
 class OTXExportFormatType(str, Enum):
@@ -14,3 +19,143 @@ class OTXExportFormatType(str, Enum):
     ONNX = "ONNX"
     OPENVINO = "OPENVINO"
     EXPORTABLE_CODE = "EXPORTABLE_CODE"
+
+
+@dataclass(frozen=True)
+class TaskLevelExportParameters:
+    """Collection of export parameters which can be defined at a task level.
+
+    Attributes:
+        model_type (str): Model type field used in ModelAPI.
+        task_type (str): Task type field used in ModelAPI.
+        label_info (LabelInfo): OTX label info metadata.
+            It will be parsed into a format compatible with ModelAPI.
+        optimization_config (dict): Configurations for NNCF PTQ model optimization.
+        multilabel (bool | None): Whether it is multilabel or not.
+            Only specified for the classification task.
+        hierarchical (bool | None): Whether it is hierarchical or not.
+            Only specified for the classification task.
+        confidence_threshold (float | None): Confidence threshold for model prediction probability.
+            It is used only for classification tasks, detection and instance segmentation tasks.
+        iou_threshold (float | None): The Intersection over Union (IoU) threshold
+            for Non-Maximum Suppression (NMS) post-processing.
+            It is used only for models in detection and instance segmentation tasks.
+        return_soft_prediction (bool | None): Whether to return soft prediction.
+            It is used only for semantic segmentation tasks.
+        soft_threshold (float | None): Minimum class confidence for each pixel.
+            The higher the value, the more strict the segmentation is (usually set to 0.5).
+            Only specified for semantic segmentation tasks.
+        blur_strength (int | None): The higher the value, the smoother the
+            segmentation output will be, but less accurate.
+            Only specified for semantic segmentation tasks.
+        tile_config (TileConfig | None): Configuration for tiling models
+            If None, the model is not trained with tiling.
+    """
+
+    # Common
+    model_type: str
+    task_type: str
+    label_info: LabelInfo
+    optimization_config: dict
+
+    # (Optional) Classification tasks
+    multilabel: bool | None = None
+    hierarchical: bool | None = None
+
+    # (Optional) Classification tasks, detection and instance segmentation task
+    confidence_threshold: float | None = None
+
+    # (Optional) Detection and instance segmentation task
+    iou_threshold: float | None = None
+
+    # (Optional) Semantic segmentation task
+    return_soft_prediction: bool | None = None
+    soft_threshold: float | None = None
+    blur_strength: int | None = None
+
+    # (Optional) Tasks with tiling
+    tile_config: TileConfig | None = None
+
+    def wrap(self, **kwargs_to_update) -> TaskLevelExportParameters:
+        """Create a new instance by wrapping it with the given keyword arguments.
+
+        Args:
+            kwargs_to_update (dict): Keyword arguments to update.
+
+        Returns:
+            TaskLevelExportParameters: A new instance with updated attributes.
+        """
+        updated_kwargs = {field.name: getattr(self, field.name) for field in fields(self)}
+        updated_kwargs.update(kwargs_to_update)
+        return TaskLevelExportParameters(**updated_kwargs)
+
+    def to_metadata(self) -> dict[tuple[str, str], str]:
+        """Convert this dataclass to dictionary format compatible with ModelAPI.
+
+        Returns:
+            dict[tuple[str, str], str]: It will be directly delivered to
+            OpenVINO IR's `rt_info` or ONNX metadata slot.
+        """
+        if self.task_type == "instance_segmentation":
+            # Instance segmentation needs to add empty label
+            all_labels = "otx_empty_lbl "
+            all_label_ids = "None "
+            for lbl in self.label_info.label_names:
+                all_labels += lbl.replace(" ", "_") + " "
+                all_label_ids += lbl.replace(" ", "_") + " "
+        else:
+            all_labels = ""
+            all_label_ids = ""
+            for lbl in self.label_info.label_names:
+                all_labels += lbl.replace(" ", "_") + " "
+                all_label_ids += lbl.replace(" ", "_") + " "
+
+        metadata = {
+            # Common
+            ("model_info", "model_type"): self.model_type,
+            ("model_info", "task_type"): self.task_type,
+            ("model_info", "label_info"): self.label_info.to_json(),
+            ("model_info", "labels"): all_labels.strip(),
+            ("model_info", "label_ids"): all_label_ids.strip(),
+            ("model_info", "optimization_config"): json.dumps(self.optimization_config),
+        }
+
+        if isinstance(self.label_info, HLabelInfo):
+            metadata[("model_info", "hierarchical_config")] = json.dumps(
+                {
+                    "cls_heads_info": self.label_info.as_dict(),
+                    "label_tree_edges": self.label_info.label_tree_edges,
+                },
+            )
+
+        if self.multilabel:
+            metadata[("model_info", "multilabel")] = str(self.multilabel)
+
+        if self.hierarchical:
+            metadata[("model_info", "hierarchical")] = str(self.hierarchical)
+
+        if self.confidence_threshold:
+            metadata[("model_info", "confidence_threshold")] = str(self.confidence_threshold)
+
+        if self.iou_threshold:
+            metadata[("model_info", "iou_threshold")] = str(self.iou_threshold)
+
+        if self.return_soft_prediction:
+            metadata[("model_info", "return_soft_prediction")] = str(self.return_soft_prediction)
+
+        if self.soft_threshold:
+            metadata[("model_info", "soft_threshold")] = str(self.soft_threshold)
+
+        if self.blur_strength:
+            metadata[("model_info", "blur_strength")] = str(self.blur_strength)
+
+        if self.tile_config:
+            metadata.update(
+                {
+                    ("model_info", "tile_size"): str(self.tile_config.tile_size[0]),
+                    ("model_info", "tiles_overlap"): str(self.tile_config.overlap),
+                    ("model_info", "max_pred_number"): str(self.tile_config.max_num_instances),
+                },
+            )
+
+        return metadata

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -128,28 +128,28 @@ class TaskLevelExportParameters:
                 },
             )
 
-        if self.multilabel:
+        if self.multilabel is not None:
             metadata[("model_info", "multilabel")] = str(self.multilabel)
 
-        if self.hierarchical:
+        if self.hierarchical is not None:
             metadata[("model_info", "hierarchical")] = str(self.hierarchical)
 
-        if self.confidence_threshold:
+        if self.confidence_threshold is not None:
             metadata[("model_info", "confidence_threshold")] = str(self.confidence_threshold)
 
-        if self.iou_threshold:
+        if self.iou_threshold is not None:
             metadata[("model_info", "iou_threshold")] = str(self.iou_threshold)
 
-        if self.return_soft_prediction:
+        if self.return_soft_prediction is not None:
             metadata[("model_info", "return_soft_prediction")] = str(self.return_soft_prediction)
 
-        if self.soft_threshold:
+        if self.soft_threshold is not None:
             metadata[("model_info", "soft_threshold")] = str(self.soft_threshold)
 
-        if self.blur_strength:
+        if self.blur_strength is not None:
             metadata[("model_info", "blur_strength")] = str(self.blur_strength)
 
-        if self.tile_config:
+        if self.tile_config is not None:
             metadata.update(
                 {
                     ("model_info", "tile_size"): str(self.tile_config.tile_size[0]),

--- a/src/otx/core/utils/utils.py
+++ b/src/otx/core/utils/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from multiprocessing import cpu_count
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import torch
 from datumaro.components.annotation import AnnotationType, LabelCategories
@@ -41,19 +41,25 @@ def is_ckpt_for_finetuning(ckpt: dict) -> bool:
     return "state_dict" in ckpt
 
 
-def get_mean_std_from_data_processing(config: DictConfig) -> dict[str, Any]:
+def get_mean_std_from_data_processing(
+    config: DictConfig,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
     """Get mean and std value from data_processing.
 
     Args:
         config (DictConfig): MM framework model config.
 
     Returns:
-        dict[str, Any]: Dictionary with mean and std value.
+        tuple[tuple[float, float, float], tuple[float, float, float]]:
+            Tuple of mean and std values.
+
+    Examples:
+        >>> mean, std = get_mean_std_from_data_processing(config)
     """
-    return {
-        "mean": config["data_preprocessor"]["mean"],
-        "std": config["data_preprocessor"]["std"],
-    }
+    return (
+        config["data_preprocessor"]["mean"],
+        config["data_preprocessor"]["std"],
+    )
 
 
 def get_adaptive_num_workers(num_dataloader: int = 1) -> int | None:

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -98,9 +98,6 @@ def test_predict_with_explain(
     if "ssd_mobilenetv2" in model_name:
         pytest.skip("There's issue with SSD model. Skip for now.")
 
-    if "maskrcnn_efficientnetb2b" in model_name:
-        pytest.xfail("Please see ticket no. 138035")
-
     tmp_path = tmp_path / f"otx_xai_{model_name}"
     engine = Engine.from_config(
         config_path=recipe,

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -98,6 +98,9 @@ def test_predict_with_explain(
     if "ssd_mobilenetv2" in model_name:
         pytest.skip("There's issue with SSD model. Skip for now.")
 
+    if "maskrcnn_efficientnetb2b" in model_name:
+        pytest.xfail("Please see ticket no. 138035")
+
     tmp_path = tmp_path / f"otx_xai_{model_name}"
     engine = Engine.from_config(
         config_path=recipe,

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 from cpuinfo import get_cpu_info
+
 from mlflow.client import MlflowClient
 
 from .benchmark import Benchmark

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -14,7 +14,6 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 from cpuinfo import get_cpu_info
-
 from mlflow.client import MlflowClient
 
 from .benchmark import Benchmark

--- a/tests/unit/algo/classification/test_torchvision_model.py
+++ b/tests/unit/algo/classification/test_torchvision_model.py
@@ -3,6 +3,7 @@ import torch
 from otx.algo.classification.torchvision_model import OTXTVModel, TVModelWithLossComputation
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.classification import MulticlassClsBatchPredEntity
+from otx.core.types.export import TaskLevelExportParameters
 
 
 @pytest.fixture()
@@ -31,16 +32,10 @@ class TestOTXTVModel:
         assert isinstance(preds, MulticlassClsBatchPredEntity)
 
     def test_export_parameters(self, fxt_tv_model):
-        params = fxt_tv_model._export_parameters
-        assert isinstance(params, dict)
-        assert "input_size" in params
-        assert "resize_mode" in params
-        assert "pad_value" in params
-        assert "swap_rgb" in params
-        assert "via_onnx" in params
-        assert "onnx_export_configuration" in params
-        assert "mean" in params
-        assert "std" in params
+        export_parameters = fxt_tv_model._export_parameters
+        assert isinstance(export_parameters, TaskLevelExportParameters)
+        assert export_parameters.model_type == "Classification"
+        assert export_parameters.task_type == "classification"
 
     @pytest.mark.parametrize("explain_mode", [True, False])
     def test_predict_step(self, fxt_tv_model: OTXTVModel, fxt_multiclass_cls_batch_data_entity, explain_mode):

--- a/tests/unit/algo/detection/test_atss.py
+++ b/tests/unit/algo/detection/test_atss.py
@@ -5,6 +5,8 @@
 import pytest
 from otx.algo.detection.atss import ATSS
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
+from otx.core.exporter.mmdeploy import MMdeployExporter
+from otx.core.types.export import TaskLevelExportParameters
 
 
 class TestATSS:
@@ -20,4 +22,5 @@ class TestATSS:
         model.load_from_otx_v1_ckpt({})
         mock_load_ckpt.assert_called_once_with({}, "model.model.")
 
-        assert isinstance(model._export_parameters, dict)
+        assert isinstance(model._export_parameters, TaskLevelExportParameters)
+        assert isinstance(model._exporter, MMdeployExporter)

--- a/tests/unit/algo/instance_segmentation/heads/test_custom_rtmdet_ins_head.py
+++ b/tests/unit/algo/instance_segmentation/heads/test_custom_rtmdet_ins_head.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import tempfile
 from pathlib import Path
 
 import torch
@@ -74,12 +73,11 @@ class TestCustomRTMDetInsSepBNHead:
             cfg=None,
         )
 
-    def test_predict_by_feat_ov(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            lit_module = RTMDetInst(num_classes=1, variant="tiny")
-            exported_model_path = lit_module.export(
-                output_dir=Path(tmpdirname),
-                base_name="exported_model",
-                export_format=OTXExportFormatType.OPENVINO,
-            )
-            Path.exists(exported_model_path)
+    def test_predict_by_feat_ov(self, tmpdir) -> None:
+        lit_module = RTMDetInst(num_classes=1, variant="tiny")
+        exported_model_path = lit_module.export(
+            output_dir=Path(tmpdir),
+            base_name="exported_model",
+            export_format=OTXExportFormatType.OPENVINO,
+        )
+        Path.exists(exported_model_path)

--- a/tests/unit/algo/segmentation/test_dino_v2_seg.py
+++ b/tests/unit/algo/segmentation/test_dino_v2_seg.py
@@ -4,10 +4,11 @@
 
 import pytest
 from otx.algo.segmentation.dino_v2_seg import DinoV2Seg
+from otx.core.exporter.base import OTXModelExporter
 
 
 class TestDinoV2Seg:
-    @pytest.fixture()
+    @pytest.fixture(scope="class")
     def fxt_dino_v2_seg(self) -> DinoV2Seg:
         return DinoV2Seg(num_classes=10)
 
@@ -15,11 +16,10 @@ class TestDinoV2Seg:
         assert isinstance(fxt_dino_v2_seg, DinoV2Seg)
         assert fxt_dino_v2_seg.num_classes == 10
 
-    def test_export_parameters(self, fxt_dino_v2_seg):
-        parameters = fxt_dino_v2_seg._export_parameters
-        assert isinstance(parameters, dict)
-        assert "input_size" in parameters
-        assert parameters["input_size"] == (1, 3, 560, 560)
+    def test_exporter(self, fxt_dino_v2_seg):
+        exporter = fxt_dino_v2_seg._exporter
+        assert isinstance(exporter, OTXModelExporter)
+        assert exporter.input_size == (1, 3, 560, 560)
 
     def test_optimization_config(self, fxt_dino_v2_seg):
         config = fxt_dino_v2_seg._optimization_config

--- a/tests/unit/core/exporter/test_mmdeploy.py
+++ b/tests/unit/core/exporter/test_mmdeploy.py
@@ -34,6 +34,7 @@ class TestMMdeployExporter:
             model_builder=MagicMock(),
             model_cfg=MagicMock(),
             deploy_cfg=self.DEFAULT_MMDEPLOY_CFG,
+            task_level_export_parameters=MagicMock(),
             test_pipeline=MagicMock(),
             input_size=(1, 3, 256, 256),
             max_num_detections=max_num_detections,

--- a/tests/unit/core/exporter/test_visual_prompting.py
+++ b/tests/unit/core/exporter/test_visual_prompting.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests of visual prompting exporter."""
 
+from unittest.mock import MagicMock
+
 import pytest
 from otx.core.exporter.visual_prompting import OTXVisualPromptingModelExporter
 from otx.core.types.export import OTXExportFormatType
@@ -22,7 +24,11 @@ class MockModel(nn.Module):
 class TestOTXVisualPromptingModelExporter:
     @pytest.fixture()
     def otx_visual_prompting_model_exporter(self) -> OTXVisualPromptingModelExporter:
-        return OTXVisualPromptingModelExporter(input_size=(10, 10), via_onnx=True)
+        return OTXVisualPromptingModelExporter(
+            task_level_export_parameters=MagicMock(),
+            input_size=(10, 10),
+            via_onnx=True,
+        )
 
     def test_export_openvino(self, mocker, tmpdir, otx_visual_prompting_model_exporter) -> None:
         """Test export for OPENVINO."""

--- a/tests/unit/core/model/test_visual_prompting.py
+++ b/tests/unit/core/model/test_visual_prompting.py
@@ -26,19 +26,24 @@ from otx.core.model.visual_prompting import (
     _inference_step,
     _inference_step_for_zero_shot,
 )
+from otx.core.types.export import TaskLevelExportParameters
 from torchvision import tv_tensors
 
 
 @pytest.fixture()
 def otx_visual_prompting_model(mocker) -> OTXVisualPromptingModel:
     mocker.patch.object(OTXVisualPromptingModel, "_create_model")
-    return OTXVisualPromptingModel(num_classes=1)
+    model = OTXVisualPromptingModel(num_classes=1)
+    model.model.image_size = 1024
+    return model
 
 
 @pytest.fixture()
 def otx_zero_shot_visual_prompting_model(mocker) -> OTXZeroShotVisualPromptingModel:
     mocker.patch.object(OTXZeroShotVisualPromptingModel, "_create_model")
-    return OTXZeroShotVisualPromptingModel(num_classes=1)
+    model = OTXZeroShotVisualPromptingModel(num_classes=1)
+    model.model.image_size = 1024
+    return model
 
 
 def test_inference_step(mocker, otx_visual_prompting_model, fxt_vpm_data_entity) -> None:
@@ -136,18 +141,20 @@ def test_inference_step_for_zero_shot_with_more_target(
 class TestOTXVisualPromptingModel:
     def test_exporter(self, otx_visual_prompting_model) -> None:
         """Test _exporter."""
-        assert isinstance(otx_visual_prompting_model._exporter, OTXVisualPromptingModelExporter)
+        exporter = otx_visual_prompting_model._exporter
+        assert isinstance(exporter, OTXVisualPromptingModelExporter)
+        assert exporter.input_size == (1, 3, 1024, 1024)
+        assert exporter.resize_mode == "fit_to_window"
+        assert exporter.mean == (123.675, 116.28, 103.53)
+        assert exporter.std == (58.395, 57.12, 57.375)
 
     def test_export_parameters(self, otx_visual_prompting_model) -> None:
         """Test _export_parameters."""
-        otx_visual_prompting_model.model.image_size = 1024
-
         export_parameters = otx_visual_prompting_model._export_parameters
 
-        assert export_parameters["input_size"] == (1, 3, 1024, 1024)
-        assert export_parameters["resize_mode"] == "fit_to_window"
-        assert export_parameters["mean"] == (123.675, 116.28, 103.53)
-        assert export_parameters["std"] == (58.395, 57.12, 57.375)
+        assert isinstance(export_parameters, TaskLevelExportParameters)
+        assert export_parameters.model_type == "Visual_Prompting"
+        assert export_parameters.task_type == "visual_prompting"
 
     def test_optimization_config(self, otx_visual_prompting_model) -> None:
         """Test _optimization_config."""
@@ -175,18 +182,20 @@ class TestOTXVisualPromptingModel:
 class TestOTXZeroShotVisualPromptingModel:
     def test_exporter(self, otx_zero_shot_visual_prompting_model) -> None:
         """Test _exporter."""
-        assert isinstance(otx_zero_shot_visual_prompting_model._exporter, OTXVisualPromptingModelExporter)
+        exporter = otx_zero_shot_visual_prompting_model._exporter
+        assert isinstance(exporter, OTXVisualPromptingModelExporter)
+        assert exporter.input_size == (1, 3, 1024, 1024)
+        assert exporter.resize_mode == "fit_to_window"
+        assert exporter.mean == (123.675, 116.28, 103.53)
+        assert exporter.std == (58.395, 57.12, 57.375)
 
     def test_export_parameters(self, otx_zero_shot_visual_prompting_model) -> None:
         """Test _export_parameters."""
-        otx_zero_shot_visual_prompting_model.model.image_size = 1024
-
         export_parameters = otx_zero_shot_visual_prompting_model._export_parameters
 
-        assert export_parameters["input_size"] == (1, 3, 1024, 1024)
-        assert export_parameters["resize_mode"] == "fit_to_window"
-        assert export_parameters["mean"] == (123.675, 116.28, 103.53)
-        assert export_parameters["std"] == (58.395, 57.12, 57.375)
+        assert isinstance(export_parameters, TaskLevelExportParameters)
+        assert export_parameters.model_type == "Visual_Prompting"
+        assert export_parameters.task_type == "visual_prompting"
 
     def test_optimization_config(self, otx_zero_shot_visual_prompting_model) -> None:
         """Test _optimization_config."""

--- a/tests/unit/core/types/conftest.py
+++ b/tests/unit/core/types/conftest.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from otx.core.types.label import LabelInfo
+
+
+@pytest.fixture(
+    params=[
+        "fxt_multiclass_labelinfo",
+        "fxt_hlabel_multilabel_info",
+        "fxt_null_label_info",
+        "fxt_seg_label_info",
+    ],
+)
+def fxt_label_info(request: pytest.FixtureRequest) -> LabelInfo:
+    return request.getfixturevalue(request.param)

--- a/tests/unit/core/types/test_export.py
+++ b/tests/unit/core/types/test_export.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from otx.core.config.data import TileConfig
+from otx.core.types.export import TaskLevelExportParameters
+
+
+@pytest.mark.parametrize("task_type", ["instance_segmentation", "classification"])
+def test_wrap(fxt_label_info, task_type):
+    params = TaskLevelExportParameters(
+        model_type="dummy model",
+        task_type=task_type,
+        label_info=fxt_label_info,
+        optimization_config={},
+    )
+
+    multilabel = False
+    hierarchical = False
+    confidence_threshold = 0.0
+    iou_threshold = 0.0
+    return_soft_prediction = False
+    soft_threshold = 0.0
+    blur_strength = 0
+    tile_config = TileConfig()
+
+    params = params.wrap(
+        multilabel=multilabel,
+        hierarchical=hierarchical,
+        confidence_threshold=confidence_threshold,
+        iou_threshold=iou_threshold,
+        return_soft_prediction=return_soft_prediction,
+        soft_threshold=soft_threshold,
+        blur_strength=blur_strength,
+        tile_config=tile_config,
+    )
+
+    metadata = params.to_metadata()
+
+    assert metadata[("model_info", "multilabel")] == str(multilabel)
+    assert metadata[("model_info", "hierarchical")] == str(hierarchical)
+    assert metadata[("model_info", "confidence_threshold")] == str(confidence_threshold)
+    assert metadata[("model_info", "iou_threshold")] == str(iou_threshold)
+    assert metadata[("model_info", "return_soft_prediction")] == str(return_soft_prediction)
+    assert metadata[("model_info", "soft_threshold")] == str(soft_threshold)
+    assert metadata[("model_info", "blur_strength")] == str(blur_strength)
+
+    # Tile config
+    assert ("model_info", "tile_size") in metadata
+    assert ("model_info", "tiles_overlap") in metadata
+    assert ("model_info", "max_pred_number") in metadata

--- a/tests/unit/core/types/test_label.py
+++ b/tests/unit/core/types/test_label.py
@@ -1,21 +1,6 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-from otx.core.types.label import LabelInfo
-
-
-@pytest.fixture(
-    params=[
-        "fxt_multiclass_labelinfo",
-        "fxt_hlabel_multilabel_info",
-        "fxt_null_label_info",
-        "fxt_seg_label_info",
-    ],
-)
-def fxt_label_info(request: pytest.FixtureRequest) -> LabelInfo:
-    return request.getfixturevalue(request.param)
-
 
 def test_as_json(fxt_label_info):
     serialized = fxt_label_info.to_json()

--- a/tests/unit/core/utils/test_utils.py
+++ b/tests/unit/core/utils/test_utils.py
@@ -63,9 +63,9 @@ def test_get_mean_std_from_data_processing():
             "std": 0.1,
         },
     }
-    result = get_mean_std_from_data_processing(config)
-    assert result["mean"] == 0.5
-    assert result["std"] == 0.1
+    mean, std = get_mean_std_from_data_processing(config)
+    assert mean == 0.5
+    assert std == 0.1
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Summary
- Ticket no. 137997
- We've been maintaining both `OTXModel._exporter` and `OTXModel._export_parameters` properties for the model exportation.
- However, this structure makes a model developer hard to know what to do to make their model to be exportable. For example, `OTXTVModel` develop should have fill in this flexible data object, `OTXModel._export_parameters` without any help of intellisense.
https://github.com/openvinotoolkit/training_extensions/blob/ce4b7fcb348c9f2b43c478dc0559b59d2e985a09/src/otx/algo/classification/torchvision_model.py#L285-L306
- This PR aims to model developers only care about the `OTXModel._exporter` property when they develop a new model. This will help them to fill in the appropriate fields with help of intellisense such as
<img width="1244" alt="image" src="https://github.com/openvinotoolkit/training_extensions/assets/26541465/2dbe903a-632a-4758-8f77-c460a1b6857e">

- It can be done by revisiting `OTXModel._export_parameters` and extracting a strict data type object, `TaskLevelExportParameters` from a subset of them.
- `TaskLevelExportParameters` tries to package what can really be shared by task. Therefore, individual model developers don't need to care about it and can just pass it to `OTXModelExporter.__init__(task_level_export_parameters=...)`.
- Other export parameters can be filled in the derived property of `OTX_Model._exporter` of each individual model.

### How to test
Fixed some tests according to the source changes as well.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
