### PR TITLE
Update TASK_METRIC_MAP for perf v2

### DIFF
--- a/tests/perf_v2/run.py
+++ b/tests/perf_v2/run.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
+import sys
 
 from otx.core.types.task import OTXTaskType
 from tests.perf_v2 import DATASET_COLLECTIONS, MODEL_COLLECTIONS
@@ -41,7 +42,7 @@ if __name__ == "__main__":
             for seed in range(args.num_repeat):
                 subprocess.run(
                     [  # noqa: S603, S607
-                        "python",
+                        sys.executable,
                         "-m",
                         "tests.perf_v2.benchmark",
                         "--task",

--- a/tests/perf_v2/summary.py
+++ b/tests/perf_v2/summary.py
@@ -26,7 +26,7 @@ pd.set_option("display.width", None)
 logger = logging.getLogger(__name__)
 
 TASK_METRIC_MAP = {
-    OTXTaskType.ANOMALY: "f1-score",  # perf v2 uses single anomaly task
+    OTXTaskType.ANOMALY: "image_F1Score",  # perf v2 uses single anomaly task
     OTXTaskType.MULTI_CLASS_CLS: "accuracy",
     OTXTaskType.MULTI_LABEL_CLS: "accuracy",
     OTXTaskType.H_LABEL_CLS: "accuracy",

--- a/tests/perf_v2/summary.py
+++ b/tests/perf_v2/summary.py
@@ -26,7 +26,7 @@ pd.set_option("display.width", None)
 logger = logging.getLogger(__name__)
 
 TASK_METRIC_MAP = {
-    OTXTaskType.ANOMALY: "f1-score", # perf v2 uses single anomaly task
+    OTXTaskType.ANOMALY: "f1-score",  # perf v2 uses single anomaly task
     OTXTaskType.MULTI_CLASS_CLS: "accuracy",
     OTXTaskType.MULTI_LABEL_CLS: "accuracy",
     OTXTaskType.H_LABEL_CLS: "accuracy",

--- a/tests/perf_v2/summary.py
+++ b/tests/perf_v2/summary.py
@@ -26,10 +26,7 @@ pd.set_option("display.width", None)
 logger = logging.getLogger(__name__)
 
 TASK_METRIC_MAP = {
-    OTXTaskType.ANOMALY: "f1-score",
-    OTXTaskType.ANOMALY_CLASSIFICATION: "f1-score",
-    OTXTaskType.ANOMALY_DETECTION: "f1-score",
-    OTXTaskType.ANOMALY_SEGMENTATION: "f1-score",
+    OTXTaskType.ANOMALY: "f1-score", # perf v2 uses single anomaly task
     OTXTaskType.MULTI_CLASS_CLS: "accuracy",
     OTXTaskType.MULTI_LABEL_CLS: "accuracy",
     OTXTaskType.H_LABEL_CLS: "accuracy",

--- a/tests/perf_v2/summary.py
+++ b/tests/perf_v2/summary.py
@@ -26,6 +26,7 @@ pd.set_option("display.width", None)
 logger = logging.getLogger(__name__)
 
 TASK_METRIC_MAP = {
+    OTXTaskType.ANOMALY: "f1-score",
     OTXTaskType.ANOMALY_CLASSIFICATION: "f1-score",
     OTXTaskType.ANOMALY_DETECTION: "f1-score",
     OTXTaskType.ANOMALY_SEGMENTATION: "f1-score",


### PR DESCRIPTION
### Summary

Benchmarking anomaly task using perf v2 fails as TASK_METRIC_MAP was outdated with 3 anomaly tasks instead of the new ANOMALY Task type. 
In this PR : 
Replace the three types of anomaly tasks with a single ANOMALY task. 
Updated only for v2 perf. 



<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
