### PR TITLE
Fix missing mAP score reporting for instance segmentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
   (<https://github.com/openvinotoolkit/training_extensions/pull/4293>)
 - Align KP detection validation with ModelAPI post processing
   (<https://github.com/openvinotoolkit/training_extensions/pull/4300>)
+- Fix missing mAP score reporting for instance segmentation
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Align KP detection validation with ModelAPI post processing
   (<https://github.com/openvinotoolkit/training_extensions/pull/4300>)
 - Fix missing mAP score reporting for instance segmentation
+  (<https://github.com/open-edge-platform/training_extensions/pull/4364>)
 
 ### Removed
 

--- a/src/otx/algo/instance_segmentation/utils/utils.py
+++ b/src/otx/algo/instance_segmentation/utils/utils.py
@@ -52,7 +52,7 @@ def unpack_inst_seg_entity(entity: TorchDataBatch) -> tuple:
         }
         batch_img_metas.append(metainfo)
 
-        gt_masks = mask if mask is not None else polygon
+        gt_masks = mask if len(mask) else polygon
 
         batch_gt_instances.append(
             InstanceData(

--- a/src/otx/core/data/dataset/instance_segmentation.py
+++ b/src/otx/core/data/dataset/instance_segmentation.py
@@ -86,7 +86,7 @@ class OTXInstanceSegDataset(OTXDataset):
             warnings.warn(f"No valid annotations found for image {item.id}!", stacklevel=2)
 
         bboxes = np.stack(gt_bboxes, dtype=np.float32, axis=0) if gt_bboxes else np.empty((0, 4))
-        masks = np.stack(gt_masks, axis=0) if gt_masks else np.zeros((len(gt_labels), *img_shape), dtype=bool)
+        masks = np.stack(gt_masks, axis=0) if gt_masks else np.zeros((0, *img_shape), dtype=bool)
 
         labels = np.array(gt_labels, dtype=np.int64)
 

--- a/src/otx/core/model/instance_segmentation.py
+++ b/src/otx/core/model/instance_segmentation.py
@@ -661,7 +661,7 @@ class OVInstanceSegmentationModel(
         for idx in range(len(inputs.labels)):  # type: ignore[arg-type]
             rles = (
                 [encode_rle(mask) for mask in _masks[idx].data]
-                if _masks is not None and _masks[idx] is not None
+                if _masks is not None and len(_masks[idx]) > 0
                 else polygon_to_rle(inputs.polygons[idx], *inputs.imgs_info[idx].ori_shape)  # type: ignore[index,union-attr]
             )
             target_info.append(


### PR DESCRIPTION
### Summary

OTX is not reporting mAP scores for instance segmentation.

Observed metrics:
```
│       test/f1-score       │    0.7494     │
│         test/mAP          │     0.0       │
│        test/mAP_50        │     0.0       │
│        test/mAP_75        │     0.0       │
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
