### PR TITLE
Update ATSS input size to 992x800

### DIFF
--- a/src/otx/algo/detection/atss.py
+++ b/src/otx/algo/detection/atss.py
@@ -65,7 +65,7 @@ class ATSS(ExplainableOTXDetModel):
             torch_compile=torch_compile,
             tile_config=tile_config,
         )
-        self.image_size = (1, 3, 736, 992)
+        self.image_size = (1, 3, 800, 992)
         self.tile_image_size = self.image_size
 
     def _create_model(self) -> nn.Module:

--- a/src/otx/recipe/detection/atss_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2.yaml
@@ -59,7 +59,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: true
           - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -84,7 +84,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true
@@ -104,7 +104,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
@@ -56,7 +56,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: true
           - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -81,7 +81,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true
@@ -101,7 +101,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/atss_resnext101.yaml
+++ b/src/otx/recipe/detection/atss_resnext101.yaml
@@ -59,7 +59,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: true
           - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -84,7 +84,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true
@@ -104,7 +104,7 @@ overrides:
             init_args:
               scale:
                 - 992
-                - 736
+                - 800
               keep_ratio: false
               transform_bbox: false
               is_numpy_to_tvtensor: true

--- a/tests/assets/mmdeploy_config_sample.py
+++ b/tests/assets/mmdeploy_config_sample.py
@@ -51,5 +51,5 @@ codebase_config = dict(
 backend_config = dict(
     type="openvino",
     mo_options=None,
-    model_inputs=[dict(opt_shapes=dict(input=[-1, 3, 736, 992]))],
+    model_inputs=[dict(opt_shapes=dict(input=[-1, 3, 800, 992]))],
 )

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -172,7 +172,7 @@ class TestAutoConfigurator:
             {
                 "class_path": "otx.core.data.transform_libs.torchvision.Resize",
                 "init_args": {
-                    "scale": [992, 736],
+                    "scale": [992, 800],
                     "keep_ratio": False,
                     "transform_bbox": False,
                     "is_numpy_to_tvtensor": True,


### PR DESCRIPTION
### Summary
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


f1-score | 1.6 | 2.0 (992x736) | 2.0 (992x800) | 2.0 (992x800) opt.
-- | -- | -- | -- | --
small | 0.5434 | 0.4966 | 0.5378 | 0.5505
medium | 0.7292 | 0.7178 | 0.7267 | 0.7328
large | 0.8036 | 0.8002 | 0.8017 | 0.8027
avg | 0.6921 | 0.6716 | 0.6887 | 0.6953



</div>

<!--EndFragment-->
</body>

</html>

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```

