### PR TITLE
Update inst-seg model export to include feature vector and saliency map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Update visual prompting pipeline for multi-label zero-shot learning support
   (https://github.com/openvinotoolkit/training_extensions/pull/3993)
-- Fix MaskRCNN Explain Mode
+- Fix MaskRCNN/RTMDet-Inst/MaskRCNNTV Explain Mode
   (https://github.com/openvinotoolkit/training_extensions/pull/4053)
 
 ## \[2.3.0\]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 - Update visual prompting pipeline for multi-label zero-shot learning support
   (https://github.com/openvinotoolkit/training_extensions/pull/3993)
+- Fix MaskRCNN Explain Mode
+  (https://github.com/openvinotoolkit/training_extensions/pull/4053)
 
 ## \[2.3.0\]
 

--- a/src/otx/algo/explain/explain_algo.py
+++ b/src/otx/algo/explain/explain_algo.py
@@ -334,7 +334,7 @@ class InstSegExplainAlgo(BaseExplainAlgo):
         """Generate saliency maps from predicted masks by averaging and normalizing them per-class.
 
         Args:
-            predictions (list[InstanceData]): Predictions of Instance Segmentation model.
+            predictions (list[InstanceData] | list[dict[str, Tensor]): Predictions of Instance Segmentation model.
 
         Returns:
             torch.Tensor: Class-wise Saliency Maps. One saliency map per each class - [batch, class_id, H, W]

--- a/src/otx/algo/explain/explain_algo.py
+++ b/src/otx/algo/explain/explain_algo.py
@@ -13,6 +13,7 @@ from otx.core.types.explain import FeatureMapType
 
 if TYPE_CHECKING:
     import numpy as np
+    from torch import Tensor
 
     from otx.algo.utils.mmengine_utils import InstanceData
 
@@ -22,7 +23,10 @@ ExplainerForwardFn = HeadForwardFn
 
 def feature_vector_fn(feature_map: FeatureMapType) -> torch.Tensor:
     """Generate the feature vector by average pooling feature maps."""
-    if isinstance(feature_map, (list, tuple)):
+    if isinstance(feature_map, (list, tuple, dict)):
+        if isinstance(feature_map, dict):
+            feature_map = list(feature_map.values())
+
         # aggregate feature maps from Feature Pyramid Network
         feature_vector = [
             # Spatially pooling and flatten, B x C x H x W => B x C'
@@ -324,7 +328,7 @@ class InstSegExplainAlgo(BaseExplainAlgo):
 
     def func(
         self,
-        predictions: list[InstanceData],
+        predictions: list[InstanceData] | list[dict[str, Tensor]],
         _: int = -1,
     ) -> list[np.array]:
         """Generate saliency maps from predicted masks by averaging and normalizing them per-class.

--- a/src/otx/algo/instance_segmentation/heads/rtmdet_inst_head.py
+++ b/src/otx/algo/instance_segmentation/heads/rtmdet_inst_head.py
@@ -1094,8 +1094,10 @@ class RTMDetInstSepBNHead(RTMDetInstHead):
             mask_thr_binary (float): Binarization threshold for masks.
 
         Returns:
-            tuple[Tensor, Tensor]: (dets, labels), `dets` of shape [N, num_det, 5]
-                and `labels` of shape [N, num_det].
+            tuple[Tensor, Tensor, Tensor]:
+                det (Tensor): The detection results of shape [N, num_boxes, 5].
+                labels (Tensor): The labels of shape [N, num_boxes].
+                masks (Tensor): The masks of shape [N, num_boxes, H, W].
         """
         dets, labels, inds = multiclass_nms(
             bboxes,

--- a/src/otx/algo/instance_segmentation/maskdino.py
+++ b/src/otx/algo/instance_segmentation/maskdino.py
@@ -247,6 +247,7 @@ class MaskDINO(nn.Module):
         self,
         batch_inputs: Tensor,
         batch_img_metas: list[dict],
+        explain_mode: bool = False,
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Export the model."""
         b, _, h, w = batch_inputs.size()

--- a/src/otx/algo/instance_segmentation/maskrcnn.py
+++ b/src/otx/algo/instance_segmentation/maskrcnn.py
@@ -327,7 +327,7 @@ class MaskRCNN(ExplainableOTXInstanceSegModel):
                 "opset_version": 11,
                 "autograd_inlining": False,
             },
-            output_names=["bboxes", "labels", "masks"],
+            output_names=["bboxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:

--- a/src/otx/algo/instance_segmentation/rtmdet_inst.py
+++ b/src/otx/algo/instance_segmentation/rtmdet_inst.py
@@ -130,6 +130,7 @@ class RTMDetInst(ExplainableOTXInstanceSegModel):
                 "opset_version": 11,
                 "autograd_inlining": False,
             },
+            # TODO(Eugene): Add XAI support for RTMDetInst
             output_names=["bboxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 

--- a/src/otx/algo/instance_segmentation/rtmdet_inst.py
+++ b/src/otx/algo/instance_segmentation/rtmdet_inst.py
@@ -130,7 +130,6 @@ class RTMDetInst(ExplainableOTXInstanceSegModel):
                 "opset_version": 11,
                 "autograd_inlining": False,
             },
-            # TODO(Eugene): Add XAI support for RTMDetInst
             output_names=["bboxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 

--- a/src/otx/algo/instance_segmentation/segmentors/two_stage.py
+++ b/src/otx/algo/instance_segmentation/segmentors/two_stage.py
@@ -226,19 +226,44 @@ class TwoStageDetector(nn.Module):
         self,
         batch_inputs: torch.Tensor,
         batch_img_metas: list[dict],
-    ) -> tuple[torch.Tensor, ...]:
-        """Export for two stage detectors."""
-        x = self.extract_feat(batch_inputs)
+        explain_mode: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | dict:
+        """Export the model for ONNX/OpenVINO.
 
+        Args:
+            batch_inputs (torch.Tensor): image tensor with shape (N, C, H, W).
+            batch_img_metas (list[dict]): image information.
+            explain_mode (bool): whether to return feature vector.
+
+        Returns:
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor] | dict:
+                - bboxes (torch.Tensor): bounding boxes.
+                - labels (torch.Tensor): labels.
+                - masks (torch.Tensor): masks.
+                - feature_vector (torch.Tensor, optional): feature vector.
+                - saliency_map (torch.Tensor, optional): saliency map.
+        """
+        x = self.extract_feat(batch_inputs)
         rpn_results_list = self.rpn_head.export(
             x,
             batch_img_metas,
             rescale=False,
         )
-
-        return self.roi_head.export(
+        bboxes, labels, masks = self.roi_head.export(
             x,
             rpn_results_list,
             batch_img_metas,
             rescale=False,
         )
+
+        if explain_mode:
+            feature_vector = self.feature_vector_fn(x)
+            return {
+                "bboxes": bboxes,
+                "labels": labels,
+                "masks": masks,
+                "feature_vector": feature_vector,
+                # create dummy tensor as model API supports saliency_map
+                "saliency_map": torch.zeros(1),
+            }
+        return bboxes, labels, masks

--- a/src/otx/algo/instance_segmentation/segmentors/two_stage.py
+++ b/src/otx/algo/instance_segmentation/segmentors/two_stage.py
@@ -20,6 +20,14 @@ class TwoStageDetector(nn.Module):
 
     Two-stage detectors typically consisting of a region proposal network and a
     task-specific regression head.
+
+    Args:
+        backbone (nn.Module): Module that extracts features from the input image.
+        neck (nn.Module): Module that further processes the features and optionally generates. (e.g FPN)
+        rpn_head (nn.Module): Region proposal network head.
+        roi_head (nn.Module): Region of interest head.
+        roi_criterion (nn.Module): Criterion to calculate ROI loss.
+        rpn_criterion (nn.Module): Criterion to calculate RPN loss.
     """
 
     def __init__(
@@ -88,9 +96,9 @@ class TwoStageDetector(nn.Module):
 
     def forward(
         self,
-        entity: torch.Tensor,
+        entity: Tensor,
         mode: str = "tensor",
-    ) -> dict[str, torch.Tensor] | list[InstanceData] | tuple[torch.Tensor] | torch.Tensor:
+    ) -> dict[str, Tensor] | list[InstanceData] | tuple[Tensor, ...] | Tensor:
         """The unified entry for a forward process in both training and test.
 
         The method should accept three modes: "tensor", "predict" and "loss":
@@ -106,18 +114,14 @@ class TwoStageDetector(nn.Module):
         parameter update, which are supposed to be done in :meth:`train_step`.
 
         Args:
-            inputs (torch.Tensor): The input tensor with shape
-                (N, C, ...) in general.
-            data_samples (list[:obj:`DetDataSample`], optional): A batch of
-                data samples that contain annotations and predictions.
-                Defaults to None.
+            entity (Tensor): The input tensor with shape (N, C, ...) in general.
             mode (str): Return what kind of value. Defaults to 'tensor'.
 
         Returns:
             The return type depends on ``mode``.
 
             - If ``mode="tensor"``, return a tensor or a tuple of tensor.
-            - If ``mode="predict"``, return a list of :obj:`DetDataSample`.
+            - If ``mode="predict"``, return a list of :obj:`InstanceData`.
             - If ``mode="loss"``, return a dict of tensor.
         """
         if mode == "loss":
@@ -142,12 +146,11 @@ class TwoStageDetector(nn.Module):
             x = self.neck(x)
         return x
 
-    def loss(self, batch_inputs: InstanceSegBatchDataEntity) -> dict:
+    def loss(self, batch_inputs: InstanceSegBatchDataEntity) -> dict[str, Tensor]:
         """Calculate losses from a batch of inputs and data samples.
 
         Args:
-            batch_inputs (Tensor): Input images of shape (N, C, H, W).
-                These should usually be mean centered and std scaled.
+            batch_inputs (InstanceSegBatchDataEntity): The input data entity.
 
         Returns:
             dict: A dictionary of loss components
@@ -224,24 +227,29 @@ class TwoStageDetector(nn.Module):
 
     def export(
         self,
-        batch_inputs: torch.Tensor,
+        batch_inputs: Tensor,
         batch_img_metas: list[dict],
-        explain_mode: bool,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | dict:
+        explain_mode: bool = False,
+    ) -> tuple[Tensor, Tensor, Tensor] | dict[str, Tensor]:
         """Export the model for ONNX/OpenVINO.
 
         Args:
-            batch_inputs (torch.Tensor): image tensor with shape (N, C, H, W).
+            batch_inputs (Tensor): image tensor with shape (N, C, H, W).
             batch_img_metas (list[dict]): image information.
-            explain_mode (bool): whether to return feature vector.
+            explain_mode (bool, optional): whether to return feature vector. Defaults to False.
 
         Returns:
-            tuple[torch.Tensor, torch.Tensor, torch.Tensor] | dict:
-                - bboxes (torch.Tensor): bounding boxes.
-                - labels (torch.Tensor): labels.
-                - masks (torch.Tensor): masks.
-                - feature_vector (torch.Tensor, optional): feature vector.
-                - saliency_map (torch.Tensor, optional): saliency map.
+            dict[str, Tensor]: Return a dictionary when explain mode is ON containing the following items:
+                - bboxes (Tensor): bounding boxes.
+                - labels (Tensor): labels.
+                - masks (Tensor): masks.
+                - feature_vector (Tensor): feature vector.
+                - saliency_map (Tensor): dummy saliency map.
+
+            tuple[Tensor, Tensor, Tensor]: Return a tuple when explain mode is OFF containing the following items:
+                - bboxes (Tensor): bounding boxes.
+                - labels (Tensor): labels.
+                - masks (Tensor): masks.
         """
         x = self.extract_feat(batch_inputs)
         rpn_results_list = self.rpn_head.export(

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -16,8 +16,10 @@ from model_api.tilers import InstanceSegmentationTiler
 from torch import Tensor
 from torchmetrics import Metric, MetricCollection
 from torchvision import tv_tensors
+from torchvision.models.detection.image_list import ImageList
 
 from otx.algo.explain.explain_algo import InstSegExplainAlgo, feature_vector_fn
+from otx.algo.instance_segmentation.segmentors.maskrcnn_tv import MaskRCNN
 from otx.algo.instance_segmentation.segmentors.two_stage import TwoStageDetector
 from otx.algo.utils.mmengine_utils import InstanceData, load_checkpoint
 from otx.core.config.data import TileConfig
@@ -473,7 +475,7 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
         mode: str = "tensor",  # noqa: ARG004
     ) -> dict[str, Tensor]:
         """Forward func of the BaseDetector instance, which located in is in ExplainableOTXInstanceSegModel().model."""
-        x = self.extract_feat(entity.images)
+        x = self.backbone(entity.images) if isinstance(self, MaskRCNN) else self.extract_feat(entity.images)
 
         feature_vector = self.feature_vector_fn(x)
         predictions = self.get_results_from_head(x, entity)
@@ -482,8 +484,8 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
             # Export case, consists of tensors
             # For OV task saliency map are generated on MAPI side
             saliency_map = torch.empty(1, dtype=torch.uint8)
-        elif isinstance(predictions, list) and isinstance(predictions[0], InstanceData):
-            # Predict case, consists of InstanceData
+        elif isinstance(predictions, list) and isinstance(predictions[0], (InstanceData, dict)):
+            # Predict case, consists of InstanceData or dict
             saliency_map = self.explain_fn(predictions)
         else:
             msg = f"Unexpected predictions type: {type(predictions)}"
@@ -499,7 +501,7 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
         self,
         x: tuple[Tensor],
         entity: InstanceSegBatchDataEntity,
-    ) -> tuple[Tensor] | list[InstanceData]:
+    ) -> tuple[Tensor, Tensor, Tensor] | list[InstanceData] | list[dict[str, Tensor]]:
         """Get the results from the head of the instance segmentation model.
 
         Args:
@@ -507,10 +509,26 @@ class ExplainableOTXInstanceSegModel(OTXInstanceSegModel):
             data_samples (OptSampleList | None): A list of data samples.
 
         Returns:
-            tuple[Tensor] | list[InstanceData]: The predicted results from the head of the model.
+            tuple[Tensor, Tensor, Tensor] | list[InstanceData]: The predicted results from the head of the model.
             Tuple for the Export case, list for the Predict case.
         """
+        from otx.algo.instance_segmentation.maskrcnn_tv import MaskRCNNTV
         from otx.algo.instance_segmentation.rtmdet_inst import RTMDetInst
+
+        if isinstance(self, MaskRCNNTV):
+            ori_shapes = [img_info.ori_shape for img_info in entity.imgs_info]
+            img_shapes = [img_info.img_shape for img_info in entity.imgs_info]
+            image_list = ImageList(entity.images, img_shapes)
+            proposals, _ = self.model.rpn(image_list, x)
+            detections, _ = self.model.roi_heads(
+                x,
+                proposals,
+                image_list.image_sizes,
+            )
+            scale_factors = [
+                img_meta.scale_factor if img_meta.scale_factor else (1.0, 1.0) for img_meta in entity.imgs_info
+            ]
+            return self.model.postprocess(detections, ori_shapes, scale_factors)
 
         if isinstance(self, RTMDetInst):
             return self.model.bbox_head.predict(x, entity, rescale=False)

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -270,7 +270,7 @@ class OTXInstanceSegModel(OTXModel[InstanceSegBatchDataEntity, InstanceSegBatchP
             "scale_factor": (1.0, 1.0),
         }
         meta_info_list = [meta_info] * len(inputs)
-        return self.model.export(inputs, meta_info_list)
+        return self.model.export(inputs, meta_info_list, explain_mode=self.explain_mode)
 
     @property
     def _export_parameters(self) -> TaskLevelExportParameters:

--- a/src/otx/core/types/explain.py
+++ b/src/otx/core/types/explain.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 import torch
 
-FeatureMapType = torch.Tensor | Sequence[torch.Tensor]
+FeatureMapType = torch.Tensor | Sequence[torch.Tensor] | dict[str, torch.Tensor]
 
 
 class TargetExplainGroup(str, Enum):

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -47,11 +47,12 @@ def test_forward_explain(
     is_semisl = model_name.endswith("_semisl")
     task = recipe_split[-2] if not is_semisl else recipe_split[-3]
 
+    if "maskdino" in model_name:
+        # TODO(Eugene): maskdino not support yet.
+        pytest.skip(f"There's issue with inst-seg: {model_name}. Skip for now.")
+
     if "dino" in model_name:
         pytest.skip("DINO is not supported.")
-
-    if "maskrcnn_r50_tv" in model_name:
-        pytest.skip("MaskRCNN R50 Torchvision model doesn't support explain.")
 
     if "rtmdet_tiny" in recipe:
         # TODO (sungchul): enable xai for rtmdet_tiny (CVS-142651)
@@ -113,9 +114,9 @@ def test_predict_with_explain(
     if "dino" in model_name:
         pytest.skip("DINO is not supported.")
 
-    if any(keyword in recipe for keyword in ["rtmdet_inst_tiny", "maskdino", "maskrcnn_r50_tv"]):
-        # TODO(Eugene): inst-seg models not fully support yet.
-        pytest.skip(f"There's issue with inst-seg: {recipe}. Skip for now.")
+    if "maskdino" in model_name:
+        # TODO(Eugene): maskdino not support yet.
+        pytest.skip(f"There's issue with inst-seg: {model_name}. Skip for now.")
 
     if "rtmdet_tiny" in recipe:
         # TODO (sungchul): enable xai for rtmdet_tiny (CVS-142651)

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -113,9 +113,9 @@ def test_predict_with_explain(
     if "dino" in model_name:
         pytest.skip("DINO is not supported.")
 
-    if "instance_segmentation" in recipe:
-        # TODO(Eugene): figure out why instance segmentation model fails after decoupling.
-        pytest.skip("There's issue with instance segmentation model. Skip for now.")
+    if any(keyword in recipe for keyword in ["rtmdet_inst_tiny", "maskdino", "maskrcnn_r50_tv"]):
+        # TODO(Eugene): inst-seg models not fully support yet.
+        pytest.skip("There's issue with rtmdet_inst_tiny. Skip for now.")
 
     if "rtmdet_tiny" in recipe:
         # TODO (sungchul): enable xai for rtmdet_tiny (CVS-142651)

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -115,7 +115,7 @@ def test_predict_with_explain(
 
     if any(keyword in recipe for keyword in ["rtmdet_inst_tiny", "maskdino", "maskrcnn_r50_tv"]):
         # TODO(Eugene): inst-seg models not fully support yet.
-        pytest.skip("There's issue with rtmdet_inst_tiny. Skip for now.")
+        pytest.skip(f"There's issue with inst-seg: {recipe}. Skip for now.")
 
     if "rtmdet_tiny" in recipe:
         # TODO (sungchul): enable xai for rtmdet_tiny (CVS-142651)


### PR DESCRIPTION
### Summary

This PR fixed explain model for MaskRCNN/RTMDet-Inst/MaskRCNN-TV instance segmentation model
- Export feature vector when `explain_mode` is ON
- Export dummy saliency map when `explain_mode` is ON (saliency map is handled in MAPI)
- Add MaskRCNN-TV explainable feature for PyTorch model

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
