### PR TITLE
Comparison of mobileNetv4_medium and mobilenet_v3_large

### DIFF
--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v4.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v4.yaml
@@ -1,0 +1,33 @@
+model:
+  class_path: otx.algo.classification.multiclass_models.timm_model.TimmModelMulticlassCls
+  init_args:
+    model_name: mobilenetv4_conv_small
+    label_info: 1000
+    optimizer:
+      class_path: torch.optim.SGD
+      init_args:
+        lr: 0.0058
+        momentum: 0.9
+        weight_decay: 0.0001
+    scheduler:
+      class_path: otx.core.schedulers.LinearWarmupSchedulerCallable
+      init_args:
+        num_warmup_steps: 10
+        main_scheduler_callable:
+          class_path: lightning.pytorch.cli.ReduceLROnPlateau
+          init_args:
+            mode: max
+            factor: 0.5
+            patience: 3
+            monitor: val/accuracy
+engine:
+  task: MULTI_CLASS_CLS
+  device: auto
+callback_monitor: val/accuracy
+data: ../../_base_/data/classification.yaml
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
+      init_args:
+        patience: 5

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v4.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v4.yaml
@@ -24,7 +24,11 @@ engine:
   task: MULTI_CLASS_CLS
   device: auto
 callback_monitor: val/accuracy
+
+
 data: ../../_base_/data/classification.yaml
+
+
 overrides:
   max_epochs: 90
   callbacks:

--- a/src/otx/recipe/classification/multi_class_cls/mobilenet_v4_medium.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/mobilenet_v4_medium.yaml
@@ -1,0 +1,33 @@
+model:
+  class_path: otx.algo.classification.multiclass_models.timm_model.TimmModelMulticlassCls
+  init_args:
+    model_name: mobilenetv4_medium_conv
+    label_info: 1000
+    optimizer:
+      class_path: torch.optim.SGD
+      init_args:
+        lr: 0.0058
+        momentum: 0.9
+        weight_decay: 0.0001
+    scheduler:
+      class_path: otx.core.schedulers.LinearWarmupSchedulerCallable
+      init_args:
+        num_warmup_steps: 10
+        main_scheduler_callable:
+          class_path: lightning.pytorch.cli.ReduceLROnPlateau
+          init_args:
+            mode: max
+            factor: 0.5
+            patience: 3
+            monitor: val/accuracy
+engine:
+  task: MULTI_CLASS_CLS
+  device: auto
+callback_monitor: val/accuracy
+data: ../../base/data/classification.yaml
+overrides:
+  max_epochs: 90
+  callbacks:
+    - class_path: otx.algo.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
+      init_args:
+        patience: 5


### PR DESCRIPTION
### Summary
Here are my results benchmarking mobilenet_v4_medium vs mobilenet_v3_large. 
| Dataset  | Model | Epochs Trained| Val Accuracy| Val Iter Time|
| ------------- | ------------- |------------- |------------- |------------- |
| Flowers 102 | MobileNetV4 Medium | 31  | 90.13 |0.0467 |
| Flowers 102  | MobileNetV3 Large  | 21  |94.52 |0.0457 |
| Stanford Cars | MobileNetV4 Medium  | 83  | 62.13 |  0.1657 |
| Stanford Cars | MobileNetV3 Large | 31  | 76.96 |  0.1643 |
| FGVC-Aircraft | MobileNetV4 Medium | 77| 47.88|  0.5311 |
| FGVC-Aircraft | MobileNetV3 Large | 28 | 50.495 |  0.5289 |
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
