### PR TITLE
Fix Datamodule creation for OV in AutoConfigurator

### DIFF
--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -410,6 +410,7 @@ class AutoConfigurator:
         subset_config.to_tv_image = ov_config[f"{subset}_subset"]["to_tv_image"]
         datamodule.image_color_channel = ov_config["image_color_channel"]
         datamodule.tile_config.enable_tiler = False
+        datamodule.unlabeled_subset.data_root = None
         msg = (
             f"For OpenVINO IR models, Update the following {subset} \n"
             f"\t transforms: {subset_config.transforms} \n"

--- a/tests/unit/engine/utils/test_auto_configurator.py
+++ b/tests/unit/engine/utils/test_auto_configurator.py
@@ -212,3 +212,5 @@ class TestAutoConfigurator:
         assert updated_datamodule.test_subset.transforms == [{"class_path": "torchvision.transforms.v2.ToImage"}]
 
         assert updated_datamodule.test_subset.transform_lib_type == TransformLibType.TORCHVISION
+        assert not updated_datamodule.tile_config.enable_tiler
+        assert updated_datamodule.unlabeled_subset.data_root is None


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-151154
Modify `unlabeled_subset.data_root` to be used as None when creating the Datamodule used for the OV task.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
