### PR TITLE
Sync rgb order between torch and ov inference of action classification task

### DIFF
--- a/src/otx/core/data/dataset/action_classification.py
+++ b/src/otx/core/data/dataset/action_classification.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import torch
 from datumaro import Label
@@ -14,10 +14,46 @@ from datumaro import Label
 from otx.core.data.dataset.base import OTXDataset
 from otx.core.data.entity.action_classification import ActionClsBatchDataEntity, ActionClsDataEntity
 from otx.core.data.entity.base import ImageInfo
+from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER
+from otx.core.types.image import ImageColorChannel
+
+if TYPE_CHECKING:
+    from datumaro import DatasetSubset
+
+    from otx.core.data.dataset.base import Transforms
+    from otx.core.data.mem_cache import MemCacheHandlerBase
 
 
 class OTXActionClsDataset(OTXDataset[ActionClsDataEntity]):
     """OTXDataset class for action classification task."""
+
+    def __init__(
+        self,
+        dm_subset: DatasetSubset,
+        transforms: Transforms,
+        mem_cache_handler: MemCacheHandlerBase = NULL_MEM_CACHE_HANDLER,
+        mem_cache_img_max_size: tuple[int, int] | None = None,
+        max_refetch: int = 1000,
+        image_color_channel: ImageColorChannel = ImageColorChannel.BGR,
+        stack_images: bool = True,
+        to_tv_image: bool = True,
+    ) -> None:
+        super().__init__(
+            dm_subset,
+            transforms,
+            mem_cache_handler,
+            mem_cache_img_max_size,
+            max_refetch,
+            image_color_channel,
+            stack_images,
+            to_tv_image,
+        )
+        # TODO(Someone): ImageColorChannel is not used in action classification task
+        # This task only supports BGR color format.
+        # There should be implementation that links between ImageColorChannel and action classification task.
+        if self.image_color_channel != ImageColorChannel.BGR:
+            msg = "Action classification task only supports BGR color format."
+            raise ValueError(msg)
 
     def _get_item_impl(self, idx: int) -> ActionClsDataEntity | None:
         item = self.dm_subset[idx]

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -236,7 +236,10 @@ class DecodeVideo(tvt_v2.Transform):
         start_index = 0
         frame_inds = np.concatenate(frame_inds) + start_index
 
-        outputs = torch.stack([torch.tensor(inpt[idx].data) for idx in frame_inds], dim=0)
+        outputs = torch.stack(
+            [torch.tensor(cv2.cvtColor(inpt[idx].data, cv2.COLOR_RGB2BGR)) for idx in frame_inds],
+            dim=0,
+        )
         outputs = outputs.permute(0, 3, 1, 2)
         outputs = tv_tensors.Video(outputs)
         inpt.close()

--- a/src/otx/recipe/_base_/data/mmaction_base.yaml
+++ b/src/otx/recipe/_base_/data/mmaction_base.yaml
@@ -78,7 +78,7 @@ config:
     transform_lib_type: MMACTION
     to_tv_image: False
     batch_size: 8
-    num_workers: 2
+    num_workers: 0
     transforms:
       - type: LoadVideoForClassification
       - type: DecordInit

--- a/src/otx/recipe/_base_/data/mmaction_base.yaml
+++ b/src/otx/recipe/_base_/data/mmaction_base.yaml
@@ -78,7 +78,7 @@ config:
     transform_lib_type: MMACTION
     to_tv_image: False
     batch_size: 8
-    num_workers: 0
+    num_workers: 2
     transforms:
       - type: LoadVideoForClassification
       - type: DecordInit

--- a/src/otx/recipe/_base_/data/mmaction_base.yaml
+++ b/src/otx/recipe/_base_/data/mmaction_base.yaml
@@ -5,7 +5,7 @@ config:
   mem_cache_img_max_size:
     - 500
     - 500
-  image_color_channel: RGB
+  image_color_channel: BGR
   stack_images: False
   unannotated_items_ratio: 0.0
   train_subset:

--- a/src/otx/recipe/action/action_classification/openvino_model.yaml
+++ b/src/otx/recipe/action/action_classification/openvino_model.yaml
@@ -18,7 +18,7 @@ overrides:
   data:
     task: ACTION_CLASSIFICATION
     config:
-      image_color_channel: RGB
+      image_color_channel: BGR
       data_format: kinetics
       train_subset:
         batch_size: 8

--- a/src/otx/recipe/action/action_classification/openvino_model.yaml
+++ b/src/otx/recipe/action/action_classification/openvino_model.yaml
@@ -18,7 +18,7 @@ overrides:
   data:
     task: ACTION_CLASSIFICATION
     config:
-      image_color_channel: BGR
+      image_color_channel: RGB
       data_format: kinetics
       train_subset:
         batch_size: 8

--- a/tests/unit/core/data/test_factory.py
+++ b/tests/unit/core/data/test_factory.py
@@ -25,6 +25,7 @@ from otx.core.data.transform_libs.mmdet import MMDetTransformLib
 from otx.core.data.transform_libs.mmpretrain import MMPretrainTransformLib
 from otx.core.data.transform_libs.mmseg import MMSegTransformLib
 from otx.core.data.transform_libs.torchvision import TorchVisionTransformLib
+from otx.core.types.image import ImageColorChannel
 from otx.core.types.task import OTXTaskType
 from otx.core.types.transformer_libs import TransformLibType
 
@@ -86,6 +87,7 @@ class TestOTXDatasetFactory:
         cfg_data_module.vpm_config = mocker.MagicMock(spec=VisualPromptingConfig)
         cfg_data_module.vpm_config.use_bbox = False
         cfg_data_module.vpm_config.use_point = False
+        cfg_data_module.image_color_channel = ImageColorChannel.BGR
         mocker.patch.object(HLabelInfo, "from_dm_label_groups", return_value=fxt_mock_hlabelinfo)
         assert isinstance(
             OTXDatasetFactory.create(

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -38,7 +38,7 @@ from torchvision.transforms.v2 import functional as F  # noqa: N812
 
 
 class MockFrame:
-    data = np.ndarray([3, 10, 10])
+    data = np.ndarray([10, 10, 3], dtype=np.uint8)
 
 
 class MockVideo:


### PR DESCRIPTION
### Summary
This PR is for synchronize RGB order of ov inference and torch inference in action classification task

Currently action classification requires video loading for inference. For torch model inference OTX use video loading pipeline from mmaction. And for ov model inference OTX use datumaro video loading pipeline. 
MMAction loads video as BGR format and Datumaro loads video as RGB format. 
I'm not sure the pretrained weight is trained by BGR or RGB. 
Therefore, we need additional PR to sync between pretrained weights and torch, ov inference
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
