### PR TITLE
Update keypoint detection export with explain

### DIFF
--- a/src/otx/algo/keypoint_detection/rtmpose.py
+++ b/src/otx/algo/keypoint_detection/rtmpose.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from otx.algo.common.backbones import CSPNeXt
@@ -25,6 +26,9 @@ if TYPE_CHECKING:
     from otx.core.types.label import LabelInfoTypes
 
 
+logger = logging.getLogger()
+
+
 class RTMPose(OTXKeypointDetectionModel):
     """OTX keypoint detection model class for RTMPose."""
 
@@ -37,7 +41,7 @@ class RTMPose(OTXKeypointDetectionModel):
 
         if self.explain_mode:
             msg = "Export with explain is not supported for RTMPose model."
-            raise ValueError(msg)
+            logger.warning(msg)
 
         return OTXNativeModelExporter(
             task_level_export_parameters=self._export_parameters,

--- a/src/otx/engine/utils/auto_configurator.py
+++ b/src/otx/engine/utils/auto_configurator.py
@@ -55,6 +55,7 @@ DEFAULT_CONFIG_PER_TASK = {
 TASK_PER_DATA_FORMAT = {
     "imagenet_with_subset_dirs": [OTXTaskType.MULTI_CLASS_CLS, OTXTaskType.H_LABEL_CLS],
     "datumaro": [OTXTaskType.MULTI_LABEL_CLS],
+    "coco_person_keypoints": [OTXTaskType.KEYPOINT_DETECTION],
     "coco_instances": [
         OTXTaskType.DETECTION,
         OTXTaskType.ROTATED_DETECTION,

--- a/src/otx/recipe/keypoint_detection/openvino_model.yaml
+++ b/src/otx/recipe/keypoint_detection/openvino_model.yaml
@@ -26,6 +26,7 @@ overrides:
       batch_size: 1
       num_workers: 2
       transforms:
+        - class_path: otx.core.data.transform_libs.torchvision.GetBBoxCenterScale
         - class_path: otx.core.data.transform_libs.torchvision.TopdownAffine
           init_args:
             input_size: $(input_size)
@@ -34,6 +35,7 @@ overrides:
       batch_size: 1
       num_workers: 2
       transforms:
+        - class_path: otx.core.data.transform_libs.torchvision.GetBBoxCenterScale
         - class_path: otx.core.data.transform_libs.torchvision.TopdownAffine
           init_args:
             input_size: $(input_size)
@@ -42,6 +44,7 @@ overrides:
       batch_size: 64
       num_workers: 2
       transforms:
+        - class_path: otx.core.data.transform_libs.torchvision.GetBBoxCenterScale
         - class_path: otx.core.data.transform_libs.torchvision.TopdownAffine
           init_args:
             input_size: $(input_size)


### PR DESCRIPTION
### Summary

- Export with explain now doesn't fail on a kp det model, even though it's not supported. A warning is shown instead
- Revert OV model template changes, as our primary model is multi-object one, single object is to be removed.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
