### PR TITLE
Use torchvision in MRCNN on CUDA

### DIFF
--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -122,7 +122,7 @@ class DetectionConfigurer(BaseConfigurer):
     def configure_device(self, cfg):
         """Setting device for training and inference."""
         super().configure_device(cfg)
-        if cfg.device in ["xpu", "hpu"]:
+        if cfg.device in ["xpu", "hpu", "cuda"]:
             NMSop.forward = monkey_patched_nms
             RoIAlign.forward = monkey_patched_roi_align
 

--- a/src/otx/algorithms/detection/adapters/mmdet/configurer.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/configurer.py
@@ -122,7 +122,12 @@ class DetectionConfigurer(BaseConfigurer):
     def configure_device(self, cfg):
         """Setting device for training and inference."""
         super().configure_device(cfg)
-        if cfg.device in ["xpu", "hpu", "cuda"]:
+
+        patch_det_ops = cfg.device in ["xpu", "hpu"] or (
+            cfg.model.backbone.get("type", "") and cfg.model.backbone.get("depth", 0) == 50
+        )
+
+        if patch_det_ops:
             NMSop.forward = monkey_patched_nms
             RoIAlign.forward = monkey_patched_roi_align
 

--- a/tests/e2e/cli/semantic_segmentation/test_segmentation.py
+++ b/tests/e2e/cli/semantic_segmentation/test_segmentation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import torch
 
+from otx.algorithms.common.utils.utils import is_xpu_available
 from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import Registry
 from tests.test_suite.e2e_test_system import e2e_pytest_component
@@ -187,6 +188,8 @@ class TestToolsOTXSegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_nncf_optimize(self, template, tmp_dir_path):
+        if is_xpu_available():
+            pytest.skip("NNCF is not supported on XPU")
         tmp_dir_path = tmp_dir_path / "segmentation"
         nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
 
@@ -194,6 +197,8 @@ class TestToolsOTXSegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_nncf_export(self, template, tmp_dir_path):
+        if is_xpu_available():
+            pytest.skip("NNCF is not supported on XPU")
         tmp_dir_path = tmp_dir_path / "segmentation"
         nncf_export_testing(template, tmp_dir_path)
 
@@ -201,6 +206,8 @@ class TestToolsOTXSegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_nncf_validate_fq(self, template, tmp_dir_path):
+        if is_xpu_available():
+            pytest.skip("NNCF is not supported on XPU")
         tmp_dir_path = tmp_dir_path / "segmentation"
         nncf_validate_fq_testing(template, tmp_dir_path, otx_dir, "semantic_segmentation", type(self).__name__)
 
@@ -208,6 +215,8 @@ class TestToolsOTXSegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_nncf_eval(self, template, tmp_dir_path):
+        if is_xpu_available():
+            pytest.skip("NNCF is not supported on XPU")
         tmp_dir_path = tmp_dir_path / "segmentation"
         nncf_eval_testing(template, tmp_dir_path, otx_dir, args, threshold=0.01)
 
@@ -215,6 +224,8 @@ class TestToolsOTXSegmentation:
     @pytest.mark.skipif(TT_STABILITY_TESTS, reason="This is TT_STABILITY_TESTS")
     @pytest.mark.parametrize("template", templates, ids=templates_ids)
     def test_nncf_eval_openvino(self, template, tmp_dir_path):
+        if is_xpu_available():
+            pytest.skip("NNCF is not supported on XPU")
         tmp_dir_path = tmp_dir_path / "segmentation"
         nncf_eval_openvino_testing(template, tmp_dir_path, otx_dir, args)
 

--- a/tests/e2e/cli/semantic_segmentation/test_segmentation.py
+++ b/tests/e2e/cli/semantic_segmentation/test_segmentation.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import torch
 
-from otx.algorithms.common.utils.utils import is_xpu_available
 from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import Registry
 from tests.test_suite.e2e_test_system import e2e_pytest_component
@@ -60,9 +59,6 @@ resume_params = [
     "--learning_parameters.batch_size",
     "4",
 ]
-
-if is_xpu_available():
-    pytest.skip("Semantic segmentation task is not supported on XPU", allow_module_level=True)
 
 otx_dir = Path.cwd()
 

--- a/tests/integration/api/detection/api_detection.py
+++ b/tests/integration/api/detection/api_detection.py
@@ -54,7 +54,6 @@ class DetectionTaskAPIBase:
                 max_shapes=20,
                 min_size=50,
                 max_size=100,
-                random_seed=None,
             )
             # Convert shapes according to task
             for anno in annos:

--- a/tests/integration/cli/semantic_segmentation/test_segmentation.py
+++ b/tests/integration/cli/semantic_segmentation/test_segmentation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import torch
 
+from otx.algorithms.common.utils.utils import is_xpu_available
 from otx.api.entities.model_template import parse_model_template
 from otx.cli.registry import Registry
 from tests.test_suite.e2e_test_system import e2e_pytest_component
@@ -181,6 +182,8 @@ class TestSegmentationCLI:
     @e2e_pytest_component
     @pytest.mark.parametrize("template", default_templates, ids=default_templates_ids)
     def test_nncf_optimize(self, template, tmp_dir_path):
+        if is_xpu_available():
+            pytest.skip("NNCF is not supported on XPU")
         tmp_dir_path = tmp_dir_path / "segmentation"
         nncf_optimize_testing(template, tmp_dir_path, otx_dir, args)
 


### PR DESCRIPTION
### Summary

This could mitigate QAT instability on some datasets
Dataset: geti test data from the ticket
Model: ResNet50 MRCNN

| Backend  | iter time  |  total train time  | f-score |
|---|---|---|---|
| mmcv  | 0.362 |  0:03:06 | 0.4021 |
| torchvision  | 0.365 | 0:03:09  | 0.405 | 

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
