### PR TITLE
Add execution example of auto batch size in docs

### DIFF
--- a/docs/source/guide/explanation/additional_features/auto_configuration.rst
+++ b/docs/source/guide/explanation/additional_features/auto_configuration.rst
@@ -84,13 +84,16 @@ To use this feature, add the following parameter:
 
         .. code-block:: python
 
-            Need to update!
+            from otx.engine import Engine
+
+            engine = Engine(data_root="<path_to_data_root>")
+            engine.train(adaptive_bs="Safe")
 
     .. tab-item:: CLI
 
         .. code-block:: bash
 
-            Need to update!
+            (otx) ...$ otx train ...  --adaptive_bs Safe
 
 2. Find the maximum executable batch size (`Full` mode)
 
@@ -107,13 +110,16 @@ To use this feature, add the following parameter:
 
         .. code-block:: python
 
-            Need to update!
+            from otx.engine import Engine
+
+            engine = Engine(data_root="<path_to_data_root>")
+            engine.train(adaptive_bs="Full")
 
     .. tab-item:: CLI
 
         .. code-block:: bash
 
-            Need to update!
+            (otx) ...$ otx train ...  --adaptive_bs Full
 
 
 .. Warning::


### PR DESCRIPTION
### Summary
This PR added execution example of auto batch size in docs
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
