### PR TITLE
🐞 Minor Bugfixes for benchmarking

### DIFF
--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -147,11 +147,11 @@ class OTXEngine(Engine):
 
     def train(
         self,
-        max_epochs: int = 200,
+        max_epochs: int | None = None,
         min_epochs: int = 1,
         seed: int | None = None,
         deterministic: bool | Literal["warn"] = False,
-        precision: _PRECISION_INPUT | None = "16",
+        precision: _PRECISION_INPUT | None = None,
         val_check_interval: int | float | None = None,
         callbacks: list[Callback] | Callback | None = None,
         logger: Logger | Iterable[Logger] | bool | None = None,

--- a/src/otx/data/dataset/anomaly.py
+++ b/src/otx/data/dataset/anomaly.py
@@ -80,7 +80,7 @@ class OTXAnomalyDataset(OTXDataset):
                 ori_shape=img_shape,
                 image_color_channel=self.image_color_channel,
             ),
-            label=torch.tensor(label, dtype=torch.long),
+            label=label.to(dtype=torch.long),
             masks=Mask(self._get_mask(datumaro_item, label, img_shape)),
         )
 
@@ -159,7 +159,7 @@ class OTXAnomalyDataset(OTXDataset):
         mask_file_path = (
             Path("/".join(datumaro_item.media.path.split("/")[:-3]))
             / "ground_truth"
-            / f"{('/'.join(datumaro_item.media.path.split('/')[-2:])).replace('.png','_mask.png')}"
+            / f"{('/'.join(datumaro_item.media.path.split('/')[-2:])).replace('.png', '_mask.png')}"
         )
         if mask_file_path.exists():
             return (io.read_image(str(mask_file_path), mode=io.ImageReadMode.GRAY) / 255).to(torch.uint8)


### PR DESCRIPTION
- Max epochs in train overrides the max_epochs value loaded from config when creating the engine
- Other fixes for benchmarking script

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
