### PR TITLE
🐞 Fix 0 image scores in Anomaly OV model

### DIFF
--- a/src/otx/backend/openvino/models/anomaly.py
+++ b/src/otx/backend/openvino/models/anomaly.py
@@ -99,7 +99,7 @@ class OVAnomalyModel(OVModel):
         """
         score_dict = {
             "pred_scores": torch.tensor(
-                [score if label == "Anomaly" else 1 - score for score, label in zip(preds.scores, preds.labels)],
+                [score if label == 1 else 1 - score for score, label in zip(preds.scores, preds.labels)],
             ),
             "labels": torch.tensor(inputs.labels) if inputs.batch_size == 1 else torch.vstack(inputs.labels),
         }


### PR DESCRIPTION
### Summary

- Image level metrics are 0 or very low. This is because `label == "Anomaly"` is never true. Since the new OV task takes `OTXDataBatch` instead of the old `AnomalyDataBatch` the labels are in a different format. This should fix it

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
