### PR TITLE
Fix Classification explain forward issue

### DIFF
--- a/src/otx/algo/classification/classifier/base_classifier.py
+++ b/src/otx/algo/classification/classifier/base_classifier.py
@@ -190,7 +190,7 @@ class ImageClassifier(BaseModule):
         logits = self.head(x)
         pred_results = self.head._get_predictions(logits)  # noqa: SLF001
         scores = pred_results.unbind(0)
-        preds = logits.argmax(-1, keepdim=True).unbind(0)
+        preds = pred_results.argmax(-1, keepdim=True).unbind(0)
 
         outputs = {
             "logits": logits,


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-150213
-> The sigmoid operation is missing when predicting label in explain.
There is a bug in the classification task that sometimes causes the label prediction of predict and explain to be different. Fix the inconsistency.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
