### PR TITLE
Update image_decode_context flow with RGB

### DIFF
--- a/src/otx/core/data/dataset/base.py
+++ b/src/otx/core/data/dataset/base.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Callable, Generic, List, Union
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Callable, Generic, Iterator, List, Union
 
 import cv2
 import numpy as np
 from datumaro.components.annotation import AnnotationType
 from datumaro.components.media import ImageFromFile
+from datumaro.util.image import IMAGE_BACKEND, IMAGE_COLOR_CHANNEL, ImageBackend
+from datumaro.util.image import ImageColorChannel as DatumaroImageColorChannel
 from torch.utils.data import Dataset
 
 from otx.core.data.entity.base import T_OTXDataEntity
@@ -27,6 +30,25 @@ if TYPE_CHECKING:
     from otx.core.data.mem_cache import MemCacheHandlerBase
 
 Transforms = Union[Compose, Callable, List[Callable]]
+
+
+@contextmanager
+def image_decode_context() -> Iterator[None]:
+    """Change Datumaro image decode context.
+
+    Use PIL Image decode because of performance issues.
+    With this context, `dm.Image.data` will return BGR numpy image tensor.
+    """
+    ori_image_backend = IMAGE_BACKEND.get()
+    ori_image_color_scale = IMAGE_COLOR_CHANNEL.get()
+
+    IMAGE_BACKEND.set(ImageBackend.PIL)
+    IMAGE_COLOR_CHANNEL.set(DatumaroImageColorChannel.COLOR_BGR)
+
+    yield
+
+    IMAGE_BACKEND.set(ori_image_backend)
+    IMAGE_COLOR_CHANNEL.set(ori_image_color_scale)
 
 
 class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
@@ -116,9 +138,12 @@ class OTXDataset(Dataset, Generic[T_OTXDataEntity]):
         if (img_data := self.mem_cache_handler.get(key=key)[0]) is not None:
             return img_data, img_data.shape[:2]
 
-        img_data = (
-            cv2.cvtColor(img.data, cv2.COLOR_BGR2RGB) if self.image_color_channel == ImageColorChannel.RGB else img.data
-        )
+        if self.image_color_channel == ImageColorChannel.RGB:
+            img_data = cv2.cvtColor(img.data, cv2.COLOR_BGR2RGB)
+        else:
+            # [TODO]: Need to check if using image_decode_context is appropriate.
+            with image_decode_context():
+                img_data = img.data
 
         if img_data is None:
             msg = "Cannot get image data"


### PR DESCRIPTION
### Summary

Fix CVS-140875

With Large dataset (food-101)
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


model |   | test/accuracy | train/e2e_time | train/iter_time | train/epochs
-- | -- | -- | -- | -- | --
efficientnet_b0 | Default | 0.8420 | 654 | 0.1584 | 18
  | Remove image_decode_context | 0.8427 | 477 | 0.0965 | 21

</div>

<!--EndFragment-->
</body>

</html>


On detection (using WGISD during 4 epochs, 00e7f284a66473f71c0153bddffef4cf99f7beaf)

| model |   | test/mAP | train/iter_time |
| -- | -- | -- | -- |
| atss_mobilenetv2 | Default | 0.103 | 0.448 |
|  | Remove image_decode_context | 0.103 | 0.396 |
| atss_resnext101 | Default | 0.369 | 0.452 |
|  | Remove image_decode_context | 0.369 | 0.422 |
| ssd_mobilenetv2 | Default | 0.050 | 0.624 |
|  | Remove image_decode_context | 0.050 | 0.566 |
| yolox_tiny | Default | 0.087 | 0.877 |
|  | Remove image_decode_context | 0.087 | 0.836 |
| yolox_s | Default | 0.113 | 0.427 |
|  | Remove image_decode_context | 0.113 | 0.353 |
| yolox_l | Default | 0.118 | 0.487 |
|  | Remove image_decode_context | 0.118 | 0.448 |
| yolox_x | Default | 0.225 | 0.324 |
|  | Remove image_decode_context | 0.225 | 0.302 |



Compare img_data

Inputs:
```python
[[[ 30  36  77]
  [ 26  32  73]
  [ 23  29  70]
  ...
  [172  92  91]
  [170  90  89]
  [167  87  86]]

 [[ 28  34  75]
  [ 27  33  74]
  [ 25  31  72]
  ...
  [176  96  95]
  [175  95  94]
  [172  92  91]]

 [[ 28  34  75]
  [ 28  34  75]
  [ 27  35  75]
  ...
  [172  92  93]
  [174  94  95]
  [173  93  94]]

 ...

 [[140 146 151]
  [143 149 154]
  [143 152 156]
  ...
  [181 176 173]
  [176 171 168]
  [175 172 168]]

 [[141 150 154]
  [143 152 156]
  [143 152 156]
  ...
  [185 181 176]
  [181 177 172]
  [179 175 170]]

 [[144 153 157]
  [144 153 157]
  [144 153 157]
  ...
  [191 185 180]
  [188 184 179]
  [184 180 175]]]
```

Before:
```python
[[[ 77  36  30]
  [ 73  32  26]
  [ 70  29  23]
  ...
  [ 91  92 172]
  [ 89  90 170]
  [ 86  87 167]]

 [[ 75  34  28]
  [ 74  33  27]
  [ 72  31  25]
  ...
  [ 95  96 176]
  [ 94  95 175]
  [ 91  92 172]]

 [[ 75  34  28]
  [ 75  34  28]
  [ 75  35  27]
  ...
  [ 93  92 172]
  [ 95  94 174]
  [ 94  93 173]]

 ...

 [[151 146 140]
  [154 149 143]
  [156 152 143]
  ...
  [173 176 181]
  [168 171 176]
  [168 172 175]]

 [[154 150 141]
  [156 152 143]
  [156 152 143]
  ...
  [176 181 185]
  [172 177 181]
  [170 175 179]]

 [[157 153 144]
  [157 153 144]
  [157 153 144]
  ...
  [180 185 191]
  [179 184 188]
  [175 180 184]]]
```

After:
```python
[[[ 77  36  30]
  [ 73  32  26]
  [ 70  29  23]
  ...
  [ 91  92 172]
  [ 89  90 170]
  [ 86  87 167]]

 [[ 75  34  28]
  [ 74  33  27]
  [ 72  31  25]
  ...
  [ 95  96 176]
  [ 94  95 175]
  [ 91  92 172]]

 [[ 75  34  28]
  [ 75  34  28]
  [ 75  35  27]
  ...
  [ 93  92 172]
  [ 95  94 174]
  [ 94  93 173]]

 ...

 [[151 146 140]
  [154 149 143]
  [156 152 143]
  ...
  [173 176 181]
  [168 171 176]
  [168 172 175]]

 [[154 150 141]
  [156 152 143]
  [156 152 143]
  ...
  [176 181 185]
  [172 177 181]
  [170 175 179]]

 [[157 153 144]
  [157 153 144]
  [157 153 144]
  ...
  [180 185 191]
  [179 184 188]
  [175 180 184]]]
```



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
