### PR TITLE
Fix RTMDet PTQ performance

### DIFF
--- a/src/otx/algo/detection/rtmdet.py
+++ b/src/otx/algo/detection/rtmdet.py
@@ -29,6 +29,7 @@ from otx.core.data.entity.utils import stack_batch
 from otx.core.exporter.base import OTXModelExporter
 from otx.core.exporter.native import OTXNativeModelExporter
 from otx.core.model.detection import ExplainableOTXDetModel
+from otx.core.types.export import TaskLevelExportParameters
 
 
 class RTMDet(ExplainableOTXDetModel):
@@ -183,6 +184,11 @@ class RTMDet(ExplainableOTXDetModel):
             },
             output_names=["bboxes", "labels", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
+
+    @property
+    def _export_parameters(self) -> TaskLevelExportParameters:
+        """Defines parameters required to export a particular model implementation."""
+        return super()._export_parameters.wrap(optimization_config={"preset": "mixed"})
 
     def forward_for_tracing(
         self,


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

ticket no. : 144647
There is RTMDet's performance degradation after PTQ.
By updating preset to `mixed`, the optimized model showed similar performance with the exported model.

PTQ configuration | pothole_small_1 | pothole_small_2 | pothole_small_3 | pothole_medium | vitens_large
| -- | -- | -- | -- | -- | -- |
| export | 0.450 | 0.518 | 0.500 | 0.725 | 0.756 |
| default | 0.427 (-0.023) | 0.439 (-0.079) | 0.433 (-0.067) | 0.654 (-0.071) | 0.711 (-0.045) |
| + preset="mixed" | 0.433 (-0.017) | 0.521 (+0.003) | 0.515 (+0.015) | 0.715 (-0.010) | 0.753 (-0.003) |


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
