### PR TITLE
Disable mem cache during API integration test

### DIFF
--- a/tests/integration/api/conftest.py
+++ b/tests/integration/api/conftest.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+from __future__ import annotations
+
+import pytest
+from otx.core.data.mem_cache import MemCacheHandlerSingleton
+
+
+@pytest.fixture(autouse=True)
+def fxt_disable_mem_cache():
+    """Disable mem cache to reduce memory usage."""
+
+    original_mem_limit = MemCacheHandlerSingleton.CPU_MEM_LIMITS_GIB
+    MemCacheHandlerSingleton.CPU_MEM_LIMITS_GIB = 99999999
+    yield
+    MemCacheHandlerSingleton.CPU_MEM_LIMITS_GIB = original_mem_limit


### PR DESCRIPTION
### Summary
Everytime data module is made during integration test, mem cache handler is created but isn't released.
It can't solve the current detection integration test issue but it can relieve the OOM issue in some degree.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
