### PR TITLE
Fix integration test commands run-category-only flag

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -42,4 +42,4 @@ jobs:
           python -m pip install --require-hashes --no-deps -r /tmp/requirements.txt
           rm /tmp/requirements.txt
       - name: Run Daily Integration Test
-        run: tox -vv -e daily-integration-test-${{ matrix.task }} -- --run-category-only=False
+        run: tox -vv -e daily-integration-test-${{ matrix.task }}

--- a/.github/workflows/pr_comment_trigger.yaml
+++ b/.github/workflows/pr_comment_trigger.yaml
@@ -54,7 +54,7 @@ jobs:
           fi
 
           echo "✅ Running integration test for: $TASK_NAME"
-          tox -vv -e "integration-test-${TASK_NAME}" -- --run-category-only=False
+          tox -vv -e "integration-test-${TASK_NAME}"
 
       - name: Update PR description with workflow run link and result
         if: always() # Ensure this runs even if the job fails

--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -117,4 +117,4 @@ jobs:
           python -m pip install --require-hashes --no-deps -r /tmp/requirements.txt
           rm /tmp/requirements.txt
       - name: Run Integration Test
-        run: tox -vv -e integration-test-${{ matrix.task }} -- --run-category-only=True
+        run: tox -vv -e integration-test-${{ matrix.task }} -- --run-category-only

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,8 +144,7 @@ def pytest_addoption(parser: pytest.Parser):
     )
     parser.addoption(
         "--run-category-only",
-        type=bool,
-        default=False,
+        action="store_true",
         help="Run only the model category tests that categorised as BALANCE, SPEED, ACCURACY.",
     )
 


### PR DESCRIPTION
### Summary

Fix integration test commands run-category-only flag

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/openvinotoolkit/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/openvinotoolkit/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/openvinotoolkit/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
