### PR TITLE
Align KP Detection Validation with Model API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - Fix DataInputParams Serialization
   (<https://github.com/openvinotoolkit/training_extensions/pull/4293>)
+- Align KP detection validation with ModelAPI post processing
+  (<https://github.com/openvinotoolkit/training_extensions/pull/4300>)
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ docs = [
 base = [
     "torch==2.5.1",
     "lightning==2.4.0",
+    "torchmetrics==1.6.0",
     "pytorchcv==0.0.67",
     "timm==1.0.3",
     "openvino==2025.0",

--- a/src/otx/core/data/dataset/keypoint_detection.py
+++ b/src/otx/core/data/dataset/keypoint_detection.py
@@ -130,7 +130,7 @@ class OTXKeypointDetectionDataset(OTXDataset):
                 format=tv_tensors.BoundingBoxFormat.XYXY,
                 canvas_size=img_shape,
             ),
-            label=torch.as_tensor([ann.label for ann in bbox_anns]),
+            label=torch.as_tensor([ann.label for ann in bbox_anns], dtype=torch.long),
             keypoints=torch.as_tensor(keypoints, dtype=torch.float32),
         )
 

--- a/src/otx/core/model/keypoint_detection.py
+++ b/src/otx/core/model/keypoint_detection.py
@@ -182,8 +182,8 @@ class OTXKeypointDetectionModel(OTXModel):
             infos.append(
                 ImageInfo(
                     img_idx=i,
-                    img_shape=img.shape,
-                    ori_shape=img.shape,
+                    img_shape=img.shape[:2],
+                    ori_shape=img.shape[:2],
                 ),
             )
 

--- a/src/otx/core/model/keypoint_detection.py
+++ b/src/otx/core/model/keypoint_detection.py
@@ -87,10 +87,28 @@ class OTXKeypointDetectionModel(OTXModel):
         scores = []
         # default visibility threshold
         visibility_threshold = 0.5
-        for output in outputs:
+        if inputs.imgs_info is None:
+            msg = "The input image information is not provided."
+            raise ValueError(msg)
+        for i, output in enumerate(outputs):
             if not isinstance(output, tuple):
                 raise TypeError(output)
-            kps = torch.as_tensor(output[0], device=self.device)
+            if inputs.imgs_info[i] is None:
+                msg = f"The image information for the image {i} is not provided."
+                raise ValueError(msg)
+            # scale to the original image size
+            orig_h, orig_w = inputs.imgs_info[i].ori_shape  # type: ignore[union-attr]
+            kp_scale_h, kp_scale_w = (
+                orig_h / self.data_input_params.input_size[0],
+                orig_w / self.data_input_params.input_size[1],
+            )
+            inverted_scale = max(kp_scale_h, kp_scale_w)
+            kp_scale_h = kp_scale_w = inverted_scale
+            # decode kps
+            kps = torch.as_tensor(output[0], device=self.device) * torch.tensor(
+                [kp_scale_w, kp_scale_h],
+                device=self.device,
+            )
             score = torch.as_tensor(output[1], device=self.device)
             visible_keypoints = torch.cat([kps, score.unsqueeze(1) > visibility_threshold], dim=1)
             keypoints.append(visible_keypoints)

--- a/src/otx/data/validations.py
+++ b/src/otx/data/validations.py
@@ -191,7 +191,7 @@ class ValidateBatchMixin:
     @staticmethod
     def _images_validator(image_batch: torch.Tensor) -> torch.Tensor:
         """Validate the image batch."""
-        if not isinstance(image_batch, list) or not isinstance(image_batch, torch.Tensor):
+        if not isinstance(image_batch, list) and not isinstance(image_batch, torch.Tensor):
             msg = f"Image batch must be a torch tensor or list of tensors. Got {type(image_batch)}"
             raise TypeError(msg)
         if isinstance(image_batch, torch.Tensor):

--- a/src/otx/data/validations.py
+++ b/src/otx/data/validations.py
@@ -191,18 +191,32 @@ class ValidateBatchMixin:
     @staticmethod
     def _images_validator(image_batch: torch.Tensor) -> torch.Tensor:
         """Validate the image batch."""
-        if not isinstance(image_batch, torch.Tensor):
-            msg = f"Image batch must be a torch tensor. Got {type(image_batch)}"
+        if not isinstance(image_batch, list) or not isinstance(image_batch, torch.Tensor):
+            msg = f"Image batch must be a torch tensor or list of tensors. Got {type(image_batch)}"
             raise TypeError(msg)
-        if image_batch.dtype != torch.float32:
-            msg = "Image batch must have dtype float32"
-            raise ValueError(msg)
-        if image_batch.ndim != 4:
-            msg = "Image batch must have 4 dimensions"
-            raise ValueError(msg)
-        if image_batch.shape[1] not in [1, 3]:
-            msg = "Image batch must have 1 or 3 channels"
-            raise ValueError(msg)
+        if isinstance(image_batch, torch.Tensor):
+            if image_batch.dtype != torch.float32:
+                msg = "Image batch must have dtype float32"
+                raise ValueError(msg)
+            if image_batch.ndim != 4:
+                msg = "Image batch must have 4 dimensions"
+                raise ValueError(msg)
+            if image_batch.shape[1] not in [1, 3]:
+                msg = "Image batch must have 1 or 3 channels"
+                raise ValueError(msg)
+        else:
+            if not all(isinstance(image, torch.Tensor) for image in image_batch):
+                msg = "Image batch must be a list of torch tensors"
+                raise TypeError(msg)
+            if not all(image.dtype == torch.float32 for image in image_batch):
+                msg = "Image batch must have dtype float32"
+                raise ValueError(msg)
+            if not all(image.ndim == 3 for image in image_batch):
+                msg = "Image batch must have 3 dimensions"
+                raise ValueError(msg)
+            if not all(image.shape[0] in [1, 3] for image in image_batch):
+                msg = "Image batch must have 1 or 3 channels"
+                raise ValueError(msg)
         return image_batch
 
     @staticmethod

--- a/src/otx/recipe/_base_/data/keypoint_detection.yaml
+++ b/src/otx/recipe/_base_/data/keypoint_detection.yaml
@@ -33,7 +33,7 @@ val_subset:
       init_args:
         scale: $(input_size)
         keep_ratio: true
-        transform_keypoints: true
+        transform_keypoints: false
     - class_path: otx.core.data.transform_libs.torchvision.Pad
       init_args:
         size: $(input_size)
@@ -55,7 +55,7 @@ test_subset:
       init_args:
         scale: $(input_size)
         keep_ratio: true
-        transform_keypoints: true
+        transform_keypoints: false
     - class_path: otx.core.data.transform_libs.torchvision.Pad
       init_args:
         size: $(input_size)


### PR DESCRIPTION
### Summary
This PR removes gap between Model API postprocessing and OTX. 
Please note, that to be able to run OV IR inference we will need to support list[Tensor] in TorchDataBatch. This behavior will be removed once we separate OV Models from core OTX Models.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
