### PR TITLE
Revisit LabelInfo to make it immutable on OTXModel side as possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,6 +298,16 @@ target-version = "py38"
 # Enumerate all fixed violations.
 show-fixes = true
 
+[tool.ruff.lint.flake8-bugbear]
+# Allow default arguments like, e.g., `data: List[str] = fastapi.Query(None)`.
+extend-immutable-calls = [
+    "otx.core.types.label.LabelInfo",
+    "otx.core.types.label.HLabelInfo",
+    "otx.core.types.label.SegLabelInfo",
+    "otx.core.types.label.NullLabelInfo",
+    "otx.core.types.label.AnomalyLabelInfo",
+]
+
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 20

--- a/src/otx/algo/action_classification/movinet.py
+++ b/src/otx/algo/action_classification/movinet.py
@@ -13,6 +13,7 @@ from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.action_classification import MMActionCompatibleModel
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -25,7 +26,7 @@ class MoViNet(MMActionCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
@@ -33,7 +34,7 @@ class MoViNet(MMActionCompatibleModel):
     ) -> None:
         config = read_mmconfig("movinet")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/action_classification/x3d.py
+++ b/src/otx/algo/action_classification/x3d.py
@@ -12,6 +12,7 @@ from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.action_classification import MMActionCompatibleModel
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -24,7 +25,7 @@ class X3D(MMActionCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
@@ -32,7 +33,7 @@ class X3D(MMActionCompatibleModel):
     ) -> None:
         config = read_mmconfig("x3d")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/action_detection/x3d_fastrcnn.py
+++ b/src/otx/algo/action_detection/x3d_fastrcnn.py
@@ -12,6 +12,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.action_detection import MMActionCompatibleModel
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -24,7 +25,7 @@ class X3DFastRCNN(MMActionCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         topk: int | tuple[int],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -34,7 +35,7 @@ class X3DFastRCNN(MMActionCompatibleModel):
         config = read_mmconfig("x3d_fastrcnn")
         config.roi_head.bbox_head.topk = topk
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/anomaly/openvino_model.py
+++ b/src/otx/algo/anomaly/openvino_model.py
@@ -35,12 +35,10 @@ class AnomalyOpenVINO(OVModel):
         max_num_requests: int | None = None,
         use_throughput_mode: bool = True,
         model_api_configuration: dict[str, Any] | None = None,
-        num_classes: int = 2,
         metric: MetricCallable = NullMetricCallable,
         **kwargs,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,  # NOTE: Ideally this should be set to 2 always
             model_name=model_name,
             model_type="AnomalyDetection",
             async_inference=async_inference,

--- a/src/otx/algo/anomaly/padim.py
+++ b/src/otx/algo/anomaly/padim.py
@@ -13,6 +13,7 @@ from anomalib.models.image import Padim as AnomalibPadim
 
 from otx.core.model.anomaly import OTXAnomaly
 from otx.core.model.base import OTXModel
+from otx.core.types.label import AnomalyLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.utilities.types import STEP_OUTPUT
@@ -39,10 +40,9 @@ class Padim(OTXAnomaly, OTXModel, AnomalibPadim):
         layers: list[str] = ["layer1", "layer2", "layer3"],  # noqa: B006
         pre_trained: bool = True,
         n_features: int | None = None,
-        num_classes: int = 2,
     ) -> None:
         OTXAnomaly.__init__(self)
-        OTXModel.__init__(self, num_classes=num_classes)
+        OTXModel.__init__(self, label_info=AnomalyLabelInfo())
         AnomalibPadim.__init__(
             self,
             backbone=backbone,

--- a/src/otx/algo/anomaly/stfpm.py
+++ b/src/otx/algo/anomaly/stfpm.py
@@ -13,6 +13,7 @@ from anomalib.models.image.stfpm import Stfpm as AnomalibStfpm
 
 from otx.core.model.anomaly import OTXAnomaly
 from otx.core.model.base import OTXModel
+from otx.core.types.label import AnomalyLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.utilities.types import STEP_OUTPUT
@@ -35,11 +36,10 @@ class Stfpm(OTXAnomaly, OTXModel, AnomalibStfpm):
         self,
         layers: Sequence[str] = ["layer1", "layer2", "layer3"],
         backbone: str = "resnet18",
-        num_classes: int = 2,
         **kwargs,
     ) -> None:
         OTXAnomaly.__init__(self)
