### PR TITLE
Fix input_size type check to accept list in OTXDataModule

### DIFF
--- a/src/otx/core/data/module.py
+++ b/src/otx/core/data/module.py
@@ -127,8 +127,8 @@ class OTXDataModule(LightningDataModule):
                 self.task,
                 input_size_multiplier,
             )
-        elif not isinstance(input_size, tuple):
-            msg = f"input_size should be tuple of ints or 'auto', but got {input_size}"
+        elif not isinstance(input_size, (tuple, list)):
+            msg = f"input_size should be tuple/list of ints or 'auto', but got {input_size}"
             raise ValueError(msg)
 
         for subset_cfg in [train_subset, val_subset, test_subset]:


### PR DESCRIPTION
### Summary

The Engine fails to initialize when provided a model, raising the following error:
```
input_size should be a tuple of ints or 'auto', but got [640, 640]
```
Code snippet:

```
engine = Engine(
    model="yolox_s",
    task=detection,
    data_root=data_root,
    work_dir=work_dir,
)
```
Fix: Update input size handling to accept both tuples and lists (e.g., [640, 640] as well as (640, 640)).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
