### PR TITLE
Move templates from OTX1.X to OTX2.X

### DIFF
--- a/src/otx/recipe/_base_/train.yaml
+++ b/src/otx/recipe/_base_/train.yaml
@@ -9,7 +9,7 @@ callbacks:
       check_on_train_epoch_end: false
       min_delta: 0.001
       warmup_iters: 30
-      warmup_epochs: 7
+      warmup_epochs: 3
   - class_path: lightning.pytorch.callbacks.RichProgressBar
     init_args:
       refresh_rate: 1

--- a/src/otx/recipe/_base_/train.yaml
+++ b/src/otx/recipe/_base_/train.yaml
@@ -9,7 +9,7 @@ callbacks:
       check_on_train_epoch_end: false
       min_delta: 0.001
       warmup_iters: 30
-      warmup_epochs: 3
+      warmup_epochs: 7
   - class_path: lightning.pytorch.callbacks.RichProgressBar
     init_args:
       refresh_rate: 1

--- a/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/src/otx/recipe/detection/rtdetr_101.yaml
@@ -13,7 +13,7 @@ model:
     scheduler:
       class_path: otx.core.schedulers.LinearWarmupSchedulerCallable
       init_args:
-        num_warmup_steps: 5
+        num_warmup_steps: 100
         main_scheduler_callable:
           class_path: lightning.pytorch.cli.ReduceLROnPlateau
           init_args:

--- a/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/src/otx/recipe/detection/rtdetr_18.yaml
@@ -13,7 +13,7 @@ model:
     scheduler:
       class_path: otx.core.schedulers.LinearWarmupSchedulerCallable
       init_args:
-        num_warmup_steps: 5
+        num_warmup_steps: 100
         main_scheduler_callable:
           class_path: lightning.pytorch.cli.ReduceLROnPlateau
           init_args:

--- a/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/src/otx/recipe/detection/rtdetr_50.yaml
@@ -13,7 +13,7 @@ model:
     scheduler:
       class_path: otx.core.schedulers.LinearWarmupSchedulerCallable
       init_args:
-        num_warmup_steps: 5
+        num_warmup_steps: 100
         main_scheduler_callable:
           class_path: lightning.pytorch.cli.ReduceLROnPlateau
           init_args:

--- a/src/otx/recipe/semantic_segmentation/dino_v2.yaml
+++ b/src/otx/recipe/semantic_segmentation/dino_v2.yaml
@@ -19,7 +19,7 @@ model:
     scheduler:
       class_path: torch.optim.lr_scheduler.PolynomialLR
       init_args:
-        total_iters: 100
+        total_iters: 150
         power: 0.9
         last_epoch: -1
 

--- a/src/otx/recipe/semantic_segmentation/segnext_b.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_b.yaml
@@ -20,7 +20,7 @@ model:
         main_scheduler_callable:
           class_path: torch.optim.lr_scheduler.PolynomialLR
           init_args:
-            total_iters: 100
+            total_iters: 150
             power: 0.9
             last_epoch: -1
 

--- a/src/otx/recipe/semantic_segmentation/segnext_s.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_s.yaml
@@ -20,7 +20,7 @@ model:
         main_scheduler_callable:
           class_path: torch.optim.lr_scheduler.PolynomialLR
           init_args:
-            total_iters: 100
+            total_iters: 150
             power: 0.9
             last_epoch: -1
 

--- a/src/otx/recipe/semantic_segmentation/segnext_t.yaml
+++ b/src/otx/recipe/semantic_segmentation/segnext_t.yaml
@@ -20,7 +20,7 @@ model:
         main_scheduler_callable:
           class_path: torch.optim.lr_scheduler.PolynomialLR
           init_args:
-            total_iters: 100
+            total_iters: 150
             power: 0.9
             last_epoch: -1
 

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -40,6 +40,18 @@ TEMPLATE_ID_DICT = {
         "task": OTXTaskType.MULTI_CLASS_CLS,
         "model_name": "mobilenet_v3_large",
     },
