### PR TITLE
Revert the old workaround for detection confidence threshold

### DIFF
--- a/src/otx/core/model/detection.py
+++ b/src/otx/core/model/detection.py
@@ -280,7 +280,7 @@ class OTXDetectionModel(OTXModel[DetBatchDataEntity, DetBatchPredEntity]):
         return super()._export_parameters.wrap(
             model_type="ssd",
             task_type="detection",
-            confidence_threshold=max(0.35, self.hparams.get("best_confidence_threshold", 0.35)),
+            confidence_threshold=self.hparams.get("best_confidence_threshold", None),
             iou_threshold=0.5,
             tile_config=self.tile_config if self.tile_config.enable_tiler else None,
         )


### PR DESCRIPTION
Workaround is reverted since the root cause was already fixed.