### PR TITLE
Add h-cls label info normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4028>)
 - Fix SupCon flag
   (https://github.com/openvinotoolkit/training_extensions/pull/4076)
+- Add h-cls label info normalization
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4173>)
+- Fix arrow support for semantic segmentation task
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4172>)
 
 ## \[2.2.2\]
 

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 """OTX export-related types definition."""
@@ -123,10 +123,11 @@ class TaskLevelExportParameters:
         }
 
         if isinstance(self.label_info, HLabelInfo):
+            dict_info = self.label_info.as_dict(normalize_label_names=True)
             metadata[("model_info", "hierarchical_config")] = json.dumps(
                 {
-                    "cls_heads_info": self.label_info.as_dict(),
-                    "label_tree_edges": self.label_info.label_tree_edges,
+                    "cls_heads_info": dict_info,
+                    "label_tree_edges": dict_info["label_tree_edges"],
                 },
             )
 

--- a/src/otx/core/types/label.py
+++ b/src/otx/core/types/label.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2023-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 """Dataclasses for label information."""
@@ -119,9 +119,28 @@ class LabelInfo:
             label_ids=label_ids,
         )
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self, normalize_label_names: bool = False) -> dict[str, Any]:
         """Return a dictionary including all params."""
-        return asdict(self)
+        result = asdict(self)
+
+        if normalize_label_names:
+
+            def normalize_fn(node: str | list | tuple | dict | int) -> str | list | tuple | dict | int:
+                """Normalizes the label names stored in various nested structures."""
+                if isinstance(node, str):
+                    return node.replace(" ", "_")
+                if isinstance(node, list):
+                    return [normalize_fn(item) for item in node]
+                if isinstance(node, tuple):
+                    return tuple(normalize_fn(item) for item in node)
+                if isinstance(node, dict):
+                    return {normalize_fn(key): normalize_fn(value) for key, value in node.items()}
+                return node
+
+            for k in result:
+                result[k] = normalize_fn(result[k])
+
+        return result
 
     def to_json(self) -> str:
         """Return JSON serialized string."""

--- a/tests/unit/core/types/test_label.py
+++ b/tests/unit/core/types/test_label.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024-205 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/tests/unit/core/types/test_label.py
+++ b/tests/unit/core/types/test_label.py
@@ -74,6 +74,11 @@ def test_hlabel_info():
 
     hlabel_info = HLabelInfo.from_dm_label_groups(dm_label_categories)
 
+    # check if label info can be normalized on export
+    dict_label_info = hlabel_info.as_dict(normalize_label_names=True)
+    for lbl in dict_label_info["label_names"]:
+        assert " " not in lbl
+
     # Check if class_to_group_idx and label_to_idx have the same keys
     assert list(hlabel_info.class_to_group_idx.keys()) == list(
         hlabel_info.label_to_idx.keys(),

--- a/tests/unit/core/types/test_label.py
+++ b/tests/unit/core/types/test_label.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-205 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 


### PR DESCRIPTION
### Summary

Since OV doesn't allow serialization of lists of strings with spaces in rt_info, we need to serialize it on export.
Previously, only label names were normalized, now we're normalizing also h_cls info to avoid errors in MAPI wrapper.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
