### PR TITLE
Fix jsonargparse cannot parse lambda default arguments

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -386,6 +386,13 @@ class OTXCLI:
             warn(warning_msg, stacklevel=0)
             skip.add("label_info")
 
+        # NOTE: Workaround for jsonargparse cannot parse lambda default with unknown reasons
+        optimizer_arg, scheduler_arg = model_config.init_args.get("optimizer"), model_config.init_args.get("scheduler")
+        if isinstance(optimizer_arg, str) and optimizer_arg.endswith("<lambda>"):
+            model_config.init_args.pop("optimizer")
+        if isinstance(scheduler_arg, str) and scheduler_arg.endswith("<lambda>"):
+            model_config.init_args.pop("scheduler")
+
         # Parses the OTXModel separately to update num_classes.
         model_parser = ArgumentParser()
         model_parser.add_subclass_arguments(OTXModel, "model", skip=skip, required=False, fail_untyped=False)


### PR DESCRIPTION
### Summary

- Address https://github.com/openvinotoolkit/training_extensions/issues/3310. I don't know why jsonargparse cannot parse lambda default arguments although it must support: https://jsonargparse.readthedocs.io/en/stable/#callable-type.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
