### PR TITLE
Remove cuda version focal loss

### DIFF
--- a/src/otx/algo/detection/losses/cross_focal_loss.py
+++ b/src/otx/algo/detection/losses/cross_focal_loss.py
@@ -11,7 +11,7 @@ from mmengine.registry import MODELS
 from torch import Tensor, nn
 from torch.cuda.amp import custom_fwd
 
-from otx.algo.detection.losses.focal_loss import py_sigmoid_focal_loss, sigmoid_focal_loss
+from otx.algo.detection.losses.focal_loss import py_sigmoid_focal_loss
 
 
 def cross_sigmoid_focal_loss(
@@ -36,13 +36,10 @@ def cross_sigmoid_focal_loss(
         avg_factor: average factors.
         valid_label_mask: ignore label mask.
     """
-    if torch.cuda.is_available() and inputs.is_cuda:
-        calculate_loss_func = sigmoid_focal_loss
-    else:
-        inputs_size = inputs.size(1)
-        targets = torch.nn.functional.one_hot(targets, num_classes=inputs_size + 1)
-        targets = targets[:, :inputs_size]
-        calculate_loss_func = py_sigmoid_focal_loss
+    inputs_size = inputs.size(1)
+    targets = torch.nn.functional.one_hot(targets, num_classes=inputs_size + 1)
+    targets = targets[:, :inputs_size]
+    calculate_loss_func = py_sigmoid_focal_loss
 
     loss = calculate_loss_func(
         inputs,

--- a/src/otx/algo/detection/losses/focal_loss.py
+++ b/src/otx/algo/detection/losses/focal_loss.py
@@ -12,10 +12,6 @@ from typing import TYPE_CHECKING
 import torch
 import torch.nn.functional
 
-# TODO(Eugene): replace mmcv.sigmoid_focal_loss with torchvision
-# https://github.com/openvinotoolkit/training_extensions/pull/3281
-from mmcv.ops import sigmoid_focal_loss as _sigmoid_focal_loss
-
 from otx.algo.detection.losses.weighted_loss import weight_reduce_loss
 
 if TYPE_CHECKING:
@@ -55,55 +51,6 @@ def py_sigmoid_focal_loss(
     # Thus it's pt.pow(gamma) rather than (1 - pt).pow(gamma)
     focal_weight = (alpha * target + (1 - alpha) * (1 - target)) * pt.pow(gamma)
     loss = torch.nn.functional.binary_cross_entropy_with_logits(pred, target, reduction="none") * focal_weight
-    if weight is not None:
-        if weight.shape != loss.shape:
-            if weight.size(0) == loss.size(0):
-                # For most cases, weight is of shape (num_priors, ),
-                #  which means it does not have the second axis num_class
-                weight = weight.view(-1, 1)
-            else:
-                # Sometimes, weight per anchor per class is also needed. e.g.
-                #  in FSAF. But it may be flattened of shape
-                #  (num_priors x num_class, ), while loss is still of shape
-                #  (num_priors, num_class).
-                if weight.numel() != loss.numel():
-                    msg = "The number of elements in weight should be equal to the number of elements in loss."
-                    raise ValueError(msg)
-                weight = weight.view(loss.size(0), -1)
-        if weight.ndim != loss.ndim:
-            msg = "The number of dimensions in weight should be equal to the number of dimensions in loss."
-            raise ValueError(msg)
-    return weight_reduce_loss(loss, weight, reduction, avg_factor)
-
-
-def sigmoid_focal_loss(
-    pred: Tensor,
-    target: Tensor,
-    weight: None | Tensor = None,
-    gamma: float = 2.0,
-    alpha: float = 0.25,
-    reduction: str = "mean",
-    avg_factor: int | None = None,
-) -> torch.Tensor:
-    r"""A wrapper of cuda version `Focal Loss <https://arxiv.org/abs/1708.02002>`_.
-
-    Args:
-        pred (torch.Tensor): The prediction with shape (N, C), C is the number
-            of classes.
-        target (torch.Tensor): The learning label of the prediction.
-        weight (torch.Tensor, optional): Sample-wise loss weight.
-        gamma (float, optional): The gamma for calculating the modulating
-            factor. Defaults to 2.0.
-        alpha (float, optional): A balanced form for Focal Loss.
-            Defaults to 0.25.
-        reduction (str, optional): The method used to reduce the loss into
-            a scalar. Defaults to 'mean'. Options are "none", "mean" and "sum".
-        avg_factor (int, optional): Average factor that is used to average
-            the loss. Defaults to None.
-    """
-    # Function.apply does not accept keyword arguments, so the decorator
-    # "weighted_loss" is not applicable
-    loss = _sigmoid_focal_loss(pred.contiguous(), target.contiguous(), gamma, alpha, None, "none")
     if weight is not None:
         if weight.shape != loss.shape:
             if weight.size(0) == loss.size(0):


### PR DESCRIPTION
### Summary
This PR is for deprecating cuda version focal loss.
In my short experience there's no much difference regarding e2e time
But this PR change performance of model. 
We need to decide whether bringing cuda version of focal loss after validation period.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
