### PR TITLE
Fix rtdetr recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4057>)
 - Fix incorrect all_groups order configuration in HLabelInfo
   (<https://github.com/openvinotoolkit/training_extensions/pull/4067>)
+- Fix RTDETR recipes
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4079>)
 
 ## \[v2.1.0\]
 

--- a/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/src/otx/recipe/detection/rtdetr_101.yaml
@@ -34,15 +34,9 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-        decay: -0.025
         min_lrschedule_patience: 3
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
-        monitor: null
-        mode: max
-        patience: 10
-        check_on_train_epoch_end: false
-        min_delta: 0.001
         warmup_iters: 100
         warmup_epochs: 7
 

--- a/src/otx/recipe/detection/rtdetr_101_tile.yaml
+++ b/src/otx/recipe/detection/rtdetr_101_tile.yaml
@@ -34,15 +34,9 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-        decay: -0.025
         min_lrschedule_patience: 3
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
-        monitor: null
-        mode: max
-        patience: 10
-        check_on_train_epoch_end: false
-        min_delta: 0.001
         warmup_iters: 100
         warmup_epochs: 7
 

--- a/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/src/otx/recipe/detection/rtdetr_18.yaml
@@ -33,15 +33,9 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-        decay: -0.025
         min_lrschedule_patience: 3
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
-        monitor: null
-        mode: max
-        patience: 10
-        check_on_train_epoch_end: false
-        min_delta: 0.001
         warmup_iters: 100
         warmup_epochs: 7
 

--- a/src/otx/recipe/detection/rtdetr_18_tile.yaml
+++ b/src/otx/recipe/detection/rtdetr_18_tile.yaml
@@ -33,15 +33,9 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-        decay: -0.025
         min_lrschedule_patience: 3
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
-        monitor: null
-        mode: max
-        patience: 10
-        check_on_train_epoch_end: false
-        min_delta: 0.001
         warmup_iters: 100
         warmup_epochs: 7
 

--- a/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/src/otx/recipe/detection/rtdetr_50.yaml
@@ -34,15 +34,9 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-        decay: -0.025
         min_lrschedule_patience: 3
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
-        monitor: null
-        mode: max
-        patience: 10
-        check_on_train_epoch_end: false
-        min_delta: 0.001
         warmup_iters: 100
         warmup_epochs: 7
 

--- a/src/otx/recipe/detection/rtdetr_50_tile.yaml
+++ b/src/otx/recipe/detection/rtdetr_50_tile.yaml
@@ -34,15 +34,9 @@ overrides:
     - class_path: otx.algo.callbacks.adaptive_train_scheduling.AdaptiveTrainScheduling
       init_args:
         max_interval: 1
-        decay: -0.025
         min_lrschedule_patience: 3
     - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
       init_args:
-        monitor: null
-        mode: max
-        patience: 10
-        check_on_train_epoch_end: false
-        min_delta: 0.001
         warmup_iters: 100
         warmup_epochs: 7
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Current RTDETR recipes have `monitor: null` in override.callback but it is not updated when using API, and it occurs an error during training.
```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/jsonargparse/_typehints.py", line 809, in adapt_typehints
    vals.append(adapt_typehints(val, subtypehint, **adapt_kwargs))
  File "/usr/local/lib/python3.10/site-packages/jsonargparse/_typehints.py", line 866, in adapt_typehints
    val[n] = adapt_typehints(v, subtypehints[0], list_item=True, **adapt_kwargs_n)
  File "/usr/local/lib/python3.10/site-packages/jsonargparse/_typehints.py", line 1019, in adapt_typehints
    val = adapt_class_type(val, serialize, instantiate_classes, sub_add_kwargs, prev_val=prev_val)
  File "/usr/local/lib/python3.10/site-packages/jsonargparse/_typehints.py", line 1257, in adapt_class_type
    return instantiator_fn(val_class, **{**init_args, **dict_kwargs})
  File "/usr/local/lib/python3.10/site-packages/jsonargparse/_common.py", line 148, in default_class_instantiator
    return class_type(*args, **kwargs)
TypeError: EarlyStoppingWithWarmup.__init__() missing 1 required positional argument: 'monitor'
```

This PR includes:
- [x] Remove redundant arguments with `_base_/train.yaml` in override.callback

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
