### PR TITLE
Bug Fix : Convert labels for multi-label Classification into LongTensor before one_hot encoding

### DIFF
--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -111,6 +111,11 @@ class OTXMultilabelClsDataset(OTXDataset):
 
     def _convert_to_onehot(self, labels: torch.tensor, ignored_labels: list[int]) -> torch.tensor:
         """Convert label to one-hot vector format."""
+
+        # Torch's one_hot() expects the input to be of type long
+        # However, when labels are empty, they are of type float32
+        labels = labels.to(dtype=torch.long, copy=False)
+
         onehot = functional.one_hot(labels, self.num_classes).sum(0).clamp_max_(1)
         if ignored_labels:
             for ignore_label in ignored_labels:

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -113,8 +113,7 @@ class OTXMultilabelClsDataset(OTXDataset):
         """Convert label to one-hot vector format."""
         # Torch's one_hot() expects the input to be of type long
         # However, when labels are empty, they are of type float32
-        labels = labels.to(dtype=torch.long, copy=False)
-
+        labels = labels.long()
         onehot = functional.one_hot(labels, self.num_classes).sum(0).clamp_max_(1)
         if ignored_labels:
             for ignore_label in ignored_labels:

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -113,8 +113,7 @@ class OTXMultilabelClsDataset(OTXDataset):
         """Convert label to one-hot vector format."""
         # Torch's one_hot() expects the input to be of type long
         # However, when labels are empty, they are of type float32
-        labels = labels.long()
-        onehot = functional.one_hot(labels, self.num_classes).sum(0).clamp_max_(1)
+        onehot = functional.one_hot(labels.long(), self.num_classes).sum(0).clamp_max_(1)
         if ignored_labels:
             for ignore_label in ignored_labels:
                 onehot[ignore_label] = -1

--- a/src/otx/core/data/dataset/classification.py
+++ b/src/otx/core/data/dataset/classification.py
@@ -111,7 +111,6 @@ class OTXMultilabelClsDataset(OTXDataset):
 
     def _convert_to_onehot(self, labels: torch.tensor, ignored_labels: list[int]) -> torch.tensor:
         """Convert label to one-hot vector format."""
-
         # Torch's one_hot() expects the input to be of type long
         # However, when labels are empty, they are of type float32
         labels = labels.to(dtype=torch.long, copy=False)


### PR DESCRIPTION
### Summary

For multilabel classification, we use torch' one_hot to get one hot encoding of the labels. This method requires labels to be for dtype LongTensor. When we have empty labels, then the tensor is of type float32. This gives an error.  This PR manually changes the labels to be LongTensor if not already before calling the one_hot function. 


[one_hot](https://pytorch.org/docs/stable/generated/torch.nn.functional.one_hot.html#torch-nn-functional-one-hot)

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
