### PR TITLE
DETR XAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4017>)
 - Add D-Fine Detection Algorithm
   (<https://github.com/openvinotoolkit/training_extensions/pull/4142>)
+- Add DETR XAI Explain Mode
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4184>)
 
 ### Enhancements
 

--- a/docs/source/guide/tutorials/base/explain.rst
+++ b/docs/source/guide/tutorials/base/explain.rst
@@ -32,6 +32,7 @@ which are heatmaps with red-colored areas indicating focus. Here's an example ho
 
             (otx) ...$ otx explain --work_dir otx-workspace \
                                    --dump True # Wherether to save saliency map images or not
+                                   --explain_config.postprocess True # Resizes and applies colormap to the saliency map
 
     .. tab-item:: CLI (with config)
 
@@ -41,6 +42,7 @@ which are heatmaps with red-colored areas indicating focus. Here's an example ho
                                    --data_root data/wgisd \
                                    --checkpoint otx-workspace/20240312_051135/checkpoints/epoch_033.ckpt \
                                    --dump True # Wherether to save saliency map images or not
+                                   --explain_config.postprocess True # Resizes and applies colormap to the saliency map
 
     .. tab-item:: API
 
@@ -49,7 +51,7 @@ which are heatmaps with red-colored areas indicating focus. Here's an example ho
             engine.explain(
                 checkpoint="<checkpoint-path>",
                 datamodule=OTXDataModule(...), # The data module to use for predictions
-                explain_config=ExplainConfig(postprocess=True),
+                explain_config=ExplainConfig(postprocess=True), # Resizes and applies colormap to the saliency map
                 dump=True # Wherether to save saliency map images or not
               )
 

--- a/src/otx/algo/detection/d_fine.py
+++ b/src/otx/algo/detection/d_fine.py
@@ -157,6 +157,9 @@ class DFine(ExplainableOTXDetModel):
                 )
             targets.append({"boxes": scaled_bboxes, "labels": ll})
 
+        if self.explain_mode:
+            return {"entity": entity}
+
         return {
             "images": entity.images,
             "targets": targets,
@@ -184,6 +187,33 @@ class DFine(ExplainableOTXDetModel):
 
         original_sizes = [img_info.ori_shape for img_info in inputs.imgs_info]
         scores, bboxes, labels = self.model.postprocess(outputs, original_sizes)
+
+        if self.explain_mode:
+            if not isinstance(outputs, dict):
+                msg = f"Model output should be a dict, but got {type(outputs)}."
+                raise ValueError(msg)
+
+            if "feature_vector" not in outputs:
+                msg = "No feature vector in the model output."
+                raise ValueError(msg)
+
+            if "saliency_map" not in outputs:
+                msg = "No saliency maps in the model output."
+                raise ValueError(msg)
+
+            saliency_map = outputs["saliency_map"].detach().cpu().numpy()
+            feature_vector = outputs["feature_vector"].detach().cpu().numpy()
+
+            return DetBatchPredEntity(
+                batch_size=len(outputs),
+                images=inputs.images,
+                imgs_info=inputs.imgs_info,
+                scores=scores,
+                bboxes=bboxes,
+                labels=labels,
+                feature_vector=feature_vector,
+                saliency_map=saliency_map,
+            )
 
         return DetBatchPredEntity(
             batch_size=len(outputs),
@@ -306,3 +336,35 @@ class DFine(ExplainableOTXDetModel):
                 },
             },
         }
