### PR TITLE
Update exportable code dependency & fix a bug

### DIFF
--- a/src/otx/core/exporter/base.py
+++ b/src/otx/core/exporter/base.py
@@ -194,16 +194,16 @@ class OTXModelExporter:
                 raise RuntimeError(msg)
 
             if not is_ir_model and self.metadata is not None:
-                parameters["type_of_model"] = self.metadata.get(("model_info", "task_type"), "")
-                parameters["converter_type"] = self.metadata.get(("model_info", "model_type"), "")
+                parameters["task_type"] = self.metadata.get(("model_info", "task_type"), "")
+                parameters["model_type"] = self.metadata.get(("model_info", "model_type"), "")
                 parameters["model_parameters"] = {
                     "labels": self.metadata.get(("model_info", "labels"), ""),
                     "labels_ids": self.metadata.get(("model_info", "label_ids"), ""),
                 }
             elif is_ir_model:
                 model_info = model.get_model().rt_info["model_info"]
-                parameters["type_of_model"] = model_info["task_type"].value if "task_type" in model_info else ""
-                parameters["converter_type"] = model_info["model_type"].value if "model_type" in model_info else ""
+                parameters["task_type"] = model_info["task_type"].value if "task_type" in model_info else ""
+                parameters["model_type"] = model_info["model_type"].value if "model_type" in model_info else ""
                 parameters["model_parameters"] = {
                     "labels": model_info["labels"].value if "labels" in model_info else "",
                     "labels_ids": model_info["label_ids"].value if "label_ids" in model_info else "",

--- a/src/otx/core/exporter/exportable_code/demo/demo_package/model_wrapper.py
+++ b/src/otx/core/exporter/exportable_code/demo/demo_package/model_wrapper.py
@@ -43,7 +43,7 @@ class ModelWrapper:
             raise RuntimeError(msg)
         self.parameters = get_parameters(model_dir / "config.json")
         self._labels = self.parameters["model_parameters"]["labels"]
-        self._task_type = TaskType[self.parameters["converter_type"].upper()]
+        self._task_type = TaskType[self.parameters["task_type"].upper()]
 
         # labels for modelAPI wrappers can be empty, because unused in pre- and postprocessing
         self.model_parameters = self.parameters["model_parameters"]
@@ -53,7 +53,7 @@ class ModelWrapper:
 
         self.core_model = Model.create_model(
             model_adapter,
-            self.parameters["type_of_model"],
+            self.parameters["model_type"],
             self.model_parameters,
             preload=True,
         )

--- a/src/otx/core/exporter/exportable_code/demo/requirements.txt
+++ b/src/otx/core/exporter/exportable_code/demo/requirements.txt
@@ -1,3 +1,3 @@
-openvino==2023.3.0
-openvino-model-api==0.1.8
-numpy==1.26.1
+openvino==2024.0.0
+openvino-model-api==0.2.0
+numpy==1.26.4

--- a/tests/unit/core/exporter/exportable_code/demo/demo_package/test_model_wrapper.py
+++ b/tests/unit/core/exporter/exportable_code/demo/demo_package/test_model_wrapper.py
@@ -32,8 +32,8 @@ class TestModelWrapper:
             "get_parameters",
             return_value={
                 "model_parameters": {"labels": "label"},
-                "converter_type": "CLASSIFICATION",
-                "type_of_model": "type_of_model",
+                "task_type": "CLASSIFICATION",
+                "model_type": "type_of_model",
             },
         )
         mocker.patch.object(target_file, "get_model_path")


### PR DESCRIPTION
### Summary
This PR includes

- Align exportable code dependency to OTX
- Fix a bug that value of `type_of_model` and `converter_type` are opposite

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
