### PR TITLE
Enable torch.complile to work with classification

### DIFF
--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -51,7 +51,7 @@ from otx.core.types.label import LabelInfo, LabelInfoTypes, NullLabelInfo
 from otx.core.types.precision import OTXPrecisionType
 from otx.core.utils.build import get_default_num_async_infer_requests
 from otx.core.utils.miscellaneous import ensure_callable
-from otx.core.utils.utils import is_ckpt_for_finetuning, is_ckpt_from_otx_v1
+from otx.core.utils.utils import is_ckpt_for_finetuning, is_ckpt_from_otx_v1, remove_state_dict_prefix
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -353,6 +353,10 @@ class OTXModel(LightningModule, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEnti
 
     def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         """Callback on saving checkpoint."""
+        if self.torch_compile:
+            # If torch_compile is True, a prefix key named _orig_mod. is added to the state_dict. Remove this.
+            compiled_state_dict = checkpoint["state_dict"]
+            checkpoint["state_dict"] = remove_state_dict_prefix(compiled_state_dict, "_orig_mod.")
         super().on_save_checkpoint(checkpoint)
 
         checkpoint["label_info"] = self.label_info

--- a/src/otx/core/utils/utils.py
+++ b/src/otx/core/utils/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from multiprocessing import cpu_count
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 from datumaro.components.annotation import AnnotationType, LabelCategories
@@ -84,3 +84,12 @@ def get_idx_list_per_classes(dm_dataset: DmDataset, use_string_label: bool = Fal
     for k in stats:
         stats[k] = list(dict.fromkeys(stats[k]))
     return stats
+
+
+def remove_state_dict_prefix(state_dict: dict[str, Any], prefix: str) -> dict[str, Any]:
+    """Remove prefix from state_dict keys."""
+    new_state_dict = {}
+    for key, value in state_dict.items():
+        new_key = key.replace(prefix, "")
+        new_state_dict[new_key] = value
+    return new_state_dict

--- a/tests/unit/core/utils/test_utils.py
+++ b/tests/unit/core/utils/test_utils.py
@@ -11,6 +11,7 @@ from otx.core.utils.utils import (
     get_mean_std_from_data_processing,
     is_ckpt_for_finetuning,
     is_ckpt_from_otx_v1,
+    remove_state_dict_prefix,
 )
 
 
@@ -113,3 +114,19 @@ def test_get_idx_list_per_classes(fxt_dm_dataset):
     expected_result["0"] = list(range(100))
     expected_result["1"] = list(range(100, 108))
     assert result == expected_result
+
+def test_remove_state_dict_prefix():
+    state_dict = {
+        "model._orig_mod.backbone.0.weight": 1,
+        "model._orig_mod.backbone.0.bias": 2,
+        "model._orig_mod.backbone.1.weight": 3,
+        "model._orig_mod.backbone.1.bias": 4,
+    }
+    new_state_dict = remove_state_dict_prefix(state_dict=state_dict, prefix="_orig_mod.")
+    expected = {
+        "model.backbone.0.weight": 1,
+        "model.backbone.0.bias": 2,
+        "model.backbone.1.weight": 3,
+        "model.backbone.1.bias": 4,
+    }
+    assert new_state_dict == expected

--- a/tests/unit/core/utils/test_utils.py
+++ b/tests/unit/core/utils/test_utils.py
@@ -115,6 +115,7 @@ def test_get_idx_list_per_classes(fxt_dm_dataset):
     expected_result["1"] = list(range(100, 108))
     assert result == expected_result
 
+
 def test_remove_state_dict_prefix():
     state_dict = {
         "model._orig_mod.backbone.0.weight": 1,


### PR DESCRIPTION
### Summary

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


  |   | torch.compile | Small |   | Medium |   |   | Large |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Task | Model | Enable | Test/Accuracy | Train/e2e_time | Test/Accuracy | Train/e2e_time | Train/iter_time | Test/Accuracy | Train/e2e_time | Train/iter_time
MULTI_CLASS_CLS | EfficientNet-B0 | X | 1.0 | 10 | 0.7819 | 87 | 0.0724 | 0.8055 | 210 | 0.0839
  |   | O | 1.0 | 85 | 0.7842 | 273 | 0.0720 | 0.8425 | 513 | 0.0858
  | DeiT-Tiny | X | 1.0 | 10 | 0.7998 | 89 | 0.0612 | 0.8633 | 336 | 0.0820
  |   | O | 1.0 | 36 | 0.8108 | 136 | 0.0635 | 0.8620 | 418 | 0.0814



</div>

<!--EndFragment-->
</body>

</html>


### How to test

`otx train ~~~ --model.torch_compile True`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
