### PR TITLE
Add a feature to adapt max value of HPO batch size search space

### DIFF
--- a/src/otx/core/config/hpo.py
+++ b/src/otx/core/config/hpo.py
@@ -38,3 +38,4 @@ class HpoConfig:
     asynchronous_bracket: bool = True
     asynchronous_sha: bool = num_workers > 1
     metric_name: str | None = None
+    adapt_bs_search_space_max_val: Literal["None", "Safe", "Full"] = "None"


### PR DESCRIPTION
### Summary
This PR adds new HPO feature.
New feature can adapt max value of HPO batch size search space automatically.
It provides user an easy way to avoid OOM due to setting wrong batch size search space.
It exploits auto-batch size feature, so it has two ways to use.

- Safe : Just check max value of batch size search space is ok and decrease it if now.
- Full : Increase max value of batch size as possible as memory can handle.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
```
  otx train --config ... --run_hpo true --hpo_config.adapt_bs_search_space_max_val Safe
  otx train --config ... --run_hpo true --hpo_config.adapt_bs_search_space_max_val Full
```
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
