### PR TITLE
Bump torch to 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - Bump OV and NNCF to 2025.1
   (https://github.com/open-edge-platform/training_extensions/pull/4334)
+- Bump torch to 2.7.0
+  (https://github.com/open-edge-platform/training_extensions/pull/4361)
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 <!-- markdownlint-disable MD042 -->
 
 [![python](https://img.shields.io/badge/python-3.10%2B-green)]()
-[![pytorch](https://img.shields.io/badge/pytorch-2.5%2B-orange)]()
-[![openvino](https://img.shields.io/badge/openvino-2025.0-purple)]()
+[![pytorch](https://img.shields.io/badge/pytorch-2.7%2B-orange)]()
+[![openvino](https://img.shields.io/badge/openvino-2025.1-purple)]()
 
 <!-- markdownlint-enable  MD042 -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ docs = [
 ]
 
 base = [
-    "torch==2.5.1",
+    "torch==2.7.0",
     "lightning==2.4.0",
     "torchmetrics==1.6.0",
     "pytorchcv==0.0.67",

--- a/src/otx/algo/common/losses/cross_focal_loss.py
+++ b/src/otx/algo/common/losses/cross_focal_loss.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import torch
 import torch.nn.functional
 from torch import Tensor, nn
-from torch.cuda.amp import custom_fwd
+from torch.amp import custom_fwd
 
 from .focal_loss import py_sigmoid_focal_loss
 
@@ -79,7 +79,7 @@ class CrossSigmoidFocalLoss(nn.Module):
 
         self.cls_criterion = cross_sigmoid_focal_loss
 
-    @custom_fwd(cast_inputs=torch.float32)
+    @custom_fwd(cast_inputs=torch.float32, device_type="cuda")
     def forward(
         self,
         pred: Tensor,

--- a/src/otx/algo/instance_segmentation/backbones/swin.py
+++ b/src/otx/algo/instance_segmentation/backbones/swin.py
@@ -17,7 +17,7 @@ from typing import Callable
 import torch
 import torch.nn.functional
 import torch.utils.checkpoint as cp
-from timm.models.layers import DropPath, to_2tuple
+from timm.layers import DropPath, to_2tuple
 from torch import Tensor, nn
 
 from otx.algo.modules.base_module import BaseModule, ModuleList

--- a/src/otx/algo/modules/transformer.py
+++ b/src/otx/algo/modules/transformer.py
@@ -11,7 +11,7 @@ from functools import partial
 from typing import Callable, Sequence
 
 import torch
-from timm.models.layers import to_2tuple
+from timm.layers import to_2tuple
 from torch import nn
 
 from otx.algo.modules.base_module import BaseModule, Sequential

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -145,7 +145,7 @@ class PadtoSquare(tvt_v2.Transform):
         super().__init__()
         self.pad_val = pad_val
 
-    def _get_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
+    def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
         height, width = tvt_v2._utils.query_size(flat_inputs)  # noqa: SLF001
         max_dim = max(width, height)
         pad_w = max_dim - width
@@ -153,7 +153,7 @@ class PadtoSquare(tvt_v2.Transform):
         padding = (0, 0, pad_w, pad_h)
         return {"padding": padding}
 
-    def _transform(self, inpt: Any, params: dict[str, Any]) -> Any:  # noqa: ANN401
+    def transform(self, inpt: Any, params: dict[str, Any]) -> Any:  # noqa: ANN401
         return self._call_kernel(F.pad, inpt, padding=params["padding"], fill=self.pad_val, padding_mode="constant")
 
 
@@ -172,12 +172,12 @@ class ResizetoLongestEdge(tvt_v2.Transform):
         self.interpolation = F._geometry._check_interpolation(interpolation)  # noqa: SLF001
         self.antialias = antialias
 
-    def _get_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
+    def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
         height, width = tvt_v2._utils.query_size(flat_inputs)  # noqa: SLF001
         target_size = self._get_preprocess_shape(height, width, self.size)
         return {"target_size": target_size}
 
-    def _transform(self, inpt: Any, params: dict[str, Any]) -> Any:  # noqa: ANN401
+    def transform(self, inpt: Any, params: dict[str, Any]) -> Any:  # noqa: ANN401
         return self._call_kernel(
             F.resize,
             inpt,

--- a/src/otx/core/data/transform_libs/torchvision.py
+++ b/src/otx/core/data/transform_libs/torchvision.py
@@ -146,6 +146,7 @@ class PadtoSquare(tvt_v2.Transform):
         self.pad_val = pad_val
 
     def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
+        """Generates parameters for internal torchvision transform kernel."""
         height, width = tvt_v2._utils.query_size(flat_inputs)  # noqa: SLF001
         max_dim = max(width, height)
         pad_w = max_dim - width
@@ -154,6 +155,7 @@ class PadtoSquare(tvt_v2.Transform):
         return {"padding": padding}
 
     def transform(self, inpt: Any, params: dict[str, Any]) -> Any:  # noqa: ANN401
+        """Applies transform to the input image."""
         return self._call_kernel(F.pad, inpt, padding=params["padding"], fill=self.pad_val, padding_mode="constant")
 
 
@@ -173,11 +175,13 @@ class ResizetoLongestEdge(tvt_v2.Transform):
         self.antialias = antialias
 
     def make_params(self, flat_inputs: list[Any]) -> dict[str, Any]:
+        """Generates parameters for internal torchvision transform kernel."""
         height, width = tvt_v2._utils.query_size(flat_inputs)  # noqa: SLF001
         target_size = self._get_preprocess_shape(height, width, self.size)
         return {"target_size": target_size}
 
     def transform(self, inpt: Any, params: dict[str, Any]) -> Any:  # noqa: ANN401
+        """Applies transform to the input image."""
         return self._call_kernel(
             F.resize,
             inpt,

--- a/src/otx/core/optimizer/callable.py
+++ b/src/otx/core/optimizer/callable.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from typing import TYPE_CHECKING, Any
 
 from torch import nn
@@ -104,8 +105,12 @@ class OptimizerCallableSupportAdaptiveBS:
         optimizer = func(dummy_params)
 
         param_group = next(iter(optimizer.param_groups))
+        init_signature_params = inspect.signature(optimizer.__class__.__init__).parameters
+        valid_param_names = init_signature_params.keys()
 
         return OptimizerCallableSupportAdaptiveBS(
             optimizer_cls=optimizer.__class__,
-            optimizer_kwargs={key: value for key, value in param_group.items() if key != "params"},
+            optimizer_kwargs={
+                key: value for key, value in param_group.items() if key != "params" and key in valid_param_names
+            },
         )

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -482,7 +482,7 @@ def test_otx_configurable_input_size_e2e(
 
     best_ckpt_files = list(tmp_path_cfg_ipt_size.rglob("best_checkpoint.ckpt"))
     assert len(best_ckpt_files) != 0
-    best_ckpt = torch.load(best_ckpt_files[0])
+    best_ckpt = torch.load(best_ckpt_files[0], weights_only=False)
     assert best_ckpt["hyper_parameters"]["data_input_params"].input_size == (448, 448)
     for param_name in best_ckpt["datamodule_hyper_parameters"]:
         if "subset" in param_name:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -204,7 +204,6 @@ class TestOTXCLI:
                 cooldown: 0
                 min_lr: 0.0
                 eps: 1.0e-08
-                verbose: deprecated
         """
         expected_config = yaml.safe_load(expected_str)
         assert expected_config["scheduler"] == result_config["model"]["init_args"]["scheduler"]

--- a/tests/unit/core/data/test_transform_libs.py
+++ b/tests/unit/core/data/test_transform_libs.py
@@ -55,7 +55,7 @@ class TestPadtoSquare:
 
         # height > width
         inpt = tv_tensors.Image(torch.ones((1, 5, 3)))
-        results = transform(inpt, transform._get_params([inpt]))
+        results = transform(inpt, transform.make_params([inpt]))
 
         assert isinstance(results, tuple)
         assert results[0].shape == torch.Size((1, 5, 5))
@@ -63,7 +63,7 @@ class TestPadtoSquare:
 
         # height < width
         inpt = tv_tensors.Image(torch.ones((1, 3, 5)))
-        results = transform(inpt, transform._get_params([inpt]))
+        results = transform(inpt, transform.make_params([inpt]))
 
         assert isinstance(results, tuple)
         assert results[0].shape == torch.Size((1, 5, 5))
@@ -76,7 +76,7 @@ class TestPadtoSquare:
             canvas_size=(5, 3),
             dtype=torch.float32,
         )
-        results = transform(inpt.clone(), transform._get_params([inpt]))
+        results = transform(inpt.clone(), transform.make_params([inpt]))
 
         assert torch.all(results[0] == inpt)
 
@@ -85,7 +85,7 @@ class TestPadtoSquare:
             canvas_size=(5, 3),
             dtype=torch.float32,
         )
-        results = transform(inpt.clone(), transform._get_params([inpt]))
+        results = transform(inpt.clone(), transform.make_params([inpt]))
 
         assert torch.all(results[0] == inpt)
 
@@ -96,7 +96,7 @@ class TestResizetoLongestEdge:
 
         # height > width
         inpt = tv_tensors.Image(torch.ones((1, 5, 3)))
-        results = transform(inpt, transform._get_params([inpt]))
+        results = transform(inpt, transform.make_params([inpt]))
 
         assert isinstance(results, tuple)
         assert results[0].shape == torch.Size((1, 10, 6))
@@ -104,7 +104,7 @@ class TestResizetoLongestEdge:
 
         # height < width
         inpt = tv_tensors.Image(torch.ones((1, 3, 5)))
-        results = transform(inpt, transform._get_params([inpt]))
+        results = transform(inpt, transform.make_params([inpt]))
 
         assert isinstance(results, tuple)
         assert results[0].shape == torch.Size((1, 6, 10))
@@ -112,7 +112,7 @@ class TestResizetoLongestEdge:
 
         # square
         inpt = tv_tensors.Image(torch.ones((1, 5, 5)))
-        results = transform(inpt, transform._get_params([inpt]))
+        results = transform(inpt, transform.make_params([inpt]))
 
         assert isinstance(results, tuple)
         assert results[0].shape == torch.Size((1, 10, 10))


### PR DESCRIPTION
### Summary

Bump torch as 2.5.1 is half year old and we have enough room for testing before the next release.
Also, that'd allow to use the latest XPU torch wheel.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
