### PR TITLE
Refactor OTXModel Class for Classification Task

### DIFF
--- a/src/otx/algo/classification/efficientnet.py
+++ b/src/otx/algo/classification/efficientnet.py
@@ -7,10 +7,9 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Literal
 
-import torch
-from torch import Tensor, nn
+from torch import nn
 
 from otx.algo.classification.backbones.efficientnet import EFFICIENTNET_VERSION, OTXEfficientNet
 from otx.algo.classification.classifier.base_classifier import ImageClassifier
@@ -25,32 +24,23 @@ from otx.algo.classification.losses.asymmetric_angular_loss_with_ignore import A
 from otx.algo.classification.necks.gap import GlobalAveragePooling
 from otx.algo.classification.utils import get_classification_layers
 from otx.algo.utils.support_otx_v1 import OTXv1Helper
-from otx.core.data.entity.base import OTXBatchLossEntity
-from otx.core.data.entity.classification import (
-    HlabelClsBatchDataEntity,
-    HlabelClsBatchPredEntity,
-    MulticlassClsBatchDataEntity,
-    MulticlassClsBatchPredEntity,
-    MultilabelClsBatchDataEntity,
-    MultilabelClsBatchPredEntity,
+from otx.core.metrics.accuracy import (
+    DefaultClsMetricCallable,
 )
-from otx.core.exporter.base import OTXModelExporter
-from otx.core.exporter.native import OTXNativeModelExporter
-from otx.core.metrics import MetricInput
-from otx.core.metrics.accuracy import HLabelClsMetricCallble, MultiClassClsMetricCallable, MultiLabelClsMetricCallable
 from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable
-from otx.core.model.classification import OTXHlabelClsModel, OTXMulticlassClsModel, OTXMultilabelClsModel
+from otx.core.model.classification import OTXClassificationModel
 from otx.core.schedulers import LRSchedulerListCallable
 from otx.core.types.label import HLabelInfo, LabelInfoTypes
+from otx.core.types.task import OTXTaskType, OTXTrainType
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 
-    from otx.core.metrics import MetricCallable
+    from otx.core.metrics import MetricCallablePerTask
 
 
-class EfficientNetForMulticlassCls(OTXMulticlassClsModel):
-    """EfficientNet Model for multi-class classification task."""
+class EfficientNetForClassification(OTXClassificationModel):
+    """EfficientNet Model for classification task."""
 
     def __init__(
         self,
@@ -58,8 +48,14 @@ class EfficientNetForMulticlassCls(OTXMulticlassClsModel):
         version: EFFICIENTNET_VERSION = "b0",
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
-        metric: MetricCallable = MultiClassClsMetricCallable,
+        metric: MetricCallablePerTask = DefaultClsMetricCallable,
         torch_compile: bool = False,
+        task: Literal[
+            OTXTaskType.MULTI_CLASS_CLS,
+            OTXTaskType.MULTI_LABEL_CLS,
+            OTXTaskType.H_LABEL_CLS,
+        ] = OTXTaskType.MULTI_CLASS_CLS,
+        train_type: Literal[OTXTrainType.SUPERVISED, OTXTrainType.SEMI_SUPERVISED] = OTXTrainType.SUPERVISED,
     ) -> None:
         self.version = version
 
@@ -69,6 +65,8 @@ class EfficientNetForMulticlassCls(OTXMulticlassClsModel):
             scheduler=scheduler,
             metric=metric,
             torch_compile=torch_compile,
+            task=task,
+            train_type=train_type,
         )
 
     def _create_model(self) -> nn.Module:
@@ -86,463 +84,66 @@ class EfficientNetForMulticlassCls(OTXMulticlassClsModel):
         return model
 
     def _build_model(self, num_classes: int) -> nn.Module:
