### PR TITLE
Move benchmark deps to ci-benchmark extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,6 @@ dev = [
     "pytest-mock",
     "pytest-csv",
     "pytest-cov",
-    "mlflow==2.15.1",     # For perf benchmark
-    "py-cpuinfo==9.0.0",  # For perf benchmark
-    "openpyxl",           # For perf benchmark
 ]
 
 docs = [
@@ -134,6 +131,8 @@ ci_benchmark = [
     "ipython==8.26.0",
     "ipykernel==6.29.5",
     "openpyxl==3.1.5",
+    "mlflow==2.15.1",
+    "py-cpuinfo==9.0.0",
 ]
 
 [project.scripts]

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands =
 
 [testenv:perf-benchmark]
 deps =
-    .[base,dev]
+    .[base,dev,ci_benchmark]
 commands =
     pytest -ra --showlocals --csv={toxworkdir}/{envname}-test.csv {posargs:tests/perf}
 


### PR DESCRIPTION
### Summary

This change is for reducing storage consumption for the unitest.
Unitest runs on the gh-hosted ci runner now and it has limited size of storage but almost of it already used now.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
