### PR TITLE
Consider loop type during adaptive batch size

### DIFF
--- a/src/otx/engine/adaptive_bs/adaptive_bs_api.py
+++ b/src/otx/engine/adaptive_bs/adaptive_bs_api.py
@@ -159,10 +159,13 @@ def _scale_batch_reset_params(trainer: Trainer, steps_per_trial: int) -> None:
     if loop is None:
         msg = "There is no active loop."
         raise RuntimeError(msg)
-    trainer.limit_train_batches = 1.0
+    if trainer.fit_loop.epoch_loop.max_steps == -1:  # epoch based loop
+        trainer.fit_loop.max_epochs = 1
+        trainer.limit_train_batches = steps_per_trial
+    else:  # iter based loop
+        trainer.fit_loop.epoch_loop.max_steps = steps_per_trial
     if trainer.limit_val_batches != 0:
         trainer.limit_val_batches = steps_per_trial
-    trainer.fit_loop.epoch_loop.max_steps = steps_per_trial
 
 
 def _apply_new_batch_size(engine: Engine, new_batch_size: int) -> None:

--- a/src/otx/engine/adaptive_bs/adaptive_bs_api.py
+++ b/src/otx/engine/adaptive_bs/adaptive_bs_api.py
@@ -164,6 +164,7 @@ def _scale_batch_reset_params(trainer: Trainer, steps_per_trial: int) -> None:
         trainer.limit_train_batches = steps_per_trial
     else:  # iter based loop
         trainer.fit_loop.epoch_loop.max_steps = steps_per_trial
+        trainer.limit_train_batches = 1.0
     if trainer.limit_val_batches != 0:
         trainer.limit_val_batches = steps_per_trial
 

--- a/tests/unit/engine/adaptive_bs/test_adaptive_bs_api.py
+++ b/tests/unit/engine/adaptive_bs/test_adaptive_bs_api.py
@@ -301,6 +301,7 @@ class TestBatchSizeFinder:
         # check steps_per_trial is set well
         assert mock_trainer.limit_val_batches == steps_per_trial
         assert mock_trainer.fit_loop.epoch_loop.max_steps == steps_per_trial
+        assert mock_trainer.limit_train_batches == 1.0
         # check active_loop is run
         assert mock_active_loop.restarting is False
         mock_active_loop.run.assert_called_once()

--- a/tests/unit/engine/adaptive_bs/test_adaptive_bs_api.py
+++ b/tests/unit/engine/adaptive_bs/test_adaptive_bs_api.py
@@ -242,7 +242,8 @@ class TestBatchSizeFinder:
     def mock_trainer(self, mock_active_loop) -> MagicMock:
         trainer = MagicMock()
         trainer.limit_val_batches = 100
-        trainer.fit_loop.epoch_loop.max_steps = 100
+        trainer.fit_loop.epoch_loop.max_steps = -1
+        trainer.fit_loop.max_epochs = 200
         trainer._active_loop = mock_active_loop
         return trainer
 
@@ -263,7 +264,9 @@ class TestBatchSizeFinder:
 
         # check steps_per_trial is set well
         assert mock_trainer.limit_val_batches == steps_per_trial
-        assert mock_trainer.fit_loop.epoch_loop.max_steps == steps_per_trial
+        assert mock_trainer.fit_loop.epoch_loop.max_steps == -1
+        assert mock_trainer.fit_loop.max_epochs == 1
+        assert mock_trainer.limit_train_batches == steps_per_trial
         # check active_loop is run
         assert mock_active_loop.restarting is False
         mock_active_loop.run.assert_called_once()
@@ -279,6 +282,24 @@ class TestBatchSizeFinder:
 
         # check steps_per_trial is set well
         assert mock_trainer.limit_val_batches == 0
+        assert mock_trainer.fit_loop.epoch_loop.max_steps == -1
+        assert mock_trainer.fit_loop.max_epochs == 1
+        assert mock_trainer.limit_train_batches == steps_per_trial
+        # check active_loop is run
+        assert mock_active_loop.restarting is False
+        mock_active_loop.run.assert_called_once()
+        # check callback and logger is removed
+        assert mock_trainer.callbacks == []
+        assert isinstance(mock_trainer.logger, DummyLogger) or mock_trainer.logger is None
+
+    def test_on_fit_start_iter_based_loop(self, mock_trainer, mock_active_loop):
+        mock_trainer.fit_loop.epoch_loop.max_steps = 200
+        steps_per_trial = 3
+        bs_finder = BatchSizeFinder(steps_per_trial=steps_per_trial)
+        bs_finder.on_fit_start(trainer=mock_trainer, pl_module=MagicMock())
+
+        # check steps_per_trial is set well
+        assert mock_trainer.limit_val_batches == steps_per_trial
         assert mock_trainer.fit_loop.epoch_loop.max_steps == steps_per_trial
         # check active_loop is run
         assert mock_active_loop.restarting is False


### PR DESCRIPTION
### Summary
Currently, adaptive batch size doesn't consider whether current loop is for iter based or epoch based.
It makes error if adaptive batch size is executed with #3452.
This PR fixes it.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
