### PR TITLE
Pad input image to square when tiling is enabled

### DIFF
--- a/src/otx/algorithms/detection/configs/base/data/tiling/base_iseg_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/base_iseg_tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=True),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", size=img_size),
+    dict(type="Pad", pad_to_square=True),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", size=img_size),
+            dict(type="Pad", pad_to_square=True),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],

--- a/src/otx/algorithms/detection/configs/base/data/tiling/efficientnet_iseg_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/efficientnet_iseg_tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=True),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", size_divisor=32),
+    dict(type="Pad", pad_to_square=True),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", size_divisor=32),
+            dict(type="Pad", pad_to_square=True),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],

--- a/src/otx/algorithms/detection/configs/rotated_detection/efficientnetb2b_maskrcnn/tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/rotated_detection/efficientnetb2b_maskrcnn/tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=False),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", size_divisor=32),
+    dict(type="Pad", pad_to_square=True),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=False),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", size_divisor=32),
+            dict(type="Pad", pad_to_square=True),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],

--- a/src/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=True),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", size=img_size),
+    dict(type="Pad", pad_to_square=True),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", size=img_size),
+            dict(type="Pad", pad_to_square=True),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],


### PR DESCRIPTION
### Summary

Tiles at the edge of a full image can be smaller than expected. Even if we pad with a divisor of 32, the tile size can still be too small, such as 64 x 512. In such cases, the feature map can become too small when downsampling in the tile classifier, leading to errors. To avoid this issue, I pad the input image to a square, ensuring the input size is always 512 x 512. I compared the tiling results with the previous version to ensure there is no regression:

| Commit        | Model           | Dataset   | Torch Accuracy | OV Accuracy |
|---------------|-----------------|-----------|----------------|-------------|
| PR            | Mask R-CNN R50  | Coliform  | 0.6153         | 0.6199      |
| release/1.6.0 | Mask R-CNN R50  | Coliform  | 0.62639        | 0.6293      |
| PR            | Mask R-CNN Eff  | Coliform  | 0.6303         | 0.6321      |
| release/1.6.0 | Mask R-CNN Eff  | Coliform  | 0.6351         | 0.6536      |
| PR            | Mask R-CNN R50  | Aeromonas | 0.9236         | 0.9303      |
| release/1.6.0 | Mask R-CNN R50  | Aeromonas | 0.9190         | 0.92819     |
| PR            | Mask R-CNN Eff  | Aeromonas | 0.9329         | 0.94206     |
| release/1.6.0 | Mask R-CNN Eff  | Aeromonas | 0.9351         | 0.9419      |

### How to test

![image](https://github.com/user-attachments/assets/64ee3be5-bfe4-40e5-9209-64f759d144d8)

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