-        return ImageClassifier(
-            backbone=OTXEfficientNet(version=self.version, pretrained=True),
-            neck=GlobalAveragePooling(dim=2),
-            head=LinearClsHead(
+        backbone = OTXEfficientNet(version=self.version, pretrained=True)
+        neck = GlobalAveragePooling(dim=2)
+        classifier = ImageClassifier if self.train_type == OTXTrainType.SUPERVISED else SemiSLClassifier
+        head = self._build_head(num_classes)
+
+        return classifier(
+            backbone=backbone,
+            neck=neck,
+            head=head,
+        )
+
+    def _build_head(self, num_classes: int) -> nn.Module:
+        if self.task == OTXTaskType.MULTI_CLASS_CLS:
+            loss = nn.CrossEntropyLoss(reduction="none")
+            if self.train_type == OTXTrainType.SEMI_SUPERVISED:
+                return OTXSemiSLLinearClsHead(
+                    num_classes=num_classes,
+                    in_channels=1280,
+                    loss=loss,
+                )
+            return LinearClsHead(
                 num_classes=num_classes,
                 in_channels=1280,
                 topk=(1, 5) if num_classes >= 5 else (1,),
-                loss=nn.CrossEntropyLoss(reduction="none"),
-            ),
-        )
-
-    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
-        """Load the previous OTX ckpt according to OTX2.0."""
-        return OTXv1Helper.load_cls_effnet_b0_ckpt(state_dict, "multiclass", add_prefix)
-
-    def _reset_prediction_layer(self, num_classes: int) -> None:
-        return
-
-    def _customize_inputs(self, inputs: MulticlassClsBatchDataEntity) -> dict[str, Any]:
-        if self.training:
-            mode = "loss"
-        elif self.explain_mode:
-            mode = "explain"
-        else:
-            mode = "predict"
-
-        return {
-            "images": inputs.stacked_images,
-            "labels": torch.cat(inputs.labels, dim=0),
-            "imgs_info": inputs.imgs_info,
-            "mode": mode,
-        }
-
-    def _customize_outputs(
-        self,
-        outputs: Any,  # noqa: ANN401
-        inputs: MulticlassClsBatchDataEntity,
-    ) -> MulticlassClsBatchPredEntity | OTXBatchLossEntity:
-        if self.training:
-            return OTXBatchLossEntity(loss=outputs)
-
-        # To list, batch-wise
-        logits = outputs if isinstance(outputs, torch.Tensor) else outputs["logits"]
-        scores = torch.unbind(logits, 0)
-        preds = logits.argmax(-1, keepdim=True).unbind(0)
-
-        return MulticlassClsBatchPredEntity(
-            batch_size=inputs.batch_size,
-            images=inputs.stacked_images,
-            imgs_info=inputs.imgs_info,
-            scores=scores,
-            labels=preds,
-        )
-
-    @property
-    def _exporter(self) -> OTXModelExporter:
-        """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(
-            task_level_export_parameters=self._export_parameters,
-            input_size=self.image_size,
-            mean=(123.675, 116.28, 103.53),
-            std=(58.395, 57.12, 57.375),
-            resize_mode="standard",
-            pad_value=0,
-            swap_rgb=False,
-            via_onnx=False,
-            onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
-        )
-
-    def forward_explain(self, inputs: MulticlassClsBatchDataEntity) -> MulticlassClsBatchPredEntity:
-        """Model forward explain function."""
-        outputs = self.model(images=inputs.stacked_images, mode="explain")
-
-        return MulticlassClsBatchPredEntity(
-            batch_size=len(outputs["preds"]),
-            images=inputs.images,
-            imgs_info=inputs.imgs_info,
-            labels=outputs["preds"],
-            scores=outputs["scores"],
-            saliency_map=outputs["saliency_map"],
-            feature_vector=outputs["feature_vector"],
-        )
-
-    def forward_for_tracing(self, image: Tensor) -> Tensor | dict[str, Tensor]:
-        """Model forward function used for the model tracing during model exportation."""
-        if self.explain_mode:
-            return self.model(images=image, mode="explain")
-
-        return self.model(images=image, mode="tensor")
-
-
-class EfficientNetForMulticlassClsSemiSL(EfficientNetForMulticlassCls):
-    """EfficientNet model for multiclass classification with semi-supervised learning.
-
-    This class extends the `EfficientNetForMulticlassCls` class and adds support for semi-supervised learning.
-    It overrides the `_build_model` and `_customize_inputs` methods to incorporate the semi-supervised learning.
-
-    Args:
-        EfficientNetForMulticlassCls (class): The base class for EfficientNet multiclass classification.
-
-    Attributes:
-        version (str): The version of the EfficientNet model.
-    """
-
-    def _build_model(self, num_classes: int) -> nn.Module:
-        return SemiSLClassifier(
-            backbone=OTXEfficientNet(version=self.version, pretrained=True),
-            neck=GlobalAveragePooling(dim=2),
-            head=OTXSemiSLLinearClsHead(
-                num_classes=num_classes,
-                in_channels=1280,
-                loss=nn.CrossEntropyLoss(reduction="none"),
-            ),
-        )
-
-    def _customize_inputs(self, inputs: MulticlassClsBatchDataEntity) -> dict[str, Any]:
-        """Customizes the input data for the model based on the current mode.
-
-        Args:
-            inputs (MulticlassClsBatchDataEntity): The input batch of data.
-
-        Returns:
-            dict[str, Any]: The customized input data.
-        """
-        if self.training:
-            mode = "loss"
-        elif self.explain_mode:
-            mode = "explain"
-        else:
-            mode = "predict"
-
-        if isinstance(inputs, dict):
-            # When used with an unlabeled dataset, it comes in as a dict.
-            images = {key: inputs[key].images for key in inputs}
-            labels = {key: torch.cat(inputs[key].labels, dim=0) for key in inputs}
-            imgs_info = {key: inputs[key].imgs_info for key in inputs}
-            return {
-                "images": images,
-                "labels": labels,
-                "imgs_info": imgs_info,
-                "mode": mode,
-            }
-        return {
-            "images": inputs.stacked_images,
-            "labels": torch.cat(inputs.labels, dim=0),
-            "imgs_info": inputs.imgs_info,
-            "mode": mode,
-        }
-
-    def training_step(self, batch: MulticlassClsBatchDataEntity, batch_idx: int) -> Tensor:
-        """Performs a single training step on a batch of data.
-
-        Args:
-            batch (MulticlassClsBatchDataEntity): The input batch of data.
-            batch_idx (int): The index of the current batch.
-
-        Returns:
-            Tensor: The computed loss for the training step.
-        """
-        loss = super().training_step(batch, batch_idx)
-        # Collect metrics related to Semi-SL Training.
-        self.log(
-            "train/unlabeled_coef",
-            self.model.head.unlabeled_coef,
-            on_step=True,
-            on_epoch=False,
-            prog_bar=True,
-        )
-        self.log(
-            "train/num_pseudo_label",
-            self.model.head.num_pseudo_label,
-            on_step=True,
-            on_epoch=False,
-            prog_bar=True,
-        )
-        return loss
-
-
-class EfficientNetForMultilabelCls(OTXMultilabelClsModel):
-    """EfficientNet Model for multi-label classification task."""
-
-    def __init__(
-        self,
-        label_info: LabelInfoTypes,
-        version: EFFICIENTNET_VERSION = "b0",
-        optimizer: OptimizerCallable = DefaultOptimizerCallable,
-        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
-        metric: MetricCallable = MultiLabelClsMetricCallable,
-        torch_compile: bool = False,
-    ) -> None:
-        self.version = version
-
-        super().__init__(
-            label_info=label_info,
-            optimizer=optimizer,
-            scheduler=scheduler,
-            metric=metric,
-            torch_compile=torch_compile,
-        )
-
-    def _create_model(self) -> nn.Module:
-        # Get classification_layers for class-incr learning
-        sample_model_dict = self._build_model(num_classes=5).state_dict()
-        incremental_model_dict = self._build_model(num_classes=6).state_dict()
-        self.classification_layers = get_classification_layers(
-            sample_model_dict,
-            incremental_model_dict,
-            prefix="model.",
-        )
-
-        model = self._build_model(num_classes=self.num_classes)
-        model.init_weights()
-        return model
-
-    def _build_model(self, num_classes: int) -> nn.Module:
-        return ImageClassifier(
-            backbone=OTXEfficientNet(version=self.version, pretrained=True),
-            neck=GlobalAveragePooling(dim=2),
-            head=MultiLabelLinearClsHead(
+                loss=loss,
+            )
+        if self.task == OTXTaskType.MULTI_LABEL_CLS:
+            if self.train_type == OTXTrainType.SEMI_SUPERVISED:
+                msg = "Semi-supervised learning is not supported for multi-label classification."
+                raise NotImplementedError(msg)
+            return MultiLabelLinearClsHead(
                 num_classes=num_classes,
                 in_channels=1280,
                 scale=7.0,
                 normalized=True,
                 loss=AsymmetricAngularLossWithIgnore(gamma_pos=0.0, gamma_neg=1.0, reduction="sum"),
-            ),
-        )
-
-    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
-        """Load the previous OTX ckpt according to OTX2.0."""
-        return OTXv1Helper.load_cls_effnet_b0_ckpt(state_dict, "multilabel", add_prefix)
-
-    def _customize_inputs(self, inputs: MultilabelClsBatchDataEntity) -> dict[str, Any]:
-        if self.training:
-            mode = "loss"
-        elif self.explain_mode:
-            mode = "explain"
-        else:
-            mode = "predict"
-
-        return {
-            "images": inputs.stacked_images,
-            "labels": torch.stack(inputs.labels),
-            "imgs_info": inputs.imgs_info,
-            "mode": mode,
-        }
-
-    def _customize_outputs(
-        self,
-        outputs: Any,  # noqa: ANN401
-        inputs: MultilabelClsBatchDataEntity,
-    ) -> MultilabelClsBatchPredEntity | OTXBatchLossEntity:
-        if self.training:
-            return OTXBatchLossEntity(loss=outputs)
-
-        # To list, batch-wise
-        logits = outputs if isinstance(outputs, torch.Tensor) else outputs["logits"]
-        scores = torch.unbind(logits, 0)
-
-        return MultilabelClsBatchPredEntity(
-            batch_size=inputs.batch_size,
-            images=inputs.images,
-            imgs_info=inputs.imgs_info,
-            scores=scores,
-            labels=logits.argmax(-1, keepdim=True).unbind(0),
-        )
-
-    @property
-    def _exporter(self) -> OTXModelExporter:
-        """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(
-            task_level_export_parameters=self._export_parameters,
-            input_size=(1, 3, 224, 224),
-            mean=(123.675, 116.28, 103.53),
-            std=(58.395, 57.12, 57.375),
-            resize_mode="standard",
-            pad_value=0,
-            swap_rgb=False,
-            via_onnx=False,
-            onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
-        )
-
-    def forward_explain(self, inputs: MultilabelClsBatchDataEntity) -> MultilabelClsBatchPredEntity:
-        """Model forward explain function."""
-        outputs = self.model(images=inputs.stacked_images, mode="explain")
-
-        return MultilabelClsBatchPredEntity(
-            batch_size=len(outputs["preds"]),
-            images=inputs.images,
-            imgs_info=inputs.imgs_info,
-            labels=outputs["preds"],
-            scores=outputs["scores"],
-            saliency_map=outputs["saliency_map"],
-            feature_vector=outputs["feature_vector"],
-        )
-
-    def forward_for_tracing(self, image: Tensor) -> Tensor | dict[str, Tensor]:
-        """Model forward function used for the model tracing during model exportation."""
-        if self.explain_mode:
-            return self.model(images=image, mode="explain")
-
-        return self.model(images=image, mode="tensor")
-
-
-class EfficientNetForHLabelCls(OTXHlabelClsModel):
-    """EfficientNetB0 Model for hierarchical label classification task."""
-
-    label_info: HLabelInfo
-
-    def __init__(
-        self,
-        label_info: HLabelInfo,
-        version: EFFICIENTNET_VERSION = "b0",
-        optimizer: OptimizerCallable = DefaultOptimizerCallable,
-        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
-        metric: MetricCallable = HLabelClsMetricCallble,
-        torch_compile: bool = False,
-    ) -> None:
-        self.version = version
-
-        super().__init__(
-            label_info=label_info,
-            optimizer=optimizer,
-            scheduler=scheduler,
-            metric=metric,
-            torch_compile=torch_compile,
-        )
-
-    def _create_model(self) -> nn.Module:
-        # Get classification_layers for class-incr learning
-        sample_config = deepcopy(self.label_info.as_head_config_dict())
-        sample_config["num_classes"] = 5
-        sample_model_dict = self._build_model(head_config=sample_config).state_dict()
-        sample_config["num_classes"] = 6
-        incremental_model_dict = self._build_model(head_config=sample_config).state_dict()
-        self.classification_layers = get_classification_layers(
-            sample_model_dict,
-            incremental_model_dict,
-            prefix="model.",
-        )
-
-        model = self._build_model(head_config=self.label_info.as_head_config_dict())
-        model.init_weights()
-        return model
-
-    def _build_model(self, head_config: dict) -> nn.Module:
-        if not isinstance(self.label_info, HLabelInfo):
-            raise TypeError(self.label_info)
-
-        return ImageClassifier(
-            backbone=OTXEfficientNet(version=self.version, pretrained=True),
-            neck=GlobalAveragePooling(dim=2),
-            head=HierarchicalLinearClsHead(
+            )
+        if self.task == OTXTaskType.H_LABEL_CLS:
+            if self.train_type == OTXTrainType.SEMI_SUPERVISED:
+                msg = "Semi-supervised learning is not supported for h-label classification."
+                raise NotImplementedError(msg)
+            if not isinstance(self.label_info, HLabelInfo):
+                msg = "LabelInfo should be HLabelInfo for H-label classification."
+                raise ValueError(msg)
+            head_config = deepcopy(self.label_info.as_head_config_dict())
+            head_config["num_classes"] = num_classes
+            return HierarchicalLinearClsHead(
                 in_channels=1280,
                 multiclass_loss=nn.CrossEntropyLoss(),
                 multilabel_loss=AsymmetricAngularLossWithIgnore(gamma_pos=0.0, gamma_neg=1.0, reduction="sum"),
                 **head_config,
-            ),
-        )
+            )
+        msg = f"Unsupported task: {self.task}"
+        raise NotImplementedError(msg)
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
         """Load the previous OTX ckpt according to OTX2.0."""