+    "Custom_Image_Classification_EfficinetNet-B3": {
+        "task": OTXTaskType.MULTI_CLASS_CLS,
+        "model_name": "tv_efficientnet_b3",
+    },
+    "Custom_Image_Classification_EfficinetNet-V2-L": {
+        "task": OTXTaskType.MULTI_CLASS_CLS,
+        "model_name": "tv_efficientnet_v2_l",
+    },
+    "Custom_Image_Classification_MobileNet-V3-small": {
+        "task": OTXTaskType.MULTI_CLASS_CLS,
+        "model_name": "tv_mobilenet_v3_small",
+    },
     # DETECTION
     "Custom_Object_Detection_Gen3_ATSS": {
         "task": OTXTaskType.DETECTION,

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -69,6 +69,22 @@ TEMPLATE_ID_DICT = {
         "task": OTXTaskType.DETECTION,
         "model_name": "yolox_tiny",
     },
+    "Object_Detection_RTDetr_18": {
+        "task": OTXTaskType.DETECTION,
+        "model_name": "rtdetr_18",
+    },
+    "Object_Detection_RTDetr_50": {
+        "task": OTXTaskType.DETECTION,
+        "model_name": "rtdetr_50",
+    },
+    "Object_Detection_RTDetr_101": {
+        "task": OTXTaskType.DETECTION,
+        "model_name": "rtdetr_101",
+    },
+    "Object_Detection_RTMDet_tiny": {
+        "task": OTXTaskType.DETECTION,
+        "model_name": "rtmdet_tiny",
+    },
     # INSTANCE_SEGMENTATION
     "Custom_Counting_Instance_Segmentation_MaskRCNN_ResNet50": {
         "task": OTXTaskType.INSTANCE_SEGMENTATION,
@@ -81,6 +97,10 @@ TEMPLATE_ID_DICT = {
     "Custom_Counting_Instance_Segmentation_MaskRCNN_EfficientNetB2B": {
         "task": OTXTaskType.INSTANCE_SEGMENTATION,
         "model_name": "maskrcnn_efficientnetb2b",
+    },
+    "Object_Detection_RTMDet_tiny": {
+        "task": OTXTaskType.DETECTION,
+        "model_name": "rtmdet_tiny",
     },
     # ROTATED_DETECTION
     "Custom_Rotated_Detection_via_Instance_Segmentation_MaskRCNN_ResNet50": {

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -98,9 +98,9 @@ TEMPLATE_ID_DICT = {
         "task": OTXTaskType.INSTANCE_SEGMENTATION,
         "model_name": "maskrcnn_efficientnetb2b",
     },
-    "Object_Detection_RTMDet_tiny": {
-        "task": OTXTaskType.DETECTION,
-        "model_name": "rtmdet_tiny",
+    "Custom_Instance_Segmentation_RTMDet_tiny": {
+        "task": OTXTaskType.INSTANCE_SEGMENTATION,
+        "model_name": "rtmdet_inst_tiny",
     },
     # ROTATED_DETECTION
     "Custom_Rotated_Detection_via_Instance_Segmentation_MaskRCNN_ResNet50": {
@@ -139,6 +139,10 @@ TEMPLATE_ID_DICT = {
     "Custom_Semantic_Segmentation_SegNext_B": {
         "task": OTXTaskType.SEMANTIC_SEGMENTATION,
         "model_name": "segnext_b",
+    },
+    "Custom_Semantic_Segmentation_DINOV2_S": {
+        "task": OTXTaskType.SEMANTIC_SEGMENTATION,
+        "model_name": "dino_v2",
     },
     # ANOMALY_CLASSIFICATION
     "ote_anomaly_classification_padim": {

--- a/src/otx/tools/templates/__init__.py
+++ b/src/otx/tools/templates/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""YAML file templates for the models OTX provides."""

--- a/src/otx/tools/templates/action/classification/configuration.yaml
+++ b/src/otx/tools/templates/action/classification/configuration.yaml
@@ -1,0 +1,453 @@
+description: Configuration for an action classification task
+header: Configuration for an action classification task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 0
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 10
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 10
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: None
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: None
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    # value: 0.35
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: NONE
+    default_value: Incremental
+    description: Quantization preset that defines quantization scheme
+    editable: false
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 200
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True

--- a/src/otx/tools/templates/action/classification/configuration.yaml
+++ b/src/otx/tools/templates/action/classification/configuration.yaml
@@ -68,7 +68,7 @@ learning_parameters:
     warning: null
   num_iters:
     affects_outcome_of: TRAINING
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.

--- a/src/otx/tools/templates/action/classification/movinet/template.yaml
+++ b/src/otx/tools/templates/action/classification/movinet/template.yaml
@@ -1,0 +1,63 @@
+# Description.
+model_template_id: Custom_Action_Classification_MoViNet
+name: MoViNet
+task_type: ACTION_CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Basic transfer learning template for MoViNet
+application: ~
+
+# Algo backend.
+framework: OTXAction v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.action.adapters.mmaction.task.MMActionTask
+  openvino: otx.algorithms.action.adapters.openvino.task.ActionOpenVINOTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.003
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 10
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 2.71
+size: 3.1
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/action/classification/movinet/template.yaml
+++ b/src/otx/tools/templates/action/classification/movinet/template.yaml
@@ -23,12 +23,8 @@ hyper_parameters:
         default_value: 8
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.003
+        default_value: 0.0003
         auto_hpo_state: POSSIBLE
-      learning_rate_warmup_iters:
-        default_value: 3
-      num_iters:
-        default_value: 10
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/action/classification/movinet/template.yaml
+++ b/src/otx/tools/templates/action/classification/movinet/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAction v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.action.adapters.mmaction.task.MMActionTask
-  openvino: otx.algorithms.action.adapters.openvino.task.ActionOpenVINOTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -34,18 +29,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 10
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/action/classification/x3d/template.yaml
+++ b/src/otx/tools/templates/action/classification/x3d/template.yaml
@@ -1,0 +1,63 @@
+# Description.
+model_template_id: Custom_Action_Classification_X3D
+name: X3D
+task_type: ACTION_CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Basic transfer learning template for X3D
+application: ~
+
+# Algo backend.
+framework: OTXAction v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.action.adapters.mmaction.task.MMActionTask
+  openvino: otx.algorithms.action.adapters.openvino.task.ActionOpenVINOTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 10
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 20.6
+size: 9.1
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/action/classification/x3d/template.yaml
+++ b/src/otx/tools/templates/action/classification/x3d/template.yaml
@@ -23,12 +23,8 @@ hyper_parameters:
         default_value: 8
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.001
+        default_value: 0.0001
         auto_hpo_state: POSSIBLE
-      learning_rate_warmup_iters:
-        default_value: 3
-      num_iters:
-        default_value: 10
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/action/classification/x3d/template.yaml
+++ b/src/otx/tools/templates/action/classification/x3d/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAction v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.action.adapters.mmaction.task.MMActionTask
-  openvino: otx.algorithms.action.adapters.openvino.task.ActionOpenVINOTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -34,18 +29,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 10
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/action/detection/configuration.yaml
+++ b/src/otx/tools/templates/action/detection/configuration.yaml
@@ -1,0 +1,453 @@
+description: Configuration for an action classification task
+header: Configuration for an action classification task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 0
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 10
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 10
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: None
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: None
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    # value: 0.35
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: NONE
+    default_value: Incremental
+    description: Quantization preset that defines quantization scheme
+    editable: false
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 200
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True

--- a/src/otx/tools/templates/action/detection/configuration.yaml
+++ b/src/otx/tools/templates/action/detection/configuration.yaml
@@ -68,7 +68,7 @@ learning_parameters:
     warning: null
   num_iters:
     affects_outcome_of: TRAINING
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.

--- a/src/otx/tools/templates/action/detection/x3d_fast_rcnn/template.yaml
+++ b/src/otx/tools/templates/action/detection/x3d_fast_rcnn/template.yaml
@@ -1,0 +1,63 @@
+# Description.
+model_template_id: Custom_Action_Detection_X3D_FAST_RCNN
+name: X3D_FAST_RCNN
+task_type: ACTION_DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Basic transfer learning template for Fast RCNN with 3D action backbone
+application: ~
+
+# Algo backend.
+framework: OTXAction v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.action.adapters.mmaction.task.MMActionTask
+  openvino: otx.algorithms.action.adapters.openvino.task.ActionOpenVINOTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.005
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 10
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 20.6
+size: 9.1
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/action/detection/x3d_fast_rcnn/template.yaml
+++ b/src/otx/tools/templates/action/detection/x3d_fast_rcnn/template.yaml
@@ -25,10 +25,6 @@ hyper_parameters:
       learning_rate:
         default_value: 0.005
         auto_hpo_state: POSSIBLE
-      learning_rate_warmup_iters:
-        default_value: 3
-      num_iters:
-        default_value: 10
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/action/detection/x3d_fast_rcnn/template.yaml
+++ b/src/otx/tools/templates/action/detection/x3d_fast_rcnn/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAction v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.action.adapters.mmaction.task.MMActionTask
-  openvino: otx.algorithms.action.adapters.openvino.task.ActionOpenVINOTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -34,18 +29,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 10
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/anomaly/classification/padim/configuration.yaml
+++ b/src/otx/tools/templates/anomaly/classification/padim/configuration.yaml
@@ -1,0 +1,183 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for Padim
+header: Configuration for Padim
+id: ""
+learning_parameters:
+  backbone:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: resnet18
+    description: Pre-trained backbone used for feature extraction
+    editable: false
+    enum_name: ModelBackbone
+    header: Model Backbone
+    options:
+      RESNET18: resnet18
+      WIDE_RESNET_50: wide_resnet50_2
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: resnet18
+    visible_in_ui: false
+    warning: null
+  description: Learning Parameters
+  header: Learning Parameters
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 32
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/anomaly/classification/padim/template.yaml
+++ b/src/otx/tools/templates/anomaly/classification/padim/template.yaml
@@ -1,0 +1,35 @@
+# Description.
+model_template_id: ote_anomaly_classification_padim
+name: PADIM
+task_type: ANOMALY_CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: This model is faster and in many cases more accurate, but it requires a fixed position of the objects within the image.
+application: ~
+
+# Algo backend.
+framework: OTXAnomalyClassification v0.1.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 3.9
+size: 168.4
+
+# Model spec
+model_category: SPEED
+is_default_for_task: true

--- a/src/otx/tools/templates/anomaly/classification/padim/template.yaml
+++ b/src/otx/tools/templates/anomaly/classification/padim/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAnomalyClassification v0.1.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.anomaly.tasks.TrainingTask
-  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
-  nncf: otx.algorithms.anomaly.tasks.NNCFTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/anomaly/classification/stfpm/configuration.yaml
+++ b/src/otx/tools/templates/anomaly/classification/stfpm/configuration.yaml
@@ -1,0 +1,312 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for STFPM
+header: Configuration for STFPM
+id: ""
+learning_parameters:
+  backbone:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: resnet18
+    description: Pre-trained backbone used for feature extraction
+    editable: true
+    enum_name: ModelBackbone
+    header: Model Backbone
+    options:
+      RESNET18: resnet18
+      WIDE_RESNET_50: wide_resnet50_2
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: resnet18
+    visible_in_ui: true
+    warning: null
+  description: Learning Parameters
+  early_stopping:
+    description: Early Stopping Parameters
+    header: Early Stopping Parameters
+    metric:
+      affects_outcome_of: NONE
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: image_F1Score
+      description: The metric used to determine if the model should stop training
+      editable: true
+      enum_name: EarlyStoppingMetrics
+      header: Early Stopping Metric
+      options:
+        IMAGE_F1: image_F1Score
+        IMAGE_ROC_AUC: image_AUROC
+      type: SELECTABLE
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: image_F1Score
+      visible_in_ui: true
+      warning: null
+    patience:
+      affects_outcome_of: TRAINING
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: 10
+      description:
+        Number of epochs to wait for an improvement in the monitored metric.
+        If the metric has not improved for this many epochs, the training will stop
+        and the best model will be returned.
+      editable: true
+      header: Early Stopping Patience
+      max_value: 100
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 10
+      visible_in_ui: true
+      warning:
+        Setting this value too low might lead to underfitting. Setting the
+        value too high will increase the training time and might lead to overfitting.
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+  header: Learning Parameters
+  lr:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.4
+    description: Learning rate used for optimizing the Student network.
+    editable: true
+    header: Learning Rate
+    max_value: 1
+    min_value: 0.001
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.4
+    visible_in_ui: true
+    warning: null
+  max_epochs:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 100
+    description: Maximum number of epochs to train the model for.
+    editable: true
+    header: Max Epochs
+    max_value: 500
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning:
+      Training for very few epochs might lead to poor performance. If Early
+      Stopping is enabled then increasing the value of max epochs might not lead to
+      desired result.
+  momentum:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.9
+    description: Momentum used for SGD optimizer
+    editable: true
+    header: Momentum
+    max_value: 1.0
+    min_value: 0.1
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.9
+    visible_in_ui: true
+    warning: null
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 32
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  weight_decay:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.0001
+    description: Decay for SGD optimizer
+    editable: true
+    header: Weight Decay
+    max_value: 1
+    min_value: 1.0e-05
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.0001
+    visible_in_ui: true
+    warning: null
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/anomaly/classification/stfpm/template.yaml
+++ b/src/otx/tools/templates/anomaly/classification/stfpm/template.yaml
@@ -1,0 +1,40 @@
+# Description.
+model_template_id: ote_anomaly_classification_stfpm
+name: STFPM
+task_type: ANOMALY_CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Use this model when the position of the objects in the image frame might differ between images.
+application: ~
+
+# Algo backend.
+framework: OTXAnomalyClassification v0.1.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      train_batch_size:
+        auto_hpo_state: POSSIBLE
+      lr:
+        auto_hpo_state: POSSIBLE
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 5.6
+size: 21.1
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/anomaly/classification/stfpm/template.yaml
+++ b/src/otx/tools/templates/anomaly/classification/stfpm/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAnomalyClassification v0.1.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.anomaly.tasks.TrainingTask
-  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
-  nncf: otx.algorithms.anomaly.tasks.NNCFTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/anomaly/detection/padim/configuration.yaml
+++ b/src/otx/tools/templates/anomaly/detection/padim/configuration.yaml
@@ -1,0 +1,183 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for Padim
+header: Configuration for Padim
+id: ""
+learning_parameters:
+  backbone:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: resnet18
+    description: Pre-trained backbone used for feature extraction
+    editable: false
+    enum_name: ModelBackbone
+    header: Model Backbone
+    options:
+      RESNET18: resnet18
+      WIDE_RESNET_50: wide_resnet50_2
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: resnet18
+    visible_in_ui: false
+    warning: null
+  description: Learning Parameters
+  header: Learning Parameters
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 32
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/anomaly/detection/padim/template.yaml
+++ b/src/otx/tools/templates/anomaly/detection/padim/template.yaml
@@ -1,0 +1,35 @@
+# Description.
+model_template_id: ote_anomaly_detection_padim
+name: PADIM
+task_type: ANOMALY_DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: This model is faster and in many cases more accurate, but it requires a fixed position of the objects within the image.
+application: ~
+
+# Algo backend.
+framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 3.9
+size: 168.4
+
+# Model spec
+model_category: SPEED
+is_default_for_task: true

--- a/src/otx/tools/templates/anomaly/detection/padim/template.yaml
+++ b/src/otx/tools/templates/anomaly/detection/padim/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.anomaly.tasks.TrainingTask
-  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
-  nncf: otx.algorithms.anomaly.tasks.NNCFTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/anomaly/detection/stfpm/configuration.yaml
+++ b/src/otx/tools/templates/anomaly/detection/stfpm/configuration.yaml
@@ -1,0 +1,312 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for STFPM
+header: Configuration for STFPM
+id: ""
+learning_parameters:
+  backbone:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: resnet18
+    description: Pre-trained backbone used for feature extraction
+    editable: true
+    enum_name: ModelBackbone
+    header: Model Backbone
+    options:
+      RESNET18: resnet18
+      WIDE_RESNET_50: wide_resnet50_2
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: resnet18
+    visible_in_ui: true
+    warning: null
+  description: Learning Parameters
+  early_stopping:
+    description: Early Stopping Parameters
+    header: Early Stopping Parameters
+    metric:
+      affects_outcome_of: NONE
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: image_F1Score
+      description: The metric used to determine if the model should stop training
+      editable: true
+      enum_name: EarlyStoppingMetrics
+      header: Early Stopping Metric
+      options:
+        IMAGE_F1: image_F1Score
+        IMAGE_ROC_AUC: image_AUROC
+      type: SELECTABLE
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: image_F1Score
+      visible_in_ui: true
+      warning: null
+    patience:
+      affects_outcome_of: TRAINING
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: 10
+      description:
+        Number of epochs to wait for an improvement in the monitored metric.
+        If the metric has not improved for this many epochs, the training will stop
+        and the best model will be returned.
+      editable: true
+      header: Early Stopping Patience
+      max_value: 100
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 10
+      visible_in_ui: true
+      warning:
+        Setting this value too low might lead to underfitting. Setting the
+        value too high will increase the training time and might lead to overfitting.
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+  header: Learning Parameters
+  lr:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.4
+    description: Learning rate used for optimizing the Student network.
+    editable: true
+    header: Learning Rate
+    max_value: 1
+    min_value: 0.001
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.4
+    visible_in_ui: true
+    warning: null
+  max_epochs:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 100
+    description: Maximum number of epochs to train the model for.
+    editable: true
+    header: Max Epochs
+    max_value: 500
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning:
+      Training for very few epochs might lead to poor performance. If Early
+      Stopping is enabled then increasing the value of max epochs might not lead to
+      desired result.
+  momentum:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.9
+    description: Momentum used for SGD optimizer
+    editable: true
+    header: Momentum
+    max_value: 1.0
+    min_value: 0.1
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.9
+    visible_in_ui: true
+    warning: null
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 32
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  weight_decay:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.0001
+    description: Decay for SGD optimizer
+    editable: true
+    header: Weight Decay
+    max_value: 1
+    min_value: 1.0e-05
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.0001
+    visible_in_ui: true
+    warning: null
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/anomaly/detection/stfpm/template.yaml
+++ b/src/otx/tools/templates/anomaly/detection/stfpm/template.yaml
@@ -1,0 +1,40 @@
+# Description.
+model_template_id: ote_anomaly_detection_stfpm
+name: STFPM
+task_type: ANOMALY_DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Use this model when the position of the objects in the image frame might differ between images.
+application: ~
+
+# Algo backend.
+framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      train_batch_size:
+        auto_hpo_state: POSSIBLE
+      lr:
+        auto_hpo_state: POSSIBLE
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 5.6
+size: 21.1
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/anomaly/detection/stfpm/template.yaml
+++ b/src/otx/tools/templates/anomaly/detection/stfpm/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.anomaly.tasks.TrainingTask
-  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
-  nncf: otx.algorithms.anomaly.tasks.NNCFTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/anomaly/segmentation/padim/configuration.yaml
+++ b/src/otx/tools/templates/anomaly/segmentation/padim/configuration.yaml
@@ -1,0 +1,183 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for Padim
+header: Configuration for Padim
+id: ""
+learning_parameters:
+  backbone:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: resnet18
+    description: Pre-trained backbone used for feature extraction
+    editable: false
+    enum_name: ModelBackbone
+    header: Model Backbone
+    options:
+      RESNET18: resnet18
+      WIDE_RESNET_50: wide_resnet50_2
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: resnet18
+    visible_in_ui: false
+    warning: null
+  description: Learning Parameters
+  header: Learning Parameters
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 32
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/anomaly/segmentation/padim/template.yaml
+++ b/src/otx/tools/templates/anomaly/segmentation/padim/template.yaml
@@ -1,0 +1,35 @@
+# Description.
+model_template_id: ote_anomaly_segmentation_padim
+name: PADIM
+task_type: ANOMALY_SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: This model is faster and in many cases more accurate, but it requires a fixed position of the objects within the image.
+application: ~
+
+# Algo backend.
+framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 3.9
+size: 168.4
+
+# Model spec
+model_category: SPEED
+is_default_for_task: true

--- a/src/otx/tools/templates/anomaly/segmentation/padim/template.yaml
+++ b/src/otx/tools/templates/anomaly/segmentation/padim/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.anomaly.tasks.TrainingTask
-  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
-  nncf: otx.algorithms.anomaly.tasks.NNCFTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/anomaly/segmentation/stfpm/configuration.yaml
+++ b/src/otx/tools/templates/anomaly/segmentation/stfpm/configuration.yaml
@@ -1,0 +1,312 @@
+dataset:
+  description: Dataset Parameters
+  header: Dataset Parameters
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 8
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of workers
+    max_value: 36
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+description: Configuration for STFPM
+header: Configuration for STFPM
+id: ""
+learning_parameters:
+  backbone:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: resnet18
+    description: Pre-trained backbone used for feature extraction
+    editable: true
+    enum_name: ModelBackbone
+    header: Model Backbone
+    options:
+      RESNET18: resnet18
+      WIDE_RESNET_50: wide_resnet50_2
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: resnet18
+    visible_in_ui: true
+    warning: null
+  description: Learning Parameters
+  early_stopping:
+    description: Early Stopping Parameters
+    header: Early Stopping Parameters
+    metric:
+      affects_outcome_of: NONE
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: image_F1Score
+      description: The metric used to determine if the model should stop training
+      editable: true
+      enum_name: EarlyStoppingMetrics
+      header: Early Stopping Metric
+      options:
+        IMAGE_F1: image_F1Score
+        IMAGE_ROC_AUC: image_AUROC
+      type: SELECTABLE
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: image_F1Score
+      visible_in_ui: true
+      warning: null
+    patience:
+      affects_outcome_of: TRAINING
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: 10
+      description:
+        Number of epochs to wait for an improvement in the monitored metric.
+        If the metric has not improved for this many epochs, the training will stop
+        and the best model will be returned.
+      editable: true
+      header: Early Stopping Patience
+      max_value: 100
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 10
+      visible_in_ui: true
+      warning:
+        Setting this value too low might lead to underfitting. Setting the
+        value too high will increase the training time and might lead to overfitting.
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+  header: Learning Parameters
+  lr:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.4
+    description: Learning rate used for optimizing the Student network.
+    editable: true
+    header: Learning Rate
+    max_value: 1
+    min_value: 0.001
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.4
+    visible_in_ui: true
+    warning: null
+  max_epochs:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 100
+    description: Maximum number of epochs to train the model for.
+    editable: true
+    header: Max Epochs
+    max_value: 500
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning:
+      Training for very few epochs might lead to poor performance. If Early
+      Stopping is enabled then increasing the value of max epochs might not lead to
+      desired result.
+  momentum:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.9
+    description: Momentum used for SGD optimizer
+    editable: true
+    header: Momentum
+    max_value: 1.0
+    min_value: 0.1
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.9
+    visible_in_ui: true
+    warning: null
+  train_batch_size:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 32
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  weight_decay:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 0.0001
+    description: Decay for SGD optimizer
+    editable: true
+    header: Weight Decay
+    max_value: 1
+    min_value: 1.0e-05
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.0001
+    visible_in_ui: true
+    warning: null
+nncf_optimization:
+  description: Optimization by NNCF
+  enable_pruning:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  enable_quantization:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  header: Optimization by NNCF
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/anomaly/segmentation/stfpm/template.yaml
+++ b/src/otx/tools/templates/anomaly/segmentation/stfpm/template.yaml
@@ -1,0 +1,40 @@
+# Description.
+model_template_id: ote_anomaly_segmentation_stfpm
+name: STFPM
+task_type: ANOMALY_SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Use this model when the position of the objects in the image frame might differ between images.
+application: ~
+
+# Algo backend.
+framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.anomaly.tasks.TrainingTask
+  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
+  nncf: otx.algorithms.anomaly.tasks.NNCFTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      train_batch_size:
+        auto_hpo_state: POSSIBLE
+      lr:
+        auto_hpo_state: POSSIBLE
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 5.6
+size: 21.1
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/anomaly/segmentation/stfpm/template.yaml
+++ b/src/otx/tools/templates/anomaly/segmentation/stfpm/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXAnomalyClassification v0.1.0 # TODO: update after the name has been changed on the platform side
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.anomaly.tasks.TrainingTask
-  openvino: otx.algorithms.anomaly.tasks.OpenVINOTask
-  nncf: otx.algorithms.anomaly.tasks.NNCFTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/classification/configuration.yaml
+++ b/src/otx/tools/templates/classification/configuration.yaml
@@ -1,0 +1,496 @@
+description: Configuration for an image classification task
+header: Configuration for an image classification task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 32
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 2048
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  unlabeled_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 32
+    description:
+      The number of unlabeled training samples seen in each iteration of semi-supervised learning.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Unlabeled batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 1.0
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  max_num_epochs:
+    affects_outcome_of: TRAINING
+    default_value: 200
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Maximum number of training epochs
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 2
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Early exit from training when validation accuracy is not changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 8
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  enable_supcon:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description:
+      Enable an auxiliar supervised contrastive loss, which might increase robustness
+      and accuracy for small datasets.
+    editable: true
+    header: Enable Supervised Contrastive helper loss
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: None
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: None
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  input_size:
+    affects_outcome_of: INFERENCE
+    default_value: Default
+    description:
+      The input size of the given model could be configured to one of the predefined resolutions.
+      Reduced training and inference time could be expected by using smaller input size.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
+    editable: true
+    enum_name: InputSizePreset
+    header: Configure model input size.
+    options:
+      DEFAULT: "Default"
+      AUTO: "Auto"
+      _64x64: "64x64"
+      _128x128: "128x128"
+      _224x224: "224x224"
+      _256x256: "256x256"
+      _384x384: "384x384"
+      _512x512: "512x512"
+      _768x768: "768x768"
+      _1024x1024: "1024x1024"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Default
+    visible_in_ui: false
+    warning: Modifying input size may decrease model performance.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: false
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Enable quantization algorithm
+    editable: true
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  enable_pruning:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop
+    editable: true
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Semisupervised: "Semisupervised"
+      Selfsupervised: "Selfsupervised"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 100000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  enable_noisy_label_detection:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Set to True to enable loss dynamics tracking for each sample to detect noisy labeled samples.
+    editable: true
+    header: Enable loss dynamics tracking for noisy label detection
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false

--- a/src/otx/tools/templates/classification/configuration.yaml
+++ b/src/otx/tools/templates/classification/configuration.yaml
@@ -86,7 +86,7 @@ learning_parameters:
     warning: null
   num_iters:
     affects_outcome_of: TRAINING
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.
@@ -100,7 +100,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 1
+    value: 200
     visible_in_ui: true
     warning: null
   num_workers:

--- a/src/otx/tools/templates/classification/configuration.yaml
+++ b/src/otx/tools/templates/classification/configuration.yaml
@@ -40,7 +40,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    visible_in_ui: true
+    visible_in_ui: false
     warning:
       Increasing this value may cause the system to use more memory than available,
       potentially causing out of memory errors, please update with caution.
@@ -236,7 +236,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    visible_in_ui: true
+    visible_in_ui: false
     warning: null
   auto_adapt_batch_size:
     affects_outcome_of: TRAINING

--- a/src/otx/tools/templates/classification/deit_tiny/template.yaml
+++ b/src/otx/tools/templates/classification/deit_tiny/template.yaml
@@ -1,0 +1,49 @@
+# Description.
+model_template_id: Custom_Image_Classification_DeiT-Tiny
+name: DeiT-Tiny
+task_type: CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Custom Image Classification for DeiT-Tiny
+application: ~
+
+# Algo backend.
+framework: OTXClassification v1.2.3
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
+  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 64
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.0001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 0
+      num_iters:
+        default_value: 90
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 1.26
+size: 5.72

--- a/src/otx/tools/templates/classification/deit_tiny/template.yaml
+++ b/src/otx/tools/templates/classification/deit_tiny/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXClassification v1.2.3
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
-  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
-
 # Capabilities.
 capabilities:
   - compute_representations

--- a/src/otx/tools/templates/classification/efficientnet_b0_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/efficientnet_b0_cls_incr/template.yaml
@@ -1,0 +1,63 @@
+# Description.
+model_template_id: Custom_Image_Classification_EfficinetNet-B0
+name: EfficientNet-B0
+task_type: CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Image Classification for EfficientNet-B0
+application: ~
+
+# Algo backend.
+framework: OTXClassification v1.2.3
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
+  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
+  nncf: otx.algorithms.classification.adapters.mmcls.nncf.task.ClassificationNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 64
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.0049
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 0
+      num_iters:
+        default_value: 90
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 0.81
+size: 4.09
+
+# Model spec
+model_category: BALANCE
+is_default_for_task: true

--- a/src/otx/tools/templates/classification/efficientnet_b0_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/efficientnet_b0_cls_incr/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXClassification v1.2.3
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
-  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
-  nncf: otx.algorithms.classification.adapters.mmcls.nncf.task.ClassificationNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -35,18 +29,6 @@ hyper_parameters:
         default_value: 0
       num_iters:
         default_value: 90
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/classification/efficientnet_b3/template.yaml
+++ b/src/otx/tools/templates/classification/efficientnet_b3/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Image_Classification_MobileNet-V3-large-1x
-name: MobileNet-V3-large-1x
+model_template_id: Custom_Image_Classification_EfficinetNet-B3
+name: EfficientNet-B3
 task_type: CLASSIFICATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Image Classification for MobileNet-V3-large-1x
+summary: Class-Incremental Image Classification for EfficientNet-B3
 application: ~
 
 # Algo backend.
@@ -23,10 +23,10 @@ hyper_parameters:
         default_value: 64
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.0058
+        default_value: 0.01
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 0
       num_iters:
         default_value: 90
 
@@ -37,8 +37,5 @@ training_targets:
   - CPU
 
 # Stats.
-gigaflops: 0.44
-size: 4.29
-
-# Model spec
-model_category: SPEED
+gigaflops: 1.92
+size: 10.3

--- a/src/otx/tools/templates/classification/efficientnet_v2_l/template.yaml
+++ b/src/otx/tools/templates/classification/efficientnet_v2_l/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Image_Classification_MobileNet-V3-large-1x
-name: MobileNet-V3-large-1x
+model_template_id: Custom_Image_Classification_EfficientNet-V2-L
+name: EfficientNet-V2-L
 task_type: CLASSIFICATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Image Classification for MobileNet-V3-large-1x
+summary: Class-Incremental Image Classification for EfficientNet-V2-L
 application: ~
 
 # Algo backend.
@@ -23,10 +23,10 @@ hyper_parameters:
         default_value: 64
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.0058
+        default_value: 0.01
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 0
       num_iters:
         default_value: 90
 
@@ -37,8 +37,5 @@ training_targets:
   - CPU
 
 # Stats.
-gigaflops: 0.44
-size: 4.29
-
-# Model spec
-model_category: SPEED
+gigaflops: 24.46
+size: 117

--- a/src/otx/tools/templates/classification/efficientnet_v2_s_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/efficientnet_v2_s_cls_incr/template.yaml
@@ -1,0 +1,62 @@
+# Description.
+model_template_id: Custom_Image_Classification_EfficientNet-V2-S
+name: EfficientNet-V2-S
+task_type: CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Image Classification for EfficientNet-V2-S
+application: ~
+
+# Algo backend.
+framework: OTXClassification v1.2.3
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
+  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
+  nncf: otx.algorithms.classification.adapters.mmcls.nncf.task.ClassificationNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 64
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.0071
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 0
+      num_iters:
+        default_value: 90
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 5.76
+size: 20.23
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/classification/efficientnet_v2_s_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/efficientnet_v2_s_cls_incr/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXClassification v1.2.3
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
-  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
-  nncf: otx.algorithms.classification.adapters.mmcls.nncf.task.ClassificationNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -35,18 +29,6 @@ hyper_parameters:
         default_value: 0
       num_iters:
         default_value: 90
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -1,0 +1,62 @@
+# Description.
+model_template_id: Custom_Image_Classification_MobileNet-V3-large-1x
+name: MobileNet-V3-large-1x
+task_type: CLASSIFICATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Image Classification for MobileNet-V3-large-1x
+application: ~
+
+# Algo backend.
+framework: OTXClassification v1.2.3
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
+  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
+  nncf: otx.algorithms.classification.adapters.mmcls.nncf.task.ClassificationNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 64
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.0058
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 10
+      num_iters:
+        default_value: 90
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 0.44
+size: 4.29
+
+# Model spec
+model_category: SPEED

--- a/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -26,7 +26,7 @@ hyper_parameters:
         default_value: 0.0058
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 0
       num_iters:
         default_value: 90
 

--- a/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXClassification v1.2.3
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.classification.adapters.mmcls.task.MMClassificationTask
-  openvino: otx.algorithms.classification.adapters.openvino.task.ClassificationOpenVINOTask
-  nncf: otx.algorithms.classification.adapters.mmcls.nncf.task.ClassificationNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -35,18 +29,6 @@ hyper_parameters:
         default_value: 10
       num_iters:
         default_value: 90
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
+++ b/src/otx/tools/templates/classification/mobilenet_v3_large_1_cls_incr/template.yaml
@@ -26,7 +26,7 @@ hyper_parameters:
         default_value: 0.0058
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 100
       num_iters:
         default_value: 90
 

--- a/src/otx/tools/templates/classification/mobilenet_v3_small/template.yaml
+++ b/src/otx/tools/templates/classification/mobilenet_v3_small/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Image_Classification_MobileNet-V3-large-1x
-name: MobileNet-V3-large-1x
+model_template_id: Custom_Image_Classification_MobileNet-V3-small
+name: MobileNet-V3-small
 task_type: CLASSIFICATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Image Classification for MobileNet-V3-large-1x
+summary: Class-Incremental Image Classification for MobileNet-V3-small
 application: ~
 
 # Algo backend.
@@ -23,10 +23,10 @@ hyper_parameters:
         default_value: 64
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.0058
+        default_value: 0.01
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 0
       num_iters:
         default_value: 90
 
@@ -37,8 +37,5 @@ training_targets:
   - CPU
 
 # Stats.
-gigaflops: 0.44
-size: 4.29
-
-# Model spec
-model_category: SPEED
+gigaflops: 0.11
+size: 1.6

--- a/src/otx/tools/templates/detection/detection/configuration.yaml
+++ b/src/otx/tools/templates/detection/detection/configuration.yaml
@@ -1,0 +1,701 @@
+description: Configuration for an object detection task
+header: Configuration for an object detection task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  inference_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description: The number of samples seen in each iteration of inference.
+      Increasing this value improves inference time and may make the inference more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Inference batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 2
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 10
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 10
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: None
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: None
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  input_size:
+    affects_outcome_of: INFERENCE
+    default_value: Default
+    description:
+      The input size of the given model could be configured to one of the predefined resolutions.
+      Reduced training and inference time could be expected by using smaller input size.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
+    editable: true
+    enum_name: InputSizePreset
+    header: Configure model input size.
+    options:
+      DEFAULT: "Default"
+      AUTO: "Auto"
+      _256x256: "256x256"
+      _384x384: "384x384"
+      _512x512: "512x512"
+      _768x768: "768x768"
+      _1024x1024: "1024x1024"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Default
+    visible_in_ui: false
+    warning: Modifying input size may decrease model performance.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    # value: 0.35
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+  nms_iou_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.5
+    description:
+      IoU Threshold for NMS Postprocessing. Intersection over Union (IoU) threshold is set to remove overlapping predictions.
+      If the IoU between two predictions is greater than or equal to the IoU threshold, they are considered overlapping and will be discarded.
+    editable: true
+    header: NMS IoU Threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: If you want to chage the value of IoU Threshold of model, then you need to re-train model with new IoU threshold.
+  max_num_detections:
+    affects_outcome_of: INFERENCE
+    default_value: 0
+    description:
+      Extra detection outputs will be discared in non-maximum suppression process.
+      Defaults to 0, which means per-model default values.
+    editable: true
+    header: Maximum number of detections per image
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  use_ellipse_shapes:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Use direct ellipse shape in inference instead of polygon from mask
+    editable: true
+    header: Use ellipse shapes
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Semisupervised: "Semisupervised"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 100000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  enable_noisy_label_detection:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Set to True to enable loss dynamics tracking for each sample to detect noisy labeled samples.
+    editable: true
+    header: Enable loss dynamics tracking for noisy label detection
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 100000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True
+
+tiling_parameters:
+  header: Tiling
+  description: Crop dataset to tiles
+
+  enable_tiling:
+    header: Enable tiling
+    description: Set to True to allow tiny objects to be better detected.
+    default_value: false
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: "Tiling trades off speed for accuracy as it increases the number of images to be processed. In turn, it's memory efficient as smaller resolution patches are handled at onces so that the possibility of OOM issues could be reduced. Important: In the current version, depending on the dataset size and the available hardware resources, a model may not train successfully when tiling is enabled."
+
+  enable_adaptive_params:
+    header: Enable adaptive tiling parameters
+    description: Config tile size and tile overlap adaptively based on annotated dataset statistic. Manual settings well be ignored if it's turned on. Please turn off this option in order to tune tiling parameters manually.
+    default_value: true
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+
+  tile_size:
+    header: Tile Image Size
+    description: Tile image size. (tile_size x tile_size) sub images will be the unit of computation.
+    affects_outcome_of: TRAINING
+    default_value: 400
+    min_value: 100
+    max_value: 4096
+    type: INTEGER
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 400
+    visible_in_ui: true
+    warning: null
+
+  tile_overlap:
+    header: Tile Overlap
+    description: Overlap ratio between each two neighboring tiles. Recommend to set as large_object_size / tile_size.
+    affects_outcome_of: TRAINING
+    default_value: 0.2
+    min_value: 0.0
+    max_value: 0.9
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.2
+    visible_in_ui: true
+    warning: null
+
+  tile_max_number:
+    header: Max object per tile
+    description: Maximum number of objects per tile. If set to 1500, the tile adaptor will automatically determine the value. Otherwise, the manually set value will be used.
+    affects_outcome_of: TRAINING
+    default_value: 1500
+    min_value: 1
+    max_value: 5000
+    type: INTEGER
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1500
+    visible_in_ui: true
+    warning: null
+
+  tile_sampling_ratio:
+    header: Sampling Ratio for entire tiling
+    description: Since tiling train and validation to all tile from large image, usually it takes lots of time than normal training. The tile_sampling_ratio is ratio for sampling entire tile dataset. Sampling tile dataset would save lots of time for training and validation time. Note that sampling will be applied to training and validation dataset, not test dataset.
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    min_value: 0.000001
+    max_value: 1.0
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+
+  object_tile_ratio:
+    header: Object tile ratio
+    description: The desired ratio of min object size and tile size.
+    affects_outcome_of: TRAINING
+    default_value: 0.03
+    min_value: 0.00
+    max_value: 1.00
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.03
+    visible_in_ui: false
+    warning: null
+
+  type: PARAMETER_GROUP
+  visible_in_ui: true

--- a/src/otx/tools/templates/detection/detection/configuration.yaml
+++ b/src/otx/tools/templates/detection/detection/configuration.yaml
@@ -57,7 +57,7 @@ learning_parameters:
     editable: true
     header: Learning rate
     max_value: 0.1
-    min_value: 1.0e-07
+    min_value: 1.0e-08
     type: FLOAT
     ui_rules:
       action: DISABLE_EDITING

--- a/src/otx/tools/templates/detection/detection/configuration.yaml
+++ b/src/otx/tools/templates/detection/detection/configuration.yaml
@@ -90,7 +90,7 @@ learning_parameters:
     warning: null
   num_iters:
     affects_outcome_of: TRAINING
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.
@@ -104,7 +104,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 1
+    value: 200
     visible_in_ui: true
     warning: null
   num_workers:

--- a/src/otx/tools/templates/detection/detection/configuration.yaml
+++ b/src/otx/tools/templates/detection/detection/configuration.yaml
@@ -378,7 +378,6 @@ algo_backend:
     header: Train type
     options:
       Incremental: "Incremental"
-      Semisupervised: "Semisupervised"
     type: SELECTABLE
     ui_rules:
       action: DISABLE_EDITING

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_YOLOX_L
+name: YOLOX-L
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for YOLOX_L
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 194.57
+size: 207
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_l/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_YOLOX_S
+name: YOLOX-S
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for YOLOX_S
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 33.51
+size: 46
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_s/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
@@ -1,0 +1,64 @@
+# Description.
+model_template_id: Custom_Object_Detection_YOLOX
+name: YOLOX-TINY
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for YOLOX-TINY
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.0002
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 6.5
+size: 20.4
+
+# Model spec
+model_category: SPEED

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0002
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0002
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_tiny/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -37,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_YOLOX_X
+name: YOLOX-X
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for YOLOX_X
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 352.42
+size: 378
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
+++ b/src/otx/tools/templates/detection/detection/cspdarknet_yolox_x/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Custom_Object_Detection_Gen3_ATSS
+name: MobileNetV2-ATSS
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for MobileNetV2-ATSS
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.004
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 20.6
+size: 9.1
+
+# Model spec
+model_category: ACCURACY
+is_default_for_task: true

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.004
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -37,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_atss/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.004
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
@@ -1,0 +1,64 @@
+# Description.
+model_template_id: Custom_Object_Detection_Gen3_SSD
+name: SSD
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for SSD
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.01
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 9.4
+size: 7.6
+
+# Model spec
+model_category: BALANCE

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.01
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -37,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
+++ b/src/otx/tools/templates/detection/detection/mobilenetv2_ssd/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.01
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_ResNeXt101_ATSS
+name: ResNeXt101-ATSS
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for ResNeXt101-ATSS
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
+      learning_rate:
+        default_value: 0.004
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 434.75
+size: 344
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.004
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
+++ b/src/otx/tools/templates/detection/detection/resnext101_atss/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.004
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 3
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
@@ -23,7 +23,7 @@ hyper_parameters:
         default_value: 4
         auto_hpo_state: POSSIBLE
       inference_batch_size:
-        default_value: 4
+        default_value: 8
       learning_rate:
         default_value: 0.0001
         auto_hpo_state: POSSIBLE

--- a/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_RTDetr_101
+name: RTDetr_101
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for RTDetr_101
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
+      learning_rate:
+        default_value: 0.0001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 3
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 259
+size: 76
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_101/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 3
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
@@ -23,7 +23,7 @@ hyper_parameters:
         default_value: 4
         auto_hpo_state: POSSIBLE
       inference_batch_size:
-        default_value: 4
+        default_value: 8
       learning_rate:
         default_value: 0.0001
         auto_hpo_state: POSSIBLE

--- a/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_RTDetr_18
+name: RTDetr_18
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for RTDetr_18
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
+      learning_rate:
+        default_value: 0.0001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 10
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 60
+size: 20
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_18/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 10
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
@@ -23,7 +23,7 @@ hyper_parameters:
         default_value: 4
         auto_hpo_state: POSSIBLE
       inference_batch_size:
-        default_value: 4
+        default_value: 8
       learning_rate:
         default_value: 0.0001
         auto_hpo_state: POSSIBLE

--- a/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_RTDetr_50
+name: RTDetr_50
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for RTDetr_50
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
+      learning_rate:
+        default_value: 0.0001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 10
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 136
+size: 42
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtdetr_50/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 10
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0007
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 10
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Object_Detection_RTMDet_tiny
+name: RTMDet_tiny
+task_type: DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Object Detection for RTMDet-tiny
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.0007
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 10
+      num_iters:
+        default_value: 200
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: true
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 8.1
+size: 4.8
+# # Inference options. Defined by OpenVINO capabilities, not Algo Backend or Platform.
+# inference_targets:
+#   - CPU
+#   - GPU
+#   - VPU

--- a/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
@@ -28,7 +28,7 @@ hyper_parameters:
         default_value: 0.0007
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 3
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/detection/rtmdet_tiny/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,18 +31,6 @@ hyper_parameters:
         default_value: 10
       num_iters:
         default_value: 200
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: true
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
@@ -1,0 +1,720 @@
+description: Configuration for an instance segmentation task
+header: Configuration for an instance segmentation task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  inference_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description: The number of samples seen in each iteration of inference.
+      Increasing this value improves inference time and may make the inference more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Inference batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 2
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 2
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 10
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 10
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: Safe
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Safe
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  input_size:
+    affects_outcome_of: INFERENCE
+    default_value: Default
+    description:
+      The input size of the given model could be configured to one of the predefined resolutions.
+      Reduced training and inference time could be expected by using smaller input size.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
+    editable: true
+    enum_name: InputSizePreset
+    header: Configure model input size.
+    options:
+      DEFAULT: "Default"
+      AUTO: "Auto"
+      _256x256: "256x256"
+      _384x384: "384x384"
+      _512x512: "512x512"
+      _768x768: "768x768"
+      _1024x1024: "1024x1024"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Default
+    visible_in_ui: false
+    warning: Modifying input size may decrease model performance.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    # value: 0.35
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+  nms_iou_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.5
+    description:
+      IoU Threshold for NMS Postprocessing. Intersection over Union (IoU) threshold is set to remove overlapping predictions.
+      If the IoU between two predictions is greater than or equal to the IoU threshold, they are considered overlapping and will be discarded.
+    editable: true
+    header: NMS IoU Threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: If you want to chage the value of IoU Threshold of model, then you need to re-train model with new IoU threshold.
+  max_num_detections:
+    affects_outcome_of: INFERENCE
+    default_value: 0
+    description:
+      Extra detection outputs will be discared in non-maximum suppression process.
+      Defaults to 0, which means per-model default values.
+    editable: true
+    header: Maximum number of detections per image
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  use_ellipse_shapes:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Use direct ellipse shape in inference instead of polygon from mask
+    editable: true
+    header: Use ellipse shapes
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Semisupervised: "Semisupervised"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 100000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 200
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True
+
+tiling_parameters:
+  header: Tiling
+  description: Crop dataset to tiles
+
+  enable_tiling:
+    header: Enable tiling
+    description: Set to True to allow tiny objects to be better detected.
+    default_value: false
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: "Tiling trades off speed for accuracy as it increases the number of images to be processed. In turn, it's memory efficient as smaller resolution patches are handled at onces so that the possibility of OOM issues could be reduced. Important: In the current version, depending on the dataset size and the available hardware resources, a model may not train successfully when tiling is enabled."
+
+  enable_tile_classifier:
+    header: Enable tile classifier
+    description: Enabling tile classifier enhances the speed of tiling inference by incorporating a tile classifier into the instance segmentation model. This feature prevents the detector from making predictions on tiles that do not contain any objects, thus optimizing its speed performance.
+    default_value: false
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: The tile classifier prioritizes inference speed over training speed, it requires more training in order to achieve its optimized performance.
+
+  enable_adaptive_params:
+    header: Enable adaptive tiling parameters
+    description: Config tile size and tile overlap adaptively based on annotated dataset statistic. Manual settings well be ignored if it's turned on. Please turn off this option in order to tune tiling parameters manually.
+    default_value: true
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+
+  tile_size:
+    header: Tile Image Size
+    description: Tile image size. (tile_size x tile_size) sub images will be the unit of computation.
+    affects_outcome_of: TRAINING
+    default_value: 400
+    min_value: 100
+    max_value: 4096
+    type: INTEGER
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 400
+    visible_in_ui: true
+    warning: null
+
+  tile_overlap:
+    header: Tile Overlap
+    description: Overlap ratio between each two neighboring tiles. Recommend to set as large_object_size / tile_size.
+    affects_outcome_of: TRAINING
+    default_value: 0.2
+    min_value: 0.0
+    max_value: 0.9
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.2
+    visible_in_ui: true
+    warning: null
+
+  tile_max_number:
+    header: Max object per tile
+    description: Maximum number of objects per tile. If set to 1500, the tile adaptor will automatically determine the value. Otherwise, the manually set value will be used.
+    affects_outcome_of: TRAINING
+    default_value: 1500
+    min_value: 1
+    max_value: 5000
+    type: INTEGER
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1500
+    visible_in_ui: true
+    warning: null
+
+  tile_ir_scale_factor:
+    header: OpenVINO IR Scale Factor
+    description: The purpose of the scale parameter is to optimize the performance and efficiency of tiling in OpenVINO IR during inference. By controlling the increase in tile size and input size, the scale parameter allows for more efficient parallelization of the workload and improve the overall performance and efficiency of the inference process on OpenVINO.
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    min_value: 1.0
+    max_value: 4.0
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+
+  tile_sampling_ratio:
+    header: Sampling Ratio for entire tiling
+    description: Since tiling train and validation to all tile from large image, usually it takes lots of time than normal training. The tile_sampling_ratio is ratio for sampling entire tile dataset. Sampling tile dataset would save lots of time for training and validation time. Note that sampling will be applied to training and validation dataset, not test dataset.
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    min_value: 0.000001
+    max_value: 1.0
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+
+  object_tile_ratio:
+    header: Object tile ratio
+    description: The desired ratio of min object size and tile size.
+    affects_outcome_of: TRAINING
+    default_value: 0.03
+    min_value: 0.00
+    max_value: 1.00
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.03
+    visible_in_ui: false
+    warning: null
+
+  type: PARAMETER_GROUP
+  visible_in_ui: true

--- a/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
@@ -57,7 +57,7 @@ learning_parameters:
     editable: true
     header: Learning rate
     max_value: 0.1
-    min_value: 1.0e-07
+    min_value: 1.0e-08
     type: FLOAT
     ui_rules:
       action: DISABLE_EDITING

--- a/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
@@ -90,7 +90,7 @@ learning_parameters:
     warning: null
   num_iters:
     affects_outcome_of: TRAINING
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.
@@ -104,7 +104,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 1
+    value: 200
     visible_in_ui: true
     warning: null
   num_workers:

--- a/src/otx/tools/templates/detection/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -1,0 +1,68 @@
+# Description.
+model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_EfficientNetB2B
+name: MaskRCNN-EfficientNetB2B
+task_type: INSTANCE_SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Instance Segmentation for MaskRCNN-EfficientNetB2B
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 1
+      learning_rate:
+        default_value: 0.015
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 1
+    nncf_optimization:
+      enable_quantization:
+        default_value: false
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 68.48
+size: 13.27
+
+# Model spec
+model_category: SPEED
+is_default_for_task: true

--- a/src/otx/tools/templates/detection/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/efficientnetb2b_maskrcnn/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -37,21 +31,6 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
-    pot_parameters:
-      stat_requests_number:
-        default_value: 1
-    nncf_optimization:
-      enable_quantization:
-        default_value: false
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/instance_segmentation/maskrcnn_swin_t/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/maskrcnn_swin_t/template.yaml
@@ -1,0 +1,63 @@
+# Description.
+model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_SwinT_FP16
+name: MaskRCNN-SwinT-FP16
+task_type: INSTANCE_SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Instance Segmentation for MaskRCNN-SwinT-FP16
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 1
+      learning_rate:
+        default_value: 0.0001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 1
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 407.32
+size: 191.46

--- a/src/otx/tools/templates/detection/instance_segmentation/maskrcnn_swin_t/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/maskrcnn_swin_t/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -36,21 +31,6 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
-    pot_parameters:
-      stat_requests_number:
-        default_value: 1
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/instance_segmentation/resnet50_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/resnet50_maskrcnn/template.yaml
@@ -1,0 +1,67 @@
+# Description.
+model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_ResNet50
+name: MaskRCNN-ResNet50
+task_type: INSTANCE_SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Instance Segmentation for MaskRCNN-ResNet50
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 1
+      learning_rate:
+        default_value: 0.007
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 1
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 533.8
+size: 177.9
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/detection/instance_segmentation/resnet50_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/resnet50_maskrcnn/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -37,21 +31,6 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
-    pot_parameters:
-      stat_requests_number:
-        default_value: 1
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/instance_segmentation/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/rtmdet_tiny/template.yaml
@@ -1,0 +1,64 @@
+# Description.
+model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_ResNet50
+name: MaskRCNN-ResNet50
+task_type: INSTANCE_SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Instance Segmentation for MaskRCNN-ResNet50
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 1
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 20
+      num_iters:
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 1
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 11.8
+size: 5.6

--- a/src/otx/tools/templates/detection/instance_segmentation/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/rtmdet_tiny/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Counting_Instance_Segmentation_MaskRCNN_ResNet50
-name: MaskRCNN-ResNet50
+model_template_id: Custom_Instance_Segmentation_RTMDet_tiny
+name: RTMDet_tiny
 task_type: INSTANCE_SEGMENTATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Instance Segmentation for MaskRCNN-ResNet50
+summary: Class-Incremental Instance Segmentation for RTMDet_tiny
 application: ~
 
 # Algo backend.

--- a/src/otx/tools/templates/detection/instance_segmentation/rtmdet_tiny/template.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/rtmdet_tiny/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -37,21 +31,6 @@ hyper_parameters:
         default_value: 20
       num_iters:
         default_value: 100
-    pot_parameters:
-      stat_requests_number:
-        default_value: 1
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/rotated_detection/configuration.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/configuration.yaml
@@ -1,0 +1,705 @@
+description: Configuration for an rotated detection task
+header: Configuration for an rotated detection task
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  inference_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description: The number of samples seen in each iteration of inference.
+      Increasing this value improves inference time and may make the inference more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Inference batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    default_value: 2
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 2
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 10
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 10
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  use_adaptive_interval:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Depending on the size of iteration per epoch, adaptively update the validation interval and related values.
+    editable: true
+    header: Use adaptive validation interval
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: This will automatically control the patience and interval when early stopping is enabled.
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: Safe
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Safe
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  input_size:
+    affects_outcome_of: INFERENCE
+    default_value: Default
+    description:
+      The input size of the given model could be configured to one of the predefined resolutions.
+      Reduced training and inference time could be expected by using smaller input size.
+      In Auto mode, the input size is automatically determined based on dataset statistics.
+      Defaults to per-model default resolution.
+    editable: true
+    enum_name: InputSizePreset
+    header: Configure model input size.
+    options:
+      DEFAULT: "Default"
+      AUTO: "Auto"
+      _256x256: "256x256"
+      _384x384: "384x384"
+      _512x512: "512x512"
+      _768x768: "768x768"
+      _1024x1024: "1024x1024"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Default
+    visible_in_ui: false
+    warning: Modifying input size may decrease model performance.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    # value: 0.35
+    value: 0.01
+    visible_in_ui: true
+    warning: null
+  nms_iou_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.5
+    description:
+      IoU Threshold for NMS Postprocessing. Intersection over Union (IoU) threshold is set to remove overlapping predictions.
+      If the IoU between two predictions is greater than or equal to the IoU threshold, they are considered overlapping and will be discarded.
+    editable: true
+    header: NMS IoU Threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.01
+    visible_in_ui: true
+    warning: If you want to chage the value of IoU Threshold of model, then you need to re-train model with new IoU threshold.
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  max_num_detections:
+    affects_outcome_of: INFERENCE
+    default_value: 0
+    description:
+      Extra detection outputs will be discared in non-maximum suppression process.
+      Defaults to 0, which means per-model default values.
+    editable: true
+    header: Maximum number of detections per image
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Semisupervised: "Semisupervised"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 100000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  stat_requests_number:
+    affects_outcome_of: NONE
+    default_value: 0
+    description: Number of requests during statistics collection
+    editable: true
+    header: Number of requests
+    max_value: 200
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True
+
+tiling_parameters:
+  header: Tiling
+  description: Crop dataset to tiles
+
+  enable_tiling:
+    header: Enable tiling
+    description: Set to True to allow tiny objects to be better detected.
+    default_value: false
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: "Tiling trades off speed for accuracy as it increases the number of images to be processed. In turn, it's memory efficient as smaller resolution patches are handled at onces so that the possibility of OOM issues could be reduced. Important: In the current version, depending on the dataset size and the available hardware resources, a model may not train successfully when tiling is enabled."
+
+  enable_tile_classifier:
+    header: Enable tile classifier
+    description: Enabling tile classifier enhances the speed of tiling inference by incorporating a tile classifier into the instance segmentation model. This feature prevents the detector from making predictions on tiles that do not contain any objects, thus optimizing its speed performance.
+    default_value: false
+    editable: false
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: The tile classifier prioritizes inference speed over training speed, it requires more training in order to achieve its optimized performance.
+
+  enable_adaptive_params:
+    header: Enable adaptive tiling parameters
+    description: Config tile size and tile overlap adaptively based on annotated dataset statistic. Manual settings well be ignored if it's turned on. Please turn off this option in order to tune tiling parameters manually.
+    default_value: true
+    editable: true
+    affects_outcome_of: TRAINING
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+
+  tile_size:
+    header: Tile Image Size
+    description: Tile image size. (tile_size x tile_size) sub images will be the unit of computation.
+    affects_outcome_of: TRAINING
+    default_value: 400
+    min_value: 100
+    max_value: 4096
+    type: INTEGER
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 400
+    visible_in_ui: true
+    warning: null
+
+  tile_overlap:
+    header: Tile Overlap
+    description: Overlap ratio between each two neighboring tiles. Recommend to set as large_object_size / tile_size.
+    affects_outcome_of: TRAINING
+    default_value: 0.2
+    min_value: 0.0
+    max_value: 0.9
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.2
+    visible_in_ui: true
+    warning: null
+
+  tile_max_number:
+    header: Max object per tile
+    description: Maximum number of objects per tile. If set to 1500, the tile adaptor will automatically determine the value. Otherwise, the manually set value will be used.
+    affects_outcome_of: TRAINING
+    default_value: 1500
+    min_value: 1
+    max_value: 5000
+    type: INTEGER
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1500
+    visible_in_ui: true
+    warning: null
+
+  tile_ir_scale_factor:
+    header: OpenVINO IR Scale Factor
+    description: The purpose of the scale parameter is to optimize the performance and efficiency of tiling in OpenVINO IR during inference. By controlling the increase in tile size and input size, the scale parameter allows for more efficient parallelization of the workload and improve the overall performance and efficiency of the inference process on OpenVINO.
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    min_value: 1.0
+    max_value: 4.0
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+
+  tile_sampling_ratio:
+    header: Sampling Ratio for entire tiling
+    description: Since tiling train and validation to all tile from large image, usually it takes lots of time than normal training. The tile_sampling_ratio is ratio for sampling entire tile dataset. Sampling tile dataset would save lots of time for training and validation time. Note that sampling will be applied to training and validation dataset, not test dataset.
+    affects_outcome_of: TRAINING
+    default_value: 1.0
+    min_value: 0.000001
+    max_value: 1.0
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: true
+    warning: null
+
+  object_tile_ratio:
+    header: Object tile ratio
+    description: The desired ratio of min object size and tile size.
+    affects_outcome_of: TRAINING
+    default_value: 0.03
+    min_value: 0.00
+    max_value: 1.00
+    type: FLOAT
+    editable: true
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.03
+    visible_in_ui: false
+    warning: null
+
+  type: PARAMETER_GROUP
+  visible_in_ui: true

--- a/src/otx/tools/templates/detection/rotated_detection/configuration.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/configuration.yaml
@@ -90,7 +90,7 @@ learning_parameters:
     warning: null
   num_iters:
     affects_outcome_of: TRAINING
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.
@@ -104,7 +104,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 1
+    value: 200
     visible_in_ui: true
     warning: null
   num_workers:

--- a/src/otx/tools/templates/detection/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
@@ -1,0 +1,66 @@
+# Description.
+model_template_id: Custom_Rotated_Detection_via_Instance_Segmentation_MaskRCNN_EfficientNetB2B
+name: MaskRCNN-EfficientNetB2B
+task_type: ROTATED_DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Rotated object detection for MaskRCNN-EfficientNetB2B
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.015
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 1
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 68.48
+size: 13.27
+
+# Model spec
+model_category: SPEED
+is_default_for_task: true

--- a/src/otx/tools/templates/detection/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
@@ -22,8 +22,10 @@ hyper_parameters:
       batch_size:
         default_value: 4
         auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
       learning_rate:
-        default_value: 0.015
+        default_value: 0.007
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 100

--- a/src/otx/tools/templates/detection/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/efficientnetb2b_maskrcnn/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -35,21 +29,6 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
-    pot_parameters:
-      stat_requests_number:
-        default_value: 1
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/rotated_detection/resnet50_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/resnet50_maskrcnn/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Custom_Rotated_Detection_via_Instance_Segmentation_MaskRCNN_ResNet50
+name: MaskRCNN-ResNet50
+task_type: ROTATED_DETECTION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Rotated object detection for MaskRCNN-ResNet50
+application: ~
+
+# Algo backend.
+framework: OTXDetection v2.9.1
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
+  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
+  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 4
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 100
+    pot_parameters:
+      stat_requests_number:
+        default_value: 1
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 533.8
+size: 177.9
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/detection/rotated_detection/resnet50_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/resnet50_maskrcnn/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXDetection v2.9.1
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.detection.adapters.mmdet.task.MMDetectionTask
-  openvino: otx.algorithms.detection.adapters.openvino.task.OpenVINODetectionTask
-  nncf: otx.algorithms.detection.adapters.mmdet.nncf.task.DetectionNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -35,21 +29,6 @@ hyper_parameters:
         default_value: 100
       num_iters:
         default_value: 100
-    pot_parameters:
-      stat_requests_number:
-        default_value: 1
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/detection/rotated_detection/resnet50_maskrcnn/template.yaml
+++ b/src/otx/tools/templates/detection/rotated_detection/resnet50_maskrcnn/template.yaml
@@ -22,8 +22,10 @@ hyper_parameters:
       batch_size:
         default_value: 4
         auto_hpo_state: POSSIBLE
+      inference_batch_size:
+        default_value: 4
       learning_rate:
-        default_value: 0.001
+        default_value: 0.007
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 100

--- a/src/otx/tools/templates/segmentation/configuration.yaml
+++ b/src/otx/tools/templates/segmentation/configuration.yaml
@@ -1,0 +1,473 @@
+description: Configuration for an semantic segmentation task
+header: Configuration for an semantic segmentation task
+id: ""
+learning_parameters:
+  batch_size:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description:
+      The number of training samples seen in each iteration of training.
+      Increasing this value improves training time and may make the training more
+      stable. A larger batch size has higher memory requirements.
+    editable: true
+    header: Batch size
+    max_value: 512
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning:
+      Increasing this value may cause the system to use more memory than available,
+      potentially causing out of memory errors, please update with caution.
+    auto_hpo_state: NOT_POSSIBLE
+  description: Learning Parameters
+  header: Learning Parameters
+  learning_rate:
+    affects_outcome_of: TRAINING
+    default_value: 0.01
+    description:
+      Increasing this value will speed up training convergence but might
+      make it unstable.
+    editable: true
+    header: Learning rate
+    max_value: 0.1
+    min_value: 1.0e-07
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.001
+    visible_in_ui: true
+    warning: null
+    auto_hpo_state: NOT_POSSIBLE
+  learning_rate_warmup_iters:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 100
+    description:
+      In this periods of initial training iterations, the model will be trained in low learning rate,
+      which will be increased incrementally up to the expected learning rate setting.
+      This warm-up phase is known to be helpful to stabilize training, thus result in better performance.
+    editable: true
+    header: Number of iterations for learning rate warmup
+    max_value: 10000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 100
+    visible_in_ui: true
+    warning: null
+  num_iters:
+    affects_outcome_of: TRAINING
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 1
+    description:
+      Increasing this value causes the results to be more robust but training
+      time will be longer.
+    editable: true
+    header: Number of training iterations
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1
+    visible_in_ui: true
+    warning: null
+  num_workers:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 2
+    description:
+      Increasing this value might improve training speed however it might
+      cause out of memory errors. If the number of workers is set to zero, data loading
+      will happen in the main training thread.
+    editable: true
+    header: Number of cpu threads to use during batch generation
+    max_value: 8
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: null
+  enable_early_stopping:
+    affects_outcome_of: TRAINING
+    default_value: true
+    description: Early exit from training when validation accuracy isn't changed or decreased for several epochs.
+    editable: true
+    header: Enable early stopping of the training
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  early_stop_start:
+    affects_outcome_of: TRAINING
+    default_value: 3
+    editable: true
+    header: Start epoch for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 3
+    visible_in_ui: false
+  early_stop_patience:
+    affects_outcome_of: TRAINING
+    default_value: 5
+    description: Training will stop if the model does not improve within the number of epochs of patience.
+    editable: true
+    header: Patience for early stopping
+    max_value: 50
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 5
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  early_stop_iteration_patience:
+    affects_outcome_of: TRAINING
+    default_value: 0
+    description:
+      Training will stop if the model does not improve within the number of iterations of patience.
+      This ensures the model is trained enough with the number of iterations of patience before early stopping.
+    editable: true
+    header: Iteration patience for early stopping
+    max_value: 1000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0
+    visible_in_ui: true
+    warning: This is applied exclusively when early stopping is enabled.
+  enable_supcon:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description:
+      Enable an auxiliar supervised contrastive loss, which might increase robustness
+      and accuracy for small datasets.
+    editable: true
+    header: Enable Supervised Contrastive helper loss
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  auto_adapt_batch_size:
+    affects_outcome_of: TRAINING
+    default_value: Safe
+    description: Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+    editable: true
+    enum_name: BatchSizeAdaptType
+    header: Decrease batch size if current batch size isn't fit to CUDA memory.
+    options:
+      NONE: "None"
+      SAFE: "Safe"
+      FULL: "Full"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Safe
+    visible_in_ui: true
+    warning:
+      Enabling this could change the actual batch size depending on the current GPU status.
+      The learning rate also could be adjusted according to the adapted batch size. This process might change
+      a model performance and take some extra computation time to try a few batch size candidates.
+  auto_num_workers:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Adapt num_workers according to current hardware status automatically.
+    editable: true
+    header: Enable auto adaptive num_workers
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: true
+    warning: null
+  input_size:
+    affects_outcome_of: INFERENCE
+    default_value: Auto
+    description:
+      The input size of the given model could be configured to one of the predefined resolutions.
+      Reduced training and inference time could be expected by using smaller input size.
+      Defaults to Auto, in which input size is automatically determined based on dataset statistics.
+    editable: true
+    enum_name: InputSizePreset
+    header: Configure model input size.
+    options:
+      DEFAULT: "Default"
+      AUTO: "Auto"
+      _256x256: "256x256"
+      _384x384: "384x384"
+      _512x512: "512x512"
+      _768x768: "768x768"
+      _1024x1024: "1024x1024"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Default
+    visible_in_ui: false
+    warning: Modifying input size may decrease model performance.
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.35
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.35
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: true
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Semisupervised: "Semisupervised"
+      Selfsupervised: "Selfsupervised"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 100000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 10000000000
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    default_value: Performance
+    description: Quantization preset that defines quantization scheme
+    editable: True
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Performance
+    visible_in_ui: True
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: True
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+nncf_optimization:
+  description: Optimization by NNCF
+  header: Optimization by NNCF
+  enable_quantization:
+    affects_outcome_of: INFERENCE
+    default_value: True
+    description: Enable quantization algorithm
+    editable: false
+    header: Enable quantization algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: true
+    visible_in_ui: false
+    warning: null
+  enable_pruning:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Enable filter pruning algorithm
+    editable: true
+    header: Enable filter pruning algorithm
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  pruning_supported:
+    affects_outcome_of: TRAINING
+    default_value: false
+    description: Whether filter pruning is supported
+    editable: false
+    header: Whether filter pruning is supported
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: false
+    warning: null
+  maximal_accuracy_degradation:
+    affects_outcome_of: NONE
+    default_value: 1.0
+    description: The maximal allowed accuracy metric drop in absolute values
+    editable: True
+    header: Maximum accuracy degradation
+    max_value: 100.0
+    min_value: 0.0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 1.0
+    visible_in_ui: True
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: True

--- a/src/otx/tools/templates/segmentation/configuration.yaml
+++ b/src/otx/tools/templates/segmentation/configuration.yaml
@@ -73,7 +73,7 @@ learning_parameters:
     affects_outcome_of: TRAINING
     auto_hpo_state: not_possible
     auto_hpo_value: null
-    default_value: 1
+    default_value: 200
     description:
       Increasing this value causes the results to be more robust but training
       time will be longer.
@@ -87,7 +87,7 @@ learning_parameters:
       operator: AND
       rules: []
       type: UI_RULES
-    value: 1
+    value: 200
     visible_in_ui: true
     warning: null
   num_workers:

--- a/src/otx/tools/templates/segmentation/configuration.yaml
+++ b/src/otx/tools/templates/segmentation/configuration.yaml
@@ -36,7 +36,7 @@ learning_parameters:
     editable: true
     header: Learning rate
     max_value: 0.1
-    min_value: 1.0e-07
+    min_value: 1.0e-08
     type: FLOAT
     ui_rules:
       action: DISABLE_EDITING
@@ -128,7 +128,7 @@ learning_parameters:
     warning: null
   early_stop_start:
     affects_outcome_of: TRAINING
-    default_value: 3
+    default_value: 70
     editable: true
     header: Start epoch for early stopping
     max_value: 1000
@@ -143,7 +143,7 @@ learning_parameters:
     visible_in_ui: false
   early_stop_patience:
     affects_outcome_of: TRAINING
-    default_value: 5
+    default_value: 7
     description: Training will stop if the model does not improve within the number of epochs of patience.
     editable: true
     header: Patience for early stopping

--- a/src/otx/tools/templates/segmentation/dinov2_small/template.yaml
+++ b/src/otx/tools/templates/segmentation/dinov2_small/template.yaml
@@ -26,7 +26,7 @@ hyper_parameters:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 20
+        default_value: 100
       num_iters:
         default_value: 200
 

--- a/src/otx/tools/templates/segmentation/dinov2_small/template.yaml
+++ b/src/otx/tools/templates/segmentation/dinov2_small/template.yaml
@@ -1,10 +1,10 @@
 # Description.
-model_template_id: Custom_Semantic_Segmentation_Lite-HRNet-18-mod2_OCR
-name: Lite-HRNet-18-mod2
+model_template_id: Custom_Semantic_Segmentation_DINOV2_S
+name: DINOV2_S
 task_type: SEGMENTATION
 task_family: VISION
 instantiation: "CLASS"
-summary: Class-Incremental Semantic Segmentation with middle-sized architecture which based on the Lite-HRNet backbone for the balance between the fast inference and long training.
+summary: Class-Incremental Semantic Segmentation with larger architecture which based on the foundational DINO model for the better accuracy, especcially on small datasets.
 application: ~
 
 # Algo backend.
@@ -21,11 +21,12 @@ hyper_parameters:
     learning_parameters:
       batch_size:
         default_value: 8
+        auto_hpo_state: POSSIBLE
       learning_rate:
         default_value: 0.001
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 100
+        default_value: 20
       num_iters:
         default_value: 200
 
@@ -36,9 +37,5 @@ training_targets:
   - CPU
 
 # Stats.
-gigaflops: 3.63
-size: 4.8
-
-# Model spec
-model_category: BALANCE
-is_default_for_task: true
+gigaflops: 62
+size: 2.37

--- a/src/otx/tools/templates/segmentation/ham_segnext_b/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_b/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Custom_Semantic_Segmentation_SegNext_B
+name: SegNext-B
+task_type: SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Semantic Segmentation with larger architecture which based on the MSCAN backbone for the better accuracy.
+application: ~
+
+# Algo backend.
+framework: OTXSegmentation v0.14.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
+  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.00008
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 20
+      num_iters:
+        default_value: 150
+      early_stop_start:
+        default_value: 15
+      early_stop_patience:
+        default_value: 10
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    pot_parameters:
+      preset:
+        default_value: Mixed
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 32.08
+size: 27.56

--- a/src/otx/tools/templates/segmentation/ham_segnext_b/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_b/template.yaml
@@ -26,7 +26,7 @@ hyper_parameters:
         default_value: 0.00006
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 20
+        default_value: 100
       num_iters:
         default_value: 200
       early_stop_start:

--- a/src/otx/tools/templates/segmentation/ham_segnext_b/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_b/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXSegmentation v0.14.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
-  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -28,31 +23,16 @@ hyper_parameters:
         default_value: 8
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.00008
+        default_value: 0.00006
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 20
       num_iters:
-        default_value: 150
+        default_value: 200
       early_stop_start:
-        default_value: 15
+        default_value: 100
       early_stop_patience:
         default_value: 10
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    pot_parameters:
-      preset:
-        default_value: Mixed
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/segmentation/ham_segnext_s/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_s/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Custom_Semantic_Segmentation_SegNext_s
+name: SegNext-s
+task_type: SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Semantic Segmentation with medium-sized architecture which based on the MSCAN backbone for the balance between accuracy and fast inference.
+application: ~
+
+# Algo backend.
+framework: OTXSegmentation v0.14.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
+  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.00008
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 20
+      num_iters:
+        default_value: 170
+      early_stop_start:
+        default_value: 15
+      early_stop_patience:
+        default_value: 10
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    pot_parameters:
+      preset:
+        default_value: Mixed
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 15.35
+size: 13.9

--- a/src/otx/tools/templates/segmentation/ham_segnext_s/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_s/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXSegmentation v0.14.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
-  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -28,31 +23,16 @@ hyper_parameters:
         default_value: 8
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.00008
+        default_value: 0.00006
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 20
       num_iters:
-        default_value: 170
+        default_value: 200
       early_stop_start:
-        default_value: 15
+        default_value: 100
       early_stop_patience:
         default_value: 10
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    pot_parameters:
-      preset:
-        default_value: Mixed
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/segmentation/ham_segnext_s/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_s/template.yaml
@@ -26,7 +26,7 @@ hyper_parameters:
         default_value: 0.00006
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 20
+        default_value: 100
       num_iters:
         default_value: 200
       early_stop_start:

--- a/src/otx/tools/templates/segmentation/ham_segnext_t/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_t/template.yaml
@@ -1,0 +1,65 @@
+# Description.
+model_template_id: Custom_Semantic_Segmentation_SegNext_t
+name: SegNext-t
+task_type: SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Semantic Segmentation with small-sized architecture which based on the MSCAN backbone for faster inference while preserving competetive accuracy.
+application: ~
+
+# Algo backend.
+framework: OTXSegmentation v0.14.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
+  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.00008
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 20
+      num_iters:
+        default_value: 170
+      early_stop_start:
+        default_value: 15
+      early_stop_patience:
+        default_value: 10
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    pot_parameters:
+      preset:
+        default_value: Mixed
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 6.07
+size: 4.23

--- a/src/otx/tools/templates/segmentation/ham_segnext_t/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_t/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXSegmentation v0.14.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
-  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -28,31 +23,16 @@ hyper_parameters:
         default_value: 8
         auto_hpo_state: POSSIBLE
       learning_rate:
-        default_value: 0.00008
+        default_value: 0.00006
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
         default_value: 20
       num_iters:
-        default_value: 170
+        default_value: 200
       early_stop_start:
-        default_value: 15
+        default_value: 100
       early_stop_patience:
         default_value: 10
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    pot_parameters:
-      preset:
-        default_value: Mixed
-    algo_backend:
-      train_type:
-        default_value: Incremental
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/segmentation/ham_segnext_t/template.yaml
+++ b/src/otx/tools/templates/segmentation/ham_segnext_t/template.yaml
@@ -26,7 +26,7 @@ hyper_parameters:
         default_value: 0.00006
         auto_hpo_state: POSSIBLE
       learning_rate_warmup_iters:
-        default_value: 20
+        default_value: 100
       num_iters:
         default_value: 200
       early_stop_start:

--- a/src/otx/tools/templates/segmentation/ocr_lite_hrnet_18_mod2/template.yaml
+++ b/src/otx/tools/templates/segmentation/ocr_lite_hrnet_18_mod2/template.yaml
@@ -1,0 +1,62 @@
+# Description.
+model_template_id: Custom_Semantic_Segmentation_Lite-HRNet-18-mod2_OCR
+name: Lite-HRNet-18-mod2
+task_type: SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Semantic Segmentation with middle-sized architecture which based on the Lite-HRNet backbone for the balance between the fast inference and long training.
+application: ~
+
+# Algo backend.
+framework: OTXSegmentation v0.14.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
+  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
+  nncf: otx.algorithms.segmentation.adapters.mmseg.nncf.task.SegmentationNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 300
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 3.63
+size: 4.8
+
+# Model spec
+model_category: BALANCE
+is_default_for_task: true

--- a/src/otx/tools/templates/segmentation/ocr_lite_hrnet_s_mod2/template.yaml
+++ b/src/otx/tools/templates/segmentation/ocr_lite_hrnet_s_mod2/template.yaml
@@ -1,0 +1,62 @@
+# Description.
+model_template_id: Custom_Semantic_Segmentation_Lite-HRNet-s-mod2_OCR
+name: Lite-HRNet-s-mod2
+task_type: SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Semantic Segmentation with lightweight architecture which based on the Lite-HRNet backbone for the fast inference and training on the limited amount of data.
+application: ~
+
+# Algo backend.
+framework: OTXSegmentation v0.14.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
+  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
+  nncf: otx.algorithms.segmentation.adapters.mmseg.nncf.task.SegmentationNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 300
+    nncf_optimization:
+      enable_quantization:
+        default_value: true
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 1.82
+size: 3.5
+
+# Model spec
+model_category: SPEED

--- a/src/otx/tools/templates/segmentation/ocr_lite_hrnet_s_mod2/template.yaml
+++ b/src/otx/tools/templates/segmentation/ocr_lite_hrnet_s_mod2/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXSegmentation v0.14.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
-  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
-  nncf: otx.algorithms.segmentation.adapters.mmseg.nncf.task.SegmentationNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -34,19 +28,7 @@ hyper_parameters:
       learning_rate_warmup_iters:
         default_value: 100
       num_iters:
-        default_value: 300
-    nncf_optimization:
-      enable_quantization:
-        default_value: true
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
+        default_value: 200
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/segmentation/ocr_lite_hrnet_x_mod3/template.yaml
+++ b/src/otx/tools/templates/segmentation/ocr_lite_hrnet_x_mod3/template.yaml
@@ -1,0 +1,62 @@
+# Description.
+model_template_id: Custom_Semantic_Segmentation_Lite-HRNet-x-mod3_OCR
+name: Lite-HRNet-x-mod3
+task_type: SEGMENTATION
+task_family: VISION
+instantiation: "CLASS"
+summary: Class-Incremental Semantic Segmentation with heavy-size architecture which based on the Lite-HRNet backbone for the accurate predictions but long training.
+application: ~
+
+# Algo backend.
+framework: OTXSegmentation v0.14.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
+  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
+  nncf: otx.algorithms.segmentation.adapters.mmseg.nncf.task.SegmentationNNCFTask
+
+# Capabilities.
+capabilities:
+  - compute_representations
+
+# Hyperparameters.
+hyper_parameters:
+  base_path: ../configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      batch_size:
+        default_value: 8
+        auto_hpo_state: POSSIBLE
+      learning_rate:
+        default_value: 0.001
+        auto_hpo_state: POSSIBLE
+      learning_rate_warmup_iters:
+        default_value: 100
+      num_iters:
+        default_value: 300
+    nncf_optimization:
+      enable_quantization:
+        default_value: false
+      enable_pruning:
+        default_value: false
+      pruning_supported:
+        default_value: false
+      maximal_accuracy_degradation:
+        default_value: 1.0
+    algo_backend:
+      train_type:
+        default_value: Incremental
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Stats.
+gigaflops: 13.97
+size: 6.4
+
+# Model spec
+model_category: ACCURACY

--- a/src/otx/tools/templates/segmentation/ocr_lite_hrnet_x_mod3/template.yaml
+++ b/src/otx/tools/templates/segmentation/ocr_lite_hrnet_x_mod3/template.yaml
@@ -10,12 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXSegmentation v0.14.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.segmentation.adapters.mmseg.task.MMSegmentationTask
-  openvino: otx.algorithms.segmentation.adapters.openvino.task.OpenVINOSegmentationTask
-  nncf: otx.algorithms.segmentation.adapters.mmseg.nncf.task.SegmentationNNCFTask
-
 # Capabilities.
 capabilities:
   - compute_representations
@@ -34,19 +28,7 @@ hyper_parameters:
       learning_rate_warmup_iters:
         default_value: 100
       num_iters:
-        default_value: 300
-    nncf_optimization:
-      enable_quantization:
-        default_value: false
-      enable_pruning:
-        default_value: false
-      pruning_supported:
-        default_value: false
-      maximal_accuracy_degradation:
-        default_value: 1.0
-    algo_backend:
-      train_type:
-        default_value: Incremental
+        default_value: 200
 
 # Training resources.
 max_nodes: 1

--- a/src/otx/tools/templates/visual_prompting/configuration.yaml
+++ b/src/otx/tools/templates/visual_prompting/configuration.yaml
@@ -1,0 +1,235 @@
+description: Configuration for SAM
+header: Configuration for SAM
+id: ""
+learning_parameters:
+  description: Learning Parameters
+  header: Learning Parameters
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  trainer:
+    description: Trainer Parameters
+    header: Trainer Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    max_epochs:
+      affects_outcome_of: TRAINING
+      default_value: 100
+      description:
+        Maximum number of epochs to train for. If not specified, the training will
+        run until the early stopping criteria is met.
+      editable: true
+      header: Maximum number of epochs
+      max_value: 1000
+      min_value: 1
+      type: INTEGER
+      value: 100
+  dataset:
+    description: Dataset Parameters
+    header: Dataset Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    use_mask:
+      header: Flag about using mask as label
+      affects_outcome_of: TRAINING
+      default_value: false
+      description: If using mask as-is (true) or converting it to polygon (false)
+      editable: true
+      value: false
+      type: BOOLEAN
+    train_batch_size:
+      affects_outcome_of: TRAINING
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: 2
+      description:
+        The number of training samples seen in each iteration of training.
+        Increasing this value improves training time and may make the training more
+        stable. A larger batch size has higher memory requirements.
+      editable: true
+      header: Batch size
+      max_value: 512
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 32
+      visible_in_ui: true
+      warning:
+        Increasing this value may cause the system to use more memory than available,
+        potentially causing out of memory errors, please update with caution.
+  optimizer:
+    description: Optimizer Parameters
+    header: Optimizer Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    lr:
+      affects_outcome_of: TRAINING
+      default_value: 0.0001
+      description:
+        Increasing this value will speed up training convergence but might
+        make it unstable.
+      editable: true
+      header: Learning rate
+      max_value: 10
+      min_value: 1.0e-07
+      type: FLOAT
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 0.0001
+      visible_in_ui: true
+      warning: null
+      auto_hpo_state: NOT_POSSIBLE
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Mixed
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Mixed
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.5
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.5
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Zeroshot: "Zeroshot"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 1000000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/visual_prompting/configuration.yaml
+++ b/src/otx/tools/templates/visual_prompting/configuration.yaml
@@ -67,7 +67,7 @@ learning_parameters:
     visible_in_ui: true
     lr:
       affects_outcome_of: TRAINING
-      default_value: 0.0001
+      default_value: 0.00001
       description:
         Increasing this value will speed up training convergence but might
         make it unstable.

--- a/src/otx/tools/templates/visual_prompting/sam_tiny_vit/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/sam_tiny_vit/template.yaml
@@ -1,0 +1,30 @@
+# Description.
+model_template_id: Visual_Prompting_SAM_Tiny_ViT
+name: SAM_Tiny_ViT
+task_type: VISUAL_PROMPTING
+task_family: VISION
+instantiation: "CLASS"
+summary: Visual Prompting with TinyViT for the accurate predictions
+application: ~
+
+# Algo backend.
+framework: OTXVisualPrompting v0.1.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.visual_prompting.tasks.TrainingTask
+  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOVisualPromptingTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ../configuration.yaml
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 38.95
+size: 47

--- a/src/otx/tools/templates/visual_prompting/sam_tiny_vit/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/sam_tiny_vit/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXVisualPrompting v0.1.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.visual_prompting.tasks.TrainingTask
-  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOVisualPromptingTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ../configuration.yaml

--- a/src/otx/tools/templates/visual_prompting/sam_vit_b/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/sam_vit_b/template.yaml
@@ -1,0 +1,30 @@
+# Description.
+model_template_id: Visual_Prompting_SAM_ViT_B
+name: SAM_ViT_B
+task_type: VISUAL_PROMPTING
+task_family: VISION
+instantiation: "CLASS"
+summary: Visual Prompting with ViT-B for the accurate predictions
+application: ~
+
+# Algo backend.
+framework: OTXVisualPrompting v0.1.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.visual_prompting.tasks.TrainingTask
+  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOVisualPromptingTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ../configuration.yaml
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 483.71
+size: 362

--- a/src/otx/tools/templates/visual_prompting/sam_vit_b/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/sam_vit_b/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXVisualPrompting v0.1.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.visual_prompting.tasks.TrainingTask
-  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOVisualPromptingTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ../configuration.yaml

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/configuration.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/configuration.yaml
@@ -1,0 +1,210 @@
+description: Configuration for SAM
+header: Configuration for SAM
+id: ""
+learning_parameters:
+  description: Learning Parameters
+  header: Learning Parameters
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  trainer:
+    description: Trainer Parameters
+    header: Trainer Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    max_epochs:
+      affects_outcome_of: TRAINING
+      default_value: 1
+      description:
+        Maximum number of epochs to train for. If not specified, the training will
+        run until the early stopping criteria is met.
+      editable: true
+      header: Maximum number of epochs
+      max_value: 1
+      min_value: 1
+      type: INTEGER
+      value: 1
+  dataset:
+    description: Dataset Parameters
+    header: Dataset Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    use_mask:
+      header: Flag about using mask as label
+      affects_outcome_of: TRAINING
+      default_value: false
+      description: If using mask as-is (true) or converting it to polygon (false)
+      editable: true
+      value: false
+      type: BOOLEAN
+    train_batch_size:
+      affects_outcome_of: TRAINING
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: 2
+      description:
+        The number of training samples seen in each iteration of training.
+        Increasing this value improves training time and may make the training more
+        stable. A larger batch size has higher memory requirements.
+      editable: true
+      header: Batch size
+      max_value: 512
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 32
+      visible_in_ui: true
+      warning:
+        Increasing this value may cause the system to use more memory than available,
+        potentially causing out of memory errors, please update with caution.
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Mixed
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Mixed
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.5
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.5
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Zeroshot: "Zeroshot"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 1000000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/configuration.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/configuration.yaml
@@ -40,7 +40,7 @@ learning_parameters:
       affects_outcome_of: TRAINING
       auto_hpo_state: not_possible
       auto_hpo_value: null
-      default_value: 2
+      default_value: 1
       description:
         The number of training samples seen in each iteration of training.
         Increasing this value improves training time and may make the training more

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/template.yaml
@@ -1,0 +1,38 @@
+# Description.
+model_template_id: Zero_Shot_SAM_Tiny_ViT
+name: Zero_Shot_SAM_Tiny_ViT
+task_type: VISUAL_PROMPTING
+task_family: VISION
+instantiation: "CLASS"
+summary: Zero SHot Visual Prompting with TinyViT for the accurate predictions
+application: ~
+
+# Algo backend.
+framework: OTXVisualPrompting v0.1.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.visual_prompting.tasks.ZeroShotTask
+  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOZeroShotVisualPromptingTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      dataset:
+        train_batch_size:
+          default_value: 1
+    algo_backend:
+      train_type:
+        default_value: Zeroshot
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 38.18
+size: 25

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_tiny_vit/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXVisualPrompting v0.1.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.visual_prompting.tasks.ZeroShotTask
-  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOZeroShotVisualPromptingTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/configuration.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/configuration.yaml
@@ -1,0 +1,210 @@
+description: Configuration for SAM
+header: Configuration for SAM
+id: ""
+learning_parameters:
+  description: Learning Parameters
+  header: Learning Parameters
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+  trainer:
+    description: Trainer Parameters
+    header: Trainer Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    max_epochs:
+      affects_outcome_of: TRAINING
+      default_value: 1
+      description:
+        Maximum number of epochs to train for. If not specified, the training will
+        run until the early stopping criteria is met.
+      editable: true
+      header: Maximum number of epochs
+      max_value: 1
+      min_value: 1
+      type: INTEGER
+      value: 1
+  dataset:
+    description: Dataset Parameters
+    header: Dataset Parameters
+    type: PARAMETER_GROUP
+    visible_in_ui: true
+    use_mask:
+      header: Flag about using mask as label
+      affects_outcome_of: TRAINING
+      default_value: false
+      description: If using mask as-is (true) or converting it to polygon (false)
+      editable: true
+      value: false
+      type: BOOLEAN
+    train_batch_size:
+      affects_outcome_of: TRAINING
+      auto_hpo_state: not_possible
+      auto_hpo_value: null
+      default_value: 2
+      description:
+        The number of training samples seen in each iteration of training.
+        Increasing this value improves training time and may make the training more
+        stable. A larger batch size has higher memory requirements.
+      editable: true
+      header: Batch size
+      max_value: 512
+      min_value: 1
+      type: INTEGER
+      ui_rules:
+        action: DISABLE_EDITING
+        operator: AND
+        rules: []
+        type: UI_RULES
+      value: 32
+      visible_in_ui: true
+      warning:
+        Increasing this value may cause the system to use more memory than available,
+        potentially causing out of memory errors, please update with caution.
+pot_parameters:
+  description: POT Parameters
+  header: POT Parameters
+  preset:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: Mixed
+    description: Quantization preset that defines quantization scheme
+    editable: true
+    enum_name: POTQuantizationPreset
+    header: Preset
+    options:
+      MIXED: Mixed
+      PERFORMANCE: Performance
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Mixed
+    visible_in_ui: true
+    warning: null
+  stat_subset_size:
+    affects_outcome_of: NONE
+    auto_hpo_state: not_possible
+    auto_hpo_value: null
+    default_value: 300
+    description: Number of data samples used for post-training optimization
+    editable: true
+    header: Number of data samples
+    max_value: 1000
+    min_value: 1
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 300
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+postprocessing:
+  confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: 0.5
+    description:
+      This threshold only takes effect if the threshold is not set based
+      on the result.
+    editable: true
+    header: Confidence threshold
+    max_value: 1
+    min_value: 0
+    type: FLOAT
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: 0.5
+    visible_in_ui: true
+    warning: null
+  description: Postprocessing
+  header: Postprocessing
+  result_based_confidence_threshold:
+    affects_outcome_of: INFERENCE
+    default_value: false
+    description: Confidence threshold is derived from the results
+    editable: true
+    header: Result based confidence threshold
+    type: BOOLEAN
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: false
+    visible_in_ui: true
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: true
+algo_backend:
+  description: parameters for algo backend
+  header: Algo backend parameters
+  train_type:
+    affects_outcome_of: TRAINING
+    default_value: Incremental
+    description: Training scheme option that determines how to train the model
+    editable: True
+    enum_name: TrainType
+    header: Train type
+    options:
+      Incremental: "Incremental"
+      Zeroshot: "Zeroshot"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    value: Incremental
+    visible_in_ui: false
+    warning: null
+  mem_cache_size:
+    affects_outcome_of: TRAINING
+    default_value: 1000000000
+    description: Size of memory pool for caching decoded data to load data faster (bytes).
+    editable: true
+    header: Size of memory pool
+    max_value: 9223372036854775807
+    min_value: 0
+    type: INTEGER
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  storage_cache_scheme:
+    affects_outcome_of: TRAINING
+    default_value: NONE
+    description: Scheme for storage cache
+    editable: true
+    enum_name: StorageCacheScheme
+    header: Scheme for storage cache
+    options:
+      NONE: "NONE"
+      AS_IS: "AS-IS"
+      JPEG_75: "JPEG/75"
+      JPEG_95: "JPEG/95"
+      PNG: "PNG"
+      TIFF: "TIFF"
+    type: SELECTABLE
+    ui_rules:
+      action: DISABLE_EDITING
+      operator: AND
+      rules: []
+      type: UI_RULES
+    visible_in_ui: false
+    warning: null
+  type: PARAMETER_GROUP
+  visible_in_ui: false
+type: CONFIGURABLE_PARAMETERS
+visible_in_ui: true

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/configuration.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/configuration.yaml
@@ -40,7 +40,7 @@ learning_parameters:
       affects_outcome_of: TRAINING
       auto_hpo_state: not_possible
       auto_hpo_value: null
-      default_value: 2
+      default_value: 1
       description:
         The number of training samples seen in each iteration of training.
         Increasing this value improves training time and may make the training more

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/template.yaml
@@ -1,0 +1,38 @@
+# Description.
+model_template_id: Zero_Shot_SAM_ViT_B
+name: Zero_Shot_SAM_ViT_B
+task_type: VISUAL_PROMPTING
+task_family: VISION
+instantiation: "CLASS"
+summary: Zero SHot Visual Prompting with ViT-B for the accurate predictions
+application: ~
+
+# Algo backend.
+framework: OTXVisualPrompting v0.1.0
+
+# Task implementations.
+entrypoints:
+  base: otx.algorithms.visual_prompting.tasks.ZeroShotTask
+  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOZeroShotVisualPromptingTask
+
+# Hyper Parameters
+hyper_parameters:
+  base_path: ./configuration.yaml
+  parameter_overrides:
+    learning_parameters:
+      dataset:
+        train_batch_size:
+          default_value: 1
+    algo_backend:
+      train_type:
+        default_value: Zeroshot
+
+# Training resources.
+max_nodes: 1
+training_targets:
+  - GPU
+  - CPU
+
+# Computational Complexity
+gigaflops: 483.71
+size: 362

--- a/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/template.yaml
+++ b/src/otx/tools/templates/visual_prompting/zero_shot_sam_vit_b/template.yaml
@@ -10,11 +10,6 @@ application: ~
 # Algo backend.
 framework: OTXVisualPrompting v0.1.0
 
-# Task implementations.
-entrypoints:
-  base: otx.algorithms.visual_prompting.tasks.ZeroShotTask
-  openvino: otx.algorithms.visual_prompting.tasks.openvino.OpenVINOZeroShotVisualPromptingTask
-
 # Hyper Parameters
 hyper_parameters:
   base_path: ./configuration.yaml


### PR DESCRIPTION
### Summary
Move templates from OTX1.6 to OTX2.2 to preserve contract between Geti and OTX and to be able to control hyperparameters from OTX2.X side

This is a workaround. In the future we will migrate to our OTX2.X recipes.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
