### PR TITLE
Don't filter empty label from kp arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4199>)
 - Fix label info on loading checkpoint
   (<https://github.com/openvinotoolkit/training_extensions/pull/4200>)
+- Don't filter empty label from kp arrow
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4214>)
 
 ## \[2.2.2\]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 ### Bug fixes
 
+- Don't filter empty label from kp arrow
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4229>)
+
 ### Removed
 
 - Remove HPO
@@ -93,8 +96,6 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4199>)
 - Fix label info on loading checkpoint
   (<https://github.com/openvinotoolkit/training_extensions/pull/4200>)
-- Don't filter empty label from kp arrow
-  (<https://github.com/openvinotoolkit/training_extensions/pull/4214>)
 
 ## \[2.2.2\]
 

--- a/src/otx/core/data/dataset/keypoint_detection.py
+++ b/src/otx/core/data/dataset/keypoint_detection.py
@@ -19,7 +19,7 @@ from otx.core.data.entity.keypoint_detection import KeypointDetBatchDataEntity, 
 from otx.core.data.mem_cache import NULL_MEM_CACHE_HANDLER, MemCacheHandlerBase
 from otx.core.data.transform_libs.torchvision import Compose
 from otx.core.types.image import ImageColorChannel
-from otx.core.types.label import LabelInfo, NullLabelInfo
+from otx.core.types.label import LabelInfo
 
 from .base import OTXDataset
 
@@ -55,15 +55,14 @@ class OTXKeypointDetectionDataset(OTXDataset[KeypointDetDataEntity]):
 
         self.dm_subset = self._get_single_bbox_dataset(dm_subset)
 
-        if self.dm_subset.categories():
+        # arrow doesn't follow common coco convention, no need to fetch kp-specific labels
+        if self.dm_subset.categories() and data_format != "arrow":
             kp_labels = self.dm_subset.categories()[AnnotationType.points][0].labels
             self.label_info = LabelInfo(
                 label_names=kp_labels,
                 label_groups=[],
                 label_ids=[str(i) for i in range(len(kp_labels))],
             )
-        else:
-            self.label_info = NullLabelInfo()
 
     def _get_single_bbox_dataset(self, dm_subset: DatasetSubset) -> Dataset:
         """Method for splitting dataset items into multiple items for each bbox/keypoint."""

--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -108,7 +108,9 @@ class OTXDataModule(LightningDataModule):
         self.save_hyperparameters(ignore=["input_size"])
 
         dataset = DmDataset.import_from(self.data_root, format=self.data_format)
-        if self.task != "H_LABEL_CLS":
+        if self.task != OTXTaskType.H_LABEL_CLS and not (
+            self.task == OTXTaskType.KEYPOINT_DETECTION and self.data_format == "arrow"
+        ):
             dataset = pre_filtering(
                 dataset,
                 self.data_format,


### PR DESCRIPTION
### Summary

https://github.com/openvinotoolkit/training_extensions/pull/4214 retargeted to develop


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
