### PR TITLE
Refine recipes for anomaly tasks

### DIFF
--- a/src/otx/recipe/_base_/data/anomaly.yaml
+++ b/src/otx/recipe/_base_/data/anomaly.yaml
@@ -1,0 +1,76 @@
+task: ANOMALY_CLASSIFICATION
+input_size: 256
+data_format: mvtec
+mem_cache_size: 1GB
+mem_cache_img_max_size: null
+image_color_channel: RGB
+stack_images: false
+unannotated_items_ratio: 0.0
+train_subset:
+  subset_name: train
+  transform_lib_type: TORCHVISION
+  to_tv_image: true
+  batch_size: 32
+  num_workers: 4
+  transforms:
+    - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+      init_args:
+        size: $(input_size)
+        antialias: true
+    - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+        scale: false
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
+  sampler:
+    class_path: torch.utils.data.RandomSampler
+
+val_subset:
+  subset_name: test
+  transform_lib_type: TORCHVISION
+  to_tv_image: true
+  batch_size: 32
+  num_workers: 4
+  transforms:
+    - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+      init_args:
+        size: $(input_size)
+        antialias: true
+    - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+        scale: false
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
+  sampler:
+    class_path: torch.utils.data.RandomSampler
+
+test_subset:
+  subset_name: test
+  transform_lib_type: TORCHVISION
+  to_tv_image: true
+  batch_size: 32
+  num_workers: 4
+  transforms:
+    - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+      init_args:
+        size: $(input_size)
+        antialias: true
+    - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
+    - class_path: torchvision.transforms.v2.ToDtype
+      init_args:
+        dtype: ${as_torch_dtype:torch.float32}
+        scale: false
+    - class_path: torchvision.transforms.v2.Normalize
+      init_args:
+        mean: [123.675, 116.28, 103.53]
+        std: [58.395, 57.12, 57.375]
+  sampler:
+    class_path: torch.utils.data.RandomSampler

--- a/src/otx/recipe/anomaly_classification/padim.yaml
+++ b/src/otx/recipe/anomaly_classification/padim.yaml
@@ -13,78 +13,11 @@ engine:
 
 callback_monitor: image_F1Score # this has no effect as Padim does not need to be trained
 
-data: ../_base_/data/torchvision_base.yaml
+data: ../_base_/data/anomaly.yaml
 overrides:
-  reset:
-    - data.train_subset.transforms
-    - data.val_subset.transforms
-    - data.test_subset.transforms
-
   precision: 32
   max_epochs: 1
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-
-  data:
-    task: ANOMALY_CLASSIFICATION
-    input_size: 256
-    data_format: mvtec
-    vpm_config:
-      use_bbox: true
-      use_point: false
-    train_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    val_subset:
-      batch_size: 32
-      num_workers: 4
-      subset_name: test
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    test_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/anomaly_classification/stfpm.yaml
+++ b/src/otx/recipe/anomaly_classification/stfpm.yaml
@@ -11,13 +11,8 @@ engine:
 
 callback_monitor: image_F1Score
 
-data: ../_base_/data/torchvision_base.yaml
+data: ../_base_/data/anomaly.yaml
 overrides:
-  reset:
-    - data.train_subset.transforms
-    - data.val_subset.transforms
-    - data.test_subset.transforms
-
   precision: 32
   max_epochs: 100
   callbacks:
@@ -27,62 +22,3 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-
-  data:
-    task: ANOMALY_CLASSIFICATION
-    input_size: 256
-    data_format: mvtec
-    train_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    val_subset:
-      batch_size: 32
-      num_workers: 4
-      subset_name: test
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    test_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/anomaly_detection/padim.yaml
+++ b/src/otx/recipe/anomaly_detection/padim.yaml
@@ -13,13 +13,8 @@ engine:
 
 callback_monitor: image_F1Score # this has no effect as Padim does not need to be trained
 
-data: ../_base_/data/torchvision_base.yaml
+data: ../_base_/data/anomaly.yaml
 overrides:
-  reset:
-    - data.train_subset.transforms
-    - data.val_subset.transforms
-    - data.test_subset.transforms
-
   precision: 32
   max_epochs: 1
   callbacks:
@@ -29,62 +24,3 @@ overrides:
 
   data:
     task: ANOMALY_DETECTION
-    input_size: 256
-    data_format: mvtec
-    vpm_config:
-      use_bbox: true
-      use_point: false
-    train_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    val_subset:
-      batch_size: 32
-      num_workers: 4
-      subset_name: test
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    test_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/anomaly_detection/stfpm.yaml
+++ b/src/otx/recipe/anomaly_detection/stfpm.yaml
@@ -11,7 +11,7 @@ engine:
 
 callback_monitor: pixel_F1Score
 
-data: ../_base_/data/torchvision_base.yaml
+data: ../_base_/data/anomaly.yaml
 overrides:
   reset:
     - data.train_subset.transforms
@@ -30,59 +30,3 @@ overrides:
 
   data:
     task: ANOMALY_DETECTION
