### PR TITLE
Remove optimizer in stfpm recipe

### DIFF
--- a/src/otx/recipe/anomaly_classification/stfpm.yaml
+++ b/src/otx/recipe/anomaly_classification/stfpm.yaml
@@ -5,14 +5,6 @@ model:
     backbone: "resnet18"
     task: ANOMALY_CLASSIFICATION
 
-    optimizer:
-      class_path: torch.optim.SGD
-      init_args:
-        lr: 0.4
-        momentum: 0.9
-        dampening: 0
-        weight_decay: 0.001
-
 engine:
   task: ANOMALY_CLASSIFICATION
   device: auto

--- a/src/otx/recipe/anomaly_detection/stfpm.yaml
+++ b/src/otx/recipe/anomaly_detection/stfpm.yaml
@@ -5,14 +5,6 @@ model:
     backbone: "resnet18"
     task: ANOMALY_DETECTION
 
-    optimizer:
-      class_path: torch.optim.SGD
-      init_args:
-        lr: 0.4
-        momentum: 0.9
-        dampening: 0
-        weight_decay: 0.001
-
 engine:
   task: ANOMALY_DETECTION
   device: auto

--- a/src/otx/recipe/anomaly_segmentation/stfpm.yaml
+++ b/src/otx/recipe/anomaly_segmentation/stfpm.yaml
@@ -5,14 +5,6 @@ model:
     backbone: "resnet18"
     task: ANOMALY_SEGMENTATION
 
-    optimizer:
-      class_path: torch.optim.SGD
-      init_args:
-        lr: 0.4
-        momentum: 0.9
-        dampening: 0
-        weight_decay: 0.001
-
 engine:
   task: ANOMALY_SEGMENTATION
   device: auto


### PR DESCRIPTION
### Summary
Currently, stfpm model doesn't get optimizer as argument and uses own way to initialize optimizer as below.
```python
class Stfpm(OTXAnomaly, OTXModel, AnomalibStfpm):
    def __init__(
        self,
        layers: Sequence[str] = ["layer1", "layer2", "layer3"],
        backbone: str = "resnet18",
        task: Literal[
            OTXTaskType.ANOMALY_CLASSIFICATION,
            OTXTaskType.ANOMALY_DETECTION,
            OTXTaskType.ANOMALY_SEGMENTATION,
        ] = OTXTaskType.ANOMALY_CLASSIFICATION,
        **kwargs,
    ) -> None:
    ...
    def configure_optimizers(self) -> tuple[list[Optimizer], list[Optimizer]] | None:
        """STFPM does not follow OTX optimizer configuration."""
        return AnomalibStfpm.configure_optimizers(self)
``` 
Due to that, when executing `otx train --config .../stfpm.yaml --print_config`, error is raised.
And changing optimizer values in recipe doesn't affect training also.
For these reasons, This PR removes optimizer from recipe.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
