### PR TITLE
Disable tiling classifier toggle in configurable parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4083>)
 - Fix RTDETR Explain Mode
   (<https://github.com/openvinotoolkit/training_extensions/pull/4106>)
+- Disable tiling classifier toggle in configurable parameters
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4107>)
 
 ## \[v2.1.0\]
 

--- a/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
+++ b/src/otx/tools/templates/detection/instance_segmentation/configuration.yaml
@@ -589,7 +589,7 @@ tiling_parameters:
       rules: []
       type: UI_RULES
     value: true
-    visible_in_ui: true
+    visible_in_ui: false
     warning: The tile classifier prioritizes inference speed over training speed, it requires more training in order to achieve its optimized performance.
 
   enable_adaptive_params:


### PR DESCRIPTION
### Summary

Enabling tiler classifier leads to a failure in Geti environment.