-        return OTXv1Helper.load_cls_effnet_b0_ckpt(state_dict, "hlabel", add_prefix)
-
-    def _customize_inputs(self, inputs: HlabelClsBatchDataEntity) -> dict[str, Any]:
-        if self.training:
-            mode = "loss"
-        elif self.explain_mode:
-            mode = "explain"
-        else:
-            mode = "predict"
-
-        return {
-            "images": inputs.stacked_images,
-            "labels": torch.stack(inputs.labels),
-            "imgs_info": inputs.imgs_info,
-            "mode": mode,
-        }
-
-    def _customize_outputs(
-        self,
-        outputs: Any,  # noqa: ANN401
-        inputs: HlabelClsBatchDataEntity,
-    ) -> HlabelClsBatchPredEntity | OTXBatchLossEntity:
-        if self.training:
-            return OTXBatchLossEntity(loss=outputs)
-
-        # To list, batch-wise
-        if isinstance(outputs, dict):
-            scores = outputs["scores"]
-            labels = outputs["labels"]
-        else:
-            scores = outputs
-            labels = outputs.argmax(-1, keepdim=True)
-
-        return HlabelClsBatchPredEntity(
-            batch_size=inputs.batch_size,
-            images=inputs.images,
-            imgs_info=inputs.imgs_info,
-            scores=scores,
-            labels=labels,
-        )
-
-    def _convert_pred_entity_to_compute_metric(
-        self,
-        preds: HlabelClsBatchPredEntity,
-        inputs: HlabelClsBatchDataEntity,
-    ) -> MetricInput:
-        hlabel_info: HLabelInfo = self.label_info  # type: ignore[assignment]
-
-        _labels = torch.stack(preds.labels) if isinstance(preds.labels, list) else preds.labels
-        _scores = torch.stack(preds.scores) if isinstance(preds.scores, list) else preds.scores
-        if hlabel_info.num_multilabel_classes > 0:
-            preds_multiclass = _labels[:, : hlabel_info.num_multiclass_heads]
-            preds_multilabel = _scores[:, hlabel_info.num_multiclass_heads :]
-            pred_result = torch.cat([preds_multiclass, preds_multilabel], dim=1)
-        else:
-            pred_result = _labels
-        return {
-            "preds": pred_result,
-            "target": torch.stack(inputs.labels),
-        }
-
-    @property
-    def _exporter(self) -> OTXModelExporter:
-        """Creates OTXModelExporter object that can export the model."""
-        return OTXNativeModelExporter(
-            task_level_export_parameters=self._export_parameters,
-            input_size=(1, 3, 224, 224),
-            mean=(123.675, 116.28, 103.53),
-            std=(58.395, 57.12, 57.375),
-            resize_mode="standard",
-            pad_value=0,
-            swap_rgb=False,
-            via_onnx=False,
-            onnx_export_configuration=None,
-            output_names=["logits", "feature_vector", "saliency_map"] if self.explain_mode else None,
-        )
-
-    def forward_explain(self, inputs: HlabelClsBatchDataEntity) -> HlabelClsBatchPredEntity:
-        """Model forward explain function."""
-        outputs = self.model(images=inputs.stacked_images, mode="explain")
-
-        return HlabelClsBatchPredEntity(
-            batch_size=len(outputs["preds"]),
-            images=inputs.images,
-            imgs_info=inputs.imgs_info,
-            labels=outputs["preds"],
-            scores=outputs["scores"],
-            saliency_map=outputs["saliency_map"],
-            feature_vector=outputs["feature_vector"],
-        )
-
-    def forward_for_tracing(self, image: Tensor) -> Tensor | dict[str, Tensor]:
-        """Model forward function used for the model tracing during model exportation."""
-        if self.explain_mode:
-            return self.model(images=image, mode="explain")
-
-        return self.model(images=image, mode="tensor")
+        label_type = {
+            OTXTaskType.MULTI_CLASS_CLS: "multiclass",
+            OTXTaskType.MULTI_LABEL_CLS: "multilabel",
+            OTXTaskType.H_LABEL_CLS: "hlabel",
+        }[self.task]
+        return OTXv1Helper.load_cls_effnet_b0_ckpt(state_dict, label_type, add_prefix)

