### PR TITLE
Move value to device before logging for metric

### DIFF
--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -349,7 +349,7 @@ class OTXModel(LightningModule, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEnti
                 warnings.warn(msg, stacklevel=1)
                 continue
 
-            self.log(log_metric_name, value, sync_dist=True, prog_bar=True)
+            self.log(log_metric_name, value.to(self.device), sync_dist=True, prog_bar=True)
 
     def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         """Callback on saving checkpoint."""


### PR DESCRIPTION
### Summary
This is for #3635 
and also to deal with https://github.com/Lightning-AI/pytorch-lightning/issues/18803
There is a bug that when updating a value on cpu to metric instance from torchmetric, error is raised during distributed training.
To fix it, I added code to move value to current device explicitly.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
