### PR TITLE
Fix detection export performance degradation

### DIFF
--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -572,7 +572,7 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity]):
         if label_shift:
             log.warning(f"label_shift: {label_shift}")
 
-        for output in outputs:
+        for i, output in enumerate(outputs):
             output_objects = output.objects
             if len(output_objects):
                 bbox = [[output.xmin, output.ymin, output.xmax, output.ymax] for output in output_objects]
@@ -582,7 +582,7 @@ class OVDetectionModel(OVModel[DetBatchDataEntity, DetBatchPredEntity]):
                 tv_tensors.BoundingBoxes(
                     bbox,
                     format="XYXY",
-                    canvas_size=inputs.imgs_info[-1].img_shape,
+                    canvas_size=inputs.imgs_info[i].img_shape,
                 ),
             )
             scores.append(torch.tensor([output.score for output in output_objects]))


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

[CVS-141030](https://jira.devtools.intel.com/browse/CVS-141030)
- [x] Fix detection export performance degradation
    - [x] atss_mobilenetv2
    - [x] atss_resnext101
    - [x] yolox_s
    - [x] yolox_l
    - [x] yolox_x

- [x] Fix to use right index when wrapping bbox predictions to `tv_tensors.BoundingBoxes`


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
