### PR TITLE
Remove left mmengine things in object detection

### DIFF
--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import torch
-from mmengine.structures import InstanceData
 from omegaconf import DictConfig
 from torchvision import tv_tensors
 
@@ -23,7 +22,7 @@ from otx.algo.detection.losses.cross_focal_loss import CrossSigmoidFocalLoss
 from otx.algo.detection.losses.iou_loss import GIoULoss
 from otx.algo.detection.necks.fpn import FPN
 from otx.algo.detection.ssd import SingleStageDetector
-from otx.algo.utils.mmengine_utils import load_checkpoint
+from otx.algo.utils.mmengine_utils import InstanceData, load_checkpoint
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -115,15 +114,15 @@ class ATSS(ExplainableOTXDetModel):
         for img_info, prediction in zip(inputs.imgs_info, predictions):
             if not isinstance(prediction, InstanceData):
                 raise TypeError(prediction)
-            scores.append(prediction.scores)
+            scores.append(prediction.scores)  # type: ignore[attr-defined]
             bboxes.append(
                 tv_tensors.BoundingBoxes(
-                    prediction.bboxes,
+                    prediction.bboxes,  # type: ignore[attr-defined]
                     format="XYXY",
                     canvas_size=img_info.ori_shape,
                 ),
             )
-            labels.append(prediction.labels)
+            labels.append(prediction.labels)  # type: ignore[attr-defined]
 
         if self.explain_mode:
             if not isinstance(outputs, dict):

--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -23,6 +23,7 @@ from otx.algo.detection.losses.cross_focal_loss import CrossSigmoidFocalLoss
 from otx.algo.detection.losses.iou_loss import GIoULoss
 from otx.algo.detection.necks.fpn import FPN
 from otx.algo.detection.ssd import SingleStageDetector
+from otx.algo.utils.mmengine_utils import load_checkpoint
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -67,8 +68,6 @@ class ATSS(ExplainableOTXDetModel):
         self.tile_image_size = self.image_size
 
     def _create_model(self) -> nn.Module:
-        from mmengine.runner import load_checkpoint
-
         detector = self._build_model(num_classes=self.label_info.num_classes)
         detector.init_weights()
         self.classification_layers = self.get_classification_layers(prefix="model.")

--- a/src/otx/algo/detection/heads/anchor_head.py
+++ b/src/otx/algo/detection/heads/anchor_head.py
@@ -9,7 +9,6 @@ import warnings
 from typing import TYPE_CHECKING
 
 import torch
-from mmengine.structures import InstanceData
 from torch import Tensor, nn
 
 from otx.algo.detection.heads.anchor_generator import AnchorGenerator
@@ -19,6 +18,7 @@ from otx.algo.detection.heads.base_sampler import PseudoSampler
 from otx.algo.detection.heads.delta_xywh_bbox_coder import DeltaXYWHBBoxCoder
 from otx.algo.detection.heads.max_iou_assigner import MaxIoUAssigner
 from otx.algo.detection.utils.utils import anchor_inside_flags, images_to_levels, multi_apply, unmap
+from otx.algo.utils.mmengine_utils import InstanceData
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -251,13 +251,13 @@ class AnchorHead(BaseDenseHead):
         anchors = flat_anchors[inside_flags]
 
         pred_instances = InstanceData(priors=anchors)
-        assign_result = self.assigner.assign(pred_instances, gt_instances, gt_instances_ignore)
+        assign_result = self.assigner.assign(pred_instances, gt_instances, gt_instances_ignore)  # type: ignore[arg-type]
         # No sampling is required except for RPN and
         # Guided Anchoring algorithms
         sampling_result = self.sampler.sample(assign_result, pred_instances, gt_instances)
 
         num_valid_anchors = anchors.shape[0]
-        target_dim = gt_instances.bboxes.size(-1) if self.reg_decoded_bbox else self.bbox_coder.encode_size
+        target_dim = gt_instances.bboxes.size(-1) if self.reg_decoded_bbox else self.bbox_coder.encode_size  # type: ignore[attr-defined]
         bbox_targets = anchors.new_zeros(num_valid_anchors, target_dim)
         bbox_weights = anchors.new_zeros(num_valid_anchors, target_dim)
 
@@ -352,7 +352,7 @@ class AnchorHead(BaseDenseHead):
             raise ValueError(msg)
 
         if batch_gt_instances_ignore is None:
-            batch_gt_instances_ignore = [None] * num_imgs
+            batch_gt_instances_ignore = [None] * num_imgs  # type: ignore[list-item]
 
         # anchor number of multi levels
         num_level_anchors = [anchors.size(0) for anchors in anchor_list[0]]

--- a/src/otx/algo/detection/heads/atss_assigner.py
+++ b/src/otx/algo/detection/heads/atss_assigner.py
@@ -13,8 +13,9 @@ from otx.algo.detection.heads.iou2d_calculator import BboxOverlaps2D
 from otx.algo.detection.utils.structures import AssignResult
 
 if TYPE_CHECKING:
