### PR TITLE
e2e tests: update XAI reference values

### DIFF
--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -327,38 +327,38 @@ def test_otx_explain_e2e_cli(
     reference_sal_vals = {
         # Classification
         "multi_label_cls_efficientnet_v2_light": (
-            np.array([66, 97, 84, 33, 42, 79, 0], dtype=np.uint8),
-            "Slide6_class_0_saliency_map.png",
+            np.array([201, 209, 196, 158, 157, 119, 77], dtype=np.uint8),
+            "American_Crow_0031_25433_class_0_saliency_map.png",
         ),
         "h_label_cls_efficientnet_v2_light": (
-            np.array([152, 193, 144, 132, 149, 204, 217], dtype=np.uint8),
-            "092_class_5_saliency_map.png",
+            np.array([102, 141, 134, 79, 66, 92, 84], dtype=np.uint8),
+            "108_class_4_saliency_map.png",
         ),
         # Detection
         "detection_yolox_tiny": (
-            np.array([111, 163, 141, 141, 146, 147, 158, 169, 184, 193], dtype=np.uint8),
-            "Slide3_class_0_saliency_map.png",
+            np.array([182, 194, 187, 179, 188, 206, 215, 207, 177, 130], dtype=np.uint8),
+            "img_371_jpg_rf_a893e0bdc6fda0ba1b2a7f07d56cec23_class_0_saliency_map.png",
         ),
         "detection_ssd_mobilenetv2": (
-            np.array([135, 80, 74, 34, 27, 32, 47, 42, 32, 34], dtype=np.uint8),
-            "Slide3_class_0_saliency_map.png",
+            np.array([118, 188, 241, 213, 160, 120, 86, 94, 111, 138], dtype=np.uint8),
+            "img_371_jpg_rf_a893e0bdc6fda0ba1b2a7f07d56cec23_class_0_saliency_map.png",
         ),
         "detection_atss_mobilenetv2": (
-            np.array([22, 62, 64, 0, 27, 60, 59, 53, 37, 45], dtype=np.uint8),
-            "Slide3_class_0_saliency_map.png",
+            np.array([29, 39, 55, 69, 80, 88, 92, 86, 100, 88], dtype=np.uint8),
+            "img_371_jpg_rf_a893e0bdc6fda0ba1b2a7f07d56cec23_class_0_saliency_map.png",
         ),
         # Instance Segmentation
         "instance_segmentation_maskrcnn_efficientnetb2b": (
-            np.array([54, 54, 54, 54, 0, 0, 0, 54, 0, 0], dtype=np.uint8),
-            "Slide3_class_0_saliency_map.png",
+            np.array([5, 5, 5, 5, 5, 5, 5, 5, 5, 5], dtype=np.uint8),
+            "CDY_2018_class_0_saliency_map.png",
         ),
     }
     test_case_name = task + "_" + model_name
     if test_case_name in reference_sal_vals:
         actual_sal_vals = cv2.imread(str(latest_dir / "saliency_maps" / reference_sal_vals[test_case_name][1]))
         if test_case_name == "instance_segmentation_maskrcnn_efficientnetb2b":
-            # Take corner values due to map sparsity of InstSeg
-            actual_sal_vals = (actual_sal_vals[-10:, -1, -1]).astype(np.uint16)
+            # Take lower corner values due to map sparsity of InstSeg
+            actual_sal_vals = (actual_sal_vals[-10:, -1, 0]).astype(np.uint16)
         else:
             actual_sal_vals = (actual_sal_vals[:10, 0, 0]).astype(np.uint16)
         ref_sal_vals = reference_sal_vals[test_case_name][0]


### PR DESCRIPTION
Updated reference tests values to correspond to new real-life small datasets (instead of toy datasets used before)

[Issue#3275](https://github.com/openvinotoolkit/training_extensions/issues/3275)

e2e tests for XAI passed: https://github.com/openvinotoolkit/training_extensions/actions/runs/8602899804

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
