### PR TITLE
Fix visual prompting dataset for empty nonzero mask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ xpu = [
     "intel-extension-for-pytorch==2.1.30+xpu",
     "oneccl_bind_pt==2.1.300+xpu",
     "lightning==2.2",
-    "pytorchcv",
+    "pytorchcv==0.0.67",
     "timm==1.0.3",
     "openvino==2024.3",
     "openvino-dev==2024.3",
@@ -93,7 +93,7 @@ xpu = [
 base = [
     "torch==2.2.2",
     "lightning==2.3.3",
-    "pytorchcv",
+    "pytorchcv==0.0.67",
     "timm==1.0.3",
     "openvino==2024.3",
     "openvino-dev==2024.3",

--- a/src/otx/core/data/dataset/visual_prompting.py
+++ b/src/otx/core/data/dataset/visual_prompting.py
@@ -90,7 +90,7 @@ class OTXVisualPromptingDataset(OTXDataset[VisualPromptingDataEntity]):
             if isinstance(annotation, dmPolygon):
                 mask = tvMask(polygon_to_bitmap([annotation], *img_shape)[0])
                 mask_points = torch.nonzero(mask)
-                if len(mask_points[0]) == 0:
+                if len(mask_points) == 0:
                     # skip very small region
                     continue
 
@@ -225,7 +225,7 @@ class OTXZeroShotVisualPromptingDataset(OTXDataset[ZeroShotVisualPromptingDataEn
                 # generate prompts from polygon
                 mask = tvMask(polygon_to_bitmap([annotation], *img_shape)[0])
                 mask_points = torch.nonzero(mask)
-                if len(mask_points[0]) == 0:
+                if len(mask_points) == 0:
                     # skip very small region
                     continue
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