-    from mmengine.structures import InstanceData
     from omegaconf import DictConfig
+
+    from otx.algo.utils.mmengine_utils import InstanceData
 
 
 def bbox_center_distance(bboxes: Tensor, priors: Tensor) -> Tensor:
@@ -120,10 +121,10 @@ class ATSSAssigner:
         Returns:
             :obj:`AssignResult`: The assign result.
         """
-        gt_bboxes = gt_instances.bboxes
-        priors = pred_instances.priors
-        gt_labels = gt_instances.labels
-        gt_bboxes_ignore = gt_instances_ignore.bboxes if gt_instances_ignore is not None else None
+        gt_bboxes = gt_instances.bboxes  # type: ignore[attr-defined]
+        priors = pred_instances.priors  # type: ignore[attr-defined]
+        gt_labels = gt_instances.labels  # type: ignore[attr-defined]
+        gt_bboxes_ignore = gt_instances_ignore.bboxes if gt_instances_ignore is not None else None  # type: ignore[attr-defined]
 
         inf = 100000000
         priors = priors[:, :4]
@@ -145,8 +146,8 @@ class ATSSAssigner:
 
         else:
             # Dynamic cost ATSSAssigner in DDOD
-            cls_scores = pred_instances.scores
-            bbox_preds = pred_instances.bboxes
+            cls_scores = pred_instances.scores  # type: ignore[attr-defined]
+            bbox_preds = pred_instances.bboxes  # type: ignore[attr-defined]
 
             # compute cls cost for bbox and GT
             cls_cost = torch.sigmoid(cls_scores[:, gt_labels])

--- a/src/otx/algo/detection/heads/atss_head.py
+++ b/src/otx/algo/detection/heads/atss_head.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import torch
-from mmengine.structures import InstanceData
 from torch import Tensor, nn
 
 from otx.algo.detection.heads.anchor_head import AnchorHead
@@ -20,6 +19,7 @@ from otx.algo.detection.utils.bbox_overlaps import bbox_overlaps
 from otx.algo.detection.utils.utils import anchor_inside_flags, multi_apply, reduce_mean, unmap
 from otx.algo.modules.conv_module import ConvModule
 from otx.algo.utils.mmcv_utils import Scale
+from otx.algo.utils.mmengine_utils import InstanceData
 
 EPS = 1e-12
 
@@ -208,7 +208,7 @@ class ATSSHead(ClassIncrementalMixin, AnchorHead):
         bbox_preds: list[Tensor],
         centernesses: list[Tensor],
         batch_gt_instances: list[InstanceData],
-        batch_img_metas: list[InstanceData],
+        batch_img_metas: list[dict],
         batch_gt_instances_ignore: list[InstanceData] | None = None,
     ) -> dict[str, Tensor]:
         """Compute losses of the head.
@@ -530,7 +530,7 @@ class ATSSHead(ClassIncrementalMixin, AnchorHead):
         pred_instances = InstanceData(priors=anchors)
         assign_result = self.assigner.assign(  # type: ignore[call-arg]
             pred_instances,
-            num_level_anchors_inside,
+            num_level_anchors_inside,  # type: ignore[arg-type]
             gt_instances,
             gt_instances_ignore,
         )

--- a/src/otx/algo/detection/heads/base_sampler.py
+++ b/src/otx/algo/detection/heads/base_sampler.py
@@ -4,9 +4,9 @@
 from abc import ABCMeta, abstractmethod
 
 import torch
-from mmengine.structures import InstanceData
 
 from otx.algo.detection.utils.structures import AssignResult, SamplingResult
+from otx.algo.utils.mmengine_utils import InstanceData
 
 
 class BaseSampler(metaclass=ABCMeta):
@@ -72,9 +72,9 @@ class BaseSampler(metaclass=ABCMeta):
         Returns:
             :obj:`SamplingResult`: Sampling result.
         """
-        gt_bboxes = gt_instances.bboxes
-        priors = pred_instances.priors
-        gt_labels = gt_instances.labels
+        gt_bboxes = gt_instances.bboxes  # type: ignore[attr-defined]
+        priors = pred_instances.priors  # type: ignore[attr-defined]
+        gt_labels = gt_instances.labels  # type: ignore[attr-defined]
         if len(priors.shape) < 2:
             priors = priors[None, :]
 
@@ -158,8 +158,8 @@ class PseudoSampler(BaseSampler):
         Returns:
             :obj:`SamplingResult`: sampler results
         """
-        gt_bboxes = gt_instances.bboxes
-        priors = pred_instances.priors
+        gt_bboxes = gt_instances.bboxes  # type: ignore[attr-defined]
+        priors = pred_instances.priors  # type: ignore[attr-defined]
 
         pos_inds = torch.nonzero(assign_result.gt_inds > 0, as_tuple=False).squeeze(-1).unique()
         neg_inds = torch.nonzero(assign_result.gt_inds == 0, as_tuple=False).squeeze(-1).unique()

