### PR TITLE
Update for using locally stored pretrained weights in the CI for torch hub models

### DIFF
--- a/src/otx/algo/classification/dino_v2.py
+++ b/src/otx/algo/classification/dino_v2.py
@@ -64,7 +64,7 @@ class DINOv2(nn.Module):
 
         if ci_data_root is not None and Path(ci_data_root).exists():
             ckpt_filename = f"{backbone}4_pretrain.pth"
-            ckpt_path = Path(Path(ci_data_root) / "torch" / "hub" / "checkpoints" / ckpt_filename)
+            ckpt_path = Path(ci_data_root) / "torch" / "hub" / "checkpoints" / ckpt_filename
             if not ckpt_path.exists():
                 msg = f"cannot find weights file: {ckpt_filename}"
                 raise FileExistsError(msg)

--- a/src/otx/algo/classification/dino_v2.py
+++ b/src/otx/algo/classification/dino_v2.py
@@ -53,7 +53,7 @@ class DINOv2(nn.Module):
 
         ci_data_root = os.environ.get("CI_DATA_ROOT")
         pretrained: bool = True
-        if ci_data_root is not None:
+        if ci_data_root is not None and Path(ci_data_root).exists():
             pretrained = False
 
         self.backbone = torch.hub.load(
@@ -62,7 +62,7 @@ class DINOv2(nn.Module):
             pretrained=pretrained,
         )
 
-        if ci_data_root is not None:
+        if ci_data_root is not None and Path(ci_data_root).exists():
             ckpt_filename = f"{backbone}4_pretrain.pth"
             ckpt_path = Path(Path(ci_data_root) / "torch" / "hub" / "checkpoints" / ckpt_filename)
             if not ckpt_path.exists():

--- a/src/otx/algo/classification/dino_v2.py
+++ b/src/otx/algo/classification/dino_v2.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import torch
@@ -48,10 +50,17 @@ class DINOv2(nn.Module):
     ):
         super().__init__()
         self._init_args = get_class_initial_arguments()
+
+        repo_or_dir: str | Path = "facebookresearch/dinov2"
+        source: str = "github"
+        ci_data_root = os.environ.get("CI_DATA_ROOT")
+        if ci_data_root is not None:
+            repo_or_dir = Path(Path(ci_data_root) / "torch" / "hub" / "facebookresearch_dinov2_main")
+            source = "local"
         self.backbone = torch.hub.load(
-            repo_or_dir="facebookresearch/dinov2",
+            repo_or_dir=repo_or_dir,
+            source=source,
             model=backbone,
-            skip_validation=True,
         )
 
         if freeze_backbone:

--- a/src/otx/algo/classification/dino_v2.py
+++ b/src/otx/algo/classification/dino_v2.py
@@ -58,7 +58,7 @@ class DINOv2(nn.Module):
             repo_or_dir = Path(Path(ci_data_root) / "torch" / "hub" / "facebookresearch_dinov2_main")
             source = "local"
         self.backbone = torch.hub.load(
-            repo_or_dir=repo_or_dir,
+            repo_or_dir=str(repo_or_dir),
             source=source,
             model=backbone,
         )

--- a/src/otx/algo/classification/dino_v2.py
+++ b/src/otx/algo/classification/dino_v2.py
@@ -51,6 +51,7 @@ class DINOv2(nn.Module):
         self.backbone = torch.hub.load(
             repo_or_dir="facebookresearch/dinov2",
             model=backbone,
+            skip_validation=True,
         )
 
         if freeze_backbone:

--- a/src/otx/algo/segmentation/backbones/dinov2.py
+++ b/src/otx/algo/segmentation/backbones/dinov2.py
@@ -33,12 +33,12 @@ class DinoVisionTransformer(BaseModule):
 
         ci_data_root = os.environ.get("CI_DATA_ROOT")
         pretrained: bool = True
-        if ci_data_root is not None:
+        if ci_data_root is not None and Path(ci_data_root).exists():
             pretrained = False
 
         self.backbone = torch.hub.load(repo_or_dir="facebookresearch/dinov2", model=name, pretrained=pretrained)
 
