### PR TITLE
Fix a wrong HPO log

### DIFF
--- a/src/otx/engine/hpo/hpo_api.py
+++ b/src/otx/engine/hpo/hpo_api.py
@@ -338,7 +338,7 @@ class HPOConfigurator:
         self._engine.model.optimizer_callable.optimizer_kwargs["lr"] = origin_lr  # type: ignore[attr-defined]
         logger.info(
             "Max value of batch size search space : "
-            f"{self._hpo_config["search_space"]["datamodule.train_subset.batch_size"]["max"]} -> {adapted_bs}"
+            f"{self._hpo_config['search_space']['datamodule.train_subset.batch_size']['max']} -> {adapted_bs}",
         )
         self._hpo_config["search_space"]["datamodule.train_subset.batch_size"]["max"] = adapted_bs
 

--- a/src/otx/engine/hpo/hpo_api.py
+++ b/src/otx/engine/hpo/hpo_api.py
@@ -336,8 +336,11 @@ class HPOConfigurator:
 
         self._engine.datamodule.train_subset.batch_size = origin_bs
         self._engine.model.optimizer_callable.optimizer_kwargs["lr"] = origin_lr  # type: ignore[attr-defined]
+        logger.info(
+            "Max value of batch size search space : "
+            f"{self._hpo_config["search_space"]["datamodule.train_subset.batch_size"]["max"]} -> {adapted_bs}"
+        )
         self._hpo_config["search_space"]["datamodule.train_subset.batch_size"]["max"] = adapted_bs
-        logger.info(f"Max value of batch size search space : {origin_bs} -> {adapted_bs}")
 
     @staticmethod
     def _remove_wrong_search_space(search_space: dict[str, dict[str, Any]]) -> None:


### PR DESCRIPTION
### Summary
This PR fixes wrong HPO log.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