--- a/src/otx/core/data/entity/classification.py
+++ b/src/otx/core/data/entity/classification.py
@@ -197,3 +197,11 @@ class HlabelClsBatchDataEntity(OTXBatchDataEntity[HlabelClsDataEntity]):
 @dataclass
 class HlabelClsBatchPredEntity(OTXBatchPredEntity, HlabelClsBatchDataEntity):
     """Data entity to represent model output predictions for H-label classification task."""
+
+
+CLASSIFICATION_BATCH_DATA_ENTITY = (
+    MulticlassClsBatchDataEntity | MultilabelClsBatchDataEntity | HlabelClsBatchDataEntity
+)
+CLASSIFICATION_BATCH_PRED_ENTITY = (
+    MulticlassClsBatchPredEntity | MultilabelClsBatchPredEntity | HlabelClsBatchPredEntity
+)

--- a/src/otx/core/metrics/__init__.py
+++ b/src/otx/core/metrics/__init__.py
@@ -3,6 +3,6 @@
 #
 """Module for OTX custom metrices."""
 
-from otx.core.metrics.types import MetricCallable, MetricInput, NullMetricCallable
+from otx.core.metrics.types import MetricCallable, MetricCallablePerTask, MetricInput, NullMetricCallable
 
-__all__ = ["MetricCallable", "MetricInput", "NullMetricCallable"]
+__all__ = ["MetricCallable", "MetricInput", "NullMetricCallable", "MetricCallablePerTask"]