-        if ci_data_root is not None:
+        if ci_data_root is not None and Path(ci_data_root).exists():
             ckpt_filename = f"{name}4_pretrain.pth"
             ckpt_path = Path(Path(ci_data_root) / "torch" / "hub" / "checkpoints" / ckpt_filename)
             if not ckpt_path.exists():

--- a/src/otx/algo/segmentation/backbones/dinov2.py
+++ b/src/otx/algo/segmentation/backbones/dinov2.py
@@ -30,7 +30,7 @@ class DinoVisionTransformer(BaseModule):
         super().__init__(init_cfg)
         self._init_args = get_class_initial_arguments()
         torch.hub._validate_not_a_forked_repo = lambda a, b, c: True  # noqa: SLF001, ARG005
-        self.backbone = torch.hub.load(repo_or_dir="facebookresearch/dinov2", model=name)
+        self.backbone = torch.hub.load(repo_or_dir="facebookresearch/dinov2", model=name, skip_validation=True)
         if freeze_backbone:
             self._freeze_backbone(self.backbone)
 

--- a/src/otx/algo/segmentation/backbones/dinov2.py
+++ b/src/otx/algo/segmentation/backbones/dinov2.py
@@ -37,7 +37,7 @@ class DinoVisionTransformer(BaseModule):
         if ci_data_root is not None:
             repo_or_dir = Path(Path(ci_data_root) / "torch" / "hub" / "facebookresearch_dinov2_main")
             source = "local"
-        self.backbone = torch.hub.load(repo_or_dir=repo_or_dir, source=source, model=name)
+        self.backbone = torch.hub.load(repo_or_dir=str(repo_or_dir), source=source, model=name)
         if freeze_backbone:
             self._freeze_backbone(self.backbone)
 

--- a/src/otx/algo/segmentation/backbones/dinov2.py
+++ b/src/otx/algo/segmentation/backbones/dinov2.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import partial
 from pathlib import Path
 
@@ -29,8 +30,14 @@ class DinoVisionTransformer(BaseModule):
     ):
         super().__init__(init_cfg)
         self._init_args = get_class_initial_arguments()
-        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True  # noqa: SLF001, ARG005
-        self.backbone = torch.hub.load(repo_or_dir="facebookresearch/dinov2", model=name, skip_validation=True)
+        # torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
+        repo_or_dir: str | Path = "facebookresearch/dinov2"
+        source: str = "github"
+        ci_data_root = os.environ.get("CI_DATA_ROOT")
+        if ci_data_root is not None:
+            repo_or_dir = Path(Path(ci_data_root) / "torch" / "hub" / "facebookresearch_dinov2_main")
+            source = "local"
+        self.backbone = torch.hub.load(repo_or_dir=repo_or_dir, source=source, model=name)
         if freeze_backbone:
             self._freeze_backbone(self.backbone)
 

--- a/src/otx/algo/segmentation/backbones/dinov2.py
+++ b/src/otx/algo/segmentation/backbones/dinov2.py
@@ -40,7 +40,7 @@ class DinoVisionTransformer(BaseModule):
 
         if ci_data_root is not None and Path(ci_data_root).exists():
             ckpt_filename = f"{name}4_pretrain.pth"
-            ckpt_path = Path(Path(ci_data_root) / "torch" / "hub" / "checkpoints" / ckpt_filename)
+            ckpt_path = Path(ci_data_root) / "torch" / "hub" / "checkpoints" / ckpt_filename
             if not ckpt_path.exists():
                 msg = f"cannot find weights file: {ckpt_filename}"
                 raise FileExistsError(msg)


### PR DESCRIPTION
### Summary

While downloading a model through torch.hub, HTTP error 403 raised on e2e tests for releases/2.0.0. (https://github.com/openvinotoolkit/training_extensions/actions/runs/9247351524/job/25440736054)
To avoid this issue, update `torch.hub.load()` call to use local source when passed data storage path through CI_DATA_ROOT environment variable for the CI test runs.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues. 
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
