### PR TITLE
Fix get_item for Chained Tasks in Classification

### DIFF
--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -87,7 +87,9 @@ class OTXMultilabelClsDataset(OTXDataset[MultilabelClsDataEntity]):
             else:
                 # If the annotation is not Label, it should be converted to Label.
                 # For Chained Task: Detection (Bbox) -> Classification (Label)
-                label_anns.append(Label(label=ann.label))
+                label = Label(label=ann.label)
+                if label not in label_anns:
+                    label_anns.append(label)
         labels = torch.as_tensor([ann.label for ann in label_anns])
 
         entity = MultilabelClsDataEntity(

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -34,7 +34,16 @@ class OTXMulticlassClsDataset(OTXDataset[MulticlassClsDataEntity]):
         img = item.media_as(Image)
         img_data, img_shape = self._get_img_data_and_shape(img)
 
-        label_anns = [ann for ann in item.annotations if isinstance(ann, Label)]
+        label_anns = []
+        for ann in item.annotations:
+            if isinstance(ann, Label):
+                label_anns.append(ann)
+            else:
+                # If the annotation is not Label, it should be converted to Label.
+                # For Task Chain: Detection (Bbox) -> Classification (Label)
+                label = Label(label=ann.label)
+                if label not in label_anns:
+                    label_anns.append(label)
         if len(label_anns) > 1:
             msg = f"Multi-class Classification can't use the multi-label, currently len(labels) = {len(label_anns)}"
             raise ValueError(msg)

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -197,7 +197,16 @@ class OTXHlabelClsDataset(OTXDataset[HlabelClsDataEntity]):
         ignored_labels: list[int] = []  # This should be assigned form item
         img_data, img_shape = self._get_img_data_and_shape(img)
 
-        label_anns = [ann for ann in item.annotations if isinstance(ann, Label)]
+        label_anns = []
+        for ann in item.annotations:
+            if isinstance(ann, Label):
+                label_anns.append(ann)
+            else:
+                # If the annotation is not Label, it should be converted to Label.
+                # For Chained Task: Detection (Bbox) -> Classification (Label)
+                label = Label(label=ann.label)
+                if label not in label_anns:
+                    label_anns.append(label)
         hlabel_labels = self._convert_label_to_hlabel_format(label_anns, ignored_labels)
 
         entity = HlabelClsDataEntity(

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -40,7 +40,7 @@ class OTXMulticlassClsDataset(OTXDataset[MulticlassClsDataEntity]):
                 label_anns.append(ann)
             else:
                 # If the annotation is not Label, it should be converted to Label.
-                # For Task Chain: Detection (Bbox) -> Classification (Label)
+                # For Chained Task: Detection (Bbox) -> Classification (Label)
                 label = Label(label=ann.label)
                 if label not in label_anns:
                     label_anns.append(label)
@@ -80,7 +80,14 @@ class OTXMultilabelClsDataset(OTXDataset[MultilabelClsDataEntity]):
         ignored_labels: list[int] = []  # This should be assigned form item
         img_data, img_shape = self._get_img_data_and_shape(img)
 
-        label_anns = [ann for ann in item.annotations if isinstance(ann, Label)]
+        label_anns = []
+        for ann in item.annotations:
+            if isinstance(ann, Label):
+                label_anns.append(ann)
+            else:
+                # If the annotation is not Label, it should be converted to Label.
+                # For Chained Task: Detection (Bbox) -> Classification (Label)
+                label_anns.append(Label(label=ann.label))
         labels = torch.as_tensor([ann.label for ann in label_anns])
 
         entity = MultilabelClsDataEntity(

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -96,10 +96,48 @@ def fxt_dm_item(request, tmpdir) -> DatasetItem:
     )
 
 
+@pytest.fixture(params=["bytes", "file"])
+def fxt_dm_item_bbox_only(request, tmpdir) -> DatasetItem:
+    np_img = np.zeros(shape=(10, 10, 3), dtype=np.uint8)
+    np_img[:, :, 0] = 0  # Set 0 for B channel
+    np_img[:, :, 1] = 1  # Set 1 for G channel
+    np_img[:, :, 2] = 2  # Set 2 for R channel
+
+    if request.param == "bytes":
+        _, np_bytes = cv2.imencode(".png", np_img)
+        media = Image.from_bytes(np_bytes.tobytes())
+        media.path = ""
+    elif request.param == "file":
+        fname = str(uuid.uuid4())
+        fpath = str(Path(tmpdir) / f"{fname}.png")
+        cv2.imwrite(fpath, np_img)
+        media = Image.from_file(fpath)
+    else:
+        raise ValueError(request.param)
+
+    return DatasetItem(
+        id="item",
+        subset="train",
+        media=media,
+        annotations=[
+            Bbox(x=0, y=0, w=1, h=1, label=0),
+        ],
+    )
+
+
 @pytest.fixture()
 def fxt_mock_dm_subset(mocker: MockerFixture, fxt_dm_item: DatasetItem) -> MagicMock:
     mock_dm_subset = mocker.MagicMock(spec=DmDataset)
     mock_dm_subset.__getitem__.return_value = fxt_dm_item
+    mock_dm_subset.__len__.return_value = 1
+    mock_dm_subset.categories().__getitem__.return_value = LabelCategories.from_iterable(_LABEL_NAMES)
+    return mock_dm_subset
+
+
+@pytest.fixture()
+def fxt_mock_det_dm_subset(mocker: MockerFixture, fxt_dm_item_bbox_only: DatasetItem) -> MagicMock:
+    mock_dm_subset = mocker.MagicMock(spec=DmDataset)
+    mock_dm_subset.__getitem__.return_value = fxt_dm_item_bbox_only
     mock_dm_subset.__len__.return_value = 1
     mock_dm_subset.categories().__getitem__.return_value = LabelCategories.from_iterable(_LABEL_NAMES)
     return mock_dm_subset

--- a/tests/unit/core/data/conftest.py
+++ b/tests/unit/core/data/conftest.py
@@ -121,6 +121,8 @@ def fxt_dm_item_bbox_only(request, tmpdir) -> DatasetItem:
         media=media,
         annotations=[
             Bbox(x=0, y=0, w=1, h=1, label=0),
+            Bbox(x=1, y=0, w=1, h=1, label=0),
+            Bbox(x=1, y=1, w=1, h=1, label=0),
         ],
     )
 

--- a/tests/unit/core/data/dataset/test_classification.py
+++ b/tests/unit/core/data/dataset/test_classification.py
@@ -5,7 +5,34 @@
 
 from unittest.mock import MagicMock
 
-from otx.core.data.dataset.classification import OTXHlabelClsDataset
+from otx.core.data.dataset.classification import OTXHlabelClsDataset, OTXMulticlassClsDataset
+from otx.core.data.entity.classification import MulticlassClsDataEntity
+
+
+class TestOTXMulticlassClsDataset:
+    def test_get_item(
+        self,
+        fxt_mock_dm_subset,
+    ) -> None:
+        dataset = OTXMulticlassClsDataset(
+            dm_subset=fxt_mock_dm_subset,
+            transforms=[lambda x: x],
+            mem_cache_img_max_size=None,
+            max_refetch=3,
+        )
+        assert isinstance(dataset[0], MulticlassClsDataEntity)
+
+    def test_get_item_from_bbox_dataset(
+        self,
+        fxt_mock_det_dm_subset,
+    ) -> None:
+        dataset = OTXMulticlassClsDataset(
+            dm_subset=fxt_mock_det_dm_subset,
+            transforms=[lambda x: x],
+            mem_cache_img_max_size=None,
+            max_refetch=3,
+        )
+        assert isinstance(dataset[0], MulticlassClsDataEntity)
 
 
 class TestOTXHlabelClsDataset:

--- a/tests/unit/core/data/dataset/test_classification.py
+++ b/tests/unit/core/data/dataset/test_classification.py
@@ -5,8 +5,13 @@
 
 from unittest.mock import MagicMock
 
-from otx.core.data.dataset.classification import OTXHlabelClsDataset, OTXMulticlassClsDataset, OTXMultilabelClsDataset
-from otx.core.data.entity.classification import MulticlassClsDataEntity, MultilabelClsDataEntity
+from otx.core.data.dataset.classification import (
+    HLabelInfo,
+    OTXHlabelClsDataset,
+    OTXMulticlassClsDataset,
+    OTXMultilabelClsDataset,
+)
+from otx.core.data.entity.classification import HlabelClsDataEntity, MulticlassClsDataEntity, MultilabelClsDataEntity
 
 
 class TestOTXMulticlassClsDataset:
@@ -73,3 +78,33 @@ class TestOTXHlabelClsDataset:
         # Added the ancestor
         adjusted_anns = hlabel_dataset.dm_subset.get(id=0, subset="train").annotations
         assert len(adjusted_anns) == 2
+
+    def test_get_item(
+        self,
+        mocker,
+        fxt_mock_dm_subset,
+        fxt_mock_hlabelinfo,
+    ) -> None:
+        mocker.patch.object(HLabelInfo, "from_dm_label_groups", return_value=fxt_mock_hlabelinfo)
+        dataset = OTXHlabelClsDataset(
+            dm_subset=fxt_mock_dm_subset,
+            transforms=[lambda x: x],
+            mem_cache_img_max_size=None,
+            max_refetch=3,
+        )
+        assert isinstance(dataset[0], HlabelClsDataEntity)
+
+    def test_get_item_from_bbox_dataset(
+        self,
+        mocker,
+        fxt_mock_det_dm_subset,
+        fxt_mock_hlabelinfo,
+    ) -> None:
+        mocker.patch.object(HLabelInfo, "from_dm_label_groups", return_value=fxt_mock_hlabelinfo)
+        dataset = OTXHlabelClsDataset(
+            dm_subset=fxt_mock_det_dm_subset,
+            transforms=[lambda x: x],
+            mem_cache_img_max_size=None,
+            max_refetch=3,
+        )
+        assert isinstance(dataset[0], HlabelClsDataEntity)

--- a/tests/unit/core/data/dataset/test_classification.py
+++ b/tests/unit/core/data/dataset/test_classification.py
@@ -5,8 +5,8 @@
 
 from unittest.mock import MagicMock
 
-from otx.core.data.dataset.classification import OTXHlabelClsDataset, OTXMulticlassClsDataset
-from otx.core.data.entity.classification import MulticlassClsDataEntity
+from otx.core.data.dataset.classification import OTXHlabelClsDataset, OTXMulticlassClsDataset, OTXMultilabelClsDataset
+from otx.core.data.entity.classification import MulticlassClsDataEntity, MultilabelClsDataEntity
 
 
 class TestOTXMulticlassClsDataset:
@@ -33,6 +33,32 @@ class TestOTXMulticlassClsDataset:
             max_refetch=3,
         )
         assert isinstance(dataset[0], MulticlassClsDataEntity)
+
+
+class TestOTXMultilabelClsDataset:
+    def test_get_item(
+        self,
+        fxt_mock_dm_subset,
+    ) -> None:
+        dataset = OTXMultilabelClsDataset(
+            dm_subset=fxt_mock_dm_subset,
+            transforms=[lambda x: x],
+            mem_cache_img_max_size=None,
+            max_refetch=3,
+        )
+        assert isinstance(dataset[0], MultilabelClsDataEntity)
+
+    def test_get_item_from_bbox_dataset(
+        self,
+        fxt_mock_det_dm_subset,
+    ) -> None:
+        dataset = OTXMultilabelClsDataset(
+            dm_subset=fxt_mock_det_dm_subset,
+            transforms=[lambda x: x],
+            mem_cache_img_max_size=None,
+            max_refetch=3,
+        )
+        assert isinstance(dataset[0], MultilabelClsDataEntity)
 
 
 class TestOTXHlabelClsDataset:


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-151501

Issue: Failed to respond to datasets containing only bboxes
![image](https://github.com/user-attachments/assets/3c88c8bc-5cc5-4803-9f06-c4ee053d0e03)

Fix
![image](https://github.com/user-attachments/assets/dc7eb732-2a17-431d-8425-caaeded431b5)


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
