### PR TITLE
Support ImageFromBytes

### DIFF
--- a/src/otx/core/data/dataset/anomaly.py
+++ b/src/otx/core/data/dataset/anomaly.py
@@ -5,13 +5,18 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 from typing import Callable
 
+import cv2
+import numpy as np
 import torch
 from anomalib.data.utils import masks_to_boxes
 from datumaro import Dataset as DmDataset
-from datumaro import Image
+from datumaro import DatasetItem, Image
+from datumaro.components.annotation import AnnotationType, Bbox, Ellipse, Polygon
+from datumaro.components.media import ImageFromBytes, ImageFromFile
 from torchvision import io
 from torchvision.tv_tensors import BoundingBoxes, BoundingBoxFormat, Mask
 
@@ -29,6 +34,13 @@ from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER, MemCacheHandlerBase
 from otx.core.types.image import ImageColorChannel
 from otx.core.types.label import AnomalyLabelInfo
 from otx.core.types.task import OTXTaskType
+
+
+class AnomalyLabel(Enum):
+    """Anomaly label to tensor mapping."""
+
+    NORMAL = torch.tensor(0.0)
+    ANOMALOUS = torch.tensor(1.0)
 
 
 class AnomalyDataset(OTXDataset):
@@ -67,12 +79,9 @@ class AnomalyDataset(OTXDataset):
         img = datumaro_item.media_as(Image)
         # returns image in RGB format if self.image_color_channel is RGB
         img_data, img_shape = self._get_img_data_and_shape(img)
