### PR TITLE
Pad tile to image size (512 x 512)

### DIFF
--- a/src/otx/algorithms/detection/configs/base/data/tiling/base_iseg_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/base_iseg_tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=True),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", pad_to_square=True),
+    dict(type="Pad", size=img_size),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", pad_to_square=True),
+            dict(type="Pad", size=img_size),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],

--- a/src/otx/algorithms/detection/configs/base/data/tiling/efficientnet_iseg_tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/base/data/tiling/efficientnet_iseg_tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=True),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", pad_to_square=True),
+    dict(type="Pad", size=img_size),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", pad_to_square=True),
+            dict(type="Pad", size=img_size),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],

--- a/src/otx/algorithms/detection/configs/rotated_detection/efficientnetb2b_maskrcnn/tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/rotated_detection/efficientnetb2b_maskrcnn/tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=False),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", pad_to_square=True),
+    dict(type="Pad", size=img_size),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=False),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", pad_to_square=True),
+            dict(type="Pad", size=img_size),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],

--- a/src/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/tile_pipeline.py
+++ b/src/otx/algorithms/detection/configs/rotated_detection/resnet50_maskrcnn/tile_pipeline.py
@@ -17,7 +17,7 @@ train_pipeline = [
     dict(type="Resize", img_scale=img_size, keep_ratio=True),
     dict(type="RandomFlip", flip_ratio=0.5),
     dict(type="Normalize", **img_norm_cfg),
-    dict(type="Pad", pad_to_square=True),
+    dict(type="Pad", size=img_size),
     dict(type="DefaultFormatBundle"),
     dict(
         type="Collect",
@@ -45,7 +45,7 @@ test_pipeline = [
             dict(type="Resize", keep_ratio=True),
             dict(type="RandomFlip"),
             dict(type="Normalize", **img_norm_cfg),
-            dict(type="Pad", pad_to_square=True),
+            dict(type="Pad", size=img_size),
             dict(type="ImageToTensor", keys=["img"]),
             dict(type="Collect", keys=["img"]),
         ],


### PR DESCRIPTION
### Summary

Revert changes in this PR: https://github.com/openvinotoolkit/training_extensions/pull/3844/files
and align with pad to image size instead

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
