### PR TITLE
Fix & Refine HPO

### DIFF
--- a/src/otx/core/config/hpo.py
+++ b/src/otx/core/config/hpo.py
@@ -6,7 +6,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from pathlib import Path  # noqa: TCH003
+from typing import Any, Literal
 
 import torch
 
@@ -18,9 +19,6 @@ elif is_xpu_available():
     num_workers = torch.xpu.device_count()
 else:
     num_workers = 1
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @dataclass

--- a/src/otx/core/config/hpo.py
+++ b/src/otx/core/config/hpo.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 
@@ -19,12 +19,15 @@ elif is_xpu_available():
 else:
     num_workers = 1
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 @dataclass
 class HpoConfig:
     """DTO for HPO configuration."""
 
-    search_space: dict[str, dict[str, Any]] | str | None = None
+    search_space: dict[str, dict[str, Any]] | str | Path | None = None
     save_path: str | None = None
     mode: Literal["max", "min"] = "max"
     num_trials: int | None = None

--- a/src/otx/core/config/hpo.py
+++ b/src/otx/core/config/hpo.py
@@ -24,7 +24,7 @@ else:
 class HpoConfig:
     """DTO for HPO configuration."""
 
-    search_space: dict[str, dict[str, Any]] | None = None
+    search_space: dict[str, dict[str, Any]] | str | None = None
     save_path: str | None = None
     mode: Literal["max", "min"] = "max"
     num_trials: int | None = None

--- a/src/otx/engine/hpo/hpo_api.py
+++ b/src/otx/engine/hpo/hpo_api.py
@@ -14,6 +14,7 @@ from threading import Thread
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import torch
+import yaml
 
 from otx.core.config.hpo import HpoConfig
 from otx.core.optimizer.callable import OptimizerCallableSupportHPO
@@ -195,7 +196,7 @@ class HPOConfigurator:
         if "search_space" not in self._hpo_config:
             self._hpo_config["search_space"] = self._get_default_search_space()
         else:
-            self._align_hp_name(self._hpo_config["search_space"])
+            self._align_search_space()
 
         if hpo_config.adapt_bs_search_space_max_val != "None":
             if "datamodule.config.train_subset.batch_size" not in self._hpo_config["search_space"]:
@@ -233,8 +234,8 @@ class HPOConfigurator:
         cur_bs = self._engine.datamodule.config.train_subset.batch_size
         search_space["datamodule.config.train_subset.batch_size"] = {
             "type": "qloguniform",
-            "min": cur_bs // 2,
-            "max": cur_bs * 2,
+            "min": cur_bs // 2 if cur_bs != 1 else 1,
+            "max": cur_bs * 2 if cur_bs != 1 else 2,
             "step": 2,
         }
 
@@ -253,6 +254,15 @@ class HPOConfigurator:
             "max": min(cur_lr * 10, 0.1),
             "step": 10 ** -get_decimal_point(min_lr),
         }
+
+    def _align_search_space(self) -> None:
+        if isinstance(self._hpo_config["search_space"], str):
+            with Path(self._hpo_config["search_space"]).open("r") as f:
+                self._hpo_config["search_space"] = yaml.safe_load(f)
+        elif not isinstance(self._hpo_config["search_space"], dict):
+            msg = "HpoConfig.search_space should be str or dict type."
+            raise TypeError(msg)
+        self._align_hp_name(self._hpo_config["search_space"])  # type: ignore[arg-type]
 
     def _align_hp_name(self, search_space: dict[str, Any]) -> None:
         available_hp_name_map: dict[str, Callable[[str], None]] = {

--- a/src/otx/engine/hpo/hpo_api.py
+++ b/src/otx/engine/hpo/hpo_api.py
@@ -256,8 +256,12 @@ class HPOConfigurator:
         }
 
     def _align_search_space(self) -> None:
-        if isinstance(self._hpo_config["search_space"], str):
-            with Path(self._hpo_config["search_space"]).open("r") as f:
+        if isinstance(self._hpo_config["search_space"], (str, Path)):
+            search_space_file = Path(self._hpo_config["search_space"])
+            if not search_space_file.exists():
+                msg = f"{search_space_file} is set to HPO search_space, but it doesn't exist."
+                raise FileExistsError(msg)
+            with search_space_file.open("r") as f:
                 self._hpo_config["search_space"] = yaml.safe_load(f)
         elif not isinstance(self._hpo_config["search_space"], dict):
             msg = "HpoConfig.search_space should be str or dict type."

