### PR TITLE
Bring ConvModule from mmcv.cnn.bricks

### DIFF
--- a/src/otx/algo/classification/backbones/otx_efficientnet.py
+++ b/src/otx/algo/classification/backbones/otx_efficientnet.py
@@ -7,8 +7,8 @@ import math
 import os
 
 import torch.nn.functional as F
-from mmcv.cnn import build_activation_layer
-from mmcv.cnn.bricks import ConvModule
+from otx.algo.modules.activation import build_activation_layer
+from otx.algo.modules.conv_module import ConvModule
 from mmengine.runner import load_checkpoint
 from mmpretrain.registry import MODELS
 from pytorchcv.models.model_store import download_model

--- a/src/otx/algo/classification/efficientnet_b0.py
+++ b/src/otx/algo/classification/efficientnet_b0.py
@@ -6,12 +6,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import torch
-from lightning.pytorch.cli import ReduceLROnPlateau
-
 from otx.algo.utils.mmconfig import read_mmconfig
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.metrics.accuracy import HLabelClsMetricCallble, MultiClassClsMetricCallable, MultiLabelClsMetricCallable
+from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.classification import (
     MMPretrainHlabelClsModel,
     MMPretrainMulticlassClsModel,
@@ -33,17 +31,8 @@ class EfficientNetB0ForHLabelCls(ExplainableMixInMMPretrainModel, MMPretrainHlab
     def __init__(
         self,
         label_info: HLabelInfo,
-        optimizer: OptimizerCallable = lambda params: torch.optim.SGD(
-            params=params,
-            lr=0.0049,
-        ),
-        scheduler: LRSchedulerCallable | LRSchedulerListCallable = lambda optimizer: ReduceLROnPlateau(
-            optimizer,
-            mode="max",
-            factor=0.1,
-            patience=1,
-            monitor="val/accuracy",
-        ),
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = HLabelClsMetricCallble,
         torch_compile: bool = False,
     ) -> None:
@@ -70,19 +59,8 @@ class EfficientNetB0ForMulticlassCls(ExplainableMixInMMPretrainModel, MMPretrain
         self,
         label_info: LabelInfoTypes,
         light: bool = False,
-        optimizer: OptimizerCallable = lambda params: torch.optim.SGD(
-            params=params,
-            lr=0.0049,
-            momentum=0.9,
-            weight_decay=0.0001,
-        ),
-        scheduler: LRSchedulerCallable | LRSchedulerListCallable = lambda optimizer: ReduceLROnPlateau(
-            optimizer,
-            mode="max",
-            factor=0.1,
-            patience=1,
-            monitor="val/accuracy",
-        ),
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiClassClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:
@@ -111,17 +89,8 @@ class EfficientNetB0ForMultilabelCls(ExplainableMixInMMPretrainModel, MMPretrain
     def __init__(
         self,
         label_info: LabelInfoTypes,
-        optimizer: OptimizerCallable = lambda params: torch.optim.SGD(
-            params=params,
-            lr=0.0049,
-        ),
-        scheduler: LRSchedulerCallable | LRSchedulerListCallable = lambda optimizer: ReduceLROnPlateau(
-            optimizer,
-            mode="max",
-            factor=0.1,
-            patience=1,
-            monitor="val/accuracy",
-        ),
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
         metric: MetricCallable = MultiLabelClsMetricCallable,
         torch_compile: bool = False,
     ) -> None:

--- a/src/otx/algo/modules/__init__.py
+++ b/src/otx/algo/modules/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenMMLab. All rights reserved.
+
+"""This module implementation is a code implementation copied or replaced from mmcv.cnn.bricks."""

--- a/src/otx/algo/modules/activation.py
+++ b/src/otx/algo/modules/activation.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenMMLab. All rights reserved.
+
+"""This implementation replaces the functionality of mmcv.cnn.bricks.activation.build_activation_layer."""
+
+import torch
+from torch import nn
+
+
+class Swish(nn.Module):
+    """Swish Module.
+
+    This module applies the swish function:
+
+    .. math::
+        Swish(x) = x * Sigmoid(x)
+
+    Returns:
+        Tensor: The output tensor.
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward function.
+
+        Args:
+            x (torch.Tensor): The input tensor.
+
+        Returns:
+            torch.Tensor: The output tensor.
+        """
+        return x * torch.sigmoid(x)
+
+
+ACTIVATION_DICT = {
+    "ReLU": nn.ReLU,
+    "LeakyReLU": nn.LeakyReLU,
+    "PReLU": nn.PReLU,
+    "RReLU": nn.RReLU,
+    "ReLU6": nn.ReLU6,
+    "ELU": nn.ELU,
+    "Sigmoid": nn.Sigmoid,
+    "Tanh": nn.Tanh,
+    "SiLU": nn.SiLU,
+    "GELU": nn.GELU,
+    "Swish": Swish,
+}
+
+
+def build_activation_layer(cfg: dict) -> nn.Module:
+    """Build activation layer.
+
+    Args:
+        cfg (dict): The activation layer config, which should contain:
+
+            - type (str): Layer type.
+            - layer args: Args needed to instantiate an activation layer.
+
+    Returns:
+        nn.Module: Created activation layer.
+    """
+    activation_type = cfg.pop("type", None)
+    if activation_type is None:
+        msg = "The cfg dict must contain the key 'type'"
+        raise KeyError(msg)
+    if activation_type not in ACTIVATION_DICT:
+        msg = f"Cannot find {activation_type} in {ACTIVATION_DICT.keys()}"
+        raise KeyError(msg)
+
+    return ACTIVATION_DICT[activation_type](**cfg)

--- a/src/otx/algo/modules/conv.py
+++ b/src/otx/algo/modules/conv.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenMMLab. All rights reserved.
+
+"""This implementation replaces the functionality of mmcv.cnn.bricks.conv.build_conv_layer."""
+
+from __future__ import annotations
+
+import inspect
+
+from torch import nn
+
+CONV_DICT = {
+    "Conv1d": nn.Conv1d,
+    "Conv2d": nn.Conv2d,
+    "Conv3d": nn.Conv3d,
+    "Conv": nn.Conv2d,
+}
+
+
+def build_conv_layer(cfg: dict | None, *args, **kwargs) -> nn.Module:
+    """Build convolution layer.
+
+    Args:
+        cfg (None or dict): The conv layer config, which should contain:
+            - type (str): Layer type.
+            - layer args: Args needed to instantiate an conv layer.
+        args (argument list): Arguments passed to the `__init__`
+            method of the corresponding conv layer.
+        kwargs (keyword arguments): Keyword arguments passed to the `__init__`
+            method of the corresponding conv layer.
+
+    Returns:
+        nn.Module: Created conv layer.
+    """
+    if cfg is None:
+        cfg_ = {"type": "Conv2d"}
+    else:
+        if not isinstance(cfg, dict):
+            msg = "cfg must be a dict"
+            raise TypeError(msg)
+        if "type" not in cfg:
+            msg = 'the cfg dict must contain the key "type"'
+            raise KeyError(msg)
+        cfg_ = cfg.copy()
+
+    layer_type = cfg_.pop("type")
+    if inspect.isclass(layer_type):
+        return layer_type(*args, **kwargs, **cfg_)
+    conv_layer = CONV_DICT.get(layer_type)
+    if conv_layer is None:
+        msg = f"Cannot find {conv_layer} in {CONV_DICT.keys()}"
+        raise KeyError(msg)
+    return conv_layer(*args, **kwargs, **cfg_)

--- a/src/otx/algo/modules/conv_module.py
+++ b/src/otx/algo/modules/conv_module.py
@@ -1,0 +1,357 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenMMLab. All rights reserved.
+
+"""This implementation copied ConvModule of mmcv.cnn.bricks.ConvModule."""
+# TODO(someone): Revisit mypy errors after deprecation of mmlab
+# mypy: ignore-errors
+from __future__ import annotations
+
+import warnings
+from functools import partial
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+from torch.nn.modules.batchnorm import _BatchNorm as BatchNorm
+from torch.nn.modules.instancenorm import _InstanceNorm as InstanceNorm
+
+from otx.algo.utils.mmengine_utils import constant_init, kaiming_init
+
+from .activation import build_activation_layer
+from .conv import build_conv_layer
+from .norm import build_norm_layer
+from .padding import build_padding_layer
+
+if TYPE_CHECKING:
+    from torch.nn.modules.conv import _ConvNd as ConvNd
+
+
+def efficient_conv_bn_eval_forward(bn: BatchNorm, conv: ConvNd, x: torch.Tensor) -> torch.Tensor:
+    """Implementation based on https://arxiv.org/abs/2305.11624.
+
+    "Tune-Mode ConvBN Blocks For Efficient Transfer Learning"
+    It leverages the associative law between convolution and affine transform,
+    i.e., normalize (weight conv feature) = (normalize weight) conv feature.
+    It works for Eval mode of ConvBN blocks during validation, and can be used
+    for training as well. It reduces memory and computation cost.
+
+    Args:
+        bn (_BatchNorm): a BatchNorm module.
+        conv (nn._ConvNd): a conv module
+        x (torch.Tensor): Input feature map.
+    """
+    # These lines of code are designed to deal with various cases
+    # like bn without affine transform, and conv without bias
+    weight_on_the_fly = conv.weight
+    bias_on_the_fly = conv.bias if conv.bias is not None else torch.zeros_like(bn.running_var)
+
+    bn_weight = bn.weight if bn.weight is not None else torch.ones_like(bn.running_var)
+
+    bn_bias = bn.bias if bn.bias is not None else torch.zeros_like(bn.running_var)
+
+    # shape of [C_out, 1, 1, 1] in Conv2d
+    weight_coeff = torch.rsqrt(bn.running_var + bn.eps).reshape([-1] + [1] * (len(conv.weight.shape) - 1))
+    # shape of [C_out, 1, 1, 1] in Conv2d
+    coefff_on_the_fly = bn_weight.view_as(weight_coeff) * weight_coeff
+
+    # shape of [C_out, C_in, k, k] in Conv2d
+    weight_on_the_fly = weight_on_the_fly * coefff_on_the_fly
+    # shape of [C_out] in Conv2d
+    bias_on_the_fly = bn_bias + coefff_on_the_fly.flatten() * (bias_on_the_fly - bn.running_mean)
+
+    return conv._conv_forward(x, weight_on_the_fly, bias_on_the_fly)  # noqa: SLF001
+
+
+class ConvModule(nn.Module):
+    """A conv block that bundles conv/norm/activation layers.
+
+    This block simplifies the usage of convolution layers, which are commonly
+    used with a norm layer (e.g., BatchNorm) and activation layer (e.g., ReLU).
+    It is based upon three build methods: `build_conv_layer()`,
+    `build_norm_layer()` and `build_activation_layer()`.
+
+    Besides, we add some additional features in this module.
+    1. Automatically set `bias` of the conv layer.
+    2. Spectral norm is supported.
+    3. More padding modes are supported. Before PyTorch 1.5, nn.Conv2d only
+    supports zero and circular padding, and we add "reflect" padding mode.
+
+    Args:
+        in_channels (int): Number of channels in the input feature map.
+            Same as that in ``nn._ConvNd``.
+        out_channels (int): Number of channels produced by the convolution.
+            Same as that in ``nn._ConvNd``.
+        kernel_size (int | tuple[int]): Size of the convolving kernel.
+            Same as that in ``nn._ConvNd``.
+        stride (int | tuple[int]): Stride of the convolution.
+            Same as that in ``nn._ConvNd``.
+        padding (int | tuple[int]): Zero-padding added to both sides of
+            the input. Same as that in ``nn._ConvNd``.
+        dilation (int | tuple[int]): Spacing between kernel elements.
+            Same as that in ``nn._ConvNd``.
+        groups (int): Number of blocked connections from input channels to
+            output channels. Same as that in ``nn._ConvNd``.
+        bias (bool | str): If specified as `auto`, it will be decided by the
+            norm_cfg. Bias will be set as True if `norm_cfg` is None, otherwise
+            False. Default: "auto".
+        conv_cfg (dict): Config dict for convolution layer. Default: None,
+            which means using conv2d.
+        norm_cfg (dict): Config dict for normalization layer. Default: None.
+        act_cfg (dict): Config dict for activation layer.
+            Default: dict(type='ReLU').
+        inplace (bool): Whether to use inplace mode for activation.
+            Default: True.
+        with_spectral_norm (bool): Whether use spectral norm in conv module.
+            Default: False.
+        padding_mode (str): If the `padding_mode` has not been supported by
+            current `Conv2d` in PyTorch, we will use our own padding layer
+            instead. Currently, we support ['zeros', 'circular'] with official
+            implementation and ['reflect'] with our own implementation.
+            Default: 'zeros'.
+        order (tuple[str]): The order of conv/norm/activation layers. It is a
+            sequence of "conv", "norm" and "act". Common examples are
+            ("conv", "norm", "act") and ("act", "conv", "norm").
+            Default: ('conv', 'norm', 'act').
+        efficient_conv_bn_eval (bool): Whether use efficient conv when the
+            consecutive bn is in eval mode (either training or testing), as
+            proposed in https://arxiv.org/abs/2305.11624 . Default: `False`.
+    """
+
+    _abbr_ = "conv_block"
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | tuple[int, int],
+        stride: int | tuple[int, int] = 1,
+        padding: int | tuple[int, int] = 0,
+        dilation: int | tuple[int, int] = 1,
+        groups: int = 1,
+        bias: bool | str = "auto",
+        conv_cfg: dict | None = None,
+        norm_cfg: dict | None = None,
+        act_cfg: dict | None = {"type": "ReLU"},  # noqa: B006
+        inplace: bool = True,
+        with_spectral_norm: bool = False,
+        padding_mode: str = "zeros",
+        order: tuple = ("conv", "norm", "act"),
+        efficient_conv_bn_eval: bool = False,
+    ):
+        super().__init__()
+        assert conv_cfg is None or isinstance(conv_cfg, dict)  # noqa: S101
+        assert norm_cfg is None or isinstance(norm_cfg, dict)  # noqa: S101
+        official_padding_mode = ["zeros", "circular"]
+        self.conv_cfg = conv_cfg
+        self.norm_cfg = norm_cfg
+        self.act_cfg = act_cfg
+        self.inplace = inplace
+        self.with_spectral_norm = with_spectral_norm
+        self.with_explicit_padding = padding_mode not in official_padding_mode
+        self.order = order
+        assert isinstance(self.order, tuple)  # noqa: S101
+        assert len(self.order) == 3  # noqa: S101
+        assert set(order) == {"conv", "norm", "act"}  # noqa: S101
+
+        self.with_norm = norm_cfg is not None
+        self.with_activation = act_cfg is not None
+        # if the conv layer is before a norm layer, bias is unnecessary.
+        if bias == "auto":
+            bias = not self.with_norm
+        self.with_bias = bias
+
+        if self.with_explicit_padding:
+            pad_cfg = {"type": padding_mode}
+            self.padding_layer = build_padding_layer(pad_cfg, padding)
+
+        # reset padding to 0 for conv module
+        conv_padding = 0 if self.with_explicit_padding else padding
+        # build convolution layer
+        self.conv = build_conv_layer(
+            conv_cfg,
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=conv_padding,
+            dilation=dilation,
+            groups=groups,
+            bias=bias,
+        )
+        # export the attributes of self.conv to a higher level for convenience
+        self.in_channels = self.conv.in_channels
+        self.out_channels = self.conv.out_channels
+        self.kernel_size = self.conv.kernel_size
+        self.stride = self.conv.stride
+        self.padding = padding
+        self.dilation = self.conv.dilation
+        self.transposed = self.conv.transposed
+        self.output_padding = self.conv.output_padding
+        self.groups = self.conv.groups
+
+        if self.with_spectral_norm:
+            self.conv = nn.utils.spectral_norm(self.conv)
+
+        # build normalization layers
+        if self.with_norm:
+            # norm layer is after conv layer
+            norm_channels = out_channels if order.index("norm") > order.index("conv") else in_channels
+            self.norm_name, norm = build_norm_layer(norm_cfg, norm_channels)
+            self.add_module(self.norm_name, norm)
+            if self.with_bias and isinstance(norm, (BatchNorm, InstanceNorm)):
+                warnings.warn("Unnecessary conv bias before batch/instance norm", stacklevel=1)
+        else:
+            self.norm_name = None
+
+        self.turn_on_efficient_conv_bn_eval(efficient_conv_bn_eval)
+
+        # build activation layer
+        if self.with_activation:
+            act_cfg_ = act_cfg.copy()
+            # nn.Tanh has no 'inplace' argument
+            if act_cfg_["type"] not in [
+                "Tanh",
+                "PReLU",
+                "Sigmoid",
+                "HSigmoid",
+                "Swish",
+                "GELU",
+            ]:
+                act_cfg_.setdefault("inplace", inplace)
+            self.activate = build_activation_layer(act_cfg_)
+
+        # Use msra init by default
+        self.init_weights()
+
+    @property
+    def norm(self) -> str | None:
+        """Get the normalization layer.
+
+        Returns:
+            str | None: The normalization layer.
+        """
+        if self.norm_name:
+            return getattr(self, self.norm_name)
+        return None
+
+    def init_weights(self) -> None:
+        """Init weights function for ConvModule."""
+        # 1. It is mainly for customized conv layers with their own
+        #    initialization manners by calling their own ``init_weights()``,
+        #    and we do not want ConvModule to override the initialization.
+        # 2. For customized conv layers without their own initialization
+        #    manners (that is, they don't have their own ``init_weights()``)
+        #    and PyTorch's conv layers, they will be initialized by
+        #    this method with default ``kaiming_init``.
+        # Note: For PyTorch's conv layers, they will be overwritten by our
+        #    initialization implementation using default ``kaiming_init``.
+        if not hasattr(self.conv, "init_weights"):
+            if self.with_activation and self.act_cfg["type"] == "LeakyReLU":
+                nonlinearity = "leaky_relu"
+                a = self.act_cfg.get("negative_slope", 0.01)
+            else:
+                nonlinearity = "relu"
+                a = 0
+            kaiming_init(self.conv, a=a, nonlinearity=nonlinearity)
+        if self.with_norm:
+            constant_init(self.norm, 1, bias=0)
+
+    def forward(self, x: torch.Tensor, activate: bool = True, norm: bool = True) -> torch.Tensor:
+        """Forward pass of the ConvModule.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+            activate (bool, optional): Whether to apply activation. Defaults to True.
+            norm (bool, optional): Whether to apply normalization. Defaults to True.
+
+        Returns:
+            torch.Tensor: Output tensor.
+        """
+        layer_index = 0
+        while layer_index < len(self.order):
+            layer = self.order[layer_index]
+            if layer == "conv":
+                if self.with_explicit_padding:
+                    x = self.padding_layer(x)
+                # if the next operation is norm and we have a norm layer in
+                # eval mode and we have enabled `efficient_conv_bn_eval` for
+                # the conv operator, then activate the optimized forward and
+                # skip the next norm operator since it has been fused
+                if (
+                    layer_index + 1 < len(self.order)
+                    and self.order[layer_index + 1] == "norm"
+                    and norm
+                    and self.with_norm
+                    and not self.norm.training
+                    and self.efficient_conv_bn_eval_forward is not None
+                ):
+                    self.conv.forward = partial(self.efficient_conv_bn_eval_forward, self.norm, self.conv)
+                    layer_index += 1
+                    x = self.conv(x)
+                    del self.conv.forward
+                else:
+                    x = self.conv(x)
+            elif layer == "norm" and norm and self.with_norm:
+                x = self.norm(x)
+            elif layer == "act" and activate and self.with_activation:
+                x = self.activate(x)
+            layer_index += 1
+        return x
+
+    def turn_on_efficient_conv_bn_eval(self, efficient_conv_bn_eval: bool = True) -> None:
+        """Turn on the efficient convolution batch normalization evaluation.
+
+        Args:
+            efficient_conv_bn_eval (bool, optional): Whether to enable efficient convolution
+                batch normalization evaluation. Defaults to True.
+        """
+        # efficient_conv_bn_eval works for conv + bn
+        # with `track_running_stats` option
+        if efficient_conv_bn_eval and self.norm and isinstance(self.norm, BatchNorm) and self.norm.track_running_stats:
+            self.efficient_conv_bn_eval_forward = efficient_conv_bn_eval_forward
+        else:
+            self.efficient_conv_bn_eval_forward = None
+
+    @staticmethod
+    def create_from_conv_bn(
+        conv: ConvNd,
+        bn: BatchNorm,
+        efficient_conv_bn_eval: bool = True,
+    ) -> ConvModule:
+        """Create a ConvModule from a conv and a bn module."""
+        self = ConvModule.__new__(ConvModule)
+        super(ConvModule, self).__init__()
+
+        self.conv_cfg = None
+        self.norm_cfg = None
+        self.act_cfg = None
+        self.inplace = False
+        self.with_spectral_norm = False
+        self.with_explicit_padding = False
+        self.order = ("conv", "norm", "act")
+
+        self.with_norm = True
+        self.with_activation = False
+        self.with_bias = conv.bias is not None
+
+        # build convolution layer
+        self.conv = conv
+        # export the attributes of self.conv to a higher level for convenience
+        self.in_channels = self.conv.in_channels
+        self.out_channels = self.conv.out_channels
+        self.kernel_size = self.conv.kernel_size
+        self.stride = self.conv.stride
+        self.padding = self.conv.padding
+        self.dilation = self.conv.dilation
+        self.transposed = self.conv.transposed
+        self.output_padding = self.conv.output_padding
+        self.groups = self.conv.groups
+
+        # build normalization layers
+        self.norm_name, norm = "bn", bn
+        self.add_module(self.norm_name, norm)
+
+        self.turn_on_efficient_conv_bn_eval(efficient_conv_bn_eval)
+
+        return self

--- a/src/otx/algo/modules/norm.py
+++ b/src/otx/algo/modules/norm.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenMMLab. All rights reserved.
+
+"""This implementation replaces the functionality of mmcv.cnn.bricks.norm.build_norm_layer."""
+# TODO(someone): Revisit mypy errors after deprecation of mmlab
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+import inspect
+
+from torch import nn
+from torch.nn import SyncBatchNorm
+from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.instancenorm import _InstanceNorm
+
+from otx.algo.utils.mmengine_utils import is_tuple_of
+
+NORM_DICT = {
+    "BN": nn.BatchNorm2d,
+    "BN1d": nn.BatchNorm1d,
+    "BN2d": nn.BatchNorm2d,
+    "BN3d": nn.BatchNorm3d,
+    "SyncBN": SyncBatchNorm,
+    "GN": nn.GroupNorm,
+    "LN": nn.LayerNorm,
+    "IN": nn.InstanceNorm2d,
+    "IN1d": nn.InstanceNorm1d,
+    "IN2d": nn.InstanceNorm2d,
+    "IN3d": nn.InstanceNorm3d,
+}
+
+
+def infer_abbr(class_type: type) -> str:
+    """Infer abbreviation from the class name.
+
+    When we build a norm layer with `build_norm_layer()`, we want to preserve
+    the norm type in variable names, e.g, self.bn1, self.gn. This method will
+    infer the abbreviation to map class types to abbreviations.
+
+    Rule 1: If the class has the property "_abbr_", return the property.
+    Rule 2: If the parent class is _BatchNorm, GroupNorm, LayerNorm or
+    InstanceNorm, the abbreviation of this layer will be "bn", "gn", "ln" and
+    "in" respectively.
+    Rule 3: If the class name contains "batch", "group", "layer" or "instance",
+    the abbreviation of this layer will be "bn", "gn", "ln" and "in"
+    respectively.
+    Rule 4: Otherwise, the abbreviation falls back to "norm".
+
+    Args:
+        class_type (type): The norm layer type.
+
+    Returns:
+        str: The inferred abbreviation.
+    """
+    if not inspect.isclass(class_type):
+        msg = f"class_type must be a type, but got {type(class_type)}"
+        raise TypeError(msg)
+    if hasattr(class_type, "_abbr_"):
+        return class_type._abbr_  # noqa: SLF001
+    if issubclass(class_type, _InstanceNorm):  # IN is a subclass of BN
+        return "in"
+    if issubclass(class_type, _BatchNorm):
+        return "bn"
+    if issubclass(class_type, nn.GroupNorm):
+        return "gn"
+    if issubclass(class_type, nn.LayerNorm):
+        return "ln"
+    class_name = class_type.__name__.lower()
+    if "batch" in class_name:
+        return "bn"
+    if "group" in class_name:
+        return "gn"
+    if "layer" in class_name:
+        return "ln"
+    if "instance" in class_name:
+        return "in"
+    return "norm_layer"
+
+
+def build_norm_layer(cfg: dict, num_features: int, postfix: int | str = "") -> tuple[str, nn.Module]:
+    """Build normalization layer.
+
+    Args:
+        cfg (dict): The norm layer config, which should contain:
+
+            - type (str): Layer type.
+            - layer args: Args needed to instantiate a norm layer.
+            - requires_grad (bool, optional): Whether stop gradient updates.
+        num_features (int): Number of input channels.
+        postfix (int | str): The postfix to be appended into norm abbreviation
+            to create named layer.
+
+    Returns:
+        tuple[str, nn.Module]: The first element is the layer name consisting
+        of abbreviation and postfix, e.g., bn1, gn. The second element is the
+        created norm layer.
+    """
+    if not isinstance(cfg, dict):
+        msg = "cfg must be a dict"
+        raise TypeError(msg)
+    if "type" not in cfg:
+        msg = 'the cfg dict must contain the key "type"'
+        raise KeyError(msg)
+    cfg_ = cfg.copy()
+
+    layer_type = cfg_.pop("type")
+
+    if inspect.isclass(layer_type):
+        norm_layer = layer_type
+    else:
+        # Switch registry to the target scope. If `norm_layer` cannot be found
+        # in the registry, fallback to search `norm_layer` in the
+        # mmengine.MODELS.
+        norm_layer = NORM_DICT.get(layer_type)
+        if norm_layer is None:
+            msg = f"Cannot find {norm_layer} in {NORM_DICT.keys()} "
+            raise KeyError(msg)
+    abbr = infer_abbr(norm_layer)
+
+    name = abbr + str(postfix)
+
+    requires_grad = cfg_.pop("requires_grad", True)
+    cfg_.setdefault("eps", 1e-5)
+    if norm_layer is not nn.GroupNorm:
+        layer = norm_layer(num_features, **cfg_)
+        if layer_type == "SyncBN" and hasattr(layer, "_specify_ddp_gpu_num"):
+            layer._specify_ddp_gpu_num(1)  # noqa: SLF001
+    else:
+        layer = norm_layer(num_channels=num_features, **cfg_)
+
+    for param in layer.parameters():
+        param.requires_grad = requires_grad
+
+    return name, layer
+
+
+def is_norm(layer: nn.Module, exclude: type | tuple | None = None) -> bool:
+    """Check if a layer is a normalization layer.
+
+    Args:
+        layer (nn.Module): The layer to be checked.
+        exclude (type | tuple[type]): Types to be excluded.
+
+    Returns:
+        bool: Whether the layer is a norm layer.
+    """
+    if exclude is not None:
+        if not isinstance(exclude, tuple):
+            exclude = (exclude,)
+        if not is_tuple_of(exclude, type):
+            msg = f"'exclude' must be either None or type or a tuple of types, but got {type(exclude)}: {exclude}"
+            raise TypeError(msg)
+
+    if exclude and isinstance(layer, exclude):
+        return False
+
+    all_norm_bases = (_BatchNorm, _InstanceNorm, nn.GroupNorm, nn.LayerNorm)
+    return isinstance(layer, all_norm_bases)

--- a/src/otx/algo/modules/padding.py
+++ b/src/otx/algo/modules/padding.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenMMLab. All rights reserved.
+
+"""This implementation replaces the functionality of mmcv.cnn.bricks.padding.build_padding_layer."""
+
+import inspect
+
+from torch import nn
+
+PADDING_DICT = {
+    "zero": nn.ZeroPad2d,
+    "reflect": nn.ReflectionPad2d,
+    "replicate": nn.ReplicationPad2d,
+}
+
+
+def build_padding_layer(cfg: dict, *args, **kwargs) -> nn.Module:
+    """Build padding layer.
+
+    Args:
+        cfg (dict): The padding layer config, which should contain:
+            - type (str): Layer type.
+            - layer args: Args needed to instantiate a padding layer.
+
+    Returns:
+        nn.Module: Created padding layer.
+    """
+    if not isinstance(cfg, dict):
+        msg = "cfg must be a dict"
+        raise TypeError(msg)
+    if "type" not in cfg:
+        msg = 'the cfg dict must contain the key "type"'
+        raise KeyError(msg)
+
+    cfg_ = cfg.copy()
+    padding_type = cfg_.pop("type")
+    if inspect.isclass(padding_type):
+        return padding_type(*args, **kwargs, **cfg_)
+    # Switch registry to the target scope. If `padding_layer` cannot be found
+    # in the registry, fallback to search `padding_layer` in the
+    # mmengine.MODELS.
+    padding_layer = PADDING_DICT.get(padding_type)
+    if padding_layer is None:
+        msg = f"Cannot find {padding_layer} in {PADDING_DICT.keys()} "
+        raise KeyError(msg)
+    return padding_layer(*args, **kwargs, **cfg_)


### PR DESCRIPTION
### Summary

`mmcv.cnn.bricks.ConvModule` is used by the `litehrnet` in the 
segmentation and `efficientnet-b0` in classification.
Import that module to work without MMCV.
@kprokofi Please see this when decoupling `LiteHRNet`.


<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


task | dataset | model | ConvModule | test/accuracy
-- | -- | -- | -- | --
MULTI_CLASS_CLS | Medium | Efficientnet-B0 | mmcv.cnn.bricks.ConvModule | 0.7944
  |   |   | otx.algo.modules.conv_module.ConvModule | 0.7944



</div>

<!--EndFragment-->
</body>

</html>


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
