### PR TITLE
Add model arch name to exported model metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   (https://github.com/open-edge-platform/training_extensions/pull/4334)
 - Bump torch to 2.7.0
   (https://github.com/open-edge-platform/training_extensions/pull/4361)
+- Add model arch name to exported model metadata
+  (https://github.com/open-edge-platform/training_extensions/pull/4407)
 
 ### Bug fixes
 

--- a/src/otx/core/exporter/anomaly.py
+++ b/src/otx/core/exporter/anomaly.py
@@ -65,6 +65,7 @@ class OTXAnomalyModelExporter(OTXNativeModelExporter):
             task_level_export_parameters=TaskLevelExportParameters(
                 model_type="anomaly",
                 task_type="anomaly",
+                model_name="anomaly",
                 label_info=NullLabelInfo(),
                 optimization_config={},
             ),

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 Intel Corporation
+# Copyright (C) 2023-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """Class definition for base model entity used in OTX."""
 

--- a/src/otx/core/model/base.py
+++ b/src/otx/core/model/base.py
@@ -774,6 +774,7 @@ class OTXModel(LightningModule):
         return TaskLevelExportParameters(
             model_type="null",
             task_type="null",
+            model_name=self.model_name,
             label_info=self.label_info,
             optimization_config=self._optimization_config,
         )

--- a/src/otx/core/types/export.py
+++ b/src/otx/core/types/export.py
@@ -27,6 +27,7 @@ class TaskLevelExportParameters:
 
     Attributes:
         model_type (str): Model type field used in ModelAPI.
+        model_name (str): Model name field.
         task_type (str): Task type field used in ModelAPI.
         label_info (LabelInfo): OTX label info metadata.
             It will be parsed into a format compatible with ModelAPI.
@@ -56,6 +57,7 @@ class TaskLevelExportParameters:
 
     # Common
     model_type: str
+    model_name: str
     task_type: str
     label_info: LabelInfo
     optimization_config: dict
@@ -114,6 +116,7 @@ class TaskLevelExportParameters:
         metadata = {
             # Common
             ("model_info", "model_type"): self.model_type,
+            ("model_info", "model_name"): self.model_name,
             ("model_info", "task_type"): self.task_type,
             ("model_info", "label_info"): self.label_info.to_json(),
             ("model_info", "labels"): all_labels.strip(),

--- a/tests/unit/core/types/test_export.py
+++ b/tests/unit/core/types/test_export.py
@@ -13,6 +13,7 @@ from otx.core.types.export import TaskLevelExportParameters
 def test_wrap(fxt_label_info, task_type):
     params = TaskLevelExportParameters(
         model_type="dummy model",
+        model_name="dummy model name",
         task_type=task_type,
         label_info=fxt_label_info,
         optimization_config={},
@@ -55,7 +56,10 @@ def test_wrap(fxt_label_info, task_type):
     assert ("model_info", "tile_size") in metadata
     assert ("model_info", "tiles_overlap") in metadata
     assert ("model_info", "max_pred_number") in metadata
+
+    # misc
     assert ("model_info", "otx_version") in metadata
+    assert ("model_info", "model_name") in metadata
 
 
 def test_to_metadata_label_consistency(fxt_label_info):
@@ -64,6 +68,7 @@ def test_to_metadata_label_consistency(fxt_label_info):
 
     params = TaskLevelExportParameters(
         model_type="dummy model",
+        model_name="dummy model name",
         task_type="instance_segmentation",
         label_info=label_info,
         optimization_config={},

--- a/tests/unit/core/types/test_export.py
+++ b/tests/unit/core/types/test_export.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy

--- a/tests/unit/core/utils/test_utils.py
+++ b/tests/unit/core/utils/test_utils.py
@@ -52,6 +52,7 @@ def get_dummy_ov_cls_model():
     model_params = TaskLevelExportParameters(
         model_type="Classification",
         task_type="classification",
+        model_name="dummy_model",
         multilabel=True,
         label_info=LabelInfo(["car", "truck"], ["0", "1"], [["car"], ["truck"]]),
         optimization_config={},


### PR DESCRIPTION
### Summary
Architecture name is convenient to have when debugging Geti: we're going to eliminate other configs containing arch names. Instead, we can keep it in the model's meta.


<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
