### PR TITLE
Update 'otx benchmark' print outputs & cli print outputs

### DIFF
--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -529,7 +529,8 @@ class OTXCLI:
             fn_kwargs = self.prepare_subcommand_kwargs(self.subcommand)
             fn = getattr(self.engine, self.subcommand)
             try:
-                fn(**fn_kwargs)
+                outputs = fn(**fn_kwargs)
+                self._print_results(outputs=outputs)
             except Exception:
                 self.console.print_exception(width=self.console.width)
                 raise
@@ -537,3 +538,25 @@ class OTXCLI:
         else:
             msg = f"Unrecognized subcommand: {self.subcommand}"
             raise ValueError(msg)
+
+    def _print_results(self, outputs: Any) -> None:  # noqa: ANN401
+        if outputs is None:
+            return
+        if self.subcommand == "train" and isinstance(outputs, dict):
+            # Print Metric like 'otx test'
+            from rich.table import Column, Table
+            from torch import Tensor
+
+            table_headers = ["Train metric", "Value"]
+            columns = [Column(h, justify="center", style="magenta", width=self.console.width) for h in table_headers]
+            columns[0].style = "cyan"
+            table = Table(*columns)
+            for metric, row in outputs.items():
+                if isinstance(row, Tensor):
+                    row = row.item() if row.numel() == 1 else row.tolist()  # noqa: PLW2901
+                table.add_row(*[metric, f"{row}"])
+            self.console.print(table)
+        elif self.subcommand in ("export", "optimize"):
+            # Print output model path
+            self.console.print(f"{self.subcommand} output: {outputs}")
+        self.console.print(f"Work Directory: {self.engine.work_dir}")

--- a/src/otx/cli/utils/help_formatter.py
+++ b/src/otx/cli/utils/help_formatter.py
@@ -66,6 +66,11 @@ REQUIRED_ARGUMENTS = {
         *BASE_ARGUMENTS,
         *ENGINE_ARGUMENTS,
     },
+    "benchmark": {
+        "checkpoint",
+        *BASE_ARGUMENTS,
+        *ENGINE_ARGUMENTS,
+    },
 }
 
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import sys
 
 import pytest
+import torch
 import yaml
 from otx.cli import OTXCLI, main
+from rich.console import Console
 
 
 class TestOTXCLI:
@@ -189,3 +191,20 @@ class TestOTXCLI:
         out, _ = capfd.readouterr()
         result_config = yaml.safe_load(out)
         assert result_config["metric"] == "otx.core.metrics.fmeasure._f_measure_callable"
+
+    def test_print_results(self, mocker, capfd):
+        mocker.patch("otx.cli.cli.OTXCLI.__init__", return_value=None)
+        cli = OTXCLI()
+        cli.console = Console()
+        cli.engine = mocker.MagicMock()
+        cli.engine.work_dir.return_value = "work_dir"
+
+        cli.subcommand = "train"
+        output = {"loss": torch.tensor(0.1), "metric": torch.tensor(0.9)}
+        cli._print_results(output)
+        out, _ = capfd.readouterr()
+        assert "Train metric" in out
+        assert "Value" in out
+        assert "loss" in out
+        assert "metric" in out
+        assert "Work Directory:" in out


### PR DESCRIPTION
### Summary

- Update otx benchmark docstring
- Update otx benchmark to use otx help formatter
- Enable rich format table for otx benchmark
    - Before
       ![image](https://github.com/user-attachments/assets/f792870e-faca-4742-a277-a0fb0603ef77)
    - After
      ![image](https://github.com/user-attachments/assets/015d43f8-99e3-4802-a70a-424cd19646da)

- Modify 'otx train' outputs like test outputs
- Add work_dir log


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
