### PR TITLE
Change location of stack_batch

### DIFF
--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -18,11 +18,11 @@ from otx.algo.detection.heads.atss_head import ATSSHead
 from otx.algo.detection.necks.fpn import FPN
 from otx.algo.detection.ssd import SingleStageDetector
 from otx.algo.utils.mmconfig import read_mmconfig
-from otx.algo.utils.mmengine_utils import stack_batch
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
+from otx.core.data.entity.utils import stack_batch
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics.mean_ap import MeanAPCallable

--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -18,6 +18,7 @@ from otx.algo.detection.heads.atss_head import ATSSHead
 from otx.algo.detection.necks.fpn import FPN
 from otx.algo.detection.ssd import SingleStageDetector
 from otx.algo.utils.mmconfig import read_mmconfig
+from otx.algo.utils.mmengine_utils import stack_batch
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -103,6 +104,8 @@ class ATSS(ExplainableOTXDetModel):
         return model
 
     def _customize_inputs(self, entity: DetBatchDataEntity) -> dict[str, Any]:
+        if isinstance(entity.images, list):
+            entity.images = stack_batch(entity.images, pad_size_divisor=32)
         inputs: dict[str, Any] = {}
 
         inputs["entity"] = entity

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -19,6 +19,7 @@ from torchvision import tv_tensors
 from otx.algo.detection.backbones.pytorchcv_backbones import _build_model_including_pytorchcv
 from otx.algo.detection.heads.ssd_head import SSDHead
 from otx.algo.utils.mmconfig import read_mmconfig
+from otx.algo.utils.mmengine_utils import stack_batch
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -407,6 +408,8 @@ class SSD(ExplainableOTXDetModel):
         return detector
 
     def _customize_inputs(self, entity: DetBatchDataEntity) -> dict[str, Any]:
+        if isinstance(entity.images, list):
+            entity.images = stack_batch(entity.images, pad_size_divisor=32)
         inputs: dict[str, Any] = {}
 
         inputs["entity"] = entity

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -19,11 +19,11 @@ from torchvision import tv_tensors
 from otx.algo.detection.backbones.pytorchcv_backbones import _build_model_including_pytorchcv
 from otx.algo.detection.heads.ssd_head import SSDHead
 from otx.algo.utils.mmconfig import read_mmconfig
-from otx.algo.utils.mmengine_utils import stack_batch
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
+from otx.core.data.entity.utils import stack_batch
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.metrics.mean_ap import MeanAPCallable

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -17,11 +17,11 @@ from otx.algo.detection.heads.yolox_head import YOLOXHead
 from otx.algo.detection.necks.yolox_pafpn import YOLOXPAFPN
 from otx.algo.detection.ssd import SingleStageDetector
 from otx.algo.utils.mmconfig import read_mmconfig
-from otx.algo.utils.mmengine_utils import stack_batch
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
+from otx.core.data.entity.utils import stack_batch
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.exporter.mmdeploy import MMdeployExporter
 from otx.core.metrics.mean_ap import MeanAPCallable

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -17,6 +17,7 @@ from otx.algo.detection.heads.yolox_head import YOLOXHead
 from otx.algo.detection.necks.yolox_pafpn import YOLOXPAFPN
 from otx.algo.detection.ssd import SingleStageDetector
 from otx.algo.utils.mmconfig import read_mmconfig
+from otx.algo.utils.mmengine_utils import stack_batch
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -115,6 +116,8 @@ class OTXYOLOX(ExplainableOTXDetModel):
         return detector
 
     def _customize_inputs(self, entity: DetBatchDataEntity) -> dict[str, Any]:
+        if isinstance(entity.images, list):
+            entity.images = stack_batch(entity.images, pad_size_divisor=32, pad_value=114)
         inputs: dict[str, Any] = {}
 
         inputs["entity"] = entity

