### PR TITLE
Temporary fix for jsonargparse issue on Python3.11.9

### DIFF
--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -43,7 +43,9 @@ jobs:
         include:
           - python-version: "3.10"
             tox-env: "py310"
-          - python-version: "3.11"
+            # TODO(vinnamki): Revisit after fixing in the upstream: https://github.com/omni-us/jsonargparse/issues/484
+            # Ticket no. 138075
+          - python-version: "3.11.8"
             tox-env: "py311"
     name: Unit-Test-with-Python${{ matrix.python-version }}
     # This is what will cancel the job concurrency


### PR DESCRIPTION
### Summary

Our CI unit test on Python 3.11 started not working today (Python 3.10 is fine).

- develop, jsonargparse=4.27.7: [Refactor to implant optimizer and scheduler into model code (#3258) · openvinotoolkit/training_extensions@bc887ed (github.com)](https://github.com/openvinotoolkit/training_extensions/actions/runs/8608850991/job/23591901236)
- jsonargparse=4.27.1: [Refactor export part 1 - export parameters · openvinotoolkit/training_extensions@4fda8cb (github.com)](https://github.com/openvinotoolkit/training_extensions/actions/runs/8608284639/job/23590400567)

This seems because Python 3.11.9 is released today (Apr. 08): [Python Insider: Python 3.11.9 is now available](https://pythoninsider.blogspot.com/2024/04/python-3119-is-now-available.html) and jsonargparse is affected by this update: https://github.com/omni-us/jsonargparse/issues/484

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```

