### PR TITLE
Add data_format validation and update in OTXDataModule

### DIFF
--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -9,6 +9,7 @@ import logging as log
 from typing import TYPE_CHECKING
 
 from datumaro import Dataset as DmDataset
+from datumaro import Environment
 from lightning import LightningDataModule
 from omegaconf import DictConfig, OmegaConf
 from torch.utils.data import DataLoader, RandomSampler
@@ -56,6 +57,18 @@ class OTXDataModule(LightningDataModule):
         from datumaro.plugins.data_formats.video import VIDEO_EXTENSIONS
 
         VIDEO_EXTENSIONS.append(".mp4")
+
+        # Data Format Check
+        available_data_formats = Environment().detect_dataset(str(self.config.data_root))
+        if not available_data_formats:
+            msg = f"Invalid data root: {self.config.data_root}. Please check if the data root is valid."
+            raise ValueError(msg)
+        if self.config.data_format not in available_data_formats:
+            log.warning(
+                f"Invalid data format: {self.config.data_format}. Available formats: {available_data_formats} "
+                f"Replace data_format: {self.config.data_format} -> {available_data_formats[0]}.",
+            )
+            self.config.data_format = available_data_formats[0]
 
         dataset = DmDataset.import_from(self.config.data_root, format=self.config.data_format)
         if self.task != "H_LABEL_CLS":

--- a/tests/unit/core/data/test_module.py
+++ b/tests/unit/core/data/test_module.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from datumaro.components.dataset import Dataset as DmDataset
+from datumaro.components.environment import Environment
 from importlib_resources import files
 from lightning.pytorch.loggers import CSVLogger
 from omegaconf import DictConfig, OmegaConf
@@ -139,3 +140,38 @@ class TestModule:
 
         hparams_path = Path(logger.log_dir) / "hparams.yaml"
         assert hparams_path.exists()
+
+    @patch("otx.core.data.module.OTXDatasetFactory.create")
+    @patch("otx.core.data.module.DmDataset.import_from")
+    def test_data_format_check(
+        self,
+        mock_dm_dataset,
+        fxt_config,
+        mocker,
+        caplog,
+    ) -> None:
+        fxt_config.mem_cache_size = "0GB"
+        fxt_config.tile_config.enable_tiler = False
+        # Our query for subset name for train, val, test
+        fxt_config.train_subset.subset_name = "train_1"
+        fxt_config.val_subset.subset_name = "val_1"
+        fxt_config.test_subset.subset_name = "test_1"
+
+        # Dataset will have "train_0", "train_1", "val_0", ..., "test_1" subsets
+        mock_dm_subsets = {f"{name}_{idx}": MagicMock() for name in ["train", "val", "test"] for idx in range(2)}
+        mock_dm_dataset.return_value.subsets.return_value = mock_dm_subsets
+
+        mocker.patch("otx.core.data.module.pre_filtering", side_effect=mock_data_filtering)
+
+        with patch.object(Environment, "detect_dataset", return_value=["voc", "voc_classification"]):
+            # with pytest.raises(ValueError, match="Invalid data root:"):
+            OTXDataModule(task="MULTI_LABEL_CLS", config=fxt_config)
+
+        assert "Invalid data format:" in caplog.text
+        assert "Replace data_format:" in caplog.text
+
+        with patch.object(Environment, "detect_dataset", return_value=[]), pytest.raises(
+            ValueError,
+            match="Invalid data root:",
+        ):
+            OTXDataModule(task="MULTI_LABEL_CLS", config=fxt_config)


### PR DESCRIPTION
### Summary

https://github.com/openvinotoolkit/training_extensions/issues/3227
Validates the structure of the dataset and replaces any invalid `data_format`.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
