### PR TITLE
Revert temporarily modified `scale_factor`

### DIFF
--- a/src/otx/algo/detection/heads/base_head.py
+++ b/src/otx/algo/detection/heads/base_head.py
@@ -402,8 +402,8 @@ class BaseDenseHead(BaseModule):
                   the last dimension 4 arrange as (x1, y1, x2, y2).
         """
         if rescale:
-            scale_factor = [1 / s for s in img_meta["scale_factor"]]
-            results.bboxes = results.bboxes * results.bboxes.new_tensor(scale_factor).repeat(  # type: ignore[attr-defined]
+            scale_factor = [1 / s for s in img_meta["scale_factor"]]  # (H, W)
+            results.bboxes = results.bboxes * results.bboxes.new_tensor(scale_factor[::-1]).repeat(  # type: ignore[attr-defined]
                 (1, int(results.bboxes.size(-1) / 2)),  # type: ignore[attr-defined]
             )
 

--- a/src/otx/algo/detection/heads/yolox_head.py
+++ b/src/otx/algo/detection/heads/yolox_head.py
@@ -464,7 +464,8 @@ class YOLOXHead(BaseDenseHead):
         """
         if rescale:
             assert img_meta.get("scale_factor") is not None  # type: ignore[union-attr] # noqa: S101
-            results.bboxes /= results.bboxes.new_tensor(img_meta["scale_factor"]).repeat((1, 2))  # type: ignore[attr-defined, index]
+            scale_factor = img_meta["scale_factor"]  # (H, W)
+            results.bboxes /= results.bboxes.new_tensor(scale_factor[::-1]).repeat((1, 2))  # type: ignore[attr-defined, index]
 
         if with_nms and results.bboxes.numel() > 0:  # type: ignore[attr-defined]
             det_bboxes, keep_idxs = batched_nms(results.bboxes, results.scores, results.labels, cfg.nms)  # type: ignore[attr-defined]

--- a/src/otx/algo/detection/heads/yolox_head.py
+++ b/src/otx/algo/detection/heads/yolox_head.py
@@ -464,8 +464,7 @@ class YOLOXHead(BaseDenseHead):
         """
         if rescale:
             assert img_meta.get("scale_factor") is not None  # type: ignore[union-attr] # noqa: S101
-            scale_factor = img_meta["scale_factor"]  # (H, W)
-            results.bboxes /= results.bboxes.new_tensor(scale_factor[::-1]).repeat((1, 2))  # type: ignore[attr-defined, index]
+            results.bboxes /= results.bboxes.new_tensor(img_meta["scale_factor"][::-1]).repeat((1, 2))  # type: ignore[attr-defined, index]
 
         if with_nms and results.bboxes.numel() > 0:  # type: ignore[attr-defined]
             det_bboxes, keep_idxs = batched_nms(results.bboxes, results.scores, results.labels, cfg.nms)  # type: ignore[attr-defined]

--- a/src/otx/algo/instance_segmentation/mmdet/models/mask_heads/fcn_mask_head.py
+++ b/src/otx/algo/instance_segmentation/mmdet/models/mask_heads/fcn_mask_head.py
@@ -5,6 +5,7 @@
 # Please refer to https://github.com/open-mmlab/mmdetection/
 
 """MMDet FCNMaskHead."""
+
 from __future__ import annotations
 
 import warnings
@@ -291,7 +292,7 @@ class FCNMaskHead(BaseModule):
         Returns:
             Tensor: Encoded masks, has shape (n, img_w, img_h)
         """
-        scale_factor = bboxes.new_tensor(img_meta["scale_factor"]).repeat((1, 2))
+        scale_factor = bboxes.new_tensor(img_meta["scale_factor"][::-1]).repeat((1, 2))
         img_h, img_w = img_meta["ori_shape"][:2]
         device = bboxes.device
 

--- a/src/otx/algo/instance_segmentation/mmdet/structures/bbox/transforms.py
+++ b/src/otx/algo/instance_segmentation/mmdet/structures/bbox/transforms.py
@@ -5,6 +5,7 @@
 # Please refer to https://github.com/open-mmlab/mmdetection/
 
 """MMDet bbox transforms."""
+
 from __future__ import annotations
 
 import torch
