### PR TITLE
Fix empty bbox error for YOLOv9 to 2.3.0

### DIFF
--- a/src/otx/algo/detection/losses/yolov9_loss.py
+++ b/src/otx/algo/detection/losses/yolov9_loss.py
@@ -305,9 +305,20 @@ class BoxMatcher:
             predict (tuple[Tensor, Tensor]): The predicted class and bounding box.
 
         Returns:
-            tuple[Tensor, Tensor]: The aligned target tensor with (batch, targets, (class + 4)).
+            tuple[Tensor, Tensor]: The aligned target tensors with (batch, targets, (class + 4)) and (batch, targets).
         """
         predict_cls, predict_bbox = predict
+
+        # return if target has no gt information.
+        n_targets = target.shape[1]
+        if n_targets == 0:
+            device = predict_bbox.device
+            align_cls = torch.zeros_like(predict_cls, device=device)
+            align_bbox = torch.zeros_like(predict_bbox, device=device)
+            valid_mask = torch.zeros(predict_cls.shape[:2], dtype=bool, device=device)
+            anchor_matched_targets = torch.cat([align_cls, align_bbox], dim=-1)
+            return anchor_matched_targets, valid_mask
+
         target_cls, target_bbox = target.split([1, 4], dim=-1)  # B x N x (C B) -> B x N x C, B x N x B
         target_cls = target_cls.long().clamp(0)
 
@@ -341,8 +352,8 @@ class BoxMatcher:
         normalize_term = (target_matrix / (max_target + 1e-9)) * max_iou
         normalize_term = normalize_term.permute(0, 2, 1).gather(2, unique_indices)
         align_cls = align_cls * normalize_term * valid_mask[:, :, None]
-
-        return torch.cat([align_cls, align_bbox], dim=-1), valid_mask.bool()
+        anchor_matched_targets = torch.cat([align_cls, align_bbox], dim=-1)
+        return anchor_matched_targets, valid_mask
 
 
 class YOLOv9Criterion(nn.Module):

--- a/tests/e2e/cli/test_cli.py
+++ b/tests/e2e/cli/test_cli.py
@@ -181,7 +181,7 @@ def test_otx_e2e_cli(
         assert (latest_dir / export_case.expected_output).exists()
 
     if task == OTXTaskType.OBJECT_DETECTION_3D:
-        return # "3D Object Detection is not supported for OV IR inference.
+        return  # "3D Object Detection is not supported for OV IR inference.
 
     # 4) infer of the exported models
     ov_output_dir = tmp_path_test / "outputs" / "OPENVINO"
@@ -319,7 +319,7 @@ def test_otx_explain_e2e_cli(
         "rtdetr_50",
         "rtdetr_101",
         "maskrcnn_r50_tv",
-        "maskrcnn_r50_tv_tile"
+        "maskrcnn_r50_tv_tile",
     ]
 
     if any(model in model_name for model in models_not_supported):

--- a/tests/unit/algo/detection/losses/test_yolov9_loss.py
+++ b/tests/unit/algo/detection/losses/test_yolov9_loss.py
@@ -176,7 +176,7 @@ class TestBoxMatcher:
         assert torch.all(align_targets == 0)
 
         assert valid_masks.shape == (1, 8400)
-        assert torch.all(valid_masks == False)
+        assert torch.all(~valid_masks)
 
 
 class TestYOLOv9Criterion:

--- a/tests/unit/algo/detection/losses/test_yolov9_loss.py
+++ b/tests/unit/algo/detection/losses/test_yolov9_loss.py
@@ -163,6 +163,21 @@ class TestBoxMatcher:
         assert align_targets.shape == torch.Size([1, 3, 14])
         assert valid_masks.shape == torch.Size([1, 3])
 
+    def test_call_with_empty_bbox(self, box_matcher: BoxMatcher) -> None:
+        target = torch.zeros((1, 0, 5))
+
+        predict_cls = torch.rand((1, 8400, 10))
+        predict_bbox = torch.rand((1, 8400, 4))
+        predict = (predict_cls, predict_bbox)
+
+        align_targets, valid_masks = box_matcher(target, predict)
+
+        assert align_targets.shape == (1, 8400, 14)
+        assert torch.all(align_targets == 0)
+
+        assert valid_masks.shape == (1, 8400)
+        assert torch.all(valid_masks == False)
+
 
 class TestYOLOv9Criterion:
     @pytest.fixture()


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

https://github.com/openvinotoolkit/training_extensions/pull/4024 to 2.3.0
Missed changelog is updated in https://github.com/openvinotoolkit/training_extensions/pull/4038

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