+
+    @staticmethod
+    def _forward_explain_detection(
+        self,  # noqa: ANN001
+        entity: DetBatchDataEntity,
+        mode: str = "tensor",  # noqa: ARG004
+    ) -> dict[str, torch.Tensor]:
+        """Forward function for explainable detection model."""
+        backbone_feats = self.encoder(self.backbone(entity.images))
+        predictions = self.decoder(backbone_feats, explain_mode=True)
+
+        feature_vector = self.feature_vector_fn(backbone_feats)
+
+        splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
+
+        # Permute and split logits in one line
+        raw_logits = torch.split(predictions["raw_logits"].permute(0, 2, 1), splits, dim=-1)
+
+        # Reshape each split in a list comprehension
+        raw_logits = [
+            logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1]) for logits, f in zip(raw_logits, backbone_feats)
+        ]
+
+        saliency_map = self.explain_fn(raw_logits)
+        predictions.update(
+            {
+                "feature_vector": feature_vector,
+                "saliency_map": saliency_map,
+            },
+        )
+
+        return predictions

--- a/src/otx/algo/detection/d_fine.py
+++ b/src/otx/algo/detection/d_fine.py
@@ -347,19 +347,13 @@ class DFine(ExplainableOTXDetModel):
         backbone_feats = self.encoder(self.backbone(entity.images))
         predictions = self.decoder(backbone_feats, explain_mode=True)
 
-        feature_vector = self.feature_vector_fn(backbone_feats)
-
-        splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
-
-        # Permute and split logits in one line
-        raw_logits = torch.split(predictions["raw_logits"].permute(0, 2, 1), splits, dim=-1)
-
-        # Reshape each split in a list comprehension
-        raw_logits = [
-            logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1]) for logits, f in zip(raw_logits, backbone_feats)
-        ]
+        raw_logits = DETR.split_and_reshape_logits(
+            backbone_feats,
+            predictions["raw_logits"],
+        )
 
         saliency_map = self.explain_fn(raw_logits)
+        feature_vector = self.feature_vector_fn(backbone_feats)
         predictions.update(
             {
                 "feature_vector": feature_vector,

--- a/src/otx/algo/detection/detectors/detection_transformer.py
+++ b/src/otx/algo/detection/detectors/detection_transformer.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 import numpy as np
@@ -96,18 +95,28 @@ class DETR(BaseModule):
         explain_mode: bool = False,
     ) -> dict[str, Any] | tuple[list[Any], list[Any], list[Any]]:
         """Exports the model."""
+        backbone_feats = self.encoder(self.backbone(batch_inputs))
+        predictions = self.decoder(backbone_feats, explain_mode=True)
         results = self.postprocess(
-            self._forward_features(batch_inputs),
+            predictions,
             [meta["img_shape"] for meta in batch_img_metas],
             deploy_mode=True,
         )
-
         if explain_mode:
-            # TODO(Eugene): Implement explain mode for DETR model.
-            warnings.warn("Explain mode is not supported for DETR model. Return dummy values.", stacklevel=2)
+            feature_vector = self.feature_vector_fn(backbone_feats)
+            splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
+            # Permute and split logits in one line
+            raw_logits = torch.split(predictions["raw_logits"].permute(0, 2, 1), splits, dim=-1)
+
+            # Reshape each split in a list comprehension
+            raw_logits = [
+                logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1])
+                for logits, f in zip(raw_logits, backbone_feats)
+            ]
+            saliency_map = self.explain_fn(raw_logits)
             xai_output = {
-                "feature_vector": torch.zeros(1, 1),
-                "saliency_map": torch.zeros(1),
+                "feature_vector": feature_vector,
+                "saliency_map": saliency_map,
             }
             results.update(xai_output)  # type: ignore[union-attr]
         return results

--- a/src/otx/algo/detection/detectors/detection_transformer.py
+++ b/src/otx/algo/detection/detectors/detection_transformer.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 """Base DETR model implementations."""

--- a/src/otx/algo/detection/detectors/detection_transformer.py
+++ b/src/otx/algo/detection/detectors/detection_transformer.py
@@ -103,16 +103,8 @@ class DETR(BaseModule):
             deploy_mode=True,
         )
         if explain_mode:
+            raw_logits = self.split_and_reshape_logits(backbone_feats, predictions["raw_logits"])
             feature_vector = self.feature_vector_fn(backbone_feats)
