### PR TITLE
Remove duplicates in get_idx_list_per_classes

### DIFF
--- a/src/otx/core/utils/utils.py
+++ b/src/otx/core/utils/utils.py
@@ -80,7 +80,7 @@ def get_idx_list_per_classes(dm_dataset: DmDataset, use_string_label: bool = Fal
                 stats[labels.items[ann.label].name].append(item_idx)
             else:
                 stats[ann.label].append(item_idx)
-    # Remove duplicates in label stats idx
+    # Remove duplicates in label stats idx: O(n)
     for k in stats:
-        stats[k] = list(set(stats[k]))
+        stats[k] = list(dict.fromkeys(stats[k]))
     return stats

--- a/src/otx/core/utils/utils.py
+++ b/src/otx/core/utils/utils.py
@@ -80,4 +80,7 @@ def get_idx_list_per_classes(dm_dataset: DmDataset, use_string_label: bool = Fal
                 stats[labels.items[ann.label].name].append(item_idx)
             else:
                 stats[ann.label].append(item_idx)
+    # Remove duplicates in label stats idx
+    for k in stats:
+        stats[k] = list(set(stats[k]))
     return stats


### PR DESCRIPTION
### Summary

Related: https://jira.devtools.intel.com/browse/CVS-138089
We found a bug in the function that records the idx per label used by the sampler and fix it.
Existing code unintentionally measures IDX duplicates based on the number of annotations.
This is unintentional and can cause problems in some cases, so we are fixing it.
Before:
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/ad2d461b-80ae-48fa-8c3f-86fc05733d05)
After:
![image](https://github.com/openvinotoolkit/training_extensions/assets/38045080/694f4db2-dd6e-44cb-9869-82cf98f2f2c0)


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
