### PR TITLE
Improve acc drop of efficientnetv2 for h-label cls

### DIFF
--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -21,7 +21,7 @@ overrides:
   reset:
     - data.train_subset.transforms
 
-  max_epochs: 200
+  max_epochs: 90
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -10,14 +10,6 @@ model:
         momentum: 0.9
         weight_decay: 0.0001
 
-    scheduler:
-      class_path: lightning.pytorch.cli.ReduceLROnPlateau
-      init_args:
-        mode: max
-        factor: 0.5
-        patience: 1
-        monitor: val/accuracy
-
 engine:
   task: H_LABEL_CLS
   device: auto
@@ -29,12 +21,12 @@ overrides:
   reset:
     - data.train_subset.transforms
 
-  max_epochs: 90
+  max_epochs: 200
   callbacks:
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
         patience: 3
-
+        warmup_iters: 750
   data:
     task: H_LABEL_CLS
     data_format: datumaro


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
- Improve acc through preserving warmup iters
  - There are enough accuracy is preserved after at least 800 steps
  - Before, train iter is only around 300-400 for some seeds.
- For perf test with `num_repeat` 3 times,

|           | test/acc mean | test/acc std |
|-------|-----------------|--------------|
| as-is   | 0.502               | 0.3875         |
| to-be | 0.9645            | 0.0048           |

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
