### PR TITLE
Bug fix in Semantic Segmentation + enable DINOV2 export in ONNX

### DIFF
--- a/src/otx/algo/segmentation/dino_v2_seg.py
+++ b/src/otx/algo/segmentation/dino_v2_seg.py
@@ -46,9 +46,8 @@ class OTXDinoV2Seg(TorchVisionCompatibleModel):
 
     def _create_model(self) -> nn.Module:
         # merge configurations with defaults overriding them
-        backbone_configuration = self.backbone_configuration | DinoV2Seg.default_backbone_configuration
-        decode_head_configuration = self.decode_head_configuration | DinoV2Seg.default_decode_head_configuration
-        # initialize backbones
+        backbone_configuration = DinoV2Seg.default_backbone_configuration | self.backbone_configuration
+        decode_head_configuration = DinoV2Seg.default_decode_head_configuration | self.decode_head_configuration
         backbone = DinoVisionTransformer(**backbone_configuration)
         decode_head = FCNHead(num_classes=self.num_classes, **decode_head_configuration)
         return DinoV2Seg(

--- a/src/otx/algo/segmentation/litehrnet.py
+++ b/src/otx/algo/segmentation/litehrnet.py
@@ -521,9 +521,9 @@ class OTXLiteHRNet(TorchVisionCompatibleModel):
     def _create_model(self) -> nn.Module:
         litehrnet_model_class = LITEHRNET_VARIANTS[self.name_base_model]
         # merge configurations with defaults overriding them
-        backbone_configuration = self.backbone_configuration | litehrnet_model_class.default_backbone_configuration
+        backbone_configuration = litehrnet_model_class.default_backbone_configuration | self.backbone_configuration
         decode_head_configuration = (
-            self.decode_head_configuration | litehrnet_model_class.default_decode_head_configuration
+            litehrnet_model_class.default_decode_head_configuration | self.decode_head_configuration
         )
         # initialize backbones
         backbone = LiteHRNet(**backbone_configuration)

--- a/src/otx/algo/segmentation/segnext.py
+++ b/src/otx/algo/segmentation/segnext.py
@@ -111,9 +111,9 @@ class OTXSegNext(TorchVisionCompatibleModel):
     def _create_model(self) -> nn.Module:
         segnext_model_class = SEGNEXT_VARIANTS[self.name_base_model]
         # merge configurations with defaults overriding them
-        backbone_configuration = self.backbone_configuration | segnext_model_class.default_backbone_configuration
+        backbone_configuration = segnext_model_class.default_backbone_configuration | self.backbone_configuration
         decode_head_configuration = (
-            self.decode_head_configuration | segnext_model_class.default_decode_head_configuration
+            segnext_model_class.default_decode_head_configuration | self.decode_head_configuration
         )
         # initialize backbones
         backbone = MSCAN(**backbone_configuration)

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -59,7 +59,13 @@ class OTXDataModule(LightningDataModule):
 
         dataset = DmDataset.import_from(self.config.data_root, format=self.config.data_format)
         if self.task != "H_LABEL_CLS":
-            dataset = pre_filtering(dataset, self.config.data_format, self.config.unannotated_items_ratio)
+            ignore_index = self.config.ignore_index if self.task == "SEMANTIC_SEGMENTATION" else None
+            dataset = pre_filtering(
+                dataset,
+                self.config.data_format,
+                self.config.unannotated_items_ratio,
+                ignore_index=ignore_index,
+            )
         if config.tile_config.enable_tiler and config.tile_config.enable_adaptive_tiling:
             adapt_tile_config(config.tile_config, dataset=dataset)
 

--- a/src/otx/core/data/pre_filtering.py
+++ b/src/otx/core/data/pre_filtering.py
@@ -29,6 +29,7 @@ def pre_filtering(
         data_format (str): The format of the dataset.
         unannotated_items_ratio (float): The ratio of background unannotated items to be used.
             This must be a float between 0 and 1.
+        ignore_index (int | None, optional): The index to be used for the ignored label. Defaults to None.
 
     Returns:
         DmDataset: The filtered dataset.

--- a/src/otx/recipe/semantic_segmentation/dino_v2.yaml
+++ b/src/otx/recipe/semantic_segmentation/dino_v2.yaml
@@ -9,7 +9,7 @@ model:
           ignore_index: 255
 
     backbone_configuration:
-      name: dinov2_vits14_reg
+      name: dinov2_vits14
       freeze_backbone: true
       out_index:
         - 8

--- a/tests/unit/core/data/test_module.py
+++ b/tests/unit/core/data/test_module.py
@@ -19,9 +19,10 @@ from otx.core.data.module import (
 )
 
 
-def mock_data_filtering(dataset: DmDataset, data_format: str, unannotated_items_ratio: float) -> DmDataset:
+def mock_data_filtering(dataset: DmDataset, data_format: str, unannotated_items_ratio: float, ignore_index: int | None) -> DmDataset:
     del data_format
     del unannotated_items_ratio
+    del ignore_index
     return dataset
 
 

--- a/tests/unit/core/data/test_module.py
+++ b/tests/unit/core/data/test_module.py
@@ -1,10 +1,12 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from datumaro.components.dataset import Dataset as DmDataset
 from importlib_resources import files
 from lightning.pytorch.loggers import CSVLogger
 from omegaconf import DictConfig, OmegaConf
@@ -18,8 +20,16 @@ from otx.core.data.module import (
     OTXTaskType,
 )
 
+if TYPE_CHECKING:
+    from datumaro.components.dataset import Dataset as DmDataset
 
-def mock_data_filtering(dataset: DmDataset, data_format: str, unannotated_items_ratio: float, ignore_index: int | None) -> DmDataset:
+
+def mock_data_filtering(
+    dataset: DmDataset,
+    data_format: str,
+    unannotated_items_ratio: float,
+    ignore_index: int | None,
+) -> DmDataset:
     del data_format
     del unannotated_items_ratio
     del ignore_index


### PR DESCRIPTION
### Summary
1) Only without registers DINOV2 can be exported to ONNX. The accuracy difference is insignificant
2) Bug fix with ignore index in labels pre-filtering. Bug fix with overriding default values in segmentation models
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
