### PR TITLE
BC improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## \[2.2.2\]
+
+### Bug fixes
+
+- BC improvement
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4154>)
+
 ## \[2.2.1\]
 
 ### Bug fixes

--- a/docs/source/guide/release_notes/index.rst
+++ b/docs/source/guide/release_notes/index.rst
@@ -4,6 +4,17 @@ Releases
 .. toctree::
   :maxdepth: 1
 
+v2.2.2 (2024.12)
+----------------
+
+Enhancements
+^^^^^^^^^^^^
+
+Bug fixes
+^^^^^^^^^
+
+- BC improvement
+
 v2.2.1 (2024.12)
 ----------------
 

--- a/src/otx/__init__.py
+++ b/src/otx/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 import os
 from pathlib import Path

--- a/src/otx/core/data/dataset/tile.py
+++ b/src/otx/core/data/dataset/tile.py
@@ -222,6 +222,7 @@ class OTXTileDataset(OTXDataset):
             dataset.image_color_channel,
             dataset.stack_images,
             dataset.to_tv_image,
+            data_format=dataset.data_format,
         )
         self.tile_config = tile_config
         self._dataset = dataset

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -391,6 +391,11 @@ class OTXModel(LightningModule, Generic[T_OTXBatchDataEntity, T_OTXBatchPredEnti
             msg = "Checkpoint should have `label_info`."
             raise ValueError(msg, ckpt_label_info)
 
+        if not hasattr(ckpt_label_info, "label_ids"):
+            msg = "Loading checkpoint from OTX < 2.2.1, label_ids are assigned automatically"
+            logger.info(msg)
+            ckpt_label_info.label_ids = [str(i) for i, _ in enumerate(ckpt_label_info.label_names)]
+
         if ckpt_label_info != self.label_info:
             msg = (
                 "Load model state dictionary incrementally: "

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -9,6 +9,7 @@ import json
 from dataclasses import dataclass, fields
 from enum import Enum
 
+import otx
 from otx.core.config.data import TileConfig
 from otx.core.types.label import HLabelInfo, LabelInfo
 
@@ -122,6 +123,7 @@ class TaskLevelExportParameters:
             ("model_info", "labels"): all_labels.strip(),
             ("model_info", "label_ids"): all_label_ids.strip(),
             ("model_info", "optimization_config"): json.dumps(self.optimization_config),
+            ("model_info", "otx_version"): otx.__version__,
         }
 
         if isinstance(self.label_info, HLabelInfo):

--- a/tests/unit/core/types/test_export.py
+++ b/tests/unit/core/types/test_export.py
@@ -52,3 +52,4 @@ def test_wrap(fxt_label_info, task_type):
     assert ("model_info", "tile_size") in metadata
     assert ("model_info", "tiles_overlap") in metadata
     assert ("model_info", "max_pred_number") in metadata
+    assert ("model_info", "otx_version") in metadata


### PR DESCRIPTION
### Summary

- [x]  Add OTX version to exported model
- [x] Fix label parsing from arrow
- [x] Implement a workaround to allow OTX 2.2.1 models loading for incremental learning (optional)

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2024 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
