### PR TITLE
Make complex unique key for mem cache handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix labels names in hierarchical config (<https://github.com/openvinotoolkit/training_extensions/pull/3879>)
 - Fix Learning Rate and Loss Handling in Tile Classifier MaskRCNN EfficientNet (<https://github.com/openvinotoolkit/training_extensions/pull/3873>)
 - Disable Tile Classifier in Rotated Detection (<https://github.com/openvinotoolkit/training_extensions/pull/3894>)
+- Enhance Memeory Cache Handler with Complex Unique Keys (<https://github.com/openvinotoolkit/training_extensions/pull/3897>)
 
 ## \[v1.6.4\]
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can find more details with examples in the [CLI command intro](https://openv
 
 - Fix labels names in hierarchical config
 - Fix Learning Rate and Loss Handling in Tile Classifier MaskRCNN EfficientNet
+- Enhance Memeory Cache Handler with Complex Unique Keys
 
 ### Release History
 

--- a/docs/source/guide/release_notes/index.rst
+++ b/docs/source/guide/release_notes/index.rst
@@ -9,6 +9,7 @@ v1.6.5 (3Q24)
 
 - Fix labels names in hierarchical config
 - Fix Learning Rate and Loss Handling in Tile Classifier MaskRCNN EfficientNet
+- Enhance Memeory Cache Handler with Complex Unique Keys
 
 v1.6.4 (3Q24)
 -------------

--- a/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
+++ b/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
@@ -44,8 +44,10 @@ class LoadImageFromOTXDataset:
         d_item = results["dataset_item"]
         if d_item.media.path:  # when video extracted frames come, media.path is None
             results["cache_key"] = d_item.media.path, d_item.roi.id
-        else:
+        elif len(d_item.annotation_scene.annotations) > 0:
             results["cache_key"] = d_item.roi.id, d_item.annotation_scene.annotations[0].id
+        else:
+            results["cache_key"] = d_item.roi.id
         return results["cache_key"]
 
     def _get_memcache_handler(self):

--- a/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
+++ b/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
@@ -42,7 +42,7 @@ class LoadImageFromOTXDataset:
         if "cache_key" in results:
             return results["cache_key"]
         d_item = results["dataset_item"]
-        if d_item.media.path: # when video extracted frames come, media.path is given by None
+        if d_item.media.path:  # when video extracted frames come, media.path is None
             results["cache_key"] = d_item.media.path, d_item.roi.id
         else:
             results["cache_key"] = d_item.roi.id, d_item.annotation_scene.annotations[0].id

--- a/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
+++ b/src/otx/algorithms/common/adapters/mmcv/pipelines/load_image_from_otx_dataset.py
@@ -42,7 +42,10 @@ class LoadImageFromOTXDataset:
         if "cache_key" in results:
             return results["cache_key"]
         d_item = results["dataset_item"]
-        results["cache_key"] = d_item.media.path, d_item.roi.id
+        if d_item.media.path: # when video extracted frames come, media.path is given by None
+            results["cache_key"] = d_item.media.path, d_item.roi.id
+        else:
+            results["cache_key"] = d_item.roi.id, d_item.annotation_scene.annotations[0].id
         return results["cache_key"]
 
     def _get_memcache_handler(self):


### PR DESCRIPTION
### Summary

This PR introduces more complex unique key for video data, where video frames are extracted from an original video and these disappear media path. So I added annotation.id for the additional unique key for mem cache handler.

- Fixed failing issue during video training [CVS-150481](https://jira.devtools.intel.com/browse/CVS-150481)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
