### PR TITLE
Fix a bug that training is stuck while detection model is trained on distrubited environment

### DIFF
--- a/src/otx/core/data/dataset/detection.py
+++ b/src/otx/core/data/dataset/detection.py
@@ -51,7 +51,7 @@ class OTXDetectionDataset(OTXDataset[DetDataEntity]):
                 canvas_size=img_shape,
                 dtype=torch.float32,
             ),
-            labels=torch.as_tensor([ann.label for ann in bbox_anns], dtype=torch.int32),
+            labels=torch.as_tensor([ann.label for ann in bbox_anns], dtype=torch.long),
         )
 
         return self._apply_transforms(entity)

--- a/src/otx/core/data/dataset/detection.py
+++ b/src/otx/core/data/dataset/detection.py
@@ -49,8 +49,9 @@ class OTXDetectionDataset(OTXDataset[DetDataEntity]):
                 bboxes,
                 format=tv_tensors.BoundingBoxFormat.XYXY,
                 canvas_size=img_shape,
+                dtype=torch.float32,
             ),
-            labels=torch.as_tensor([ann.label for ann in bbox_anns]),
+            labels=torch.as_tensor([ann.label for ann in bbox_anns], dtype=torch.int32),
         )
 
         return self._apply_transforms(entity)

--- a/src/otx/core/data/dataset/instance_segmentation.py
+++ b/src/otx/core/data/dataset/instance_segmentation.py
@@ -75,6 +75,7 @@ class OTXInstanceSegDataset(OTXDataset[InstanceSegDataEntity]):
                 bboxes,
                 format=tv_tensors.BoundingBoxFormat.XYXY,
                 canvas_size=img_shape,
+                dtype=torch.float32,
             ),
             masks=tv_tensors.Mask(masks, dtype=torch.uint8),
             labels=torch.as_tensor(labels),

--- a/src/otx/core/metrics/fmeasure.py
+++ b/src/otx/core/metrics/fmeasure.py
@@ -636,6 +636,8 @@ class FMeasure(Metric):
     IoU > threshold are reduced to one. This threshold can be determined automatically by setting `vary_nms_threshold`
     to True.
 
+    # TODO(someone): need to update for distriubted training. refer https://lightning.ai/docs/torchmetrics/stable/pages/implement.html
+
     Args:
         label_info (int): Dataclass including label information.
         vary_nms_threshold (bool): if True the maximal F-measure is determined by optimizing for different NMS threshold

--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -297,7 +297,7 @@ class OTXDetectionModel(OTXModel[DetBatchDataEntity, DetBatchPredEntity]):
             "preds": [
                 {
                     "boxes": bboxes.data,
-                    "scores": scores,
+                    "scores": scores.type(torch.float32),
                     "labels": labels,
                 }
                 for bboxes, scores, labels in zip(


### PR DESCRIPTION
### Summary
This PR fixes #3635

### How this change solves the bug
In distributed training, torchmetric package tries to sync values across processes.
If one process has a value in bbox, label or scores and other process not, then torchmetric makes empty torch Tensor.
But if dtype of tensor between processes is different, then process is stuck during sync.
To avoid it, this PR specifies dtype properly.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
