### PR TITLE
Add HuggingFace Model Wrapper for Semantic-Segmentation

### DIFF
--- a/src/otx/algo/segmentation/huggingface_model.py
+++ b/src/otx/algo/segmentation/huggingface_model.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hugging-Face pretrained model for the OTX Semantic Segmentation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from torch import nn
+from transformers import (
+    AutoImageProcessor,
+    AutoModelForSemanticSegmentation,
+)
+
+from otx.core.data.entity.base import OTXBatchLossEntity
+from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity
+from otx.core.exporter.base import OTXModelExporter
+from otx.core.exporter.native import OTXNativeModelExporter
+from otx.core.metrics.dice import SegmCallable
+from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
+from otx.core.model.segmentation import OTXSegmentationModel
+from otx.core.schedulers import LRSchedulerListCallable
+from otx.core.types.label import LabelInfoTypes
+
+if TYPE_CHECKING:
+    from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+    from transformers.modeling_outputs import SemanticSegmenterOutput
+
+    from otx.core.metrics import MetricCallable
+
+
+class HuggingFaceModelForSegmentation(OTXSegmentationModel):
+    """A class representing a Hugging Face model for segmentation.
+
+    Args:
+        model_name_or_path (str): The name or path of the pre-trained model.
+        label_info (LabelInfoTypes): The label information for the model.
+        optimizer (OptimizerCallable, optional): The optimizer for training the model.
+            Defaults to DefaultOptimizerCallable.
+        scheduler (LRSchedulerCallable | LRSchedulerListCallable, optional):
+            The learning rate scheduler for training the model. Defaults to DefaultSchedulerCallable.
+        metric (MetricCallable, optional): The evaluation metric for the model.
+            Defaults to MeanAveragePrecisionFMeasureCallable.
+        torch_compile (bool, optional): Whether to compile the model using TorchScript. Defaults to False.
+
+    Example:
+        1. API
+            >>> model = HuggingFaceModelForSegmentation(
+            ...     model_name_or_path="nvidia/segformer-b0-finetuned-ade-512-512",
+            ...     label_info=<Number-of-classes>,
+            ... )
+        2. CLI
+            >>> otx train \
+            ... --model otx.algo.segmentation.huggingface_model.HuggingFaceModelForSegmentation \
+            ... --model.model_name_or_path nvidia/segformer-b0-finetuned-ade-512-512
+    """
+
+    def __init__(
+        self,
+        model_name_or_path: str,  # https://huggingface.co/models?pipeline_tag=image-segmentation
+        label_info: LabelInfoTypes,
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
+        metric: MetricCallable = SegmCallable,  # type: ignore[assignment]
+        torch_compile: bool = False,
+    ) -> None:
+        self.model_name = model_name_or_path
+        self.load_from = None
+
+        super().__init__(
+            label_info=label_info,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            metric=metric,
+            torch_compile=torch_compile,
+        )
+        self.image_processor = AutoImageProcessor.from_pretrained(self.model_name)
+
+    def _create_model(self) -> nn.Module:
+        return AutoModelForSemanticSegmentation.from_pretrained(
+            pretrained_model_name_or_path=self.model_name,
+            num_labels=self.label_info.num_classes,
+            ignore_mismatched_sizes=True,
+        )
+
+    def _customize_inputs(self, entity: SegBatchDataEntity) -> dict[str, Any]:
+        masks = torch.stack(entity.masks).long() if self.training else None
+
+        return {
+            "pixel_values": entity.images,
+            "labels": masks,
+        }
+
+    def _customize_outputs(
+        self,
+        outputs: SemanticSegmenterOutput,
+        inputs: SegBatchDataEntity,
+    ) -> SegBatchPredEntity | OTXBatchLossEntity:
+        if self.training:
+            return OTXBatchLossEntity(loss=outputs.loss)
+        if self.explain_mode:
+            msg = "Explain mode is not supported yet."
+            raise NotImplementedError(msg)
+
+        target_sizes = [info.img_shape for info in inputs.imgs_info]
+        results = self.image_processor.post_process_semantic_segmentation(
+            outputs,
+            target_sizes=target_sizes,
+        )
+
+        return SegBatchPredEntity(
+            batch_size=inputs.batch_size,
+            images=inputs.images,
+            imgs_info=inputs.imgs_info,
+            scores=[],
+            masks=results,
+        )
+
+    @property
+    def _exporter(self) -> OTXModelExporter:
+        """Creates OTXModelExporter object that can export the model."""
+        size = self.image_processor.size.values()
+        size = (*size, *size) if len(size) == 1 else size
+        image_size = (1, 3, *size)
+        image_mean = (123.675, 116.28, 103.53)
+        image_std = (58.395, 57.12, 57.375)
+
+        return OTXNativeModelExporter(
+            task_level_export_parameters=self._export_parameters,
+            input_size=image_size,
+            mean=image_mean,
+            std=image_std,
+            resize_mode="standard",
+            pad_value=0,
+            swap_rgb=False,
+            via_onnx=False,
+            onnx_export_configuration=None,
+            output_names=None,
+        )
+
+    def forward_for_tracing(self, image: torch.Tensor) -> torch.Tensor | dict[str, torch.Tensor]:
+        """Model forward function used for the model tracing during model exportation."""
+        return self.model(image)