--- a/src/otx/algo/detection/heads/class_incremental_mixin.py
+++ b/src/otx/algo/detection/heads/class_incremental_mixin.py
@@ -13,7 +13,7 @@ from torch import Tensor
 from otx.algo.detection.utils.utils import images_to_levels, multi_apply
 
 if TYPE_CHECKING:
-    from mmengine.structures import InstanceData
+    from otx.algo.utils.mmengine_utils import InstanceData
 
 
 class ClassIncrementalMixin:
@@ -54,7 +54,7 @@ class ClassIncrementalMixin:
 
         # compute targets for each image
         if batch_gt_instances_ignore is None:
-            batch_gt_instances_ignore = [None] * num_imgs
+            batch_gt_instances_ignore = [None] * num_imgs  # type: ignore[list-item]
         (
             all_anchors,
             all_labels,

--- a/src/otx/algo/detection/heads/max_iou_assigner.py
+++ b/src/otx/algo/detection/heads/max_iou_assigner.py
@@ -15,7 +15,7 @@ from otx.algo.detection.heads.iou2d_calculator import BboxOverlaps2D
 from otx.algo.detection.utils.structures import AssignResult
 
 if TYPE_CHECKING:
-    from mmengine.structures import InstanceData
+    from otx.algo.utils.mmengine_utils import InstanceData
 
 
 # This class and its supporting functions below lightly adapted from the mmdet MaxIoUAssigner available at:
@@ -122,7 +122,7 @@ class MaxIoUAssigner:
             :obj:`AssignResult`: The assign result.
 
         Example:
-            >>> from mmengine.structures import InstanceData
+            >>> from otx.algo.utils.mmengine_utils import InstanceData
             >>> self = MaxIoUAssigner(0.5, 0.5)
             >>> pred_instances = InstanceData()
             >>> pred_instances.priors = torch.Tensor([[0, 0, 10, 10],
@@ -134,10 +134,10 @@ class MaxIoUAssigner:
             >>> expected_gt_inds = torch.LongTensor([1, 0])
             >>> assert torch.all(assign_result.gt_inds == expected_gt_inds)
         """
-        gt_bboxes = gt_instances.bboxes
-        priors = pred_instances.priors
-        gt_labels = gt_instances.labels
-        gt_bboxes_ignore = gt_instances_ignore.bboxes if gt_instances_ignore is not None else None
+        gt_bboxes = gt_instances.bboxes  # type: ignore[attr-defined]
+        priors = pred_instances.priors  # type: ignore[attr-defined]
+        gt_labels = gt_instances.labels  # type: ignore[attr-defined]
+        gt_bboxes_ignore = gt_instances_ignore.bboxes if gt_instances_ignore is not None else None  # type: ignore[attr-defined]
 
         assign_on_cpu = (self.gpu_assign_thr > 0) and (gt_bboxes.shape[0] > self.gpu_assign_thr)
         # compute overlap and assign gt on CPU when number of GT is large

--- a/src/otx/algo/detection/heads/sim_ota_assigner.py
+++ b/src/otx/algo/detection/heads/sim_ota_assigner.py
@@ -15,8 +15,9 @@ from otx.algo.detection.heads.iou2d_calculator import BboxOverlaps2D
 from otx.algo.detection.utils.structures import AssignResult
 
 if TYPE_CHECKING:
-    from mmengine.structures import InstanceData
     from omegaconf import DictConfig
+
+    from otx.algo.utils.mmengine_utils import InstanceData
 
 INF = 100000.0
 EPS = 1.0e-7
@@ -82,13 +83,13 @@ class SimOTAAssigner:
         Returns:
             obj:`AssignResult`: The assigned result.
         """
-        gt_bboxes = gt_instances.bboxes
-        gt_labels = gt_instances.labels
+        gt_bboxes = gt_instances.bboxes  # type: ignore[attr-defined]
+        gt_labels = gt_instances.labels  # type: ignore[attr-defined]
         num_gt = gt_bboxes.size(0)
 
-        decoded_bboxes = pred_instances.bboxes
-        pred_scores = pred_instances.scores
-        priors = pred_instances.priors
+        decoded_bboxes = pred_instances.bboxes  # type: ignore[attr-defined]
+        pred_scores = pred_instances.scores  # type: ignore[attr-defined]
+        priors = pred_instances.priors  # type: ignore[attr-defined]
         num_bboxes = decoded_bboxes.size(0)
 
         # assign 0 by default

--- a/src/otx/algo/detection/heads/yolox_head.py
+++ b/src/otx/algo/detection/heads/yolox_head.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Sequence
 
 import torch
 import torch.nn.functional as F  # noqa: N812
-from mmengine.structures import InstanceData  # TODO (sungchul): remove
 from torch import Tensor, nn
 
 from otx.algo.detection.heads.base_head import BaseDenseHead
@@ -22,6 +21,7 @@ from otx.algo.detection.ops.nms import batched_nms, multiclass_nms
 from otx.algo.detection.utils.utils import multi_apply, reduce_mean
 from otx.algo.modules.conv_module import ConvModule
 from otx.algo.modules.depthwise_separable_conv_module import DepthwiseSeparableConvModule
+from otx.algo.utils.mmengine_utils import InstanceData
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
@@ -464,10 +464,10 @@ class YOLOXHead(BaseDenseHead):
         """
         if rescale:
             assert img_meta.get("scale_factor") is not None  # type: ignore[union-attr] # noqa: S101
-            results.bboxes /= results.bboxes.new_tensor(img_meta["scale_factor"]).repeat((1, 2))  # type: ignore[index]
+            results.bboxes /= results.bboxes.new_tensor(img_meta["scale_factor"]).repeat((1, 2))  # type: ignore[attr-defined, index]
 
-        if with_nms and results.bboxes.numel() > 0:
-            det_bboxes, keep_idxs = batched_nms(results.bboxes, results.scores, results.labels, cfg.nms)
+        if with_nms and results.bboxes.numel() > 0:  # type: ignore[attr-defined]
+            det_bboxes, keep_idxs = batched_nms(results.bboxes, results.scores, results.labels, cfg.nms)  # type: ignore[attr-defined]
             results = results[keep_idxs]
             # some nms would reweight the score, such as softnms
             results.scores = det_bboxes[:, -1]
@@ -509,7 +509,7 @@ class YOLOXHead(BaseDenseHead):
         """
         num_imgs = len(batch_img_metas)
         if batch_gt_instances_ignore is None:
-            batch_gt_instances_ignore = [None] * num_imgs
+            batch_gt_instances_ignore = [None] * num_imgs  # type: ignore[list-item]
 
         featmap_sizes = [cls_score.shape[2:] for cls_score in cls_scores]
         mlvl_priors = self.prior_generator.grid_priors(

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import torch
 from datumaro.components.annotation import Bbox
-from mmengine.structures import InstanceData
 from omegaconf import DictConfig
 from torch import nn
 from torchvision import tv_tensors
@@ -22,7 +21,7 @@ from otx.algo.detection.heads.delta_xywh_bbox_coder import DeltaXYWHBBoxCoder
 from otx.algo.detection.heads.max_iou_assigner import MaxIoUAssigner
 from otx.algo.detection.heads.ssd_head import SSDHead
 from otx.algo.modules.base_module import BaseModule
-from otx.algo.utils.mmengine_utils import load_checkpoint
+from otx.algo.utils.mmengine_utils import InstanceData, load_checkpoint
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -431,15 +430,15 @@ class SSD(ExplainableOTXDetModel):
         for img_info, prediction in zip(inputs.imgs_info, predictions):
             if not isinstance(prediction, InstanceData):
                 raise TypeError(prediction)
-            scores.append(prediction.scores)
+            scores.append(prediction.scores)  # type: ignore[attr-defined]
             bboxes.append(
                 tv_tensors.BoundingBoxes(
-                    prediction.bboxes,
+                    prediction.bboxes,  # type: ignore[attr-defined]
                     format="XYXY",
                     canvas_size=img_info.ori_shape,
                 ),
             )
-            labels.append(prediction.labels)
+            labels.append(prediction.labels)  # type: ignore[attr-defined]
 
         if self.explain_mode:
             if not isinstance(outputs, dict):

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -22,6 +22,7 @@ from otx.algo.detection.heads.delta_xywh_bbox_coder import DeltaXYWHBBoxCoder
 from otx.algo.detection.heads.max_iou_assigner import MaxIoUAssigner
 from otx.algo.detection.heads.ssd_head import SSDHead
 from otx.algo.modules.base_module import BaseModule
+from otx.algo.utils.mmengine_utils import load_checkpoint
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.config.data import TileConfig
 from otx.core.data.entity.base import OTXBatchLossEntity
@@ -327,8 +328,6 @@ class SSD(ExplainableOTXDetModel):
         self.tile_image_size = self.image_size
 
     def _create_model(self) -> nn.Module:
-        from mmengine.runner import load_checkpoint
-
         detector = self._build_model(num_classes=self.label_info.num_classes)
         detector.init_weights()
         self.classification_layers = self.get_classification_layers(prefix="model.")

--- a/src/otx/algo/detection/utils/utils.py
+++ b/src/otx/algo/detection/utils/utils.py
@@ -10,9 +10,9 @@ from typing import Callable
 
 import torch
 import torch.distributed as dist
-from mmengine.structures import InstanceData
 from torch import Tensor
 
+from otx.algo.utils.mmengine_utils import InstanceData
 from otx.core.data.entity.detection import DetBatchDataEntity
 
 

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -16,6 +16,7 @@ from otx.algo.detection.backbones.csp_darknet import CSPDarknet
 from otx.algo.detection.heads.yolox_head import YOLOXHead
 from otx.algo.detection.necks.yolox_pafpn import YOLOXPAFPN
 from otx.algo.detection.ssd import SingleStageDetector
+from otx.algo.utils.mmengine_utils import load_checkpoint
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
@@ -32,8 +33,6 @@ class YOLOX(ExplainableOTXDetModel):
     """OTX Detection model class for YOLOX."""
 
     def _create_model(self) -> nn.Module:
-        from mmengine.runner import load_checkpoint
-
         detector = self._build_model(num_classes=self.label_info.num_classes)
         detector.init_weights()
         self.classification_layers = self.get_classification_layers(prefix="model.")

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import torch
-from mmengine.structures import InstanceData
 from omegaconf import DictConfig
 from torchvision import tv_tensors
 
@@ -16,7 +15,7 @@ from otx.algo.detection.backbones.csp_darknet import CSPDarknet
 from otx.algo.detection.heads.yolox_head import YOLOXHead
 from otx.algo.detection.necks.yolox_pafpn import YOLOXPAFPN
 from otx.algo.detection.ssd import SingleStageDetector
-from otx.algo.utils.mmengine_utils import load_checkpoint
+from otx.algo.utils.mmengine_utils import InstanceData, load_checkpoint
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
@@ -80,15 +79,15 @@ class YOLOX(ExplainableOTXDetModel):
         for img_info, prediction in zip(inputs.imgs_info, predictions):
             if not isinstance(prediction, InstanceData):
                 raise TypeError(prediction)
-            scores.append(prediction.scores)
+            scores.append(prediction.scores)  # type: ignore[attr-defined]
             bboxes.append(
                 tv_tensors.BoundingBoxes(
-                    prediction.bboxes,
+                    prediction.bboxes,  # type: ignore[attr-defined]
                     format="XYXY",
                     canvas_size=img_info.ori_shape,
                 ),
             )
-            labels.append(prediction.labels)
+            labels.append(prediction.labels)  # type: ignore[attr-defined]
 
         if self.explain_mode:
             if not isinstance(outputs, dict):

--- a/src/otx/algo/utils/mmengine_utils.py
+++ b/src/otx/algo/utils/mmengine_utils.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import os
 import re
 from collections import OrderedDict, abc, namedtuple
+from pathlib import Path
 from typing import Any
 from warnings import warn
 
+import torch
 from torch import distributed as torch_dist
 from torch import nn
 from torch.utils.model_zoo import load_url
@@ -39,6 +41,30 @@ def get_dist_info() -> tuple[int, int]:
         world_size = 1
         rank = 0
     return rank, world_size
+
+
+def load_checkpoint(
+    model: nn.Module,
+    checkpoint: str,
+    map_location: str = "cpu",
+    strict: bool = False,
+    prefix: str = "",
+) -> None:
+    """Load state dict from path of checkpoint and dump to model."""
+    if Path(checkpoint).exists():
+        load_checkpoint_to_model(
+            model,
+            torch.load(checkpoint, map_location),
+            strict=strict,
+            prefix=prefix,
+        )
+    else:
+        load_checkpoint_to_model(
+            model,
+            load_from_http(checkpoint, map_location),
+            strict=strict,
+            prefix=prefix,
+        )
 
 
 def load_from_http(

--- a/src/otx/algo/utils/mmengine_utils.py
+++ b/src/otx/algo/utils/mmengine_utils.py
@@ -7,13 +7,15 @@
 
 from __future__ import annotations
 
+import copy
 import os
 import re
 from collections import OrderedDict, abc, namedtuple
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator, Union
 from warnings import warn
 
+import numpy as np
 import torch
 from torch import distributed as torch_dist
 from torch import nn
@@ -254,3 +256,436 @@ def is_tuple_of(seq: Any, expected_type: type | tuple) -> bool:  # noqa: ANN401
     A partial method of :func:`is_seq_of`.
     """
     return is_seq_of(seq, expected_type, seq_type=tuple)
+
+
+BoolTypeTensor = Union[torch.BoolTensor, torch.cuda.BoolTensor]
+LongTypeTensor = Union[torch.LongTensor, torch.cuda.LongTensor]
+IndexType = Union[str, slice, int, list, LongTypeTensor, BoolTypeTensor, np.ndarray]
+
+
+class InstanceData:
+    """A base data interface that supports Tensor-like and dict-like operations.
+
+    This class is from https://github.com/open-mmlab/mmengine/blob/66fb81f7b392b2cd304fc1979d8af3cc71a011f5/mmengine/structures/instance_data.py
+    and slightly modified.
+
+    Args:
+        metainfo (dict, optional): A dict contains the meta information
+            of single image, such as ``dict(img_shape=(512, 512, 3),
+            scale_factor=(1, 1, 1, 1))``. Defaults to None.
+        kwargs (dict, optional): A dict contains annotations of single image or
+            model predictions. Defaults to None.
+    """
+
+    def __init__(self, *, metainfo: dict | None = None, **kwargs) -> None:
+        self._metainfo_fields: set = set()
+        self._data_fields: set = set()
+
+        if metainfo is not None:
+            self.set_metainfo(metainfo=metainfo)
+        if kwargs:
+            self.set_data(kwargs)
+
+    def set_metainfo(self, metainfo: dict) -> None:
+        """Set or change key-value pairs in ``metainfo_field`` by parameter ``metainfo``.
+
+        Args:
+            metainfo (dict): A dict contains the meta information
+                of image, such as ``img_shape``, ``scale_factor``, etc.
+        """
+        meta = copy.deepcopy(metainfo)
+        for k, v in meta.items():
+            self.set_field(name=k, value=v, field_type="metainfo", dtype=None)
+
+    def set_data(self, data: dict) -> None:
+        """Set or change key-value pairs in ``data_field`` by parameter ``data``.
+
+        Args:
+            data (dict): A dict contains annotations of image or
+                model predictions.
+        """
+        for k, v in data.items():
+            # Use `setattr()` rather than `self.set_field` to allow `set_data`
+            # to set property method.
+            setattr(self, k, v)
+
+    def update(self, instance: InstanceData) -> None:
+        """The method updates the InstanceData with the elements from another InstanceData object.
+
+        Args:
+            instance (InstanceData): Another InstanceData object for
+                update the current object.
+        """
+        self.set_metainfo(dict(instance.metainfo_items()))
+        self.set_data(dict(instance.items()))
+
+    def new(self, *, metainfo: dict | None = None, **kwargs) -> InstanceData:
+        """Return a new data element with same type.
+
+        If ``metainfo`` and ``data`` are None, the new data element will have same metainfo and
+        data. If metainfo or data is not None, the new result will overwrite it
+        with the input value.
+
+        Args:
+            metainfo (dict, optional): A dict contains the meta information
+                of image, such as ``img_shape``, ``scale_factor``, etc.
+                Defaults to None.
+            kwargs (dict): A dict contains annotations of image or
+                model predictions.
+
+        Returns:
+            InstanceData: A new data element with same type.
+        """
+        new_data = self.__class__()
+
+        if metainfo is not None:
+            new_data.set_metainfo(metainfo)
+        else:
+            new_data.set_metainfo(dict(self.metainfo_items()))
+        if kwargs:
+            new_data.set_data(kwargs)
+        else:
+            new_data.set_data(dict(self.items()))
+        return new_data
+
+    def clone(self) -> InstanceData:
+        """Deep copy the current data element.
+
+        Returns:
+            InstanceData: The copy of current data element.
+        """
+        clone_data = self.__class__()
+        clone_data.set_metainfo(dict(self.metainfo_items()))
+        clone_data.set_data(dict(self.items()))
+        return clone_data
+
+    def keys(self) -> list:
+        """Returns lits contains all keys in data_fields."""
+        private_keys = {"_" + key for key in self._data_fields if isinstance(getattr(type(self), key, None), property)}
+        return list(self._data_fields - private_keys)
+
+    def metainfo_keys(self) -> list:
+        """Returns list contains all keys in metainfo_fields."""
+        return list(self._metainfo_fields)
+
+    def values(self) -> list:
+        """Returns list contains all values in data."""
+        return [getattr(self, k) for k in self.keys()]
+
+    def metainfo_values(self) -> list:
+        """Returns list contains all values in metainfo."""
+        return [getattr(self, k) for k in self.metainfo_keys()]
+
+    def all_keys(self) -> list:
+        """Returns list contains all keys in metainfo and data."""
+        return self.metainfo_keys() + self.keys()
+
+    def all_values(self) -> list:
+        """Returns list contains all values in metainfo and data."""
+        return self.metainfo_values() + self.values()
+
+    def all_items(self) -> Iterator[tuple[str, Any]]:
+        """Returns iterator object whose element is (key, value) tuple pairs for ``metainfo`` and ``data``."""
+        for k in self.all_keys():
+            yield (k, getattr(self, k))
+
+    def items(self) -> Iterator[tuple[str, Any]]:
+        """Returns iterator object whose element is (key, value) tuple pairs for ``data``."""
+        for k in self.keys():
+            yield (k, getattr(self, k))
+
+    def metainfo_items(self) -> Iterator[tuple[str, Any]]:
+        """Returns iterator object whose element is (key, value) tuple pairs for ``metainfo``."""
+        for k in self.metainfo_keys():
+            yield (k, getattr(self, k))
+
+    @property
+    def metainfo(self) -> dict:
+        """dict: A dict contains metainfo of current data element."""
+        return dict(self.metainfo_items())
+
+    def __setattr__(self, name: str, value: Any):  # noqa: ANN401
+        """Setattr is only used to set data."""
+        if name in ("_metainfo_fields", "_data_fields"):
+            if not hasattr(self, name):
+                super().__setattr__(name, value)
+            else:
+                msg = f"{name} has been used as a private attribute, which is immutable."
+                raise AttributeError(msg)
+        else:
+            self.set_field(name=name, value=value, field_type="data", dtype=None)
+
+    __setitem__ = __setattr__
+
+    def __getitem__(self, item: IndexType) -> InstanceData:
+        """Get item mehod.
+
+        Args:
+            item (str, int, list, :obj:`slice`, :obj:`numpy.ndarray`,
+                :obj:`torch.LongTensor`, :obj:`torch.BoolTensor`):
+                Get the corresponding values according to item.
+
+        Returns:
+            :obj:`InstanceData`: Corresponding values.
+        """
+        if isinstance(item, list):
+            item = np.array(item)
+        if isinstance(item, np.ndarray):
+            # The default int type of numpy is platform dependent, int32 for
+            # windows and int64 for linux. `torch.Tensor` requires the index
+            # should be int64, therefore we simply convert it to int64 here.
+            # More details in https://github.com/numpy/numpy/issues/9464
+            item = item.astype(np.int64) if item.dtype == np.int32 else item
+            item = torch.from_numpy(item)
+
+        if isinstance(item, str):
+            return getattr(self, item)
+
+        if isinstance(item, int):
+            if item >= len(self) or item < -len(self):
+                msg = f"Index {item} out of range!"
+                raise IndexError(msg)
+            item = slice(item, None, len(self))
+
+        new_data = self.__class__(metainfo=self.metainfo)
+        if isinstance(item, torch.Tensor):
+            for k, v in self.items():
+                if isinstance(v, torch.Tensor):
+                    new_data[k] = v[item]
+                elif isinstance(v, np.ndarray):
+                    new_data[k] = v[item.cpu().numpy()]
+                elif isinstance(v, (str, list, tuple)) or (hasattr(v, "__getitem__") and hasattr(v, "cat")):
+                    # convert to indexes from BoolTensor
+                    if isinstance(item, BoolTypeTensor.__args__):
+                        indexes = torch.nonzero(item).view(-1).cpu().numpy().tolist()
+                    else:
+                        indexes = item.cpu().numpy().tolist()
+                    slice_list = []
+                    if indexes:
+                        for index in indexes:
+                            slice_list.append(slice(index, None, len(v)))  # noqa: PERF401
+                    else:
+                        slice_list.append(slice(None, 0, None))
+                    r_list = [v[s] for s in slice_list]
+                    if isinstance(v, (str, list, tuple)):
+                        new_value = r_list[0]
+                        for r in r_list[1:]:
+                            new_value = new_value + r
+                    else:
+                        new_value = v.cat(r_list)
+                    new_data[k] = new_value
+                else:
+                    msg = (
+                        f"The type of `{k}` is `{type(v)}`, "
+                        "which has no attribute of `cat`, so it does not support slice with `bool`"
+                    )
+                    raise ValueError(msg)
+
+        else:
+            # item is a slice
+            for k, v in self.items():
+                new_data[k] = v[item]
+        return new_data
+
+    def __delattr__(self, item: str):
+        """Delete the item in dataelement.
+
+        Args:
+            item (str): The key to delete.
+        """
+        if item in ("_metainfo_fields", "_data_fields"):
+            msg = f"{item} has been used as a private attribute, which is immutable."
+            raise AttributeError(msg)
+        super().__delattr__(item)
+        if item in self._metainfo_fields:
+            self._metainfo_fields.remove(item)
+        elif item in self._data_fields:
+            self._data_fields.remove(item)
+
+    # dict-like methods
+    __delitem__ = __delattr__
+
+    def get(self, key: str, default: Any | None = None) -> Any:  # noqa: ANN401
+        """Get property in data and metainfo as the same as python."""
+        # Use `getattr()` rather than `self.__dict__.get()` to allow getting
+        # properties.
+        return getattr(self, key, default)
+
+    def pop(self, *args) -> Any:  # noqa: ANN401
+        """Pop property in data and metainfo as the same as python."""
+        name = args[0]
+        if name in self._metainfo_fields:
+            self._metainfo_fields.remove(args[0])
+            return self.__dict__.pop(*args)
+
+        if name in self._data_fields:
+            self._data_fields.remove(args[0])
+            return self.__dict__.pop(*args)
+
+        # with default value
+        if len(args) == 2:
+            return args[1]
+
+        msg = f"{args[0]} is not contained in metainfo or data"
+        raise KeyError(msg)
+
+    def __contains__(self, item: str) -> bool:
+        """Whether the item is in dataelement.
+
+        Args:
+            item (str): The key to inquire.
+        """
+        return item in self._data_fields or item in self._metainfo_fields
+
+    def set_field(
+        self,
+        value: Any,  # noqa: ANN401
+        name: str,
+        dtype: type | tuple[type, ...] | None = None,
+        field_type: str = "data",
+    ) -> None:
+        """Special method for set union field, used as property.setter functions."""
+        if field_type == "metainfo":
+            if name in self._data_fields:
+                msg = f"Cannot set {name} to be a field of metainfo because {name} is already a data field"
+                raise AttributeError(msg)
+            self._metainfo_fields.add(name)
+        else:
+            if name in self._metainfo_fields:
+                msg = f"Cannot set {name} to be a field of data because {name} is already a metainfo field"
+                raise AttributeError(msg)
+            self._data_fields.add(name)
+        super().__setattr__(name, value)
+
+    # Tensor-like methods
+    def to(self, *args, **kwargs) -> InstanceData:
+        """Apply same name function to all tensors in data_fields."""
+        new_data = self.new()
+        for k, v in self.items():
+            if hasattr(v, "to"):
+                v = v.to(*args, **kwargs)  # noqa: PLW2901
+                data = {k: v}
+                new_data.set_data(data)
+        return new_data
+
+    # Tensor-like methods
+    def cpu(self) -> InstanceData:
+        """Convert all tensors to CPU in data."""
+        new_data = self.new()
+        for k, v in self.items():
+            if isinstance(v, (torch.Tensor, InstanceData)):
+                v = v.cpu()  # noqa: PLW2901
+                data = {k: v}
+                new_data.set_data(data)
+        return new_data
+
+    # Tensor-like methods
+    def cuda(self) -> InstanceData:
+        """Convert all tensors to GPU in data."""
+        new_data = self.new()
+        for k, v in self.items():
+            if isinstance(v, (torch.Tensor, InstanceData)):
+                v = v.cuda()  # noqa: PLW2901
+                data = {k: v}
+                new_data.set_data(data)
+        return new_data
+
+    # Tensor-like methods
+    def detach(self) -> InstanceData:
+        """Detach all tensors in data."""
+        new_data = self.new()
+        for k, v in self.items():
+            if isinstance(v, (torch.Tensor, InstanceData)):
+                v = v.detach()  # noqa: PLW2901
+                data = {k: v}
+                new_data.set_data(data)
+        return new_data
+
+    # Tensor-like methods
+    def numpy(self) -> InstanceData:
+        """Convert all tensors to np.ndarray in data."""
+        new_data = self.new()
+        for k, v in self.items():
+            if isinstance(v, (torch.Tensor, InstanceData)):
+                v = v.detach().cpu().numpy()  # noqa: PLW2901
+                data = {k: v}
+                new_data.set_data(data)
+        return new_data
+
+    def to_tensor(self) -> InstanceData:
+        """Convert all np.ndarray to tensor in data."""
+        new_data = self.new()
+        for k, v in self.items():
+            data = {}
+            if isinstance(v, np.ndarray):
+                v = torch.from_numpy(v)  # noqa: PLW2901
+                data[k] = v
+            elif isinstance(v, InstanceData):
+                v = v.to_tensor()  # noqa: PLW2901
+                data[k] = v
+            new_data.set_data(data)
+        return new_data
+
+    def to_dict(self) -> dict:
+        """Convert InstanceData to dict."""
+        return {k: v.to_dict() if isinstance(v, InstanceData) else v for k, v in self.all_items()}
+
+    def __repr__(self) -> str:
+        """Represent the object."""
+
+        def _addindent(s_: str, num_spaces: int) -> str:
+            """This func is modified from `pytorch`.
+
+            https://github.com/pytorch/
+            pytorch/blob/b17b2b1cc7b017c3daaeff8cc7ec0f514d42ec37/torch/nn/modu
+            les/module.py#L29.
+
+            Args:
+                s_ (str): The string to add spaces.
+                num_spaces (int): The num of space to add.
+
+            Returns:
+                str: The string after add indent.
+            """
+            s = s_.split("\n")
+            # don't do anything for single-line stuff
+            if len(s) == 1:
+                return s_
+            first = s.pop(0)
+            s = [(num_spaces * " ") + line for line in s]
+            s = "\n".join(s)
+            return first + "\n" + s
+
+        def dump(obj: Any) -> str:  # noqa: ANN401
+            """Represent the object.
+
+            Args:
+                obj (Any): The obj to represent.
+
+            Returns:
+                str: The represented str.
+            """
+            _repr = ""
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    _repr += f"\n{k}: {_addindent(dump(v), 4)}"
+            elif isinstance(obj, InstanceData):
+                _repr += "\n\n    META INFORMATION"
+                metainfo_items = dict(obj.metainfo_items())
+                _repr += _addindent(dump(metainfo_items), 4)
+                _repr += "\n\n    DATA FIELDS"
+                items = dict(obj.items())
+                _repr += _addindent(dump(items), 4)
+                classname = obj.__class__.__name__
+                _repr = f"<{classname}({_repr}\n) at {hex(id(obj))}>"
+            else:
+                _repr += repr(obj)
+            return _repr
+
+        return dump(self)
+
+    def __len__(self) -> int:
+        """int: The length of InstanceData."""
+        if len(self._data_fields) > 0:
+            return len(self.values()[0])
+        return 0


### PR DESCRIPTION
### Summary
This PR is for remove the left mmengine things in object detection.
As you can see bringing InstanceData from mmengine harms the codes.
Therefore we need to deprecate InstanceData and the nn module should communicate through explicit tensor or meta info dictionary.
However, that cannot be done before code freeze.
Therefore this PR just brings InstanceData from mmengine
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
