### PR TITLE
[RFC] Engine Refactor Proposal

### DIFF
--- a/src/otx/cli/cli_poc.py
+++ b/src/otx/cli/cli_poc.py
@@ -1,0 +1,44 @@
+from jsonargparse import ActionConfigFile, ArgumentParser, namespace_to_dict
+
+from otx.cli.utils.jsonargparse import get_short_docstring
+from otx.engine.engine_poc import Engine
+
+
+class CLI:
+    """CLI.
+
+    Limited CLI to show how the api does not change externally while retaining the ability to expose models from the
+    adapters.
+    """
+
+    def __init__(self):
+        self.parser = ArgumentParser()
+        self.parser.add_argument(
+            "--config",
+            action=ActionConfigFile,
+            help="Configuration file in JSON format.",
+        )
+        self.add_subcommands()
+        self.run()
+
+    def subcommands(self):
+        return ["train", "test"]
+
+    def add_subcommands(self):
+        parser_subcommand = self.parser.add_subcommands()
+        for subcommand in self.subcommands():
+            subparser = ArgumentParser()
+            subparser.add_method_arguments(Engine, subcommand)
+            fn = getattr(Engine, subcommand)
+            description = get_short_docstring(fn)
+            parser_subcommand.add_subcommand(subcommand, subparser, help=description)
+
+    def run(self):
+        args = self.parser.parse_args()
+        args_dict = namespace_to_dict(args)
+        engine = Engine()
+        # do something here
+
+
+if __name__ == "__main__":
+    CLI()

--- a/src/otx/engine/__init__.py
+++ b/src/otx/engine/__init__.py
@@ -3,6 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from .engine import Engine
+from .engine_poc import Engine
 
 __all__ = ["Engine"]

--- a/src/otx/engine/anomalib.py
+++ b/src/otx/engine/anomalib.py
@@ -1,0 +1,48 @@
+from anomalib.data import AnomalibDataModule
+from anomalib.engine import Engine as AnomalibEngine
+from anomalib.models import AnomalyModule
+
+from otx.core.data.module import OTXDataModule
+from otx.engine.base import METRICS, Adapter
+
+
+def wrap_to_anomalib_datamodule(datamodule: OTXDataModule) -> AnomalibDataModule:
+    """Mock function to wrap OTXDataModule to AnomalibDataModule."""
+    return AnomalibDataModule(
+        train=datamodule.train,
+        val=datamodule.val,
+        test=datamodule.test,
+        batch_size=datamodule.batch_size,
+        num_workers=datamodule.num_workers,
+        pin_memory=datamodule.pin_memory,
+        shuffle=datamodule.shuffle,
+    )
+
+
+class AnomalibAdapter(Adapter):
+    def __init__(self):
+        self._engine = AnomalibEngine()
+
+    def train(
+        self,
+        model: AnomalyModule,
+        datamodule: OTXDataModule | AnomalibDataModule,
+        max_epochs: int = 1,
+        **kwargs,
+    ) -> METRICS:
+        if not isinstance(datamodule, AnomalibDataModule):
+            datamodule = wrap_to_anomalib_datamodule(datamodule)
+        self._engine = AnomalibEngine(max_epochs=max_epochs, **kwargs)
+        return self._engine.train(model=model, datamodule=datamodule)
+
+    def test(
+        self,
+        model: AnomalyModule,
+        datamodule: OTXDataModule | AnomalibDataModule,
+        max_epochs: int = 1,
+        **kwargs,
+    ) -> METRICS:
+        if not isinstance(datamodule, AnomalibDataModule):
+            datamodule = wrap_to_anomalib_datamodule(datamodule)
+        self._engine = AnomalibEngine(max_epochs=max_epochs, **kwargs)
+        return self._engine.test(model=model, datamodule=datamodule)

