### PR TITLE
Fix zero-shot learning performance degradation after PTQ

### DIFF
--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -1118,7 +1118,7 @@ class OVZeroShotVisualPromptingModel(
         # ticket no. : CVS-135462
         # There is segmentation fault issue when using num_workers > 0 during releasing memory.
         # To avoid this issue, force num_workers to 0.
-        data_module.config.train_subset.num_workers = 0
+        data_module.config.val_subset.num_workers = 0
 
         output_model_paths: dict[str, Path] = {}
         for module in ["image_encoder", "decoder"]:
@@ -1129,7 +1129,7 @@ class OVZeroShotVisualPromptingModel(
                 msg = "Model is already optimized by PTQ"
                 raise RuntimeError(msg)
 
-            train_dataset = data_module.train_dataloader()
+            val_dataset = data_module.val_dataloader()
 
             ptq_config_from_ir = self._read_ptq_config_from_ir(ov_model)
             if ptq_config is not None:
@@ -1138,7 +1138,7 @@ class OVZeroShotVisualPromptingModel(
             else:
                 ptq_config = ptq_config_from_ir
 
-            quantization_dataset = nncf.Dataset(train_dataset, partial(transform_fn, module=module))  # type: ignore[attr-defined]
+            quantization_dataset = nncf.Dataset(val_dataset, partial(transform_fn, module=module))  # type: ignore[attr-defined]
 
             compressed_model = nncf.quantize(  # type: ignore[attr-defined]
                 ov_model,


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

ticket no : 145764

Current benchmark dataset for zsl has a very small sample in trainset, so insufficient statistics for PTQ can be obtained.
By temporarily changing dataset from trainset to valset, more samples can be used during PTQ.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
