### PR TITLE
Bump OV and NNCF to 2025.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## \[Unreleased\]
 
+### Enhancements
+
+- Bump OV and NNCF to 2025.1
+  (https://github.com/open-edge-platform/training_extensions/pull/4334)
+
 ### Bug fixes
 
 - Fix DataInputParams Serialization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ base = [
     "torchmetrics==1.6.0",
     "pytorchcv==0.0.67",
     "timm==1.0.3",
-    "openvino==2025.0",
+    "openvino==2025.1",
     "openvino-model-api==0.3.0.2",
     "onnx==1.17.0",
     "onnxconverter-common==1.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ base = [
     "openvino-model-api==0.3.0.2",
     "onnx==1.17.0",
     "onnxconverter-common==1.14.0",
-    "nncf==2.15.0",
+    "nncf==2.16.0",
     "anomalib[core]==1.1.3",
 ]
 

--- a/src/otx/core/exporter/native.py
+++ b/src/otx/core/exporter/native.py
@@ -78,13 +78,13 @@ class OTXNativeModelExporter(OTXModelExporter):
                 )
                 exported_model = openvino.convert_model(
                     tmp_dir / (base_model_name + ".onnx"),
-                    input=(openvino.runtime.PartialShape(input_size),),
+                    input=(openvino.PartialShape(input_size),),
                 )
         else:
             exported_model = openvino.convert_model(
                 model,
                 example_input=dummy_tensor,
-                input=(openvino.runtime.PartialShape(input_size),),
+                input=(openvino.PartialShape(input_size),),
             )
         exported_model = self._postprocess_openvino_model(exported_model)
 


### PR DESCRIPTION
### Summary

Minor version upgrade

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
