### PR TITLE
Generate label info from v1 checkpoint

### DIFF
--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -218,7 +218,7 @@ class ATSS(ExplainableOTXDetModel):
         meta_info_list = [meta_info] * len(inputs)
         return self.model.export(inputs, meta_info_list, explain_mode=self.explain_mode)
 
-    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
+    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
         return OTXv1Helper.load_det_ckpt(state_dict, add_prefix)
 

--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -692,6 +692,6 @@ class SSD(ExplainableOTXDetModel):
 
         return super().on_load_checkpoint(checkpoint)
 
-    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
+    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
         return OTXv1Helper.load_ssd_ckpt(state_dict, add_prefix)

--- a/src/otx/algo/detection/yolox.py
+++ b/src/otx/algo/detection/yolox.py
@@ -206,7 +206,7 @@ class YOLOX(ExplainableOTXDetModel):
         meta_info_list = [meta_info] * len(inputs)
         return self.model.export(inputs, meta_info_list, explain_mode=self.explain_mode)
 
-    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.model.") -> dict:
+    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
         return OTXv1Helper.load_det_ckpt(state_dict, add_prefix)
 

--- a/tests/unit/algo/detection/test_atss.py
+++ b/tests/unit/algo/detection/test_atss.py
@@ -13,7 +13,7 @@ class TestATSS:
         model = MobileNetV2ATSS(2)
         mock_load_ckpt = mocker.patch.object(OTXv1Helper, "load_det_ckpt")
         model.load_from_otx_v1_ckpt({})
-        mock_load_ckpt.assert_called_once_with({}, "model.model.")
+        mock_load_ckpt.assert_called_once_with({}, "model.")
 
         assert isinstance(model._export_parameters, TaskLevelExportParameters)
         assert isinstance(model._exporter, OTXModelExporter)

--- a/tests/unit/core/model/test_base.py
+++ b/tests/unit/core/model/test_base.py
@@ -88,6 +88,16 @@ class TestOTXModel:
         # Regardless of the activation status, LinearWarmupScheduler can be called
         assert mock_linear_warmup_scheduler.step.call_count == 2
 
+    def test_v1_checkpoint_loading(self, mocker):
+        model = OTXModel(label_info=3)
+        mocker.patch.object(model, "load_from_otx_v1_ckpt", return_value={})
+        v1_ckpt = {
+            "model": {"state_dict": {"backbone": torch.randn(2, 2)}},
+            "labels": {"label_0": (), "label_1": (), "label_2": ()},
+            "VERSION": 1,
+        }
+        assert model.load_state_dict_incrementally(v1_ckpt) is None
+
 
 class TestOVModel:
     @pytest.fixture()


### PR DESCRIPTION
### Summary
This PR is for training models using v1 checkpoint
Before this PR training models using v1 checkpoint raises errors since v1 checkpoint do not have label info.
Therefore this PR automatically generates label info from v1 checkpoint.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
