### PR TITLE
Fix `load_from_checkpoint` to apply original model's hparams

### DIFF
--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -368,8 +368,8 @@ class Engine:
         # NOTE, trainer.test takes only lightning based checkpoint.
         # So, it can't take the OTX1.x checkpoint.
         if checkpoint is not None and not is_ir_ckpt:
-            model_cls = self.model.__class__
-            model = model_cls.load_from_checkpoint(checkpoint_path=checkpoint)
+            model_cls = model.__class__
+            model = model_cls.load_from_checkpoint(checkpoint_path=checkpoint, **model.hparams)
 
         if model.label_info != self.datamodule.label_info:
             msg = (


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

When testing the model with the parameters different from one used during training, they haven't been appropriately applied.
Check `infer_reference_info_root` in the below example. The default value of `infer_reference_info_root` is `../.latest/train` and I want to update it to another path.
The order is:
- original model set for test
- previously created model by `load_from_checkpoint(...)`
- updated one by `load_from_checkpoint(..., **model.hparams)`

![image](https://github.com/openvinotoolkit/training_extensions/assets/97221135/d4bcc28f-9315-4e25-b337-e0dab6bb6f96)


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
