### PR TITLE
Add '--test-only' flag in perf test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,10 +120,19 @@ def pytest_addoption(parser: pytest.Parser):
         "and reverted after run. Works only for v2.x assuming CLI compatibility.",
     )
     parser.addoption(
-        "--resume-from",
+        "--resume",
         type=str,
         help="Previous performance test directory which contains execution results. "
         "If training was already done in previous performance test, training is skipped and refer previous result.",
+    )
+    parser.addoption(
+        "--resume-from",
+        action="store",
+        default="train",
+        choices=("train", "export", "optimize"),
+        help="Which otx command to start from when resume argument is given. "
+        "If it's set, previous commands are skipped and necessary OV IRs are copied from resume directory. "
+        "Choose train|export|optimize. Defaults to train."
     )
     parser.addoption(
         "--open-subprocess",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,19 +120,17 @@ def pytest_addoption(parser: pytest.Parser):
         "and reverted after run. Works only for v2.x assuming CLI compatibility.",
     )
     parser.addoption(
-        "--resume",
+        "--resume-from",
         type=str,
         help="Previous performance test directory which contains execution results. "
         "If training was already done in previous performance test, training is skipped and refer previous result.",
     )
     parser.addoption(
-        "--resume-from",
+        "--test-only",
         action="store",
-        default="train",
-        choices=("train", "export", "optimize"),
-        help="Which otx command to start from when resume argument is given. "
-        "Commands executed before `resume_from` are skipped and necessary OV IRs are copied from resume directory. "
-        "Choose train|export|optimize. Defaults to train.",
+        choices=("all", "train", "export", "optimize"),
+        help="Execute test only when resume argument is given. If necessary files are not found in resume directory, "
+        "necessary operations can be executed. Choose all|train|export|optimize.",
     )
     parser.addoption(
         "--open-subprocess",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def pytest_addoption(parser: pytest.Parser):
         default="train",
         choices=("train", "export", "optimize"),
         help="Which otx command to start from when resume argument is given. "
-        "If it's set, previous commands are skipped and necessary OV IRs are copied from resume directory. "
+        "Commands executed before `resume_from` are skipped and necessary OV IRs are copied from resume directory. "
         "Choose train|export|optimize. Defaults to train.",
     )
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def pytest_addoption(parser: pytest.Parser):
         choices=("train", "export", "optimize"),
         help="Which otx command to start from when resume argument is given. "
         "If it's set, previous commands are skipped and necessary OV IRs are copied from resume directory. "
