### PR TITLE
Fix multilabel_accuracy of MixedHLabelAccuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4014>)
 - Fix out_features in HierarchicalCBAMClsHead
   (<https://github.com/openvinotoolkit/training_extensions/pull/4016>)
+- Fix multilabel_accuracy of MixedHLabelAccuracy
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4042>)
 
 ## \[v2.1.0\]
 

--- a/tests/unit/core/metrics/test_accuracy.py
+++ b/tests/unit/core/metrics/test_accuracy.py
@@ -13,7 +13,7 @@ from otx.core.metrics.accuracy import (
     MultilabelAccuracywithLabelGroup,
 )
 from otx.core.types.label import HLabelInfo, LabelInfo
-from torchmetrics.classification.accuracy import BinaryAccuracy, MulticlassAccuracy
+from torchmetrics.classification.accuracy import BinaryAccuracy, MulticlassAccuracy, MultilabelAccuracy
 
 
 class TestAccuracy:
@@ -120,3 +120,28 @@ class TestMixedHLabelAccuracy:
                 head_logits_info={"head1": (0, 5), "head2": (5, 10)},
                 threshold_multilabel=0.5,
             )
+
+    def test_multilabel_accuracy(self, hlabel_accuracy) -> None:
+        # Normal Case: num_multilabel_classes > 1 -> MultilabelAccuracy
+        assert hlabel_accuracy.num_multilabel_classes == 3
+        assert isinstance(hlabel_accuracy.multilabel_accuracy, MultilabelAccuracy)
+
+        # Edge Case: num_multilabel_classes = 1 -> BinaryAccuracy
+        acc = MixedHLabelAccuracy(
+            num_multiclass_heads=2,
+            num_multilabel_classes=1,
+            head_logits_info={"head1": (0, 5), "head2": (5, 10)},
+            threshold_multilabel=0.5,
+        )
+        assert acc.num_multilabel_classes == 1
+        assert isinstance(acc.multilabel_accuracy, BinaryAccuracy)
+
+        # None Case: num_multilabel_classes = 0 -> None
+        acc = MixedHLabelAccuracy(
+            num_multiclass_heads=2,
+            num_multilabel_classes=0,
+            head_logits_info={"head1": (0, 5), "head2": (5, 10)},
+            threshold_multilabel=0.5,
+        )
+        assert acc.num_multilabel_classes == 0
+        assert acc.multilabel_accuracy is None


### PR DESCRIPTION
### Summary

https://jira.devtools.intel.com/browse/CVS-155228

https://github.com/Lightning-AI/torchmetrics/blob/6377aa5b6fe2863761839e6b8b5a857ef1b8acfa/src/torchmetrics/functional/classification/stat_scores.py#L583-L584

Due to the above code, an error is thrown if `num_multilabel_classes` is 1. To prevent this. (if num_multilabel_classes == 1, then use binary classification for that)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
