### PR TITLE
Improve polygon utils

### DIFF
--- a/src/otx/core/data/transform_libs/utils.py
+++ b/src/otx/core/data/transform_libs/utils.py
@@ -192,13 +192,12 @@ def rescale_polygons(polygons: list[Polygon], scale_factor: float | tuple[float,
     else:
         h_scale, w_scale = scale_factor
 
-    resized_polygons = []
     for polygon in polygons:
-        p = np.asarray(polygon.points).copy()
+        p = np.asarray(polygon.points)
         p[0::2] *= w_scale
         p[1::2] *= h_scale
-        resized_polygons.append(Polygon(points=p.tolist(), label=polygon.label, z_order=polygon.z_order))
-    return resized_polygons
+        polygon.points = p.tolist()
+    return polygons
 
 
 def translate_bboxes(boxes: Tensor, distances: Sequence[float]) -> Tensor:
@@ -295,15 +294,14 @@ def translate_polygons(
         border_value is None or border_value == 0
     ), f"Here border_value is not used, and defaultly should be None or 0. got {border_value}."
 
-    translated_polygons = []
     for polygon in polygons:
-        p = np.asarray(polygon.points).copy()
+        p = np.asarray(polygon.points)
         if direction == "horizontal":
             p[0::2] = np.clip(p[0::2] + offset, 0, out_shape[1])
         elif direction == "vertical":
             p[1::2] = np.clip(p[1::2] + offset, 0, out_shape[0])
-        translated_polygons.append(Polygon(points=p.tolist(), label=polygon.label, z_order=polygon.z_order))
-    return translated_polygons
+        polygon.points = p.tolist()
+    return polygons
 
 
 def _get_translate_matrix(offset: int | float, direction: str = "horizontal") -> np.ndarray:
@@ -701,9 +699,8 @@ def flip_masks(masks: np.ndarray, direction: str = "horizontal") -> np.ndarray:
 
 def flip_polygons(polygons: list[Polygon], height: int, width: int, direction: str = "horizontal") -> list[Polygon]:
     """Flip polygons alone the given direction."""
-    flipped_masks = []
     for polygon in polygons:
-        p = np.asarray(polygon.points).copy()
+        p = np.asarray(polygon.points)
         if direction == "horizontal":
             p[0::2] = width - p[0::2]
         elif direction == "vertical":
@@ -711,8 +708,8 @@ def flip_polygons(polygons: list[Polygon], height: int, width: int, direction: s
         else:
             p[0::2] = width - p[0::2]
             p[1::2] = height - p[1::2]
-        flipped_masks.append(Polygon(points=p.tolist(), label=polygon.label, z_order=polygon.z_order))
-    return flipped_masks
+        polygon.points = p.tolist()
+    return polygons
 
 
 def project_bboxes(boxes: Tensor, homography_matrix: Tensor | np.ndarray) -> Tensor:

--- a/src/otx/core/data/transform_libs/utils.py
+++ b/src/otx/core/data/transform_libs/utils.py
@@ -804,7 +804,6 @@ def crop_polygons(polygons: list[Polygon], bbox: np.ndarray, height: int, width:
 
     # reference: https://github.com/facebookresearch/fvcore/blob/main/fvcore/transforms/transform.py
     crop_box = geometry.box(x1, y1, x2, y2).buffer(0.0)
-    # cropped_polygons: list[Polygon] = []
     # suppress shapely warnings util it incorporates GEOS>=3.11.2
     # reference: https://github.com/shapely/shapely/issues/1345
     initial_settings = np.seterr()


### PR DESCRIPTION
### Summary

Creating dm.Polygon is not compute-efficient way because of running annotation validation.
So, through this PR, I would like to reuse the current dm.Polygon annotations instead.

With RTMDet-Tiny model on large instance segmentation dataset (5 times repeat), I can reduce 2.5% iteration time on average.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/wonjulee/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/wonjulee/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
</head>

<body link="#467886" vlink="#96607D">


  | epoch | e2e | iter time | f1
-- | -- | -- | -- | --
develop | 30.2 | 326.5254 | 0.32453617 | 0.44547
fix_polygon | 29 | 310.143 | 0.31644868 | 0.451077

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/wonjulee/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/wonjulee/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-family:Consolas, monospace;
	mso-font-charset:0;}
.xl66
	{background:yellow;
	mso-pattern:black none;}
.xl67
	{font-family:Consolas, monospace;
	mso-font-charset:0;
	background:yellow;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


  | develop | fix_polygon | reduction (%)
-- | -- | -- | --
otx.core.data.transform_libs.torchvision.CachedMosaic: | 0.28111 | 0.27406 | 2.507683577
otx.core.data.transform_libs.torchvision.RandomResize: | 0.02781 | 0.02545 | 8.486345826
otx.core.data.transform_libs.torchvision.RandomCrop: | 0.00561 | 0.00499 | 11.1882294
otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug: | 0.00529 | 0.00513 | 3.088670277
otx.core.data.transform_libs.torchvision.RandomFlip: | 0.00058 | 0.00044 | 24.97037152
otx.core.data.transform_libs.torchvision.Pad: | 0.00109 | 0.00107 | 2.479535156
otx.core.data.transform_libs.torchvision.CachedMixUp: | 0.01892 | 0.01944 | -2.76476453
otx.core.data.transform_libs.torchvision.FilterAnnotations: | 0.00186 | 0.00186 | 0.312082033
torchvision.transforms.v2._misc.ToDtype: | 0.00122 | 0.00139 | -13.44773689
torchvision.transforms.v2._misc.Normalize: | 0.00256 | 0.00265 | -3.36598766
SUM | 0.346057 | 0.336452 | 2.775750417



</body>

</html>


</body>

</html>


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
