### PR TITLE
Downgrade OV to 2024.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,12 @@ base = [
     "lightning==2.1.2",
     "pytorchcv",
     "timm",
-    "openvino==2024.1.0",
-    "openvino-dev==2024.1.0",
+    "openvino==2024.0",
+    "openvino-dev==2024.0",
     "openvino-model-api==0.2.0",
     "onnx==1.16.0",
     "onnxconverter-common==1.14.0",
-    "nncf==2.10.0",
+    "nncf==2.9.0",
 ]
 mmlab = [
     "mmdet==3.2.0",


### PR DESCRIPTION
### Summary

Reason: OV 2024.1 fails on loading converted SegNext models (depends on machine, possibly hardware), therefore CI fails sometimes.
