### PR TITLE
Align integration test to exportable code interface update

### DIFF
--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections import namedtuple
 from pathlib import Path
 
 import cv2
@@ -12,6 +13,17 @@ from otx.core.types.task import OTXTaskType
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
 from tests.utils import run_main
+
+ExportCase2Test = namedtuple("ExportCase2Test", ["export_format", "export_demo_package", "expected_output"])
+
+
+@pytest.fixture()
+def fxt_export_list() -> list[ExportCase2Test]:
+    return [
+        ExportCase2Test("ONNX", False, "exported_model.onnx"),
+        ExportCase2Test("OPENVINO", False, "exported_model.xml"),
+        ExportCase2Test("OPENVINO", True, "exportable_code.zip"),
+    ]
 
 
 @pytest.fixture(
@@ -67,6 +79,7 @@ def test_otx_e2e(
     fxt_target_dataset_per_task: dict,
     fxt_cli_override_command_per_task: dict,
     fxt_open_subprocess: bool,
+    fxt_export_list: list[ExportCase2Test],
     tmp_path: Path,
 ) -> None:
     """
@@ -156,24 +169,14 @@ def test_otx_e2e(
         return
 
     if task in ("visual_prompting", "zero_shot_visual_prompting"):
-        format_to_file = {
-            "ONNX": "exported_model_decoder.onnx",
-            "OPENVINO": "exported_model_decoder.xml",
-            # TODO (sungchul): EXPORTABLE_CODE will be supported
-        }
-    else:
-        format_to_file = {
-            "ONNX": "exported_model.onnx",
-            "OPENVINO": "exported_model.xml",
-            "EXPORTABLE_CODE": "exportable_code.zip",
-        }
+        del fxt_export_list[-1]  # TODO (sungchul): EXPORTABLE_CODE will be supported
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:
         overrides = {}  # Overrides are not needed in export
 
     tmp_path_test = tmp_path / f"otx_test_{model_name}"
-    for fmt in format_to_file:
+    for export_case in fxt_export_list:
         command_cfg = [
             "otx",
             "export",
@@ -182,35 +185,35 @@ def test_otx_e2e(
             "--data_root",
             fxt_target_dataset_per_task[task],
             "--work_dir",
-            str(tmp_path_test / "outputs" / fmt),
+            str(tmp_path_test / "outputs" / export_case.export_format),
             *overrides,
             "--checkpoint",
             str(ckpt_file),
             "--export_format",
-            f"{fmt}",
+            export_case.export_format,
+            "--export_demo_package",
+            str(export_case.export_demo_package),
         ]
 
         run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 
-        outputs_dir = tmp_path_test / "outputs" / fmt
+        outputs_dir = tmp_path_test / "outputs" / export_case.export_format
         latest_dir = max(
             (p for p in outputs_dir.iterdir() if p.is_dir() and p.name != ".latest"),
             key=lambda p: p.stat().st_mtime,
         )
         assert latest_dir.exists()
-        assert (latest_dir / f"{format_to_file[fmt]}").exists()
+        assert (latest_dir / export_case.expected_output).exists()
 
     # 4) infer of the exported models
     ov_output_dir = tmp_path_test / "outputs" / "OPENVINO"
-    ov_latest_dir = max(
-        (p for p in ov_output_dir.iterdir() if p.is_dir() and p.name != ".latest"),
-        key=lambda p: p.stat().st_mtime,
-    )
+    ov_files = list(ov_output_dir.rglob("exported*.xml"))
+    if not ov_files:
+        msg = ""
+        raise RuntimeError(msg)
+    exported_model_path = str(ov_files[0])
     if task in ("visual_prompting", "zero_shot_visual_prompting"):
-        exported_model_path = str(ov_latest_dir / "exported_model_decoder.xml")
         recipe = str(Path(recipe).parents[0] / "openvino_model.yaml")
-    else:
-        exported_model_path = str(ov_latest_dir / "exported_model.xml")
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:
@@ -257,14 +260,8 @@ def test_otx_e2e(
     if "dino" in model_name:
         return  # DINO is not supported.
 
-    format_to_file = {
-        "ONNX": "exported_model.onnx",
-        "OPENVINO": "exported_model.xml",
-        "EXPORTABLE_CODE": "exportable_code.zip",
-    }
-
     tmp_path_test = tmp_path / f"otx_export_xai_{model_name}"
-    for fmt in format_to_file:
+    for export_case in fxt_export_list:
         command_cfg = [
             "otx",
             "export",
@@ -273,25 +270,27 @@ def test_otx_e2e(
             "--data_root",
             fxt_target_dataset_per_task[task],
             "--work_dir",
-            str(tmp_path_test / "outputs" / fmt),
+            str(tmp_path_test / "outputs" / export_case.export_format),
             *fxt_cli_override_command_per_task[task],
             "--checkpoint",
             str(ckpt_file),
             "--export_format",
-            f"{fmt}",
+            f"{export_case.export_format}",
+            "--export_demo_package",
+            str(export_case.export_demo_package),
             "--explain",
             "True",
         ]
 
         run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 
-        fmt_dir = tmp_path_test / "outputs" / fmt
+        fmt_dir = tmp_path_test / "outputs" / export_case.export_format
         assert fmt_dir.exists()
         fmt_latest_dir = max(
             (p for p in fmt_dir.iterdir() if p.is_dir() and p.name != ".latest"),
             key=lambda p: p.stat().st_mtime,
         )
-        assert (fmt_latest_dir / f"{format_to_file[fmt]}").exists()
+        assert (fmt_latest_dir / f"{export_case.expected_output}").exists()
 
 
 def test_otx_explain_e2e(

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -209,7 +209,7 @@ def test_otx_e2e(
     ov_output_dir = tmp_path_test / "outputs" / "OPENVINO"
     ov_files = list(ov_output_dir.rglob("exported*.xml"))
     if not ov_files:
-        msg = ""
+        msg = "There is no OV IR."
         raise RuntimeError(msg)
     exported_model_path = str(ov_files[0])
     if task in ("visual_prompting", "zero_shot_visual_prompting"):

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -169,7 +169,10 @@ def test_otx_e2e(
         return
 
     if task in ("visual_prompting", "zero_shot_visual_prompting"):
-        del fxt_export_list[-1]  # TODO (sungchul): EXPORTABLE_CODE will be supported
+        fxt_export_list = [
+            ExportCase2Test("ONNX", False, "exported_model_decoder.onnx"),
+            ExportCase2Test("OPENVINO", False, "exported_model_decoder.xml"),
+        ]  # TODO (sungchul): EXPORTABLE_CODE will be supported
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:


### PR DESCRIPTION
### Summary
After #3577 , the interface to execute exportable_code was changed.
But integration test has been using still previous interface. This PR aligned it to current interface.

### Integration test result
![image](https://github.com/openvinotoolkit/training_extensions/assets/92974184/6378a621-1486-49c8-9630-333707ae8838)
failed tests will be passed after #3672 is merged

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
