### PR TITLE
Disable weight computation in TransformerEncoderLayer

### DIFF
--- a/src/otx/algo/common/layers/transformer_layers.py
+++ b/src/otx/algo/common/layers/transformer_layers.py
@@ -71,9 +71,9 @@ class TransformerEncoderLayer(nn.Module):
             src = self.norm1(src)
         q = k = self.with_pos_embed(src, pos_embed)
         if self.key_mask:
-            src = self.self_attn(q, k, value=src, key_padding_mask=src_mask)[0]
+            src, _ = self.self_attn(q, k, value=src, key_padding_mask=src_mask, need_weights=False)
         else:
-            src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask)
+            src, _ = self.self_attn(q, k, value=src, attn_mask=src_mask, need_weights=False)
 
         src = residual + self.dropout1(src)
         if not self.normalize_before:


### PR DESCRIPTION
### Summary

Disable weight computation in TransformerEncoderLayer

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
