### PR TITLE
Fix confusion matrix calculation

### DIFF
--- a/src/otx/api/usecases/evaluation/accuracy.py
+++ b/src/otx/api/usecases/evaluation/accuracy.py
@@ -323,7 +323,7 @@ def compute_unnormalized_confusion_matrices_from_resultset(
         true_label_idx,
         predicted_label_idx,
     ) = __get_gt_and_predicted_label_indices_from_resultset(resultset)
-    task_labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=False)
+    task_labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=True)
 
     # Confusion matrix computation
     for label_group in resultset.model.configuration.get_label_schema().get_groups():

--- a/src/otx/api/usecases/evaluation/accuracy.py
+++ b/src/otx/api/usecases/evaluation/accuracy.py
@@ -218,7 +218,7 @@ def __get_gt_and_predicted_label_indices_from_resultset(
     pred_dataset.sort_items()
 
     # Iterate over each dataset item, and collect the labels for this item (pred and gt)
-    task_labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=True)
+    task_labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=False)
     for gt_item, pred_item in zip(gt_dataset, pred_dataset):
         if isinstance(gt_item, DatasetItemEntity) and isinstance(pred_item, DatasetItemEntity):
             true_label_idx.append({task_labels.index(label) for label in gt_item.get_roi_labels(task_labels)})
@@ -323,7 +323,7 @@ def compute_unnormalized_confusion_matrices_from_resultset(
         true_label_idx,
         predicted_label_idx,
     ) = __get_gt_and_predicted_label_indices_from_resultset(resultset)
-    task_labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=True)
+    task_labels = resultset.model.configuration.get_label_schema().get_labels(include_empty=False)
 
     # Confusion matrix computation
     for label_group in resultset.model.configuration.get_label_schema().get_groups():


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-149491 
but this PR is not root cause resolving

gt and pred idx generated from: https://github.com/openvinotoolkit/training_extensions/blob/67be79bb70444cb0c483880b82bdbf5ec7d8878e/src/otx/api/usecases/evaluation/accuracy.py#L221
![image](https://github.com/user-attachments/assets/4a63c52b-527b-4cc0-96f8-27cb3cf11a6c)

confusion matrix from: https://github.com/openvinotoolkit/training_extensions/blob/67be79bb70444cb0c483880b82bdbf5ec7d8878e/src/otx/api/usecases/evaluation/accuracy.py#L326
![image](https://github.com/user-attachments/assets/6e0a6f45-5f94-4da5-a7bf-a708e459b3f6)

above causes a mismatch in the label index.
Unify this to `False`.


### How to test

![image](https://github.com/user-attachments/assets/4704b87c-a550-4a2f-91c8-c90b65fa54b9)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
