### PR TITLE
Add GPU memory monitoring callback and corresponding tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4039>)
 - Turn on/off detection and instance segmentation augmentations
   (<https://github.com/openvinotoolkit/training_extensions/pull/4066>)
+- Add GPU memory monitor hook
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4118>)
 
 ### Enhancements
 

--- a/src/otx/algo/callbacks/gpu_mem_monitor.py
+++ b/src/otx/algo/callbacks/gpu_mem_monitor.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Monitor GPU memory hook."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from lightning.pytorch.callbacks.callback import Callback
+
+if TYPE_CHECKING:
+    from lightning import LightningModule, Trainer
+
+
+class GPUMemMonitor(Callback):
+    """Monitor GPU memory hook."""
+
+    def _get_and_log_device_stats(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+    ) -> None:
+        """Get and log current GPU memory usage.
+
+        Args:
+            trainer (Trainer): pl trainer.
+            pl_module (LightningModule): pl module.
+            batch_size (int): batch size.
+        """
+        device = trainer.strategy.root_device
+        if device.type == "cpu":
+            return
+
+        device_stats = trainer.accelerator.get_device_stats(device)
+        allocated = device_stats["allocated_bytes.all.current"]
+        reserved = device_stats["reserved_bytes.all.current"]
+        used_memory = (allocated + reserved) / 1024**3  # convert to GiB
+        used_memory = round(used_memory, 2)
+
+        pl_module.log(
+            name="gpu_mem",
+            value=used_memory,
+            prog_bar=True,
+            on_step=True,
+            on_epoch=False,
+        )
+
+    def on_train_batch_start(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+    ) -> None:
+        """Log GPU memory usage at the start of every train batch.
+
+        Args:
+            trainer (Trainer): pl trainer.
+            pl_module (LightningModule): pl module.
+            batch (Any): current batch.
+            batch_idx (int): current batch index.
+        """
+        self._get_and_log_device_stats(
+            trainer,
+            pl_module,
+        )
+
+    def on_validation_batch_start(
+        self,
+        trainer: Trainer,
+        pl_module: LightningModule,
+        batch: Any,  # noqa: ANN401
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Log GPU memory usage at the start of every validation batch.
+
+        Args:
+            trainer (Trainer): pl trainer.
+            pl_module (LightningModule): pl module.
+            batch (Any): current batch.
+            batch_idx (int): current batch index.
+            dataloader_idx (int, optional): dataloader index. Defaults to 0.
+        """
+        self._get_and_log_device_stats(
+            trainer,
+            pl_module,
+        )

--- a/src/otx/recipe/_base_/train.yaml
+++ b/src/otx/recipe/_base_/train.yaml
@@ -28,6 +28,7 @@ callbacks:
       prog_bar: true
       on_step: false
       on_epoch: true
+  - class_path: otx.algo.callbacks.gpu_mem_monitor.GPUMemMonitor
   - class_path: lightning.pytorch.callbacks.RichModelSummary
     init_args:
       max_depth: 1

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -478,7 +478,7 @@ class ConfigConverter:
         )
         # Update callbacks & logger dir as engine.work_dir
         for callback in config["callbacks"]:
-            if "dirpath" in callback["init_args"]:
+            if "init_args" in callback and "dirpath" in callback["init_args"]:
                 callback["init_args"]["dirpath"] = engine.work_dir
         for logger in config["logger"]:
             if "save_dir" in logger["init_args"]:

--- a/tests/unit/algo/callbacks/test_gpu_mem_monitor.py
+++ b/tests/unit/algo/callbacks/test_gpu_mem_monitor.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+import torch
+from lightning.pytorch import Trainer
+from lightning.pytorch.demos.boring_classes import BoringModel
+from lightning.pytorch.loggers import CSVLogger
+from otx.algo.callbacks.gpu_mem_monitor import GPUMemMonitor
+
+
+class TestGPUMemMonitor:
+    def test_gpu_monitor(self, tmpdir):
+        if not torch.cuda.is_available():
+            pytest.skip("No GPU available")
+
+        monitor = GPUMemMonitor()
+        model = BoringModel()
+
+        class DebugLogger(CSVLogger):
+            def log_metrics(self, metrics: dict[str, float], step: int | None = None) -> None:
+                assert "gpu_mem" in metrics
+
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=2,
+            log_every_n_steps=1,
+            accelerator="gpu",
+            devices=1,
+            callbacks=[monitor],
+            logger=DebugLogger(tmpdir),
+            enable_checkpointing=False,
+            enable_progress_bar=False,
+        )
+
+        trainer.fit(model)


### PR DESCRIPTION
### Summary

Added a GPU memory monitoring callback as a default hook, with `gpu_mem` stats saved in CSVLogger.

With the hook: 10 epochs elapsed time: 0:01:53.946211
Without the hook: 10 epochs elapsed time: 0:01:52.329156

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