--- a/tests/unit/algo/segmentation/test_huggingface_model.py
+++ b/tests/unit/algo/segmentation/test_huggingface_model.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from otx.core.data.entity.base import ImageInfo, OTXBatchLossEntity
+from otx.core.data.entity.segmentation import SegBatchDataEntity, SegBatchPredEntity
+
+SKIP_TRANSFORMERS_TEST = False
+try:
+    from otx.algo.segmentation.huggingface_model import HuggingFaceModelForSegmentation
+    from transformers.modeling_outputs import SemanticSegmenterOutput
+    from transformers.models.segformer.image_processing_segformer import SegformerImageProcessor
+    from transformers.models.segformer.modeling_segformer import SegformerForSemanticSegmentation
+except ImportError:
+    SKIP_TRANSFORMERS_TEST = True
+
+
+@pytest.mark.skipif(SKIP_TRANSFORMERS_TEST, reason="'transformers' is not installed")
+class TestHuggingFaceModelForSegmentation:
+    @pytest.fixture()
+    def fxt_seg_model(self):
+        return HuggingFaceModelForSegmentation(
+            model_name_or_path="nvidia/segformer-b0-finetuned-ade-512-512",
+            label_info=2,
+        )
+
+    @pytest.fixture()
+    def fxt_seg_batch_data_entity(self) -> SegBatchDataEntity:
+        return SegBatchDataEntity(
+            images=[torch.randn(3, 32, 32), torch.randn(3, 32, 32)],
+            masks=[
+                torch.randint(low=0, high=2, size=(32, 32), dtype=torch.uint8),
+                torch.randint(low=0, high=2, size=(32, 32), dtype=torch.uint8),
+            ],
+            imgs_info=[
+                ImageInfo(img_idx=1, img_shape=(32, 32), ori_shape=(32, 32)),
+                ImageInfo(img_idx=2, img_shape=(32, 32), ori_shape=(32, 32)),
+            ],
+            batch_size=2,
+        )
+
+    def test_init(self, fxt_seg_model):
+        assert isinstance(fxt_seg_model.model, SegformerForSemanticSegmentation)
+        assert isinstance(fxt_seg_model.image_processor, SegformerImageProcessor)
+
+    def test_customize_inputs(self, fxt_seg_model, fxt_seg_batch_data_entity):
+        outputs = fxt_seg_model._customize_inputs(fxt_seg_batch_data_entity)
+        assert "pixel_values" in outputs
+        assert "labels" in outputs
+        assert isinstance(outputs["labels"], torch.Tensor)
+
+    def test_customize_outputs(self, fxt_seg_model, fxt_seg_batch_data_entity):
+        outputs = SemanticSegmenterOutput(
+            loss=torch.tensor(0.1),
+            logits=torch.randn(2, 2, 32, 32),
+        )
+        fxt_seg_model.training = True
+        result = fxt_seg_model._customize_outputs(outputs, fxt_seg_batch_data_entity)
+        assert isinstance(result, OTXBatchLossEntity)
+        assert "loss" in result
+
+        fxt_seg_model.training = False
+        result = fxt_seg_model._customize_outputs(outputs, fxt_seg_batch_data_entity)
+        assert isinstance(result, SegBatchPredEntity)
+        assert result.batch_size == 2
+        assert len(result.masks) == 2
+
+        fxt_seg_model.explain_mode = True
+        with pytest.raises(NotImplementedError):
+            fxt_seg_model._customize_outputs(outputs, fxt_seg_batch_data_entity)


### PR DESCRIPTION
### Summary

![image](https://github.com/user-attachments/assets/4f7a76f9-4698-471c-84f5-9b691bb95403)
*pipeline: /_base_/data/semantic_segmentation.yaml & optimizer: AdamW (lr 0.0001)
*The current settings are probably not optimal for each model, so we should be able to improve performance based on the more optimal settings.

### How to test

Install transformers
`pip install transformers`
or
`pip install -e .[transformers]`

API Examples
```python
from otx.algo.segmentation.huggingface_model import HuggingFaceModelForSegmentation
from otx.engine import Engine

data_root = "/datasets/otx_v2_dataset/semantic_seg/kvasir_medium"

otx_model = HuggingFaceModelForSegmentation(
    model_name_or_path="nvidia/segformer-b0-finetuned-ade-512-512",
    label_info=2,
)

engine = Engine(
    data_root=data_root,
    model=otx_model,
    work_dir="otx-workspace-hf",
)

engine.train(max_epochs=2)
engine.test()
engine.export()
engine.test(checkpoint="otx-workspace-hf/exported_model.xml")
```

CLI Examples
```shell
(venv) ~/otx$ otx train \
    --model otx.algo.segmentation.huggingface_model.HuggingFaceModelForSegmentation \
    --model.model_name_or_path nvidia/segformer-b0-finetuned-ade-512-512 \
    --data_root /datasets/otx_v2_dataset/semantic_seg/kvasir_medium \
    --work_dir otx-workspace-hf-cli --max_epochs 3
```

Unit-Test:
![image](https://github.com/user-attachments/assets/2421c096-e464-4834-8f8d-9b399aedac70)

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
