### PR TITLE
Fix segmentation fault on VPM PTQ

### DIFF
--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -1110,6 +1110,11 @@ class OVZeroShotVisualPromptingModel(
             prompt_for_optim.update(**image_embeddings)
             return prompt_for_optim
 
+        # ticket no. : CVS-135462
+        # There is segmentation fault issue when using num_workers > 0 during releasing memory.
+        # To avoid this issue, force num_workers to 0.
+        data_module.config.train_subset.num_workers = 0
+
         output_model_paths: dict[str, Path] = {}
         for module in ["image_encoder", "decoder"]:
             output_model_path = output_dir / (self._OPTIMIZED_MODEL_BASE_NAME + f"_{module}.xml")


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

ticket no. : 135462

After PTQ with `num_workers > 0`, sometimes segmentation fault error has occurred during releasing memory.
In recent performance benchmark test, it occurred and the test was failed even though PTQ was normally done.
https://github.com/openvinotoolkit/training_extensions/actions/runs/9608456874/job/26501287346#step:5:3091

To avoid this issue, temporarily force `num_workers` to 0 before PTQ.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
