### PR TITLE
Matches settings with Multi-label classification OTX 1.5

### DIFF
--- a/src/otx/algo/callbacks/adaptive_train_scheduling.py
+++ b/src/otx/algo/callbacks/adaptive_train_scheduling.py
@@ -29,10 +29,10 @@ class AdaptiveTrainScheduling(Callback):
             Defaults to -0.025.
     """
 
-    def __init__(self, max_interval: int = 5, decay: float = -0.025):
+    def __init__(self, max_interval: int = 5, decay: float = -0.025, min_earlystop_patience: int = 3):
         self.max_interval = max_interval
         self.decay = decay
-        self.min_earlystop_interval = 3
+        self.min_earlystop_patience = min_earlystop_patience
         self.min_lrschedule_patience = 2
         self._saved_check_val_every_n_epoch: int | None = None
         self._saved_log_every_n_steps: int | None = None
@@ -153,7 +153,7 @@ class AdaptiveTrainScheduling(Callback):
 
         for callback in callbacks:
             if isinstance(callback, EarlyStopping):
-                adjusted_patience = max(int(callback.patience / adaptive_interval), self.min_earlystop_interval)
+                adjusted_patience = max(int(callback.patience / adaptive_interval), self.min_earlystop_patience)
                 msg = (
                     "The patience of early stopping will be changed due to the effect of adaptive interval: "
                     f"{callback.patience} --> {adjusted_patience}."

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -12,7 +12,7 @@ scheduler:
   class_path: lightning.pytorch.cli.ReduceLROnPlateau
   init_args:
     mode: max
-    factor: 0.1
+    factor: 0.5
     patience: 1
     monitor: val/accuracy
 
@@ -31,11 +31,14 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
-  max_epochs: 90
+  max_epochs: 200
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 4
+        patience: 8
+    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
+      init_args:
+        min_earlystop_patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:
@@ -45,7 +48,10 @@ overrides:
           - type: LoadImageFromFile
           - backend: cv2
             scale: 224
-            type: Resize
+            type: RandomResizedCrop
+          # - backend: cv2
+          #   scale: 224
+          #   type: Resize
           - type: PackInputs
       val_subset:
         transforms:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -35,7 +35,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -49,9 +49,6 @@ overrides:
           - backend: cv2
             scale: 224
             type: RandomResizedCrop
-          # - backend: cv2
-          #   scale: 224
-          #   type: Resize
           - type: PackInputs
       val_subset:
         transforms:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -37,7 +37,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -8,14 +8,15 @@ optimizer:
   init_args:
     lr: 0.0071
     momentum: 0.9
-    weight_decay: 0.0001
+    weight_decay: 0.0005
 
 scheduler:
   class_path: lightning.pytorch.cli.ReduceLROnPlateau
   init_args:
     mode: max
-    factor: 0.1
+    factor: 0.5
     patience: 1
+    min_lr: 0.000001
     monitor: val/accuracy
 
 metric:
@@ -33,11 +34,14 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
-  max_epochs: 90
+  max_epochs: 200
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 4
+        patience: 8
+    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
+      init_args:
+        min_earlystop_patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:
@@ -47,7 +51,7 @@ overrides:
           - type: LoadImageFromFile
           - backend: cv2
             scale: 224
-            type: Resize
+            type: RandomResizedCrop
           - direction: horizontal
             prob: 0.5
             type: RandomFlip

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
@@ -17,7 +17,7 @@ scheduler:
   - class_path: lightning.pytorch.cli.ReduceLROnPlateau
     init_args:
       mode: max
-      factor: 0.1
+      factor: 0.5
       patience: 1
       monitor: val/accuracy
 
@@ -36,11 +36,14 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
-  max_epochs: 90
+  max_epochs: 200
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 4
+        patience: 8
+    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
+      init_args:
+        min_earlystop_patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:
@@ -50,7 +53,7 @@ overrides:
           - type: LoadImageFromFile
           - backend: cv2
             scale: 224
-            type: Resize
+            type: RandomResizedCrop
           - direction: horizontal
             prob: 0.5
             type: RandomFlip

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large_light.yaml
@@ -40,7 +40,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -10,13 +10,10 @@ optimizer:
     weight_decay: 0.05
 
 scheduler:
-  - class_path: otx.algo.schedulers.warmup_schedulers.LinearWarmupScheduler
-    init_args:
-      num_warmup_steps: 10
   - class_path: lightning.pytorch.cli.ReduceLROnPlateau
     init_args:
       mode: max
-      factor: 0.1
+      factor: 0.5
       patience: 1
       monitor: val/accuracy
 
@@ -35,11 +32,14 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/mmpretrain_base.yaml
 overrides:
-  max_epochs: 90
+  max_epochs: 200
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 4
+        patience: 8
+    - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
+      init_args:
+        min_earlystop_patience: 8
   data:
     task: MULTI_LABEL_CLS
     config:
@@ -47,9 +47,12 @@ overrides:
       train_subset:
         transforms:
           - type: LoadImageFromFile
+          # - backend: cv2
+          #   scale: 224
+          #   type: Resize
           - backend: cv2
             scale: 224
-            type: Resize
+            type: RandomResizedCrop
           - type: PackInputs
       val_subset:
         transforms:

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -47,9 +47,6 @@ overrides:
       train_subset:
         transforms:
           - type: LoadImageFromFile
-          # - backend: cv2
-          #   scale: 224
-          #   type: Resize
           - backend: cv2
             scale: 224
             type: RandomResizedCrop

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -39,7 +39,7 @@ overrides:
   callbacks:
     - class_path: lightning.pytorch.callbacks.EarlyStopping
       init_args:
-        patience: 3
+        patience: 4
   data:
     task: MULTI_LABEL_CLS
     config:


### PR DESCRIPTION
### Summary

- Multi-label classification for OTX 1.5 use Adaptive Repeat Dataset (Not Adaptive Training Schedule)
    - Patience not changed
    - if OTX 1.5 training epochs 25 (Adaptive Repeat)-> then OTX 2.0 (Adaptive schedule) 25 * 5 (small) = 125 epochs needed
    - so, increase max_epochs to 200
- Data pipeline
    - Resize -> RandomResizedCrop

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Small |   | test/accuracy | train/e2e_time | OTX 2.0 - OTX 1.5
-- | -- | -- | -- | --
Efficientnet_b0_light | OTX 1.5 | 0.9896 | 29 |  
  | OTX 2.0 (before) | 0.8486 | 16 |  
  | OTX 2.0 (after) | 0.8987 | 24 | -0.091
Efficientnet_v2_light | OTX 1.5 | 0.9917 | 43 |  
  | OTX 2.0 (before) | 0.7160 | 18 |  
  | OTX 2.0 (after) | 0.8267 | 33 | -0.165
Mobilenet_v3_large_light | OTX 1.5 | 0.9887 | 25 |  
  | OTX 2.0 (before) | 0.9751 | 15 |  
  | OTX 2.0 (after) | 0.9876 | 19 | -0.001
otx_deit_tiny | OTX 1.5 | 0.9925 | 22 |  
  | OTX 2.0 (before) | 0.8369 | 16 |  
  | OTX 2.0 (after) | 0.9782 | 22 | -0.014



</div>

<!--EndFragment-->
</body>

</html>

Efficientnet-b0, v2 still show low performance
(WIP) Looking for any other additional differences


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
