### PR TITLE
Change default option 'full' to 'base' in otx install

### DIFF
--- a/docs/source/guide/get_started/installation.rst
+++ b/docs/source/guide/get_started/installation.rst
@@ -62,7 +62,7 @@ according to your system environment.
 
         .. code-block:: shell
 
-            otx install -v
+            otx install -v --option full
 
 [Optional] Refer to the `torch official installation guide <https://pytorch.org/get-started/previous-versions/>`_
 

--- a/src/otx/cli/install.py
+++ b/src/otx/cli/install.py
@@ -49,8 +49,8 @@ def add_install_parser(subcommands_action: _ActionSubCommands) -> None:
     parser = ArgumentParser()
     parser.add_argument(
         "--option",
-        help="Install the mmlab library or optional-dependencies.",
-        default="full",
+        help="Install optional-dependencies. The 'full' option will install all dependencies.",
+        default="base",
         type=str,
     )
     parser.add_argument(

--- a/src/otx/cli/install.py
+++ b/src/otx/cli/install.py
@@ -123,7 +123,6 @@ def otx_install(
     )
 
     # Parse mmX requirements if the task requires mmX packages.
-    mmcv_install_args = ["--user"] if user else []
     if mmcv_requirements:
         mmcv_install_args = get_mmcv_install_args(torch_requirement, mmcv_requirements)
         install_args += ["openmim"]
@@ -146,6 +145,8 @@ def otx_install(
 
         # Install mmX requirements if the task requires mmX packages using mim.
         if mmcv_install_args and status_code == 0:
+            if user:
+                mmcv_install_args.append("--user")
             console.log(f"Installation list: [yellow]{mmcv_install_args}[/yellow]")
             status_code = mim_installation(mmcv_install_args)
             if status_code == 0:

--- a/src/otx/cli/install.py
+++ b/src/otx/cli/install.py
@@ -123,6 +123,7 @@ def otx_install(
     )
 
     # Parse mmX requirements if the task requires mmX packages.
+    mmcv_install_args = []
     if mmcv_requirements:
         mmcv_install_args = get_mmcv_install_args(torch_requirement, mmcv_requirements)
         install_args += ["openmim"]


### PR DESCRIPTION
### Summary

full option:
```bash
REPOSITORY                                                       TAG                                            IMAGE ID       CREATED          SIZE
otx                                                              2.2.0rc0-cuda-pretrained-ready                 01f03102d358   10 seconds ago   16.1GB
otx                                                              2.2.0rc0-cuda                                  f21b592300a1   14 minutes ago   11GB
```

base option:
```bash
REPOSITORY                                                       TAG                                            IMAGE ID       CREATED          SIZE
otx                                                              2.2.0rc0-cuda-pretrained-ready                 75d34f23b6b6   17 seconds ago   15.2GB
otx                                                              2.2.0rc0-cuda                                  7c382e39aa29   7 minutes ago    10.1GB
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
