### PR TITLE
Fix maskrcnn accuracy drop on tiling

### DIFF
--- a/src/otx/core/data/dataset/tile.py
+++ b/src/otx/core/data/dataset/tile.py
@@ -142,6 +142,7 @@ class OTXTileTransform(Tile):
         cols = range(0, img_w, int(tile_w * (1 - w_ovl)))
         rows = range(0, img_h, int(tile_h * (1 - h_ovl)))
 
+        rois += [x1y1x2y2_to_xywh(0, 0, img_w, img_h)]
         for offset_x, offset_y in product(cols, rows):
             x2 = min(offset_x + tile_w, img_w)
             y2 = min(offset_y + tile_h, img_h)

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -112,7 +112,7 @@ class OTXInstanceSegModel(OTXModel[InstanceSegBatchDataEntity, InstanceSegBatchP
         return super()._export_parameters.wrap(
             model_type="MaskRCNN",
             task_type="instance_segmentation",
-            confidence_threshold=self.hparams.get("best_confidence_threshold", None),
+            confidence_threshold=self.hparams.get("best_confidence_threshold", 0.05),
             iou_threshold=0.5,
             tile_config=self.tile_config if self.tile_config.enable_tiler else None,
         )

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -30,6 +30,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  export_precision: FP32
   max_epochs: 100
   data:
     task: INSTANCE_SEGMENTATION

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -30,6 +30,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  export_precision: FP32
   max_epochs: 100
   gradient_clip_val: 35.0
   data:

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
@@ -29,6 +29,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  export_precision: FP32
   max_epochs: 100
   data:
     task: INSTANCE_SEGMENTATION

--- a/tests/unit/core/data/test_tiling.py
+++ b/tests/unit/core/data/test_tiling.py
@@ -252,7 +252,7 @@ class TestOTXTiling:
         w_stride = max(int((1 - overlap[1]) * tile_size[1]), 1)
         num_tile_rows = (height + h_stride - 1) // h_stride
         num_tile_cols = (width + w_stride - 1) // w_stride
-        assert len(tiled_dataset) == (num_tile_rows * num_tile_cols * len(dataset)), "Incorrect number of tiles"
+        assert len(tiled_dataset) == (num_tile_rows * num_tile_cols * len(dataset)) + 1, "Incorrect number of tiles"
 
     def test_tile_polygon_func(self):
         points = np.array([(1, 2), (3, 5), (4, 2), (4, 6), (1, 6)])

--- a/tests/unit/core/data/test_tiling.py
+++ b/tests/unit/core/data/test_tiling.py
@@ -252,7 +252,9 @@ class TestOTXTiling:
         w_stride = max(int((1 - overlap[1]) * tile_size[1]), 1)
         num_tile_rows = (height + h_stride - 1) // h_stride
         num_tile_cols = (width + w_stride - 1) // w_stride
-        assert len(tiled_dataset) == (num_tile_rows * num_tile_cols * len(dataset)) + 1, "Incorrect number of tiles"
+        assert len(tiled_dataset) == (num_tile_rows * num_tile_cols * len(dataset)) + len(
+            dataset,
+        ), "Incorrect number of tiles"
 
     def test_tile_polygon_func(self):
         points = np.array([(1, 2), (3, 5), (4, 2), (4, 6), (1, 6)])

--- a/tests/unit/core/utils/test_tile.py
+++ b/tests/unit/core/utils/test_tile.py
@@ -38,4 +38,4 @@ def test_tile_transform_consistency(mocker):
 
     dm_rois = [xywh_to_x1y1x2y2(*roi) for roi in tile_transform._extract_rois(dm_image)]
     # 0 index in tiler is the full image so we skip it
-    assert np.allclose(dm_rois, tiler._tile(np_image)[1:])
+    assert np.allclose(dm_rois, tiler._tile(np_image))


### PR DESCRIPTION
### Summary

We've noticed a significant drop in accuracy in the benchmark following the mmdeploy decoupling. As a stopgap, switching to FP32 during export seems to resolve the issue. However, it's worth noting that the model is still trained using FP16 mixed precision.

PyTorch Accuracy
│       test/f1-score       │     0.79885333776474      │

OV Accuracy
│       test/f1-score       │    0.7994282841682434     │

### How to test

* `otx train --config src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml --data_root vitens_aeromonas_small/1 --engine.device gpu --deterministic False --metric otx.core.metrics.fmeasure.FMeasureCallable --callback_monitor val/f1-score --model.scheduler.monitor val/f1-score --seed 0`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