@@ -46,7 +47,7 @@ def scale_boxes(boxes: Tensor, scale_factor: list[float]) -> Tensor:
     """
     # Tensor boxes will be treated as horizontal boxes
     repeat_num = int(boxes.size(-1) / 2)
-    scale_factor = boxes.new_tensor(scale_factor).repeat((1, repeat_num))
+    scale_factor = boxes.new_tensor(scale_factor[::-1]).repeat((1, repeat_num))
     return boxes * scale_factor
 
 

--- a/src/otx/core/data/entity/base.py
+++ b/src/otx/core/data/entity/base.py
@@ -218,7 +218,7 @@ def _resize_image_info(image_info: ImageInfo, size: list[int], **kwargs) -> Imag
 
     ori_h, ori_w = image_info.ori_shape
     new_h, new_w = image_info.img_shape
-    image_info.scale_factor = (new_w / ori_w, new_h / ori_h)  # TODO (sungchul): ticket no. 138831
+    image_info.scale_factor = (new_h / ori_h, new_w / ori_w)
     return image_info
 
 

--- a/src/otx/core/data/transform_libs/mmaction.py
+++ b/src/otx/core/data/transform_libs/mmaction.py
@@ -179,14 +179,14 @@ class PackActionInputs(MMPackActionInputs):
 
         ori_shape = results["original_shape"]
         img_shape = data_samples.img_shape
-        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
+        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))  # (W, H) because it is from mm pipeline
 
         data_entity: ActionClsDataEntity | ActionDetDataEntity = results["__otx__"]
 
         image_info = deepcopy(data_entity.img_info)
         image_info.img_shape = img_shape
         image_info.ori_shape = ori_shape
-        image_info.scale_factor = scale_factor
+        image_info.scale_factor = scale_factor[::-1]  # convert to (H, W)
 
         labels = data_entity.labels
 

--- a/src/otx/core/data/transform_libs/mmdet.py
+++ b/src/otx/core/data/transform_libs/mmdet.py
@@ -189,12 +189,12 @@ class PackDetInputs(MMDetPackDetInputs):
         # Some MM* transforms return (H, W, C), not (H, W)
         img_shape = data_samples.img_shape if len(data_samples.img_shape) == 2 else data_samples.img_shape[:2]
         ori_shape = data_samples.ori_shape if len(data_samples.ori_shape) == 2 else data_samples.ori_shape[:2]
-        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
+        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))  # (W, H) because it is from mm pipeline
 
         image_info = deepcopy(src_image_info)
         image_info.img_shape = img_shape
         image_info.ori_shape = ori_shape
-        image_info.scale_factor = scale_factor
+        image_info.scale_factor = scale_factor[::-1]  # convert to (H, W)
 
         return image_info
 

--- a/src/otx/core/data/transform_libs/mmpretrain.py
+++ b/src/otx/core/data/transform_libs/mmpretrain.py
@@ -52,14 +52,14 @@ class PackInputs(MMPretrainPackInputs):
         # Some MM* transforms return (H, W, C), not (H, W)
         img_shape = data_samples.img_shape if len(data_samples.img_shape) == 2 else data_samples.img_shape[:2]
         ori_shape = data_samples.ori_shape
-        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
+        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))  # (W, H) because it is from mm pipeline
 
         data_entity: MulticlassClsDataEntity | MultilabelClsDataEntity | HlabelClsDataEntity = results["__otx__"]
 
         image_info = deepcopy(data_entity.img_info)
         image_info.img_shape = img_shape
         image_info.ori_shape = ori_shape
-        image_info.scale_factor = scale_factor
+        image_info.scale_factor = scale_factor  # convert to (H, W)
 
         return {
             "image": image,

--- a/src/otx/core/data/transform_libs/mmpretrain.py
+++ b/src/otx/core/data/transform_libs/mmpretrain.py
@@ -59,7 +59,7 @@ class PackInputs(MMPretrainPackInputs):
         image_info = deepcopy(data_entity.img_info)
         image_info.img_shape = img_shape
         image_info.ori_shape = ori_shape
-        image_info.scale_factor = scale_factor  # convert to (H, W)
+        image_info.scale_factor = scale_factor[::-1]  # convert to (H, W)
 
         return {
             "image": image,

--- a/src/otx/core/data/transform_libs/mmseg.py
+++ b/src/otx/core/data/transform_libs/mmseg.py
@@ -62,7 +62,7 @@ class PackSegInputs(MMSegPackInputs):
         image_info = deepcopy(results["__otx__"].img_info)
         image_info.img_shape = img_shape
         image_info.ori_shape = ori_shape
-        image_info.scale_factor = scale_factor  # convert to (H, W)
+        image_info.scale_factor = scale_factor[::-1]  # convert to (H, W)
 
         masks = data_samples.gt_sem_seg.data
 

--- a/src/otx/core/data/transform_libs/mmseg.py
+++ b/src/otx/core/data/transform_libs/mmseg.py
@@ -57,12 +57,12 @@ class PackSegInputs(MMSegPackInputs):
 
         img_shape = data_samples.img_shape
         ori_shape = data_samples.ori_shape
-        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))
+        scale_factor = data_samples.metainfo.get("scale_factor", (1.0, 1.0))  # (W, H) because it is from mm pipeline
 
         image_info = deepcopy(results["__otx__"].img_info)
         image_info.img_shape = img_shape
         image_info.ori_shape = ori_shape
-        image_info.scale_factor = scale_factor
+        image_info.scale_factor = scale_factor  # convert to (H, W)
 
         masks = data_samples.gt_sem_seg.data
 

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -2183,17 +2183,15 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
     Reference : https://github.com/open-mmlab/mmcv/blob/v2.1.0/mmcv/transforms/processing.py#L1381-L1562
 
     Args:
-        scale (Sequence): Images scales for resizing.
-            Defaults to None.
-        ratio_range (tuple[float], optional): (min_ratio, max_ratio).
-            Defaults to None.
+        scale (Sequence): Images scales for resizing with (height, width). Defaults to None.
+        ratio_range (tuple[float], optional): (min_ratio, max_ratio). Defaults to None.
         is_numpy_to_tvtensor(bool): Whether convert outputs to tensor. Defaults to False.
         **resize_kwargs: Other keyword arguments for the ``resize_type``.
     """
 
     def __init__(
         self,
-        scale: Sequence[int | tuple[int, int]],
+        scale: Sequence[int | tuple[int, int]],  # (H, W)
         ratio_range: tuple[float, float] | None = None,
         is_numpy_to_tvtensor: bool = False,
         **resize_kwargs,

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -1095,7 +1095,8 @@ class RandomFlip(tvt_v2.Transform, NumpytoTVTensorMixin):
     def __repr__(self) -> str:
         repr_str = self.__class__.__name__
         repr_str += f"(prob={self.prob}, "
-        repr_str += f"direction={self.direction})"
+        repr_str += f"direction={self.direction}, "
+        repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
         return repr_str
 
 
@@ -1242,7 +1243,8 @@ class PhotoMetricDistortion(tvt_v2.Transform, NumpytoTVTensorMixin):
         repr_str += f"{(self.contrast_lower, self.contrast_upper)}, "
         repr_str += "saturation_range="
         repr_str += f"{(self.saturation_lower, self.saturation_upper)}, "
-        repr_str += f"hue_delta={self.hue_delta})"
+        repr_str += f"hue_delta={self.hue_delta}, "
+        repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
         return repr_str
 
 
@@ -1264,7 +1266,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             scaling transform. Defaults to (0.5, 1.5).
         max_shear_degree (float): Maximum degrees of shear
             transform. Defaults to 2.
-        border (tuple[int]): Distance from width and height sides of input
+        border (tuple[int]): Distance from height and width sides of input
             image to adjust output shape. Only used in mosaic dataset.
             Defaults to (0, 0).
         border_val (tuple[int]): Border padding values of 3 channels.
@@ -1282,7 +1284,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         max_translate_ratio: float = 0.1,
         scaling_ratio_range: tuple[float, float] = (0.5, 1.5),
         max_shear_degree: float = 2.0,
-        border: tuple[int, int] = (0, 0),
+        border: tuple[int, int] = (0, 0),  # (H, W)
         border_val: tuple[int, int, int] = (114, 114, 114),
         bbox_clip_border: bool = True,
         is_numpy_to_tvtensor: bool = False,
@@ -1296,7 +1298,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         self.max_translate_ratio = max_translate_ratio
         self.scaling_ratio_range = scaling_ratio_range
         self.max_shear_degree = max_shear_degree
-        self.border = border
+        self.border = border  # (H, W)
         self.border_val = border_val
         self.bbox_clip_border = bbox_clip_border
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
@@ -1329,8 +1331,8 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         inputs = _inputs[0]
 
         img = to_np_image(inputs.image)
-        height = img.shape[0] + self.border[1] * 2
-        width = img.shape[1] + self.border[0] * 2
+        height = img.shape[0] + self.border[0] * 2
+        width = img.shape[1] + self.border[1] * 2
 
         warp_matrix = self._get_random_homography_matrix(height, width)
 
@@ -1359,7 +1361,8 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         repr_str += f"max_shear_degree={self.max_shear_degree}, "
         repr_str += f"border={self.border}, "
         repr_str += f"border_val={self.border_val}, "
-        repr_str += f"bbox_clip_border={self.bbox_clip_border})"
+        repr_str += f"bbox_clip_border={self.bbox_clip_border}, "
+        repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
         return repr_str
 
     @staticmethod

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -526,7 +526,10 @@ class Resize(tvt_v2.Transform, NumpytoTVTensorMixin):
             img = to_np_image(img)
 
             img_shape = img.shape[:2]  # (H, W)
-            scale: tuple[int, int] = self.scale or scale_size(img_shape, self.scale_factor)  # (H, W)
+            scale: tuple[int, int] = self.scale or scale_size(
+                img_shape,
+                self.scale_factor,  # type: ignore[arg-type]
+            )  # (H, W)
 
             if self.keep_ratio:
                 scale = rescale_size(img_shape, scale)  # type: ignore[assignment]

--- a/src/otx/core/data/transform_libs/utils.py
+++ b/src/otx/core/data/transform_libs/utils.py
@@ -607,7 +607,7 @@ def rescale_size(
     old_size: tuple,
     scale: float | int | tuple[float, float] | tuple[int, int],
     return_scale: bool = False,
-) -> tuple[int, int] | tuple[tuple[int, int], tuple[int, int]]:
+) -> tuple[int, int] | tuple[tuple[int, int], float | int]:
     """Calculate the new size to be rescaled to.
 
     Args:

--- a/src/otx/core/data/transform_libs/utils.py
+++ b/src/otx/core/data/transform_libs/utils.py
@@ -166,7 +166,8 @@ def rescale_polygons(polygons: list[Polygon], scale_factor: float | tuple[float,
 
     Args:
         polygons (np.ndarray): Polygons to be rescaled.
-        scale_factor (float | tuple[float, float]): Scale factor to be applied to polygons with (height, width).
+        scale_factor (float | tuple[float, float]): Scale factor to be applied to polygons with (height, width)
+            or single float value.
 
     Returns:
         (np.ndarray) : The rescaled polygons.

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -359,7 +359,7 @@ class MMDetCompatibleModel(ExplainableOTXDetModel):
             {"type": "LoadAnnotations", "with_bbox": True},
             {
                 "type": "PackDetInputs",
-                "meta_keys": ["ori_filenamescale_factor", "ori_shape", "filename", "img_shape"],
+                "meta_keys": ["ori_filename", "scale_factor", "ori_shape", "filename", "img_shape"],
             },
         ]
 

--- a/src/otx/recipe/detection/atss_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2.yaml
@@ -58,8 +58,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: true
           - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -83,8 +83,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true
@@ -103,8 +103,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
@@ -55,8 +55,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: true
           - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -80,8 +80,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true
@@ -100,8 +100,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/atss_resnext101.yaml
+++ b/src/otx/recipe/detection/atss_resnext101.yaml
@@ -58,8 +58,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: true
           - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -83,8 +83,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true
@@ -103,8 +103,8 @@ overrides:
           - class_path: otx.core.data.transform_libs.torchvision.Resize
             init_args:
               scale:
-                - 992
                 - 736
+                - 992
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true

--- a/tests/unit/core/data/entity/test_base.py
+++ b/tests/unit/core/data/entity/test_base.py
@@ -61,9 +61,9 @@ class TestImageInfo:
         assert fxt_torchvision_data_entity.image.shape[1:] == transformed.img_info.ori_shape
 
         scale_factor = (
-            transformed.image.shape[2] / fxt_torchvision_data_entity.image.shape[2],
             transformed.image.shape[1] / fxt_torchvision_data_entity.image.shape[1],
-        )  # TODO (sungchul): ticket no. 138831
+            transformed.image.shape[2] / fxt_torchvision_data_entity.image.shape[2],
+        )
         assert scale_factor == transformed.img_info.scale_factor
 
     @pytest.fixture()

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -578,7 +578,7 @@ class TestRandomCrop:
         with pytest.raises(AssertionError):
             RandomCrop(crop_size=crop_size, crop_type=crop_type)
 
-    @pytest.mark.parametrize(("crop_type", "crop_size"), [("relative", (0.5, 0.5)), ("absolute", (16, 12))])
+    @pytest.mark.parametrize(("crop_type", "crop_size"), [("relative", (0.5, 0.5)), ("absolute", (12, 16))])
     def test_forward_relative_absolute(self, entity, crop_type: str, crop_size: tuple[float | int]) -> None:
         # test relative and absolute crop
         transform = RandomCrop(crop_size=crop_size, crop_type=crop_type)
@@ -601,13 +601,13 @@ class TestRandomCrop:
 
     def test_forward_relative_range(self, entity) -> None:
         # test relative_range crop
-        transform = RandomCrop(crop_size=(0.5, 0.5), crop_type="relative_range")
+        transform = RandomCrop(crop_size=(0.9, 0.8), crop_type="relative_range")
 
         results = transform(deepcopy(entity))
 
         h, w = results.image.shape
-        assert 16 <= w <= 32
-        assert 12 <= h <= 24
+        assert 24 * 0.9 <= h <= 24
+        assert 32 * 0.8 <= w <= 32
         assert results.img_info.img_shape == results.image.shape[:2]
 
     def test_forward_bboxes_labels_masks_polygons(self, iseg_entity) -> None:
@@ -616,11 +616,11 @@ class TestRandomCrop:
 
         results = transform(deepcopy(iseg_entity))
 
-        assert results.image.shape[:2] == (5, 7)
+        assert results.image.shape[:2] == (7, 5)
         assert results.bboxes.shape[0] == 2
         assert results.labels.shape[0] == 2
         assert results.masks.shape[0] == 2
-        assert results.masks.shape[1:] == (5, 7)
+        assert results.masks.shape[1:] == (7, 5)
         assert results.img_info.img_shape == results.image.shape[:2]
 
     def test_forward_recompute_bbox_from_mask(self, iseg_entity) -> None:
@@ -683,7 +683,7 @@ class TestRandomCrop:
         results = transform(deepcopy(det_entity))
 
         if allow_negative_crop:
-            assert results.image.shape == transform.crop_size[::-1]
+            assert results.image.shape == transform.crop_size
             assert len(results.bboxes) == len(det_entity.bboxes) == 0
         else:
             assert results is None

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -497,7 +497,7 @@ class TestRandomResize:
         results = transform(deepcopy(entity))
 
         # choose target scale from init when override is False and scale is a list of tuples
-        transform = RandomResize([(224, 448), (112, 224)], keep_ratio=False, transform_bbox=True, transform_mask=True)
+        transform = RandomResize([(448, 224), (224, 112)], keep_ratio=False, transform_bbox=True, transform_mask=True)
 
         results = transform(deepcopy(entity))
 
@@ -508,7 +508,7 @@ class TestRandomResize:
 
         # the type of scale is invalid in init
         with pytest.raises(NotImplementedError):
-            RandomResize([(224, 448), [112, 224]], keep_ratio=True)(deepcopy(entity))
+            RandomResize([(448, 224), [224, 112]], keep_ratio=True)(deepcopy(entity))
 
 
 class TestRandomCrop:

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -172,7 +172,7 @@ class TestAutoConfigurator:
             {
                 "class_path": "otx.core.data.transform_libs.torchvision.Resize",
                 "init_args": {
-                    "scale": [992, 736],
+                    "scale": [736, 992],
                     "keep_ratio": False,
                     "transform_bbox": False,
                     "is_numpy_to_tvtensor": True,


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

ticket : [CVS-142649](https://jira.devtools.intel.com/browse/CVS-142649)

This PR includes:
- [x] Revert `scale_factor` from (width, height) to (height, width)
    - [x] Update transforms, models, recipes, and tests affected by this revert
- [x] Minor refactoring & fix

After this update, benchmark results about detection models affected by this task are normal.
These benchmark tests were conducted in releases/2.0.0.
|  | atss_mobilenetv2 | atss_resnext101 | ssd_mobilenetv2 | yolox_l | yolox_s | yolox_tiny | yolox_x |
| -- | -- | -- | -- | -- | -- | -- | -- |
| f1-score | 0.67 | 0.70 | 0.57 | 0.65 | 0.64 | 0.67 | 0.66 |

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
