### PR TITLE
Disable Resnext101_ATSS model on XPU

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,9 +347,9 @@ max-returns = 10
 convention = "google"
 
 [tool.pytest.ini_options]
-# TODO: Add cpu when OTX can run integration test parallelly for each task.
 markers = [
-    "gpu: mark tests which require NVIDIA GPU device",
-    # "cpu: mark tests which require CPU device",
+    "gpu",  # mark tests which require NVIDIA GPU
+    "cpu",
+    "xpu",  # mark tests which require Intel dGPU
 ]
 python_files = "tests/**/*.py"

--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -40,6 +40,7 @@ from otx.core.types.label import LabelInfoTypes
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
     from torch import Tensor, nn
+    from typing_extensions import Self
 
     from otx.core.metrics import MetricCallable
 
@@ -362,3 +363,11 @@ class ResNeXt101ATSS(ATSS):
             test_cfg=test_cfg,
         )
         return SingleStageDetector(backbone, bbox_head, neck=neck, train_cfg=train_cfg, test_cfg=test_cfg)
+
+    def to(self, *args, **kwargs) -> Self:
+        """Return a model with specified device."""
+        ret = super().to(*args, **kwargs)
+        if self.device.type == "xpu":
+            msg = f"{type(self).__name__} doesn't support XPU."
+            raise RuntimeError(msg)
+        return ret

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,13 @@ def pytest_addoption(parser: pytest.Parser):
         type=str,
         help="Task type of OTX to use test.",
     )
+    parser.addoption(
+        "--device",
+        action="store",
+        default="gpu",
+        type=str,
+        help="Which device to use.",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -344,10 +351,9 @@ def fxt_clean_up_mem_cache():
     MemCacheHandlerSingleton.delete()
 
 
-# TODO(Jaeguk): Add cpu param when OTX can run integration test parallelly for each task.
-@pytest.fixture(scope="module", params=[pytest.param("gpu", marks=pytest.mark.gpu)])
+@pytest.fixture(scope="session")
 def fxt_accelerator(request: pytest.FixtureRequest) -> str:
-    return request.param
+    return request.config.getoption("--device", "gpu")
 
 
 @pytest.fixture(params=set(OTXTaskType) - {OTXTaskType.DETECTION_SEMI_SL})

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -238,7 +238,8 @@ def fxt_tags(fxt_user_name: str, fxt_version_tags: dict[str, str], fxt_accelerat
     if fxt_accelerator == "gpu":
         tags["accelerator_info"] = subprocess.check_output(["nvidia-smi", "-L"]).decode().strip()  # noqa: S603, S607
     elif fxt_accelerator == "xpu":
-        tags["accelerator_info"] = "xpu"
+        raw = subprocess.check_output(args=["xpu-smi", "discovery", "--dump", "1,2"]).decode().strip()
+        tags["accelerator_info"] = "\n".join([ret.replace('"', "").replace(",", " : ") for ret in raw.split("\n")[1:]])
     msg = f"{tags = }"
     log.info(msg)
     return tags

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -227,19 +227,18 @@ def fxt_dataset(request: pytest.FixtureRequest, fxt_data_group) -> Benchmark.Dat
 
 
 @pytest.fixture(scope="session")
-def fxt_tags(fxt_user_name: str, fxt_version_tags: dict[str, str]) -> dict[str, str]:
+def fxt_tags(fxt_user_name: str, fxt_version_tags: dict[str, str], fxt_accelerator: str) -> dict[str, str]:
     """Tag fields to record the machine and user executing this perf test."""
     tags = {
         **fxt_version_tags,
         "user_name": fxt_user_name,
         "machine_name": platform.node(),
         "cpu_info": get_cpu_info()["brand_raw"],
-        "accelerator_info": subprocess.check_output(
-            ["nvidia-smi", "-L"],  # noqa: S603, S607
-        )
-        .decode()
-        .strip(),
     }
+    if fxt_accelerator == "gpu":
+        tags["accelerator_info"] = subprocess.check_output(["nvidia-smi", "-L"]).decode().strip()  # noqa: S603, S607
+    elif fxt_accelerator == "xpu":
+        tags["accelerator_info"] = "xpu"
     msg = f"{tags = }"
     log.info(msg)
     return tags

--- a/tests/perf/test_classification.py
+++ b/tests/perf/test_classification.py
@@ -80,7 +80,11 @@ class TestPerfSingleLabelClassification(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
@@ -155,7 +159,11 @@ class TestPerfMultiLabelClassification(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
@@ -224,7 +232,11 @@ class TestPerfHierarchicalLabelClassification(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,

--- a/tests/perf/test_detection.py
+++ b/tests/perf/test_detection.py
@@ -17,10 +17,7 @@ class TestPerfObjectDetection(PerfTestBase):
     """Benchmark object detection."""
 
     MODEL_TEST_CASES = [  # noqa: RUF012
-        pytest.param(
-            Benchmark.Model(task="detection", name="atss_mobilenetv2", category="accuracy"),
-            marks=pytest.mark.xpu,
-        ),
+        Benchmark.Model(task="detection", name="atss_mobilenetv2", category="accuracy"),
         Benchmark.Model(task="detection", name="atss_resnext101", category="other"),
         Benchmark.Model(task="detection", name="ssd_mobilenetv2", category="balance"),
         Benchmark.Model(task="detection", name="yolox_tiny", category="speed"),

--- a/tests/perf/test_detection.py
+++ b/tests/perf/test_detection.py
@@ -17,7 +17,10 @@ class TestPerfObjectDetection(PerfTestBase):
     """Benchmark object detection."""
 
     MODEL_TEST_CASES = [  # noqa: RUF012
-        Benchmark.Model(task="detection", name="atss_mobilenetv2", category="accuracy"),
+        pytest.param(
+            Benchmark.Model(task="detection", name="atss_mobilenetv2", category="accuracy"),
+            marks=pytest.mark.xpu,
+        ),
         Benchmark.Model(task="detection", name="atss_resnext101", category="other"),
         Benchmark.Model(task="detection", name="ssd_mobilenetv2", category="balance"),
         Benchmark.Model(task="detection", name="yolox_tiny", category="speed"),
@@ -103,7 +106,11 @@ class TestPerfObjectDetection(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "atss_resnext101" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,

--- a/tests/perf/test_instance_segmentation.py
+++ b/tests/perf/test_instance_segmentation.py
@@ -108,7 +108,11 @@ class TestPerfInstanceSegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "maskrcnn_r50" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
@@ -196,7 +200,11 @@ class TestPerfTilingInstanceSegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "maskrcnn_r50" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,

--- a/tests/perf/test_semantic_segmentation.py
+++ b/tests/perf/test_semantic_segmentation.py
@@ -82,7 +82,11 @@ class TestPerfSemanticSegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
+        fxt_accelerator: str,
     ):
+        if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
+            pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
+
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,


### PR DESCRIPTION
### Summary
Resnext101_ATSS doesn't support XPU currently.
This PR disables it on XPU.
Additionally, add device argument into test code.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
