### PR TITLE
Remove unnecessary model weights during HPO

### DIFF
--- a/src/otx/cli/utils/hpo.py
+++ b/src/otx/cli/utils/hpo.py
@@ -478,7 +478,9 @@ class HpoRunner:
             progress_updater_thread = Thread(target=self._update_hpo_progress, args=[hpo_algo], daemon=True)
             progress_updater_thread.start()
 
-        remove_unused_model_weight = Thread(target=self._remove_unused_weight, args=[hpo_algo, self._hpo_workdir])
+        remove_unused_model_weight = Thread(
+            target=self._remove_unused_weight, args=[hpo_algo, self._hpo_workdir], daemon=True
+        )
         remove_unused_model_weight.start()
 
         if torch.cuda.is_available():
@@ -586,11 +588,12 @@ class HpoRunner:
         """Function for a thread to report a HPO progress regularly.
 
         Args:
-            hpo_algo (HpoBase): HPO algorithm class
+            hpo_algo (HpoBase): HPO algorithm instance.
+            hpo_work_dir (Path): HPO work directory.
         """
 
         while not hpo_algo.is_done():
-            finished_trials = hpo_algo.get_finished_trials()
+            finished_trials = hpo_algo.get_inferior_trials()
             for trial in finished_trials:
                 dir_to_remove = hpo_work_dir / "weight" / str(trial.id)
                 if dir_to_remove.exists():
