### PR TITLE
Add HuggingFace Model Wrapper for Detection

### DIFF
--- a/src/otx/algo/detection/huggingface_model.py
+++ b/src/otx/algo/detection/huggingface_model.py
@@ -163,12 +163,6 @@ class HuggingFaceModelForDetection(OTXDetectionModel):
             onnx_export_configuration={
                 "input_names": ["images"],
                 "output_names": ["bboxes", "labels", "scores"],
-                "dynamic_axes": {
-                    "images": {0: "batch", 2: "height", 3: "width"},
-                    "boxes": {0: "batch", 1: "num_dets"},
-                    "labels": {0: "batch", 1: "num_dets"},
-                    "scores": {0: "batch", 1: "num_dets"},
-                },
                 "autograd_inlining": False,
                 "opset_version": 16,
             },

--- a/src/otx/algo/detection/huggingface_model.py
+++ b/src/otx/algo/detection/huggingface_model.py
@@ -1,0 +1,201 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hugging-Face pretrained model for the OTX Object Detection."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch import nn
+from torchvision import tv_tensors
+from transformers import AutoImageProcessor, AutoModelForObjectDetection
+
+from otx.core.data.entity.base import OTXBatchLossEntity
+from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
+from otx.core.data.entity.utils import stack_batch
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.native import OTXNativeModelExporter
+from otx.core.metrics.fmeasure import MeanAveragePrecisionFMeasureCallable
+from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
+from otx.core.model.detection import OTXDetectionModel
+from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.export import TaskLevelExportParameters
+from otx.core.types.label import LabelInfoTypes
+
+if TYPE_CHECKING:
+    from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+    from transformers.utils.generic import ModelOutput
+
+    from otx.core.metrics import MetricCallable
+
+
+class HuggingFaceModelForDetection(OTXDetectionModel):
+    """A class representing a Hugging Face model for object detection.
+
+    Args:
+        model_name_or_path (str): The name or path of the pre-trained model.
+        label_info (LabelInfoTypes): The label information for the model.
+        optimizer (OptimizerCallable, optional): The optimizer for training the model.
+            Defaults to DefaultOptimizerCallable.
+        scheduler (LRSchedulerCallable | LRSchedulerListCallable, optional):
+            The learning rate scheduler for training the model. Defaults to DefaultSchedulerCallable.
+        metric (MetricCallable, optional): The evaluation metric for the model.
+            Defaults to MeanAveragePrecisionFMeasureCallable.
+        torch_compile (bool, optional): Whether to compile the model using TorchScript. Defaults to False.
+
+    Example:
+        1. API
+            >>> model = HuggingFaceModelForDetection(
+            ...     model_name_or_path="facebook/detr-resnet-50",
+            ...     label_info=<Number-of-classes>,
+            ... )
+        2. CLI
+            >>> otx train \
+            ... --model otx.algo.detection.huggingface_model.HuggingFaceModelForDetection \
+            ... --model.model_name_or_path facebook/detr-resnet-50
+    """
+
+    def __init__(
+        self,
+        model_name_or_path: str,  # https://huggingface.co/models?pipeline_tag=object-detection
+        label_info: LabelInfoTypes,
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
+        metric: MetricCallable = MeanAveragePrecisionFMeasureCallable,
+        torch_compile: bool = False,
+    ) -> None:
+        self.model_name = model_name_or_path
+        self.load_from = None
+
+        super().__init__(
+            label_info=label_info,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            metric=metric,
+            torch_compile=torch_compile,
+        )
+        self.image_processor = AutoImageProcessor.from_pretrained(self.model_name)
+
+    def _build_model(self, num_classes: int) -> nn.Module:
+        return AutoModelForObjectDetection.from_pretrained(
+            pretrained_model_name_or_path=self.model_name,
+            num_labels=num_classes,
+            ignore_mismatched_sizes=True,
+        )
+
+    def _customize_inputs(
+        self,
+        entity: DetBatchDataEntity,
+        pad_size_divisor: int = 32,
+        pad_value: int = 0,
+    ) -> dict[str, Any]:
+        labels = [{"class_labels": entity.labels[i], "boxes": entity.bboxes[i]} for i in range(entity.batch_size)]
+
+        if isinstance(entity.images, list):
+            entity.images, entity.imgs_info = stack_batch(
+                entity.images,
+                entity.imgs_info,
+                pad_size_divisor=pad_size_divisor,
+                pad_value=pad_value,
+            )
+
+        return {
+            "pixel_values": entity.images,
+            "labels": labels,
+        }
+
+    def _customize_outputs(
+        self,
+        outputs: ModelOutput,
+        inputs: DetBatchDataEntity,
+    ) -> DetBatchPredEntity | OTXBatchLossEntity:
+        if self.training:
+            return outputs.loss_dict
+
+        target_sizes = torch.tensor([box.canvas_size for box in inputs.bboxes])
+        results = self.image_processor.post_process_object_detection(
+            outputs,
+            0.0,
+            target_sizes=target_sizes,
+        )
+
+        scores, labels, bboxes = [], [], []
+        for i, result in enumerate(results):
+            scores.append(result["scores"])
+            labels.append(result["labels"])
+            bboxes.append(
+                tv_tensors.BoundingBoxes(
+                    result["boxes"],
+                    format="XYXY",
+                    canvas_size=inputs.bboxes[i].canvas_size,
+                ),
+            )
+
+        if self.explain_mode:
+            msg = "Explain mode is not supported yet."
+            raise NotImplementedError(msg)
+
+        return DetBatchPredEntity(
+            batch_size=inputs.batch_size,
+            images=inputs.images,
+            imgs_info=inputs.imgs_info,
+            scores=scores,
+            labels=labels,
+            bboxes=bboxes,
+        )
+
+    @property
+    def _export_parameters(self) -> TaskLevelExportParameters:
+        """Defines parameters required to export a particular model implementation."""
+        return super()._export_parameters.wrap(model_type="DETR")
+
+    @property
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        image_size = (1, 3, *self.image_processor.size.values())
+        image_mean = tuple(self.image_processor.image_mean)
+        image_std = tuple(self.image_processor.image_std)
+
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=image_size,
+            mean=image_mean,  # type: ignore[arg-type]
+            std=image_std,  # type: ignore[arg-type]
+            resize_mode="standard",
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration={
+                "input_names": ["images"],
+                "output_names": ["bboxes", "labels", "scores"],
+                "dynamic_axes": {
+                    "images": {0: "batch", 2: "height", 3: "width"},
+                    "boxes": {0: "batch", 1: "num_dets"},
+                    "labels": {0: "batch", 1: "num_dets"},
+                    "scores": {0: "batch", 1: "num_dets"},
+                },
+                "autograd_inlining": False,
+                "opset_version": 16,
+            },
+            output_names=["bboxes", "labels", "feature_vector", "saliency_map"] if self.explain_mode else None,
+        )
+
+    def forward_for_tracing(self, inputs: torch.Tensor) -> dict[str, Any]:  # type: ignore[override]
+        """Forward function for export."""
+        outputs = self.model(inputs)
+        results = self.image_processor.post_process_object_detection(
+            outputs,
+            0.0,
+        )
+        scores, labels, bboxes = [], [], []
+        for result in results:
+            scores.append(result["scores"])
+            labels.append(result["labels"])
+            bboxes.append(result["boxes"])
+
+        return {
+            "bboxes": torch.stack(bboxes),
+            "labels": torch.stack(labels),
+            "scores": torch.stack(scores),
+        }

