### PR TITLE
Update anomaly transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+- Update anomaly base transforms to use square resizing
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4059>)
 - Fix Combined Dataloader & unlabeled warmup loss in Semi-SL
   (<https://github.com/openvinotoolkit/training_extensions/pull/3723>)
 - Revert #3579 to fix issues with replacing coco_instance with a different format in some dataset

--- a/src/otx/__init__.py
+++ b/src/otx/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "2.2.0rc10"
+__version__ = "2.2.0rc11"
 
 import os
 from pathlib import Path

--- a/src/otx/recipe/_base_/data/anomaly.yaml
+++ b/src/otx/recipe/_base_/data/anomaly.yaml
@@ -13,11 +13,10 @@ train_subset:
   batch_size: 32
   num_workers: 4
   transforms:
-    - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+    - class_path: torchvision.transforms.v2.Resize
       init_args:
-        size: $(input_size)
+        size: [256, 256]
         antialias: true
-    - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
@@ -36,11 +35,10 @@ val_subset:
   batch_size: 32
   num_workers: 4
   transforms:
-    - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+    - class_path: torchvision.transforms.v2.Resize
       init_args:
-        size: $(input_size)
+        size: [256, 256]
         antialias: true
-    - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
@@ -59,11 +57,10 @@ test_subset:
   batch_size: 32
   num_workers: 4
   transforms:
-    - class_path: otx.core.data.transform_libs.torchvision.ResizetoLongestEdge
+    - class_path: torchvision.transforms.v2.Resize
       init_args:
-        size: $(input_size)
+        size: [256, 256]
         antialias: true
-    - class_path: otx.core.data.transform_libs.torchvision.PadtoSquare
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}

--- a/src/otx/recipe/_base_/data/anomaly.yaml
+++ b/src/otx/recipe/_base_/data/anomaly.yaml
@@ -1,5 +1,5 @@
 task: ANOMALY_CLASSIFICATION
-input_size: 256
+input_size: [256, 256]
 data_format: mvtec
 mem_cache_size: 1GB
 mem_cache_img_max_size: null


### PR DESCRIPTION
### Summary

The OV model expects a square resized image, whereas the default transform in OTX was resizing it to the longest size. Hence the effect was more pronounced in Padim (patch based model).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