--- a/src/otx/engine/base.py
+++ b/src/otx/engine/base.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+METRICS = dict[str, float]
+ANNOTATIONS = Any
+
+
+class Adapter(ABC):
+    @abstractmethod
+    def train(self, **kwargs) -> METRICS:
+        pass
+
+    @abstractmethod
+    def test(self, **kwargs) -> METRICS:
+        pass
+
+    # @abstractmethod
+    # def predict(self, **kwargs) -> ANNOTATIONS:
+    #     pass
+
+    # @abstractmethod
+    # def export(self, **kwargs) -> Path:
+    #     pass
+
+    # @abstractmethod
+    # def optimize(self, **kwargs) -> Path:
+    #     pass
+
+    # @abstractmethod
+    # def explain(self, **kwargs) -> list[Tensor]:
+    #     pass
+
+    # @abstractmethod
+    # @classmethod
+    # def from_config(cls, **kwargs) -> "Backend":
+    #     pass
+
+    # @abstractmethod
+    # @classmethod
+    # def from_model_name(cls, **kwargs) -> "Backend":
+    #     pass

--- a/src/otx/engine/engine_poc.py
+++ b/src/otx/engine/engine_poc.py
@@ -1,0 +1,67 @@
+import logging
+
+from anomalib.data import AnomalibDataModule
+from anomalib.models import AnomalyModule
+from ultralytics.data import ClassificationDataset as UltralyticsDataset
+from ultralytics.engine.model import Model
+
+from otx.core.data.module import OTXDataModule
+from otx.core.model.base import OTXModel
+from otx.core.utils.cache import TrainerArgumentsCache
+from otx.engine.base import METRICS, Adapter
+
+from .anomalib import AnomalibAdapter
+from .lightning import LightningAdapter
+from .ultralytics import UltralyticsAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class Engine:
+    """Automatically selects the engine based on the model passed to the engine."""
+
+    def __init__(
+        self,
+        **kwargs,
+    ) -> None:
+        self._adapter: Adapter | None = None
+        self._cache = TrainerArgumentsCache(**kwargs)
+
+    @property
+    def adapter(self) -> Adapter:
+        return self._adapter
+
+    @adapter.setter
+    def adapter(self, adapter: adapter) -> None:
+        self._adapter = adapter
+
+    def get_adapter(self, model: OTXModel | AnomalyModule | Model) -> adapter:
+        if isinstance(model, AnomalyModule) and (
+            self.adapter is not isinstance(self.adapter, AnomalibAdapter) or self.adapter is None
+        ):
+            self.adapter = AnomalibAdapter(**self._cache.args)
+        elif isinstance(model, OTXModel) and (self.adapter is None or not isinstance(self.adapter, LightningAdapter)):
+            self.adapter = LightningAdapter(**self._cache.args)
+        elif isinstance(model, Model) and (self.adapter is None or not isinstance(self.adapter, UltralyticsAdapter)):
+            self.adapter = UltralyticsAdapter(**self._cache.args)
+
+        return self.adapter
+
+    def train(
+        self,
+        model: OTXModel | AnomalyModule | Model,
+        datamodule: OTXDataModule | AnomalibDataModule | UltralyticsDataset,
+        **kwargs,
+    ) -> METRICS:
+        """Train the model."""
+        adapter: Adapter = self.get_adapter(model)
+        adapter.train(model=model, datamodule=datamodule, **kwargs)
+
+    def test(
+        self,
+        model: OTXModel | AnomalyModule | Model,
+        datamodule: OTXDataModule | AnomalibDataModule | UltralyticsDataset,
+    ) -> METRICS:
+        """Test the model."""
+        adapter = self.get_adapter(model)
+        return adapter.test(model=model, datamodule=datamodule)

