### PR TITLE
Improve MaskRCNN SwinT NNCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/3684>)
 - Fix MaskRCNN SwinT NNCF Accuracy Drop
   (<https://github.com/openvinotoolkit/training_extensions/pull/3685>)
+- Fix MaskRCNN SwinT NNCF Accuracy Drop By Adding More PTQ Configs
+  (<https://github.com/openvinotoolkit/training_extensions/pull/3929>)
 
 ### Known issues
 

--- a/src/otx/algo/instance_segmentation/maskrcnn.py
+++ b/src/otx/algo/instance_segmentation/maskrcnn.py
@@ -683,6 +683,17 @@ class MaskRCNNSwinT(MaskRCNN):
             },
             "advanced_parameters": {
                 "smooth_quant_alpha": -1,
+                "activations_range_estimator_params": {
+                    "min": {
+                        "statistics_type": "QUANTILE",
+                        "aggregator_type": "MIN",
+                        "quantile_outlier_prob": "1e-4",
+                    },
+                    "max": {
+                        "statistics_type": "QUANTILE",
+                        "aggregator_type": "MAX",
+                        "quantile_outlier_prob": "1e-4",
+                    },
+                },
             },
-            "preset": "mixed",
         }

--- a/src/otx/algo/instance_segmentation/maskrcnn.py
+++ b/src/otx/algo/instance_segmentation/maskrcnn.py
@@ -675,4 +675,14 @@ class MaskRCNNSwinT(MaskRCNN):
     @property
     def _optimization_config(self) -> dict[str, Any]:
         """PTQ config for MaskRCNN-SwinT."""
-        return {"model_type": "transformer"}
+        return {
+            "model_type": "transformer",
+            "ignored_scope": {
+                "patterns": [".*head.*"],
+                "validate": False,
+            },
+            "advanced_parameters": {
+                "smooth_quant_alpha": -1,
+            },
+            "preset": "mixed",
+        }


### PR DESCRIPTION
### Summary
Ignore quantization optimization on heads and disable smooth quantization

|      model     |     Dataset     | Seed | OV export F1-score |    PTQ F1-score    |
|:--------------:|:---------------:|:----:|:------------------:|:------------------:|
| MaskRCNN-SwinT | Vitens-Coliform | 0    | 0.612862527370453  | 0.6167512536048889 |
| MaskRCNN-SwinT | Vitens-Coliform | 1    | 0.619446218013763  | 0.6176470518112183 |
| MaskRCNN-SwinT | Vitens-Coliform | 2    | 0.623544633388519  | 0.6253229975700378 |
| MaskRCNN-SwinT | Vitens-Coliform | 3    | 0.611392378807068  | 0.6107936501502991 |
| MaskRCNN-SwinT | Vitens-Coliform | 4    | 0.615186631679535  | 0.6186495423316956 |

Original OV model binary size: 190.7 MB 
Quantized model binary size: 99.6 MB

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
