### PR TITLE
Revert "Change ci-runner to a10g for integration tests (#3553)"

### DIFF
--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -81,10 +81,7 @@ jobs:
           ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage_unit-test-${{ matrix.tox-env }}.xml -F ${{ matrix.tox-env }}
 
   Integration-Test:
-    runs-on: [otx-gpu-a10g-1]
-    container:
-      image: 219678651685.dkr.ecr.eu-west-1.amazonaws.com/ote-ci:11.7.1.2-devel-ubuntu20.04
-      options: "--runtime=nvidia --env-file=/home/runner/.nvidia.env --ipc=host"
+    runs-on: [self-hosted, linux, x64, dev]
     needs: Unit-Test
     strategy:
       fail-fast: false


### PR DESCRIPTION
This reverts commit 59b4855691d86ff1e5922578eb8732d3de0848ea.

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