--- a/src/otx/engine/lightning.py
+++ b/src/otx/engine/lightning.py
@@ -1,0 +1,148 @@
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from lightning.pytorch import Trainer
+
+from otx.core.data.module import OTXDataModule
+from otx.core.metrics import MetricCallable
+from otx.core.model.base import OTXModel
+from otx.core.types.task import OTXTaskType
+from otx.core.utils.cache import TrainerArgumentsCache
+
+from .base import Adapter
+
+
+@contextmanager
+def override_metric_callable(model: OTXModel, new_metric_callable: MetricCallable | None) -> Iterator[OTXModel]:
+    """Override `OTXModel.metric_callable` to change the evaluation metric.
+
+    Args:
+        model: Model to override its metric callable
+        new_metric_callable: If not None, override the model's one with this. Otherwise, do not override.
+    """
+    if new_metric_callable is None:
+        yield model
+        return
+
+    orig_metric_callable = model.metric_callable
+    try:
+        model.metric_callable = new_metric_callable
+        yield model
+    finally:
+        model.metric_callable = orig_metric_callable
+
+
+class LightningAdapter(Adapter):
+    """OTX Engine.
+
+    This is a temporary name and we can change it later. It is basically a subset of what is currently present in the
+    original OTX Engine class (engine.py)
+    """
+
+    def __init__(
+        self,
+        datamodule: OTXDataModule | None = None,
+        model: OTXModel | str | None = None,
+        task: OTXTaskType | None = None,
+        **kwargs,
+    ):
+        self._cache = TrainerArgumentsCache(**kwargs)
+        self.task = task
+        self._trainer: Trainer | None = None
+        self._datamodule: OTXDataModule = datamodule
+        self._model: OTXModel = model
+
+    def train(
+        self,
+        model: OTXModel | None = None,
+        datamodule: OTXDataModule | None = None,
+        max_epochs: int = 10,
+        deterministic: bool = True,
+        val_check_interval: int | float | None = 1,
+        metric: MetricCallable | None = None,
+    ) -> dict[str, float]:
+        if model is not None:
+            self.model = model
+        if datamodule is not None:
+            self.datamodule = datamodule
+        self._build_trainer(
+            logger=None,
+            callbacks=None,
+            max_epochs=max_epochs,
+            deterministic=deterministic,
+            val_check_interval=val_check_interval,
+        )
+
+        # NOTE: Model's label info should be converted datamodule's label info before ckpt loading
+        # This is due to smart weight loading check label name as well as number of classes.
+        if self.model.label_info != self.datamodule.label_info:
+            msg = (
+                "Model label_info is not equal to the Datamodule label_info. "
+                f"It will be overriden: {self.model.label_info} => {self.datamodule.label_info}"
+            )
+            logging.warning(msg)
+            self.model.label_info = self.datamodule.label_info
+
+        with override_metric_callable(model=self.model, new_metric_callable=metric) as model:
+            self.trainer.fit(
+                model=model,
+                datamodule=self.datamodule,
+            )
+        self.checkpoint = self.trainer.checkpoint_callback.best_model_path
+
+        if not isinstance(self.checkpoint, (Path, str)):
+            msg = "self.checkpoint should be Path or str at this time."
+            raise TypeError(msg)
+
+        best_checkpoint_symlink = Path(self.work_dir) / "best_checkpoint.ckpt"
+        if best_checkpoint_symlink.is_symlink():
+            best_checkpoint_symlink.unlink()
+        best_checkpoint_symlink.symlink_to(self.checkpoint)
+
+        return self.trainer.callback_metrics
+
+    def test(self, **kwargs) -> dict[str, float]:
+        pass
+
+    @property
+    def trainer(self) -> Trainer:
+        """Returns the trainer object associated with the engine.
+
+        To get this property, you should execute `Engine.train()` function first.
+
+        Returns:
+            Trainer: The trainer object.
+        """
+        if self._trainer is None:
+            msg = "Please run train() first"
+            raise RuntimeError(msg)
+        return self._trainer
+
+    def _build_trainer(self, **kwargs) -> None:
+        """Instantiate the trainer based on the model parameters."""
+        if self._cache.requires_update(**kwargs) or self._trainer is None:
+            self._cache.update(**kwargs)
+
+            kwargs = self._cache.args
+            self._trainer = Trainer(**kwargs)
+            self._cache.is_trainer_args_identical = True
+            self._trainer.task = self.task
+            self.work_dir = self._trainer.default_root_dir
+
+    @property
+    def model(self) -> OTXModel:
+        return self._model
+
+    @model.setter
+    def model(self, model: OTXModel) -> None:
+        self._model = model
+
+    @property
+    def datamodule(self) -> OTXDataModule:
+        return self._datamodule
+
+    @datamodule.setter
+    def datamodule(self, datamodule: OTXDataModule) -> None:
+        self._datamodule = datamodule

