### PR TITLE
Fix a wrong action classification transform_fn for PTQ

### DIFF
--- a/src/otx/core/model/action_classification.py
+++ b/src/otx/core/model/action_classification.py
@@ -349,8 +349,7 @@ class OVActionClsModel(
         """Data transform function for PTQ."""
         np_data = self._customize_inputs(data_batch)
         vid = np_data["inputs"][0]
-        vid = self.model.preprocess(vid)[0][self.model.image_blob_name]
-        return self.model._change_layout(vid)  # noqa: SLF001
+        return self.model.preprocess(vid)[0][self.model.image_blob_name]
 
     @property
     def model_adapter_parameters(self) -> dict:


### PR DESCRIPTION
### Summary
After updating model_api version, Action cls OV model wrapper is moved from OTX to model_api w/ refactoring.
The refactoring changed `preprocess` function to execute `_change_layout`.
But `transform_fn` function in current OTX executes `preprocess` and `_change_layout`, which executes same function twice.
This PR fixes it.

### Integration test result
![image](https://github.com/openvinotoolkit/training_extensions/assets/92974184/6df1febe-62d5-4003-9990-56820ad4ebed)
command : python -m pytest tests/integration -ra --showlocals --task action --open-subprocess


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