--- a/src/otx/algo/utils/mmengine_utils.py
+++ b/src/otx/algo/utils/mmengine_utils.py
@@ -13,6 +13,7 @@ from collections import OrderedDict, abc, namedtuple
 from typing import Any
 from warnings import warn
 
+import torch
 from torch import distributed as torch_dist
 from torch import nn
 from torch.utils.model_zoo import load_url
@@ -228,3 +229,48 @@ def is_tuple_of(seq: Any, expected_type: type | tuple) -> bool:  # noqa: ANN401
     A partial method of :func:`is_seq_of`.
     """
     return is_seq_of(seq, expected_type, seq_type=tuple)
+
+
+def stack_batch(
+    tensor_list: list[torch.Tensor],
+    pad_size_divisor: int = 1,
+    pad_value: int | float = 0,
+) -> torch.Tensor:
+    """Stack multiple tensors to form a batch.
+
+    Pad the tensor to the max shape use the right bottom padding mode in these images.
+    If ``pad_size_divisor > 0``, add padding to ensure the shape of each dim is
+    divisible by ``pad_size_divisor``.
+
+    Args:
+        tensor_list (List[Tensor]): A list of tensors with the same dim.
+        pad_size_divisor (int): If ``pad_size_divisor > 0``, add padding
+            to ensure the shape of each dim is divisible by
+            ``pad_size_divisor``. This depends on the model, and many
+            models need to be divisible by 32. Defaults to 1
+        pad_value (int, float): The padding value. Defaults to 0.
+
+    Returns:
+        Tensor: The n dim tensor.
+    """
+    dim = tensor_list[0].dim()
+    num_img = len(tensor_list)
+    all_sizes: torch.Tensor = torch.Tensor([tensor.shape for tensor in tensor_list])
+    max_sizes = torch.ceil(torch.max(all_sizes, dim=0)[0] / pad_size_divisor) * pad_size_divisor
+    padded_sizes = max_sizes - all_sizes
+    # The first dim normally means channel,  which should not be padded.
+    padded_sizes[:, 0] = 0
+    if padded_sizes.sum() == 0:
+        return torch.stack(tensor_list)
+    # `pad` is the second arguments of `F.pad`. If pad is (1, 2, 3, 4),
+    # it means that padding the last dim with 1(left) 2(right), padding the
+    # penultimate dim to 3(top) 4(bottom). The order of `pad` is opposite of
+    # the `padded_sizes`. Therefore, the `padded_sizes` needs to be reversed,
+    # and only odd index of pad should be assigned to keep padding "right" and
+    # "bottom".
+    pad = torch.zeros(num_img, 2 * dim, dtype=torch.int)
+    pad[:, 1::2] = padded_sizes[:, range(dim - 1, -1, -1)]
+    batch_tensor = []
+    for idx, tensor in enumerate(tensor_list):
+        batch_tensor.append(torch.nn.functional.pad(tensor, tuple(pad[idx].tolist()), value=pad_value))
+    return torch.stack(batch_tensor)

--- a/src/otx/core/data/entity/base.py
+++ b/src/otx/core/data/entity/base.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field, fields
 from typing import TYPE_CHECKING, Any, Dict, Generic, Iterator, TypeVar
@@ -607,9 +608,19 @@ class OTXBatchDataEntity(Generic[T_OTXDataEntity]):
         images = [entity.image for entity in entities]
         like = next(iter(images))
 
+        if stack_images and not all(like.shape == entity.image.shape for entity in entities):  # type: ignore[union-attr]
+            msg = (
+                "You set stack_images as True, but not all images in the batch has same shape. "
+                "In this case, we cannot stack images. Some tasks, e.g., detection, "
+                "can have different image shapes among samples in the batch. However, if it is not your intention, "
+                "consider setting stack_images as False in the config."
+            )
+            warnings.warn(msg, stacklevel=1)
+            stack_images = False
+
         return OTXBatchDataEntity(
             batch_size=batch_size,
-            images=tv_tensors.wrap(cls.stack_batch(images), like=like) if stack_images else images,
+            images=tv_tensors.wrap(torch.stack(images), like=like) if stack_images else images,
             imgs_info=[entity.img_info for entity in entities],
         )
 
@@ -626,52 +637,6 @@ class OTXBatchDataEntity(Generic[T_OTXDataEntity]):
 
         like = next(iter(self.images))
         return tv_tensors.wrap(stack(self.images), like=like)
-
-    @staticmethod
-    # TODO(someone): Pad size divisior and pad value should be configurable
-    def stack_batch(
-        tensor_list: list[torch.Tensor],
-        pad_size_divisor: int = 1,
-        pad_value: int | float = 0,
-    ) -> torch.Tensor:
-        """Stack multiple tensors to form a batch.
-
-        Pad the tensor to the max shape use the right bottom padding mode in these images.
-        If ``pad_size_divisor > 0``, add padding to ensure the shape of each dim is
-        divisible by ``pad_size_divisor``.
-
-        Args:
-            tensor_list (List[Tensor]): A list of tensors with the same dim.
-            pad_size_divisor (int): If ``pad_size_divisor > 0``, add padding
-                to ensure the shape of each dim is divisible by
-                ``pad_size_divisor``. This depends on the model, and many
-                models need to be divisible by 32. Defaults to 1
-            pad_value (int, float): The padding value. Defaults to 0.
-
-        Returns:
-            Tensor: The n dim tensor.
-        """
-        dim = tensor_list[0].dim()
-        num_img = len(tensor_list)
-        all_sizes: torch.Tensor = torch.Tensor([tensor.shape for tensor in tensor_list])
-        max_sizes = torch.ceil(torch.max(all_sizes, dim=0)[0] / pad_size_divisor) * pad_size_divisor
-        padded_sizes = max_sizes - all_sizes
-        # The first dim normally means channel,  which should not be padded.
-        padded_sizes[:, 0] = 0
-        if padded_sizes.sum() == 0:
-            return torch.stack(tensor_list)
-        # `pad` is the second arguments of `F.pad`. If pad is (1, 2, 3, 4),
-        # it means that padding the last dim with 1(left) 2(right), padding the
-        # penultimate dim to 3(top) 4(bottom). The order of `pad` is opposite of
-        # the `padded_sizes`. Therefore, the `padded_sizes` needs to be reversed,
-        # and only odd index of pad should be assigned to keep padding "right" and
-        # "bottom".
-        pad = torch.zeros(num_img, 2 * dim, dtype=torch.int)
-        pad[:, 1::2] = padded_sizes[:, range(dim - 1, -1, -1)]
-        batch_tensor = []
-        for idx, tensor in enumerate(tensor_list):
-            batch_tensor.append(torch.nn.functional.pad(tensor, tuple(pad[idx].tolist()), value=pad_value))
-        return torch.stack(batch_tensor)
 
     def pin_memory(self: T_OTXBatchDataEntity) -> T_OTXBatchDataEntity:
         """Pin memory for member tensor variables."""

--- a/src/otx/core/data/entity/tile.py
+++ b/src/otx/core/data/entity/tile.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Sequence
 
+from otx.algo.utils.mmengine_utils import stack_batch
 from otx.core.types.task import OTXTaskType
 
-from .base import ImageInfo, OTXBatchDataEntity, T_OTXBatchDataEntity, T_OTXDataEntity
+from .base import ImageInfo, T_OTXBatchDataEntity, T_OTXDataEntity
 from .detection import DetBatchDataEntity, DetDataEntity
 from .instance_segmentation import InstanceSegBatchDataEntity, InstanceSegDataEntity
 
@@ -112,7 +113,7 @@ class TileBatchDetDataEntity(OTXTileBatchDataEntity):
         batch_data_entities = [
             DetBatchDataEntity(
                 batch_size=self.batch_size,
-                images=OTXBatchDataEntity.stack_batch(tiles[i : i + self.batch_size]),
+                images=stack_batch(tiles[i : i + self.batch_size]),
                 imgs_info=tile_infos[i : i + self.batch_size],
                 bboxes=[[] for _ in range(self.batch_size)],
                 labels=[[] for _ in range(self.batch_size)],

--- a/src/otx/core/data/entity/tile.py
+++ b/src/otx/core/data/entity/tile.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Sequence
 
-from otx.algo.utils.mmengine_utils import stack_batch
+from otx.core.data.entity.utils import stack_batch
 from otx.core.types.task import OTXTaskType
 
 from .base import ImageInfo, T_OTXBatchDataEntity, T_OTXDataEntity

--- a/src/otx/core/data/entity/utils.py
+++ b/src/otx/core/data/entity/utils.py
@@ -71,3 +71,48 @@ def clamp_points(inpt: Tensor, canvas_size: tuple[int, int] | None = None) -> Te
         raise TypeError(  # noqa: TRY003
             f"Input can either be a plain tensor or a point tv_tensor, but got {type(inpt)} instead.",  # noqa: EM102
         )
+
+
+def stack_batch(
+    tensor_list: list[torch.Tensor],
+    pad_size_divisor: int = 1,
+    pad_value: int | float = 0,
+) -> torch.Tensor:
+    """Stack multiple tensors to form a batch.
+
+    Pad the tensor to the max shape use the right bottom padding mode in these images.
+    If ``pad_size_divisor > 0``, add padding to ensure the shape of each dim is
+    divisible by ``pad_size_divisor``.
+
+    Args:
+        tensor_list (List[Tensor]): A list of tensors with the same dim.
+        pad_size_divisor (int): If ``pad_size_divisor > 0``, add padding
+            to ensure the shape of each dim is divisible by
+            ``pad_size_divisor``. This depends on the model, and many
+            models need to be divisible by 32. Defaults to 1
+        pad_value (int, float): The padding value. Defaults to 0.
+
+    Returns:
+        Tensor: The n dim tensor.
+    """
+    dim = tensor_list[0].dim()
+    num_img = len(tensor_list)
+    all_sizes: torch.Tensor = torch.Tensor([tensor.shape for tensor in tensor_list])
+    max_sizes = torch.ceil(torch.max(all_sizes, dim=0)[0] / pad_size_divisor) * pad_size_divisor
+    padded_sizes = max_sizes - all_sizes
+    # The first dim normally means channel,  which should not be padded.
+    padded_sizes[:, 0] = 0
+    if padded_sizes.sum() == 0:
+        return torch.stack(tensor_list)
+    # `pad` is the second arguments of `F.pad`. If pad is (1, 2, 3, 4),
+    # it means that padding the last dim with 1(left) 2(right), padding the
+    # penultimate dim to 3(top) 4(bottom). The order of `pad` is opposite of
+    # the `padded_sizes`. Therefore, the `padded_sizes` needs to be reversed,
+    # and only odd index of pad should be assigned to keep padding "right" and
+    # "bottom".
+    pad = torch.zeros(num_img, 2 * dim, dtype=torch.int)
+    pad[:, 1::2] = padded_sizes[:, range(dim - 1, -1, -1)]
+    batch_tensor = []
+    for idx, tensor in enumerate(tensor_list):
+        batch_tensor.append(torch.nn.functional.pad(tensor, tuple(pad[idx].tolist()), value=pad_value))
+    return torch.stack(batch_tensor)


### PR DESCRIPTION
### Summary
Stack batch is function for stack list of Tensors whose sizes are different.
This function is useful when the batch of Tensors has different shapes with each other.
Normal torch.stack will raise shape error, but stack batch pad to match shapes of batch to largest tensor of batch.
Stack batch requires pad_size_divisor and pad_val, but previous implementation can't configure that values.
This PR changes the location of stack batch so that stack batch can get those value from model directly. 
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