--- a/src/otx/algo/detection/huggingface_model.py
+++ b/src/otx/algo/detection/huggingface_model.py
@@ -21,7 +21,6 @@ from otx.core.metrics.fmeasure import MeanAveragePrecisionFMeasureCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
 from otx.core.model.detection import OTXDetectionModel
 from otx.core.schedulers import LRSchedulerListCallable
-from otx.core.types.export import TaskLevelExportParameters
 from otx.core.types.label import LabelInfoTypes
 
 if TYPE_CHECKING:
@@ -147,16 +146,11 @@ class HuggingFaceModelForDetection(OTXDetectionModel):
         )
 
     @property
-    def _export_parameters(self) -> TaskLevelExportParameters:
-        """Defines parameters required to export a particular model implementation."""
-        return super()._export_parameters.wrap(model_type="DETR")
-
-    @property
     def _exporter(self) -> OTXModelExporter:
         """Creates OTXModelExporter object that can export the model."""
         image_size = (1, 3, *self.image_processor.size.values())
-        image_mean = tuple(self.image_processor.image_mean)
-        image_std = tuple(self.image_processor.image_std)
+        image_mean = (0.0, 0.0, 0.0)
+        image_std = (255.0, 255.0, 255.0)
 
         return OTXNativeModelExporter(
             task_level_export_parameters=self._export_parameters,

--- a/tests/unit/algo/detection/test_huggingface_model.py
+++ b/tests/unit/algo/detection/test_huggingface_model.py
@@ -43,7 +43,10 @@ class TestHuggingFaceModelForDetection:
                 ),
             ],
             images=[torch.randn(3, 48, 48), torch.randn(3, 48, 48)],
-            imgs_info=[ImageInfo(img_idx=1, img_shape=(48, 48), ori_shape=(48, 48)), ImageInfo(img_idx=2, img_shape=(48, 48), ori_shape=(48, 48))],
+            imgs_info=[
+                ImageInfo(img_idx=1, img_shape=(48, 48), ori_shape=(48, 48)),
+                ImageInfo(img_idx=2, img_shape=(48, 48), ori_shape=(48, 48)),
+            ],
             batch_size=2,
         )
 