--- a/src/otx/core/metrics/accuracy.py
+++ b/src/otx/core/metrics/accuracy.py
@@ -16,7 +16,8 @@ from torchmetrics.classification.accuracy import (
 )
 from torchmetrics.collections import MetricCollection
 
-from otx.core.metrics.types import MetricCallable
+from otx.core.metrics.types import MetricCallable, MetricCallablePerTask
+from otx.core.types.task import OTXTaskType
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -378,3 +379,17 @@ def _mixed_hlabel_accuracy(label_info: HLabelInfo) -> MetricCollection:
 
 
 HLabelClsMetricCallble: MetricCallable = _mixed_hlabel_accuracy  # type: ignore[assignment]
+
+
+def _default_cls_accuracy(label_info: LabelInfo, task: OTXTaskType) -> MetricCollection:
+    if task == OTXTaskType.MULTI_CLASS_CLS:
+        return _multi_class_cls_metric_callable(label_info)
+    if task == OTXTaskType.MULTI_LABEL_CLS:
+        return _multi_label_cls_metric_callable(label_info)
+    if task == OTXTaskType.H_LABEL_CLS:
+        return _mixed_hlabel_accuracy(label_info)  # type: ignore[arg-type]
+    msg = f"Unsupported task type: {task}"
+    raise ValueError(msg)
+
+
+DefaultClsMetricCallable: MetricCallablePerTask = _default_cls_accuracy

