### PR TITLE
Fix Combined Dataloader & unlabeled warmup loss to work correctly in Semi-SL case

### DIFF
--- a/src/otx/algo/callbacks/unlabeled_loss_warmup.py
+++ b/src/otx/algo/callbacks/unlabeled_loss_warmup.py
@@ -36,7 +36,12 @@ class UnlabeledLossWarmUpCallback(Callback):
         """Calculate the unlabeled warm-up loss coefficient before training iteration."""
         if self.unlabeled_coef < 1.0:
             if self.total_steps == 0:
-                self.total_steps = int(trainer.max_epochs * len(trainer.train_dataloader) * self.warmup_steps_ratio)
+                dataloader = (
+                    trainer.train_dataloader["labeled"]
+                    if isinstance(trainer.train_dataloader, dict)
+                    else trainer.train_dataloader
+                )
+                self.total_steps = int(trainer.max_epochs * len(dataloader) * self.warmup_steps_ratio)
             self.unlabeled_coef = 0.5 * (
                 1 - math.cos(min(math.pi, (2 * math.pi * self.current_step) / self.total_steps))
             )


### PR DESCRIPTION
### Summary

Fixes some edge cases showing unintended behavior.
1. If the number of iters in the unlabeled dataloader is less than the number of iters in the labeled dataloader, find that combined dataloader are acting on the basis of the unlabeled dataloader and fix this.
2. Found that unlabeled warmup loss in Semi-SL was not working properly and had a shorter warmup time than expected, so fix this.

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Model | Method | Test/Accuracy | E2E Time | Epochs
-- | -- | -- | -- | --
EfficientNet-B0 | SL     (Pseudo-Labeled dataset) | 0.5863 | 0:00:27 | 24
  | Semi-SL     (batch size: 16/48) | 0.4675 | 0:08:55 | 60
  | Semi-SL #Hot-Fix     (batch size: 16/48) | 0.6058 | 0:17:24 | 115



</div>

<!--EndFragment-->
</body>

</html>



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
