### PR TITLE
Add OV inference for 3d detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
   (https://github.com/openvinotoolkit/training_extensions/pull/3954)
 - Add 3D Object Detection task with MonoDETR model
   (https://github.com/openvinotoolkit/training_extensions/pull/3979)
+- Add OpenVINO inference for 3D Object Detection task
+  (https://github.com/openvinotoolkit/training_extensions/pull/4017)
 
 ### Enhancements
 

--- a/src/otx/algo/common/losses/cross_focal_loss.py
+++ b/src/otx/algo/common/losses/cross_focal_loss.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import torch
 import torch.nn.functional
 from torch import Tensor, nn
-from torch.cuda.amp import custom_fwd
+from torch.amp import custom_fwd
 
 from .focal_loss import py_sigmoid_focal_loss
 
@@ -79,7 +79,7 @@ class CrossSigmoidFocalLoss(nn.Module):
 
         self.cls_criterion = cross_sigmoid_focal_loss
 
-    @custom_fwd(cast_inputs=torch.float32)
+    @custom_fwd(cast_inputs=torch.float32, device_type="cuda")
     def forward(
         self,
         pred: Tensor,

--- a/src/otx/algo/object_detection_3d/backbones/monodetr_resnet.py
+++ b/src/otx/algo/object_detection_3d/backbones/monodetr_resnet.py
@@ -12,6 +12,7 @@ import torchvision
 from torch import nn
 from torchvision.models._utils import IntermediateLayerGetter
 
+from otx.algo.classification.backbones.torchvision import get_model_weights
 from otx.algo.modules.norm import FrozenBatchNorm2d
 from otx.algo.object_detection_3d.utils.utils import NestedTensor
 
@@ -111,7 +112,7 @@ class Backbone(BackboneBase):
         norm_layer = FrozenBatchNorm2d
         backbone = getattr(torchvision.models, name)(
             replace_stride_with_dilation=[False, False, dilation],
-            pretrained=True,
+            weights=get_model_weights(name).IMAGENET1K_V1, # the same as pretrained=True
             norm_layer=norm_layer,
         )
         super().__init__(backbone, train_backbone, return_interm_layers)

--- a/src/otx/algo/object_detection_3d/backbones/monodetr_resnet.py
+++ b/src/otx/algo/object_detection_3d/backbones/monodetr_resnet.py
@@ -112,7 +112,7 @@ class Backbone(BackboneBase):
         norm_layer = FrozenBatchNorm2d
         backbone = getattr(torchvision.models, name)(
             replace_stride_with_dilation=[False, False, dilation],
-            weights=get_model_weights(name).IMAGENET1K_V1, # the same as pretrained=True
+            weights=get_model_weights(name).IMAGENET1K_V1,  # the same as pretrained=True
             norm_layer=norm_layer,
         )
         super().__init__(backbone, train_backbone, return_interm_layers)

--- a/src/otx/algo/object_detection_3d/backbones/monodetr_resnet.py
+++ b/src/otx/algo/object_detection_3d/backbones/monodetr_resnet.py
@@ -10,9 +10,9 @@ from typing import Any, ClassVar
 import torch
 import torchvision
 from torch import nn
+from torchvision.models import get_model_weights
 from torchvision.models._utils import IntermediateLayerGetter
 
-from otx.algo.classification.backbones.torchvision import get_model_weights
 from otx.algo.modules.norm import FrozenBatchNorm2d
 from otx.algo.object_detection_3d.utils.utils import NestedTensor
 

--- a/src/otx/algo/object_detection_3d/heads/depthaware_transformer.py
+++ b/src/otx/algo/object_detection_3d/heads/depthaware_transformer.py
@@ -409,6 +409,7 @@ class VisualEncoder(nn.Module):
             ref_y, ref_x = torch.meshgrid(
                 torch.linspace(0.5, h_ - 0.5, h_, dtype=torch.float32, device=device),
                 torch.linspace(0.5, w_ - 0.5, w_, dtype=torch.float32, device=device),
+                indexing="ij",
             )
             ref_y = ref_y.reshape(-1)[None] / (valid_ratios[:, None, lvl, 1] * h_)
             ref_x = ref_x.reshape(-1)[None] / (valid_ratios[:, None, lvl, 0] * w_)

--- a/src/otx/algo/object_detection_3d/monodetr3d.py
+++ b/src/otx/algo/object_detection_3d/monodetr3d.py
@@ -28,8 +28,8 @@ from otx.core.model.detection_3d import OTX3DDetectionModel
 class MonoDETR3D(OTX3DDetectionModel):
     """OTX Detection model class for MonoDETR3D."""
 
-    mean: tuple[float, float, float] = (0.485, 0.456, 0.406)
-    std: tuple[float, float, float] = (0.229, 0.224, 0.225)
+    mean: tuple[float, float, float] = (123.675, 116.28, 103.53)
+    std: tuple[float, float, float] = (58.395, 57.12, 57.375)
     input_size: tuple[int, int] = (384, 1280)  # HxW
     load_from: str | None = None
 
@@ -240,7 +240,7 @@ class MonoDETR3D(OTX3DDetectionModel):
                 "opset_version": 16,
             },
             input_names=["images", "calib_matrix", "img_sizes"],
-            output_names=["scores", "boxes_3d", "size_3d", "heading_angle", "depth"],
+            output_names=["scores", "boxes_3d", "size_3d", "depth", "heading_angle"],
         )
 
     @property

--- a/src/otx/core/data/entity/utils.py
+++ b/src/otx/core/data/entity/utils.py
@@ -34,7 +34,7 @@ def register_pytree_node(cls: type[T_OTXDataEntity]) -> type[T_OTXDataEntity]:
     """
     flatten_fn = lambda obj: (list(obj.values()), list(obj.keys()))
     unflatten_fn = lambda values, context: cls(**dict(zip(context, values)))
-    pytree._register_pytree_node(  # noqa: SLF001
+    pytree.register_pytree_node(  # noqa: SLF001
         cls,
         flatten_fn=flatten_fn,
         unflatten_fn=unflatten_fn,

--- a/src/otx/core/data/entity/utils.py
+++ b/src/otx/core/data/entity/utils.py
@@ -34,7 +34,7 @@ def register_pytree_node(cls: type[T_OTXDataEntity]) -> type[T_OTXDataEntity]:
     """
     flatten_fn = lambda obj: (list(obj.values()), list(obj.keys()))
     unflatten_fn = lambda values, context: cls(**dict(zip(context, values)))
-    pytree.register_pytree_node(  # noqa: SLF001
+    pytree.register_pytree_node(
         cls,
         flatten_fn=flatten_fn,
         unflatten_fn=unflatten_fn,

--- a/src/otx/core/model/detection_3d.py
+++ b/src/otx/core/model/detection_3d.py
@@ -229,7 +229,6 @@ class MonoDETRModel(ImageModel):
         Args:
             inference_adapter (InferenceAdapter): inference adapter containing the underlying model.
             configuration (dict, optional): configuration overrides the model parameters (see parameters() method).
-              Defaults to dict().
             preload (bool, optional): forces inference adapter to load the model. Defaults to False.
         """
         super().__init__(inference_adapter, configuration, preload)
@@ -449,7 +448,6 @@ class OV3DDetectionModel(OVModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
         depth = torch.gather(depth, 1, topk_boxes.repeat(1, 1, 2))
         # 3d dims decoding
         size_3d = torch.gather(size_3d, 1, topk_boxes.repeat(1, 1, 3))
-        # 2d boxes of the corners decoding
 
         return labels, scores, size_3d, heading, boxes_3d, depth
 

--- a/src/otx/core/model/detection_3d.py
+++ b/src/otx/core/model/detection_3d.py
@@ -5,23 +5,26 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 import torch
+from model_api.models import ImageModel
 from torchvision.ops import box_convert
 
+from otx.algo.object_detection_3d.utils.utils import box_cxcylrtb_to_xyxy
 from otx.algo.utils.mmengine_utils import load_checkpoint
 from otx.core.data.dataset.utils.kitti_utils import class2angle
-from otx.core.data.entity.base import ImageInfo
+from otx.core.data.entity.base import ImageInfo, OTXBatchLossEntity
 from otx.core.data.entity.object_detection_3d import Det3DBatchDataEntity, Det3DBatchPredEntity
 from otx.core.metrics import MetricInput
 from otx.core.metrics.average_precision_3d import KittiMetric
-from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel
+from otx.core.model.base import DefaultOptimizerCallable, DefaultSchedulerCallable, OTXModel, OVModel
 from otx.core.types.export import TaskLevelExportParameters
 
 if TYPE_CHECKING:
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+    from model_api.adapters.inference_adapter import InferenceAdapter
     from torch import nn
 
     from otx.core.metrics import MetricCallable
@@ -73,8 +76,8 @@ class OTX3DDetectionModel(OTXModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
     def _export_parameters(self) -> TaskLevelExportParameters:
         """Defines parameters required to export a particular model implementation."""
         return super()._export_parameters.wrap(
-            model_type="ssd",
-            task_type="detection",
+            model_type="mono_3d_det",
+            task_type="3d_detection",
         )
 
     def _convert_pred_entity_to_compute_metric(
@@ -82,68 +85,10 @@ class OTX3DDetectionModel(OTXModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
         preds: Det3DBatchPredEntity,
         inputs: Det3DBatchDataEntity,
     ) -> MetricInput:
-        """Converts the prediction entity to the format required for computing metrics.
-
-        Args:
-            preds (Det3DBatchPredEntity): Prediction entity.
-            inputs (Det3DBatchDataEntity): Input data entity.
-        """
-        boxes = preds.boxes_3d
-        # bbox 2d decoding
-        xywh_2d = box_convert(preds.boxes, "xyxy", "cxcywh")
-
-        xs3d = boxes[:, :, 0:1]
-        ys3d = boxes[:, :, 1:2]
-        xs2d = xywh_2d[:, :, 0:1]
-        ys2d = xywh_2d[:, :, 1:2]
-
-        batch = len(boxes)
-        labels = preds.labels.view(batch, -1, 1)
-        scores = preds.scores.view(batch, -1, 1)
-        xs2d = xs2d.view(batch, -1, 1)
-        ys2d = ys2d.view(batch, -1, 1)
-        xs3d = xs3d.view(batch, -1, 1)
-        ys3d = ys3d.view(batch, -1, 1)
-
-        detections = (
-            torch.cat(
-                [
-                    labels,
-                    scores,
-                    xs2d,
-                    ys2d,
-                    preds.size_2d,
-                    preds.depth[:, :, 0:1],
-                    preds.heading_angle,
-                    preds.size_3d,
-                    xs3d,
-                    ys3d,
-                    torch.exp(-preds.depth[:, :, 1:2]),
-                ],
-                dim=2,
-            )
-            .detach()
-            .cpu()
-            .numpy()
-        )
-
-        img_sizes = np.array([img_info.ori_shape for img_info in inputs.imgs_info])
-        calib_matrix = [p2.detach().cpu().numpy() for p2 in inputs.calib_matrix]
-        result_list = self._decode_detections_for_kitti_format(
-            detections,
-            img_sizes,
-            calib_matrix,
-            class_names=self.label_info.label_names,
-            threshold=self.score_threshold,
-        )
-
-        return {
-            "preds": result_list,
-            "target": inputs.original_kitti_format,  # type: ignore[dict-item]
-        }
+        return _convert_pred_entity_to_compute_metric(preds, inputs, self.label_info.label_names, self.score_threshold)
 
     @staticmethod
-    def _decode_detections_for_kitti_format(
+    def decode_detections_for_kitti_format(
         dets: np.ndarray,
         img_size: np.ndarray,
         calib_matrix: list[np.ndarray],
@@ -256,7 +201,7 @@ class OTX3DDetectionModel(OTXModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
             raise ValueError(msg)
 
         images = torch.rand(batch_size, 3, *self.input_size)
-        calib_matrix = torch.rand(batch_size, 3, 4)
+        calib_matrix = [torch.rand(3, 4) for _ in range(batch_size)]
         infos = []
         for i, img in enumerate(images):
             infos.append(
@@ -270,15 +215,15 @@ class OTX3DDetectionModel(OTXModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
             batch_size,
             images,
             infos,
-            boxes=torch.zeros(batch_size, 0, 4),
-            labels=torch.zeros(batch_size, 0, 1),
+            boxes=[torch.Tensor(0)] * batch_size,
+            labels=[torch.LongTensor(0)] * batch_size,
             calib_matrix=calib_matrix,
-            boxes_3d=torch.zeros(batch_size, 0, 6),
-            size_2d=torch.zeros(batch_size, 0, 2),
-            size_3d=torch.zeros(batch_size, 0, 3),
-            depth=torch.zeros(batch_size, 0, 1),
-            heading_angle=torch.zeros(batch_size, 0, 2),
-            original_kitti_format=[None],
+            boxes_3d=[torch.LongTensor(0)] * batch_size,
+            size_2d=[],
+            size_3d=[torch.LongTensor(0)] * batch_size,
+            depth=[torch.LongTensor(0)] * batch_size,
+            heading_angle=[torch.LongTensor(0)] * batch_size,
+            original_kitti_format=[],
         )
 
     def get_classification_layers(self, prefix: str = "model.") -> dict[str, dict[str, int]]:
@@ -295,3 +240,315 @@ class OTX3DDetectionModel(OTXModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
                 num_extra_classes = 6 * sample_model_dim - 5 * incremental_model_dim
                 classification_layers[prefix + key] = {"stride": stride, "num_extra_classes": num_extra_classes}
         return classification_layers
+
+
+class MonoDETRModel(ImageModel):
+    """A wrapper for MonoDETR 3d object detection model."""
+
+    __model__ = "mono_3d_det"
+
+    def __init__(self, inference_adapter: InferenceAdapter, configuration: dict[str, Any], preload: bool = False):
+        """Initializes a 3d detection model.
+
+        Args:
+            inference_adapter (InferenceAdapter): inference adapter containing the underlying model.
+            configuration (dict, optional): configuration overrides the model parameters (see parameters() method).
+              Defaults to dict().
+            preload (bool, optional): forces inference adapter to load the model. Defaults to False.
+        """
+        super().__init__(inference_adapter, configuration, preload)
+        self._check_io_number(3, 5)
+
+    def preprocess(self, inputs: dict[str, np.ndarray]) -> tuple[dict[str, Any], ...]:
+        """Preprocesses the input data for the model.
+
+        Args:
+            inputs (dict[str, np.ndarray]): a dict with image, calibration matrix, and image size
+
+        Returns:
+            tuple[dict[str, Any], ...]: a tuple with the preprocessed inputs and meta information
+        """
+        return {
+            self.image_blob_name: inputs["image"][None],
+            "calib_matrix": inputs["calib"],
+            "img_sizes": inputs["img_size"][None],
+        }, {
+            "original_shape": inputs["image"].shape,
+            "resized_shape": (self.w, self.h, self.c),
+        }
+
+    def _get_inputs(self) -> tuple[list[Any], list[Any]]:
+        """Defines the model inputs for images and additional info.
+
+        Raises:
+            WrapperError: if the wrapper failed to define appropriate inputs for images
+
+        Returns:
+            - list of inputs names for images
+            - list of inputs names for additional info
+        """
+        image_blob_names, image_info_blob_names = [], []
+        for name, metadata in self.inputs.items():
+            if len(metadata.shape) == 4:
+                image_blob_names.append(name)
+            elif len(metadata.shape) == 2:
+                image_info_blob_names.append(name)
+
+        if not image_blob_names:
+            self.raise_error(
+                "Failed to identify the input for the image: no 4D input layer found",
+            )
+        return image_blob_names, image_info_blob_names
+
+    def postprocess(
+        self,
+        outputs: dict[str, np.ndarray],
+        meta: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Applies SCC decoded to the model outputs.
+
+        Args:
+            outputs (dict[str, np.ndarray]): raw outputs of the model
+            meta (dict[str, Any]): meta information about the input data
+
+        Returns:
+            dict[str, Any]: postprocessed model outputs
+        """
+        result = {}
+        for k in outputs:
+            result[k] = np.copy(outputs[k])
+
+        return result
+
+
+class OV3DDetectionModel(OVModel[Det3DBatchDataEntity, Det3DBatchPredEntity]):
+    """3d detection model compatible for OpenVINO IR inference.
+
+    It can consume OpenVINO IR model path or model name from Intel OMZ repository
+    and create the OTX 3d detection model compatible for OTX testing pipeline.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        model_type: str = "mono_3d_det",
+        async_inference: bool = True,
+        max_num_requests: int | None = None,
+        use_throughput_mode: bool = True,
+        model_api_configuration: dict[str, Any] | None = None,
+        metric: MetricCallable = KittiMetric,
+        score_threshold: float = 0.2,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            model_name=model_name,
+            model_type=model_type,
+            async_inference=async_inference,
+            max_num_requests=max_num_requests,
+            use_throughput_mode=use_throughput_mode,
+            model_api_configuration=model_api_configuration,
+            metric=metric,
+        )
+        self.score_threshold = score_threshold
+
+    def _customize_inputs(
+        self,
+        entity: Det3DBatchDataEntity,
+    ) -> dict[str, Any]:
+        img_sizes = np.array([img_info.ori_shape for img_info in entity.imgs_info])
+        images = [np.transpose(im.cpu().numpy(), (1, 2, 0)) for im in entity.images]
+
+        return {
+            "images": images,
+            "calibs": [p2.unsqueeze(0).cpu().numpy() for p2 in entity.calib_matrix],
+            "targets": [],
+            "img_sizes": img_sizes,
+            "mode": "predict",
+        }
+
+    def _customize_outputs(
+        self,
+        outputs: list[NamedTuple],
+        inputs: Det3DBatchDataEntity,
+    ) -> Det3DBatchPredEntity | OTXBatchLossEntity:
+        stacked_outputs: dict[str, Any] = {}
+
+        for output in outputs:
+            for k in output:
+                if k in stacked_outputs:
+                    stacked_outputs[k] = torch.cat((stacked_outputs[k], torch.tensor(output[k])), 0)
+                else:
+                    stacked_outputs[k] = torch.tensor(output[k])
+
+        labels, scores, size_3d, heading_angle, boxes_3d, depth = self.extract_dets_from_outputs(stacked_outputs)
+        # bbox 2d decoding
+        boxes_2d = box_cxcylrtb_to_xyxy(boxes_3d)
+        xywh_2d = box_convert(boxes_2d, "xyxy", "cxcywh")
+        # size 2d decoding
+        size_2d = xywh_2d[:, :, 2:4]
+
+        return Det3DBatchPredEntity(
+            batch_size=len(outputs),
+            images=inputs.images,
+            imgs_info=inputs.imgs_info,
+            calib_matrix=inputs.calib_matrix,
+            boxes=boxes_2d,
+            labels=labels,
+            boxes_3d=boxes_3d,
+            size_2d=size_2d,
+            size_3d=size_3d,
+            depth=depth,
+            heading_angle=heading_angle,
+            scores=scores,
+            original_kitti_format=[None],
+        )
+
+    def _forward(self, inputs: Det3DBatchDataEntity) -> Det3DBatchPredEntity:
+        """Model forward function."""
+        all_inputs = self._customize_inputs(inputs)
+
+        model_ready_inputs = []
+        for image, calib, img_size in zip(all_inputs["images"], all_inputs["calibs"], all_inputs["img_sizes"]):
+            model_ready_inputs.append(
+                {
+                    "image": image,
+                    "calib": calib,
+                    "img_size": img_size,
+                },
+            )
+
+        if self.async_inference:
+            outputs = self.model.infer_batch(model_ready_inputs)
+        else:
+            outputs = []
+            for model_input in model_ready_inputs:
+                outputs.append(self.model(model_input))
+
+        customized_outputs = self._customize_outputs(outputs, inputs)
+
+        if isinstance(customized_outputs, OTXBatchLossEntity):
+            raise TypeError(customized_outputs)
+
+        return customized_outputs
+
+    def transform_fn(self, data_batch: Det3DBatchDataEntity) -> dict:
+        """Data transform function for PTQ."""
+        all_inputs = self._customize_inputs(data_batch)
+        image = all_inputs["images"][0]
+        model = self.model
+        resized_image = model.resize(image, (model.w, model.h))
+        resized_image = model.input_transform(resized_image)
+
+        return {
+            "images": model._change_layout(resized_image),  # noqa: SLF001,
+            "calib_matrix": all_inputs["calibs"][0],
+            "img_sizes": all_inputs["img_sizes"][0][None],
+        }
+
+    @staticmethod
+    def extract_dets_from_outputs(outputs: dict[str, torch.Tensor], topk: int = 50) -> tuple[torch.Tensor, ...]:
+        """Extract detection results from model outputs."""
+        # b, q, c
+        out_logits = outputs["scores"]
+        out_bbox = outputs["boxes_3d"]
+
+        prob = out_logits
+        topk_values, topk_indexes = torch.topk(prob.view(out_logits.shape[0], -1), topk, dim=1)
+
+        # final scores
+        scores = topk_values
+        # final indexes
+        topk_boxes = (topk_indexes // out_logits.shape[2]).unsqueeze(-1)
+        # final labels
+        labels = topk_indexes % out_logits.shape[2]
+
+        heading = outputs["heading_angle"]
+        size_3d = outputs["size_3d"]
+        depth = outputs["depth"]
+        # decode boxes
+        boxes_3d = torch.gather(out_bbox, 1, topk_boxes.repeat(1, 1, 6))  # b, q', 4
+        # heading angle decoding
+        heading = torch.gather(heading, 1, topk_boxes.repeat(1, 1, 24))
+        # depth decoding
+        depth = torch.gather(depth, 1, topk_boxes.repeat(1, 1, 2))
+        # 3d dims decoding
+        size_3d = torch.gather(size_3d, 1, topk_boxes.repeat(1, 1, 3))
+        # 2d boxes of the corners decoding
+
+        return labels, scores, size_3d, heading, boxes_3d, depth
+
+    def _convert_pred_entity_to_compute_metric(
+        self,
+        preds: Det3DBatchPredEntity,
+        inputs: Det3DBatchDataEntity,
+    ) -> MetricInput:
+        return _convert_pred_entity_to_compute_metric(preds, inputs, self.label_info.label_names, self.score_threshold)
+
+
+def _convert_pred_entity_to_compute_metric(
+    preds: Det3DBatchPredEntity,
+    inputs: Det3DBatchDataEntity,
+    label_names: list[str],
+    score_threshold: float,
+) -> MetricInput:
+    """Converts the prediction entity to the format required for computing metrics.
+
+    Args:
+        preds (Det3DBatchPredEntity): Prediction entity.
+        inputs (Det3DBatchDataEntity): Input data entity.
+        label_names (list[str]): List of label names.
+        score_threshold (float): Score threshold for filtering the predictions.
+    """
+    boxes = preds.boxes_3d
+    # bbox 2d decoding
+    xywh_2d = box_convert(preds.boxes, "xyxy", "cxcywh")
+
+    xs3d = boxes[:, :, 0:1]
+    ys3d = boxes[:, :, 1:2]
+    xs2d = xywh_2d[:, :, 0:1]
+    ys2d = xywh_2d[:, :, 1:2]
+
+    batch = len(boxes)
+    labels = preds.labels.view(batch, -1, 1)
+    scores = preds.scores.view(batch, -1, 1)
+    xs2d = xs2d.view(batch, -1, 1)
+    ys2d = ys2d.view(batch, -1, 1)
+    xs3d = xs3d.view(batch, -1, 1)
+    ys3d = ys3d.view(batch, -1, 1)
+
+    detections = (
+        torch.cat(
+            [
+                labels,
+                scores,
+                xs2d,
+                ys2d,
+                preds.size_2d,
+                preds.depth[:, :, 0:1],
+                preds.heading_angle,
+                preds.size_3d,
+                xs3d,
+                ys3d,
+                torch.exp(-preds.depth[:, :, 1:2]),
+            ],
+            dim=2,
+        )
+        .detach()
+        .cpu()
+        .numpy()
+    )
+
+    img_sizes = np.array([img_info.ori_shape for img_info in inputs.imgs_info])
+    calib_matrix = [p2.detach().cpu().numpy() for p2 in inputs.calib_matrix]
+    result_list = OTX3DDetectionModel.decode_detections_for_kitti_format(
+        detections,
+        img_sizes,
+        calib_matrix,
+        class_names=label_names,
+        threshold=score_threshold,
+    )
+
+    return {
+        "preds": result_list,
+        "target": inputs.original_kitti_format,  # type: ignore[dict-item]
+    }

--- a/src/otx/engine/engine.py
+++ b/src/otx/engine/engine.py
@@ -874,7 +874,7 @@ class Engine:
                 input_batch = self.model.get_dummy_input(1)
                 model_fwd = lambda: self.model.forward(input_batch)
                 depth = 3 if extended_stats else 0
-                fwd_flops = measure_flops(self.model.model, model_fwd, print_stats_depth=depth)
+                fwd_flops = measure_flops(model_fwd, print_stats_depth=depth)
                 flops_str = convert_num_with_suffix(fwd_flops, get_suffix_str(fwd_flops * 10**3))
                 final_stats["complexity"] = flops_str + " MACs"
             except Exception as e:

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -92,6 +92,7 @@ OVMODEL_PER_TASK = {
     OTXTaskType.ANOMALY_DETECTION: "otx.algo.anomaly.openvino_model.AnomalyOpenVINO",
     OTXTaskType.ANOMALY_SEGMENTATION: "otx.algo.anomaly.openvino_model.AnomalyOpenVINO",
     OTXTaskType.KEYPOINT_DETECTION: "otx.core.model.keypoint_detection.OVKeypointDetectionModel",
+    OTXTaskType.OBJECT_DETECTION_3D: "otx.core.model.detection_3d.OV3DDetectionModel",
 }
 
 

--- a/src/otx/recipe/object_detection_3d/openvino_model.yaml
+++ b/src/otx/recipe/object_detection_3d/openvino_model.yaml
@@ -1,0 +1,39 @@
+model:
+  class_path: otx.core.model.detection_3d.OV3DDetectionModel
+  init_args:
+    label_info: 3
+    model_name: monodetr-001
+    model_type: "mono_3d_det"
+    async_inference: true
+    use_throughput_mode: true
+
+engine:
+  task: OBJECT_DETECTION_3D
+  device: cpu
+
+callback_monitor: val/mAP_bbox_2d
+
+data: ../_base_/data/object_detection_3d.yaml
+overrides:
+  reset:
+    - data.train_subset.transforms
+    - data.val_subset.transforms
+    - data.test_subset.transforms
+
+  data:
+    stack_images: false
+    train_subset:
+      to_tv_image: false
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+
+    val_subset:
+      to_tv_image: false
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage
+
+    test_subset:
+      to_tv_image: false
+      batch_size: 64
+      transforms:
+        - class_path: torchvision.transforms.v2.ToImage

--- a/src/otx/utils/utils.py
+++ b/src/otx/utils/utils.py
@@ -263,7 +263,6 @@ def check_pickleable(obj: Any) -> bool:  # noqa: ANN401
 
 
 def measure_flops(
-    model: torch.nn.Module,
     forward_fn: Callable[[], torch.Tensor],
     loss_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
     print_stats_depth: int = 0,

--- a/src/otx/utils/utils.py
+++ b/src/otx/utils/utils.py
@@ -271,7 +271,7 @@ def measure_flops(
     """Utility to compute the total number of FLOPs used by a module during training or during inference."""
     from torch.utils.flop_counter import FlopCounterMode
 
-    flop_counter = FlopCounterMode(model, display=print_stats_depth > 0, depth=print_stats_depth)
+    flop_counter = FlopCounterMode(display=print_stats_depth > 0, depth=print_stats_depth)
     with flop_counter:
         if loss_fn is None:
             forward_fn()

--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -181,7 +181,7 @@ def test_otx_e2e_cli(
         assert (latest_dir / export_case.expected_output).exists()
 
     if task == OTXTaskType.OBJECT_DETECTION_3D:
-        return # "3D Object Detection is not supported for OV IR inference.
+        return  # "3D Object Detection is not supported for OV IR inference.
 
     # 4) infer of the exported models
     ov_output_dir = tmp_path_test / "outputs" / "OPENVINO"
@@ -319,7 +319,7 @@ def test_otx_explain_e2e_cli(
         "rtdetr_50",
         "rtdetr_101",
         "maskrcnn_r50_tv",
-        "maskrcnn_r50_tv_tile"
+        "maskrcnn_r50_tv_tile",
     ]
 
     if any(model in model_name for model in models_not_supported):

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -195,14 +195,6 @@ def test_otx_e2e(
         assert latest_dir.exists()
         assert (latest_dir / export_case.expected_output).exists()
 
-    if "keypoint" in recipe:
-        print("Inference and explain are not supported for keypoint detection")
-        return
-
-    if "monodetr3d" in recipe:
-        print("Inference and explain are not supported for object detection 3d")
-        return
-
     # 4) infer of the exported models
     ov_output_dir = tmp_path_test / "outputs" / "OPENVINO"
     ov_files = list(ov_output_dir.rglob("exported*.xml"))
@@ -265,8 +257,13 @@ def test_otx_e2e(
 
     if "yolov9" in model_name:
         return  # RT-DETR currently is not supported.
+
     if "keypoint" in recipe:
         print("Explain is not supported for keypoint detection")
+        return
+
+    if "monodetr3d" in recipe:
+        print("Explain is not supported for object detection 3d")
         return
 
     tmp_path_test = tmp_path / f"otx_export_xai_{model_name}"

--- a/tests/integration/cli/test_export_inference.py
+++ b/tests/integration/cli/test_export_inference.py
@@ -49,6 +49,7 @@ TASK_NAME_TO_MAIN_METRIC_NAME = {
     "zero_shot_visual_prompting": "test/f1-score",
     "action_classification": "test/accuracy",
     "keypoint_detection": "test/PCK",
+    "object_detection_3d": "test/mAP_bbox_3d",
 }
 
 

--- a/tests/unit/core/model/test_detection_3d.py
+++ b/tests/unit/core/model/test_detection_3d.py
@@ -54,8 +54,8 @@ class TestOTX3DDetectionModel:
 
     def test_export_parameters(self, model):
         params = model._export_parameters
-        assert params.model_type == "ssd"  # TODO(Vlad): should be "object_detection_3d" when IR Inference is integrated
-        assert params.task_type == "detection"
+        assert params.model_type == "mono_3d_det"
+        assert params.task_type == "3d_detection"
 
     @pytest.mark.parametrize(
         ("label_info", "expected_label_info"),

--- a/tests/unit/core/model/test_detection_3d.py
+++ b/tests/unit/core/model/test_detection_3d.py
@@ -109,3 +109,19 @@ class TestOTX3DDetectionModel:
         batch_size = 2
         batch = model.get_dummy_input(batch_size)
         assert batch.batch_size == batch_size
+
+    def test_convert_pred_entity_to_compute_metric(self, model: OTX3DDetectionModel, batch_data_entity):
+        model.training = False
+        outputs = {
+            "scores": torch.randn(2, 50, 2),
+            "boxes_3d": torch.randn(2, 50, 6),
+            "boxes": torch.randn(2, 50, 4),
+            "size_3d": torch.randn(2, 50, 3),
+            "depth": torch.randn(2, 50, 2),
+            "heading_angle": torch.randn(2, 50, 24),
+        }
+        customized_outputs = model._customize_outputs(outputs, batch_data_entity)
+        converted_pred = model._convert_pred_entity_to_compute_metric(customized_outputs, batch_data_entity)
+
+        assert "preds" in converted_pred
+        assert "target" in converted_pred


### PR DESCRIPTION
### Summary
- PTQ shows 0 accuracy now, additional configuration finetuning is required. One of the root causes is lower than before quantization confidence.
- MAPI wrapper is temporally located in OTX, since the models design is not finalized yet.
- Fix warnings related to 3d detection
- CLI integration tests are enabled

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
