### PR TITLE
Revert metrics threshold

### DIFF
--- a/src/otx/algo/anomaly/openvino_model.py
+++ b/src/otx/algo/anomaly/openvino_model.py
@@ -34,10 +34,6 @@ class _OVMetricCallback(Callback):
     def __init__(self) -> None:
         super().__init__()
 
-    def on_test_start(self, trainer: Trainer, pl_module: AnomalyOpenVINO) -> None:
-        pl_module.image_metrics.set_threshold(pl_module.model.image_threshold / pl_module.model.normalization_scale)
-        pl_module.pixel_metrics.set_threshold(pl_module.model.pixel_threshold / pl_module.model.normalization_scale)
-
     def on_test_epoch_start(self, trainer: Trainer, pl_module: AnomalyOpenVINO) -> None:
         pl_module.image_metrics.reset()
         pl_module.pixel_metrics.reset()


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- The normalized values are already centered around 0.5 so we don't need to set the metric threshold
- The performance increase in POT was probably by chance as setting the normalized threshold might not always lead to a number in the same domain as the anomaly maps. I'll investigate the POT issue. But meanwhile this is the correct computation.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