--- a/src/otx/engine/ultralytics/__init__.py
+++ b/src/otx/engine/ultralytics/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import UltralyticsAdapter
+
+__all__ = ["UltralyticsAdapter"]

--- a/src/otx/engine/ultralytics/adapter.py
+++ b/src/otx/engine/ultralytics/adapter.py
@@ -1,0 +1,42 @@
+from torch.utils.data import DataLoader
+from ultralytics.engine.model import Model
+
+from otx.core.data.module import OTXDataModule
+from otx.engine.base import METRICS, Adapter
+
+from .trainer import UltralyticsTrainer
+
+
+def wrap_to_ultralytics_dataset(datamodule: OTXDataModule) -> DataLoader:
+    """Mock function to wrap OTXDataModule to ultralytics classification.
+
+    Ideally we want a general ultralytics dataset
+    """
+    return DataLoader()
+
+
+class UltralyticsAdapter(Adapter):
+    def __init__(self):
+        self._engine: UltralyticsTrainer
+
+    def train(
+        self,
+        model: Model,
+        datamodule: OTXDataModule | DataLoader,
+        max_epochs: int = 5,
+        **kwargs,
+    ) -> METRICS:
+        if not isinstance(datamodule, DataLoader):
+            datamodule = wrap_to_ultralytics_dataset(datamodule)
+        self._engine = UltralyticsTrainer(
+            model=model,
+            dataloader=datamodule,
+            overrides={"epochs": max_epochs, **kwargs},
+        )
+        return self._engine.train()
+
+    def test(self, model: Model, datamodule: OTXDataModule | DataLoader, **kwargs) -> METRICS:
+        if not isinstance(datamodule, DataLoader):
+            datamodule = wrap_to_ultralytics_dataset(datamodule)
+        self._engine = UltralyticsTrainer(model=model, dataloader=datamodule, overrides={**kwargs})
+        return self._engine.train()

