### PR TITLE
Include more models to export test into test_otx_e2e

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ from torch import LongTensor
 from torchvision import tv_tensors
 from torchvision.tv_tensors import Image, Mask
 
+from tests.utils import ExportCase2Test
+
 
 def pytest_addoption(parser: pytest.Parser):
     """Add custom options for perf tests."""
@@ -468,4 +470,13 @@ def fxt_xpu_support_task() -> list[OTXTaskType]:
         OTXTaskType.ROTATED_DETECTION,
         OTXTaskType.DETECTION_SEMI_SL,
         OTXTaskType.SEMANTIC_SEGMENTATION,
+    ]
+
+
+@pytest.fixture()
+def fxt_export_list() -> list[ExportCase2Test]:
+    return [
+        ExportCase2Test("ONNX", False, "exported_model.onnx"),
+        ExportCase2Test("OPENVINO", False, "exported_model.xml"),
+        ExportCase2Test("OPENVINO", True, "exportable_code.zip"),
     ]

--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -11,6 +11,7 @@ from otx.core.types.task import OTXTaskType
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
 from tests.e2e.cli.utils import run_main
+from tests.utils import ExportCase2Test
 
 
 @pytest.mark.parametrize(
@@ -25,6 +26,7 @@ def test_otx_e2e_cli(
     fxt_target_dataset_per_task: dict,
     fxt_cli_override_command_per_task: dict,
     fxt_open_subprocess: bool,
+    fxt_export_list: list[ExportCase2Test],
 ) -> None:
     """
     Test OTX CLI e2e commands.
@@ -121,34 +123,28 @@ def test_otx_e2e_cli(
     if any(
         task_name in recipe
         for task_name in [
-            "h_label_cls",
-            "detection",
             "dino_v2",
-            "instance_segmentation",
-            "action",
+            "rotated_detection/maskrcnn",
         ]
     ):
         return
-
     if task in ("visual_prompting", "zero_shot_visual_prompting"):
-        format_to_file = {
-            "ONNX": "exported_model_decoder.onnx",
-            "OPENVINO": "exported_model_decoder.xml",
-            # TODO (sungchul): EXPORTABLE_CODE will be supported
-        }
-    else:
-        format_to_file = {
-            "ONNX": "exported_model.onnx",
-            "OPENVINO": "exported_model.xml",
-            "EXPORTABLE_CODE": "exportable_code.zip",
-        }
+        fxt_export_list = [
+            ExportCase2Test("ONNX", False, "exported_model_decoder.onnx"),
+            ExportCase2Test("OPENVINO", False, "exported_model_decoder.xml"),
+        ]  # TODO (sungchul): EXPORTABLE_CODE will be supported
+    elif "anomaly" in task:
+        fxt_export_list = [
+            ExportCase2Test("ONNX", False, "exported_model.onnx"),
+            ExportCase2Test("OPENVINO", False, "exported_model.xml"),
+        ]  # anomaly doesn't support exportable code
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:
         overrides = {}  # Overrides are not needed in export
 
     tmp_path_test = tmp_path / f"otx_test_{model_name}"
-    for fmt in format_to_file:
+    for export_case in fxt_export_list:
         command_cfg = [
             "otx",
             "export",
@@ -157,31 +153,35 @@ def test_otx_e2e_cli(
             "--data_root",
             str(dataset_path),
             "--work_dir",
-            str(tmp_path_test / "outputs" / fmt),
+            str(tmp_path_test / "outputs" / export_case.export_format),
             *overrides,
             "--checkpoint",
             str(ckpt_files[-1]),
             "--export_format",
-            f"{fmt}",
+            export_case.export_format,
+            "--export_demo_package",
+            str(export_case.export_demo_package),
         ]
 
         run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 
-        outputs_dir = tmp_path_test / "outputs" / fmt
+        outputs_dir = tmp_path_test / "outputs" / export_case.export_format
         latest_dir = max(
             (p for p in outputs_dir.iterdir() if p.is_dir() and p.name != ".latest"),
             key=lambda p: p.stat().st_mtime,
         )
         assert latest_dir.exists()
-        assert (latest_dir / f"{format_to_file[fmt]}").exists()
+        assert (latest_dir / export_case.expected_output).exists()
 
     # 4) infer of the exported models
     ov_output_dir = tmp_path_test / "outputs" / "OPENVINO"
-    ov_latest_dir = max(
-        (p for p in ov_output_dir.iterdir() if p.is_dir() and p.name != ".latest"),
-        key=lambda p: p.stat().st_mtime,
-    )
-    exported_model_path = str(ov_latest_dir / "exported_model.xml")
+    ov_files = list(ov_output_dir.rglob("exported*.xml"))
+    if not ov_files:
+        msg = "There is no OV IR."
+        raise RuntimeError(msg)
+    exported_model_path = str(ov_files[0])
+    if task in ("visual_prompting", "zero_shot_visual_prompting"):
+        recipe = str(Path(recipe).parents[0] / "openvino_model.yaml")
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:
@@ -213,20 +213,16 @@ def test_otx_e2e_cli(
     assert latest_dir.exists()
 
     # 5) otx export with XAI
+    if "instance_segmentation/rtmdet_inst_tiny" in recipe:
+        return
     if ("_cls" not in task) and (task not in ["detection", "instance_segmentation"]):
         return  # Supported only for classification, detection and instance segmentation task.
 
     if "dino" in model_name:
         return  # DINO is not supported.
 
-    format_to_file = {
-        "ONNX": "exported_model.onnx",
-        "OPENVINO": "exported_model.xml",
-        "EXPORTABLE_CODE": "exportable_code.zip",
-    }
-
     tmp_path_test = tmp_path / f"otx_export_xai_{model_name}"
-    for fmt in format_to_file:
+    for export_case in fxt_export_list:
         command_cfg = [
             "otx",
             "export",
@@ -235,25 +231,27 @@ def test_otx_e2e_cli(
             "--data_root",
             str(dataset_path),
             "--work_dir",
-            str(tmp_path_test / "outputs" / fmt),
+            str(tmp_path_test / "outputs" / export_case.export_format),
             *fxt_cli_override_command_per_task[task],
             "--checkpoint",
             str(ckpt_files[-1]),
             "--export_format",
-            f"{fmt}",
+            f"{export_case.export_format}",
+            "--export_demo_package",
+            str(export_case.export_demo_package),
             "--explain",
             "True",
         ]
 
         run_main(command_cfg=command_cfg, open_subprocess=fxt_open_subprocess)
 
-        fmt_dir = tmp_path_test / "outputs" / fmt
+        fmt_dir = tmp_path_test / "outputs" / export_case.export_format
         assert fmt_dir.exists()
         fmt_latest_dir = max(
             (p for p in fmt_dir.iterdir() if p.is_dir() and p.name != ".latest"),
             key=lambda p: p.stat().st_mtime,
         )
-        assert (fmt_latest_dir / f"{format_to_file[fmt]}").exists()
+        assert (fmt_latest_dir / f"{export_case.expected_output}").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -169,6 +169,11 @@ def test_otx_e2e(
             ExportCase2Test("ONNX", False, "exported_model_decoder.onnx"),
             ExportCase2Test("OPENVINO", False, "exported_model_decoder.xml"),
         ]  # TODO (sungchul): EXPORTABLE_CODE will be supported
+    elif "anomaly" in task:
+        fxt_export_list = [
+            ExportCase2Test("ONNX", False, "exported_model.onnx"),
+            ExportCase2Test("OPENVINO", False, "exported_model.xml"),
+        ]  # anomaly doesn't support exportable code
 
     overrides = fxt_cli_override_command_per_task[task]
     if "anomaly" in task:

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from collections import namedtuple
 from pathlib import Path
 
 import cv2
@@ -12,18 +11,7 @@ import yaml
 from otx.core.types.task import OTXTaskType
 from otx.engine.utils.auto_configurator import DEFAULT_CONFIG_PER_TASK
 
-from tests.utils import run_main
-
-ExportCase2Test = namedtuple("ExportCase2Test", ["export_format", "export_demo_package", "expected_output"])
-
-
-@pytest.fixture()
-def fxt_export_list() -> list[ExportCase2Test]:
-    return [
-        ExportCase2Test("ONNX", False, "exported_model.onnx"),
-        ExportCase2Test("OPENVINO", False, "exported_model.xml"),
-        ExportCase2Test("OPENVINO", True, "exportable_code.zip"),
-    ]
+from tests.utils import ExportCase2Test, run_main
 
 
 @pytest.fixture(

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -156,6 +156,14 @@ def test_otx_e2e(
     assert (latest_dir / "csv").exists()
 
     # 3) otx export
+    if any(
+        task_name in recipe
+        for task_name in [
+            "dino_v2",
+            "rotated_detection/maskrcnn",
+        ]
+    ):
+        return
     if task in ("visual_prompting", "zero_shot_visual_prompting"):
         fxt_export_list = [
             ExportCase2Test("ONNX", False, "exported_model_decoder.onnx"),
@@ -245,6 +253,8 @@ def test_otx_e2e(
     assert latest_dir.exists()
 
     # 5) otx export with XAI
+    if "instance_segmentation/rtmdet_inst_tiny" in recipe:
+        return
     if ("_cls" not in task) and (task not in ["detection", "instance_segmentation"]):
         return  # Supported only for classification, detection and instance segmentation task.
 

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -156,18 +156,6 @@ def test_otx_e2e(
     assert (latest_dir / "csv").exists()
 
     # 3) otx export
-    if any(
-        task_name in recipe
-        for task_name in [
-            "h_label_cls",
-            "detection",
-            "dino_v2",
-            "instance_segmentation",
-            "action",
-        ]
-    ):
-        return
-
     if task in ("visual_prompting", "zero_shot_visual_prompting"):
         fxt_export_list = [
             ExportCase2Test("ONNX", False, "exported_model_decoder.onnx"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import logging
 import subprocess
 import sys
+from collections import namedtuple
 from unittest.mock import patch
 
 from otx.cli import main
+
+ExportCase2Test = namedtuple("ExportCase2Test", ["export_format", "export_demo_package", "expected_output"])
 
 
 def run_main(command_cfg: list[str], open_subprocess: bool) -> None:


### PR DESCRIPTION
### Summary
Currently, some tasks and models are excluded from export test in `test_otx_e2e`,
because it isn't supported at that time. But it's supported now so include these tasks and models.
Additionally, PR excluded exportable code test from anomaly tasks. Anomaly tasks don't support exportable_code now.

### Integration test result

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