-        OTXModel.__init__(self, num_classes=num_classes)
+        OTXModel.__init__(self, label_info=AnomalyLabelInfo())
         AnomalibStfpm.__init__(
             self,
             backbone=backbone,

--- a/src/otx/algo/classification/deit_tiny.py
+++ b/src/otx/algo/classification/deit_tiny.py
@@ -22,7 +22,7 @@ from otx.core.model.classification import (
 )
 from otx.core.model.utils.mmpretrain import ExplainableMixInMMPretrainModel
 from otx.core.schedulers import LRSchedulerListCallable
-from otx.core.types.label import HLabelInfo
+from otx.core.types.label import HLabelInfo, LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -150,7 +150,7 @@ class DeitTinyForHLabelCls(ForwardExplainMixInForDeit, MMPretrainHlabelClsModel)
 
     def __init__(
         self,
-        hlabel_info: HLabelInfo,
+        label_info: HLabelInfo,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
@@ -159,7 +159,7 @@ class DeitTinyForHLabelCls(ForwardExplainMixInForDeit, MMPretrainHlabelClsModel)
         config = read_mmconfig("deit_tiny", subdir_name="hlabel_classification")
 
         super().__init__(
-            hlabel_info=hlabel_info,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -177,7 +177,7 @@ class DeitTinyForMulticlassCls(ForwardExplainMixInForDeit, MMPretrainMulticlassC
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
@@ -185,7 +185,7 @@ class DeitTinyForMulticlassCls(ForwardExplainMixInForDeit, MMPretrainMulticlassC
     ) -> None:
         config = read_mmconfig("deit_tiny", subdir_name="multiclass_classification")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -203,7 +203,7 @@ class DeitTinyForMultilabelCls(ForwardExplainMixInForDeit, MMPretrainMultilabelC
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiLabelClsMetricCallable,
@@ -211,7 +211,7 @@ class DeitTinyForMultilabelCls(ForwardExplainMixInForDeit, MMPretrainMultilabelC
     ) -> None:
         config = read_mmconfig("deit_tiny", subdir_name="multilabel_classification")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/classification/efficientnet_b0.py
+++ b/src/otx/algo/classification/efficientnet_b0.py
@@ -19,7 +19,7 @@ from otx.core.model.classification import (
 )
 from otx.core.model.utils.mmpretrain import ExplainableMixInMMPretrainModel
 from otx.core.schedulers import LRSchedulerListCallable
-from otx.core.types.label import HLabelInfo
+from otx.core.types.label import HLabelInfo, LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -32,7 +32,7 @@ class EfficientNetB0ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlab
 
     def __init__(
         self,
-        hlabel_info: HLabelInfo,
+        label_info: HLabelInfo,
         optimizer: OptimizerCallable = lambda params: torch.optim.SGD(
             params=params,
             lr=0.0049,
@@ -50,7 +50,7 @@ class EfficientNetB0ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlab
         config = read_mmconfig(model_name="efficientnet_b0_light", subdir_name="hlabel_classification")
 
         super().__init__(
-            hlabel_info=hlabel_info,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -68,7 +68,7 @@ class EfficientNetB0ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrain
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         light: bool = False,
         optimizer: OptimizerCallable = lambda params: torch.optim.SGD(
             params=params,
@@ -89,7 +89,7 @@ class EfficientNetB0ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrain
         model_name = "efficientnet_b0_light" if light else "efficientnet_b0"
         config = read_mmconfig(model_name=model_name, subdir_name="multiclass_classification")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -110,7 +110,7 @@ class EfficientNetB0ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrain
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = lambda params: torch.optim.SGD(
             params=params,
             lr=0.0049,
@@ -127,7 +127,7 @@ class EfficientNetB0ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrain
     ) -> None:
         config = read_mmconfig(model_name="efficientnet_b0_light", subdir_name="multilabel_classification")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/classification/efficientnet_v2.py
+++ b/src/otx/algo/classification/efficientnet_v2.py
@@ -17,7 +17,7 @@ from otx.core.model.classification import (
 )
 from otx.core.model.utils.mmpretrain import ExplainableMixInMMPretrainModel
 from otx.core.schedulers import LRSchedulerListCallable
-from otx.core.types.label import HLabelInfo
+from otx.core.types.label import HLabelInfo, LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -30,7 +30,7 @@ class EfficientNetV2ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlab
 
     def __init__(
         self,
-        hlabel_info: HLabelInfo,
+        label_info: HLabelInfo,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
@@ -39,7 +39,7 @@ class EfficientNetV2ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlab
         config = read_mmconfig("efficientnet_v2_light", subdir_name="hlabel_classification")
 
         super().__init__(
-            hlabel_info=hlabel_info,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -57,7 +57,7 @@ class EfficientNetV2ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrain
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         light: bool = False,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -67,7 +67,7 @@ class EfficientNetV2ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrain
         model_name = "efficientnet_v2_light" if light else "efficientnet_v2"
         config = read_mmconfig(model_name=model_name, subdir_name="multiclass_classification")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -85,7 +85,7 @@ class EfficientNetV2ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrain
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiLabelClsMetricCallable,
@@ -93,7 +93,7 @@ class EfficientNetV2ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrain
     ) -> None:
         config = read_mmconfig("efficientnet_v2_light", subdir_name="multilabel_classification")
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/classification/mobilenet_v3.py
+++ b/src/otx/algo/classification/mobilenet_v3.py
@@ -32,7 +32,7 @@ from otx.core.metrics.accuracy import HLabelClsMetricCallble, MultiClassClsMetri
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.classification import OTXHlabelClsModel, OTXMulticlassClsModel, OTXMultilabelClsModel
 from otx.core.schedulers import LRSchedulerListCallable
-from otx.core.types.label import HLabelInfo
+from otx.core.types.label import HLabelInfo, LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -57,7 +57,7 @@ class MobileNetV3ForMulticlassCls(OTXMulticlassClsModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         mode: Literal["large", "small"] = "large",
         loss_callable: Callable[[], nn.Module] = nn.CrossEntropyLoss,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
@@ -69,7 +69,7 @@ class MobileNetV3ForMulticlassCls(OTXMulticlassClsModel):
         self.head_config = {"loss_callable": loss_callable}
 
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -171,7 +171,7 @@ class MobileNetV3ForMultilabelCls(OTXMultilabelClsModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         mode: Literal["large", "small"] = "large",
         loss_callable: Callable[[], nn.Module] = nn.CrossEntropyLoss,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
@@ -183,7 +183,7 @@ class MobileNetV3ForMultilabelCls(OTXMultilabelClsModel):
         self.head_config = {"loss_callable": loss_callable}
 
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -288,7 +288,7 @@ class MobileNetV3ForHLabelCls(OTXHlabelClsModel):
 
     def __init__(
         self,
-        hlabel_info: HLabelInfo,
+        label_info: HLabelInfo,
         mode: Literal["large", "small"] = "large",
         multiclass_loss_callable: Callable[[], nn.Module] = nn.CrossEntropyLoss,
         multilabel_loss_callable: Callable[[], nn.Module] = nn.CrossEntropyLoss,
@@ -302,10 +302,9 @@ class MobileNetV3ForHLabelCls(OTXHlabelClsModel):
             "multiclass_loss_callable": multiclass_loss_callable,
             "multilabel_loss_callable": multilabel_loss_callable,
         }
-        self.hlabel_info = hlabel_info
 
         super().__init__(
-            hlabel_info=hlabel_info,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -315,6 +314,9 @@ class MobileNetV3ForHLabelCls(OTXHlabelClsModel):
     def _create_model(self) -> nn.Module:
         multiclass_loss = self.head_config["multiclass_loss_callable"]
         multilabel_loss = self.head_config["multilabel_loss_callable"]
+        if not isinstance(self.label_info, HLabelInfo):
+            raise TypeError(self.label_info)
+
         return ImageClassifier(
             backbone=OTXMobileNetV3(mode=self.mode),
             neck=GlobalAveragePooling(dim=2),
@@ -322,7 +324,7 @@ class MobileNetV3ForHLabelCls(OTXHlabelClsModel):
                 in_channels=960,
                 multiclass_loss=multiclass_loss if isinstance(multiclass_loss, nn.Module) else multiclass_loss(),
                 multilabel_loss=multilabel_loss if isinstance(multilabel_loss, nn.Module) else multilabel_loss(),
-                **self.hlabel_info.as_head_config_dict(),
+                **self.label_info.as_head_config_dict(),
             ),
         )
 

--- a/src/otx/algo/classification/otx_dino_v2.py
+++ b/src/otx/algo/classification/otx_dino_v2.py
@@ -22,6 +22,7 @@ from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.classification import OTXMulticlassClsModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
@@ -76,7 +77,7 @@ class DINOv2RegisterClassifier(OTXMulticlassClsModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
@@ -84,13 +85,13 @@ class DINOv2RegisterClassifier(OTXMulticlassClsModel):
         freeze_backbone: bool = False,
     ) -> None:
         config = read_mmconfig(model_name="dino_v2", subdir_name="multiclass_classification")
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         config.backbone.frozen = freeze_backbone
 
         self.config = config
 
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/algo/classification/torchvision_model.py
+++ b/src/otx/algo/classification/torchvision_model.py
@@ -20,6 +20,7 @@ from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.classification import OTXMulticlassClsModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -218,7 +219,7 @@ class OTXTVModel(OTXMulticlassClsModel):
     def __init__(
         self,
         backbone: TVModelType,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         loss_callable: Callable[[], nn.Module] = nn.CrossEntropyLoss,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -232,7 +233,7 @@ class OTXTVModel(OTXMulticlassClsModel):
         self.freeze_backbone = freeze_backbone
 
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ class ATSS(MMDetCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["mobilenetv2", "resnext101"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -39,7 +40,7 @@ class ATSS(MMDetCompatibleModel):
         model_name = f"atss_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/detection/rtmdet.py
+++ b/src/otx/algo/detection/rtmdet.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ class RTMDet(MMDetCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["tiny"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -39,7 +40,7 @@ class RTMDet(MMDetCompatibleModel):
         model_name = f"rtmdet_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -24,6 +24,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.build import modify_num_classes
 from otx.core.utils.config import convert_conf_to_mmconfig_dict
 from otx.core.utils.utils import get_mean_std_from_data_processing
@@ -348,7 +349,7 @@ class SSD(MMDetCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["mobilenetv2"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -358,7 +359,7 @@ class SSD(MMDetCompatibleModel):
         model_name = f"ssd_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import MMDetCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ class YoloX(MMDetCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["l", "s", "x"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -39,7 +40,7 @@ class YoloX(MMDetCompatibleModel):
         model_name = f"yolox_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -83,7 +84,7 @@ class YoloXTiny(MMDetCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MeanAPCallable,
@@ -92,7 +93,7 @@ class YoloXTiny(MMDetCompatibleModel):
         model_name = "yolox_tiny"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/instance_segmentation/maskrcnn.py
+++ b/src/otx/algo/instance_segmentation/maskrcnn.py
@@ -16,6 +16,7 @@ from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.instance_segmentation import MMDetInstanceSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ class MaskRCNN(MMDetInstanceSegCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["efficientnetb2b", "r50"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -39,7 +40,7 @@ class MaskRCNN(MMDetInstanceSegCompatibleModel):
         model_name = f"maskrcnn_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,
@@ -83,7 +84,7 @@ class MaskRCNNSwinT(MMDetInstanceSegCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MaskRLEMeanAPCallable,
@@ -92,7 +93,7 @@ class MaskRCNNSwinT(MMDetInstanceSegCompatibleModel):
         model_name = "maskrcnn_swint"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/instance_segmentation/rtmdet_inst.py
+++ b/src/otx/algo/instance_segmentation/rtmdet_inst.py
@@ -15,6 +15,7 @@ from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.instance_segmentation import MMDetInstanceSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -28,7 +29,7 @@ class RTMDetInst(MMDetInstanceSegCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["tiny"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -38,7 +39,7 @@ class RTMDetInst(MMDetInstanceSegCompatibleModel):
         model_name = f"rtmdet_inst_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/segmentation/dino_v2_seg.py
+++ b/src/otx/algo/segmentation/dino_v2_seg.py
@@ -13,6 +13,7 @@ from otx.core.metrics.dice import SegmCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.segmentation import MMSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -26,7 +27,7 @@ class DinoV2Seg(MMSegCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = SegmCallable,  # type: ignore[assignment]
@@ -35,7 +36,7 @@ class DinoV2Seg(MMSegCompatibleModel):
         model_name = "dino_v2_seg"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/segmentation/litehrnet.py
+++ b/src/otx/algo/segmentation/litehrnet.py
@@ -17,6 +17,7 @@ from otx.core.metrics.dice import SegmCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.segmentation import MMSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ class LiteHRNet(MMSegCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["18", 18, "s", "x"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -40,7 +41,7 @@ class LiteHRNet(MMSegCompatibleModel):
         self.model_name = f"litehrnet_{variant}"
         config = read_mmconfig(model_name=self.model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/segmentation/segnext.py
+++ b/src/otx/algo/segmentation/segnext.py
@@ -14,6 +14,7 @@ from otx.core.metrics.dice import SegmCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.segmentation import MMSegCompatibleModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
 if TYPE_CHECKING:
@@ -27,7 +28,7 @@ class SegNext(MMSegCompatibleModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         variant: Literal["b", "s", "t"],
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
@@ -37,7 +38,7 @@ class SegNext(MMSegCompatibleModel):
         model_name = f"segnext_{variant}"
         config = read_mmconfig(model_name=model_name)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             config=config,
             optimizer=optimizer,
             scheduler=scheduler,

--- a/src/otx/algo/visual_prompting/segment_anything.py
+++ b/src/otx/algo/visual_prompting/segment_anything.py
@@ -21,6 +21,7 @@ from otx.core.metrics.visual_prompting import VisualPromptingMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.visual_prompting import OTXVisualPromptingModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes, NullLabelInfo
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -492,7 +493,7 @@ class OTXSegmentAnything(OTXVisualPromptingModel):
     def __init__(
         self,
         backbone: Literal["tiny_vit", "vit_b"],
-        num_classes: int = 0,
+        label_info: LabelInfoTypes = NullLabelInfo(),
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = VisualPromptingMetricCallable,
@@ -517,7 +518,7 @@ class OTXSegmentAnything(OTXVisualPromptingModel):
             **DEFAULT_CONFIG_SEGMENT_ANYTHING[backbone],
         }
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -31,6 +31,7 @@ from otx.core.metrics.visual_prompting import VisualPromptingMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.visual_prompting import OTXZeroShotVisualPromptingModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes, NullLabelInfo
 
 if TYPE_CHECKING:
     import numpy as np
@@ -627,7 +628,7 @@ class OTXZeroShotSegmentAnything(OTXZeroShotVisualPromptingModel):
     def __init__(
         self,
         backbone: Literal["tiny_vit", "vit_b"],
-        num_classes: int = 0,
+        label_info: LabelInfoTypes = NullLabelInfo(),
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = VisualPromptingMetricCallable,
@@ -660,7 +661,7 @@ class OTXZeroShotSegmentAnything(OTXZeroShotVisualPromptingModel):
             **DEFAULT_CONFIG_SEGMENT_ANYTHING[backbone],
         }
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -24,7 +24,6 @@ from otx.cli.utils.jsonargparse import get_short_docstring, patch_update_configs
 from otx.cli.utils.workspace import Workspace
 from otx.core.types.task import OTXTaskType
 from otx.core.utils.imports import get_otx_root_path
-from otx.utils.utils import get_model_cls_from_config, should_pass_label_info
 
 if TYPE_CHECKING:
     from jsonargparse._actions import _ActionSubCommands
@@ -366,6 +365,7 @@ class OTXCLI:
             tuple: The model and optimizer and scheduler.
         """
         from otx.core.model.base import OTXModel, OVModel
+        from otx.utils.utils import get_model_cls_from_config, should_pass_label_info
 
         skip = set()
 

--- a/src/otx/core/data/dataset/anomaly/dataset.py
+++ b/src/otx/core/data/dataset/anomaly/dataset.py
@@ -26,7 +26,7 @@ from otx.core.data.entity.anomaly import (
 from otx.core.data.entity.base import ImageInfo
 from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER, MemCacheHandlerBase
 from otx.core.types.image import ImageColorChannel
-from otx.core.types.label import LabelInfo
+from otx.core.types.label import AnomalyLabelInfo
 from otx.core.types.task import OTXTaskType
 
 
@@ -54,7 +54,7 @@ class AnomalyDataset(OTXDataset):
             image_color_channel,
             stack_images,
         )
-        self.label_info = LabelInfo(label_names=["Normal", "Anomaly"], label_groups=[["Normal", "Anomaly"]])
+        self.label_info = AnomalyLabelInfo()
 
     def _get_item_impl(
         self,

--- a/src/otx/core/model/action_classification.py
+++ b/src/otx/core/model/action_classification.py
@@ -18,6 +18,7 @@ from otx.core.metrics.accuracy import MultiClassClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.export import TaskLevelExportParameters
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
@@ -36,14 +37,14 @@ class OTXActionClsModel(OTXModel[ActionClsBatchDataEntity, ActionClsBatchPredEnt
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -81,19 +82,19 @@ class MMActionCompatibleModel(OTXActionClsModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
         self.image_size = (1, 1, 3, 8, 224, 224)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/core/model/action_detection.py
+++ b/src/otx/core/model/action_detection.py
@@ -15,6 +15,7 @@ from otx.core.metrics import MetricInput
 from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel
 from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
@@ -30,14 +31,14 @@ class OTXActionDetModel(OTXModel[ActionDetBatchDataEntity, ActionDetBatchPredEnt
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -84,18 +85,18 @@ class MMActionCompatibleModel(OTXActionDetModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/core/model/anomaly.py
+++ b/src/otx/core/model/anomaly.py
@@ -28,7 +28,7 @@ from otx.core.data.entity.anomaly import (
 )
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.types.export import OTXExportFormatType, TaskLevelExportParameters
-from otx.core.types.label import LabelInfo, NullLabelInfo
+from otx.core.types.label import NullLabelInfo
 from otx.core.types.precision import OTXPrecisionType
 from otx.core.types.task import OTXTaskType
 
@@ -205,27 +205,6 @@ class OTXAnomaly:
         else:
             msg = f"Unexpected task type: {value}"
             raise ValueError(msg)
-
-    @property
-    def label_info(self) -> LabelInfo:
-        """Get this model label information."""
-        return self._label_info
-
-    @label_info.setter
-    def label_info(self, value: LabelInfo | list[str]) -> None:
-        """Set this model label information.
-
-        It changes the number of classes to 2 and sets the labels as Normal and Anomaly.
-        This is because Datumaro returns multiple classes from the dataset. If self.label_info != 2,
-        then It will call self._reset_prediction_layer() to reset the prediction layer. Which is not required.
-
-        This overrides the OTXModel's label_info setter.
-        """
-        if isinstance(value, list):
-            # value can be greater than 2 as datumaro returns all anomalous categories separately
-            self._label_info = LabelInfo(label_names=["Normal", "Anomaly"], label_groups=[["Normal", "Anomaly"]])
-        else:
-            self._label_info = value
 
     def _extract_mean_scale_from_transforms(self, transforms: list[Transform]) -> None:
         """Extract mean and scale values from transforms."""

--- a/src/otx/core/model/classification.py
+++ b/src/otx/core/model/classification.py
@@ -31,7 +31,7 @@ from otx.core.metrics.accuracy import (
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.export import TaskLevelExportParameters
-from otx.core.types.label import HLabelInfo
+from otx.core.types.label import HLabelInfo, LabelInfo, LabelInfoTypes
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.utils import get_mean_std_from_data_processing
 
@@ -50,14 +50,14 @@ class OTXMulticlassClsModel(OTXModel[MulticlassClsBatchDataEntity, MulticlassCls
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -97,19 +97,19 @@ class MMPretrainMulticlassClsModel(OTXMulticlassClsModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
         self.image_size = (1, 3, 224, 224)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -243,14 +243,14 @@ class OTXMultilabelClsModel(OTXModel[MultilabelClsBatchDataEntity, MultilabelCls
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiLabelClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -293,19 +293,19 @@ class MMPretrainMultilabelClsModel(OTXMultilabelClsModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = lambda num_labels: Accuracy(task="multilabel", num_labels=num_labels),
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
         self.image_size = (1, 3, 224, 224)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -433,21 +433,19 @@ class OTXHlabelClsModel(OTXModel[HlabelClsBatchDataEntity, HlabelClsBatchPredEnt
 
     def __init__(
         self,
-        hlabel_info: HLabelInfo,
+        label_info: HLabelInfo,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=hlabel_info.num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
             torch_compile=torch_compile,
         )
-        # NOTE: This should be behind of super().__init__() to avoid overwriting
-        self._label_info = hlabel_info
 
     @property
     def _export_parameters(self) -> TaskLevelExportParameters:
@@ -478,6 +476,13 @@ class OTXHlabelClsModel(OTXModel[HlabelClsBatchDataEntity, HlabelClsBatchPredEnt
             "target": torch.stack(inputs.labels),
         }
 
+    @staticmethod
+    def _dispatch_label_info(label_info: LabelInfoTypes) -> LabelInfo:
+        if not isinstance(label_info, HLabelInfo):
+            raise TypeError(label_info)
+
+        return label_info
+
 
 class MMPretrainHlabelClsModel(OTXHlabelClsModel):
     """H-label Classification model compatible for MMPretrain.
@@ -489,26 +494,26 @@ class MMPretrainHlabelClsModel(OTXHlabelClsModel):
 
     def __init__(
         self,
-        hlabel_info: HLabelInfo,
+        label_info: HLabelInfo,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=hlabel_info.num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
 
         if (head_config := getattr(config, "head", None)) is None:
             msg = 'Config should have "head" section'
             raise ValueError(msg)
 
-        head_config.update(**hlabel_info.as_head_config_dict())
+        head_config.update(**label_info.as_head_config_dict())
 
         self.config = config
         self.load_from = config.pop("load_from", None)
         self.image_size = (1, 3, 224, 224)
         super().__init__(
-            hlabel_info=hlabel_info,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -24,6 +24,7 @@ from otx.core.metrics.mean_ap import MeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.export import TaskLevelExportParameters
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.tile_merge import DetectionTileMerge
 
@@ -43,14 +44,14 @@ class OTXDetectionModel(OTXModel[DetBatchDataEntity, DetBatchPredEntity]):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -175,14 +176,14 @@ class ExplainableOTXDetModel(OTXDetectionModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -335,19 +336,19 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = config.pop("load_from", None)
         self.image_size: tuple[int, int, int, int] | None = None
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -27,6 +27,7 @@ from otx.core.metrics.mean_ap import MaskRLEMeanAPCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.export import TaskLevelExportParameters
+from otx.core.types.label import LabelInfoTypes
 from otx.core.utils.config import inplace_num_classes
 from otx.core.utils.mask_util import encode_rle, polygon_to_rle
 from otx.core.utils.tile_merge import InstanceSegTileMerge
@@ -49,14 +50,14 @@ class OTXInstanceSegModel(OTXModel[InstanceSegBatchDataEntity, InstanceSegBatchP
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MaskRLEMeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -211,14 +212,14 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MaskRLEMeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -342,19 +343,19 @@ class MMDetInstanceSegCompatibleModel(ExplainableOTXInstanceSegModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MaskRLEMeanAPCallable,
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = self.config.pop("load_from", None)
         self.image_size: tuple[int, int, int, int] | None = None
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,

--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -265,14 +265,3 @@ class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity]):
 
         msg = "Cannot construct LabelInfo from OpenVINO IR. Please check this model is trained by OTX."
         raise ValueError(msg)
-
-    @staticmethod
-    def _dispatch_label_info(label_info: LabelInfoTypes) -> LabelInfo:
-        if isinstance(label_info, int):
-            return SegLabelInfo.from_num_classes(num_classes=label_info)
-        if isinstance(label_info, Sequence) and all(isinstance(name, str) for name in label_info):
-            return SegLabelInfo(label_names=label_info, label_groups=[label_info])
-        if isinstance(label_info, SegLabelInfo):
-            return label_info
-
-        raise TypeError(label_info)

--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from torchvision import tv_tensors
@@ -17,7 +18,7 @@ from otx.core.metrics.dice import SegmCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.export import TaskLevelExportParameters
-from otx.core.types.label import SegLabelInfo
+from otx.core.types.label import LabelInfo, LabelInfoTypes, SegLabelInfo
 from otx.core.utils.config import inplace_num_classes
 
 if TYPE_CHECKING:
@@ -35,14 +36,14 @@ class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity]):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = SegmCallable,  # type: ignore[assignment]
         torch_compile: bool = False,
     ):
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -73,6 +74,17 @@ class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity]):
             for pred_mask, target_mask in zip(preds.masks, inputs.masks)
         ]
 
+    @staticmethod
+    def _dispatch_label_info(label_info: LabelInfoTypes) -> LabelInfo:
+        if isinstance(label_info, int):
+            return SegLabelInfo.from_num_classes(num_classes=label_info)
+        if isinstance(label_info, Sequence) and all(isinstance(name, str) for name in label_info):
+            return SegLabelInfo(label_names=label_info, label_groups=[label_info])
+        if isinstance(label_info, SegLabelInfo):
+            return label_info
+
+        raise TypeError(label_info)
+
 
 class MMSegCompatibleModel(OTXSegmentationModel):
     """Segmentation model compatible for MMSeg.
@@ -84,19 +96,19 @@ class MMSegCompatibleModel(OTXSegmentationModel):
 
     def __init__(
         self,
-        num_classes: int,
+        label_info: LabelInfoTypes,
         config: DictConfig,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = SegmCallable,  # type: ignore[assignment]
         torch_compile: bool = False,
     ) -> None:
-        config = inplace_num_classes(cfg=config, num_classes=num_classes)
+        config = inplace_num_classes(cfg=config, num_classes=self._dispatch_label_info(label_info).num_classes)
         self.config = config
         self.load_from = self.config.pop("load_from", None)
         self.image_size = (1, 3, 544, 544)
         super().__init__(
-            num_classes=num_classes,
+            label_info=label_info,
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
@@ -253,3 +265,14 @@ class OVSegmentationModel(OVModel[SegBatchDataEntity, SegBatchPredEntity]):
 
         msg = "Cannot construct LabelInfo from OpenVINO IR. Please check this model is trained by OTX."
         raise ValueError(msg)
+
+    @staticmethod
+    def _dispatch_label_info(label_info: LabelInfoTypes) -> LabelInfo:
+        if isinstance(label_info, int):
+            return SegLabelInfo.from_num_classes(num_classes=label_info)
+        if isinstance(label_info, Sequence) and all(isinstance(name, str) for name in label_info):
+            return SegLabelInfo(label_names=label_info, label_groups=[label_info])
+        if isinstance(label_info, SegLabelInfo):
+            return label_info
+
+        raise TypeError(label_info)

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -39,7 +39,7 @@ from otx.core.metrics.visual_prompting import VisualPromptingMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.export import TaskLevelExportParameters
-from otx.core.types.label import LabelInfo, NullLabelInfo
+from otx.core.types.label import LabelInfo, LabelInfoTypes, NullLabelInfo
 from otx.core.utils.mask_util import polygon_to_bitmap
 
 if TYPE_CHECKING:
@@ -173,20 +173,21 @@ class OTXVisualPromptingModel(OTXModel[VisualPromptingBatchDataEntity, VisualPro
 
     def __init__(
         self,
-        num_classes: int = 0,
+        label_info: LabelInfoTypes = NullLabelInfo(),
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = VisualPromptingMetricCallable,
         torch_compile: bool = False,
     ) -> None:
+        msg = f"Given label_info={label_info} has no effect."
+        log.debug(msg)
         super().__init__(
-            num_classes=num_classes,
+            label_info=NullLabelInfo(),
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
             torch_compile=torch_compile,
         )
-        self._label_info = NullLabelInfo()
 
     @property
     def _exporter(self) -> OTXModelExporter:
@@ -279,20 +280,21 @@ class OTXZeroShotVisualPromptingModel(
 
     def __init__(
         self,
-        num_classes: int = 0,
+        label_info: LabelInfoTypes = NullLabelInfo(),
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = VisualPromptingMetricCallable,
         torch_compile: bool = False,
     ) -> None:
+        msg = f"Given label_info={label_info} has no effect."
+        log.debug(msg)
         super().__init__(
-            num_classes=num_classes,
+            label_info=NullLabelInfo(),
             optimizer=optimizer,
             scheduler=scheduler,
             metric=metric,
             torch_compile=torch_compile,
         )
-        self._label_info = NullLabelInfo()
 
     @property
     def _exporter(self) -> OTXModelExporter:

--- a/src/otx/core/optimizer/callable.py
+++ b/src/otx/core/optimizer/callable.py
@@ -106,7 +106,7 @@ class OptimizerCallableSupportHPO:
             class MyAwesomeMulticlassClsModel(OTXMulticlassClsModel):
                 def __init__(
                     self,
-                    num_classes: int,
+                    label_info: LabelInfoTypes,
                     optimizer: OptimizerCallable = OptimizerCallableSupportHPO(
                         optimizer_cls=SGD,
                         optimizer_kwargs={

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -265,7 +265,6 @@ class Engine:
         # NOTE: Model's label info should be converted datamodule's label info before ckpt loading
         # This is due to smart weight loading check label name as well as number of classes.
         if self.model.label_info != self.datamodule.label_info:
-            # TODO (vinnamki): Revisit label_info logic to make it cleaner
             msg = (
                 "Model label_info is not equal to the Datamodule label_info. "
                 f"It will be overriden: {self.model.label_info} => {self.datamodule.label_info}"

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -18,10 +18,11 @@ from otx.core.config.data import DataModuleConfig, SamplerConfig, SubsetConfig, 
 from otx.core.data.module import OTXDataModule
 from otx.core.model.base import OTXModel, OVModel
 from otx.core.types import PathLike
-from otx.core.types.label import LabelInfo
+from otx.core.types.label import LabelInfo, LabelInfoTypes
 from otx.core.types.task import OTXTaskType
 from otx.core.utils.imports import get_otx_root_path
 from otx.core.utils.instantiators import partial_instantiate_class
+from otx.utils.utils import get_model_cls_from_config, should_pass_label_info
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
@@ -229,13 +230,13 @@ class AutoConfigurator:
             ),
         )
 
-    def get_model(self, model_name: str | None = None, label_info: LabelInfo | None = None) -> OTXModel:
+    def get_model(self, model_name: str | None = None, label_info: LabelInfoTypes | None = None) -> OTXModel:
         """Retrieves the OTXModel instance based on the provided model name and meta information.
 
         Args:
             model_name (str | None): The name of the model to retrieve. If None, the default model will be used.
-            label_info (LabelInfo | None): The meta information about the labels. If provided, the number of classes
-                will be updated in the model's configuration.
+            label_info (LabelInfoTypes | None): The meta information about the labels.
+                If provided, the number of classes will be updated in the model's configuration.
 
         Returns:
             OTXModel: The instantiated OTXModel instance.
@@ -258,20 +259,25 @@ class AutoConfigurator:
         if model_name is not None:
             self._config = self._load_default_config(self.model_name)
 
-        skip = {} if self.task != OTXTaskType.H_LABEL_CLS else {"hlabel_info"}
-
         model_parser = ArgumentParser()
-        model_parser.add_subclass_arguments(OTXModel, "model", skip=skip, required=False, fail_untyped=False)
+        model_parser.add_subclass_arguments(
+            OTXModel,
+            "model",
+            skip={"label_info"},
+            required=False,
+            fail_untyped=False,
+        )
 
         model_config = deepcopy(self.config["model"])
 
-        if label_info is not None and self.task != OTXTaskType.H_LABEL_CLS:
-            model_config["init_args"]["num_classes"] = label_info.num_classes
-        elif label_info is not None and self.task == OTXTaskType.H_LABEL_CLS:
-            model_config["init_args"]["hlabel_info"] = label_info
-        elif label_info is None and self.task == OTXTaskType.H_LABEL_CLS:
-            msg = "You should explicitly give label_info for `OTXTaskType.H_LABEL_CLS` task."
-            raise ValueError(msg)
+        model_cls = get_model_cls_from_config(Namespace(model_config))
+
+        if should_pass_label_info(model_cls):
+            if label_info is None:
+                msg = f"Given model class {model_cls} requires a valid label_info to instantiate."
+                raise ValueError(msg)
+
+            model_config["init_args"]["label_info"] = label_info
 
         return model_parser.instantiate_classes(Namespace(model=model_config)).get("model")
 

--- a/src/otx/recipe/action/action_classification/movinet.yaml
+++ b/src/otx/recipe/action/action_classification/movinet.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.action_classification.movinet.MoViNet
   init_args:
-    num_classes: 400
+    label_info: 400
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/action/action_classification/openvino_model.yaml
+++ b/src/otx/recipe/action/action_classification/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.action_classification.OVActionClsModel
   init_args:
-    num_classes: 400
+    label_info: 400
     model_name: x3d
     async_inference: True
     use_throughput_mode: True

--- a/src/otx/recipe/action/action_classification/x3d.yaml
+++ b/src/otx/recipe/action/action_classification/x3d.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.action_classification.x3d.X3D
   init_args:
-    num_classes: 400
+    label_info: 400
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/action/action_detection/x3d_fastrcnn.yaml
+++ b/src/otx/recipe/action/action_detection/x3d_fastrcnn.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.action_detection.x3d_fastrcnn.X3DFastRCNN
   init_args:
-    num_classes: 81
+    label_info: 81
     topk: 3
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_light.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.efficientnet_b0.EfficientNetB0ForMulticlassCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
     light: True
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2_light.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.efficientnet_v2.EfficientNetV2ForMulticlassCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
     light: True
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.mobilenet_v3.MobileNetV3ForMulticlassCls
   init_args:
     mode: large
-    num_classes: 1000
+    label_info: 1000
     loss_callable:
       class_path: torch.nn.CrossEntropyLoss
       init_args:

--- a/src/otx/recipe/classification/multi_class_cls/openvino_model.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.classification.OVMulticlassClassificationModel
   init_args:
-    num_classes: 1000
+    label_info: 1000
     model_name: efficientnet-b0-pytorch
     async_inference: True
     use_throughput_mode: False

--- a/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_deit_tiny.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.deit_tiny.DeitTinyForMulticlassCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/classification/multi_class_cls/otx_dino_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_dino_v2.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.otx_dino_v2.DINOv2RegisterClassifier
   init_args:
-    num_classes: 1000
+    label_info: 1000
     freeze_backbone: true
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/otx_dino_v2_linear_probe.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_dino_v2_linear_probe.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.otx_dino_v2.DINOv2RegisterClassifier
   init_args:
-    num_classes: 1000
+    label_info: 1000
     freeze_backbone: false
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_b0.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.efficientnet_b0.EfficientNetB0ForMulticlassCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
     light: false
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/otx_efficientnet_v2.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.efficientnet_v2.EfficientNetV2ForMulticlassCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
     light: false
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b0.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: efficientnet_b0
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b1.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b1.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: efficientnet_b1
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b3.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: efficientnet_b3
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b4.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b4.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: efficientnet_b4
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: efficientnet_v2_l
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_mobilenet_v3_small.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: mobilenet_v3_small
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/tv_resnet_50.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_resnet_50.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.torchvision_model.OTXTVModel
   init_args:
     backbone: resnet50
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0_light.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.efficientnet_b0.EfficientNetB0ForMultilabelCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2_light.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.efficientnet_v2.EfficientNetV2ForMultilabelCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.mobilenet_v3.MobileNetV3ForMultilabelCls
   init_args:
     mode: large
-    num_classes: 1000
+    label_info: 1000
     loss_callable:
       class_path: otx.algo.classification.losses.AsymmetricAngularLossWithIgnore
       init_args:

--- a/src/otx/recipe/classification/multi_label_cls/openvino_model.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.classification.OVMultilabelClassificationModel
   init_args:
-    num_classes: 1000
+    label_info: 1000
     model_name: openvino.xml
     async_inference: True
     use_throughput_mode: False

--- a/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/otx_deit_tiny.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.classification.deit_tiny.DeitTinyForMultilabelCls
   init_args:
-    num_classes: 1000
+    label_info: 1000
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/detection/atss_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.atss.ATSS
   init_args:
-    num_classes: 1000
+    label_info: 1000
     variant: mobilenetv2
 
     optimizer:

--- a/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.atss.ATSS
   init_args:
-    num_classes: 1000
+    label_info: 1000
     variant: mobilenetv2
 
     optimizer:

--- a/src/otx/recipe/detection/atss_mobilenetv2_tv.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.atss.ATSS
   init_args:
-    num_classes: 1000
+    label_info: 1000
     variant: mobilenetv2
 
     optimizer:

--- a/src/otx/recipe/detection/atss_resnext101.yaml
+++ b/src/otx/recipe/detection/atss_resnext101.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.atss.ATSS
   init_args:
-    num_classes: 1000
+    label_info: 1000
     variant: resnext101
 
     optimizer:

--- a/src/otx/recipe/detection/atss_resnext101_tv.yaml
+++ b/src/otx/recipe/detection/atss_resnext101_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.atss.ATSS
   init_args:
-    num_classes: 1000
+    label_info: 1000
     variant: resnext101
 
     optimizer:

--- a/src/otx/recipe/detection/openvino_model.yaml
+++ b/src/otx/recipe/detection/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.detection.OVDetectionModel
   init_args:
-    num_classes: 80
+    label_info: 80
     model_name: ssd300
     use_throughput_mode: True
     model_type: "SSD"

--- a/src/otx/recipe/detection/ssd_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.ssd.SSD
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: mobilenetv2
 
     optimizer:

--- a/src/otx/recipe/detection/ssd_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.ssd.SSD
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: mobilenetv2
 
     optimizer:

--- a/src/otx/recipe/detection/ssd_mobilenetv2_tv.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.ssd.SSD
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: mobilenetv2
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: l
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: l
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_l_tv.yaml
+++ b/src/otx/recipe/detection/yolox_l_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: l
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: s
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: s
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_s_tv.yaml
+++ b/src/otx/recipe/detection/yolox_s_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: s
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloXTiny
   init_args:
-    num_classes: 80
+    label_info: 80
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloXTiny
   init_args:
-    num_classes: 80
+    label_info: 80
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/detection/yolox_tiny_tv.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloXTiny
   init_args:
-    num_classes: 80
+    label_info: 80
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: x
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: x
 
     optimizer:

--- a/src/otx/recipe/detection/yolox_x_tv.yaml
+++ b/src/otx/recipe/detection/yolox_x_tv.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.detection.yolox.YoloX
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: x
 
     optimizer:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNN
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: efficientnetb2b
 
     optimizer:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNN
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: efficientnetb2b
 
     optimizer:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNN
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: r50
 
     optimizer:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNN
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: r50
 
     optimizer:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNNSwinT
   init_args:
-    num_classes: 80
+    label_info: 80
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNNSwinT
   init_args:
-    num_classes: 80
+    label_info: 80
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/instance_segmentation/openvino_model.yaml
+++ b/src/otx/recipe/instance_segmentation/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.instance_segmentation.OVInstanceSegmentationModel
   init_args:
-    num_classes: 80
+    label_info: 80
     model_name: openvino.xml
     model_type: MaskRCNN
     async_inference: True

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.rtmdet_inst.RTMDetInst
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: tiny
 
     optimizer:

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.rtmdet_inst.RTMDetInst
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: tiny
 
     optimizer:

--- a/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNN
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: efficientnetb2b
 
     optimizer:

--- a/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.instance_segmentation.maskrcnn.MaskRCNN
   init_args:
-    num_classes: 80
+    label_info: 80
     variant: r50
 
     optimizer:

--- a/src/otx/recipe/semantic_segmentation/dino_v2.yaml
+++ b/src/otx/recipe/semantic_segmentation/dino_v2.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.dino_v2_seg.DinoV2Seg
   init_args:
-    num_classes: 2
+    label_info: 2
 
     optimizer:
       class_path: torch.optim.AdamW

--- a/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_18.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.litehrnet.LiteHRNet
   init_args:
-    num_classes: 2
+    label_info: 2
     variant: 18
 
     optimizer:

--- a/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_s.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.litehrnet.LiteHRNet
   init_args:
-    num_classes: 2
+    label_info: 2
     variant: s
 
     optimizer:

--- a/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
+++ b/src/otx/recipe/semantic_segmentation/litehrnet_x.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.litehrnet.LiteHRNet
   init_args:
-    num_classes: 2
+    label_info: 2
     variant: x
 
     optimizer:

--- a/src/otx/recipe/semantic_segmentation/openvino_model.yaml
+++ b/src/otx/recipe/semantic_segmentation/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.segmentation.OVSegmentationModel
   init_args:
-    num_classes: 19
+    label_info: 19
     model_name: drn-d-38
     async_inference: True
     use_throughput_mode: True

--- a/src/otx/recipe/semantic_segmentation/segnext_b.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_b.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.segnext.SegNext
   init_args:
-    num_classes: 2
+    label_info: 2
     variant: b
 
     optimizer:

--- a/src/otx/recipe/semantic_segmentation/segnext_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_s.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.segnext.SegNext
   init_args:
-    num_classes: 2
+    label_info: 2
     variant: s
 
     optimizer:

--- a/src/otx/recipe/semantic_segmentation/segnext_t.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_t.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.algo.segmentation.segnext.SegNext
   init_args:
-    num_classes: 2
+    label_info: 2
     variant: t
 
     optimizer:

--- a/src/otx/recipe/visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/visual_prompting/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.visual_prompting.OVVisualPromptingModel
   init_args:
-    num_classes: 0
+    label_info: 0
     model_name: segment_anything
     model_type: Visual_Prompting
     async_inference: False

--- a/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml
+++ b/src/otx/recipe/visual_prompting/sam_tiny_vit.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.visual_prompting.segment_anything.OTXSegmentAnything
   init_args:
     backbone: tiny_vit
-    num_classes: 0
+    label_info: 0
     freeze_image_encoder: True
     freeze_prompt_encoder: True
     freeze_mask_decoder: False

--- a/src/otx/recipe/visual_prompting/sam_vit_b.yaml
+++ b/src/otx/recipe/visual_prompting/sam_vit_b.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.visual_prompting.segment_anything.OTXSegmentAnything
   init_args:
     backbone: vit_b
-    num_classes: 0
+    label_info: 0
     freeze_image_encoder: True
     freeze_prompt_encoder: True
     freeze_mask_decoder: False

--- a/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
@@ -1,7 +1,7 @@
 model:
   class_path: otx.core.model.visual_prompting.OVZeroShotVisualPromptingModel
   init_args:
-    num_classes: 0
+    label_info: 0
     model_name: segment_anything
     model_type: Zero_Shot_Visual_Prompting
     async_inference: False

--- a/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.visual_prompting.zero_shot_segment_anything.OTXZeroShotSegmentAnything
   init_args:
     backbone: tiny_vit
-    num_classes: 0
+    label_info: 0
     freeze_image_encoder: True
     freeze_prompt_encoder: True
     freeze_mask_decoder: True

--- a/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.visual_prompting.zero_shot_segment_anything.OTXZeroShotSegmentAnything
   init_args:
     backbone: vit_b
-    num_classes: 0
+    label_info: 0
     freeze_image_encoder: True
     freeze_prompt_encoder: True
     freeze_mask_decoder: True

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -376,14 +376,12 @@ class ConfigConverter:
             ),
         )
 
-        num_classes = datamodule.label_info.num_classes
-
         # Update num_classes & Instantiate Model
         model_config = config.pop("model")
-        model_config["init_args"]["num_classes"] = num_classes
+        model_config["init_args"]["label_info"] = datamodule.label_info
 
         model_parser = ArgumentParser()
-        model_parser.add_subclass_arguments(OTXModel, "model", required=False, fail_untyped=False)
+        model_parser.add_subclass_arguments(OTXModel, "model", required=False, fail_untyped=False, skip={"label_info"})
         model = model_parser.instantiate_classes(Namespace(model=model_config)).get("model")
 
         # Instantiate Engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from otx.core.data.entity.instance_segmentation import (
 )
 from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity, SegDataEntity
 from otx.core.data.mem_cache import MemCacheHandlerSingleton
+from otx.core.types.label import HLabelInfo, LabelInfo, NullLabelInfo, SegLabelInfo
 from otx.core.types.task import OTXTaskType
 from torch import LongTensor
 from torchvision import tv_tensors
@@ -259,3 +260,111 @@ def fxt_accelerator(request: pytest.FixtureRequest) -> str:
 @pytest.fixture(params=set(OTXTaskType) - {OTXTaskType.DETECTION_SEMI_SL})
 def fxt_task(request: pytest.FixtureRequest) -> OTXTaskType:
     return request.param
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fxt_null_label_info() -> LabelInfo:
+    return NullLabelInfo()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fxt_seg_label_info() -> SegLabelInfo:
+    label_names = ["class1", "class2", "class3"]
+    return SegLabelInfo(
+        label_names=label_names,
+        label_groups=[
+            label_names,
+            ["class2", "class3"],
+        ],
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fxt_multiclass_labelinfo() -> LabelInfo:
+    label_names = ["class1", "class2", "class3"]
+    return LabelInfo(
+        label_names=label_names,
+        label_groups=[
+            label_names,
+            ["class2", "class3"],
+        ],
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fxt_multilabel_labelinfo() -> LabelInfo:
+    label_names = ["class1", "class2", "class3"]
+    return LabelInfo(
+        label_names=label_names,
+        label_groups=[
+            [label_names[0]],
+            [label_names[1]],
+            [label_names[2]],
+        ],
+    )
+
+
+@pytest.fixture()
+def fxt_hlabel_multilabel_info() -> HLabelInfo:
+    return HLabelInfo(
+        label_names=[
+            "Heart",
+            "Spade",
+            "Heart_Queen",
+            "Heart_King",
+            "Spade_A",
+            "Spade_King",
+            "Black_Joker",
+            "Red_Joker",
+            "Extra_Joker",
+        ],
+        label_groups=[
+            ["Heart", "Spade"],
+            ["Heart_Queen", "Heart_King"],
+            ["Spade_A", "Spade_King"],
+            ["Black_Joker"],
+            ["Red_Joker"],
+            ["Extra_Joker"],
+        ],
+        num_multiclass_heads=3,
+        num_multilabel_classes=3,
+        head_idx_to_logits_range={"0": (0, 2), "1": (2, 4), "2": (4, 6)},
+        num_single_label_classes=3,
+        empty_multiclass_head_indices=[],
+        class_to_group_idx={
+            "Heart": (0, 0),
+            "Spade": (0, 1),
+            "Heart_Queen": (1, 0),
+            "Heart_King": (1, 1),
+            "Spade_A": (2, 0),
+            "Spade_King": (2, 1),
+            "Black_Joker": (3, 0),
+            "Red_Joker": (3, 1),
+            "Extra_Joker": (3, 2),
+        },
+        all_groups=[
+            ["Heart", "Spade"],
+            ["Heart_Queen", "Heart_King"],
+            ["Spade_A", "Spade_King"],
+            ["Black_Joker"],
+            ["Red_Joker"],
+            ["Extra_Joker"],
+        ],
+        label_to_idx={
+            "Heart": 0,
+            "Spade": 1,
+            "Heart_Queen": 2,
+            "Heart_King": 3,
+            "Spade_A": 4,
+            "Spade_King": 5,
+            "Black_Joker": 6,
+            "Red_Joker": 7,
+            "Extra_Joker": 8,
+        },
+        label_tree_edges=[
+            ["Heart_Queen", "Heart"],
+            ["Heart_King", "Heart"],
+            ["Spade_A", "Spade"],
+            ["Spade_King", "Spade"],
+        ],
+    )

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -172,7 +172,7 @@ def test_otx_hpo(
         reason = f"test_otx_hpo for {task} isn't prepared yet."
         pytest.xfail(reason=reason)
 
-    model = EfficientNetB0ForMulticlassCls(num_classes=2)
+    model = EfficientNetB0ForMulticlassCls(label_info=2)
     hpo_config = HpoConfig(metric_name=METRIC_NAME[task], expected_time_ratio=2, num_workers=1)
     work_dir = str(tmp_path)
     engine = Engine(

--- a/tests/unit/algo/action_classification/test_movinet.py
+++ b/tests/unit/algo/action_classification/test_movinet.py
@@ -9,7 +9,7 @@ from otx.algo.utils.support_otx_v1 import OTXv1Helper
 class TestMoViNet:
     @pytest.fixture()
     def fxt_movinet(self) -> MoViNet:
-        return MoViNet(num_classes=10)
+        return MoViNet(label_info=10)
 
     def test_load_from_otx_v1_ckpt(self, fxt_movinet, mocker) -> None:
         mock_load_ckpt = mocker.patch.object(OTXv1Helper, "load_action_ckpt")

--- a/tests/unit/algo/action_classification/test_x3d.py
+++ b/tests/unit/algo/action_classification/test_x3d.py
@@ -9,8 +9,8 @@ from otx.algo.utils.support_otx_v1 import OTXv1Helper
 
 class TestX3D:
     @pytest.fixture()
-    def fxt_x3d(self) -> X3D:
-        return X3D(num_classes=10)
+    def fxt_x3d(self, fxt_multiclass_labelinfo) -> X3D:
+        return X3D(label_info=10)
 
     def test_load_from_otx_v1_ckpt(self, fxt_x3d, mocker):
         mock_load_ckpt = mocker.patch.object(OTXv1Helper, "load_action_ckpt")

--- a/tests/unit/algo/action_detection/test_x3d_fastrcnn.py
+++ b/tests/unit/algo/action_detection/test_x3d_fastrcnn.py
@@ -10,7 +10,7 @@ from otx.algo.utils.support_otx_v1 import OTXv1Helper
 class TestX3DFastRCNN:
     @pytest.fixture()
     def fxt_x3d_fast_rcnn(self) -> X3DFastRCNN:
-        return X3DFastRCNN(num_classes=10, topk=3)
+        return X3DFastRCNN(label_info=10, topk=3)
 
     def test_load_from_otx_v1_ckpt(self, fxt_x3d_fast_rcnn, mocker):
         mock_load_ckpt = mocker.patch.object(OTXv1Helper, "load_action_ckpt")

--- a/tests/unit/algo/classification/conftest.py
+++ b/tests/unit/algo/classification/conftest.py
@@ -159,14 +159,14 @@ def fxt_multiclass_cls_batch_data_entity() -> MulticlassClsBatchDataEntity:
 @pytest.fixture()
 def fxt_multilabel_cls_batch_data_entity(
     fxt_multiclass_cls_batch_data_entity,
-    fxt_hlabel_data,
+    fxt_multilabel_labelinfo,
 ) -> MultilabelClsBatchDataEntity:
     return MultilabelClsBatchDataEntity(
         batch_size=2,
         images=fxt_multiclass_cls_batch_data_entity.images,
         imgs_info=fxt_multiclass_cls_batch_data_entity.imgs_info,
         labels=[
-            torch.nn.functional.one_hot(label, num_classes=fxt_hlabel_data.num_classes).flatten()
+            torch.nn.functional.one_hot(label, num_classes=fxt_multilabel_labelinfo.num_classes).flatten()
             for label in fxt_multiclass_cls_batch_data_entity.labels
         ],
     )

--- a/tests/unit/algo/classification/test_deit_tiny.py
+++ b/tests/unit/algo/classification/test_deit_tiny.py
@@ -19,21 +19,18 @@ from otx.core.types.precision import OTXPrecisionType
 class TestDeitTiny:
     @pytest.fixture(
         params=[
-            (DeitTinyForMulticlassCls, "fxt_multiclass_cls_batch_data_entity"),
-            (DeitTinyForMultilabelCls, "fxt_multilabel_cls_batch_data_entity"),
-            (DeitTinyForHLabelCls, "fxt_hlabel_cls_batch_data_entity"),
+            (DeitTinyForMulticlassCls, "fxt_multiclass_cls_batch_data_entity", "fxt_multiclass_labelinfo"),
+            (DeitTinyForMultilabelCls, "fxt_multilabel_cls_batch_data_entity", "fxt_multilabel_labelinfo"),
+            (DeitTinyForHLabelCls, "fxt_hlabel_cls_batch_data_entity", "fxt_hlabel_data"),
         ],
         ids=["multiclass", "multilabel", "hlabel"],
     )
-    def fxt_model_and_input(self, request, fxt_hlabel_data):
-        model_cls, input_fxt_name = request.param
+    def fxt_model_and_input(self, request):
+        model_cls, input_fxt_name, label_info_fxt_name = request.param
         fxt_input = request.getfixturevalue(input_fxt_name)
-        num_classes = fxt_hlabel_data.num_classes
+        fxt_label_info = request.getfixturevalue(label_info_fxt_name)
 
-        if model_cls == DeitTinyForHLabelCls:
-            model = model_cls(hlabel_info=fxt_hlabel_data)
-        else:
-            model = model_cls(num_classes=num_classes)
+        model = model_cls(label_info=fxt_label_info)
 
         return model, fxt_input
 

--- a/tests/unit/algo/classification/test_mobilenet_v3.py
+++ b/tests/unit/algo/classification/test_mobilenet_v3.py
@@ -21,7 +21,7 @@ from otx.core.data.entity.classification import (
 def fxt_multi_class_cls_model():
     return MobileNetV3ForMulticlassCls(
         mode="large",
-        num_classes=10,
+        label_info=10,
     )
 
 
@@ -59,7 +59,7 @@ class TestMobileNetV3ForMulticlassCls:
 def fxt_multi_label_cls_model():
     return MobileNetV3ForMultilabelCls(
         mode="large",
-        num_classes=10,
+        label_info=10,
     )
 
 
@@ -97,7 +97,7 @@ class TestMobileNetV3ForMultilabelCls:
 def fxt_h_label_cls_model(fxt_hlabel_data):
     return MobileNetV3ForHLabelCls(
         mode="large",
-        hlabel_info=fxt_hlabel_data,
+        label_info=fxt_hlabel_data,
     )
 
 

--- a/tests/unit/algo/classification/test_torchvision_model.py
+++ b/tests/unit/algo/classification/test_torchvision_model.py
@@ -8,7 +8,7 @@ from otx.core.types.export import TaskLevelExportParameters
 
 @pytest.fixture()
 def fxt_tv_model():
-    return OTXTVModel(backbone="mobilenet_v3_small", num_classes=10)
+    return OTXTVModel(backbone="mobilenet_v3_small", label_info=10)
 
 
 class TestOTXTVModel:
@@ -47,6 +47,6 @@ class TestOTXTVModel:
         assert outputs.has_xai_outputs == explain_mode
 
     def test_freeze_backbone(self):
-        freezed_model = OTXTVModel(backbone="resnet50", num_classes=10, freeze_backbone=True)
+        freezed_model = OTXTVModel(backbone="resnet50", label_info=10, freeze_backbone=True)
         for param in freezed_model.model.backbone.parameters():
             assert not param.requires_grad

--- a/tests/unit/algo/detection/test_atss.py
+++ b/tests/unit/algo/detection/test_atss.py
@@ -13,8 +13,8 @@ class TestATSS:
     @pytest.mark.parametrize(
         "model",
         [
-            ATSS(num_classes=2, variant="mobilenetv2"),
-            ATSS(num_classes=2, variant="resnext101"),
+            ATSS(label_info=2, variant="mobilenetv2"),
+            ATSS(label_info=2, variant="resnext101"),
         ],
     )
     def test(self, model, mocker) -> None:

--- a/tests/unit/algo/detection/test_ssd.py
+++ b/tests/unit/algo/detection/test_ssd.py
@@ -12,7 +12,7 @@ from otx.algo.detection.ssd import SSD
 class TestSSD:
     @pytest.fixture()
     def fxt_model(self) -> SSD:
-        return SSD(num_classes=3, variant="mobilenetv2")
+        return SSD(label_info=3, variant="mobilenetv2")
 
     @pytest.fixture()
     def fxt_checkpoint(self, fxt_model, fxt_data_module, tmpdir, monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/algo/instance_segmentation/heads/test_custom_rtmdet_ins_head.py
+++ b/tests/unit/algo/instance_segmentation/heads/test_custom_rtmdet_ins_head.py
@@ -68,7 +68,7 @@ class TestCustomRTMDetInsSepBNHead:
         )
 
     def test_predict_by_feat_ov(self, tmpdir) -> None:
-        lit_module = RTMDetInst(num_classes=1, variant="tiny")
+        lit_module = RTMDetInst(label_info=1, variant="tiny")
         exported_model_path = lit_module.export(
             output_dir=Path(tmpdir),
             base_name="exported_model",

--- a/tests/unit/algo/segmentation/test_dino_v2_seg.py
+++ b/tests/unit/algo/segmentation/test_dino_v2_seg.py
@@ -10,7 +10,7 @@ from otx.core.exporter.base import OTXModelExporter
 class TestDinoV2Seg:
     @pytest.fixture(scope="class")
     def fxt_dino_v2_seg(self) -> DinoV2Seg:
-        return DinoV2Seg(num_classes=10)
+        return DinoV2Seg(label_info=10)
 
     def test_dino_v2_seg_init(self, fxt_dino_v2_seg):
         assert isinstance(fxt_dino_v2_seg, DinoV2Seg)

--- a/tests/unit/algo/visual_prompting/test_segment_anything.py
+++ b/tests/unit/algo/visual_prompting/test_segment_anything.py
@@ -294,7 +294,7 @@ class TestSegmentAnything:
 class TestOTXSegmentAnything:
     @pytest.fixture()
     def model(self) -> OTXSegmentAnything:
-        return OTXSegmentAnything(backbone="tiny_vit", num_classes=0)
+        return OTXSegmentAnything(backbone="tiny_vit")
 
     def test_create_model(self, model) -> None:
         """Test _create_model."""

--- a/tests/unit/algo/visual_prompting/test_zero_shot_segment_anything.py
+++ b/tests/unit/algo/visual_prompting/test_zero_shot_segment_anything.py
@@ -461,7 +461,7 @@ class TestZeroShotSegmentAnything:
 class TestOTXZeroShotSegmentAnything:
     @pytest.fixture()
     def model(self) -> OTXZeroShotSegmentAnything:
-        return OTXZeroShotSegmentAnything(backbone="tiny_vit", num_classes=0)
+        return OTXZeroShotSegmentAnything(backbone="tiny_vit")
 
     def test_create_model(self, model) -> None:
         """Test _create_model."""

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -84,7 +84,7 @@ class TestOTXCLI:
             "src/otx/recipe/detection/atss_mobilenetv2.yaml",
             "--data_root",
             "tests/assets/car_tree_bug",
-            "--model.num_classes",
+            "--model.label_info",
             "3",
             "--work_dir",
             str(tmpdir),

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -19,55 +19,12 @@ from otx.core.data.entity.visual_prompting import (
     ZeroShotVisualPromptingBatchPredEntity,
     ZeroShotVisualPromptingDataEntity,
 )
-from otx.core.types.label import HLabelInfo, LabelInfo, NullLabelInfo, SegLabelInfo
 from torchvision import tv_tensors
 
 
 @pytest.fixture(scope="session", autouse=True)
 def fxt_register_configs() -> None:
     register_configs()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def fxt_null_label_info() -> LabelInfo:
-    return NullLabelInfo()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def fxt_seg_label_info() -> SegLabelInfo:
-    label_names = ["class1", "class2", "class3"]
-    return SegLabelInfo(
-        label_names=label_names,
-        label_groups=[
-            label_names,
-            ["class2", "class3"],
-        ],
-    )
-
-
-@pytest.fixture(scope="session", autouse=True)
-def fxt_multiclass_labelinfo() -> LabelInfo:
-    label_names = ["class1", "class2", "class3"]
-    return LabelInfo(
-        label_names=label_names,
-        label_groups=[
-            label_names,
-            ["class2", "class3"],
-        ],
-    )
-
-
-@pytest.fixture(scope="session", autouse=True)
-def fxt_multilabel_labelinfo() -> LabelInfo:
-    label_names = ["class1", "class2", "class3"]
-    return LabelInfo(
-        label_names=label_names,
-        label_groups=[
-            [label_names[0]],
-            [label_names[1]],
-            [label_names[2]],
-        ],
-    )
 
 
 @pytest.fixture()
@@ -120,72 +77,6 @@ def fxt_hlabel_dataset_subset() -> Dataset:
             ),
         },
     ).get_subset("train")
-
-
-@pytest.fixture()
-def fxt_hlabel_multilabel_info() -> HLabelInfo:
-    return HLabelInfo(
-        label_names=[
-            "Heart",
-            "Spade",
-            "Heart_Queen",
-            "Heart_King",
-            "Spade_A",
-            "Spade_King",
-            "Black_Joker",
-            "Red_Joker",
-            "Extra_Joker",
-        ],
-        label_groups=[
-            ["Heart", "Spade"],
-            ["Heart_Queen", "Heart_King"],
-            ["Spade_A", "Spade_King"],
-            ["Black_Joker"],
-            ["Red_Joker"],
-            ["Extra_Joker"],
-        ],
-        num_multiclass_heads=3,
-        num_multilabel_classes=3,
-        head_idx_to_logits_range={"0": (0, 2), "1": (2, 4), "2": (4, 6)},
-        num_single_label_classes=3,
-        empty_multiclass_head_indices=[],
-        class_to_group_idx={
-            "Heart": (0, 0),
-            "Spade": (0, 1),
-            "Heart_Queen": (1, 0),
-            "Heart_King": (1, 1),
-            "Spade_A": (2, 0),
-            "Spade_King": (2, 1),
-            "Black_Joker": (3, 0),
-            "Red_Joker": (3, 1),
-            "Extra_Joker": (3, 2),
-        },
-        all_groups=[
-            ["Heart", "Spade"],
-            ["Heart_Queen", "Heart_King"],
-            ["Spade_A", "Spade_King"],
-            ["Black_Joker"],
-            ["Red_Joker"],
-            ["Extra_Joker"],
-        ],
-        label_to_idx={
-            "Heart": 0,
-            "Spade": 1,
-            "Heart_Queen": 2,
-            "Heart_King": 3,
-            "Spade_A": 4,
-            "Spade_King": 5,
-            "Black_Joker": 6,
-            "Red_Joker": 7,
-            "Extra_Joker": 8,
-        },
-        label_tree_edges=[
-            ["Heart_Queen", "Heart"],
-            ["Heart_King", "Heart"],
-            ["Spade_A", "Spade"],
-            ["Spade_King", "Spade"],
-        ],
-    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/core/data/test_tiling.py
+++ b/tests/unit/core/data/test_tiling.py
@@ -332,7 +332,7 @@ class TestOTXTiling:
             assert isinstance(batch, TileBatchDetDataEntity)
 
     def test_det_tile_merge(self, fxt_det_data_config):
-        model = OTXDetectionModel(num_classes=3)
+        model = OTXDetectionModel(label_info=3)
         # Enable tile adapter
         fxt_det_data_config.tile_config.enable_tiler = True
         tile_datamodule = OTXDataModule(
@@ -348,7 +348,7 @@ class TestOTXTiling:
             model.forward_tiles(batch)
 
     def test_explain_det_tile_merge(self, fxt_det_data_config):
-        model = OTXDetectionModel(num_classes=3)
+        model = OTXDetectionModel(label_info=3)
         # Enable tile adapter
         fxt_det_data_config.tile_config.enable_tiler = True
         fxt_det_data_config.tile_config.enable_adaptive_tiling = False
@@ -367,7 +367,7 @@ class TestOTXTiling:
         self.explain_mode = False
 
     def test_instseg_tile_merge(self, fxt_instseg_data_config):
-        model = OTXInstanceSegModel(num_classes=3)
+        model = OTXInstanceSegModel(label_info=3)
         # Enable tile adapter
         fxt_instseg_data_config.tile_config.enable_tiler = True
         tile_datamodule = OTXDataModule(
@@ -383,7 +383,7 @@ class TestOTXTiling:
             model.forward_tiles(batch)
 
     def test_explain_instseg_tile_merge(self, fxt_instseg_data_config):
-        model = OTXInstanceSegModel(num_classes=3)
+        model = OTXInstanceSegModel(label_info=3)
         # Enable tile adapter
         fxt_instseg_data_config.tile_config.enable_tiler = True
         fxt_instseg_data_config.tile_config.enable_adaptive_tiling = False

--- a/tests/unit/core/model/test_base.py
+++ b/tests/unit/core/model/test_base.py
@@ -22,12 +22,12 @@ class MockNNModule(torch.nn.Module):
 class TestOTXModel:
     def test_smart_weight_loading(self, mocker) -> None:
         with mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(2)):
-            prev_model = OTXModel(num_classes=2)
+            prev_model = OTXModel(label_info=2)
             prev_model.label_info = ["car", "truck"]
             prev_state_dict = prev_model.state_dict()
 
         with mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(3)):
-            current_model = OTXModel(num_classes=3)
+            current_model = OTXModel(label_info=3)
             current_model.classification_layers = ["model.head.weight", "model.head.bias"]
             current_model.classification_layers = {
                 "model.head.weight": {"stride": 1, "num_extra_classes": 0},
@@ -57,7 +57,7 @@ class TestOTXModel:
         mock_main_scheduler = mocker.create_autospec(spec=torch.optim.lr_scheduler.LRScheduler)
 
         with mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(3)):
-            current_model = OTXModel(num_classes=3)
+            current_model = OTXModel(label_info=3)
 
         mock_trainer = mocker.create_autospec(spec=Trainer)
         mock_trainer.lr_scheduler_configs = [

--- a/tests/unit/core/model/test_detection.py
+++ b/tests/unit/core/model/test_detection.py
@@ -55,7 +55,7 @@ class TestOTXDetectionModel:
 
     @pytest.fixture()
     def otx_model(self, config) -> MMDetCompatibleModel:
-        return MMDetCompatibleModel(num_classes=1, config=config)
+        return MMDetCompatibleModel(label_info=1, config=config)
 
     def test_configure_metric_with_ckpt(
         self,
@@ -64,7 +64,7 @@ class TestOTXDetectionModel:
         mock_ckpt,
     ) -> None:
         model = OTXDetectionModel(
-            num_classes=1,
+            label_info=1,
             torch_compile=False,
             optimizer=mock_optimizer,
             scheduler=mock_scheduler,

--- a/tests/unit/core/model/test_inst_segmentation.py
+++ b/tests/unit/core/model/test_inst_segmentation.py
@@ -14,7 +14,7 @@ from otx.core.types.export import TaskLevelExportParameters
 class TestOTXInstanceSegModel:
     @pytest.fixture()
     def otx_model(self) -> MMDetInstanceSegCompatibleModel:
-        return MaskRCNN(num_classes=1, variant="efficientnetb2b")
+        return MaskRCNN(label_info=1, variant="efficientnetb2b")
 
     def test_create_model(self, otx_model) -> None:
         mmdet_model = otx_model._create_model()

--- a/tests/unit/core/model/test_segmentation.py
+++ b/tests/unit/core/model/test_segmentation.py
@@ -26,8 +26,11 @@ class TestOTXSegmentationModel:
 
     @pytest.fixture()
     def model(self, config) -> MMSegCompatibleModel:
-        model = MMSegCompatibleModel(num_classes=2, config=config)
-        model.label_info = SegLabelInfo(label_names=["Background", "label_1"], label_groups=[["Background", "label_1"]])
+        model = MMSegCompatibleModel(label_info=3, config=config)
+        model.label_info = SegLabelInfo(
+            label_names=["Background", "label_0", "label_1"],
+            label_groups=[["Background", "label_0", "label_1"]],
+        )
         return model
 
     def test_create_model(self, model) -> None:

--- a/tests/unit/core/model/test_visual_prompting.py
+++ b/tests/unit/core/model/test_visual_prompting.py
@@ -33,7 +33,7 @@ from torchvision import tv_tensors
 @pytest.fixture()
 def otx_visual_prompting_model(mocker) -> OTXVisualPromptingModel:
     mocker.patch.object(OTXVisualPromptingModel, "_create_model")
-    model = OTXVisualPromptingModel(num_classes=1)
+    model = OTXVisualPromptingModel(label_info=1)
     model.model.image_size = 1024
     return model
 
@@ -41,7 +41,7 @@ def otx_visual_prompting_model(mocker) -> OTXVisualPromptingModel:
 @pytest.fixture()
 def otx_zero_shot_visual_prompting_model(mocker) -> OTXZeroShotVisualPromptingModel:
     mocker.patch.object(OTXZeroShotVisualPromptingModel, "_create_model")
-    model = OTXZeroShotVisualPromptingModel(num_classes=1)
+    model = OTXZeroShotVisualPromptingModel(label_info=1)
     model.model.image_size = 1024
     return model
 

--- a/tests/unit/core/optimizer/test_callable.py
+++ b/tests/unit/core/optimizer/test_callable.py
@@ -94,13 +94,13 @@ class TestOptimizerCallableSupportHPO:
         class _TestOTXModel(OTXModel):
             def __init__(
                 self,
-                num_classes=10,
+                label_info=10,
                 optimizer=default_optimizer_callable,
                 scheduler=DefaultSchedulerCallable,
                 metric=NullMetricCallable,
                 torch_compile: bool = False,
             ) -> None:
-                super().__init__(num_classes, optimizer, scheduler, metric, torch_compile)
+                super().__init__(label_info, optimizer, scheduler, metric, torch_compile)
 
             def _create_model(self) -> nn.Module:
                 return nn.Linear(10, self.num_classes)

--- a/tests/unit/core/types/test_label.py
+++ b/tests/unit/core/types/test_label.py
@@ -1,8 +1,19 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from otx.core.types.label import SegLabelInfo
+
 
 def test_as_json(fxt_label_info):
     serialized = fxt_label_info.to_json()
     deserialized = fxt_label_info.__class__.from_json(serialized)
     assert fxt_label_info == deserialized
+
+
+def test_seg_label_info():
+    # Automatically insert background label at zero index
+    assert SegLabelInfo(["car", "bug", "tree"], []) == SegLabelInfo(["Background", "car", "bug", "tree"], [])
+    assert SegLabelInfo.from_num_classes(3) == SegLabelInfo(
+        ["Background", "label_0", "label_1"],
+        [["Background", "label_0", "label_1"]],
+    )

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from otx.core.data.module import OTXDataModule
 from otx.core.model.base import OTXModel
-from otx.core.types.label import LabelInfo
+from otx.core.types.label import LabelInfo, SegLabelInfo
 from otx.core.types.task import OTXTaskType
 from otx.core.types.transformer_libs import TransformLibType
 from otx.engine.utils.auto_configurator import (
@@ -15,6 +15,7 @@ from otx.engine.utils.auto_configurator import (
     AutoConfigurator,
     configure_task,
 )
+from otx.utils.utils import should_pass_label_info
 
 
 @pytest.fixture()
@@ -112,15 +113,21 @@ class TestAutoConfigurator:
 
         auto_configurator = AutoConfigurator(task=fxt_task)
 
-        # Default Model
-        model = auto_configurator.get_model()
-        assert isinstance(model, OTXModel)
-
         # With label_info
         label_names = ["class1", "class2", "class3"]
-        label_info = LabelInfo(label_names=label_names, label_groups=[label_names])
+        label_info = (
+            LabelInfo(label_names=label_names, label_groups=[label_names])
+            if fxt_task != OTXTaskType.SEMANTIC_SEGMENTATION
+            else SegLabelInfo(label_names=label_names, label_groups=[label_names])
+        )
         model = auto_configurator.get_model(label_info=label_info)
         assert isinstance(model, OTXModel)
+
+        model_cls = model.__class__
+
+        if should_pass_label_info(model_cls):
+            with pytest.raises(ValueError, match="Given model class (.*) requires a valid label_info to instantiate."):
+                _ = auto_configurator.get_model(label_info=None)
 
     def test_get_optimizer(self, fxt_task: OTXTaskType) -> None:
         if fxt_task in {


### PR DESCRIPTION
### Summary
- Ticket no. 138709
- Replace `num_classes` common `OTXModel` argument with `label_info: LabelInfoTypes` (`LabelInfoTypes := int | list[str] | LabelInfo`).
- Merge `HLabel` task's `hlabel_info` into `label_info` as well.
- Do not runtime assignments of `OTXModel.label_info` at `Engine` and `CLI` as possible to make them immutable during the train pipeline. It should be declarative at the very first stage (`OTXModel.__init__(label_info=label_info, ...)`).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
