### PR TITLE
Improve Vitens Kiemgetal OTX 1.6.x

### DIFF
--- a/src/otx/algorithms/common/configs/training_base.py
+++ b/src/otx/algorithms/common/configs/training_base.py
@@ -409,7 +409,8 @@ class BaseConfig(ConfigurableParameters):
 
         tile_max_number = configurable_integer(
             header="Max object per image",
-            description="Max object per image",
+            description="description: Maximum number of objects per tile. If set to 1500, the tile adaptor "
+            "will automatically determine the value. Otherwise, the manually set value will be used.",
             default_value=1500,
             min_value=1,
             max_value=5000,

--- a/src/otx/algorithms/common/configs/training_base.py
+++ b/src/otx/algorithms/common/configs/training_base.py
@@ -409,7 +409,7 @@ class BaseConfig(ConfigurableParameters):
 
         tile_max_number = configurable_integer(
             header="Max object per image",
-            description="description: Maximum number of objects per tile. If set to 1500, the tile adaptor "
+            description="Maximum number of objects per tile. If set to 1500, the tile adaptor "
             "will automatically determine the value. Otherwise, the manually set value will be used.",
             default_value=1500,
             min_value=1,

--- a/src/otx/algorithms/detection/configs/base/data/tiling/atss_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/atss_tile_pipeline.py
@@ -14,15 +14,9 @@ tile_cfg = dict(
 img_norm_cfg = dict(mean=[0, 0, 0], std=[255, 255, 255], to_rgb=True)
 
 train_pipeline = [
-    dict(type="MinIoURandomCrop", min_ious=(0.1, 0.3, 0.5, 0.7, 0.9), min_crop_size=0.3),
-    dict(
-        type="Resize",
-        img_scale=[(992, 736), (896, 736), (1088, 736), (992, 672), (992, 800)],
-        multiscale_mode="value",
-        keep_ratio=False,
-    ),
-    dict(type="RandomFlip", flip_ratio=0.5),
+    dict(type="Resize", img_scale=img_size, keep_ratio=False),
     dict(type="Normalize", **img_norm_cfg),
+    dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",

--- a/src/otx/algorithms/detection/configs/base/data/tiling/yolox_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/yolox_tile_pipeline.py
@@ -16,6 +16,7 @@ tile_cfg = dict(
 img_norm_cfg = dict(mean=[0.0, 0.0, 0.0], std=[1.0, 1.0, 1.0], to_rgb=False)
 
 train_pipeline = [
+    dict(type="YOLOXHSVRandomAug"),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Resize", img_scale=img_scale, keep_ratio=True),
     dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),

--- a/src/otx/algorithms/detection/configs/base/data/tiling/yolox_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/yolox_tile_pipeline.py
@@ -16,7 +16,6 @@ tile_cfg = dict(
 img_norm_cfg = dict(mean=[0.0, 0.0, 0.0], std=[1.0, 1.0, 1.0], to_rgb=False)
 
 train_pipeline = [
-    dict(type="YOLOXHSVRandomAug"),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Resize", img_scale=img_scale, keep_ratio=True),
     dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),

--- a/src/otx/algorithms/detection/configs/base/data/tiling/yolox_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/yolox_tile_pipeline.py
@@ -16,12 +16,6 @@ tile_cfg = dict(
 img_norm_cfg = dict(mean=[0.0, 0.0, 0.0], std=[1.0, 1.0, 1.0], to_rgb=False)
 
 train_pipeline = [
-    dict(
-        type="RandomAffine",
-        scaling_ratio_range=(0.1, 2),
-        border=(-img_scale[0] // 2, -img_scale[1] // 2),
-    ),
-    dict(type="YOLOXHSVRandomAug"),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Resize", img_scale=img_scale, keep_ratio=True),
     dict(type="Pad", pad_to_square=True, pad_val=dict(img=(114.0, 114.0, 114.0))),

--- a/src/otx/algorithms/detection/configs/detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/detection/configuration.yaml
@@ -645,7 +645,7 @@ tiling_parameters:
 
   tile_max_number:
     header: Max object per tile
-    description: Maximum number of objects per tile
+    description: Maximum number of objects per tile. If set to 1500, the tile adaptor will automatically determine the value. Otherwise, the manually set value will be used.
     affects_outcome_of: TRAINING
     default_value: 1500
     min_value: 1

--- a/src/otx/algorithms/detection/configs/detection/cspdarknet_yolox_tiny/tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/detection/cspdarknet_yolox_tiny/tile_pipeline.py
@@ -29,14 +29,6 @@ tile_cfg = dict(
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type="RandomAffine", scaling_ratio_range=(0.5, 1.5), border=(-img_scale[0] // 2, -img_scale[1] // 2)),
-    dict(
-        type="PhotoMetricDistortion",
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18,
-    ),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Resize", img_scale=img_scale, keep_ratio=False),
     dict(type="Pad", pad_to_square=True, pad_val=114.0),
@@ -62,12 +54,12 @@ train_pipeline = [
 test_pipeline = [
     dict(
         type="MultiScaleFlipAug",
-        img_scale=(416, 416),
+        img_scale=img_scale,
         flip=False,
         transforms=[
             dict(type="Resize", keep_ratio=False),
             dict(type="RandomFlip"),
-            dict(type="Pad", size=(416, 416), pad_val=114.0),
+            dict(type="Pad", size=img_scale, pad_val=114.0),
             dict(type="Normalize", **img_norm_cfg),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),

--- a/src/otx/algorithms/detection/configs/detection/cspdarknet_yolox_tiny/tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/detection/cspdarknet_yolox_tiny/tile_pipeline.py
@@ -29,6 +29,13 @@ tile_cfg = dict(
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
+    dict(
+        type="PhotoMetricDistortion",
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18,
+    ),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Resize", img_scale=img_scale, keep_ratio=False),
     dict(type="Pad", pad_to_square=True, pad_val=114.0),

--- a/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/instance_segmentation/configuration.yaml
@@ -646,7 +646,7 @@ tiling_parameters:
 
   tile_max_number:
     header: Max object per tile
-    description: Maximum number of objects per tile
+    description: Maximum number of objects per tile. If set to 1500, the tile adaptor will automatically determine the value. Otherwise, the manually set value will be used.
     affects_outcome_of: TRAINING
     default_value: 1500
     min_value: 1

--- a/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
+++ b/src/otx/algorithms/detection/configs/rotated_detection/configuration.yaml
@@ -631,7 +631,7 @@ tiling_parameters:
 
   tile_max_number:
     header: Max object per tile
-    description: Maximum number of objects per tile
+    description: Maximum number of objects per tile. If set to 1500, the tile adaptor will automatically determine the value. Otherwise, the manually set value will be used.
     affects_outcome_of: TRAINING
     default_value: 1500
     min_value: 1

--- a/src/otx/algorithms/detection/utils/data.py
+++ b/src/otx/algorithms/detection/utils/data.py
@@ -434,7 +434,7 @@ def adaptive_tile_params(
     """Config tile parameters.
 
     Adapt based on annotation statistics.
-    i.e. tile size, tile overlap, ratio and max objects per sample
+    i.e. tile size, tile overlap, and ratio.
 
     Args:
         tiling_parameters (BaseTilingParameters): tiling parameters of the model
@@ -447,7 +447,6 @@ def adaptive_tile_params(
     assert rule in ["min", "avg"], f"Unknown rule: {rule}"
 
     stat = compute_robust_dataset_statistics(dataset, ann_stat=True)
-    max_num_objects = round(stat["annotation"]["num_per_image"]["max"])
     avg_size = stat["annotation"]["size_of_shape"]["avg"]
     min_size = stat["annotation"]["size_of_shape"]["robust_min"]
     max_size = stat["annotation"]["size_of_shape"]["robust_max"]
@@ -484,11 +483,6 @@ def adaptive_tile_params(
         tiling_parameters.get_metadata("tile_overlap")["min_value"],
         min(tiling_parameters.get_metadata("tile_overlap")["max_value"], tile_overlap),
     )
-    max_num_objects = max(
-        tiling_parameters.get_metadata("tile_max_number")["min_value"],
-        min(tiling_parameters.get_metadata("tile_max_number")["max_value"], max_num_objects),
-    )
 
     tiling_parameters.tile_size = tile_size
-    tiling_parameters.tile_max_number = max_num_objects
     tiling_parameters.tile_overlap = tile_overlap

--- a/src/otx/cli/tools/eval.py
+++ b/src/otx/cli/tools/eval.py
@@ -36,11 +36,6 @@ from otx.cli.utils.parser import (
 from otx.core.data.adapter import get_dataset_adapter
 from otx.utils.logger import config_logger
 
-from otx.utils.logger import get_logger
-import time
-
-logger = get_logger()
-
 # pylint: disable=too-many-locals
 
 
@@ -143,7 +138,6 @@ def main():
     task = task_class(task_environment=environment)
 
     validation_dataset = dataset.get_subset(Subset.TESTING)
-    start_time = time.perf_counter()
     predicted_validation_dataset = task.infer(
         # temp (sungchul): remain annotation for visual prompting
         validation_dataset
@@ -151,8 +145,6 @@ def main():
         else validation_dataset.with_empty_annotations(),
         InferenceParameters(is_evaluation=False),
     )
-    total_time = time.perf_counter() - start_time
-    _avg_time_per_image = total_time / len(predicted_validation_dataset)
 
     resultset = ResultSetEntity(
         model=environment.model,
@@ -161,8 +153,6 @@ def main():
     )
     task.evaluate(resultset)
     assert resultset.performance is not None
-
-    logger.info(f"Avg time per image: {_avg_time_per_image} secs")
 
     output_path = Path(args.output) if args.output else config_manager.output_path
     performance = {resultset.performance.score.name: resultset.performance.score.value}

--- a/src/otx/cli/tools/eval.py
+++ b/src/otx/cli/tools/eval.py
@@ -36,6 +36,11 @@ from otx.cli.utils.parser import (
 from otx.core.data.adapter import get_dataset_adapter
 from otx.utils.logger import config_logger
 
+from otx.utils.logger import get_logger
+import time
+
+logger = get_logger()
+
 # pylint: disable=too-many-locals
 
 
@@ -138,6 +143,7 @@ def main():
     task = task_class(task_environment=environment)
 
     validation_dataset = dataset.get_subset(Subset.TESTING)
+    start_time = time.perf_counter()
     predicted_validation_dataset = task.infer(
         # temp (sungchul): remain annotation for visual prompting
         validation_dataset
@@ -145,6 +151,8 @@ def main():
         else validation_dataset.with_empty_annotations(),
         InferenceParameters(is_evaluation=False),
     )
+    total_time = time.perf_counter() - start_time
+    _avg_time_per_image = total_time / len(predicted_validation_dataset)
 
     resultset = ResultSetEntity(
         model=environment.model,
@@ -153,6 +161,8 @@ def main():
     )
     task.evaluate(resultset)
     assert resultset.performance is not None
+
+    logger.info(f"Avg time per image: {_avg_time_per_image} secs")
 
     output_path = Path(args.output) if args.output else config_manager.output_path
     performance = {resultset.performance.score.name: resultset.performance.score.value}

--- a/tests/unit/algorithms/detection/tiling/test_tiling_detection.py
+++ b/tests/unit/algorithms/detection/tiling/test_tiling_detection.py
@@ -432,14 +432,15 @@ class TestTilingDetection:
             assert len(data["gt_masks"].data[0][0]) <= max_annotation
 
     @e2e_pytest_unit
-    def test_adaptive_tile_parameters(self):
+    @pytest.mark.parametrize("max_num_img", [100, 300, 1500, 1501])
+    def test_adaptive_tile_parameters(self, max_num_img):
         model_template = parse_model_template(os.path.join(DEFAULT_ISEG_TEMPLATE_DIR, "template.yaml"))
         hp = create(model_template.hyper_parameters.data)
 
         default_tile_size = hp.tiling_parameters.tile_size
         default_tile_overlap = hp.tiling_parameters.tile_overlap
         # manually set tile max number
-        hp.tiling_parameters.tile_max_number = np.random.randint(low=1, high=5000)
+        hp.tiling_parameters.tile_max_number = max_num_img
         default_tile_max_number = hp.tiling_parameters.tile_max_number
 
         adaptive_tile_params(hp.tiling_parameters, self.otx_dataset)
@@ -450,5 +451,9 @@ class TestTilingDetection:
         # check tile overlap is changed
         assert hp.tiling_parameters.tile_overlap != default_tile_overlap
 
-        # check tile max number is being manually set and not changed by adaptive_tile_params
-        assert hp.tiling_parameters.tile_max_number == default_tile_max_number
+        if default_tile_max_number == 1500:
+            # check tile max number is being set by adaptive_tile_params
+            assert hp.tiling_parameters.tile_max_number != default_tile_max_number
+        else:
+            # check tile max number is being manually set
+            assert hp.tiling_parameters.tile_max_number == default_tile_max_number

--- a/tests/unit/algorithms/detection/tiling/test_tiling_detection.py
+++ b/tests/unit/algorithms/detection/tiling/test_tiling_detection.py
@@ -438,6 +438,8 @@ class TestTilingDetection:
 
         default_tile_size = hp.tiling_parameters.tile_size
         default_tile_overlap = hp.tiling_parameters.tile_overlap
+        # manually set tile max number
+        hp.tiling_parameters.tile_max_number = np.random.randint(low=1, high=5000)
         default_tile_max_number = hp.tiling_parameters.tile_max_number
 
         adaptive_tile_params(hp.tiling_parameters, self.otx_dataset)
@@ -448,5 +450,5 @@ class TestTilingDetection:
         # check tile overlap is changed
         assert hp.tiling_parameters.tile_overlap != default_tile_overlap
 
-        # check max output prediction size is changed
-        assert hp.tiling_parameters.tile_max_number != default_tile_max_number
+        # check tile max number is being manually set and not changed by adaptive_tile_params
+        assert hp.tiling_parameters.tile_max_number == default_tile_max_number


### PR DESCRIPTION
### Summary

* Remove the maximum number of detections from the tile adaptor and make it manually configurable. 
  * e.g. `otx train --workspace=... params --tiling_parameters.enable_tiling=true --tiling_parameters.tile_max_number=200`
* Remove random affine and color augmentation for YOLOX and ATSS tile recipes.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