-    input_size: 256
-    data_format: mvtec
-    train_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    val_subset:
-      batch_size: 32
-      num_workers: 4
-      subset_name: test
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    test_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/anomaly_segmentation/padim.yaml
+++ b/src/otx/recipe/anomaly_segmentation/padim.yaml
@@ -13,13 +13,8 @@ engine:
 
 callback_monitor: image_F1Score # this has no effect as Padim does not need to be trained
 
-data: ../_base_/data/torchvision_base.yaml
+data: ../_base_/data/anomaly.yaml
 overrides:
-  reset:
-    - data.train_subset.transforms
-    - data.val_subset.transforms
-    - data.test_subset.transforms
-
   precision: 32
   max_epochs: 1
   callbacks:
@@ -29,62 +24,3 @@ overrides:
 
   data:
     task: ANOMALY_SEGMENTATION
-    input_size: 256
-    data_format: mvtec
-    vpm_config:
-      use_bbox: true
-      use_point: false
-    train_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    val_subset:
-      batch_size: 32
-      num_workers: 4
-      subset_name: test
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    test_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]

--- a/src/otx/recipe/anomaly_segmentation/stfpm.yaml
+++ b/src/otx/recipe/anomaly_segmentation/stfpm.yaml
@@ -11,13 +11,8 @@ engine:
 
 callback_monitor: pixel_F1Score
 
-data: ../_base_/data/torchvision_base.yaml
+data: ../_base_/data/anomaly.yaml
 overrides:
-  reset:
-    - data.train_subset.transforms
-    - data.val_subset.transforms
-    - data.test_subset.transforms
-
   precision: 32
   max_epochs: 100
   callbacks:
@@ -30,59 +25,3 @@ overrides:
 
   data:
     task: ANOMALY_SEGMENTATION
-    input_size: 256
-    data_format: mvtec
-    train_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    val_subset:
-      batch_size: 32
-      num_workers: 4
-      subset_name: test
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]
-
-    test_subset:
-      batch_size: 32
-      num_workers: 4
-      transforms:
-        - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
-          init_args:
-            size: $(input_size)
-            antialias: true
-        - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
-        - class_path: torchvision.transforms.v2.ToDtype
-          init_args:
-            dtype: ${as_torch_dtype:torch.float32}
-            scale: false
-        - class_path: torchvision.transforms.v2.Normalize
-          init_args:
-            mean: [123.675, 116.28, 103.53]
-            std: [58.395, 57.12, 57.375]


### PR DESCRIPTION
### Summary

develop:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


data_group |   |   | all | all | all | all | all
-- | -- | -- | -- | -- | -- | -- | --
metric | model | version | test/image_F1Score | test/pixel_F1Score | train/e2e_time | train/epoch | train/iter_time
anomaly_classification | all | 2.2.0rc0 | 0.918756858 |   | 18.61885953 | 2.5 | 0.120162631
anomaly_classification | padim | 2.2.0rc0 | 0.892587751 |   | 13.31844556 | 0 | 0.156389803
anomaly_classification | stfpm | 2.2.0rc0 | 0.944925964 |   | 23.9192735 | 5 | 0.083935459
anomaly_detection | all | 2.2.0rc0 | 0.927533776 |   | 31.21787441 | 2.5 | 0.182556183
anomaly_detection | padim | 2.2.0rc0 | 0.892587751 |   | 16.20350766 | 0 | 0.212021656
anomaly_detection | stfpm | 2.2.0rc0 | 0.9624798 |   | 46.23224115 | 5 | 0.153090709
anomaly_segmentation | all | 2.2.0rc0 |   | 0.507930472 | 24.85795206 | 2.5 | 0.127835605
anomaly_segmentation | padim | 2.2.0rc0 |   | 0.465199262 | 14.76411808 | 0 | 0.166612387
anomaly_segmentation | stfpm | 2.2.0rc0 |   | 0.550661683 | 34.95178604 | 5 | 0.089058824



</div>

<!--EndFragment-->
</body>

</html>


This PR:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


data_group |   |   | all | all | all | all | all
-- | -- | -- | -- | -- | -- | -- | --
metric | model | version | test/image_F1Score | test/pixel_F1Score | train/e2e_time | train/epoch | train/iter_time
anomaly_classification | all | This   PR | 0.922791034 |   | 18.71696931 | 2.5 | 0.118438791
anomaly_classification | padim | This   PR | 0.892587751 |   | 13.58946884 | 0 | 0.153102659
anomaly_classification | stfpm | This   PR | 0.952994317 |   | 23.84446979 | 5 | 0.083774922
anomaly_detection | all | This   PR | 0.92526184 |   | 30.95773166 | 2.5 | 0.182039823
anomaly_detection | padim | This   PR | 0.892587751 |   | 16.20588744 | 0 | 0.220617317
anomaly_detection | stfpm | This   PR | 0.957935929 |   | 45.70957589 | 5 | 0.14346233
anomaly_segmentation | all | This   PR |   | 0.498639509 | 24.68134141 | 2.5 | 0.126755816
anomaly_segmentation | padim | This   PR |   | 0.465199262 | 14.61250138 | 0 | 0.166625477
anomaly_segmentation | stfpm | This   PR |   | 0.532079756 | 34.75018144 | 5 | 0.086886155



</div>

<!--EndFragment-->
</body>

</html>


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
