### PR TITLE
Fix KP task to work in Geti scenario

### DIFF
--- a/src/otx/core/data/dataset/keypoint_detection.py
+++ b/src/otx/core/data/dataset/keypoint_detection.py
@@ -81,9 +81,12 @@ class OTXKeypointDetectionDataset(OTXDataset[KeypointDetDataEntity]):
                     if isinstance(ann, Points) and max(ann.points) <= 0:
                         continue
                     available_types.append(ann.type)
-                if available_types != [AnnotationType.points, AnnotationType.bbox]:
+                if AnnotationType.points not in available_types:
                     continue
                 dm_items.append(item.wrap(id=item.id + "_" + str(ann_id), annotations=anns))
+        if len(dm_items) == 0:
+            msg = "No keypoints found in the dataset. Please, check dataset annotations."
+            raise ValueError(msg)
         return Dataset.from_iterable(dm_items, categories=self.dm_subset.categories())
 
     def _get_item_impl(self, index: int) -> KeypointDetDataEntity | None:

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -115,6 +115,7 @@ class OTXDataModule(LightningDataModule):
                 self.unannotated_items_ratio,
                 ignore_index=self.ignore_index if self.task == "SEMANTIC_SEGMENTATION" else None,
             )
+
         unlabeled_dataset = None
         if self.unlabeled_subset.data_root is not None:
             # If unlabeled_subset's data_root is not None, use that folder as the Unlabeled dataset root.
@@ -181,6 +182,7 @@ class OTXDataModule(LightningDataModule):
             if name not in config_mapping:
                 log.warning(f"{name} is not available. Skip it")
                 continue
+
             dataset = OTXDatasetFactory.create(
                 task=self.task,
                 dm_subset=dm_subset.as_dataset(),

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -115,7 +115,6 @@ class OTXDataModule(LightningDataModule):
                 self.unannotated_items_ratio,
                 ignore_index=self.ignore_index if self.task == "SEMANTIC_SEGMENTATION" else None,
             )
-
         unlabeled_dataset = None
         if self.unlabeled_subset.data_root is not None:
             # If unlabeled_subset's data_root is not None, use that folder as the Unlabeled dataset root.
@@ -182,7 +181,6 @@ class OTXDataModule(LightningDataModule):
             if name not in config_mapping:
                 log.warning(f"{name} is not available. Skip it")
                 continue
-
             dataset = OTXDatasetFactory.create(
                 task=self.task,
                 dm_subset=dm_subset.as_dataset(),

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -199,7 +199,7 @@ TEMPLATE_ID_DICT = {
     # KEYPOINT_DETECTION
     "Keypoint_Detection_RTMPose_Tiny": {
         "task": OTXTaskType.KEYPOINT_DETECTION,
-        "model_name": "rtmpose_tiny",
+        "model_name": "rtmpose_tiny_single_obj",
     },
 }
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

1. Only keypoint annotations are available in arrow file in Geti.
2. We need to use different set of augmentations to work as expected without Bboxes (==different config). 

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