--- a/src/otx/engine/hpo/hpo_trial.py
+++ b/src/otx/engine/hpo/hpo_trial.py
@@ -75,7 +75,7 @@ def run_hpo_trial(
         train_args["checkpoint"] = checkpoint
         train_args["resume"] = True
 
-    callbacks = _register_hpo_callback(report_func, callbacks, metric_name)
+    callbacks = _register_hpo_callback(report_func, callbacks, engine, metric_name)
     _set_to_validate_every_epoch(callbacks, train_args)
 
     with TemporaryDirectory(prefix="OTX-HPO-") as temp_dir:
@@ -99,12 +99,13 @@ def _find_last_weight(weight_dir: Path) -> Path | None:
 def _register_hpo_callback(
     report_func: Callable,
     callbacks: list[Callback] | Callback | None = None,
+    engine: Engine | None = None,
     metric_name: str | None = None,
 ) -> list[Callback]:
     if isinstance(callbacks, Callback):
         callbacks = [callbacks]
     elif callbacks is None:
-        callbacks = []
+        callbacks = [] if engine is None else engine._cache.args.get("callbacks", [])  # noqa: SLF001
     callbacks.append(HPOCallback(report_func, get_metric(callbacks) if metric_name is None else metric_name))
     return callbacks
 

--- a/src/otx/engine/hpo/hpo_trial.py
+++ b/src/otx/engine/hpo/hpo_trial.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Callable
@@ -137,4 +138,5 @@ def _keep_best_and_last_weight(trial_work_dir: Path, hpo_workdir: Path, trial_id
 
 def _move_all_ckpt(src: Path, dest: Path) -> None:
     for ckpt_file in src.rglob("*.ckpt"):
-        ckpt_file.replace(dest / ckpt_file.name)
+        shutil.copy(ckpt_file, dest)
+        ckpt_file.unlink()

--- a/tests/unit/engine/hpo/test_hpo_api.py
+++ b/tests/unit/engine/hpo/test_hpo_api.py
@@ -5,12 +5,12 @@
 
 from __future__ import annotations
 
-import yaml
 from math import sqrt
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 from otx.core.config.hpo import HpoConfig
 from otx.core.optimizer.callable import OptimizerCallableSupportHPO
 from otx.core.schedulers import LinearWarmupSchedulerCallable, SchedulerCallableSupportHPO

--- a/tests/unit/engine/hpo/test_hpo_api.py
+++ b/tests/unit/engine/hpo/test_hpo_api.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import yaml
 from math import sqrt
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
@@ -179,6 +180,17 @@ class TestHPOConfigurator:
         for hp_name in HPO_NAME_MAP.values():
             assert hp_name in search_sapce
 
+    def test_get_default_search_space_bs1(self, mock_engine: MagicMock, hpo_config: HpoConfig):
+        """Check batch sizes search space is set as [1, 2] if default bs is 1."""
+        mock_engine.datamodule.config.train_subset.batch_size = 1
+        hpo_configurator = HPOConfigurator(mock_engine, 10, hpo_config)
+        search_sapce = hpo_configurator._get_default_search_space()
+
+        for hp_name in HPO_NAME_MAP.values():
+            assert hp_name in search_sapce
+        assert search_sapce[HPO_NAME_MAP["bs"]]["min"] == 1
+        assert search_sapce[HPO_NAME_MAP["bs"]]["max"] == 2
+
     def test_align_lr_bs_name(self, mock_engine: MagicMock, hpo_config: HpoConfig, dataset_size):
         """Check learning rate and batch size names are aligned well."""
         search_space = {
@@ -268,6 +280,27 @@ class TestHPOConfigurator:
         }
         hpo_configurator._remove_wrong_search_space(wrong_search_space)
         assert wrong_search_space == {}
+
+    def test_search_space_file(self, mock_engine: MagicMock, hpo_config: HpoConfig, dataset_size, tmp_path):
+        """Check search space is set well if search space file is given."""
+        search_space = {
+            "model.optimizer.lr": {
+                "type": "loguniform",
+                "min": 0.0001,
+                "max": 0.1,
+            },
+        }
+
+        search_space_file = tmp_path / "search_space.yaml"
+        with search_space_file.open("w") as f:
+            yaml.dump(search_space, f)
+
+        hpo_config.search_space = str(search_space_file)
+
+        hpo_configurator = HPOConfigurator(mock_engine, 10, hpo_config)
+
+        assert hpo_configurator.hpo_config["search_space"][HPO_NAME_MAP["lr"]] == search_space["model.optimizer.lr"]
+        assert len(hpo_configurator.hpo_config["search_space"].keys()) == 1
 
     def test_get_hpo_algo(self, mocker, mock_engine: MagicMock, hpo_config: HpoConfig):
         hpo_configurator = HPOConfigurator(mock_engine, 10, hpo_config)

--- a/tests/unit/engine/hpo/test_hpo_trial.py
+++ b/tests/unit/engine/hpo/test_hpo_trial.py
@@ -27,13 +27,13 @@ from torch import tensor
 if TYPE_CHECKING:
     from lightning import Callback
 
-    
-@pytest.fixture
+
+@pytest.fixture()
 def mock_callback1() -> MagicMock:
     return MagicMock()
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_callback2() -> MagicMock:
     return MagicMock()
 
@@ -50,7 +50,7 @@ def mock_engine(mock_callback1, mock_callback2) -> MagicMock:
             (work_dir / "last.ckpt").write_text("last_ckpt")
 
     engine.train.side_effect = train_side_effect
-    engine._cache.args = {"callbacks" : [mock_callback1, mock_callback2]}
+    engine._cache.args = {"callbacks": [mock_callback1, mock_callback2]}
 
     return engine
 


### PR DESCRIPTION
### Summary
This PR includes

- Fix [CVS-142423](https://jira.devtools.intel.com/browse/CVS-142423)
- Add interface to pass HPO search space as a file considering CLI user
- If user doesn't set `checkpoint`, make all HPO trials to use same initial model weight

### Detail
#### [CVS-142423](https://jira.devtools.intel.com/browse/CVS-142423)

- When model batch size is set to 1, HPO raises an error. This PR fixes it.

#### Add interface to pass HPO search space as a file considering CLI user

- CLI user can't set HPO search space because it requires dict format.
- So, if user want to change it, user should use API.
- Refine it by supporting file format for HPO search space.

#### If user doesn't set `checkpoint`, make all HPO trials to use same initial model weight

- Make HPO trials to use same initial model weight for stable result.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
