### PR TITLE
Fix classification rt_info

### DIFF
--- a/src/otx/core/model/classification.py
+++ b/src/otx/core/model/classification.py
@@ -154,6 +154,7 @@ class OTXMulticlassClsModel(OTXModel[MulticlassClsBatchDataEntity, MulticlassCls
             task_type="classification",
             multilabel=False,
             hierarchical=False,
+            output_raw_scores=True,
         )
 
     @property
@@ -279,6 +280,7 @@ class OTXMultilabelClsModel(OTXModel[MultilabelClsBatchDataEntity, MultilabelCls
             multilabel=True,
             hierarchical=False,
             confidence_threshold=0.5,
+            output_raw_scores=True,
         )
 
     @property
@@ -401,6 +403,7 @@ class OTXHlabelClsModel(OTXModel[HlabelClsBatchDataEntity, HlabelClsBatchPredEnt
             multilabel=False,
             hierarchical=True,
             confidence_threshold=0.5,
+            output_raw_scores=True,
         )
 
     @property

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -34,6 +34,8 @@ class TaskLevelExportParameters:
             Only specified for the classification task.
         hierarchical (bool | None): Whether it is hierarchical or not.
             Only specified for the classification task.
+        output_raw_scores (bool | None): Whether to output raw scores.
+            Only specified for the classification task.
         confidence_threshold (float | None): Confidence threshold for model prediction probability.
             It is used only for classification tasks, detection and instance segmentation tasks.
         iou_threshold (float | None): The Intersection over Union (IoU) threshold
@@ -60,6 +62,7 @@ class TaskLevelExportParameters:
     # (Optional) Classification tasks
     multilabel: bool | None = None
     hierarchical: bool | None = None
+    output_raw_scores: bool | None = None
 
     # (Optional) Classification tasks, detection and instance segmentation task
     confidence_threshold: float | None = None
@@ -132,6 +135,9 @@ class TaskLevelExportParameters:
 
         if self.hierarchical is not None:
             metadata[("model_info", "hierarchical")] = str(self.hierarchical)
+
+        if self.output_raw_scores is not None:
+            metadata[("model_info", "output_raw_scores")] = str(self.output_raw_scores)
 
         if self.confidence_threshold is not None:
             metadata[("model_info", "confidence_threshold")] = str(self.confidence_threshold)

--- a/tests/unit/core/model/test_classification.py
+++ b/tests/unit/core/model/test_classification.py
@@ -48,6 +48,7 @@ class TestOTXMulticlassClsModel:
         assert model._export_parameters.task_type.lower() == "classification"
         assert not model._export_parameters.multilabel
         assert not model._export_parameters.hierarchical
+        assert model._export_parameters.output_raw_scores == True
 
         model = OTXMultilabelClsModel(
             label_info=1,

--- a/tests/unit/core/model/test_classification.py
+++ b/tests/unit/core/model/test_classification.py
@@ -48,7 +48,7 @@ class TestOTXMulticlassClsModel:
         assert model._export_parameters.task_type.lower() == "classification"
         assert not model._export_parameters.multilabel
         assert not model._export_parameters.hierarchical
-        assert model._export_parameters.output_raw_scores == True
+        assert model._export_parameters.output_raw_scores
 
         model = OTXMultilabelClsModel(
             label_info=1,

--- a/tests/unit/core/types/test_export.py
+++ b/tests/unit/core/types/test_export.py
@@ -17,6 +17,7 @@ def test_wrap(fxt_label_info, task_type):
 
     multilabel = False
     hierarchical = False
+    output_raw_scores = True
     confidence_threshold = 0.0
     iou_threshold = 0.0
     return_soft_prediction = False
@@ -27,6 +28,7 @@ def test_wrap(fxt_label_info, task_type):
     params = params.wrap(
         multilabel=multilabel,
         hierarchical=hierarchical,
+        output_raw_scores=output_raw_scores,
         confidence_threshold=confidence_threshold,
         iou_threshold=iou_threshold,
         return_soft_prediction=return_soft_prediction,
@@ -44,6 +46,7 @@ def test_wrap(fxt_label_info, task_type):
     assert metadata[("model_info", "return_soft_prediction")] == str(return_soft_prediction)
     assert metadata[("model_info", "soft_threshold")] == str(soft_threshold)
     assert metadata[("model_info", "blur_strength")] == str(blur_strength)
+    assert metadata[("model_info", "output_raw_scores")] == str(output_raw_scores)
 
     # Tile config
     assert ("model_info", "tile_size") in metadata


### PR DESCRIPTION
### Summary
rt_info was missing one field which was there in 1.x

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