--- a/src/otx/engine/ultralytics/trainer.py
+++ b/src/otx/engine/ultralytics/trainer.py
@@ -1,0 +1,169 @@
+import math
+
+import torch
+from torch.cuda import amp
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader
+from ultralytics.cfg import get_cfg, get_save_dir
+from ultralytics.engine.model import Model
+from ultralytics.engine.trainer import BaseTrainer
+from ultralytics.utils import (
+    DEFAULT_CFG,
+    LOGGER,
+    RANK,
+    callbacks,
+    yaml_save,
+)
+from ultralytics.utils.autobatch import check_train_batch_size
+from ultralytics.utils.checks import check_amp, check_imgsz, print_args
+from ultralytics.utils.torch_utils import (
+    EarlyStopping,
+    init_seeds,
+    one_cycle,
+    select_device,
+    torch_distributed_zero_first,
+)
+
+
+class UltralyticsTrainer(BaseTrainer):
+    def __init__(self, model: Model, dataloader: DataLoader, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
+        """Most of the code here is taken from the BaseTrainer."""
+        if overrides is None:
+            overrides = {}
+        overrides["task"] = "classify"
+        if overrides.get("imgsz") is None:
+            overrides["imgsz"] = 224
+        self.args = get_cfg(cfg, overrides)
+        self.check_resume(overrides)
+        self.device = select_device(self.args.device, self.args.batch)
+        self.validator = None
+        self.metrics = None
+        self.plots = {}
+        init_seeds(self.args.seed + 1 + RANK, deterministic=self.args.deterministic)
+
+        # Dirs
+        self.save_dir = get_save_dir(self.args)
+        self.args.name = self.save_dir.name  # update name for loggers
+        self.wdir = self.save_dir / "weights"  # weights dir
+        if RANK in {-1, 0}:
+            self.wdir.mkdir(parents=True, exist_ok=True)  # make dir
+            self.args.save_dir = str(self.save_dir)
+            yaml_save(self.save_dir / "args.yaml", vars(self.args))  # save run args
+        self.last, self.best = self.wdir / "last.pt", self.wdir / "best.pt"  # checkpoint paths
+        self.save_period = self.args.save_period
+
+        self.batch_size = self.args.batch
+        self.epochs = self.args.epochs
+        self.start_epoch = 0
+        if RANK == -1:
+            print_args(vars(self.args))
+
+        # Device
+        if self.device.type in {"cpu", "mps"}:
+            self.args.workers = 0  # faster CPU training as time dominated by inference, not dataloading
+
+        # Model and Dataset
+        self.model = model
+        with torch_distributed_zero_first(RANK):  # avoid auto-downloading dataset multiple times
+            self.train_loader, self.test_loader = dataloader, dataloader
+        self.ema = None
+
+        # Optimization utils init
+        self.lf = None
+        self.scheduler = None
+
+        # Epoch level metrics
+        self.best_fitness = None
+        self.fitness = None
+        self.loss = None
+        self.tloss = None
+        self.loss_names = ["Loss"]
+        self.csv = self.save_dir / "results.csv"
+        self.plot_idx = [0, 1, 2]
+
+        # HUB
+        self.hub_session = None
+
+        # Callbacks
+        self.callbacks = _callbacks or callbacks.get_default_callbacks()
+        if RANK in {-1, 0}:
+            callbacks.add_integration_callbacks(self)
+
+    def _setup_train(self, world_size):
+        """Builds dataloaders and optimizer on correct rank process."""
+        # Model
+        self.run_callbacks("on_pretrain_routine_start")
+        self.model = self.model.to(self.device)
+        # self.set_model_attributes()
+
+        # Freeze layers
+        freeze_list = (
+            self.args.freeze
+            if isinstance(self.args.freeze, list)
+            else range(self.args.freeze)
+            if isinstance(self.args.freeze, int)
+            else []
+        )
+        always_freeze_names = [".dfl"]  # always freeze these layers
+        freeze_layer_names = [f"model.{x}." for x in freeze_list] + always_freeze_names
+        for k, v in self.model.named_parameters():
+            # v.register_hook(lambda x: torch.nan_to_num(x))  # NaN to 0 (commented for erratic training results)
+            if any(x in k for x in freeze_layer_names):
+                LOGGER.info(f"Freezing layer '{k}'")
+                v.requires_grad = False
+            elif not v.requires_grad:
+                LOGGER.info(
+                    f"WARNING ⚠️ setting 'requires_grad=True' for frozen layer '{k}'. "
+                    "See ultralytics.engine.trainer for customization of frozen layers.",
+                )
+                v.requires_grad = True
+
+        # Check AMP
+        self.amp = torch.tensor(self.args.amp).to(self.device)  # True or False
+        if self.amp and RANK in (-1, 0):  # Single-GPU and DDP
+            callbacks_backup = callbacks.default_callbacks.copy()  # backup callbacks as check_amp() resets them
+            self.amp = torch.tensor(check_amp(self.model), device=self.device)
+            callbacks.default_callbacks = callbacks_backup  # restore callbacks
+        if RANK > -1 and world_size > 1:  # DDP
+            torch.distributed.broadcast(
+                self.amp,
+                src=0,
+            )  # broadcast the tensor from rank 0 to all other ranks (returns None)
+        self.amp = bool(self.amp)  # as boolean
+        self.scaler = amp.GradScaler(enabled=self.amp)
+        if world_size > 1:
+            self.model = DDP(self.model, device_ids=[RANK])
+
+        # Check imgsz
+        gs = max(int(self.model.stride.max() if hasattr(self.model, "stride") else 32), 32)  # grid size (max stride)
+        self.args.imgsz = check_imgsz(self.args.imgsz, stride=gs, floor=gs, max_dim=1)
+
+        # # Batch size
+        if self.batch_size == -1 and RANK == -1:  # single-GPU only, estimate best batch size
+            self.args.batch = self.batch_size = check_train_batch_size(self.model, self.args.imgsz, self.amp)
+
+        # Optimizer
+        self.accumulate = max(round(self.args.nbs / self.batch_size), 1)  # accumulate loss before optimizing
+        weight_decay = self.args.weight_decay * self.batch_size * self.accumulate / self.args.nbs  # scale weight_decay
+        iterations = math.ceil(len(self.train_loader.dataset) / max(self.batch_size, self.args.nbs)) * self.epochs
+        self.optimizer = self.build_optimizer(
+            model=self.model,
+            name=self.args.optimizer,
+            lr=self.args.lr0,
+            momentum=self.args.momentum,
+            decay=weight_decay,
+            iterations=iterations,
+        )
+        # Scheduler
+        if self.args.cos_lr:
+            self.lf = one_cycle(1, self.args.lrf, self.epochs)  # cosine 1->hyp['lrf']
+        else:
+            self.lf = lambda x: (1 - x / self.epochs) * (1.0 - self.args.lrf) + self.args.lrf  # linear
+        self.scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=self.lf)
+        self.stopper, self.stop = EarlyStopping(patience=self.args.patience), False
+        # self.resume_training(ckpt)
+        self.scheduler.last_epoch = self.start_epoch - 1  # do not move
+        self.run_callbacks("on_pretrain_routine_end")
+
+    def _do_train(self, world_size=1):
+        """Skip real training for this PoC."""


