### PR TITLE
[Experiments] Increase ES patience for multi-label-cls

### DIFF
--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -35,7 +35,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -37,7 +37,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
@@ -40,7 +40,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -39,7 +39,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-138087

- Overall, All cases are about 3x faster (E2E time)
- But, Drops occur for small case

Solution:
Way 1: Increase ES-patience
Way 2: Add feature for start_epoch of mm's ES like OTX 1.5


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
