### PR TITLE
Decrease CPU memory usage during unit test

### DIFF
--- a/tests/unit/core/data/test_tiling.py
+++ b/tests/unit/core/data/test_tiling.py
@@ -516,7 +516,7 @@ class TestOTXTiling:
     def test_seg_tiler(self, mocker):
         rng = np.random.default_rng()
         rnd_tile_size = rng.integers(low=100, high=500)
-        rnd_tile_overlap = min(rng.random(), 0.99)
+        rnd_tile_overlap = rng.random() * 0.75
         image_size = rng.integers(low=1000, high=5000)
         np_image = np.zeros((image_size, image_size, 3), dtype=np.uint8)
 


### PR DESCRIPTION
### Summary
tests/unit/core/data/test_tiling.py::TestOTXTiling::test_seg_tiler uses more CPU memory than expectation sometimes, which makes an error during CI.
This PR fixes it.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
