### PR TITLE
Update transforms for configurable input size

### DIFF
--- a/src/otx/algo/detection/ssd.py
+++ b/src/otx/algo/detection/ssd.py
@@ -395,7 +395,7 @@ class SSD(ExplainableOTXDetModel):
         if isinstance(dataset.transforms, Compose):
             for transform in dataset.transforms.transforms:
                 if isinstance(transform, Resize):
-                    target_wh = transform.scale
+                    target_wh = transform.resize_size
         if target_wh is None:
             target_wh = (864, 864)
             msg = f"Cannot get target_wh from the dataset. Assign it with the default value: {target_wh}"

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -2492,30 +2492,28 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
         **resize_kwargs,
     ) -> None:
         super().__init__()
-        if resize_size is not None and (
-            not isinstance(resize_size, Sequence)
+
+        # for configurable input size
+        self.input_size = input_size
+        self._resize_size = resize_size
+        self.resize_size_scale = resize_size_scale
+
+        if self.resize_size is not None and (
+            not isinstance(self.resize_size, Sequence)
             or not (
-                all(isinstance(rs, int) for rs in resize_size)
-                or all(isinstance(rs, tuple) and all(isinstance(ps, int) for ps in rs) for rs in resize_size)
+                all(isinstance(rs, int) for rs in self.resize_size)
+                or all(isinstance(rs, tuple) and all(isinstance(ps, int) for ps in rs) for rs in self.resize_size)
             )
         ):
-            msg = f"resize_size must be Sequence[int] or Sequence[tuple[int, int]], but got `{type(resize_size)}"
-            if isinstance(resize_size, Sequence):
-                msg += f"[{type(resize_size[0])}"
-                if isinstance(resize_size[0], tuple):
-                    msg += f"[{type(resize_size[0][0])}]"
+            msg = f"resize_size must be Sequence[int] or Sequence[tuple[int, int]], but got `{type(self.resize_size)}"
+            if isinstance(self.resize_size, Sequence):
+                msg += f"[{type(self.resize_size[0])}"
+                if isinstance(self.resize_size[0], tuple):
+                    msg += f"[{type(self.resize_size[0][0])}]"
                 msg += "]"
             msg += "`."
             raise TypeError(msg)
 
-        if isinstance(resize_size, list):
-            resize_size = tuple(resize_size)
-
-        # for configurable input size
-        self._resize_size = resize_size
-        self.resize_size_scale = resize_size_scale
-
-        self.input_size = input_size
         self.ratio_range = ratio_range
         self.resize_kwargs = resize_kwargs
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
@@ -2529,6 +2527,8 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
                 int(self.input_size[0] * self.resize_size_scale[0]),
                 int(self.input_size[1] * self.resize_size_scale[1]),
             )
+        elif isinstance(self._resize_size, list):
+            self._resize_size = tuple(self._resize_size)
 
         return self._resize_size
 

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -472,8 +472,8 @@ class Resize(tvt_v2.Transform, NumpytoTVTensorMixin):
     TODO : optimize logic to torcivision pipeline
 
     Args:
-        scale (int or tuple): Images scales for resizing with (height, width). Defaults to None
-        scale_factor (float or tuple[float]): Scale factors for resizing with (height, width).
+        scale (int or Sequence[int]): Images scales for resizing with (height, width). Defaults to None
+        scale_factor (float or Sequence[float]): Scale factors for resizing with (height, width).
             Defaults to None.
         keep_ratio (bool): Whether to keep the aspect ratio when resizing the
             image. Defaults to False.
