### PR TITLE
Fix `load_reference_info` for zero-shot learning

### DIFF
--- a/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
+++ b/src/otx/algo/visual_prompting/zero_shot_segment_anything.py
@@ -926,15 +926,19 @@ class OTXZeroShotSegmentAnything(OTXZeroShotVisualPromptingModel):
             log.info(f"reference info saved at {path_to_directly_load} was successfully loaded.")
 
         else:
-            _infer_reference_info_root: Path = (
-                self.infer_reference_info_root
-                if self.infer_reference_info_root == self.infer_reference_info_root.absolute()
-                else Path(default_root_dir) / self.infer_reference_info_root
-            )
+            if str(self.infer_reference_info_root) == "../.latest/train":
+                # for default setting
+                path_reference_info = (
+                    Path(default_root_dir)
+                    / self.infer_reference_info_root
+                    / self.reference_info_dir
+                    / "reference_info.pt"
+                )
+            else:
+                # for user input
+                path_reference_info = self.infer_reference_info_root / self.reference_info_dir / "reference_info.pt"
 
-            if (
-                path_reference_info := _infer_reference_info_root / self.reference_info_dir / "reference_info.pt"
-            ).is_file():
+            if path_reference_info.is_file():
                 reference_info = torch.load(path_reference_info)
                 retval = True
                 log.info(f"reference info saved at {path_reference_info} was successfully loaded.")

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -1193,15 +1193,19 @@ class OVZeroShotVisualPromptingModel(
             # if `path_to_directly_load` is given, forcely load
             return _load_and_assign_reference_info(path_to_directly_load)
 
-        _infer_reference_info_root: Path = (
-            self.infer_reference_info_root
-            if self.infer_reference_info_root == self.infer_reference_info_root.absolute()
-            else Path(default_root_dir) / self.infer_reference_info_root
-        )
+        if str(self.infer_reference_info_root) == "../.latest/train":
+            # for default setting
+            path_reference_info = (
+                Path(default_root_dir)
+                / self.infer_reference_info_root
+                / self.reference_info_dir
+                / "reference_info.pickle"
+            )
+        else:
+            # for user input
+            path_reference_info = self.infer_reference_info_root / self.reference_info_dir / "reference_info.pickle"
 
-        if (
-            path_reference_info := _infer_reference_info_root / self.reference_info_dir / "reference_info.pickle"
-        ).is_file():
+        if path_reference_info.is_file():
             return _load_and_assign_reference_info(path_reference_info)
 
         return False

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -363,6 +363,7 @@ class OTXZeroShotVisualPromptingModel(
         if not self.load_reference_info(self.trainer.default_root_dir, self.device):
             log.warning("No reference info found. `Learn` will be automatically executed first.")
             self.trainer.lightning_module.automatic_optimization = False
+            self.training = True
             self.trainer.fit_loop.run()
             # to use infer logic
             self.training = False
@@ -1244,6 +1245,7 @@ class OVZeroShotVisualPromptingModel(
         if not self.load_reference_info(self.trainer.default_root_dir):
             log.warning("No reference info found. `Learn` will be automatically executed first.")
             self.trainer.lightning_module.automatic_optimization = False
+            self.training = True
             self.trainer.fit_loop.run()
             # to use infer logic
             self.training = False

--- a/src/otx/core/model/visual_prompting.py
+++ b/src/otx/core/model/visual_prompting.py
@@ -345,6 +345,7 @@ class OTXZeroShotVisualPromptingModel(
         if not self.load_reference_info(self.trainer.default_root_dir, self.device):
             log.warning("No reference info found. `Learn` will be automatically executed first.")
             self.trainer.lightning_module.automatic_optimization = False
+            self.training = True
             self.trainer.fit_loop.run()
             # to use infer logic
             self.training = False
@@ -1226,6 +1227,7 @@ class OVZeroShotVisualPromptingModel(
         if not self.load_reference_info(self.trainer.default_root_dir):
             log.warning("No reference info found. `Learn` will be automatically executed first.")
             self.trainer.lightning_module.automatic_optimization = False
+            self.training = True
             self.trainer.fit_loop.run()
             # to use infer logic
             self.training = False

--- a/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
@@ -7,7 +7,7 @@ model:
     async_inference: False
     use_throughput_mode: True
     reference_info_dir: reference_infos
-    infer_reference_info_root: ../.latest/train # set absolute path for using reference_info saved in other location
+    infer_reference_info_root: ../.latest/train
     save_outputs: True
 
 engine:

--- a/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml
@@ -10,7 +10,7 @@ model:
     default_threshold_target: 0.65
     save_outputs: True
     reference_info_dir: reference_infos
-    infer_reference_info_root: ../.latest/train # set absolute path for using reference_info saved in other location
+    infer_reference_info_root: ../.latest/train
     # options
     use_stability_score: False
     return_single_mask: False

--- a/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/sam_vit_b.yaml
@@ -10,7 +10,7 @@ model:
     default_threshold_target: 0.65
     save_outputs: True
     reference_info_dir: reference_infos
-    infer_reference_info_root: ../.latest/train # set absolute path for using reference_info saved in other location
+    infer_reference_info_root: ../.latest/train
     # options
     use_stability_score: False
     return_single_mask: False

--- a/tests/integration/api/test_auto_configuration.py
+++ b/tests/integration/api/test_auto_configuration.py
@@ -44,7 +44,7 @@ def test_auto_configuration(
         device=fxt_accelerator,
     )
     if task.lower() == "zero_shot_visual_prompting":
-        engine.model.infer_reference_info_root = Path()
+        engine.model.infer_reference_info_root = Path(tmp_path_train)
         # update litmodule.hparams to reflect changed hparams
         engine.model.hparams.update({"infer_reference_info_root": str(engine.model.infer_reference_info_root)})
 

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -48,7 +48,7 @@ def test_engine_from_config(
         device=fxt_accelerator,
     )
     if task.lower() == "zero_shot_visual_prompting":
-        engine.model.infer_reference_info_root = Path()
+        engine.model.infer_reference_info_root = Path(tmp_path_train)
         # update litmodule.hparams to reflect changed hparams
         engine.model.hparams.update({"infer_reference_info_root": str(engine.model.infer_reference_info_root)})
 
@@ -97,7 +97,7 @@ def test_engine_from_config(
                     model_name=str(exported_model_path["decoder"]),
                     label_info=engine.datamodule.label_info,
                 )
-                engine.model.infer_reference_info_root = Path()
+                engine.model.infer_reference_info_root = Path(tmp_path_train)
                 # update litmodule.hparams to reflect changed hparams
                 engine.model.hparams.update({"infer_reference_info_root": str(engine.model.infer_reference_info_root)})
             test_metric_from_ov_model = engine.test(checkpoint=exported_model_path["decoder"], accelerator="cpu")


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
issue : https://github.com/openvinotoolkit/training_extensions/issues/3708

This PR includes:

- [x] Fix `load_reference_info`
    - If `model.infer_reference_info_root` isn't given, the default value `../.latest/train` is used.
    - If `model.infer_reference_info_root` is given regardless of relative or absolute path, given path is used.
    - If given `model.infer_reference_info_root` is wrong, `learn` is automatically executed before `infer`.
- [x] Fix `on_test_start` and `on_predict_start`

After this fix, e2e logs are below:
```python
$ otx train \
    --config src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl

...
┏━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┓
┃   ┃ Name  ┃ Type                    ┃ Params ┃
┡━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━┩
│ 0 │ model │ ZeroShotSegmentAnything │  9.8 M │
└───┴───────┴─────────────────────────┴────────┘
Trainable params: 0                                                                                                                                                                                                                                             
Non-trainable params: 9.8 M                                                                                                                                                                                                                                     
Total params: 9.8 M                                                                                                                                                                                                                                             
Total estimated model params size (MB): 39
...
Epoch 0/0  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 0:00:05 • 0:00:00 0.41it/s v_num: 0`Trainer.fit` stopped: `max_epochs=1` reached.
Epoch 0/0  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 0:00:05 • 0:00:00 0.41it/s v_num: 0 train/data_time: 2.371 train/iter_time: 2.412
Elapsed time: 0:00:30.213791
```
```python
# for default reference_info path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl

...
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │    0.08899950236082077    │
│         test/dice         │    0.6554691791534424     │
│       test/f1-score       │    0.6554691791534424     │
│         test/iou          │    0.48750776052474976    │
│      test/iter_time       │    0.22162841260433197    │
...
└───────────────────────────┴───────────────────────────┘
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:00:33 • 0:00:00 5.10it/s  
Elapsed time: 0:00:43.963639
```
```python
# for manual input with relative path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --model.infer_reference_info_root otx-workspace/zsl/20240704_060002

...
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │    0.09288851171731949    │
│         test/dice         │    0.6554691791534424     │
│       test/f1-score       │    0.6554691791534424     │
│         test/iou          │    0.48750776052474976    │
│      test/iter_time       │    0.22786562144756317    │
...
└───────────────────────────┴───────────────────────────┘
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:00:34 • 0:00:00 4.98it/s  
Elapsed time: 0:00:45.216707
```
```python
# for manual input with absolute path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --model.infer_reference_info_root /home/sungchul/workspace/src/otx_v2/otx-workspace/zsl/20240704_060002

...
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │    0.09724551439285278    │
│         test/dice         │    0.6554691791534424     │
│       test/f1-score       │    0.6554691791534424     │
│         test/iou          │    0.48750776052474976    │
│      test/iter_time       │    0.2406773418188095     │
...
└───────────────────────────┴───────────────────────────┘
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:00:36 • 0:00:00 5.64it/s  
Elapsed time: 0:00:49.751407
```
```python
# for manual input with wrong path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --model.infer_reference_info_root otx-workspace/zsl/20240704_060002

...
WARNING:root:No reference info found. `Learn` will be automatically executed first.
Epoch 0/0  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 0:00:33 • 0:00:00 0.18it/s  `Trainer.fit` stopped: `max_epochs=1` reached.
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │    0.10635541379451752    │
│         test/dice         │    0.6533128619194031     │
│       test/f1-score       │    0.6533128619194031     │
│         test/iou          │    0.48512592911720276    │
│      test/iter_time       │    0.2627294957637787     │
...
└───────────────────────────┴───────────────────────────┘
Epoch 0/0  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2     0:00:33 • 0:00:00 0.18it/s  
Testing    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:00:39 • 0:00:00 5.12it/s  
Elapsed time: 0:01:40.345291
```
```python
$ otx export \
    --config src/otx/recipe/zero_shot_visual_prompting/sam_tiny_vit.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --checkpoint otx-workspace/zsl/.latest/train/best_checkpoint.ckpt
```
```python
# for default reference_info path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --checkpoint otx-workspace/zsl/.latest/export/exported_model_decoder.xml

...
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │   0.023147372528910637    │
│         test/dice         │    0.6657536029815674     │
│       test/f1-score       │    0.6657536029815674     │
│         test/iou          │    0.4989734888076782     │
│      test/iter_time       │    0.8636393547058105     │
...
└───────────────────────────┴───────────────────────────┘
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:02:09 • 0:00:00 1.21it/s  
Elapsed time: 0:02:28.921404
```
```python
# for manual input with relative path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --checkpoint otx-workspace/zsl/.latest/export/exported_model_decoder.xml

...
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │   0.021157853305339813    │
│         test/dice         │    0.6657536029815674     │
│       test/f1-score       │    0.6657536029815674     │
│         test/iou          │    0.4989734888076782     │
│      test/iter_time       │    0.8655378222465515     │
...
└───────────────────────────┴───────────────────────────┘
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:02:09 • 0:00:00 1.20it/s  
Elapsed time: 0:02:27.640549
```
```python
# for manual input with absolute path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --checkpoint otx-workspace/zsl/.latest/export/exported_model_decoder.xml \
    --model.infer_reference_info_root /home/sungchul/workspace/src/otx_v2/otx-workspace/zsl/20240704_060002

...
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │   0.011705875396728516    │
│         test/dice         │    0.6657536029815674     │
│       test/f1-score       │    0.6657536029815674     │
│         test/iou          │    0.4989734888076782     │
│      test/iter_time       │    0.8791705369949341     │
...
└───────────────────────────┴───────────────────────────┘
Testing ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:02:12 • 0:00:00 1.18it/s  
Elapsed time: 0:02:31.881842
```
```python
# for manual input with wrong path
$ otx test \
    --config src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml \
    --data_root data/coco_car_person_medium \
    --work_dir otx-workspace/zsl \
    --checkpoint otx-workspace/zsl/.latest/export/exported_model_decoder.xml \
    --model.infer_reference_info_root otx-workspace/zsl/wrong_path

...
WARNING:root:No reference info found. `Learn` will be automatically executed first.
Epoch 0/0  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 0:00:27 • 0:00:00 0.09it/s  `Trainer.fit` stopped: `max_epochs=1` reached.
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃        Test metric        ┃       DataLoader 0        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│      test/data_time       │    0.02215653471648693    │
│         test/dice         │    0.6496707797050476     │
│       test/f1-score       │    0.6496707797050476     │
│         test/iou          │    0.4811202585697174     │
│      test/iter_time       │    0.9241068959236145     │
...
└───────────────────────────┴───────────────────────────┘
Epoch 0/0  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2     0:00:27 • 0:00:00 0.09it/s  
Testing    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 150/150 0:02:17 • 0:00:00 1.12it/s  
Elapsed time: 0:03:01.468946
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```shell
$ tox -vv -e integration-test-visual_prompting
===== 18 passed, 13 skipped, 2 xfailed, 55 warnings in 976.88s (0:16:16) =====
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