-        "Choose train|export|optimize. Defaults to train."
+        "Choose train|export|optimize. Defaults to train.",
     )
     parser.addoption(
         "--open-subprocess",

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -51,9 +51,12 @@ class Benchmark:
         deterministic (bool): Whether to turn on deterministic training mode. Defaults to False.
         accelerator (str): Accelerator device on which to run benchmark. Defaults to gpu.
         reference_results (pd.DataFrame): Reference benchmark results for performance checking.
-        resume(Path | None, optional):
+        resume (Path | None, optional):
             Previous performance directory to load. If training was already done in previous performance test,
             training is skipped and refer previous result.
+        resume_from (str):
+            Which otx command to start from when resume argument is given.
+            Commands executed before `resume_from` are skipped and necessary OV IRs are copied from resume directory.
     """
 
     @dataclass

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -314,7 +314,9 @@ class Benchmark:
         prev_otx_cmd = None
         for otx_cmd in ["train", "export", "optimize"]:
             prev_symlink = prev_work_dir / ".latest" / otx_cmd
-            if not prev_symlink.exists():
+            try:  # check symlink exists
+                prev_symlink.resolve(strict=True)
+            except FileNotFoundError:
                 break
             prev_cmd_dir_name = prev_symlink.resolve().name
             prev_cmd_dir = prev_work_dir / prev_cmd_dir_name

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -307,11 +307,12 @@ class Benchmark:
         return result.set_index(["task", "model", "data_group", "data"])
 
     def _prepare_resume(self, tags: dict[str, str], work_dir: Path) -> list[str]:
+        copied_ops_dir = []
         if self.resume_from is None:
-            return None
+            return copied_ops_dir
         prev_work_dir = self._find_corresponding_dir(tags)
         if prev_work_dir is None:
-            return None
+            return copied_ops_dir
 
         latest_dir = work_dir / ".latest"
 
@@ -322,7 +323,6 @@ class Benchmark:
         else:
             copy_until = self.test_only
 
-        copied_ops_dir = []
         for otx_cmd in ["train", "export", "optimize"]:
             prev_symlink = prev_work_dir / ".latest" / otx_cmd
             try:  # check symlink exists

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -307,7 +307,7 @@ class Benchmark:
         return result.set_index(["task", "model", "data_group", "data"])
 
     def _prepare_resume(self, tags: dict[str, str], work_dir: Path) -> list[str]:
-        if self.resume is None:
+        if self.resume_from is None:
             return None
         prev_work_dir = self._find_corresponding_dir(tags)
         if prev_work_dir is None:
@@ -353,9 +353,9 @@ class Benchmark:
         return copied_ops_dir
 
     def _find_corresponding_dir(self, tags: dict[str, str]) -> Path | None:
-        if self.resume is None:
+        if self.resume_from is None:
             return None
-        for csv_file in self.resume.rglob("benchmark.raw.csv"):
+        for csv_file in self.resume_from.rglob("benchmark.raw.csv"):
             if csv_file.parent.name == ".latest":
                 continue
             raw_data = pd.read_csv(csv_file)

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -55,7 +55,7 @@ class Benchmark:
             Previous performance directory to load. If training was already done in previous performance test,
             training is skipped and refer previous result.
         test_only (Literal["all", "train", "export", "optimize"] | None):
-            Execute test only when resume argument is given. If necessary files are not found in resume directory, 
+            Execute test only when resume argument is given. If necessary files are not found in resume directory,
             necessary operations can be executed. Defaults to None.
     """
 
@@ -140,7 +140,8 @@ class Benchmark:
         if (test_only == "export" and eval_upto == "train") or (
             test_only == "optimize" and eval_upto in ["train", "export"]
         ):
-            raise ValueError("test_only should be set to previous otx command than eval_upto.")
+            msg = "test_only should be set to previous otx command than eval_upto."
+            raise ValueError(msg)
         self.test_only = test_only
 
     def run(
@@ -347,7 +348,7 @@ class Benchmark:
         if copy_until != otx_cmd:
             log.warning(
                 f"There is no {otx_cmd} directory for {work_dir} in resume directory. "
-                f"{work_dir} starts from {otx_cmd}."
+                f"{work_dir} starts from {otx_cmd}.",
             )
 
         return copied_ops_dir

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -177,9 +177,7 @@ class Benchmark:
                 tags["seed"] = str(seed)
 
                 # Train & test
-                if self.resume is not None:
-                    resume_from = self._prepare_resume(tags, sub_work_dir)
-
+                resume_from = self._prepare_resume(tags, sub_work_dir)
                 command = [
                     "otx",
                     "train",
@@ -245,9 +243,9 @@ class Benchmark:
                             command.append(str(value))
                         self._run_command(command)
 
-                        exported_model_path = sub_work_dir / ".latest" / "export" / "exported_model.xml"
-                        if not exported_model_path.exists():
-                            exported_model_path = sub_work_dir / ".latest" / "export" / "exported_model_decoder.xml"
+                    exported_model_path = sub_work_dir / ".latest" / "export" / "exported_model.xml"
+                    if not exported_model_path.exists():
+                        exported_model_path = sub_work_dir / ".latest" / "export" / "exported_model_decoder.xml"
 
                     self._run_test(
                         sub_work_dir,
@@ -274,9 +272,9 @@ class Benchmark:
                             command.append(str(value))
                         self._run_command(command)
 
-                        optimized_model_path = sub_work_dir / ".latest" / "optimize" / "optimized_model.xml"
-                        if not optimized_model_path.exists():
-                            optimized_model_path = sub_work_dir / ".latest" / "optimize" / "optimized_model_decoder.xml"
+                    optimized_model_path = sub_work_dir / ".latest" / "optimize" / "optimized_model.xml"
+                    if not optimized_model_path.exists():
+                        optimized_model_path = sub_work_dir / ".latest" / "optimize" / "optimized_model_decoder.xml"
 
                     self._run_test(
                         sub_work_dir,
@@ -315,7 +313,7 @@ class Benchmark:
         for otx_cmd in ["train", "export", "optimize"]:
             prev_symlink = prev_work_dir / ".latest" / otx_cmd
             try:  # check symlink exists
-                prev_symlink.resolve(strict=True)
+                prev_symlink.readlink()
             except FileNotFoundError:
                 break
             prev_cmd_dir_name = prev_symlink.resolve().name

--- a/tests/perf/benchmark.py
+++ b/tests/perf/benchmark.py
@@ -137,6 +137,11 @@ class Benchmark:
         self.accelerator = accelerator
         self.reference_results = reference_results
         self.resume = resume
+        if (resume_from == "export" and eval_upto == "train") or (
+            resume_from == "optimize" and eval_upto in ["train", "export"]
+        ):
+            msg = "resume_from should be set to previous otx command than eval_upto."
+            raise ValueError(msg)
         self.resume_from = resume_from
 
     def run(

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -9,7 +9,7 @@ import platform
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlparse
 
 import pytest
@@ -248,21 +248,21 @@ def fxt_tags(fxt_user_name: str, fxt_version_tags: dict[str, str], fxt_accelerat
 
 
 @pytest.fixture(scope="session")
-def fxt_resume(request: pytest.FixtureRequest) -> Path | None:
-    resume = request.config.getoption("--resume")
-    if resume is not None:
-        resume = Path(resume)
-    msg = f"{resume = }"
-    log.info(msg)
-    return resume
-
-
-@pytest.fixture(scope="session")
-def fxt_resume_from(request: pytest.FixtureRequest) -> str:
+def fxt_resume_from(request: pytest.FixtureRequest) -> Path | None:
     resume_from = request.config.getoption("--resume-from")
+    if resume_from is not None:
+        resume_from = Path(resume_from)
     msg = f"{resume_from = }"
     log.info(msg)
     return resume_from
+
+
+@pytest.fixture(scope="session")
+def fxt_test_only(request: pytest.FixtureRequest) -> Literal["all", "train", "export", "optimize"] | None:
+    test_only = request.config.getoption("--test-only")
+    msg = f"{test_only = }"
+    log.info(msg)
+    return test_only
 
 
 @pytest.fixture()
@@ -277,8 +277,8 @@ def fxt_benchmark(
     fxt_deterministic: bool,
     fxt_accelerator: str,
     fxt_benchmark_reference: pd.DataFrame | None,
-    fxt_resume: Path | None,
-    fxt_resume_from: str,
+    fxt_resume_from: Path | None,
+    fxt_test_only: Literal["all", "train", "export", "optimize"] | None,
 ) -> Benchmark:
     """Configure benchmark."""
     return Benchmark(
@@ -292,8 +292,8 @@ def fxt_benchmark(
         deterministic=fxt_deterministic,
         accelerator=fxt_accelerator,
         reference_results=fxt_benchmark_reference,
-        resume=fxt_resume,
         resume_from=fxt_resume_from,
+        test_only=fxt_test_only,
     )
 
 

--- a/tests/perf/test_action.py
+++ b/tests/perf/test_action.py
@@ -102,12 +102,10 @@ class TestPerfActionClassification(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )

--- a/tests/perf/test_anomaly.py
+++ b/tests/perf/test_anomaly.py
@@ -74,14 +74,12 @@ class TestPerfAnomalyClassification(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -145,14 +143,12 @@ class TestPerfAnomalyDetection(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -216,12 +212,10 @@ class TestPerfAnomalySegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )

--- a/tests/perf/test_classification.py
+++ b/tests/perf/test_classification.py
@@ -99,7 +99,6 @@ class TestPerfSingleLabelClassification(PerfTestBase):
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
         fxt_accelerator: str,
-        fxt_resume_from: Path | None,
     ):
         if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
             pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
@@ -109,7 +108,6 @@ class TestPerfSingleLabelClassification(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -183,7 +181,6 @@ class TestPerfMultiLabelClassification(PerfTestBase):
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
         fxt_accelerator: str,
-        fxt_resume_from: Path | None,
     ):
         if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
             pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
@@ -193,7 +190,6 @@ class TestPerfMultiLabelClassification(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -261,7 +257,6 @@ class TestPerfHierarchicalLabelClassification(PerfTestBase):
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
         fxt_accelerator: str,
-        fxt_resume_from: Path | None,
     ):
         if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
             pytest.skip(f"{fxt_model.name} doesn't support {fxt_accelerator}.")
@@ -271,7 +266,6 @@ class TestPerfHierarchicalLabelClassification(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -379,12 +373,10 @@ class TestPerfSemiSLMultiClass(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )

--- a/tests/perf/test_detection.py
+++ b/tests/perf/test_detection.py
@@ -110,7 +110,6 @@ class TestPerfObjectDetection(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
         fxt_accelerator: str,
     ):
         if fxt_model.name == "atss_resnext101" and fxt_accelerator == "xpu":
@@ -121,5 +120,4 @@ class TestPerfObjectDetection(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )

--- a/tests/perf/test_instance_segmentation.py
+++ b/tests/perf/test_instance_segmentation.py
@@ -110,7 +110,6 @@ class TestPerfInstanceSegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
         fxt_accelerator: str,
     ):
         if fxt_model.name == "maskrcnn_r50" and fxt_accelerator == "xpu":
@@ -121,7 +120,6 @@ class TestPerfInstanceSegmentation(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -207,7 +205,6 @@ class TestPerfTilingInstanceSegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
         fxt_accelerator: str,
     ):
         if fxt_model.name == "maskrcnn_r50" and fxt_accelerator == "xpu":
@@ -218,5 +215,4 @@ class TestPerfTilingInstanceSegmentation(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )

--- a/tests/perf/test_semantic_segmentation.py
+++ b/tests/perf/test_semantic_segmentation.py
@@ -85,7 +85,6 @@ class TestPerfSemanticSegmentation(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
         fxt_accelerator: str,
     ):
         if fxt_model.name == "dino_v2" and fxt_accelerator == "xpu":
@@ -96,5 +95,4 @@ class TestPerfSemanticSegmentation(PerfTestBase):
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )

--- a/tests/perf/test_visual_prompting.py
+++ b/tests/perf/test_visual_prompting.py
@@ -80,14 +80,12 @@ class TestPerfVisualPrompting(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )
 
 
@@ -146,12 +144,10 @@ class TestPerfZeroShotVisualPrompting(PerfTestBase):
         fxt_model: Benchmark.Model,
         fxt_dataset: Benchmark.Dataset,
         fxt_benchmark: Benchmark,
-        fxt_resume_from: Path | None,
     ):
         self._test_perf(
             model=fxt_model,
             dataset=fxt_dataset,
             benchmark=fxt_benchmark,
             criteria=self.BENCHMARK_CRITERIA,
-            resume_from=fxt_resume_from,
         )


### PR DESCRIPTION
### Summary
This PR adds `--test-only` flags to perf test. When it's set, perf test copies all necessary files from resume directory and executes only `otx test` with specified operation. If files can't be found from resume directory, necessary operations will be executed automatically.
Additionally, bug that error is raised when setting device to `cpu` is fixed.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
