### PR TITLE
Add dummy XAI to RTDETR (export mode) & disable strong aug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4082>)
 - Fix RTMDet Inst Explain Mode
   (<https://github.com/openvinotoolkit/training_extensions/pull/4083>)
+- Fix RTDETR Explain Mode
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4106>)
 
 ## \[v2.1.0\]
 

--- a/src/otx/algo/detection/base_models/detection_transformer.py
+++ b/src/otx/algo/detection/base_models/detection_transformer.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -95,15 +96,21 @@ class DETR(BaseModule):
         explain_mode: bool = False,
     ) -> dict[str, Any] | tuple[list[Any], list[Any], list[Any]]:
         """Exports the model."""
-        if explain_mode:
-            msg = "Explain mode is not supported for DETR models yet."
-            raise NotImplementedError(msg)
-
-        return self.postprocess(
+        results = self.postprocess(
             self._forward_features(batch_inputs),
             [meta["img_shape"] for meta in batch_img_metas],
             deploy_mode=True,
         )
+
+        if explain_mode:
+            # TODO(Eugene): Implement explain mode for DETR model.
+            warnings.warn("Explain mode is not supported for DETR model. Return dummy values.", stacklevel=2)
+            xai_output = {
+                "feature_vector": torch.zeros(1, 1),
+                "saliency_map": torch.zeros(1),
+            }
+            results.update(xai_output)  # type: ignore[union-attr]
+        return results
 
     def postprocess(
         self,

--- a/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/src/otx/recipe/detection/rtdetr_101.yaml
@@ -53,10 +53,11 @@ overrides:
       transforms:
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           init_args:
-            p: 0.5
+            p: 0.0
         - class_path: torchvision.transforms.v2.RandomZoomOut
           init_args:
             fill: 0
+            p: 0.0
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/src/otx/recipe/detection/rtdetr_101.yaml
@@ -53,11 +53,7 @@ overrides:
       transforms:
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           init_args:
-            p: 0.0
-        - class_path: torchvision.transforms.v2.RandomZoomOut
-          init_args:
-            fill: 0
-            p: 0.0
+            p: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/src/otx/recipe/detection/rtdetr_18.yaml
@@ -52,11 +52,7 @@ overrides:
       transforms:
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           init_args:
-            p: 0.0
-        - class_path: torchvision.transforms.v2.RandomZoomOut
-          init_args:
-            fill: 0
-            p: 0.0
+            p: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/src/otx/recipe/detection/rtdetr_18.yaml
@@ -52,10 +52,11 @@ overrides:
       transforms:
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           init_args:
-            p: 0.5
+            p: 0.0
         - class_path: torchvision.transforms.v2.RandomZoomOut
           init_args:
             fill: 0
+            p: 0.0
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/src/otx/recipe/detection/rtdetr_50.yaml
@@ -53,10 +53,11 @@ overrides:
       transforms:
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           init_args:
-            p: 0.5
+            p: 0.0
         - class_path: torchvision.transforms.v2.RandomZoomOut
           init_args:
             fill: 0
+            p: 0.0
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5

--- a/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/src/otx/recipe/detection/rtdetr_50.yaml
@@ -53,11 +53,7 @@ overrides:
       transforms:
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           init_args:
-            p: 0.0
-        - class_path: torchvision.transforms.v2.RandomZoomOut
-          init_args:
-            fill: 0
-            p: 0.0
+            p: 0.5
         - class_path: otx.core.data.transform_libs.torchvision.RandomFlip
           init_args:
             prob: 0.5


### PR DESCRIPTION
### Summary

* Disable strong aug in RTDETR recipes
* Add dummy tensors XAI for RTDETR export mode (PyTorch mode still broken)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
