### PR TITLE
Enhance labels handling from arrow format for Semantic Segmentation

### DIFF
--- a/src/otx/core/data/dataset/segmentation.py
+++ b/src/otx/core/data/dataset/segmentation.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Callable
 import cv2
 import numpy as np
 import torch
-from datumaro.components.annotation import Ellipse, Image, Mask, Polygon, Bbox
+from datumaro.components.annotation import Bbox, Ellipse, Image, Mask, Polygon
 from torchvision import tv_tensors
 
 from otx.core.data.dataset.base import Transforms
@@ -179,12 +179,15 @@ class OTXSegmentationDataset(OTXDataset[SegDataEntity]):
             to_tv_image,
         )
 
-        if self.has_polygons:
-            # Geti case, correct the label names and groups
-            # we assume that last label is empty label
+        labels_id = self.label_info.label_names
+        if self.has_polygons and self.label_info.label_groups[-1][0] == "Empty":
+            # arrow format case, correct the label names and groups
+            # We assume that last label is empty label -> make it as background, 0 label
             self.label_info.label_groups = self.label_info.label_groups[::-1]
             labels_id = [self.label_info.label_names[-1], *self.label_info.label_names[:-1]]
-            self.label_info.label_names = [label for label_group in self.label_info.label_groups for label in label_group]
+            self.label_info.label_names = [
+                label for label_group in self.label_info.label_groups for label in label_group
+            ]
 
         self.label_info = SegLabelInfo(
             label_names=self.label_info.label_names,

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -120,6 +120,7 @@ class OTXDataModule(LightningDataModule):
                 dataset,
                 self.data_format,
                 self.unannotated_items_ratio,
+                task=task,
                 ignore_index=self.ignore_index if self.task == "SEMANTIC_SEGMENTATION" else None,
             )
 

--- a/src/otx/core/data/pre_filtering.py
+++ b/src/otx/core/data/pre_filtering.py
@@ -86,8 +86,10 @@ def remove_unused_labels(dataset: DmDataset, data_format: str, ignore_index: int
             "Please, check `dataset_meta.json` file."
         )
         raise ValueError(msg)
-    if len(used_labels) == len(original_categories):
+
+    if len(used_labels) == len(original_categories) or data_format == "arrow":
         return dataset
+
     msg = "There are unused labels in dataset, they will be filtered out before training."
     warnings.warn(msg, stacklevel=2)
     mapping = {original_categories[idx]: original_categories[idx] for idx in used_labels}

--- a/src/otx/core/model/segmentation.py
+++ b/src/otx/core/model/segmentation.py
@@ -95,6 +95,7 @@ class OTXSegmentationModel(OTXModel[SegBatchDataEntity, SegBatchPredEntity]):
             torch_compile=torch_compile,
             train_type=train_type,
         )
+
         self.input_size: tuple[int, int]
 
     def _create_model(self) -> nn.Module:

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -117,7 +117,7 @@ class TaskLevelExportParameters:
                     all_label_ids += lbl.replace(" ", "_") + " "
 
         if has_labels_ids:
-            for lbl in self.label_info.labels_id:
+            for lbl in self.label_info.labels_id:  # type: ignore[attr-defined]
                 all_label_ids += lbl.replace(" ", "_") + " "
 
         metadata = {

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -95,18 +95,26 @@ class TaskLevelExportParameters:
             dict[tuple[str, str], str]: It will be directly delivered to
             OpenVINO IR's `rt_info` or ONNX metadata slot.
         """
+        has_labels_ids = hasattr(self.label_info, "labels_id")
+
         if self.task_type == "instance_segmentation":
             # Instance segmentation needs to add empty label
             all_labels = "otx_empty_lbl "
             all_label_ids = "None "
             for lbl in self.label_info.label_names:
                 all_labels += lbl.replace(" ", "_") + " "
-                all_label_ids += lbl.replace(" ", "_") + " "
+                if not has_labels_ids:
+                    all_label_ids += lbl.replace(" ", "_") + " "
         else:
             all_labels = ""
             all_label_ids = ""
             for lbl in self.label_info.label_names:
                 all_labels += lbl.replace(" ", "_") + " "
+                if not has_labels_ids:
+                    all_label_ids += lbl.replace(" ", "_") + " "
+
+        if has_labels_ids:
+            for lbl in self.label_info.labels_id:
                 all_label_ids += lbl.replace(" ", "_") + " "
 
         metadata = {

--- a/src/otx/core/types/label.py
+++ b/src/otx/core/types/label.py
@@ -281,6 +281,7 @@ class SegLabelInfo(LabelInfo):
     """Meta information of Semantic Segmentation."""
 
     ignore_index: int = 255
+    labels_id: list[str] | None = None
 
     @classmethod
     def from_num_classes(cls, num_classes: int) -> LabelInfo:


### PR DESCRIPTION
### Summary
Make use of Empty label instead of background label. Derive label names from Datumaro arrow dataset
Before:
![image](https://github.com/user-attachments/assets/d4335e79-e37d-43f4-b1ae-6b57f643a149)
After:
![image](https://github.com/user-attachments/assets/f4e91a25-90f0-420a-9816-e04fac3667b7)

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