-            splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
-            # Permute and split logits in one line
-            raw_logits = torch.split(predictions["raw_logits"].permute(0, 2, 1), splits, dim=-1)
-
-            # Reshape each split in a list comprehension
-            raw_logits = [
-                logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1])
-                for logits, f in zip(raw_logits, backbone_feats)
-            ]
             saliency_map = self.explain_fn(raw_logits)
             xai_output = {
                 "feature_vector": feature_vector,
@@ -120,6 +112,29 @@ class DETR(BaseModule):
             }
             results.update(xai_output)  # type: ignore[union-attr]
         return results
+
+    @staticmethod
+    def split_and_reshape_logits(
+        backbone_feats: tuple[Tensor, ...],
+        raw_logits: Tensor,
+    ) -> tuple[Tensor, ...]:
+        """Splits and reshapes raw logits for explain mode.
+
+        Args:
+            backbone_feats (tuple[Tensor,...]): Tuple of backbone features.
+            raw_logits (Tensor): Raw logits.
+
+        Returns:
+            tuple[Tensor,...]: The reshaped logits.
+        """
+        splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
+        # Permute and split logits in one line
+        raw_logits = torch.split(raw_logits.permute(0, 2, 1), splits, dim=-1)
+
+        # Reshape each split in a list comprehension
+        return tuple(
+            logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1]) for logits, f in zip(raw_logits, backbone_feats)
+        )
 
     def postprocess(
         self,

--- a/src/otx/algo/detection/heads/rtdetr_decoder.py
+++ b/src/otx/algo/detection/heads/rtdetr_decoder.py
@@ -546,10 +546,10 @@ class RTDETRTransformerModule(BaseModule):
 
         output_memory = self.enc_output(memory)
 
-        enc_outputs_class = self.enc_score_head(output_memory)
+        enc_outputs_logits = self.enc_score_head(output_memory)
         enc_outputs_coord_unact = self.enc_bbox_head(output_memory) + anchors
 
-        _, topk_ind = torch.topk(enc_outputs_class.max(-1).values, self.num_queries, dim=1)
+        _, topk_ind = torch.topk(enc_outputs_logits.max(-1).values, self.num_queries, dim=1)
 
         reference_points_unact = enc_outputs_coord_unact.gather(
             dim=1,
@@ -560,9 +560,9 @@ class RTDETRTransformerModule(BaseModule):
         if denoising_bbox_unact is not None:
             reference_points_unact = torch.concat([denoising_bbox_unact, reference_points_unact], 1)
 
-        enc_topk_logits = enc_outputs_class.gather(
+        enc_topk_logits = enc_outputs_logits.gather(
             dim=1,
-            index=topk_ind.unsqueeze(-1).repeat(1, 1, enc_outputs_class.shape[-1]),
+            index=topk_ind.unsqueeze(-1).repeat(1, 1, enc_outputs_logits.shape[-1]),
         )
 
         # extract region features
@@ -575,10 +575,24 @@ class RTDETRTransformerModule(BaseModule):
         if denoising_class is not None:
             target = torch.concat([denoising_class, target], 1)
 
-        return target, reference_points_unact.detach(), enc_topk_bboxes, enc_topk_logits
+        return target, reference_points_unact.detach(), enc_topk_bboxes, enc_topk_logits, enc_outputs_logits
 
-    def forward(self, feats: torch.Tensor, targets: list[dict[str, torch.Tensor]] | None = None) -> torch.Tensor:
-        """Forward pass of the RTDETRTransformer module."""
+    def forward(
+        self,
+        feats: torch.Tensor,
+        targets: list[dict[str, torch.Tensor]] | None = None,
+        explain_mode: bool = False,
+    ) -> dict[str, torch.Tensor]:
+        """Forward function of RTDETRTransformer.
+
+        Args:
+            feats (Tensor): Input features.
+            targets (List[Dict[str, Tensor]]): List of target dictionaries.
+            explain_mode (bool): Whether to return raw logits for explanation.
+
+        Returns:
+            dict[str, Tensor]: Output dictionary containing predicted logits, losses and boxes.
+        """
         # input projection and embedding
         (memory, spatial_shapes, level_start_index) = self._get_encoder_input(feats)
 
@@ -596,7 +610,7 @@ class RTDETRTransformerModule(BaseModule):
         else:
             denoising_class, denoising_bbox_unact, attn_mask, dn_meta = None, None, None, None
 
-        target, init_ref_points_unact, enc_topk_bboxes, enc_topk_logits = self._get_decoder_input(
+        target, init_ref_points_unact, enc_topk_bboxes, enc_topk_logits, raw_logits = self._get_decoder_input(
             memory,
             spatial_shapes,
             denoising_class,
@@ -629,6 +643,9 @@ class RTDETRTransformerModule(BaseModule):
             if self.training and dn_meta is not None:
                 out["dn_aux_outputs"] = self._set_aux_loss(dn_out_logits, dn_out_bboxes)
                 out["dn_meta"] = dn_meta
+
+        if explain_mode:
+            out["raw_logits"] = raw_logits
 
         return out
 

--- a/src/otx/algo/detection/heads/rtdetr_decoder.py
+++ b/src/otx/algo/detection/heads/rtdetr_decoder.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 """RTDETR decoder, modified from https://github.com/lyuwenyu/RT-DETR."""

--- a/src/otx/algo/detection/rtdetr.py
+++ b/src/otx/algo/detection/rtdetr.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import torch
 from torch import Tensor, nn
@@ -302,23 +302,6 @@ class RTDETR(ExplainableOTXDetModel):
         """PTQ config for RT-DETR."""
         return {"model_type": "transformer"}
 
-    @torch.no_grad()
-    def head_forward_fn(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward function for the score head of the model."""
-        x = x.squeeze()
-        return self.model.decoder.dec_score_head[-1](x)
-
-    def get_explain_fn(self) -> Callable:
-        """Returns explain function."""
-        from otx.algo.explain.explain_algo import ReciproCAM
-
-        explainer = ReciproCAM(
-            head_forward_fn=self.head_forward_fn,
-            num_classes=self.num_classes,
-            optimize_gap=True,
-        )
-        return explainer.func
-
     @staticmethod
     def _forward_explain_detection(
         self,  # noqa: ANN001
@@ -327,10 +310,21 @@ class RTDETR(ExplainableOTXDetModel):
     ) -> dict[str, torch.Tensor]:
         """Forward function for explainable detection model."""
         backbone_feats = self.encoder(self.backbone(entity.images))
-        predictions = self.decoder(backbone_feats)
+        predictions = self.decoder(backbone_feats, explain_mode=True)
 
         feature_vector = self.feature_vector_fn(backbone_feats)
-        saliency_map = self.explain_fn(backbone_feats[-1])
+
+        splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
+
+        # Permute and split logits in one line
+        raw_logits = torch.split(predictions["raw_logits"].permute(0, 2, 1), splits, dim=-1)
+
+        # Reshape each split in a list comprehension
+        raw_logits = [
+            logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1]) for logits, f in zip(raw_logits, backbone_feats)
+        ]
+
+        saliency_map = self.explain_fn(raw_logits)
         predictions.update(
             {
                 "feature_vector": feature_vector,

--- a/src/otx/algo/detection/rtdetr.py
+++ b/src/otx/algo/detection/rtdetr.py
@@ -128,6 +128,9 @@ class RTDETR(ExplainableOTXDetModel):
                 )
             targets.append({"boxes": scaled_bboxes, "labels": ll})
 
+        if self.explain_mode:
+            return {"entity": entity}
+
         return {
             "images": entity.images,
             "targets": targets,

--- a/src/otx/algo/detection/rtdetr.py
+++ b/src/otx/algo/detection/rtdetr.py
@@ -312,19 +312,13 @@ class RTDETR(ExplainableOTXDetModel):
         backbone_feats = self.encoder(self.backbone(entity.images))
         predictions = self.decoder(backbone_feats, explain_mode=True)
 
-        feature_vector = self.feature_vector_fn(backbone_feats)
-
-        splits = [f.shape[-2] * f.shape[-1] for f in backbone_feats]
-
-        # Permute and split logits in one line
-        raw_logits = torch.split(predictions["raw_logits"].permute(0, 2, 1), splits, dim=-1)
-
-        # Reshape each split in a list comprehension
-        raw_logits = [
-            logits.reshape(f.shape[0], -1, f.shape[-2], f.shape[-1]) for logits, f in zip(raw_logits, backbone_feats)
-        ]
+        raw_logits = DETR.split_and_reshape_logits(
+            backbone_feats,
+            predictions["raw_logits"],
+        )
 
         saliency_map = self.explain_fn(raw_logits)
+        feature_vector = self.feature_vector_fn(backbone_feats)
         predictions.update(
             {
                 "feature_vector": feature_vector,

--- a/src/otx/algo/detection/rtdetr.py
+++ b/src/otx/algo/detection/rtdetr.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 """RTDetr model implementations."""

--- a/src/otx/algo/detection/rtdetr.py
+++ b/src/otx/algo/detection/rtdetr.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import torch
 from torch import Tensor, nn
@@ -159,6 +159,33 @@ class RTDETR(ExplainableOTXDetModel):
         original_sizes = [img_info.ori_shape for img_info in inputs.imgs_info]
         scores, bboxes, labels = self.model.postprocess(outputs, original_sizes)
 
+        if self.explain_mode:
+            if not isinstance(outputs, dict):
+                msg = f"Model output should be a dict, but got {type(outputs)}."
+                raise ValueError(msg)
+
+            if "feature_vector" not in outputs:
+                msg = "No feature vector in the model output."
+                raise ValueError(msg)
+
+            if "saliency_map" not in outputs:
+                msg = "No saliency maps in the model output."
+                raise ValueError(msg)
+
+            saliency_map = outputs["saliency_map"].detach().cpu().numpy()
+            feature_vector = outputs["feature_vector"].detach().cpu().numpy()
+
+            return DetBatchPredEntity(
+                batch_size=len(outputs),
+                images=inputs.images,
+                imgs_info=inputs.imgs_info,
+                scores=scores,
+                bboxes=bboxes,
+                labels=labels,
+                feature_vector=feature_vector,
+                saliency_map=saliency_map,
+            )
+
         return DetBatchPredEntity(
             batch_size=len(outputs),
             images=inputs.images,
@@ -274,3 +301,41 @@ class RTDETR(ExplainableOTXDetModel):
     def _optimization_config(self) -> dict[str, Any]:
         """PTQ config for RT-DETR."""
         return {"model_type": "transformer"}
+
+    @torch.no_grad()
+    def head_forward_fn(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward function for the score head of the model."""
+        x = x.squeeze()
+        return self.model.decoder.dec_score_head[-1](x)
+
+    def get_explain_fn(self) -> Callable:
+        """Returns explain function."""
+        from otx.algo.explain.explain_algo import ReciproCAM
+
+        explainer = ReciproCAM(
+            head_forward_fn=self.head_forward_fn,
+            num_classes=self.num_classes,
+            optimize_gap=True,
+        )
+        return explainer.func
+
+    @staticmethod
+    def _forward_explain_detection(
+        self,  # noqa: ANN001
+        entity: DetBatchDataEntity,
+        mode: str = "tensor",  # noqa: ARG004
+    ) -> dict[str, torch.Tensor]:
+        """Forward function for explainable detection model."""
+        backbone_feats = self.encoder(self.backbone(entity.images))
+        predictions = self.decoder(backbone_feats)
+
+        feature_vector = self.feature_vector_fn(backbone_feats)
+        saliency_map = self.explain_fn(backbone_feats[-1])
+        predictions.update(
+            {
+                "feature_vector": feature_vector,
+                "saliency_map": saliency_map,
+            },
+        )
+
+        return predictions

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -51,20 +51,12 @@ def test_forward_explain(
         # TODO(Eugene): maskdino not support yet.
         pytest.skip(f"There's issue with inst-seg: {model_name}. Skip for now.")
 
-    if "dfine" in model_name:
-        # TODO(Eugene): dfine not support yet.
-        # https://jira.devtools.intel.com/browse/CVS-160781
-        pytest.skip(f"There's issue with dfine: {model_name}. Skip for now.")
-
     if "dino" in model_name:
         pytest.skip("DINO is not supported.")
 
     if "rtmdet_tiny" in recipe:
         # TODO (sungchul): enable xai for rtmdet_tiny (CVS-142651)
         pytest.skip("rtmdet_tiny on detection is not supported yet.")
-
-    if "rtdetr" in recipe:
-        pytest.skip("rtdetr on detection is not supported yet.")
 
     if "yolov9" in recipe:
         pytest.skip("yolov9 on detection is not supported yet.")
@@ -123,11 +115,6 @@ def test_predict_with_explain(
         # TODO(Eugene): maskdino not support yet.
         pytest.skip(f"There's issue with inst-seg: {model_name}. Skip for now.")
 
-    if "dfine" in model_name:
-        # TODO(Eugene): dfine not support yet.
-        # https://jira.devtools.intel.com/browse/CVS-160781
-        pytest.skip(f"There's issue with dfine: {model_name}. Skip for now.")
-
     if "rtmdet_tiny" in recipe:
         # TODO (sungchul): enable xai for rtmdet_tiny (CVS-142651)
         pytest.skip("rtmdet_tiny on detection is not supported yet.")
@@ -135,9 +122,6 @@ def test_predict_with_explain(
     if "yolox_tiny_tile" in recipe:
         # TODO (Galina): required to update model-api to 2.1
         pytest.skip("yolox_tiny_tile on detection requires model-api update")
-
-    if "rtdetr" in recipe:
-        pytest.skip("rtdetr on detection is not supported yet.")
 
     if "yolov9" in recipe:
         pytest.skip("yolov9 on detection is not supported yet.")

--- a/tests/integration/api/test_xai.py
+++ b/tests/integration/api/test_xai.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -252,12 +252,6 @@ def test_otx_e2e(
     if "dino" in model_name:
         return  # DINO is not supported.
 
-    if "dfine" in model_name:
-        return  # DFine is not supported.
-
-    if "rtdetr" in model_name:
-        return  # RT-DETR currently is not supported.
-
     if "yolov9" in model_name:
         return  # RT-DETR currently is not supported.
 
@@ -334,13 +328,8 @@ def test_otx_explain_e2e(
     if "dino" in model_name:
         pytest.skip("DINO is not supported.")
 
-    if "dfine" in model_name:
-        pytest.skip("DFine is not supported.")
-
     if "maskrcnn_r50_tv" in model_name:
         pytest.skip("MaskRCNN R50 Torchvision model doesn't support explain.")
-    elif "rtdetr" in recipe:
-        pytest.skip("rtdetr model is not supported yet with explain.")
     elif "keypoint" in recipe:
         pytest.skip("keypoint detection models don't support explain.")
     elif "yolov9" in recipe:

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2023-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations


### PR DESCRIPTION
### Summary

Enhance XAI capabilities for RTDETR and D-Fine models by implementing support for saliency map generation and feature vector outputs, compatibility with both PyTorch and OpenVINO frameworks.

Person Saliency Map:
![000000046872_class_0_overlay](https://github.com/user-attachments/assets/7e800ac9-fa83-4a7c-adb5-b5ed7327fd71)

Car Saliency Map:
![000000046872_class_1_overlay](https://github.com/user-attachments/assets/b3fba764-2706-4d07-9b9f-dc33604ebf33)


### How to test

`otx explain --work_dir otx-workspace --dump True --explain_config.postprocess True`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have ran e2e tests and there is no issues.
- [x] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [x] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
