### PR TITLE
Add type checker in converter for callable functions (optimizer, scheduler)

### DIFF
--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -277,12 +277,22 @@ class ConfigConverter:
             config["data"]["test_subset"]["batch_size"] = param_value
 
         def update_learning_rate(param_value: float) -> None:
-            config["model"]["init_args"]["optimizer"]["init_args"]["lr"] = param_value
+            optimizer = config["model"]["init_args"]["optimizer"]
+            if isinstance(optimizer, dict) and "init_args" in optimizer:
+                optimizer["init_args"]["lr"] = param_value
+            else:
+                warn("Warning: learning_rate is not updated", stacklevel=1)
 
         def update_learning_rate_warmup_iters(param_value: int) -> None:
             scheduler = config["model"]["init_args"]["scheduler"]
-            if scheduler["class_path"] == "otx.core.schedulers.LinearWarmupSchedulerCallable":
+            if (
+                isinstance(scheduler, dict)
+                and "class_path" in scheduler
+                and scheduler["class_path"] == "otx.core.schedulers.LinearWarmupSchedulerCallable"
+            ):
                 scheduler["init_args"]["num_warmup_steps"] = param_value
+            else:
+                warn("Warning: learning_rate_warmup_iters is not updated", stacklevel=1)
 
         def update_num_iters(param_value: int) -> None:
             config["max_epochs"] = param_value


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-152429
Currently, 2.2 causes the following issue when using converter if no scheduler or optimizer is declared in the configuration.
![image](https://github.com/user-attachments/assets/3ea67707-4e5f-497e-b8f1-78db83ca616e)
This is because the scheduler or optimizer is returning a callable as the default value.
So for now, fix it to check for `dict` types to avoid the issue.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
