### PR TITLE
Disable mixed preicision to NMS on CPU

### DIFF
--- a/tests/unit/algo/common/utils/test_nms.py
+++ b/tests/unit/algo/common/utils/test_nms.py
@@ -133,7 +133,7 @@ class TestNMSop:
         assert (mock_torch_nms.call_args[0][1] == mock_scores[0]).all()
         assert list(nms) == [0]
 
-    def test_forward_cpu_bfx(
+    def test_forward_cpu_bf16(
         self,
         mock_torch_nms: MagicMock,
         mock_torch_autocast: MagicMock,

--- a/tests/unit/algo/common/utils/test_nms.py
+++ b/tests/unit/algo/common/utils/test_nms.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Test NMS related class and functions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from otx.algo.common.utils import nms as target_file
+from otx.algo.common.utils.nms import NMSop
+
+
+class TestNMSop:
+    @pytest.fixture()
+    def mock_torch_nms(self, mocker) -> MagicMock:
+        def func(bboxes: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+            return torch.tensor(range(min(bboxes.size(0), 2)))
+
+        return mocker.patch.object(target_file, "torch_nms", side_effect=func)
+
+    @pytest.fixture()
+    def mock_torch_autocast(self, mocker) -> MagicMock:
+        return mocker.patch("otx.algo.common.utils.nms.torch.autocast")
+
+    @pytest.fixture()
+    def mock_bboxes(self) -> torch.Tensor:
+        bboxes = torch.tensor(
+            [
+                [1.0, 1.0, 2.0, 2.0],
+                [2.0, 2.0, 3.0, 3.0],
+                [3.0, 3.0, 4.0, 4.0],
+                [4.0, 4.0, 5.0, 5.0],
+                [5.0, 5.0, 6.0, 6.0],
+                [6.0, 6.0, 7.0, 7.0],
+            ],
+            dtype=torch.float32,
+        )
+        bboxes.get_device = MagicMock(return_value=0)
+        return bboxes
+
+    @pytest.fixture()
+    def mock_bboxes_bfp16_cpu(self, mock_bboxes: torch.Tensor) -> torch.Tensor:
+        bboxes = mock_bboxes.type(torch.bfloat16)
+        bboxes.get_device = MagicMock(return_value=-1)
+        return bboxes
+
+    @pytest.fixture()
+    def mock_scores(self) -> torch.Tensor:
+        scores = torch.tensor([0.9, 0.8, 0.7, 0.6, 0.5, 0.4], dtype=torch.float32)
+        scores.get_device = MagicMock(return_value=0)
+        return scores
+
+    @pytest.fixture()
+    def mock_scores_bfp16_cpu(self, mock_scores: torch.Tensor) -> torch.Tensor:
+        scores = mock_scores.type(torch.bfloat16)
+        scores.get_device = MagicMock(return_value=-1)
+        return scores
+
+    @pytest.fixture()
+    def mock_iou_threshold(self) -> MagicMock:
+        return MagicMock()
+
+    def test_forward(
+        self,
+        mock_torch_nms: MagicMock,
+        mock_torch_autocast: MagicMock,
+        mock_iou_threshold: MagicMock,
+        mock_bboxes: target_file.Tensor,
+        mock_scores: target_file.Tensor,
+    ):
+        nmsop = NMSop()
+        nms = nmsop.forward(
+            ctx=MagicMock(),
+            bboxes=mock_bboxes,
+            scores=mock_scores,
+            iou_threshold=mock_iou_threshold,
+            offset=MagicMock(),
+            score_threshold=0.0,
+            max_num=0,
+        )
+
+        mock_torch_autocast.assert_not_called()
+        mock_torch_nms.assert_called_once_with(mock_bboxes, mock_scores, mock_iou_threshold)
+        assert list(nms) == [0, 1]
+
+    def test_forward_w_max_num(
+        self,
+        mock_torch_nms: MagicMock,
+        mock_torch_autocast: MagicMock,
+        mock_iou_threshold: MagicMock,
+        mock_bboxes: target_file.Tensor,
+        mock_scores: target_file.Tensor,
+    ):
+        nmsop = NMSop()
+        nms = nmsop.forward(
+            ctx=MagicMock(),
+            bboxes=mock_bboxes,
+            scores=mock_scores,
+            iou_threshold=mock_iou_threshold,
+            offset=MagicMock(),
+            score_threshold=0.0,
+            max_num=1,
+        )
+
+        mock_torch_autocast.assert_not_called()
+        mock_torch_nms.assert_called_once_with(mock_bboxes, mock_scores, mock_iou_threshold)
+        assert list(nms) == [0]
+
+    def test_forward_w_score_threshold(
+        self,
+        mock_torch_nms: MagicMock,
+        mock_torch_autocast: MagicMock,
+        mock_iou_threshold: MagicMock,
+        mock_bboxes: target_file.Tensor,
+        mock_scores: target_file.Tensor,
+    ):
+        nmsop = NMSop()
+        nms = nmsop.forward(
+            ctx=MagicMock(),
+            bboxes=mock_bboxes,
+            scores=mock_scores,
+            iou_threshold=mock_iou_threshold,
+            offset=MagicMock(),
+            score_threshold=0.85,
+            max_num=0,
+        )
+
+        mock_torch_autocast.assert_not_called()
+        mock_torch_nms.assert_called()
+        assert (mock_torch_nms.call_args[0][0] == mock_bboxes[0]).all()
+        assert (mock_torch_nms.call_args[0][1] == mock_scores[0]).all()
+        assert list(nms) == [0]
+
+    def test_forward_cpu_bfx(
+        self,
+        mock_torch_nms: MagicMock,
+        mock_torch_autocast: MagicMock,
+        mock_iou_threshold: MagicMock,
+        mock_bboxes_bfp16_cpu: target_file.Tensor,
+        mock_scores_bfp16_cpu: target_file.Tensor,
+    ):
+        nmsop = NMSop()
+        nms = nmsop.forward(
+            ctx=MagicMock(),
+            bboxes=mock_bboxes_bfp16_cpu,
+            scores=mock_scores_bfp16_cpu,
+            iou_threshold=mock_iou_threshold,
+            offset=MagicMock(),
+            score_threshold=0.0,
+            max_num=0,
+        )
+
+        mock_torch_autocast.assert_called()
+        assert mock_torch_autocast.call_args.kwargs["enabled"] is False
+        mock_torch_nms.assert_called()
+        assert mock_torch_nms.call_args.args[0][0].dtype == torch.float32
+        assert mock_torch_nms.call_args.args[0][1].dtype == torch.float32
+        assert list(nms) == [0, 1]


### PR DESCRIPTION
### Summary
when using mixed precision on CPU, lightning uses bfp16 because torch amp doesn't support fp16 on CPU.
But torch nms kernel doesn't support bfp16, which makes error when running detection models on CPU.
This PR fixes it.

**Integration test result**
<img width="737" alt="image" src="https://github.com/user-attachments/assets/32604618-6530-4c59-a8c5-ddeabefba69c">
detection intg test : pytest tests/integration -ra --showlocals --task detection --open-subprocess
<img width="734" alt="image" src="https://github.com/user-attachments/assets/d7b3bb18-ece9-4b9e-906e-dbbd302bb2a2">
ins seg intg test : pytest tests/integration -ra --showlocals --task instance_segmentation --open-subprocess

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