--- a/src/otx/core/metrics/types.py
+++ b/src/otx/core/metrics/types.py
@@ -10,8 +10,10 @@ from torch import Tensor, zeros
 from torchmetrics import Metric, MetricCollection
 
 from otx.core.types.label import LabelInfo
+from otx.core.types.task import OTXTaskType
 
 MetricCallable = Callable[[LabelInfo], Metric | MetricCollection]
+MetricCallablePerTask = Callable[[LabelInfo, OTXTaskType], Metric | MetricCollection]
 
 
 class NullMetric(Metric):

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
 
     from otx.core.data.module import OTXDataModule
     from otx.core.exporter.base import OTXModelExporter
-    from otx.core.metrics import MetricCallable
+    from otx.core.metrics import MetricCallable, MetricCallablePerTask
 
 logger = logging.getLogger()
 
@@ -106,7 +106,7 @@ class OTXModel(LightningModule, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEnti
         label_info: LabelInfoTypes,
         optimizer: OptimizerCallable = DefaultOptimizerCallable,
         scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
-        metric: MetricCallable = NullMetricCallable,
+        metric: MetricCallable | MetricCallablePerTask = NullMetricCallable,
         torch_compile: bool = False,
         tile_config: TileConfig = TileConfig(enable_tiler=False),
     ) -> None:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
