### PR TITLE
Fix incorrect cache loading

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -245,7 +245,8 @@ class OTXCLI:
 
             parser_kwargs = self._set_default_config()
             sub_parser, added_arguments = self.engine_subcommand_parser(subcommand=subcommand, **parser_kwargs)
-            if "checkpoint" in added_arguments and self.cache_dir.exists():
+            if "--config" not in sys.argv and "checkpoint" in added_arguments and self.cache_dir.exists():
+                # If the user specifies the config directly, not set the cache ckpt as default.
                 self._load_cache_ckpt(parser=sub_parser)
 
             fn = getattr(Engine, subcommand)
@@ -269,7 +270,7 @@ class OTXCLI:
 
     def _set_default_config(self) -> dict:
         parser_kwargs = {}
-        if (self.cache_dir / "configs.yaml").exists():
+        if "--config" not in sys.argv and (self.cache_dir / "configs.yaml").exists():
             parser_kwargs["default_config_files"] = [str(self.cache_dir / "configs.yaml")]
             if "--print_config" not in sys.argv:
                 warn(f"Load default config from {self.cache_dir / 'configs.yaml'}.", stacklevel=0)


### PR DESCRIPTION
### Summary

Fix https://github.com/openvinotoolkit/training_extensions/issues/3383
If the user specifies config, this should run independently, but currently it unintentionally loads config and ckpt if they specify the same work_dir.
Fix to check whether the user specified config in the command.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have added e2e tests for validation.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