@@ -654,15 +657,7 @@ def run_hpo(
             logger.debug(f"{best_hpo_weight} will be loaded as best HPO weight")
             env_manager.load_model_weight(best_hpo_weight, dataset)
 
-    # _remove_model_weights_except_best(hpo_save_path, best_hpo_weight)
     return env_manager.environment
-
-
-def _remove_model_weights_except_best(hpo_save_path: Path, best_hpo_weight: Optional[str] = None):
-    for weight in hpo_save_path.rglob("*.pth"):
-        if best_hpo_weight is not None and str(weight) == best_hpo_weight:
-            continue
-        weight.unlink()
 
 
 def get_best_hpo_weight(hpo_dir: Union[str, Path], trial_id: Union[str, Path]) -> Optional[str]:
@@ -681,27 +676,7 @@ def get_best_hpo_weight(hpo_dir: Union[str, Path], trial_id: Union[str, Path]) -
         return None
     trial_output_file = trial_output_files[0]
 
-    _, best_epochs = _get_best_score_and_epoch(trial_output_file)
-
-    best_weight = None
-    for best_epoch in best_epochs:
-        best_weight_path = list(hpo_dir.glob(f"weight/{trial_id}/*epoch*{best_epoch}*"))
-        if best_weight_path:
-            best_weight = str(best_weight_path[0])
-
-    return best_weight
-
-    
-def _get_best_score_and_epoch(trial_json: Path)-> tuple[int | float | None, list[int]]:
-    """Get best score and epochs according to json file of the trial.
-
-    Args:
-        trial_json (Path): Json file of the trial.
-
-    Returns:
-        tuple[int | float | None, list[int]]: best score and best epochs list.
-    """
-    with trial_json.open("r") as f:
+    with trial_output_file.open("r") as f:
         trial_output = json.load(f)
 
     best_epochs = []
@@ -715,8 +690,14 @@ def _get_best_score_and_epoch(trial_json: Path)-> tuple[int | float | None, list
             best_epochs = [eph]
         elif best_score == score:
             best_epochs.append(eph)
-    
-    return best_score, best_epochs
+
+    best_weight = None
+    for best_epoch in best_epochs:
+        best_weight_path = list(hpo_dir.glob(f"weight/{trial_id}/*epoch*{best_epoch}*"))
+        if best_weight_path:
+            best_weight = str(best_weight_path[0])
+
+    return best_weight
 
 
 class Trainer:
@@ -772,7 +753,6 @@ class Trainer:
 
         need_to_save_initial_weight = False
         resume_weight_path = self._get_resume_weight_path()
-        resume_epoch = None
         if resume_weight_path is not None:
             ret = re.search(r"(\d+)\.pth", resume_weight_path)
             if ret is not None:
@@ -863,19 +843,18 @@ class Trainer:
         return self._hpo_workdir / self._initial_weight_name
 
     def _finalize_trial(self, task):
-        weight_dir_path = self._get_weight_dir_path()
-        weight_dir_path.mkdir(parents=True, exist_ok=True)
         self._report_func(0, 0, done=True)
 
-        trial_id: str = self._hp_config["id"]
+        weight_dir_path = self._get_weight_dir_path()
+        weight_dir_path.mkdir(parents=True, exist_ok=True)
         self._task.copy_weight(task.project_path, weight_dir_path)
-        weight_dir = self._hpo_workdir / "weight" / trial_id
-        if not weight_dir.exists():
-            return
-        latest_model_weight = self._task.get_latest_weight(weight_dir)
-        best_model_weight = get_best_hpo_weight(self._hpo_workdir, trial_id)
-        for each_model_weight in weight_dir.iterdir():
-            if str(each_model_weight) not in [latest_model_weight, best_model_weight]:
+        latest_model_weight = self._task.get_latest_weight(weight_dir_path)
+        best_model_weight = get_best_hpo_weight(self._hpo_workdir, self._hp_config["id"])
+        for each_model_weight in weight_dir_path.iterdir():
+            for neccesary_weight in [latest_model_weight, best_model_weight]:
+                if each_model_weight.samefile(neccesary_weight):
+                    break
+            else:
                 each_model_weight.unlink()
 
     def _get_weight_dir_path(self) -> Path:

--- a/src/otx/cli/utils/hpo.py
+++ b/src/otx/cli/utils/hpo.py
@@ -594,9 +594,7 @@ class HpoRunner:
             for trial in finished_trials:
                 dir_to_remove = hpo_work_dir / "weight" / str(trial.id)
                 if dir_to_remove.exists():
-                    for file in dir_to_remove.iterdir():
-                        file.unlink()
-                    # shutil.rmtree(dir_to_remove)
+                    shutil.rmtree(dir_to_remove)
             time.sleep(1)
 
 

--- a/src/otx/hpo/hpo_base.py
+++ b/src/otx/hpo/hpo_base.py
@@ -18,7 +18,7 @@ import json
 import tempfile
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from otx.hpo.search_space import SearchSpace
 from otx.hpo.utils import check_mode_input, check_positive
@@ -36,7 +36,7 @@ class HpoBase(ABC):
     Args:
         search_space (Dict[str, Dict[str, Any]]): hyper parameter search space to find.
         save_path (Optional[str]): path where result of HPO is saved.
-        mode (str, optinal): One of {min, max}. Determines whether objective is
+        mode (Literal["min", "max], optinal): One of {min, max}. Determines whether objective is
                     minimizing or maximizing the metric attribute.
         num_trials (Optional[int]): How many training to conduct for HPO.
         num_workers (int): How many trains are executed in parallel.
@@ -66,7 +66,7 @@ class HpoBase(ABC):
         self,
         search_space: Dict[str, Dict[str, Any]],
         save_path: Optional[str] = None,
-        mode: str = "max",
+        mode: Literal["min", "max"] = "max",
         num_trials: Optional[int] = None,
         num_workers: int = 1,
         num_full_iterations: Union[int, float] = 1,
@@ -164,6 +164,11 @@ class HpoBase(ABC):
     @abstractmethod
     def get_best_config(self):
         """Get best config of HPO algorithm."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_inferior_trials(self) -> List["Trial"]:
+        """Get trials which can't be best a trial."""
         raise NotImplementedError
 
 


### PR DESCRIPTION
### Summary
This PR reduces storage usage during HPO.
Currently, best and latest model weights for each trial are saved.
To reduce storage usage, then model weights of trials, which can't be promoted, are removed even if rung isn't done.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