@@ -489,10 +489,12 @@ class Resize(tvt_v2.Transform, NumpytoTVTensorMixin):
         is_numpy_to_tvtensor (bool): Whether convert outputs to tensor. Defaults to False.
     """
 
+    scale_factor: float | Sequence[float] | None
+
     def __init__(
         self,
-        scale: int | tuple[int, int] | None = None,  # (H, W)
-        scale_factor: float | tuple[float, float] | None = None,  # (H, W)
+        scale: int | Sequence[int] | None = None,  # (H, W)
+        scale_factor: float | Sequence[float] | None = None,  # (H, W)
         keep_ratio: bool = False,
         clip_object_border: bool = True,
         interpolation: str = "bilinear",
@@ -524,10 +526,10 @@ class Resize(tvt_v2.Transform, NumpytoTVTensorMixin):
             self.scale_factor = None
         elif isinstance(scale_factor, float):
             self.scale_factor = (scale_factor, scale_factor)
-        elif isinstance(scale_factor, tuple) and len(scale_factor) == 2:
-            self.scale_factor = scale_factor
+        elif isinstance(scale_factor, Sequence) and len(scale_factor) == 2:
+            self.scale_factor = tuple(scale_factor)
         else:
-            msg = f"expect scale_factor is float or Tuple(float), butget {type(scale_factor)}"
+            msg = f"expect scale_factor is float or Sequence[float], but get {type(scale_factor)}"
             raise TypeError(msg)
 
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
@@ -633,12 +635,12 @@ class RandomResizedCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
     is made. This crop is finally resized to given size.
 
     Args:
-        scale (sequence | int): Desired output scale of the crop. If size is an
-            int instead of sequence like (h, w), a square crop (size, size) is
+        scale (Sequence[int] or int): Desired output scale of the crop. If size is an
+            int instead of Sequence[int] like (h, w), a square crop (size, size) is
             made.
-        crop_ratio_range (tuple): Range of the random size of the cropped
+        crop_ratio_range (Sequence[float]): Range of the random size of the cropped
             image compared to the original image. Defaults to (0.08, 1.0).
-        aspect_ratio_range (tuple): Range of the random aspect ratio of the
+        aspect_ratio_range (Sequence[float]): Range of the random aspect ratio of the
             cropped image compared to the original image.
             Defaults to (3. / 4., 4. / 3.).
         max_attempts (int): Maximum number of attempts before falling back to
@@ -652,9 +654,9 @@ class RandomResizedCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     def __init__(
         self,
-        scale: Sequence | int,
-        crop_ratio_range: tuple[float, float] = (0.08, 1.0),
-        aspect_ratio_range: tuple[float, float] = (3.0 / 4.0, 4.0 / 3.0),
+        scale: Sequence[int] | int,
+        crop_ratio_range: Sequence[float] = (0.08, 1.0),
+        aspect_ratio_range: Sequence[float] = (3.0 / 4.0, 4.0 / 3.0),
         max_attempts: int = 10,
         interpolation: str = "bilinear",
         transform_mask: bool = False,
@@ -795,7 +797,7 @@ class RandomResizedCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
             bboxes (ndarray): Shape (k, 4) or (4, ), location of cropped bboxes.
             scale (float, optional): Scale ratio of bboxes, the default value
                 1.0 means no scaling.
-            pad_fill (Number | list[Number]): Value to be filled for padding.
+            pad_fill (float | list | list[float | list]): Value to be filled for padding.
                 Default: None, which means no padding.
 
         Returns:
@@ -897,7 +899,7 @@ class EfficientNetRandomCrop(RandomResizedCrop):
     Args:
         scale (int): Desired output scale of the crop. Only int size is
             accepted, a square crop (size, size) is made.
-        min_covered (Number): Minimum ratio of the cropped area to the original
+        min_covered (float): Minimum ratio of the cropped area to the original
              area. Defaults to 0.1.
         crop_padding (int): The crop padding parameter in efficientnet style
             center crop. Defaults to 32.
@@ -911,8 +913,6 @@ class EfficientNetRandomCrop(RandomResizedCrop):
         interpolation (str): Interpolation method, accepted values are
             'nearest', 'bilinear', 'bicubic', 'area', 'lanczos'. Defaults to
             'bicubic'.
-        backend (str): The image resize backend type, accepted values are
-            'cv2' and 'pillow'. Defaults to 'cv2'.
     """
 
     def __init__(
@@ -1027,9 +1027,9 @@ class RandomFlip(tvt_v2.Transform, NumpytoTVTensorMixin):
         probability of 0.3, vertically with probability of 0.5.
 
     Args:
-        prob (float | list[float], optional): The flipping probability.
+        prob (float | Iterable[float], optional): The flipping probability.
             Defaults to None.
-        direction(str | list[str]): The flipping direction. Options
+        direction(str | Sequence[str]): The flipping direction. Options
             If input is a list, the length must equal ``prob``. Each
             element in ``prob`` indicates the flip probability of
             corresponding direction. Defaults to 'horizontal'.
@@ -1150,8 +1150,8 @@ class PhotoMetricDistortion(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     Args:
         brightness_delta (int): delta of brightness.
-        contrast_range (sequence): range of contrast.
-        saturation_range (sequence): range of saturation.
+        contrast_range (Sequence[int | float]): range of contrast.
+        saturation_range (Sequence[int | float]): range of saturation.
         hue_delta (int): delta of hue.
         is_numpy_to_tvtensor (bool): Whether convert outputs to tensor. Defaults to False.
     """
@@ -1290,14 +1290,14 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             Defaults to 10.
         max_translate_ratio (float): Maximum ratio of translation.
             Defaults to 0.1.
-        scaling_ratio_range (tuple[float]): Min and max ratio of
+        scaling_ratio_range (Sequence[float]): Min and max ratio of
             scaling transform. Defaults to (0.5, 1.5).
         max_shear_degree (float): Maximum degrees of shear
             transform. Defaults to 2.
-        border (tuple[int]): Distance from height and width sides of input
+        border (Sequence[int]): Distance from height and width sides of input
             image to adjust output shape. Only used in mosaic dataset.
             Defaults to (0, 0).
-        border_val (tuple[int]): Border padding values of 3 channels.
+        border_val (Sequence[int]): Border padding values of 3 channels.
             Defaults to (114, 114, 114).
         bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. In some dataset like MOT17, the gt bboxes
@@ -1310,10 +1310,10 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         self,
         max_rotate_degree: float = 10.0,
         max_translate_ratio: float = 0.1,
-        scaling_ratio_range: tuple[float, float] = (0.5, 1.5),
+        scaling_ratio_range: Sequence[float] = (0.5, 1.5),
         max_shear_degree: float = 2.0,
-        border: tuple[int, int] = (0, 0),  # (H, W)
-        border_val: tuple[int, int, int] = (114, 114, 114),
+        border: Sequence[int] = (0, 0),  # (H, W)
+        border_val: Sequence[int] = (114, 114, 114),
         bbox_clip_border: bool = True,
         is_numpy_to_tvtensor: bool = False,
     ) -> None:
@@ -1368,13 +1368,13 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         inputs.image = img
         inputs.img_info = _resize_image_info(inputs.img_info, img.shape[:2])
 
-        bboxes = inputs.bboxes
-        num_bboxes = len(bboxes)
-        if num_bboxes:
+        if (bboxes := getattr(inputs, "bboxes", None)) is not None and len(bboxes) > 0:
             bboxes = project_bboxes(bboxes, warp_matrix)
             if self.bbox_clip_border:
                 bboxes = clip_bboxes(bboxes, (height, width))
             # remove outside bbox
+            # TODO (sungchul): fix the case about no valid index when height < 0 or width < 0
+            # due to border * 2 > height and width
             valid_index = is_inside_bboxes(bboxes, (height, width))
             inputs.bboxes = tv_tensors.BoundingBoxes(bboxes[valid_index], format="XYXY", canvas_size=(height, width))
             inputs.labels = inputs.labels[valid_index]
@@ -1430,7 +1430,7 @@ class CachedMosaic(tvt_v2.Transform, NumpytoTVTensorMixin):
         img_scale (Sequence[int]): Image size before mosaic pipeline of single
             image. The shape order should be (height, width).
             Defaults to (640, 640).
-        center_ratio_range (tuple[float]): Center ratio range of mosaic
+        center_ratio_range (Sequence[float]): Center ratio range of mosaic
             output. Defaults to (0.5, 1.5).
         bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. In some dataset like MOT17, the gt bboxes
@@ -1451,8 +1451,8 @@ class CachedMosaic(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     def __init__(
         self,
-        img_scale: tuple[int, int] | list[int] = (640, 640),  # (H, W)
-        center_ratio_range: tuple[float, float] = (0.5, 1.5),
+        img_scale: Sequence[int] = (640, 640),  # (H, W)
+        center_ratio_range: Sequence[float] = (0.5, 1.5),
         bbox_clip_border: bool = True,
         pad_val: float = 114.0,
         prob: float = 1.0,
@@ -1755,8 +1755,8 @@ class CachedMixUp(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     def __init__(
         self,
-        img_scale: tuple[int, int] | list[int] = (640, 640),  # (H, W)
-        ratio_range: tuple[float, float] = (0.5, 1.5),
+        img_scale: Sequence[int] = (640, 640),  # (H, W)
+        ratio_range: Sequence[float] = (0.5, 1.5),
         flip_ratio: float = 0.5,
         pad_val: float = 114.0,
         max_iters: int = 15,
@@ -2063,7 +2063,7 @@ class Pad(tvt_v2.Transform, NumpytoTVTensorMixin):
     TODO : optimize logic to torcivision pipeline
 
     Args:
-        size (tuple, optional): Fixed padding size.
+        size (Sequence[int], optional): Fixed padding size.
             Expected padding shape (height, width). Defaults to None.
         size_divisor (int, optional): The divisor of padded size. Defaults to
             None.
@@ -2106,7 +2106,7 @@ class Pad(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     def __init__(
         self,
-        size: tuple[int, int] | None = None,  # (H, W)
+        size: Sequence[int] | None = None,  # (H, W)
         size_divisor: int | None = None,
         pad_to_square: bool = False,
         pad_val: int | float | dict | None = None,
@@ -2142,7 +2142,7 @@ class Pad(tvt_v2.Transform, NumpytoTVTensorMixin):
         img: np.ndarray = to_np_image(inputs.image)
         pad_val = self.pad_val.get("img", 0)
 
-        size: tuple[int, int]
+        size: Sequence[int]
         if self.pad_to_square:
             max_size = max(img.shape[:2])
             size = (max_size, max_size)
@@ -2231,8 +2231,9 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
     Reference : https://github.com/open-mmlab/mmcv/blob/v2.1.0/mmcv/transforms/processing.py#L1381-L1562
 
     Args:
-        scale (Sequence): Images scales for resizing with (height, width). Defaults to None.
-        ratio_range (tuple[float], optional): (min_ratio, max_ratio). Defaults to None.
+        scale (Sequence[int | tuple[int, int]]): Images scales for resizing with (height, width).
+            Defaults to None.
+        ratio_range (Sequence[float], optional): (min_ratio, max_ratio). Defaults to None.
         is_numpy_to_tvtensor (bool): Whether convert outputs to tensor. Defaults to False.
         **resize_kwargs: Other keyword arguments for the ``resize_type``.
     """
@@ -2240,7 +2241,7 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
     def __init__(
         self,
         scale: Sequence[int | tuple[int, int]],  # (H, W)
-        ratio_range: tuple[float, float] | None = None,
+        ratio_range: Sequence[float] | None = None,
         is_numpy_to_tvtensor: bool = False,
         **resize_kwargs,
     ) -> None:
@@ -2275,7 +2276,7 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
         return (edge_0, edge_1)
 
     @staticmethod
-    def _random_sample_ratio(scale: tuple, ratio_range: tuple[float, float]) -> tuple:
+    def _random_sample_ratio(scale: Sequence, ratio_range: Sequence[float]) -> tuple:
         """Private function to randomly sample a scale from a tuple.
 
         A ratio will be randomly sampled from the range specified by
@@ -2283,14 +2284,14 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
         generate sampled scale.
 
         Args:
-            scale (tuple): Images scale base to multiply with ratio.
-            ratio_range (tuple[float]): The minimum and maximum ratio to scale
+            scale (Sequence): Images scale base to multiply with ratio.
+            ratio_range (Sequence[float]): The minimum and maximum ratio to scale
                 the ``scale``.
 
         Returns:
             (tuple): The targeted scale of the image to be resized.
         """
-        assert isinstance(scale, tuple)  # noqa: S101
+        assert isinstance(scale, Sequence)  # noqa: S101
         assert len(scale) == 2  # noqa: S101
         min_ratio, max_ratio = ratio_range
         assert min_ratio <= max_ratio  # noqa: S101
@@ -2340,7 +2341,7 @@ class RandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
     The absolute `crop_size` is sampled based on `crop_type` and `image_size`, then the cropped results are generated.
 
     Args:
-        crop_size (tuple): The relative ratio or absolute pixels of
+        crop_size (Sequence[int | float]): The relative ratio or absolute pixels of
             (height, width).
         crop_type (str, optional): One of "relative_range", "relative",
             "absolute", "absolute_range". "relative" randomly crops
@@ -2365,7 +2366,7 @@ class RandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     def __init__(
         self,
-        crop_size: tuple,  # (H, W)
+        crop_size: Sequence[int | float],  # (H, W)
         crop_type: str = "absolute",
         cat_max_ratio: int | float = 1,
         allow_negative_crop: bool = False,
@@ -2517,7 +2518,7 @@ class RandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
         return offset_h, offset_w
 
     @cache_randomness
-    def _get_crop_size(self, image_size: tuple[int, int]) -> tuple[int, int]:
+    def _get_crop_size(self, image_size: tuple[int, int]) -> tuple[int | float, int | float]:
         """Randomly generates the absolute crop size based on `crop_type` and `image_size`.
 
         Args:
@@ -2571,7 +2572,7 @@ class FilterAnnotations(tvt_v2.Transform, NumpytoTVTensorMixin):
     Reference : https://github.com/open-mmlab/mmdetection/blob/v3.2.0/mmdet/datasets/transforms/loading.py#L713-L800
 
     Args:
-        min_gt_bbox_wh (tuple[float]): Minimum width and height of ground truth
+        min_gt_bbox_wh (Sequence[float | int]): Minimum width and height of ground truth
             boxes. Default: (1., 1.)
         min_gt_mask_area (int): Minimum foreground area of ground truth masks.
             Default: 1
@@ -2588,7 +2589,7 @@ class FilterAnnotations(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     def __init__(
         self,
-        min_gt_bbox_wh: tuple[int, int] = (1, 1),
+        min_gt_bbox_wh: Sequence[float | int] = (1, 1),
         min_gt_mask_area: int = 1,
         by_box: bool = True,
         by_mask: bool = False,
@@ -3086,7 +3087,7 @@ class DecordDecode(tvt_v2.Transform):
 class Normalize3D(tvt_v2.Normalize):
     """Using normalize the 3D video data."""
 
-    def __init__(self, mean: list[float], std: list[float], inplace: bool = False) -> None:
+    def __init__(self, mean: Sequence[float], std: Sequence[float], inplace: bool = False) -> None:
         self.mean = torch.Tensor(mean).view(1, 3, 1, 1, 1)
         self.std = torch.Tensor(std).view(1, 3, 1, 1, 1)
         self.inplace = inplace

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -1,6 +1,5 @@
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-#
 """Helper to support TorchVision data transform functions."""
 
 from __future__ import annotations

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -116,6 +116,8 @@ class NumpytoTVTensorMixin:
                 inputs.image = F.to_image(image.copy())
             if (bboxes := getattr(inputs, "bboxes", None)) is not None and isinstance(bboxes, np.ndarray):
                 inputs.bboxes = tv_tensors.BoundingBoxes(bboxes, format="xyxy", canvas_size=inputs.img_info.img_shape)  # type: ignore[attr-defined]
+            if (points := getattr(inputs, "points", None)) is not None and isinstance(points, np.ndarray):
+                inputs.points = Points(points, canvas_size=inputs.img_info.img_shape)
             if (masks := getattr(inputs, "masks", None)) is not None and isinstance(masks, np.ndarray):
                 inputs.masks = tv_tensors.Mask(masks)
         return inputs

--- a/src/otx/recipe/_base_/data/semantic_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/semantic_segmentation.yaml
@@ -15,7 +15,7 @@ train_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
       init_args:
-        scale:
+        input_size: # TODO (eunwoo): integrate this into a common part
           - 512
           - 512
         crop_ratio_range:

--- a/src/otx/recipe/_base_/data/semantic_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/semantic_segmentation.yaml
@@ -49,7 +49,7 @@ val_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale:
+        input_size: # TODO (eunwoo): integrate this into a common part
           - 512
           - 512
         transform_mask: true
@@ -73,7 +73,7 @@ test_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale:
+        input_size: # TODO (eunwoo): integrate this into a common part
           - 512
           - 512
         transform_mask: true

--- a/src/otx/recipe/_base_/data/torchvision_semisl.yaml
+++ b/src/otx/recipe/_base_/data/torchvision_semisl.yaml
@@ -16,7 +16,7 @@ train_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale: 224
+        input_size: 224 # TODO (eunwoo): integrate this into a common part
     - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
       init_args:
         prob: 0.5
@@ -40,7 +40,7 @@ val_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale: 224
+        input_size: 224 # TODO (eunwoo): integrate this into a common part
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
@@ -61,7 +61,7 @@ test_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale: 224
+        input_size: 224 # TODO (eunwoo): integrate this into a common part
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
@@ -82,7 +82,7 @@ unlabeled_subset:
     weak_transforms:
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale: 224
+          input_size: 224 # TODO (eunwoo): integrate this into a common part
       - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
         init_args:
           prob: 0.5
@@ -104,7 +104,7 @@ unlabeled_subset:
     strong_transforms:
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale: 224
+          input_size: 224 # TODO (eunwoo): integrate this into a common part
       - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
         init_args:
           prob: 0.5

--- a/src/otx/recipe/_base_/data/visual_prompting.yaml
+++ b/src/otx/recipe/_base_/data/visual_prompting.yaml
@@ -18,7 +18,7 @@ train_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale:
+        input_size: # TODO (eunwoo): integrate this into a common part
           - 1024
           - 1024
         keep_ratio: true
@@ -50,7 +50,7 @@ val_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale:
+        input_size: # TODO (eunwoo): integrate this into a common part
           - 1024
           - 1024
         keep_ratio: true
@@ -82,7 +82,7 @@ test_subset:
   transforms:
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
-        scale:
+        input_size: # TODO (eunwoo): integrate this into a common part
           - 1024
           - 1024
         keep_ratio: true

--- a/src/otx/recipe/_base_/data/visual_prompting.yaml
+++ b/src/otx/recipe/_base_/data/visual_prompting.yaml
@@ -26,6 +26,9 @@ train_subset:
         transform_point: true
     - class_path: otx.core.data.transform_libs.torchvision.Pad
       init_args:
+        input_size: # TODO (eunwoo): integrate this into a common part
+          - 1024
+          - 1024
         pad_to_square: true
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.ToDtype
@@ -55,6 +58,9 @@ val_subset:
         transform_point: true
     - class_path: otx.core.data.transform_libs.torchvision.Pad
       init_args:
+        input_size: # TODO (eunwoo): integrate this into a common part
+          - 1024
+          - 1024
         pad_to_square: true
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.ToDtype
@@ -84,6 +90,9 @@ test_subset:
         transform_point: true
     - class_path: otx.core.data.transform_libs.torchvision.Pad
       init_args:
+        input_size: # TODO (eunwoo): integrate this into a common part
+          - 1024
+          - 1024
         pad_to_square: true
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/action_classification/movinet.yaml
+++ b/src/otx/recipe/action_classification/movinet.yaml
@@ -48,7 +48,7 @@ data:
       - class_path: otx.core.data.transform_libs.torchvision.DecordDecode
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale:
+          input_size: # TODO (eunwoo): integrate this into a common part
             - 224
             - 224
           keep_ratio: false
@@ -83,7 +83,7 @@ data:
       - class_path: otx.core.data.transform_libs.torchvision.DecordDecode
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale:
+          input_size: # TODO (eunwoo): integrate this into a common part
             - 224
             - 224
           keep_ratio: false
@@ -116,7 +116,7 @@ data:
       - class_path: otx.core.data.transform_libs.torchvision.DecordDecode
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale:
+          input_size: # TODO (eunwoo): integrate this into a common part
             - 224
             - 224
           keep_ratio: false

--- a/src/otx/recipe/action_classification/x3d.yaml
+++ b/src/otx/recipe/action_classification/x3d.yaml
@@ -48,7 +48,7 @@ data:
       - class_path: otx.core.data.transform_libs.torchvision.DecordDecode
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale:
+          input_size: # TODO (eunwoo): integrate this into a common part
             - 224
             - 224
           keep_ratio: false
@@ -83,7 +83,7 @@ data:
       - class_path: otx.core.data.transform_libs.torchvision.DecordDecode
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale:
+          input_size: # TODO (eunwoo): integrate this into a common part
             - 224
             - 224
           keep_ratio: false
@@ -116,7 +116,7 @@ data:
       - class_path: otx.core.data.transform_libs.torchvision.DecordDecode
       - class_path: otx.core.data.transform_libs.torchvision.Resize
         init_args:
-          scale:
+          input_size: # TODO (eunwoo): integrate this into a common part
             - 224
             - 224
           keep_ratio: false

--- a/src/otx/recipe/classification/h_label_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/deit_tiny.yaml
@@ -64,7 +64,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -80,7 +80,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/deit_tiny.yaml
@@ -43,7 +43,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
@@ -42,7 +42,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
@@ -63,7 +63,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -79,7 +79,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -42,7 +42,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -63,7 +63,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -79,7 +79,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large.yaml
@@ -69,7 +69,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -85,7 +85,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large.yaml
@@ -48,7 +48,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
@@ -44,7 +44,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
@@ -65,7 +65,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -81,7 +81,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
@@ -44,7 +44,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
@@ -65,7 +65,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -81,7 +81,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_mobilenet_v3_small.yaml
@@ -65,7 +65,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -81,7 +81,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_mobilenet_v3_small.yaml
@@ -44,7 +44,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_class_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/deit_tiny.yaml
@@ -42,7 +42,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_class_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/deit_tiny.yaml
@@ -63,7 +63,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -79,7 +79,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_class_cls/dino_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/dino_v2.yaml
@@ -49,7 +49,7 @@ overrides:
             std: [58.395, 57.12, 57.375]
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler

--- a/src/otx/recipe/classification/multi_class_cls/dino_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/dino_v2.yaml
@@ -66,7 +66,7 @@ overrides:
             std: [58.395, 57.12, 57.375]
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
     test_subset:
       batch_size: 64
@@ -81,5 +81,5 @@ overrides:
             std: [58.395, 57.12, 57.375]
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -43,7 +43,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -64,7 +64,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -80,7 +80,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
@@ -42,7 +42,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
@@ -63,7 +63,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -79,7 +79,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
@@ -68,7 +68,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -84,7 +84,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
@@ -47,7 +47,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/deit_tiny.yaml
@@ -69,7 +69,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -85,7 +85,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/deit_tiny.yaml
@@ -48,7 +48,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
@@ -45,7 +45,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
@@ -66,7 +66,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -82,7 +82,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
@@ -69,7 +69,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -85,7 +85,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
@@ -48,7 +48,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
@@ -49,7 +49,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
@@ -70,7 +70,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -86,7 +86,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
@@ -44,7 +44,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
@@ -65,7 +65,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -81,7 +81,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
@@ -69,7 +69,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -85,7 +85,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
@@ -48,7 +48,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/classification/multi_label_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_mobilenet_v3_small.yaml
@@ -65,7 +65,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
@@ -81,7 +81,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_mobilenet_v3_small.yaml
@@ -44,7 +44,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale: 224
+            input_size: 224 # TODO (eunwoo): integrate this into a common part
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/detection/atss_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2.yaml
@@ -45,7 +45,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             transform_bbox: true
@@ -68,7 +68,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             is_numpy_to_tvtensor: true
@@ -85,7 +85,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
@@ -42,7 +42,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             transform_bbox: true
@@ -65,7 +65,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             is_numpy_to_tvtensor: true
@@ -82,7 +82,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/atss_resnext101.yaml
+++ b/src/otx/recipe/detection/atss_resnext101.yaml
@@ -45,7 +45,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             transform_bbox: true
@@ -68,7 +68,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             is_numpy_to_tvtensor: true
@@ -85,7 +85,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 800
               - 992
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -44,7 +44,7 @@ overrides:
             random_pop: false
         - class_path: otx.core.data.transform_libs.torchvision.RandomResize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1280
               - 1280
             ratio_range:
@@ -92,7 +92,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -116,7 +116,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -63,7 +63,7 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            size:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             pad_val: 114
@@ -98,7 +98,7 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            size:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             pad_val: 114
@@ -122,7 +122,7 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            size:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             pad_val: 114

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -37,7 +37,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.CachedMosaic
           init_args:
-            img_scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             max_cached_images: 20

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -54,7 +54,7 @@ overrides:
             transform_bbox: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomCrop
           init_args:
-            crop_size:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -69,7 +69,7 @@ overrides:
             pad_val: 114
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
-            img_scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             ratio_range:

--- a/src/otx/recipe/detection/ssd_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2.yaml
@@ -39,7 +39,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 864
               - 864
             transform_bbox: true
@@ -62,7 +62,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 864
               - 864
             is_numpy_to_tvtensor: true
@@ -79,7 +79,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 864
               - 864
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/ssd_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2_tile.yaml
@@ -43,7 +43,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 864
               - 864
             transform_bbox: true
@@ -66,7 +66,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 864
               - 864
             is_numpy_to_tvtensor: true
@@ -83,7 +83,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 864
               - 864
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -75,6 +75,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -99,6 +102,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -121,6 +127,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -45,12 +45,12 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             scaling_ratio_range:
               - 0.1
               - 2.0
-            border:
-              - -320
-              - -320
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
             img_scale: # (H, W)

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -53,7 +53,7 @@ overrides:
               - 2.0
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
-            img_scale: # (H, W)
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             ratio_range:

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -38,11 +38,11 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.CachedMosaic
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             random_pop: false
             max_cached_images: 20
-            img_scale: # (H, W)
-              - 640
-              - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -65,7 +65,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -96,7 +96,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -121,7 +121,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -53,6 +53,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -75,6 +78,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -97,6 +103,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -44,7 +44,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             transform_bbox: true
@@ -73,7 +73,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -98,7 +98,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -75,6 +75,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -99,6 +102,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -121,6 +127,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -45,12 +45,12 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             scaling_ratio_range:
               - 0.1
               - 2.0
-            border:
-              - -320
-              - -320
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
             img_scale: # (H, W)

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -53,7 +53,7 @@ overrides:
               - 2.0
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
-            img_scale: # (H, W)
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             ratio_range:

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -38,11 +38,11 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.CachedMosaic
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             random_pop: false
             max_cached_images: 20
-            img_scale: # (H, W)
-              - 640
-              - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -65,7 +65,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -96,7 +96,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -121,7 +121,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -53,6 +53,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -75,6 +78,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -97,6 +103,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -44,7 +44,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             transform_bbox: true
@@ -73,7 +73,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -98,7 +98,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -37,11 +37,11 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.CachedMosaic
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             random_pop: false
             max_cached_images: 20
-            img_scale: # (H, W)
-              - 640
-              - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -50,7 +50,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.PhotoMetricDistortion
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -81,15 +81,15 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 416
               - 416
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part
-              - 640
-              - 640
+              - 416
+              - 416
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -106,15 +106,15 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 416
               - 416
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part
-              - 640
-              - 640
+              - 416
+              - 416
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -60,6 +60,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -84,6 +87,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -106,6 +112,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -44,9 +44,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
-            border:
-              - -320
-              - -320
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
         - class_path: otx.core.data.transform_libs.torchvision.PhotoMetricDistortion
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -43,7 +43,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.PhotoMetricDistortion
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             transform_bbox: true
@@ -72,14 +72,14 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 416
               - 416
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part
-              - 640
-              - 640
+              - 416
+              - 416
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -97,14 +97,14 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 416
               - 416
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part
-              - 640
-              - 640
+              - 416
+              - 416
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -52,6 +52,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -74,6 +77,9 @@ overrides:
               - 416
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -96,6 +102,9 @@ overrides:
               - 416
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -45,9 +45,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
-            border:
-              - -320
-              - -320
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
             img_scale: # (H, W)

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -72,6 +72,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -96,6 +99,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -118,6 +124,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -62,7 +62,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -93,7 +93,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -118,7 +118,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -38,11 +38,11 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.CachedMosaic
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             random_pop: false
             max_cached_images: 20
-            img_scale: # (H, W)
-              - 640
-              - 640
         - class_path: otx.core.data.transform_libs.torchvision.RandomAffine
           init_args:
             input_size: # TODO (eunwoo): integrate this into a common part

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -50,7 +50,7 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
-            img_scale: # (H, W)
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             ratio_range:

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -53,6 +53,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -75,6 +78,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -97,6 +103,9 @@ overrides:
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -44,7 +44,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             transform_bbox: true
@@ -73,7 +73,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -98,7 +98,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -46,6 +46,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             size_divisor: 32
             transform_mask: true
@@ -74,6 +77,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             size_divisor: 32
             is_numpy_to_tvtensor: true
@@ -96,6 +102,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             size_divisor: 32
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -41,7 +41,7 @@ overrides:
             keep_ratio: true
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -72,7 +72,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -97,7 +97,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -43,7 +43,7 @@ overrides:
           init_args:
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -72,7 +72,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -95,7 +95,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -48,6 +48,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -74,6 +77,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -94,6 +100,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
@@ -42,7 +42,7 @@ overrides:
             keep_ratio: true
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -71,7 +71,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -96,7 +96,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
@@ -47,6 +47,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             size_divisor: 32
             transform_mask: true
@@ -73,6 +76,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             size_divisor: 32
             is_numpy_to_tvtensor: true
@@ -95,6 +101,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             size_divisor: 32
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -44,7 +44,7 @@ overrides:
           init_args:
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -71,7 +71,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -94,7 +94,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -49,6 +49,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -73,6 +76,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -93,6 +99,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
@@ -47,6 +47,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -72,6 +75,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -93,6 +99,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             pad_to_square: true
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
@@ -42,7 +42,7 @@ overrides:
             keep_ratio: true
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -70,7 +70,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -94,7 +94,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv_tile.yaml
@@ -44,7 +44,7 @@ overrides:
           init_args:
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -71,7 +71,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -94,7 +94,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv_tile.yaml
@@ -49,6 +49,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -73,6 +76,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -93,6 +99,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
@@ -45,6 +45,9 @@ overrides:
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1344
+              - 1344
             pad_to_square: true
             size_divisor: 32
             transform_mask: true
@@ -71,6 +74,9 @@ overrides:
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1344
+              - 1344
             pad_to_square: true
             size_divisor: 32
             is_numpy_to_tvtensor: true
@@ -93,6 +99,9 @@ overrides:
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1344
+              - 1344
             pad_to_square: true
             size_divisor: 32
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
@@ -40,7 +40,7 @@ overrides:
             keep_ratio: true
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1344
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -69,7 +69,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1344
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -94,7 +94,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1344
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
@@ -42,7 +42,7 @@ overrides:
           init_args:
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -69,7 +69,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -92,7 +92,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
@@ -47,6 +47,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -71,6 +74,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -91,6 +97,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -68,6 +68,9 @@ overrides:
             prob: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             transform_mask: true
@@ -104,6 +107,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true
@@ -126,6 +132,9 @@ overrides:
             keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 640
+              - 640
             pad_to_square: true
             pad_val: 114
             is_numpy_to_tvtensor: true

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -41,7 +41,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.CachedMosaic
           init_args:
-            img_scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             max_cached_images: 20

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -48,7 +48,7 @@ overrides:
             random_pop: false
         - class_path: otx.core.data.transform_libs.torchvision.RandomResize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1280
               - 1280
             ratio_range:
@@ -101,7 +101,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true
@@ -126,7 +126,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             keep_ratio: true

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -73,7 +73,7 @@ overrides:
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.CachedMixUp
           init_args:
-            img_scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
             ratio_range:

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -59,7 +59,7 @@ overrides:
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomCrop
           init_args:
-            crop_size:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 640
               - 640
         - class_path: otx.core.data.transform_libs.torchvision.YOLOXHSVRandomAug

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -46,7 +46,7 @@ overrides:
           init_args:
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -73,7 +73,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -96,7 +96,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -51,6 +51,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -75,6 +78,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -95,6 +101,9 @@ overrides:
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 512
+              - 512
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
@@ -45,6 +45,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -71,6 +74,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -91,6 +97,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
@@ -40,7 +40,7 @@ overrides:
             keep_ratio: true
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -69,7 +69,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -92,7 +92,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
@@ -40,7 +40,7 @@ overrides:
             keep_ratio: true
             transform_bbox: true
             transform_mask: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -67,7 +67,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
@@ -90,7 +90,7 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
             keep_ratio: true
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 1024
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad

--- a/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
@@ -45,6 +45,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             size_divisor: 32
             transform_mask: true
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
@@ -69,6 +72,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype
@@ -89,6 +95,9 @@ overrides:
               - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            input_size: # TODO (eunwoo): integrate this into a common part
+              - 1024
+              - 1024
             size_divisor: 32
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/semantic_segmentation/dino_v2.yaml
+++ b/src/otx/recipe/semantic_segmentation/dino_v2.yaml
@@ -71,7 +71,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 560
               - 560
             transform_mask: true
@@ -88,7 +88,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 560
               - 560
             transform_mask: true

--- a/src/otx/recipe/semantic_segmentation/dino_v2.yaml
+++ b/src/otx/recipe/semantic_segmentation/dino_v2.yaml
@@ -44,7 +44,7 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
-            scale:
+            input_size: # TODO (eunwoo): integrate this into a common part
               - 560
               - 560
             crop_ratio_range:

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -772,7 +772,7 @@ class TestRandomResize:
         assert transform.resize_size == (224, 224)
 
     def test_repr(self):
-        transform = RandomResize((224, 224), (1.0, 2.0))
+        transform = RandomResize(input_size=(224, 224), ratio_range=(1.0, 2.0))
         transform_str = str(transform)
         assert isinstance(transform_str, str)
 
@@ -845,7 +845,7 @@ class TestRandomResize:
         assert results.img_info.img_shape[0] <= 448
 
         # the type of resize_size is invalid in init
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(TypeError):
             RandomResize(input_size=(224, 224), resize_size=[(448, 224), [224, 112]], keep_ratio=True)(deepcopy(entity))
 
 

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -424,7 +424,7 @@ class TestCachedMosaic:
     def test_init_invalid_max_cached_images(self) -> None:
         max_cached_images: int = 3
         with pytest.raises(ValueError, match=f"The length of cache must >= 4, but got {max_cached_images}."):
-            CachedMosaic(input_size=(128, 128), max_cached_images=3)
+            CachedMosaic(input_size=(128, 128), max_cached_images=max_cached_images)
 
     def test_init_set_mosaic_size_automatically(self, cached_mosaic: CachedMosaic) -> None:
         # use default value of `mosaic_size_scale`
@@ -485,15 +485,50 @@ class TestCachedMosaic:
 class TestCachedMixUp:
     @pytest.fixture()
     def cached_mixup(self) -> CachedMixUp:
-        return CachedMixUp(ratio_range=(1.0, 1.0), prob=1.0, random_pop=False, max_cached_images=10)
+        return CachedMixUp(
+            input_size=(64, 64),
+            ratio_range=(1.0, 1.0),
+            prob=1.0,
+            random_pop=False,
+            max_cached_images=10,
+        )
 
-    @pytest.mark.xfail(raises=AssertionError)
-    def test_init_invalid_img_scale(self) -> None:
-        CachedMixUp(img_scale=640)
+    def test_init_without_input_size(self) -> None:
+        with pytest.raises(TypeError):
+            CachedMixUp()
 
-    @pytest.mark.xfail(raises=AssertionError)
+    def test_init_invalid_mixup_size(self) -> None:
+        with pytest.raises(TypeError):
+            CachedMixUp(input_size=(128, 128), mixup_size=640.0)
+
+        with pytest.raises(TypeError):
+            CachedMixUp(input_size=(128, 128), mixup_size=[640.0, 640.0])
+
     def test_init_invalid_probability(self) -> None:
-        CachedMosaic(prob=1.5)
+        prob: float = 1.5
+        with pytest.raises(ValueError, match=rf"The probability should be in range \[0,1\]\. got {prob}\."):
+            CachedMixUp(input_size=(128, 128), prob=prob)
+
+    def test_init_invalid_max_cached_images(self) -> None:
+        max_cached_images: int = 1
+        with pytest.raises(ValueError, match=f"The length of cache must >= 2, but got {max_cached_images}."):
+            CachedMixUp(input_size=(128, 128), max_cached_images=max_cached_images)
+
+    def test_init_set_mixup_size_automatically(self, cached_mixup: CachedMixUp) -> None:
+        # use default value of `mixup_size_scale`
+        assert cached_mixup.mixup_size == (64, 64)
+
+        # use given value of `mixup_size_scale`
+        cached_mixup = CachedMixUp(input_size=(128, 128), mixup_size_scale=(0.5, 2.0))
+        assert cached_mixup.mixup_size == (64, 256)
+
+        # use `mixup_size` value first if it is given
+        cached_mixup = CachedMixUp(input_size=(128, 128), mixup_size=(256, 64), mixup_size_scale=(0.5, 2.0))
+        assert cached_mixup.mixup_size == (256, 64)
+
+        # change int of `mixup_size` to tuple
+        cached_mixup = CachedMixUp(input_size=(128, 128), mixup_size=64)
+        assert cached_mixup.mixup_size == (64, 64)
 
     def test_forward_pop_small_cache(
         self,

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -359,19 +359,35 @@ class TestPhotoMetricDistortion:
 class TestRandomAffine:
     @pytest.fixture()
     def random_affine(self) -> RandomAffine:
-        return RandomAffine()
+        return RandomAffine(input_size=(112, 224))
 
-    @pytest.mark.xfail(raises=AssertionError)
+    def test_init_without_input_size(self) -> None:
+        with pytest.raises(TypeError):
+            RandomAffine()
+
     def test_init_invalid_translate_ratio(self) -> None:
-        RandomAffine(max_translate_ratio=1.5)
+        with pytest.raises(AssertionError):
+            RandomAffine(input_size=(112, 224), max_translate_ratio=1.5)
 
-    @pytest.mark.xfail(raises=AssertionError)
     def test_init_invalid_scaling_ratio_range_inverse_order(self) -> None:
-        RandomAffine(scaling_ratio_range=(1.5, 0.5))
+        with pytest.raises(AssertionError):
+            RandomAffine(input_size=(112, 224), scaling_ratio_range=(1.5, 0.5))
 
-    @pytest.mark.xfail(raises=AssertionError)
     def test_init_invalid_scaling_ratio_range_zero_value(self) -> None:
-        RandomAffine(scaling_ratio_range=(0, 0.5))
+        with pytest.raises(AssertionError):
+            RandomAffine(input_size=(112, 224), scaling_ratio_range=(0, 0.5))
+
+    def test_init_set_border_automatically(self, random_affine: RandomAffine) -> None:
+        # use default value of `border_scale`
+        assert random_affine.border == (-56, -112)
+
+        # use given value of `border_scale`
+        random_affine = RandomAffine(input_size=(112, 224), border_scale=(1.0, 1.0))
+        assert random_affine.border == (112, 224)
+
+        # use `border` value first if it is given
+        random_affine = RandomAffine(input_size=(112, 224), border=(0, 0), border_scale=(1.0, 1.0))
+        assert random_affine.border == (0, 0)
 
     def test_forward(self, random_affine: RandomAffine, det_data_entity: DetDataEntity) -> None:
         """Test forward."""

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -365,16 +365,26 @@ class TestRandomAffine:
         with pytest.raises(TypeError):
             RandomAffine()
 
-    def test_init_invalid_translate_ratio(self) -> None:
-        with pytest.raises(AssertionError):
+    def test_init_invalid_border(self) -> None:
+        with pytest.raises(TypeError):
+            RandomAffine(input_size=(128, 128), border=640.0)
+
+        with pytest.raises(TypeError):
+            RandomAffine(input_size=(128, 128), border=[640.0, 640.0])
+
+    def test_init_invalid_max_translate_ratio(self) -> None:
+        with pytest.raises(ValueError, match=r"max_translate_ratio must be in \[0, 1\]."):
             RandomAffine(input_size=(112, 224), max_translate_ratio=1.5)
 
+        with pytest.raises(ValueError, match=r"max_translate_ratio must be in \[0, 1\]."):
+            RandomAffine(input_size=(112, 224), max_translate_ratio=-1)
+
     def test_init_invalid_scaling_ratio_range_inverse_order(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match=r"scaling_ratio_range\[0\] must be less than scaling_ratio_range\[1\]."):
             RandomAffine(input_size=(112, 224), scaling_ratio_range=(1.5, 0.5))
 
     def test_init_invalid_scaling_ratio_range_zero_value(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match=r"scaling_ratio_range\[0\] must be greater than 0."):
             RandomAffine(input_size=(112, 224), scaling_ratio_range=(0, 0.5))
 
     def test_init_set_border_automatically(self, random_affine: RandomAffine) -> None:

--- a/tests/unit/core/data/transform_libs/test_torchvision.py
+++ b/tests/unit/core/data/transform_libs/test_torchvision.py
@@ -1045,7 +1045,9 @@ class TestRandomCrop:
             bbox_clip_border=bbox_clip_border,
         )
         assert (
-            repr(transform) == f"RandomCrop(crop_size={transform.crop_size}, crop_type={crop_type}, "
+            repr(transform) == f"RandomCrop(crop_size={transform.crop_size}, "
+            f"crop_size_scale={transform.crop_size_scale}, "
+            f"crop_type={crop_type}, "
             f"allow_negative_crop={allow_negative_crop}, "
             f"recompute_bbox={recompute_bbox}, "
             f"bbox_clip_border={bbox_clip_border}, "

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -171,7 +171,7 @@ class TestAutoConfigurator:
             {
                 "class_path": "otx.core.data.transform_libs.torchvision.Resize",
                 "init_args": {
-                    "scale": [800, 992],
+                    "input_size": [800, 992],
                     "is_numpy_to_tvtensor": True,
                 },
             },


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

ticket no. : 146448
This PR includes:
- [x] Update transforms which have parameters related to input size to calculate the parameters when they are not given automatically
    - get `input_size` as an argument
    - set `input_size` related parameter when it is not given
- [x] Support `Points` in `NumpytoTVTensorMixin`
- [x] Update related tests
- [x] Performance check w/ medium dataset for reproducibility
    - all benchmark tests proceeded with medium dataset, single trial, and seed = 0, these results are just for checking trend
    - before : 97d6018 | after : ea1e06b
    - [x] action_classification
        - benchmark test for `movinet` occurred deterministic related error

        model |   | test/accuracy | export/accuracy
        -- | -- | -- | --
        movinet | before | - | - |
          | after | - | - |
        x3d | before | 0.88 | 0.,88 |
          | after | 0.88 | 0.88 |

    - [x] classification (multi class)
        model |   | test/accuracy | export/accuracy
        -- | -- | -- | --
        deit_tiny | before | 0.80 | 0.80 |
          | after | 0.80 | 0.80 |
        efficientnet_b0 | before | 0.77 | 0.77 |
          | after | 0.77 | 0.77 |
        efficientnet_v2 | before | 0.85 | 0.85 |
          | after | 0.85 | 0.85 |
        mobilenet_v3_large | before | 0.78 | 0.78 |
          | after | 0.78 | 0.78 |
        tv_efficientnet_b3 | before | 0.82 | 0.82 |
          | after | 0.82 | 0.82 |
        tv_efficientnet_v2_l | before | 0.85 | 0.85 |
          | after | 0.85 | 0.85 |
        tv_mobilenet_v3_small | before | 0.62 | 0.62 |
          | after | 0.62 | 0.62 |

    - [x] detection
        model |   | test/f1-score | export/f1-score
        -- | -- | -- | --
        atss_mobilenetv2 | before | 0.72 | 0.72 |
          | after | 0.72 | 0.72 |
        atss_resnext101 | before | 0.77 | 0.77 |
          | after | 0.77 | 0.77 |
        rtmdet_tiny | before | 0.70 | 0.70 |
          | after | 0.71 | 0.72 |
        ssd_mobilenetv2 | before | 0.59 | 0.59 |
          | after | 0.59 | 0.59 |
        yolox_l | before | 0.77 | 0.74 |
          | after | 0.72 | 0.70 |
        yolox_s | before | 0.70 | 0.71 |
          | after | 0.73 | 0.71 |
        yolox_tiny | before | 0.73 | 0.75 |
          | after | 0.72 | 0.71 |
        yolox_x | before | 0.72 | 0.71 |
          | after | 0.72 | 0.71 |

    - [x] instance segmentation
        model |   | test/f1-score | export/f1-score
        -- | -- | -- | --
        maskrcnn_efficientnetb2b | before | 0.59 | 0.58 |
          | after | 0.57 | 0.57 |
        maskrcnn_r50 | before | 0.60 | 0.59 |
          | after | 0.61 | 0.61 |
        maskrcnn_r50_tv | before | 0.69 | 0.70 |
          | after | 0.68 | 0.68 |
        maskrcnn_swint | before | 0.69 | 0.69 | 
          | after | 0.69 | 0.68 |
        rtmdet_inst_tiny| before | 0.60 | 0.60 |
          | after | 0.61 | 0.61 |

    - [x] semantic segmentation
        model |   | test/Dice | export/Dice
        -- | -- | -- | --
        dino_v2 | before | 0.90 | 0.90 |
          | after | 0.90 | 0.90 |
        litehrnet_18 | before | 0.90 | 0.90 |
          | after | 0.89 | 0.89 |
        litehrnet_s | before | 0.89 | 0.88 |
          | after | 0.89 | 0.86 |
        litehrnet_x | before | 0.90 | 0.89 |
          | after | 0.90 | 0.90 |
        segnext_b | before | 0.91 | 0.89 |
          | after | 0.90 | 0.88 |
        segnext_s | before | 0.92 | 0.91 |
          | after | 0.91 | 0.91 |
        segnext_t | before | 0.90 | 0.89 |
          | after | 0.91 | 0.90 |

    - [x] visual prompting
        model |   | test/dice | export/dice
        -- | -- | -- | --
        sam_tiny_vit | before | 0.92 | 0.99 |
          | after | 0.91 | 0.99 |
        sam_vit_b | before | 0.93 | 1.00 |
          | after | 0.92 | 1.00 | 
        sam_tiny_vit (zsl) | before | 0.60 | 0.60 |
          | after | 0.60 | 0.60 |
        sam_vit_b (zsl) | before | 0.33 | 0.33 |
          | after | 0.33 | 0.33 |



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