-        # Note: This assumes that the dataset is in MVTec format.
-        # We can't use datumaro label id as it returns some number like 3 for good from which it is hard to infer
-        # whether the image is Anomalous or Normal. Because it leads to other questions like what do numbers 0,1,2 mean?
-        label: torch.LongTensor = (
-            torch.tensor(0.0, dtype=torch.long) if "good" in datumaro_item.id else torch.tensor(1.0, dtype=torch.long)
-        )
+
+        label = self._get_label(datumaro_item)
+
         item: AnomalyClassificationDataItem | AnomalySegmentationDataItem | AnomalyDetectionDataItem
         if self.task_type == OTXTaskType.ANOMALY_CLASSIFICATION:
             item = AnomalyClassificationDataItem(
@@ -88,15 +97,6 @@ class AnomalyDataset(OTXDataset):
         elif self.task_type == OTXTaskType.ANOMALY_SEGMENTATION:
             # Note: this part of code is brittle. Ideally Datumaro should return masks
             # Another major problem with this is that it assumes that the dataset passed is in MVTec format
-            mask_file_path = (
-                Path("/".join(datumaro_item.media.path.split("/")[:-3]))
-                / "ground_truth"
-                / f"{('/'.join(datumaro_item.media.path.split('/')[-2:])).replace('.png','_mask.png')}"
-            )
-            mask = torch.zeros(1, img_shape[0], img_shape[1], dtype=torch.uint8)
-            if mask_file_path.exists():
-                # read and convert to binary mask
-                mask = (io.read_image(str(mask_file_path), mode=io.ImageReadMode.GRAY) / 255).to(torch.uint8)
             item = AnomalySegmentationDataItem(
                 image=img_data,
                 img_info=ImageInfo(
@@ -106,20 +106,9 @@ class AnomalyDataset(OTXDataset):
                     image_color_channel=self.image_color_channel,
                 ),
                 label=label,
-                mask=Mask(mask),
+                mask=Mask(self._get_mask(datumaro_item, label, img_shape)),
             )
         elif self.task_type == OTXTaskType.ANOMALY_DETECTION:
-            # Note: this part of code is brittle. Ideally Datumaro should return masks
-            mask_file_path = (
-                Path("/".join(datumaro_item.media.path.split("/")[:-3]))
-                / "ground_truth"
-                / f"{('/'.join(datumaro_item.media.path.split('/')[-2:])).replace('.png','_mask.png')}"
-            )
-            mask = torch.zeros(1, img_shape[0], img_shape[1], dtype=torch.uint8)
-            if mask_file_path.exists():
-                # read and convert to binary mask
-                mask = (io.read_image(str(mask_file_path), mode=io.ImageReadMode.GRAY) / 255).to(torch.uint8)
-            boxes, _ = masks_to_boxes(mask)
             item = AnomalyDetectionDataItem(
                 image=img_data,
                 img_info=ImageInfo(
@@ -129,9 +118,9 @@ class AnomalyDataset(OTXDataset):
                     image_color_channel=self.image_color_channel,
                 ),
                 label=label,
-                boxes=BoundingBoxes(boxes[0], format=BoundingBoxFormat.XYXY, canvas_size=img_shape),
+                boxes=self._get_boxes(datumaro_item, label, img_shape),
                 # mask is used for pixel-level metric computation. We can't assume that this will always be available
-                mask=Mask(mask),
+                mask=Mask(self._get_mask(datumaro_item, label, img_shape)),
             )
         else:
             msg = f"Task {self.task_type} is not supported yet."
@@ -141,6 +130,106 @@ class AnomalyDataset(OTXDataset):
         # Incompatible return value type (got "Any | None", expected
         # "AnomalyClassificationDataItem | AnomalySegmentationDataBatch | AnomalyDetectionDataBatch")
         return self._apply_transforms(item)  # type: ignore[return-value]
+
+    def _get_mask(self, datumaro_item: DatasetItem, label: torch.Tensor, img_shape: tuple[int, int]) -> torch.Tensor:
+        """Get mask from datumaro_item.
+
+        Converts bounding boxes to mask if mask is not available.
+        """
+        if isinstance(datumaro_item.media, ImageFromFile):
+            if label == AnomalyLabel.ANOMALOUS.value:
+                mask = self._mask_image_from_file(datumaro_item)
+            else:
+                mask = torch.zeros(1, *img_shape).to(torch.uint8)
+        elif isinstance(datumaro_item.media, ImageFromBytes):
+            mask = torch.zeros(1, *img_shape).to(torch.uint8)
+            if label == AnomalyLabel.ANOMALOUS.value:
+                for annotation in datumaro_item.annotations:
+                    # There is only one mask
+                    if isinstance(annotation, (Ellipse, Polygon)):
+                        polygons = np.asarray(annotation.as_polygon(), dtype=np.int32).reshape((-1, 1, 2))
+                        mask = np.zeros(img_shape, dtype=np.uint8)
+                        mask = cv2.drawContours(
+                            mask,
+                            [polygons],
+                            0,
+                            (1, 1, 1),
+                            thickness=cv2.FILLED,
+                        )
+                        mask = torch.from_numpy(mask).to(torch.uint8).unsqueeze(0)
+                        break
+                    # If there is no mask, create a mask from bbox
+                    if isinstance(annotation, Bbox):
+                        bbox = annotation
+                        mask = self._bbox_to_mask(bbox, img_shape)
+                        break
+        return mask
+
+    def _get_boxes(self, datumaro_item: DatasetItem, label: torch.Tensor, img_shape: tuple[int, int]) -> BoundingBoxes:
+        """Get bounding boxes from datumaro item.
+
+        Uses masks if available to get bounding boxes.
+        """
+        boxes = BoundingBoxes(torch.empty(0, 4), format=BoundingBoxFormat.XYXY, canvas_size=img_shape)
+        if isinstance(datumaro_item.media, ImageFromFile):
+            if label == AnomalyLabel.ANOMALOUS.value:
+                mask = self._mask_image_from_file(datumaro_item)
+                boxes, _ = masks_to_boxes(mask)
+                # Assumes only one bounding box is present
+                boxes = BoundingBoxes(boxes[0], format=BoundingBoxFormat.XYXY, canvas_size=img_shape)
+        elif isinstance(datumaro_item.media, ImageFromBytes) and label == AnomalyLabel.ANOMALOUS.value:
+            for annotation in datumaro_item.annotations:
+                if isinstance(annotation, Bbox):
+                    bbox = annotation
+                    boxes = BoundingBoxes(bbox.get_bbox(), format=BoundingBoxFormat.XYXY, canvas_size=img_shape)
+                    break
+        return boxes
+
+    def _bbox_to_mask(self, bbox: Bbox, img_shape: tuple[int, int]) -> torch.Tensor:
+        mask = torch.zeros(1, *img_shape).to(torch.uint8)
+        x1, y1, x2, y2 = bbox.get_bbox()
+        x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
+        mask[:, y1:y2, x1:x2] = 1
+        return mask
+
+    def _get_label(self, datumaro_item: DatasetItem) -> torch.LongTensor:
+        """Get label from datumaro item."""
+        if isinstance(datumaro_item.media, ImageFromFile):
+            # Note: This assumes that the dataset is in MVTec format.
+            # We can't use datumaro label id as it returns some number like 3 for good from which it is hard to infer
+            # whether the image is Anomalous or Normal. Because it leads to other questions like what do numbers 0,1,2
+            # mean?
+            label: torch.LongTensor = AnomalyLabel.NORMAL if "good" in datumaro_item.id else AnomalyLabel.ANOMALOUS
+        elif isinstance(datumaro_item.media, ImageFromBytes):
+            # Geti labels have strange ids so it walks through the attributes to get the label
+            # id_label_mapping can be made efficient by caching it somewhere.
+            id_label_mapping = {}
+            label_items = self.dm_subset.categories()[AnnotationType.label].items
+            for label_item in label_items:
+                if any("normal" in attribute.lower() for attribute in label_item.attributes):
+                    label = AnomalyLabel.NORMAL
+                else:
+                    label = AnomalyLabel.ANOMALOUS
+                id_label_mapping[label_item.name] = label
+            # There is probably a better way to get the label id from datumaro
+            label = id_label_mapping[datumaro_item.attributes["roi"]["labels"][0]["label"]["_id"]]
+        else:
+            msg = f"Media type {type(datumaro_item.media)} is not supported."
+            raise NotImplementedError(msg)
+        return label.value
+
+    def _mask_image_from_file(self, datumaro_item: DatasetItem) -> torch.Tensor | None:
+        """Assumes MVTec format and returns mask from disk."""
+        mask_file_path = (
+            Path("/".join(datumaro_item.media.path.split("/")[:-3]))
+            / "ground_truth"
+            / f"{('/'.join(datumaro_item.media.path.split('/')[-2:])).replace('.png','_mask.png')}"
+        )
+        if not mask_file_path.exists():
+            msg = f"Mask file not found at {mask_file_path}"
+            raise FileNotFoundError(msg)
+
+        return (io.read_image(str(mask_file_path), mode=io.ImageReadMode.GRAY) / 255).to(torch.uint8)
 
     @property
     def collate_fn(self) -> Callable:

--- a/src/otx/core/model/anomaly.py
+++ b/src/otx/core/model/anomaly.py
@@ -181,18 +181,12 @@ class OTXAnomaly(OTXModel):
         inputs: AnomalyModelInputs,
     ) -> dict[str, Any]:
         """Customize inputs for the model."""