@@ -1,7 +1,8 @@
 model:
-  class_path: otx.algo.classification.efficientnet.EfficientNetForHLabelCls
+  class_path: otx.algo.classification.efficientnet.EfficientNetForClassification
   init_args:
     version: b0
+    task: H_LABEL_CLS
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -1,5 +1,5 @@
 model:
-  class_path: otx.algo.classification.efficientnet.EfficientNetForMulticlassCls
+  class_path: otx.algo.classification.efficientnet.EfficientNetForClassification
   init_args:
     label_info: 1000
     version: b0

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_semisl.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0_semisl.yaml
@@ -1,8 +1,9 @@
 model:
-  class_path: otx.algo.classification.efficientnet.EfficientNetForMulticlassClsSemiSL
+  class_path: otx.algo.classification.efficientnet.EfficientNetForClassification
   init_args:
     label_info: 1000
     version: b0
+    train_type: SEMI_SUPERVISED
 
     optimizer:
       class_path: torch.optim.SGD

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
@@ -1,8 +1,9 @@
 model:
-  class_path: otx.algo.classification.efficientnet.EfficientNetForMultilabelCls
+  class_path: otx.algo.classification.efficientnet.EfficientNetForClassification
   init_args:
     label_info: 1000
     version: b0
+    task: MULTI_LABEL_CLS
 
     optimizer:
       class_path: torch.optim.SGD

--- a/tests/integration/api/test_engine_api.py
+++ b/tests/integration/api/test_engine_api.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 from model_api.tilers import Tiler
-from otx.algo.classification.efficientnet import EfficientNetForMulticlassCls
+from otx.algo.classification.efficientnet import EfficientNetForClassification
 from otx.core.config.hpo import HpoConfig
 from otx.core.data.module import OTXDataModule
 from otx.core.model.base import OTXModel
