### PR TITLE
Simplify async OV inference

### DIFF
--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -12,7 +12,7 @@ import json
 import logging
 import warnings
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, NamedTuple, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, Sequence
 
 import numpy as np
 import openvino
@@ -928,20 +928,9 @@ class OVModel(OTXModel, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEntity]):
 
     def _forward(self, inputs: T_OTXBatchDataEntity) -> T_OTXBatchPredEntity:
         """Model forward function."""
-
-        def _callback(result: NamedTuple, idx: int) -> None:
-            output_dict[idx] = result
-
         numpy_inputs = self._customize_inputs(inputs)["inputs"]
         if self.async_inference:
-            output_dict: dict[int, NamedTuple] = {}
-            self.model.set_callback(_callback)
-            for idx, im in enumerate(numpy_inputs):
-                if not self.model.is_ready():
-                    self.model.await_any()
-                self.model.infer_async(im, user_data=idx)
-            self.model.await_all()
-            outputs = [out[1] for out in sorted(output_dict.items())]
+            outputs = self.model.infer_batch(numpy_inputs)
         else:
             outputs = [self.model(im) for im in numpy_inputs]
 


### PR DESCRIPTION
### Summary
Use MAPI's method instead of an external pipeline
