### PR TITLE
Raise an error if dino is moved to XPU

### DIFF
--- a/src/otx/algo/classification/dino_v2.py
+++ b/src/otx/algo/classification/dino_v2.py
@@ -26,6 +26,7 @@ from otx.core.types.label import LabelInfoTypes
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+    from typing_extensions import Self
 
     from otx.core.metrics import MetricCallable
 
@@ -182,3 +183,11 @@ class DINOv2RegisterClassifier(OTXMulticlassClsModel):
     def forward_for_tracing(self, image: Tensor) -> Tensor | dict[str, Tensor]:
         """Model forward function used for the model tracing during model exportation."""
         return self.model(image)
+
+    def to(self, *args, **kwargs) -> Self:
+        """Return a model with specified device."""
+        ret = super().to(*args, **kwargs)
+        if self.device.type == "xpu":
+            msg = f"{type(self).__name__} doesn't support XPU."
+            raise RuntimeError(msg)
+        return ret

--- a/src/otx/algo/segmentation/dino_v2_seg.py
+++ b/src/otx/algo/segmentation/dino_v2_seg.py
@@ -15,6 +15,7 @@ from .base_model import BaseSegmModel
 
 if TYPE_CHECKING:
     from torch import nn
+    from typing_extensions import Self
 
 
 class DinoV2Seg(BaseSegmModel):
@@ -60,3 +61,11 @@ class OTXDinoV2Seg(TorchVisionCompatibleModel):
     def _optimization_config(self) -> dict[str, Any]:
         """PTQ config for DinoV2Seg."""
         return {"model_type": "transformer"}
+
+    def to(self, *args, **kwargs) -> Self:
+        """Return a model with specified device."""
+        ret = super().to(*args, **kwargs)
+        if self.device.type == "xpu":
+            msg = f"{type(self).__name__} doesn't support XPU."
+            raise RuntimeError(msg)
+        return ret


### PR DESCRIPTION
### Summary
Currently, Dino v2 model doesn't support XPU.
This PR add a code to raise an error at that case explicitly.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
