### PR TITLE
Improve Semi-SL for LiteHRNet (small-medium case)

### DIFF
--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -54,9 +54,9 @@ class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity]):
         torch_compile: bool = False,
         train_type: Literal[OTXTrainType.SUPERVISED, OTXTrainType.SEMI_SUPERVISED] = OTXTrainType.SUPERVISED,
         model_version: str | None = None,
-        unsupervised_weight: float = 0.6,
+        unsupervised_weight: float = 0.7,
         semisl_start_epoch: int = 2,
-        drop_unreliable_pixels_percent: int = 80,
+        drop_unreliable_pixels_percent: int = 20,
     ):
         """Base semantic segmentation model.
 

--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -54,9 +54,9 @@ class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity]):
         torch_compile: bool = False,
         train_type: Literal[OTXTrainType.SUPERVISED, OTXTrainType.SEMI_SUPERVISED] = OTXTrainType.SUPERVISED,
         model_version: str | None = None,
-        unsupervised_weight: float = 0.7,
+        unsupervised_weight: float = 0.6,
         semisl_start_epoch: int = 2,
-        drop_unreliable_pixels_percent: int = 20,
+        drop_unreliable_pixels_percent: int = 80,
     ):
         """Base semantic segmentation model.
 

--- a/src/otx/recipe/semantic_segmentation/semisl/litehrnet_18_semisl.yaml
+++ b/src/otx/recipe/semantic_segmentation/semisl/litehrnet_18_semisl.yaml
@@ -4,6 +4,7 @@ model:
     label_info: 2
     model_version: lite_hrnet_18
     train_type: SEMI_SUPERVISED
+    drop_unreliable_pixels_percent: 80
 
     optimizer:
       class_path: torch.optim.Adam

--- a/src/otx/recipe/semantic_segmentation/semisl/litehrnet_s_semisl.yaml
+++ b/src/otx/recipe/semantic_segmentation/semisl/litehrnet_s_semisl.yaml
@@ -4,6 +4,7 @@ model:
     label_info: 2
     model_version: lite_hrnet_s
     train_type: SEMI_SUPERVISED
+    drop_unreliable_pixels_percent: 80
 
     optimizer:
       class_path: torch.optim.Adam
@@ -42,3 +43,4 @@ overrides:
       init_args:
         momentum: 0.99
         start_epoch: 2
+

--- a/src/otx/recipe/semantic_segmentation/semisl/litehrnet_s_semisl.yaml
+++ b/src/otx/recipe/semantic_segmentation/semisl/litehrnet_s_semisl.yaml
@@ -43,4 +43,3 @@ overrides:
       init_args:
         momentum: 0.99
         start_epoch: 2
-


### PR DESCRIPTION
### Summary

Slight change for Semi-SL. Improves accuracy for medium-small dataset in my experiments.

**litehrnets_s**
Kitti_36:
Supervised: 0.602 -> Semi-SL: 0.678 (before: 0.622)
Kvasir_24
Supervised: 0.801 -> Semi-SL: 0.889 (before: 0.789)

**litehrnet18**
Cityscapes:
Supervised:0.49 -> Semi-SL: 0.583 (before: 0.43)
Kitti_36:
Supervised:0.634 -> Semi-SL: 0.7 

Full benchmark in progress

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
