### PR TITLE
Fix Learning Rate and Loss Handling in Tile Classifier MaskRCNN EfficientNet

### DIFF
--- a/src/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/models/detectors/custom_maskrcnn_tile_optimized.py
@@ -149,6 +149,8 @@ class CustomMaskRCNNTileOptimized(CustomMaskRCNN):
             img, img_metas, gt_bboxes, gt_labels, gt_bboxes_ignore, gt_masks, proposals, **kwargs
         )
         losses.update(rcnn_loss)
+        if "acc" in losses:
+            losses.pop("acc")
         return losses
 
     @staticmethod

--- a/src/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
+++ b/src/otx/algorithms/detection/adapters/mmdet/utils/config_utils.py
@@ -122,11 +122,8 @@ def patch_tiling(config, hparams, dataset=None):
 
             if config.model.backbone.type == "efficientnet_b2b":
                 learning_rate = 0.002
-                logger.info(
-                    f"Patched {config.model.backbone.type} LR: "
-                    f"{hparams.learning_parameters.learning_rate} -> {learning_rate}"
-                )
-                hparams.learning_parameters.learning_rate = learning_rate
+                logger.info(f"Patched {config.model.backbone.type} LR: " f"{config.optimizer.lr} -> {learning_rate}")
+                config.optimizer.lr = learning_rate
 
             config.data.train.filter_empty_gt = False
 

--- a/tests/unit/algorithms/detection/tiling/test_tiling_tile_classifier.py
+++ b/tests/unit/algorithms/detection/tiling/test_tiling_tile_classifier.py
@@ -211,3 +211,4 @@ class TestTilingTileClassifier:
         hyper_parameters.tiling_parameters.enable_tiling = True
         hyper_parameters.tiling_parameters.enable_tile_classifier = True
         patch_tiling(cfg, hyper_parameters, self.dataset)
+        assert cfg.optimizer.lr == 0.002, "Learning rate should be 0.002 when MRCNN EfficientNet is used"


### PR DESCRIPTION
### Summary

* Custom Learning Rate Adjustment: Fixed an issue with the customized learning rate for MaskRCNN EfficientNet that caused 0% accuracy when the tile classifier was enabled.
* Loss Dictionary Update: stable training by removing "acc" from loss_dict to prevent gradient explosion

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