--- a/tests/unit/algo/detection/test_huggingface_model.py
+++ b/tests/unit/algo/detection/test_huggingface_model.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from otx.core.data.entity.base import ImageInfo
+from otx.core.data.entity.detection import DetBatchDataEntity, DetBatchPredEntity
+from torchvision import tv_tensors
+
+SKIP_TRANSFORMERS_TEST = False
+try:
+    from otx.algo.detection.huggingface_model import HuggingFaceModelForDetection
+    from transformers.models.detr.image_processing_detr import DetrImageProcessor
+    from transformers.models.detr.modeling_detr import DetrForObjectDetection
+    from transformers.utils.generic import ModelOutput
+except ImportError:
+    SKIP_TRANSFORMERS_TEST = True
+
+
+@pytest.mark.skipif(SKIP_TRANSFORMERS_TEST, reason="'transformers' is not installed")
+class TestHuggingFaceModelForDetection:
+    @pytest.fixture()
+    def fxt_detection_model(self) -> HuggingFaceModelForDetection:
+        return HuggingFaceModelForDetection(
+            model_name_or_path="facebook/detr-resnet-50",
+            label_info=2,
+        )
+
+    @pytest.fixture()
+    def fxt_det_batch_data_entity(self) -> DetBatchDataEntity:
+        return DetBatchDataEntity(
+            labels=[torch.tensor([0, 1]), torch.tensor([1, 1])],
+            bboxes=[
+                tv_tensors.BoundingBoxes(
+                    torch.tensor([[0, 0, 1, 1], [0, 0, 1, 1]]),
+                    format="XYXY",
+                    canvas_size=(48, 48),
+                ),
+                tv_tensors.BoundingBoxes(
+                    torch.tensor([[0, 0, 1, 1], [0.5, 0.5, 0.6, 0.6]]),
+                    format="XYXY",
+                    canvas_size=(48, 48),
+                ),
+            ],
+            images=[torch.randn(3, 48, 48), torch.randn(3, 48, 48)],
+            imgs_info=[ImageInfo(img_idx=1, img_shape=(48, 48), ori_shape=(48, 48)), ImageInfo(img_idx=2, img_shape=(48, 48), ori_shape=(48, 48))],
+            batch_size=2,
+        )
+
+    def test_init(self, fxt_detection_model):
+        assert isinstance(fxt_detection_model.model, DetrForObjectDetection)
+        assert isinstance(fxt_detection_model.image_processor, DetrImageProcessor)
+
+    def test_customize_inputs(self, fxt_detection_model, fxt_det_batch_data_entity):
+        outputs = fxt_detection_model._customize_inputs(fxt_det_batch_data_entity)
+        assert "pixel_values" in outputs
+        assert "labels" in outputs
+        assert len(outputs["labels"]) > 0
+        assert "class_labels" in outputs["labels"][0]
+        assert "boxes" in outputs["labels"][0]
+
+    def test_customize_outputs(self, fxt_detection_model, fxt_det_batch_data_entity):
+        outputs = ModelOutput(
+            loss=torch.tensor(0.1),
+            loss_dict={"ce_loss": torch.tensor(0.1), "bbox_loss": torch.tensor(0.1)},
+            logits=torch.randn(2, 100, 2),
+            pred_boxes=torch.randn(2, 100, 4),
+        )
+        fxt_detection_model.training = True
+        result = fxt_detection_model._customize_outputs(outputs, fxt_det_batch_data_entity)
+        assert isinstance(result, dict)
+        assert "ce_loss" in result
+        assert "bbox_loss" in result
+
+        fxt_detection_model.training = False
+        result = fxt_detection_model._customize_outputs(outputs, fxt_det_batch_data_entity)
+        assert isinstance(result, DetBatchPredEntity)
+        assert len(result.bboxes) == 2
+        assert len(result.labels) == 2
+        assert len(result.scores) == 2

--- a/tests/unit/algo/detection/test_huggingface_model.py
+++ b/tests/unit/algo/detection/test_huggingface_model.py
@@ -20,7 +20,7 @@ except ImportError:
 @pytest.mark.skipif(SKIP_TRANSFORMERS_TEST, reason="'transformers' is not installed")
 class TestHuggingFaceModelForDetection:
     @pytest.fixture()
-    def fxt_detection_model(self) -> HuggingFaceModelForDetection:
+    def fxt_detection_model(self):
         return HuggingFaceModelForDetection(
             model_name_or_path="facebook/detr-resnet-50",
             label_info=2,


### PR DESCRIPTION
### Summary

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


  |   |   | WGISD |   |   |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | --
task | model | otx_version | test/f1-score | test/map_50 | export/f1-score | export/map_50 | train/epoch | train/e2e_time
detection | facebook/detr-resnet-50 | 2.2.0rc0 | 0.5197 | 0.4121 | 0.5109 | 0.4205 | 29 | 0:06:49



</div>

<!--EndFragment-->
</body>

</html>
**Notes: This is not an optimal setting, using OTX's default scheduling setting. In addition, only Resize and BBOX Normalize are used as data transforms. Therefore, there is room for improvement depending on the setting.


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