### PR DESCRIPTION
# TL;DR
 This PoC aims to propose and discuss refactoring of the current OTX Engine. It will help make the task more flexible, reduce code duplication, and help directly expose all features of the upstream framework. The code changes here are at a very high level.
 # Intro
This is a very limited PoC (think of it like pseudo-code) to get the discussions rolling. It is not as extensive in features as what Harim had made last year (https://github.com/harimkang/training_extensions/tree/harimkan/feature-v2-ultralytics/src/otx/v2/adapters/torch/ultralytics)
The main reason is that Anomalib Engine does a lot of things under-the-hood which would require major effort when implementing in OTX. I'll share the presentation in Teams. It would be nice to get feedback on this to flesh it out further. Also, we can schedule 1:1s to discuss any concerns and modify accordingly.
 # Motivation
 - Currently, the Anomaly task is limited, and impacted by the requirement of moulding it to match OTX Model, Engine, and DataLoader. This involves duplication of code, re-implementing features in Anomalib, and complex inheritance hierarchy. This makes it harder for maintenance, and can lead to divergence of the same features across repos.
 - Anomalib Engine also internally takes care of attaching the right post/pre-processing callbacks, modifying the training loop based on the learning type, setting up model-specific transforms, and update dataloaders based on the task type. Supporting these in OTX without Anomalib's Engine will require a lot of effort and some complex logic. 
 - From Geti and OTX perspective, the only output artefacts we care about are the metrics produced, input dataset, and output annotations. So, this means that till the time we have the right converters, internally, the tasks have more flexibility on the representation they use for models and dataset. And, if we directly pass the trained model weights to the upstream framework, and produce a standard result, we don't need the models to conform to a specific format.

# Approach
- The Engine can remain as-is and will work like `AutoEngine` as proposed by Harim in his initial design. see: `engine_poc.py`
- The contents of the current engine can be extracted to a separate adapter that trains the current OTX model.
- Another adapter for Anomalib can be introduced along with the `AnomalibEngine` to directly use the Anomalib's own engine for training.
- Add datumaro adapter in Anomalib so it can ingest dataset from OTX and Geti.
- Anomalib, OTX, and modelAPI will require updating so that the OpenVINO models produced by both the frameworks are the same, and can use the same inferencers.


# Outcome
- This will make it easier to expose all the models, and features of Anomalib such as Zero-shot, Few-shot, and LLM based models, as well as synthetic data generation.
- Since, the underlying models will remain same for Anomalib and OTX, models trained on one framework will be interchangeable with the other.
- Further, we can unify the OpenVINO models exported from Anomalib and OTX so that they are interchangeable.

# API Example
Single Engine as entrypoint for all backends.

Allows us to not only directly use all the models of the other framework but also allows us to use its dataloaders.

```python
from otx.engine.engine_poc import Engine
from anomalib.data import MVTec
from anomalib.models import Padim

engine = Engine()
model = Padim()
datamodule = MVTec(root="./datasets/MVTec")
engine.train(model, datamodule)
```

Ultralytics example just to show that we can extend it to other frameworks.
```python
model = YOLO("yolov8n.pt")
engine = Engine()
dataset = ClassificationDataset(root="./datasets/hazelnut_toy", args=DEFAULT_CFG)
dataloader = DataLoader(dataset, batch_size=32, shuffle=True)
engine.train(model=model, datamodule=dataloader)
```


Current OTX models are compatible and use the same entry-points.
```python
from otx.algo.classification.mobilenet_v3 import MobileNetV3ForMulticlassCls
from otx.core.config.data import SubsetConfig
from otx.core.data import OTXDataModule

datamodule = OTXDataModule(
	task=OTXTaskType.MULTI_CLASS_CLS,
	data_format="cifar",
	data_root="./datasets/cifar/cifar-10-batches-py",
	train_subset=SubsetConfig(
		batch_size=64,
		subset_name="data_batch_1",
		transform_lib_type="TORCHVISION",
		transforms=simple_transforms,
	),
	val_subset=SubsetConfig(
		batch_size=64,
		subset_name="test_batch",
		transform_lib_type="TORCHVISION",
		transforms=simple_transforms,
	),
	test_subset=SubsetConfig(
		batch_size=64,
		subset_name="test_batch",
		transform_lib_type="TORCHVISION",
		transforms=simple_transforms,
	),
)
model = MobileNetV3ForMulticlassCls(
	label_info=datamodule.label_info,
)
engine = Engine()
engine.train(model, datamodule, max_epochs=1, deterministic=False, val_check_interval=0.5)
```
# CLI Registration
If the `Engine` class is decorated correctly to accept models from different frameworks, we can directly expose these models to the `cli`

```python
class Engine:
	...
	def train(
		self,
		model: OTXModel | AnomalyModule | UltralyticsModel,
		...
	) -> METRICS
```

```python
class CLI:
	def add_subcommands(self)->None:
		...
		subparser.add_method_arguments(Engine, "train")
		...
```

Models from the upstream repos are automatically exposed, and can work with OTX
```bash
python cli_poc.py train --help
```

```bash
...
Train the model:
  --model.help CLASS_PATH_OR_NAME
                        Show the help for the given subclass of {OTXModel,AnomalyModule,Model} and exit.
  --model MODEL         (required, type: OTXModel | AnomalyModule | Model, known subclasses: otx.core.model.base.OTXModel, otx.core.model.base.OVModel, anomalib.models.Cfa, anomalib.models.Cflow, anomalib.models.Csflow, anomalib.models.Dfkde,
                        anomalib.models.Dfm, anomalib.models.Draem, anomalib.models.Dsr, anomalib.models.EfficientAd, anomalib.models.Fastflow, anomalib.models.Fre, anomalib.models.Ganomaly, anomalib.models.Padim, anomalib.models.Patchcore,
                        anomalib.models.ReverseDistillation, anomalib.models.Rkde, anomalib.models.Stfpm, anomalib.models.Uflow, anomalib.models.WinClip, anomalib.models.AiVad, ultralytics.engine.model.Model, ultralytics.YOLO,
                        ultralytics.YOLOWorld, ultralytics.FastSAM, ultralytics.NAS, ultralytics.RTDETR, ultralytics.SAM)
...
```