### PR TITLE
Add num_devices in Engine for multi-gpu training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/3759>)
 - Enable to use polygon and bitmap mask as prompt inputs for zero-shot learning
   (<https://github.com/openvinotoolkit/training_extensions/pull/3769>)
+- Add num_devices in Engine for multi-gpu training
+  (<https://github.com/openvinotoolkit/training_extensions/pull/3778>)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/3759>)
 - Enable to use polygon and bitmap mask as prompt inputs for zero-shot learning
   (<https://github.com/openvinotoolkit/training_extensions/pull/3769>)
-- Add num_devices in Engine for multi-gpu training
-  (<https://github.com/openvinotoolkit/training_extensions/pull/3778>)
 
 ### Bug fixes
 
@@ -36,6 +34,8 @@ All notable changes to this project will be documented in this file.
   (https://github.com/openvinotoolkit/training_extensions/pull/3723)
 - Revert #3579 to fix issues with replacing coco_instance with a different format in some dataset
   (https://github.com/openvinotoolkit/training_extensions/pull/3753)
+- Add num_devices in Engine for multi-gpu training
+  (https://github.com/openvinotoolkit/training_extensions/pull/3778)
 
 ## \[v2.1.0\]
 

--- a/docs/source/guide/tutorials/advanced/index.rst
+++ b/docs/source/guide/tutorials/advanced/index.rst
@@ -7,5 +7,6 @@ Advanced Tutorials
    configuration
    semi_supervised_learning
    huggingface_model
+   multi_gpu
 
 .. Once we have enough material, we might need to categorize these into `data`, `model learning` sections.

--- a/docs/source/guide/tutorials/advanced/multi_gpu.rst
+++ b/docs/source/guide/tutorials/advanced/multi_gpu.rst
@@ -1,0 +1,51 @@
+Multi-GPU Support
+=================
+
+Overview
+--------
+
+OpenVINO™ Training Extensions now supports operations in a multi-GPU environment, offering faster computation speeds and enhanced performance. With this new feature, users can efficiently process large datasets and complex models, significantly reducing the time required for machine learning and deep learning tasks.
+
+Benefits of Multi-GPU Support
+-----------------------------
+
+- **Speed Improvement**: Training times can be greatly reduced by utilizing multiple GPUs in parallel.
+- **Large Dataset Handling**: Load larger datasets into memory and work with larger batch sizes.
+- **Efficient Resource Utilization**: Maximize the computational efficiency by fully utilizing the GPU resources of the system.
+
+How to Set Up Multi-GPU
+-----------------------
+
+Setting up multi-GPU in OpenVINO™ Training Extensions is straightforward. Follow these steps to complete the setup:
+
+1. **Environment Check**: Ensure that multiple GPUs are installed in your system and that all GPUs are compatible with OpenVINO™ Training Extensions.
+2. **Driver Installation**: Install the latest GPU drivers to ensure all GPUs are properly recognized and available for use.
+3. **Configuration**: Activate the multi-GPU option in the OpenVINO™ Training Extensions configuration file or through the user interface.
+
+Using Multi-GPU
+---------------
+
+Once the multi-GPU feature is enabled, you can use multi-GPU for model training as follows:
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train \
+                        ... \
+                        --engine.num_devices 2
+
+    .. tab-item:: API
+
+        .. code-block:: python
+
+            from otx.engine import Engine
+
+            engine = Engine.from_config(
+                        ...
+                        num_devices=2,
+                    )
+
+            engine.train(...)

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -951,12 +951,12 @@ class Engine:
 
     @property
     def num_devices(self) -> int:
-        """Device engine uses."""
+        """Number of devices for Engine use."""
         return self._device.devices
 
     @num_devices.setter
     def num_devices(self, num_devices: int) -> None:
-        """Number of GPUs for multi-gpu."""
+        """Setter function for multi-gpu."""
         self._device.devices = num_devices
         self._cache.update(devices=self._device.devices)
         self._cache.is_trainer_args_identical = False

--- a/tests/unit/engine/test_engine.py
+++ b/tests/unit/engine/test_engine.py
@@ -367,3 +367,16 @@ class TestEngine:
         assert engine is not None
         assert engine.datamodule.train_subset.batch_size == 3
         assert engine.datamodule.test_subset.subset_name == "TESTING"
+
+    def test_num_devices(self, fxt_engine, tmp_path) -> None:
+        assert fxt_engine.num_devices == 1
+        assert fxt_engine._cache.args.get("devices") == 1
+
+        fxt_engine.num_devices = 2
+        assert fxt_engine.num_devices == 2
+        assert fxt_engine._cache.args.get("devices") == 2
+
+        data_root = "tests/assets/classification_dataset"
+        engine = Engine(work_dir=tmp_path, data_root=data_root, num_devices=3)
+        assert engine.num_devices == 3
+        assert engine._cache.args.get("devices") == 3


### PR DESCRIPTION
### Summary

I noticed that multi-gpu settings are not available through Engine, fix this.
https://jira.devtools.intel.com/browse/CVS-148420
This allows us to set up multi-gpu in the API and CLI.

- Add `num_devices` property and setter function in `Engine`
- Update Docs to use multi-gpu training
- Update CHANGELOG

![image](https://github.com/user-attachments/assets/779470fc-e1bd-42ea-95e2-3dae37ad3806)


### How to test

1. API
```python
engine = Engine(..., num_devices=2)
```

2. CLI
```shell
otx train ... --engine.num_devices 2
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