-        return_dict = {}
-        if isinstance(inputs, AnomalyClassificationDataBatch):
-            return_dict = {"image": inputs.images, "label": torch.vstack(inputs.labels).squeeze()}
-        if isinstance(inputs, AnomalySegmentationDataBatch):
-            return_dict = {"image": inputs.images, "label": torch.vstack(inputs.labels).squeeze(), "mask": inputs.masks}
-        if isinstance(inputs, AnomalyDetectionDataBatch):
-            return_dict = {
-                "image": inputs.images,
-                "label": torch.vstack(inputs.labels).squeeze(),
-                "mask": inputs.masks,
-                "boxes": inputs.boxes,
-            }
+        return_dict = {"image": inputs.images, "label": torch.vstack(inputs.labels).squeeze()}
+        if isinstance(inputs, AnomalySegmentationDataBatch) and inputs.masks is not None:
+            return_dict["mask"] = inputs.masks
+        if isinstance(inputs, AnomalyDetectionDataBatch) and inputs.masks is not None and inputs.boxes is not None:
+            return_dict["mask"] = inputs.masks
+            return_dict["boxes"] = inputs.boxes
 
         if return_dict["label"].size() == torch.Size([]):  # when last batch size is 1
             return_dict["label"] = return_dict["label"].unsqueeze(0)


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

- Addresses: CVS-151819

> [!WARNING]
> There is one major UX issue here. Geti allows passing dataset that do not have pixel-level annotations even though the task is of type segmentation or detection. This means that the task returns pixel-level metrics as 0. This might mislead users.


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