@@ -183,7 +183,7 @@ def test_otx_hpo(
         reason = f"test_otx_hpo for {task} isn't prepared yet."
         pytest.xfail(reason=reason)
 
-    model = EfficientNetForMulticlassCls(label_info=2)
+    model = EfficientNetForClassification(label_info=2)
     hpo_config = HpoConfig(
         search_space={
             "model.scheduler.factor": {

--- a/tests/unit/algo/callbacks/test_unlabeled_loss_warmup.py
+++ b/tests/unit/algo/callbacks/test_unlabeled_loss_warmup.py
@@ -3,12 +3,13 @@ import math
 import pytest
 from lightning import Trainer
 from otx.algo.callbacks.unlabeled_loss_warmup import UnlabeledLossWarmUpCallback
-from otx.algo.classification.efficientnet import EfficientNetForMulticlassClsSemiSL
+from otx.algo.classification.efficientnet import EfficientNetForClassification
+from otx.core.types.task import OTXTrainType
 
 
 @pytest.fixture()
 def fxt_semisl_model():
-    return EfficientNetForMulticlassClsSemiSL(10)
+    return EfficientNetForClassification(10, train_type=OTXTrainType.SEMI_SUPERVISED)
 
 
 def test_unlabeled_loss_warmup_callback(mocker, fxt_semisl_model):

--- a/tests/unit/algo/classification/test_efficientnet.py
+++ b/tests/unit/algo/classification/test_efficientnet.py
@@ -4,11 +4,7 @@
 import pytest
 import torch
 from otx.algo.classification.classifier import ImageClassifier
-from otx.algo.classification.efficientnet import (
-    EfficientNetForHLabelCls,
-    EfficientNetForMulticlassCls,
-    EfficientNetForMultilabelCls,
-)
+from otx.algo.classification.efficientnet import EfficientNetForClassification
 from otx.core.data.entity.base import OTXBatchLossEntity
 from otx.core.data.entity.classification import (
     HlabelClsBatchPredEntity,
@@ -19,7 +15,7 @@ from otx.core.data.entity.classification import (
 
 @pytest.fixture()
 def fxt_multi_class_cls_model():
-    return EfficientNetForMulticlassCls(
+    return EfficientNetForClassification(
         version="b0",
         label_info=10,
     )
@@ -57,9 +53,10 @@ class TestEfficientNetForMulticlassCls:
 
 @pytest.fixture()
 def fxt_multi_label_cls_model():
-    return EfficientNetForMultilabelCls(
+    return EfficientNetForClassification(
         version="b0",
         label_info=10,
+        task="MULTI_LABEL_CLS",
     )
 
 
@@ -95,9 +92,10 @@ class TestEfficientNetForMultilabelCls:
 
 @pytest.fixture()
 def fxt_h_label_cls_model(fxt_hlabel_data):
-    return EfficientNetForHLabelCls(
+    return EfficientNetForClassification(
         version="b0",
         label_info=fxt_hlabel_data,
+        task="H_LABEL_CLS",
     )
 
 

--- a/tests/unit/engine/test_engine.py
+++ b/tests/unit/engine/test_engine.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 import pytest
-from otx.algo.classification.efficientnet import EfficientNetForMulticlassCls
+from otx.algo.classification.efficientnet import EfficientNetForClassification
 from otx.algo.classification.torchvision_model import OTXTVModel
 from otx.core.model.base import OTXModel, OVModel
 from otx.core.types.export import OTXExportFormatType
@@ -38,7 +38,7 @@ class TestEngine:
         engine = Engine(work_dir=tmp_path, data_root=data_root)
         assert engine.task == "MULTI_CLASS_CLS"
         assert engine.datamodule.task == "MULTI_CLASS_CLS"
-        assert isinstance(engine.model, EfficientNetForMulticlassCls)
+        assert isinstance(engine.model, EfficientNetForClassification)
 
         assert "default_root_dir" in engine.trainer_params
         assert engine.trainer_params["default_root_dir"] == tmp_path
@@ -54,7 +54,7 @@ class TestEngine:
     def test_model_setter(self, fxt_engine, mocker) -> None:
         assert isinstance(fxt_engine.model, OTXTVModel)
         fxt_engine.model = "efficientnet_b0"
-        assert isinstance(fxt_engine.model, EfficientNetForMulticlassCls)
+        assert isinstance(fxt_engine.model, EfficientNetForClassification)
 
     def test_training_with_override_args(self, fxt_engine, mocker) -> None:
         mocker.patch("pathlib.Path.symlink_to")


### PR DESCRIPTION
### Summary

- Introduce New `OTXModel` Class for Classification that include all `task` & `train_type`
- Introduce `MetricCallablePerTask` for Union sub-task metric of classification
- Replace EfficientNet-B0
![image](https://github.com/user-attachments/assets/83176d0b-99ca-4246-9c50-f0654150beb0)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
