### PR TITLE
Disable integration test in pr-merge workflow

### DIFF
--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -90,37 +90,37 @@ jobs:
           chmod +x codecov
           ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage_unit-test-${{ matrix.tox-env }}.xml -F ${{ matrix.tox-env }}
 
-  Integration-Test:
-    runs-on: [self-hosted, linux, x64, dev]
-    needs: Unit-Test
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - task: "action"
-          - task: "classification"
-          - task: "detection"
-          - task: "instance_segmentation"
-          - task: "semantic_segmentation"
-          - task: "visual_prompting"
-          - task: "anomaly"
-    name: Integration-Test-${{ matrix.task }}-py310
-    # This is what will cancel the job concurrency
-    concurrency:
-      group: ${{ github.workflow }}-Integration-${{ github.event.pull_request.number || github.ref }}-${{ matrix.task }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Install Python
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-        with:
-          python-version: "3.10"
-      - name: Install tox
-        run: |
-          python -m pip install --require-hashes --no-deps -r .ci/requirements.txt
-          pip-compile --generate-hashes --output-file=/tmp/requirements.txt --extra=ci_tox pyproject.toml
-          python -m pip install --require-hashes --no-deps -r /tmp/requirements.txt
-          rm /tmp/requirements.txt
-      - name: Run Integration Test
-        run: tox -vv -e integration-test-${{ matrix.task }}
+  # Integration-Test:
+  #   runs-on: [self-hosted, linux, x64, dev]
+  #   needs: Unit-Test
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - task: "action"
+  #         - task: "classification"
+  #         - task: "detection"
+  #         - task: "instance_segmentation"
+  #         - task: "semantic_segmentation"
+  #         - task: "visual_prompting"
+  #         - task: "anomaly"
+  #   name: Integration-Test-${{ matrix.task }}-py310
+  #   # This is what will cancel the job concurrency
+  #   concurrency:
+  #     group: ${{ github.workflow }}-Integration-${{ github.event.pull_request.number || github.ref }}-${{ matrix.task }}
+  #     cancel-in-progress: true
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  #     - name: Install Python
+  #       uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install tox
+  #       run: |
+  #         python -m pip install --require-hashes --no-deps -r .ci/requirements.txt
+  #         pip-compile --generate-hashes --output-file=/tmp/requirements.txt --extra=ci_tox pyproject.toml
+  #         python -m pip install --require-hashes --no-deps -r /tmp/requirements.txt
+  #         rm /tmp/requirements.txt
+  #     - name: Run Integration Test
+  #       run: tox -vv -e integration-test-${{ matrix.task }}


### PR DESCRIPTION
### Summary

Disable integration test job on pr-merge workflow that required to be run on self-hosted runner.
once self-hosted runner updated, it will be reverted.

ps. other workflow was disabled through the github configuration.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
