### PR TITLE
Enable to override data configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Enhancements
 
+- Enable to override data configurations
+  (<https://github.com/openvinotoolkit/training_extensions/pull/3748>)
+
 ### Bug fixes
 
 ## \[v2.1.0\]

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -136,7 +136,15 @@ def apply_config(self: ActionConfigFile, parser: ArgumentParser, cfg: Namespace,
         cfg.__dict__.update(cfg_merged.__dict__)
         overrides = cfg.__dict__.pop("overrides", None)
         if overrides is not None:
-            # This is a feature to handle the callbacks & logger override for user-convinience
+            # replace the config with the overrides for keys in reset list
+            reset = overrides.pop("reset", [])
+            if isinstance(reset, str):
+                reset = [reset]
+            for key in reset:
+                if key in overrides:
+                    cfg[key] = overrides.pop(key)
+
+            # This is a feature to handle the callbacks, logger, and data override for user-convinience
             list_override(configs=cfg, key="callbacks", overrides=overrides.pop("callbacks", []))
             list_override(configs=cfg, key="logger", overrides=overrides.pop("logger", []))
             namespace_override(configs=cfg, key="data", overrides=overrides.pop("data", Namespace()))

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -163,7 +163,8 @@ def namespace_override(configs: Namespace, key: str, overrides: Namespace) -> No
         overrides (Namespace): The configuration object to override the existing ones.
     """
     for sub_key, sub_value in overrides.items():
-        if isinstance(sub_value, list):
+        if isinstance(sub_value, list) and all(isinstance(sv, dict) for sv in sub_value):
+            # only enable list of dictionary items
             list_override(configs=configs[key], key=sub_key, overrides=sub_value)
         else:
             configs[key].update(sub_value, sub_key)

--- a/src/otx/cli/utils/jsonargparse.py
+++ b/src/otx/cli/utils/jsonargparse.py
@@ -1,6 +1,6 @@
 """Functions related to jsonargparse."""
 
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2023-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
@@ -139,10 +139,26 @@ def apply_config(self: ActionConfigFile, parser: ArgumentParser, cfg: Namespace,
             # This is a feature to handle the callbacks & logger override for user-convinience
             list_override(configs=cfg, key="callbacks", overrides=overrides.pop("callbacks", []))
             list_override(configs=cfg, key="logger", overrides=overrides.pop("logger", []))
+            namespace_override(configs=cfg, key="data", overrides=overrides.pop("data", Namespace()))
             cfg.update(overrides)
         if cfg.get(dest) is None:
             cfg[dest] = []
         cfg[dest].append(cfg_path)
+
+
+def namespace_override(configs: Namespace, key: str, overrides: Namespace) -> None:
+    """Overrides the nested dictionary type in the given configs with the provided override_dict.
+
+    Args:
+        configs (Namespace): The configuration object containing the key.
+        key (str): key of the configs want to override.
+        overrides (Namespace): The configuration object to override the existing ones.
+    """
+    for sub_key, sub_value in overrides.items():
+        if isinstance(sub_value, list):
+            list_override(configs=configs[key], key=sub_key, overrides=sub_value)
+        else:
+            configs[key].update(sub_value, sub_key)
 
 
 def list_override(configs: Namespace, key: str, overrides: list) -> None:

--- a/src/otx/recipe/_base_/data/detection.yaml
+++ b/src/otx/recipe/_base_/data/detection.yaml
@@ -12,7 +12,24 @@ train_subset:
   num_workers: 2
   to_tv_image: false
   transforms:
-    - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        scale:
+          - 800
+          - 992
+        transform_bbox: true
+    - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
+      init_args:
+        prob: 0.5
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [0.0, 0.0, 0.0]
+        std: [255.0, 255.0, 255.0]
   sampler:
     class_path: torch.utils.data.RandomSampler
 
@@ -23,7 +40,19 @@ val_subset:
   num_workers: 2
   to_tv_image: false
   transforms:
-    - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        scale:
+          - 800
+          - 992
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [0.0, 0.0, 0.0]
+        std: [255.0, 255.0, 255.0]
   sampler:
     class_path: torch.utils.data.RandomSampler
 
@@ -34,6 +63,18 @@ test_subset:
   num_workers: 2
   to_tv_image: false
   transforms:
-    - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        scale:
+          - 800
+          - 992
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [0.0, 0.0, 0.0]
+        std: [255.0, 255.0, 255.0]
   sampler:
     class_path: torch.utils.data.RandomSampler

--- a/src/otx/recipe/_base_/data/instance_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/instance_segmentation.yaml
@@ -13,7 +13,6 @@ train_subset:
   num_workers: 2
   to_tv_image: true
   transforms:
-    # - class_path: torchvision.transforms.v2.ToImage
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
         keep_ratio: true
@@ -47,7 +46,6 @@ val_subset:
   num_workers: 2
   to_tv_image: true
   transforms:
-    # - class_path: torchvision.transforms.v2.ToImage
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
         keep_ratio: true
@@ -75,7 +73,6 @@ test_subset:
   num_workers: 2
   to_tv_image: true
   transforms:
-    # - class_path: torchvision.transforms.v2.ToImage
     - class_path: otx.core.data.transform_libs.torchvision.Resize
       init_args:
         keep_ratio: true

--- a/src/otx/recipe/_base_/data/instance_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/instance_segmentation.yaml
@@ -9,32 +9,89 @@ unannotated_items_ratio: 0.0
 train_subset:
   subset_name: train
   transform_lib_type: TORCHVISION
-  to_tv_image: true
-  transforms:
-    - class_path: torchvision.transforms.v2.ToImage
   batch_size: 1
   num_workers: 2
+  to_tv_image: true
+  transforms:
+    # - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        keep_ratio: true
+        transform_bbox: true
+        transform_mask: true
+        scale:
+          - 1024
+          - 1024
+    - class_path: otx.core.data.transform_libs.torchvision.Pad
+      init_args:
+        pad_to_square: true
+        transform_mask: true
+    - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
+      init_args:
+        prob: 0.5
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
   sampler:
     class_path: torch.utils.data.RandomSampler
 
 val_subset:
   subset_name: val
   transform_lib_type: TORCHVISION
-  to_tv_image: true
-  transforms:
-    - class_path: torchvision.transforms.v2.ToImage
   batch_size: 1
   num_workers: 2
+  to_tv_image: true
+  transforms:
+    # - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        keep_ratio: true
+        scale:
+          - 1024
+          - 1024
+    - class_path: otx.core.data.transform_libs.torchvision.Pad
+      init_args:
+        pad_to_square: true
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
   sampler:
     class_path: torch.utils.data.RandomSampler
 
 test_subset:
   subset_name: test
   transform_lib_type: TORCHVISION
-  to_tv_image: true
-  transforms:
-    - class_path: torchvision.transforms.v2.ToImage
   batch_size: 1
   num_workers: 2
+  to_tv_image: true
+  transforms:
+    # - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        keep_ratio: true
+        scale:
+          - 1024
+          - 1024
+    - class_path: otx.core.data.transform_libs.torchvision.Pad
+      init_args:
+        pad_to_square: true
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
   sampler:
     class_path: torch.utils.data.RandomSampler

--- a/src/otx/recipe/_base_/data/rotated_detection.yaml
+++ b/src/otx/recipe/_base_/data/rotated_detection.yaml
@@ -11,7 +11,29 @@ train_subset:
   transform_lib_type: TORCHVISION
   to_tv_image: false
   transforms:
-    - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        keep_ratio: true
+        transform_bbox: true
+        transform_mask: true
+        scale:
+          - 1024
+          - 1024
+    - class_path: otx.core.data.transform_libs.torchvision.Pad
+      init_args:
+        size_divisor: 32
+        transform_mask: true
+    - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
+      init_args:
+        prob: 0.5
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
   batch_size: 1
   num_workers: 2
   sampler:
@@ -22,7 +44,23 @@ val_subset:
   transform_lib_type: TORCHVISION
   to_tv_image: false
   transforms:
-    - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        keep_ratio: true
+        scale:
+          - 1024
+          - 1024
+    - class_path: otx.core.data.transform_libs.torchvision.Pad
+      init_args:
+        size_divisor: 32
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
   batch_size: 1
   num_workers: 2
   sampler:
@@ -33,7 +71,23 @@ test_subset:
   transform_lib_type: TORCHVISION
   to_tv_image: false
   transforms:
-    - class_path: torchvision.transforms.v2.ToImage
+    - class_path: otx.core.data.transform_libs.torchvision.Resize
+      init_args:
+        keep_ratio: true
+        scale:
+          - 1024
+          - 1024
+    - class_path: otx.core.data.transform_libs.torchvision.Pad
+      init_args:
+        size_divisor: 32
+        is_numpy_to_tvtensor: true
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
   batch_size: 1
   num_workers: 2
   sampler:

--- a/src/otx/recipe/action_classification/openvino_model.yaml
+++ b/src/otx/recipe/action_classification/openvino_model.yaml
@@ -15,6 +15,11 @@ callback_monitor: val/accuracy
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   data:
     task: ACTION_CLASSIFICATION
     image_color_channel: BGR
@@ -27,6 +32,7 @@ overrides:
           init_args:
             test_mode: False
         - class_path: otx.core.data.transform_libs.torchvision.PackVideo
+
     val_subset:
       batch_size: 8
       num_workers: 2
@@ -35,6 +41,7 @@ overrides:
           init_args:
             test_mode: true
         - class_path: otx.core.data.transform_libs.torchvision.PackVideo
+
     test_subset:
       batch_size: 8
       num_workers: 2

--- a/src/otx/recipe/anomaly_classification/padim.yaml
+++ b/src/otx/recipe/anomaly_classification/padim.yaml
@@ -3,7 +3,7 @@ model:
   init_args:
     layers: ["layer1", "layer2", "layer3"]
     backbone: "resnet18"
-    pre_trained: True
+    pre_trained: true
     n_features: null
     task: ANOMALY_CLASSIFICATION
 
@@ -15,18 +15,25 @@ callback_monitor: image_F1Score # this has no effect as Padim does not need to b
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   precision: 32
   max_epochs: 1
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
+
   data:
     task: ANOMALY_CLASSIFICATION
     data_format: mvtec
     vpm_config:
-      use_bbox: True
-      use_point: False
+      use_bbox: true
+      use_point: false
+
     train_subset:
       batch_size: 32
       num_workers: 4
@@ -34,16 +41,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 32
       num_workers: 4
@@ -52,16 +60,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 32
       num_workers: 4
@@ -69,12 +78,12 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/anomaly_classification/stfpm.yaml
+++ b/src/otx/recipe/anomaly_classification/stfpm.yaml
@@ -13,6 +13,11 @@ callback_monitor: image_F1Score
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   precision: 32
   max_epochs: 100
   callbacks:
@@ -22,6 +27,7 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
+
   data:
     task: ANOMALY_CLASSIFICATION
     data_format: mvtec
@@ -32,16 +38,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 32
       num_workers: 4
@@ -50,16 +57,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 32
       num_workers: 4
@@ -67,12 +75,12 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/anomaly_detection/padim.yaml
+++ b/src/otx/recipe/anomaly_detection/padim.yaml
@@ -3,7 +3,7 @@ model:
   init_args:
     layers: ["layer1", "layer2", "layer3"]
     backbone: "resnet18"
-    pre_trained: True
+    pre_trained: true
     n_features: null
     task: ANOMALY_DETECTION
 
@@ -15,18 +15,24 @@ callback_monitor: image_F1Score # this has no effect as Padim does not need to b
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   precision: 32
   max_epochs: 1
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
+
   data:
     task: ANOMALY_DETECTION
     data_format: mvtec
     vpm_config:
-      use_bbox: True
-      use_point: False
+      use_bbox: true
+      use_point: false
     train_subset:
       batch_size: 32
       num_workers: 4
@@ -34,16 +40,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 32
       num_workers: 4
@@ -52,16 +59,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 32
       num_workers: 4
@@ -69,12 +77,12 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/anomaly_detection/stfpm.yaml
+++ b/src/otx/recipe/anomaly_detection/stfpm.yaml
@@ -13,6 +13,11 @@ callback_monitor: pixel_F1Score
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   precision: 32
   max_epochs: 100
   callbacks:
@@ -22,6 +27,7 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
+
   data:
     task: ANOMALY_DETECTION
     data_format: mvtec
@@ -32,16 +38,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 32
       num_workers: 4
@@ -50,16 +57,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 32
       num_workers: 4
@@ -67,12 +75,12 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/anomaly_segmentation/padim.yaml
+++ b/src/otx/recipe/anomaly_segmentation/padim.yaml
@@ -3,7 +3,7 @@ model:
   init_args:
     layers: ["layer1", "layer2", "layer3"]
     backbone: "resnet18"
-    pre_trained: True
+    pre_trained: true
     n_features: null
     task: ANOMALY_SEGMENTATION
 
@@ -15,18 +15,24 @@ callback_monitor: image_F1Score # this has no effect as Padim does not need to b
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   precision: 32
   max_epochs: 1
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
+
   data:
     task: ANOMALY_SEGMENTATION
     data_format: mvtec
     vpm_config:
-      use_bbox: True
-      use_point: False
+      use_bbox: true
+      use_point: false
     train_subset:
       batch_size: 32
       num_workers: 4
@@ -34,16 +40,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 32
       num_workers: 4
@@ -52,16 +59,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 32
       num_workers: 4
@@ -69,12 +77,12 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/anomaly_segmentation/stfpm.yaml
+++ b/src/otx/recipe/anomaly_segmentation/stfpm.yaml
@@ -13,6 +13,11 @@ callback_monitor: pixel_F1Score
 
 data: ../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   precision: 32
   max_epochs: 100
   callbacks:
@@ -22,6 +27,7 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
+
   data:
     task: ANOMALY_SEGMENTATION
     data_format: mvtec
@@ -32,16 +38,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 32
       num_workers: 4
@@ -50,16 +57,17 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 32
       num_workers: 4
@@ -67,12 +75,12 @@ overrides:
         - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
           init_args:
             size: 256
-            antialias: True
+            antialias: true
         - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/h_label_cls/deit_tiny.yaml
@@ -25,21 +25,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -51,16 +57,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -69,14 +76,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -85,7 +93,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
@@ -24,21 +24,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -50,16 +56,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -68,14 +75,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -84,7 +92,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -24,21 +24,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -50,16 +56,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -68,14 +75,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -84,7 +92,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/h_label_cls/mobilenet_v3_large.yaml
@@ -30,21 +30,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -56,16 +62,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -74,14 +81,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -90,7 +98,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/openvino_model.yaml
+++ b/src/otx/recipe/classification/h_label_cls/openvino_model.yaml
@@ -3,8 +3,8 @@ model:
   class_path: otx.core.model.classification.OVHlabelClassificationModel
   init_args:
     model_name: openvino.xml
-    async_inference: True
-    use_throughput_mode: False
+    async_inference: true
+    use_throughput_mode: false
     model_type: Classification
 
 engine:

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
@@ -26,21 +26,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -52,16 +58,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -70,14 +77,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -86,7 +94,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
@@ -26,21 +26,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -52,16 +58,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -70,14 +77,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -86,7 +94,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_mobilenet_v3_small.yaml
@@ -26,21 +26,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: H_LABEL_CLS
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     data_format: datumaro
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -52,16 +58,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -70,14 +77,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -86,7 +94,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/deit_tiny.yaml
@@ -3,7 +3,7 @@ model:
   init_args:
     label_info: 1000
     arch: "vit-tiny"
-    lora: False
+    lora: false
 
     optimizer:
       class_path: torch.optim.AdamW
@@ -27,19 +27,25 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -51,16 +57,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -69,14 +76,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -85,7 +93,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/dino_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/dino_v2.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.dino_v2.DINOv2RegisterClassifier
   init_args:
     label_info: 1000
-    freeze_backbone: False
+    freeze_backbone: false
     backbone: dinov2_vits14_reg
 
     optimizer:
@@ -26,23 +26,29 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
       transforms:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
@@ -53,13 +59,14 @@ overrides:
             is_numpy_to_tvtensor: true
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
       transforms:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
@@ -68,13 +75,14 @@ overrides:
           init_args:
             scale: 224
             is_numpy_to_tvtensor: true
+
     test_subset:
       batch_size: 64
       transforms:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/dino_v2_semisl.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/dino_v2_semisl.yaml
@@ -2,7 +2,7 @@ model:
   class_path: otx.algo.classification.dino_v2.DINOv2ForMulticlassClsSemiSL
   init_args:
     label_info: 1000
-    freeze_backbone: False
+    freeze_backbone: false
     backbone: dinov2_vits14_reg
 
     optimizer:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -27,19 +27,25 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -51,16 +57,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -69,14 +76,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -85,7 +93,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
@@ -26,19 +26,25 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -50,16 +56,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -68,14 +75,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -84,7 +92,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v3_large.yaml
@@ -31,19 +31,25 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -55,16 +61,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -73,14 +80,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -89,7 +97,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/openvino_model.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/openvino_model.yaml
@@ -3,8 +3,8 @@ model:
   init_args:
     label_info: 1000
     model_name: efficientnet-b0-pytorch
-    async_inference: True
-    use_throughput_mode: False
+    async_inference: true
+    use_throughput_mode: false
     model_type: Classification
 
 engine:

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_b3.yaml
@@ -27,11 +27,17 @@ callback_monitor: val/accuracy
 data: ../../_base_/data/torchvision_base.yaml
 
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     train_subset:
       batch_size: 64
@@ -41,7 +47,7 @@ overrides:
             size:
               - 224
               - 224
-            antialias: True
+            antialias: true
         - class_path: torchvision.transforms.v2.RandomHorizontalFlip
           init_args:
             p: 0.5
@@ -49,7 +55,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:
@@ -62,6 +68,7 @@ overrides:
               - 0.225
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
       transforms:
@@ -74,7 +81,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:
@@ -85,6 +92,7 @@ overrides:
               - 0.229
               - 0.224
               - 0.225
+
     test_subset:
       batch_size: 64
       transforms:
@@ -97,7 +105,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
@@ -27,11 +27,17 @@ callback_monitor: val/accuracy
 data: ../../_base_/data/torchvision_base.yaml
 
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     train_subset:
       batch_size: 64
@@ -41,7 +47,7 @@ overrides:
             size:
               - 224
               - 224
-            antialias: True
+            antialias: true
         - class_path: torchvision.transforms.v2.RandomHorizontalFlip
           init_args:
             p: 0.5
@@ -49,7 +55,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:
@@ -62,6 +68,7 @@ overrides:
               - 0.225
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
       transforms:
@@ -74,7 +81,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:
@@ -85,6 +92,7 @@ overrides:
               - 0.229
               - 0.224
               - 0.225
+
     test_subset:
       batch_size: 64
       transforms:
@@ -97,7 +105,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:

--- a/src/otx/recipe/classification/multi_class_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_mobilenet_v3_small.yaml
@@ -27,11 +27,17 @@ callback_monitor: val/accuracy
 data: ../../_base_/data/torchvision_base.yaml
 
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     train_subset:
       batch_size: 64
@@ -41,7 +47,7 @@ overrides:
             size:
               - 224
               - 224
-            antialias: True
+            antialias: true
         - class_path: torchvision.transforms.v2.RandomHorizontalFlip
           init_args:
             p: 0.5
@@ -49,7 +55,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:
@@ -62,6 +68,7 @@ overrides:
               - 0.225
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
       transforms:
@@ -74,7 +81,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:
@@ -85,6 +92,7 @@ overrides:
               - 0.229
               - 0.224
               - 0.225
+
     test_subset:
       batch_size: 64
       transforms:
@@ -97,7 +105,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: True
+            scale: true
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean:

--- a/src/otx/recipe/classification/multi_label_cls/deit_tiny.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/deit_tiny.yaml
@@ -26,6 +26,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
@@ -35,16 +40,17 @@ overrides:
       init_args:
         min_earlystop_patience: 4
         min_lrschedule_patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -56,16 +62,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -74,14 +81,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -90,7 +98,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
@@ -27,21 +27,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -53,16 +59,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -71,14 +78,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -87,7 +95,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
@@ -26,6 +26,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
@@ -35,16 +40,17 @@ overrides:
       init_args:
         min_earlystop_patience: 4
         min_lrschedule_patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -56,16 +62,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -74,14 +81,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -90,7 +98,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/mobilenet_v3_large.yaml
@@ -31,21 +31,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -57,16 +63,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -75,14 +82,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -91,7 +99,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/openvino_model.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/openvino_model.yaml
@@ -3,8 +3,8 @@ model:
   init_args:
     label_info: 1000
     model_name: openvino.xml
-    async_inference: True
-    use_throughput_mode: False
+    async_inference: true
+    use_throughput_mode: false
     model_type: Classification
 
 engine:

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
@@ -26,21 +26,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -52,16 +58,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -70,14 +77,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -86,7 +94,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
@@ -26,6 +26,11 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
@@ -35,16 +40,17 @@ overrides:
       init_args:
         min_earlystop_patience: 4
         min_lrschedule_patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.EfficientNetRandomCrop
           init_args:
@@ -56,16 +62,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -74,14 +81,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -90,7 +98,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/tv_mobilenet_v3_small.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_mobilenet_v3_small.yaml
@@ -26,21 +26,27 @@ callback_monitor: val/accuracy
 
 data: ../../_base_/data/torchvision_base.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
+
   data:
     task: MULTI_LABEL_CLS
     data_format: datumaro
     mem_cache_img_max_size:
       - 500
       - 500
-    stack_images: True
+    stack_images: true
     train_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.RandomResizedCrop
           init_args:
@@ -52,16 +58,17 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -70,14 +77,15 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 64
-      to_tv_image: False
+      to_tv_image: false
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
@@ -86,7 +94,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-            scale: False
+            scale: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/detection/atss_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2.yaml
@@ -41,58 +41,11 @@ overrides:
   data:
     train_subset:
       batch_size: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            transform_bbox: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
 
     val_subset:
       batch_size: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
 
     test_subset:
       batch_size: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]

--- a/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/atss_mobilenetv2_tile.yaml
@@ -38,58 +38,11 @@ overrides:
 
     train_subset:
       batch_size: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            transform_bbox: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
 
     val_subset:
       batch_size: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
 
     test_subset:
       batch_size: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]

--- a/src/otx/recipe/detection/atss_resnext101.yaml
+++ b/src/otx/recipe/detection/atss_resnext101.yaml
@@ -41,58 +41,11 @@ overrides:
   data:
     train_subset:
       batch_size: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.MinIoURandomCrop
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            transform_bbox: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
 
     val_subset:
       batch_size: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
 
     test_subset:
       batch_size: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            scale:
-              - 800
-              - 992
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]

--- a/src/otx/recipe/detection/openvino_model.yaml
+++ b/src/otx/recipe/detection/openvino_model.yaml
@@ -15,12 +15,25 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   data:
     stack_images: false
     train_subset:
       to_tv_image: true
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+
     val_subset:
       to_tv_image: true
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+
     test_subset:
       to_tv_image: true
       batch_size: 64
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -29,6 +29,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/detection/ssd_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2.yaml
@@ -30,6 +30,9 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     train_subset:
@@ -65,14 +68,6 @@ overrides:
             scale:
               - 864
               - 864
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
 
     test_subset:
       batch_size: 8
@@ -82,11 +77,3 @@ overrides:
             scale:
               - 864
               - 864
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]

--- a/src/otx/recipe/detection/ssd_mobilenetv2_tile.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2_tile.yaml
@@ -30,6 +30,9 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     tile_config:
@@ -69,14 +72,6 @@ overrides:
             scale:
               - 864
               - 864
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]
 
     test_subset:
       batch_size: 8
@@ -86,11 +81,3 @@ overrides:
             scale:
               - 864
               - 864
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [0.0, 0.0, 0.0]
-            std: [255.0, 255.0, 255.0]

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     train_subset:

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     tile_config:

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -30,6 +30,11 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   gradient_clip_val: 35.0
   data:
     image_color_channel: BGR

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -30,12 +30,15 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/instance_segmentation.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
   max_epochs: 100
   data:
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
+        - class_path: torchvision.transforms.v2.ToImage
         # - class_path: otx.core.data.transform_libs.torchvision.Resize
         #   init_args:
         #     keep_ratio: true

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -36,73 +36,75 @@ overrides:
       batch_size: 4
       num_workers: 8
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            transform_bbox: true
-            transform_mask: true
-            scale:
-              - 1024
-              - 1024
+        # - class_path: otx.core.data.transform_libs.torchvision.Resize
+        #   init_args:
+        #     keep_ratio: true
+        #     transform_bbox: true
+        #     transform_mask: true
+        #     scale:
+        #       - 1024
+        #       - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
+            # pad_to_square: true
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
+            # transform_mask: true
+        # - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
+        #   init_args:
+        #     prob: 0.5
+        #     is_numpy_to_tvtensor: true
+        # - class_path: torchvision.transforms.v2.ToDtype
+        #   init_args:
+        #     dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
+            # mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 1
       num_workers: 4
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
+        # - class_path: otx.core.data.transform_libs.torchvision.Resize
+        #   init_args:
+        #     keep_ratio: true
+        #     scale:
+        #       - 1024
+        #       - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
+            # pad_to_square: true
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
+            # is_numpy_to_tvtensor: true
+        # - class_path: torchvision.transforms.v2.ToDtype
+        #   init_args:
+        #     dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
+            # mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
+
     test_subset:
       batch_size: 1
       num_workers: 4
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
+        # - class_path: otx.core.data.transform_libs.torchvision.Resize
+        #   init_args:
+        #     keep_ratio: true
+        #     scale:
+        #       - 1024
+        #       - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
+            # pad_to_square: true
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
+            # is_numpy_to_tvtensor: true
+        # - class_path: torchvision.transforms.v2.ToDtype
+        #   init_args:
+        #     dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
+            # mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b.yaml
@@ -30,84 +30,37 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/instance_segmentation.yaml
 overrides:
-  reset:
-    - data.train_subset.transforms
   max_epochs: 100
   data:
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
-        - class_path: torchvision.transforms.v2.ToImage
-        # - class_path: otx.core.data.transform_libs.torchvision.Resize
-        #   init_args:
-        #     keep_ratio: true
-        #     transform_bbox: true
-        #     transform_mask: true
-        #     scale:
-        #       - 1024
-        #       - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            # pad_to_square: true
             size_divisor: 32
-            # transform_mask: true
-        # - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-        #   init_args:
-        #     prob: 0.5
-        #     is_numpy_to_tvtensor: true
-        # - class_path: torchvision.transforms.v2.ToDtype
-        #   init_args:
-        #     dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            # mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
 
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
-        # - class_path: otx.core.data.transform_libs.torchvision.Resize
-        #   init_args:
-        #     keep_ratio: true
-        #     scale:
-        #       - 1024
-        #       - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            # pad_to_square: true
             size_divisor: 32
-            # is_numpy_to_tvtensor: true
-        # - class_path: torchvision.transforms.v2.ToDtype
-        #   init_args:
-        #     dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            # mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
 
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
-        # - class_path: otx.core.data.transform_libs.torchvision.Resize
-        #   init_args:
-        #     keep_ratio: true
-        #     scale:
-        #       - 1024
-        #       - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            # pad_to_square: true
             size_divisor: 32
-            # is_numpy_to_tvtensor: true
-        # - class_path: torchvision.transforms.v2.ToDtype
-        #   init_args:
-        #     dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            # mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_efficientnetb2b_tile.yaml
@@ -35,71 +35,57 @@ overrides:
     tile_config:
       enable_tiler: true
       enable_adaptive_tiling: true
+
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            transform_bbox: true
-            transform_mask: true
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50.yaml
@@ -37,71 +37,20 @@ overrides:
       batch_size: 4
       num_workers: 8
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            transform_bbox: true
-            transform_mask: true
-            scale:
-              - 1024
-              - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tile.yaml
@@ -36,69 +36,46 @@ overrides:
     tile_config:
       enable_tiler: true
       enable_adaptive_tiling: true
+
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            transform_bbox: true
-            transform_mask: true
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
@@ -36,69 +36,9 @@ overrides:
     train_subset:
       batch_size: 4
       num_workers: 8
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            transform_bbox: true
-            transform_mask: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            pad_to_square: true
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            pad_to_square: true
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            pad_to_square: true
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv_tile.yaml
@@ -36,69 +36,46 @@ overrides:
     tile_config:
       enable_tiler: true
       enable_adaptive_tiling: true
+
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            transform_bbox: true
-            transform_mask: true
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint.yaml
@@ -37,69 +37,33 @@ overrides:
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            keep_ratio: true
-            transform_bbox: true
-            transform_mask: true
             scale:
               - 1344
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            keep_ratio: true
             scale:
               - 1344
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            keep_ratio: true
             scale:
               - 1344
               - 1344
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_swint_tile.yaml
@@ -34,69 +34,46 @@ overrides:
     tile_config:
       enable_tiler: true
       enable_adaptive_tiling: true
+
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            transform_bbox: true
-            transform_mask: true
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/openvino_model.yaml
+++ b/src/otx/recipe/instance_segmentation/openvino_model.yaml
@@ -15,7 +15,19 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/instance_segmentation.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
   data:
     stack_images: false
+    train_subset:
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+    val_subset:
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
     test_subset:
       batch_size: 64
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage

--- a/src/otx/recipe/instance_segmentation/openvino_model.yaml
+++ b/src/otx/recipe/instance_segmentation/openvino_model.yaml
@@ -19,14 +19,17 @@ overrides:
     - data.train_subset.transforms
     - data.val_subset.transforms
     - data.test_subset.transforms
+
   data:
     stack_images: false
     train_subset:
       transforms:
         - class_path: torchvision.transforms.v2.ToImage
+
     val_subset:
       transforms:
         - class_path: torchvision.transforms.v2.ToImage
+
     test_subset:
       batch_size: 64
       transforms:

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -31,6 +31,7 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/instance_segmentation.yaml
 overrides:
+  reset: data.train_subset.transforms
   precision: 16
   max_epochs: 100
   gradient_clip_val: 35.0
@@ -92,8 +93,8 @@ overrides:
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
@@ -101,21 +102,11 @@ overrides:
             scale:
               - 640
               - 640
-            keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             pad_val: 114
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
@@ -123,16 +114,6 @@ overrides:
             scale:
               - 640
               - 640
-            keep_ratio: true
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
-            pad_to_square: true
             pad_val: 114
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -38,69 +38,46 @@ overrides:
     tile_config:
       enable_tiler: true
       enable_adaptive_tiling: true
+
     train_subset:
       batch_size: 4
       num_workers: 8
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
-            transform_bbox: true
-            transform_mask: true
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
-      batch_size: 1
       num_workers: 4
       transforms:
         - class_path: otx.core.data.transform_libs.torchvision.Resize
           init_args:
+            keep_ratio: false
             scale:
               - 512
               - 512
         - class_path: otx.core.data.transform_libs.torchvision.Pad
           init_args:
+            pad_to_square: false
             size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_efficientnetb2b.yaml
@@ -35,68 +35,22 @@ overrides:
     train_subset:
       batch_size: 4
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            transform_bbox: true
-            transform_mask: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
       sampler:
         class_path: otx.algo.samplers.balanced_sampler.BalancedSampler
+
     val_subset:
       batch_size: 1
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]
+
     test_subset:
       batch_size: 1
       transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
-            mean: [123.675, 116.28, 103.53]
             std: [1.0, 1.0, 1.0]

--- a/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
+++ b/src/otx/recipe/rotated_detection/maskrcnn_r50.yaml
@@ -34,67 +34,9 @@ overrides:
   data:
     train_subset:
       batch_size: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            transform_bbox: true
-            transform_mask: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            size_divisor: 32
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     val_subset:
       batch_size: 1
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
+
     test_subset:
       batch_size: 1
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.Resize
-          init_args:
-            keep_ratio: true
-            scale:
-              - 1024
-              - 1024
-        - class_path: otx.core.data.transform_libs.torchvision.Pad
-          init_args:
-            size_divisor: 32
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/rotated_detection/openvino_model.yaml
+++ b/src/otx/recipe/rotated_detection/openvino_model.yaml
@@ -15,8 +15,25 @@ callback_monitor: val/map_50
 
 data: ../_base_/data/rotated_detection.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   data:
     stack_images: false
+    train_subset:
+      to_tv_image: true
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+
+    val_subset:
+      to_tv_image: true
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+
     test_subset:
       to_tv_image: true
       batch_size: 24
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage

--- a/src/otx/recipe/semantic_segmentation/dino_v2.yaml
+++ b/src/otx/recipe/semantic_segmentation/dino_v2.yaml
@@ -47,25 +47,6 @@ overrides:
             scale:
               - 560
               - 560
-            crop_ratio_range:
-              - 0.2
-              - 1.0
-            aspect_ratio_range:
-              - 0.5
-              - 2.0
-            transform_mask: true
-        - class_path: otx.core.data.transform_libs.torchvision.PhotoMetricDistortion
-        - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            prob: 0.5
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
 
     val_subset:
       transforms:
@@ -74,15 +55,6 @@ overrides:
             scale:
               - 560
               - 560
-            transform_mask: true
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
 
     test_subset:
       transforms:
@@ -91,15 +63,6 @@ overrides:
             scale:
               - 560
               - 560
-            transform_mask: true
-            is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
 
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup

--- a/src/otx/recipe/semantic_segmentation/openvino_model.yaml
+++ b/src/otx/recipe/semantic_segmentation/openvino_model.yaml
@@ -15,6 +15,11 @@ callback_monitor: val/Dice
 
 data: ../_base_/data/semantic_segmentation.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   data:
     stack_images: false
     train_subset:
@@ -22,11 +27,13 @@ overrides:
       num_workers: 2
       transforms:
         - class_path: torchvision.transforms.v2.ToImage
+
     val_subset:
       batch_size: 1
       num_workers: 2
       transforms:
         - class_path: torchvision.transforms.v2.ToImage
+
     test_subset:
       batch_size: 64
       num_workers: 2

--- a/src/otx/recipe/visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/visual_prompting/openvino_model.yaml
@@ -15,6 +15,11 @@ callback_monitor: val/Dice
 
 data: ../_base_/data/visual_prompting.yaml
 overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
   data:
     train_subset:
       batch_size: 1
@@ -24,14 +29,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToImage
 
     val_subset:
-      batch_size: 1
       num_workers: 0 # TODO (sungchul): CVS-135462
       to_tv_image: true
       transforms:
         - class_path: torchvision.transforms.v2.ToImage
 
     test_subset:
-      batch_size: 1
       num_workers: 0 # TODO (sungchul): CVS-135462
       to_tv_image: true
       transforms:

--- a/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
+++ b/src/otx/recipe/zero_shot_visual_prompting/openvino_model.yaml
@@ -23,7 +23,9 @@ overrides:
   data:
     train_subset:
       num_workers: 0 # TODO (sungchul): CVS-135462
+
     val_subset:
       num_workers: 0 # TODO (sungchul): CVS-135462
+
     test_subset:
       num_workers: 0 # TODO (sungchul): CVS-135462

--- a/tests/unit/cli/utils/test_jsonargparse.py
+++ b/tests/unit/cli/utils/test_jsonargparse.py
@@ -22,6 +22,7 @@ from otx.cli.utils.jsonargparse import (
 def fxt_configs() -> Namespace:
     return Namespace(
         data=Namespace(
+            stack_images=True,
             train_subset=Namespace(
                 batch_size=32,
                 num_workers=4,
@@ -143,15 +144,25 @@ def test_namespace_override(fxt_configs) -> None:
 
         namespace_override(configs=cfg, key="data", overrides=overrides)
 
+        assert cfg.data.stack_images == fxt_configs.data.stack_images
         assert cfg.data.train_subset.batch_size == fxt_configs.data.train_subset.batch_size
         assert cfg.data.train_subset.num_workers == fxt_configs.data.train_subset.num_workers
         assert cfg.data.train_subset.transforms == fxt_configs.data.train_subset.transforms
+        assert cfg.data.train_subset.sampler == fxt_configs.data.train_subset.sampler
+        assert cfg.callbacks == fxt_configs.callbacks
+        assert cfg.logger == fxt_configs.logger
 
         # test for single key override
-        overrides = Namespace(train_subset=Namespace(batch_size=64, num_workers=8))
+        overrides = Namespace(
+            mem_cache_img_max_size=[100, 100],
+            stack_images=False,
+            train_subset=Namespace(batch_size=64, num_workers=8),
+        )
 
         namespace_override(configs=cfg, key="data", overrides=overrides)
 
+        assert cfg.data.mem_cache_img_max_size == overrides.mem_cache_img_max_size
+        assert cfg.data.stack_images == overrides.stack_images
         assert cfg.data.train_subset.batch_size == overrides.train_subset.batch_size
         assert cfg.data.train_subset.num_workers == overrides.train_subset.num_workers
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR includes:

- [x] Enable to override data configs in recipes
    - It enables to override data configs:
        - including single config (e.g. batch_size or num_workers )
        - nested namespace (e.g. sampler)
        - list of dicts (e.g. transforms)) like callbacks or logger
        ```yaml
        ...
        overrides:
          data:
            ...
            train_subset:
              batch_size: 4 # update batch_size to 4
              transforms:
                # set transform's parameter(s) to be updated
                - class_path: old_transform1
                  init_args:
                    scale: # update scale to (320, 320)
                      - 320
                      - 320
                # if no old_transform2, it will be used as is
                - class_path: old_transform3
                  init_args:
                    prob: 0.7 # update prob to 0.7
                ...
              sampler:
                class_path: new_sampler # update samper from old one to new_sampler
        ```
    - If there is no predefined config in base config, it adds this
    - If you want to reset specific configs (especially transforms), use `reset` with list or string like below:
        ```yaml
        ...
        overrides:
          reset:
            - data.train_subset.transforms
            - data.val_subset.transforms
            - data.test_subset.transforms
          ...
          data:
            ...
            train_subset:
              ...
              transforms:
                # set all new transforms for reinitialization
                - class_path: new_transform1
                - class_path: new_transform2
                - class_path: new_transform3
                ...
            # update val_subset.transforms and test_subset.transforms as well
        ```
        ```yaml
        ...
        overrides:
          reset: data.train_subset.transforms # only update train_subset.transforms
          ...
          data:
            ...
            train_subset:
              ...
              transforms:
                - class_path: new_transform1
                - class_path: new_transform2
                - class_path: new_transform3
                ...
            # val_subset.transforms and test_subset.transforms will not be reset, but can be updated
        ```
- [x] Update recipes

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
