### PR TITLE
Bump anomalib from 1.0.1 to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "datumaro==1.6.1",
     "omegaconf==2.3.0",
     "rich==13.7.1",
-    "jsonargparse==4.27.1",
+    "jsonargparse==4.27.7",
     "psutil==5.9.8", # Mem cache needs system checks
     "ftfy==6.1.3",
     "regex==2023.12.25",
@@ -69,7 +69,7 @@ docs = [
 ]
 base = [
     "torch==2.1.1",
-    "lightning==2.1.2",
+    "lightning==2.2",
     "pytorchcv",
     "timm",
     "openvino==2024.0",
@@ -78,7 +78,7 @@ base = [
     "onnx==1.16.0",
     "onnxconverter-common==1.14.0",
     "nncf==2.9.0",
-    "anomalib[core]==1.0.1",
+    "anomalib[core]==1.1.0",
 ]
 mmlab = [
     "mmdet==3.2.0",

--- a/src/otx/cli/install.py
+++ b/src/otx/cli/install.py
@@ -153,15 +153,6 @@ def otx_install(
                 msg = "Cannot complete installation"
                 raise RuntimeError(msg)
 
-        # TODO(harimkang): Remove this reinstalling after resolving conflict with anomalib==1.0.1
-        # https://github.com/openvinotoolkit/training_extensions/actions/runs/8531851027/job/23372146228?pr=3258#step:5:2587
-        install_args = ["--user"] if user else []
-        install_args += ["jsonargparse==4.27.7"]
-        status_code = create_command("install").main(install_args)
-        if status_code != 0:
-            msg = "Cannot install jsonargparse==4.27.7"
-            raise RuntimeError(msg)
-
     # Patch MMAction2 with src/otx/cli/patches/mmaction2.patch
     patch_mmaction2()
 


### PR DESCRIPTION
### Summary

This is addressed by removing the workaround and updating the dependency to address the issue in python 3.11.

- Bump Anomalib -> 1.1.0
- Bump Lightning -> 2.2
- Bump jsonargparse -> 4.27.7 (Remove workaround installation in install.py & Modify in pyproject.toml)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
