### PR TITLE
Fix binary classification metric task

### DIFF
--- a/src/otx/core/metrics/accuracy.py
+++ b/src/otx/core/metrics/accuracy.py
@@ -346,8 +346,10 @@ class MixedHLabelAccuracy(Metric):
 
 
 def _multi_class_cls_metric_callable(label_info: LabelInfo) -> MetricCollection:
+    num_classes = label_info.num_classes
+    task = "binary" if num_classes == 1 else "multiclass"
     return MetricCollection(
-        {"accuracy": TorchmetricAcc(task="multiclass", num_classes=label_info.num_classes)},
+        {"accuracy": TorchmetricAcc(task=task, num_classes=num_classes)},
     )
 
 

--- a/tests/unit/core/metrics/test_accuracy.py
+++ b/tests/unit/core/metrics/test_accuracy.py
@@ -9,9 +9,11 @@ from otx.core.metrics.accuracy import (
     HlabelAccuracy,
     MixedHLabelAccuracy,
     MulticlassAccuracywithLabelGroup,
+    MultiClassClsMetricCallable,
     MultilabelAccuracywithLabelGroup,
 )
 from otx.core.types.label import HLabelInfo, LabelInfo
+from torchmetrics.classification.accuracy import BinaryAccuracy, MulticlassAccuracy
 
 
 class TestAccuracy:
@@ -44,6 +46,16 @@ class TestAccuracy:
         result = metric.compute()
         acc = result["accuracy"]
         assert round(acc.item(), 3) == 0.792
+
+    def test_default_multi_class_cls_metric_callable(self, fxt_multiclass_labelinfo: LabelInfo) -> None:
+        assert fxt_multiclass_labelinfo.num_classes > 1
+        metric = MultiClassClsMetricCallable(fxt_multiclass_labelinfo)
+        assert isinstance(metric.accuracy, MulticlassAccuracy)
+
+        one_class_label_info = LabelInfo(label_names=["class1"], label_groups=[["class1"]])
+        assert one_class_label_info.num_classes == 1
+        binary_metric = MultiClassClsMetricCallable(one_class_label_info)
+        assert isinstance(binary_metric.accuracy, BinaryAccuracy)
 
     def test_multilabel_accuracy(self, fxt_multilabel_labelinfo: LabelInfo) -> None:
         """Check whether accuracy is same with OTX1.x version."""


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-151448
```shell
File "/opt/otx/otx/core/metrics/accuracy.py", line 350, in _multi_class_cls_metric_callable
    {"accuracy": TorchmetricAcc(task="multiclass", num_classes=label_info.num_classes)},
  File "/home/non-root/.local/lib/python3.10/site-packages/torchmetrics/classification/accuracy.py", line 522, in __new__
    return MulticlassAccuracy(num_classes, top_k, average, **kwargs)
  File "/home/non-root/.local/lib/python3.10/site-packages/torchmetrics/classification/stat_scores.py", line 321, in __init__
    _multiclass_stat_scores_arg_validation(
  File "/home/non-root/.local/lib/python3.10/site-packages/torchmetrics/functional/classification/stat_scores.py", line 240, in _multiclass_stat_scores_arg_validation
    raise ValueError(f"Expected argument `num_classes` to be an integer larger than 1, but got {num_classes}")
```

Fix issue
![image](https://github.com/user-attachments/assets/3e3335e5-bea1-4767-b755-21c7e66c4881)



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
