### PR TITLE
Add support for transforming masks and polygons in RandomAffine

### DIFF
--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -2263,22 +2263,32 @@ class Pad(tvt_v2.Transform, NumpytoTVTensorMixin):
             pad_val = self.pad_val.get("mask", 0)
             padding = inputs.img_info.padding
 
-            padded_masks = np.stack(
-                [
-                    cv2.copyMakeBorder(
-                        mask,
-                        padding[1],
-                        padding[3],
-                        padding[0],
-                        padding[2],
-                        self.border_type[self.padding_mode],
-                        value=pad_val,
-                    )
-                    for mask in masks
-                ],
-            )
+            padded_masks = []
+            for mask in masks:
+                orig_dtype = mask.dtype
+                # cv2.copyMakeBorder does not support bool, so cast to uint8 if needed
+                if mask.dtype == np.bool_:
+                    mask_to_pad = mask.astype(np.uint8)
+                    pad_val_cast = int(bool(pad_val))
+                else:
+                    mask_to_pad = mask
+                    pad_val_cast = pad_val
 
-            inputs.masks = padded_masks
+                padded = cv2.copyMakeBorder(
+                    mask_to_pad,
+                    padding[1],
+                    padding[3],
+                    padding[0],
+                    padding[2],
+                    self.border_type[self.padding_mode],
+                    value=pad_val_cast,
+                )
+                # Cast back to original dtype if needed
+                if orig_dtype == np.bool_:
+                    padded = padded.astype(np.bool_)
+                padded_masks.append(padded)
+
+            inputs.masks = np.stack(padded_masks)
 
         return inputs
 

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1276,6 +1276,10 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         if not self.transform_mask or not hasattr(inputs, "masks") or inputs.masks is None or len(inputs.masks) == 0:
             return
 
+        # Convert valid_index to numpy boolean array if it's a tensor
+        if hasattr(valid_index, 'numpy'):
+            valid_index = valid_index.numpy()
+        
         # Filter masks using valid_index first
         masks = inputs.masks[valid_index]
         masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
@@ -1341,6 +1345,10 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             or len(inputs.polygons) == 0
         ):
             return
+
+        # Convert valid_index to numpy boolean array if it's a tensor
+        if hasattr(valid_index, 'numpy'):
+            valid_index = valid_index.numpy()
 
         # Filter polygons using valid_index
         filtered_polygons = [p for p, keep in zip(inputs.polygons, valid_index) if keep]

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1199,7 +1199,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
 
             if hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0:
                 self._transform_polygons(inputs, homography_matrix, output_shape, valid_index)
-            
+
             if self.recompute_bbox:
                 self._recompute_bboxes(inputs, output_shape)
 
@@ -1348,45 +1348,42 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         if filtered_polygons:
             inputs.polygons = project_polygons(filtered_polygons, warp_matrix, output_shape)
 
-    def _recompute_bboxes(self, inputs: OTXDataItem, output_shape: tuple[int, int],) -> None:
+    def _recompute_bboxes(self, inputs: OTXDataItem, output_shape: tuple[int, int]) -> None:
         """Recomputes the bounding boxes after tranforming from the mask or polygons if available.
 
         Args:
             inputs: Input data item.
             output_shape: Output shape (height, width).
         """
-                
         has_polygons = hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0
         has_masks = hasattr(inputs, "masks") and inputs.masks is not None and len(inputs.masks) > 0
 
         if not has_polygons and not has_masks:
             return
-        
+
         # bboxes here are XYXY format
         bboxes = inputs.bboxes
-        bboxes = bboxes.numpy() if not isinstance(bboxes, np.ndarray) else bboxes
+        bboxes = bboxes.numpy() if not isinstance(bboxes, np.ndarray) else bboxes  # type: ignore[union-attr]
 
         if has_masks:
             masks = inputs.masks
-            masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
+            masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks  # type: ignore[union-attr]
             for i, mask in enumerate(masks):
                 points = cv2.findNonZero(mask.astype(np.uint8))
                 if points is not None:
                     x, y, w, h = cv2.boundingRect(points)
-                    bboxXYXY = [x, y, x + w, y + h]
-                    bboxes[i] = np.array(bboxXYXY)
+                    bboxes[i] = np.array([x, y, x + w, y + h])
 
         elif has_polygons:
             polygons = inputs.polygons
-            for i, polygon in enumerate(polygons):
+            for i, polygon in enumerate(polygons):  # type: ignore[arg-type]
                 points_1d = np.array(polygon.points, dtype=np.float32)
                 if len(points_1d) % 2 != 0:
                     continue
 
                 points = points_1d.reshape(-1, 2)
                 x, y, w, h = cv2.boundingRect(points)
-                bboxXYXY = [x, y, x + w, y + h]
-                bboxes[i] = np.array(bboxXYXY)
+                bboxes[i] = np.array([x, y, x + w, y + h])
 
         inputs.bboxes = tv_tensors.BoundingBoxes(
             bboxes,

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1277,9 +1277,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             return
 
         # Convert valid_index to numpy boolean array if it's a tensor
-        if hasattr(valid_index, 'numpy'):
+        if hasattr(valid_index, "numpy"):
             valid_index = valid_index.numpy()
-        
+
         # Filter masks using valid_index first
         masks = inputs.masks[valid_index]
         masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
@@ -1347,7 +1347,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             return
 
         # Convert valid_index to numpy boolean array if it's a tensor
-        if hasattr(valid_index, 'numpy'):
+        if hasattr(valid_index, "numpy"):
             valid_index = valid_index.numpy()
 
         # Filter polygons using valid_index

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1099,10 +1099,10 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         is_numpy_to_tvtensor: bool = False,
     ) -> None:
         super().__init__()
-
         assert 0 <= max_translate_ratio <= 1  # noqa: S101
         assert scaling_ratio_range[0] <= scaling_ratio_range[1]  # noqa: S101
         assert scaling_ratio_range[0] > 0  # noqa: S101
+
         self.max_rotate_degree = max_rotate_degree
         self.max_translate_ratio = max_translate_ratio
         self.scaling_ratio_range = scaling_ratio_range
@@ -1111,8 +1111,8 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         self.border_val = border_val
         self.bbox_clip_border = bbox_clip_border
         self.transform_mask = transform_mask
-        self.mask_fill_value = mask_fill_value
         self.transform_polygon = transform_polygon
+        self.mask_fill_value = mask_fill_value
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
 
     @cache_randomness
@@ -1152,9 +1152,8 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         inputs.image = img
         inputs.img_info = _resize_image_info(inputs.img_info, img.shape[:2])
 
-        bboxes = inputs.bboxes
-        num_bboxes = len(bboxes) if bboxes is not None else 0
-        if num_bboxes:
+        # Handle bboxes first to get valid_index for filtering other annotations
+        if (bboxes := getattr(inputs, "bboxes", None)) is not None:
             bboxes = project_bboxes(bboxes, warp_matrix)
             if self.bbox_clip_border:
                 bboxes = clip_bboxes(bboxes, (height, width))
@@ -1163,26 +1162,52 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             inputs.bboxes = tv_tensors.BoundingBoxes(bboxes[valid_index], format="XYXY", canvas_size=(height, width))  # type: ignore[union-attr]
             inputs.label = inputs.label[valid_index]  # type: ignore[union-attr,index]
 
-        if self.transform_mask and (masks := getattr(inputs, "masks", None)) is not None and len(masks) > 0:
-            masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
-            transformed_masks = []
-            for mask in masks:
-                # Apply the same warp matrix used for the image
-                warped_mask = cv2.warpPerspective(
-                    mask,
-                    warp_matrix,
-                    dsize=(width, height),
-                    borderValue=self.mask_fill_value,
-                    flags=cv2.INTER_NEAREST,  # Use nearest neighbor for masks
-                )
-                transformed_masks.append(warped_mask)
-            inputs.masks = tv_tensors.Mask(np.stack(transformed_masks))
+            # Transform masks - filter first, then transform for efficiency
+            if self.transform_mask and (masks := getattr(inputs, "masks", None)) is not None and len(masks) > 0:
+                # Filter masks using valid_index first to avoid unnecessary computation
+                masks = masks[valid_index]
+                masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
+                if isinstance(masks, np.ndarray) and masks.ndim == 3:
+                    masks = list(masks)
 
-        # Transform polygons
-        if self.transform_polygon and (polygons := getattr(inputs, "polygons", None)) is not None and len(polygons) > 0:
-            # Transform polygons using the same warp matrix
-            transformed_polygons = project_polygons(polygons, warp_matrix, (height, width))
-            inputs.polygons = transformed_polygons  # type: ignore[union-attr]
+                # Smart mask warping: binary masks get 255/127 treatment, others use INTER_NEAREST
+                transformed_masks = []
+                for mask in masks:
+                    unique_values = np.unique(mask)
+                    if len(unique_values) <= 2 and np.max(unique_values) <= 1:
+                        # Binary mask: use 255/127 approach for cleaner results
+                        warped_mask = (
+                            cv2.warpPerspective(
+                                mask.astype(np.uint8) * 255,
+                                warp_matrix,
+                                dsize=(width, height),
+                                borderValue=0,  # Always 0 for binary masks to avoid artifacts
+                            )
+                            > 127
+                        )
+                    else:
+                        # Multi-class mask: use INTER_NEAREST to preserve discrete values
+                        warped_mask = cv2.warpPerspective(
+                            mask.astype(np.uint8),
+                            warp_matrix,
+                            dsize=(width, height),
+                            borderValue=self.mask_fill_value,  # Use configurable fill value
+                            flags=cv2.INTER_NEAREST,
+                        )
+                    transformed_masks.append(warped_mask)
+                masks = np.stack(transformed_masks).astype(np.uint8)
+                inputs.masks = tv_tensors.Mask(torch.from_numpy(masks > 0).to(torch.bool))
+
+            # Transform polygons - filter first, then use project_polygons for clean implementation
+            if (
+                self.transform_polygon
+                and (polygons := getattr(inputs, "polygons", None)) is not None
+                and len(polygons) > 0
+            ):
+                # Filter polygons using valid_index first to avoid unnecessary computation
+                filtered_polygons = [p for p, keep in zip(polygons, valid_index) if keep]
+                # Use existing project_polygons function for clean, tested implementation
+                inputs.polygons = project_polygons(filtered_polygons, warp_matrix, (height, width))
 
         return self.convert(inputs)
 
@@ -1196,8 +1221,8 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         repr_str += f"border_val={self.border_val}, "
         repr_str += f"bbox_clip_border={self.bbox_clip_border}, "
         repr_str += f"transform_mask={self.transform_mask}, "
-        repr_str += f"mask_fill_value={self.mask_fill_value}, "
         repr_str += f"transform_polygon={self.transform_polygon}, "
+        repr_str += f"mask_fill_value={self.mask_fill_value}, "
         repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
         return repr_str
 

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1065,14 +1065,14 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             Defaults to 10.
         max_translate_ratio (float): Maximum ratio of translation.
             Defaults to 0.1.
-        scaling_ratio_range (tuple[float]): Min and max ratio of
+        scaling_ratio_range (tuple[float, float]): Min and max ratio of
             scaling transform. Defaults to (0.5, 1.5).
         max_shear_degree (float): Maximum degrees of shear
             transform. Defaults to 2.
-        border (tuple[int]): Distance from height and width sides of input
+        border (tuple[int, int]): Distance from height and width sides of input
             image to adjust output shape. Only used in mosaic dataset.
             Defaults to (0, 0).
-        border_val (tuple[int]): Border padding values of 3 channels.
+        border_val (tuple[int, int, int]): Border padding values of 3 channels.
             Defaults to (114, 114, 114).
         bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. In some dataset like MOT17, the gt bboxes
@@ -1099,9 +1099,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         is_numpy_to_tvtensor: bool = False,
     ) -> None:
         super().__init__()
-        assert 0 <= max_translate_ratio <= 1  # noqa: S101
-        assert scaling_ratio_range[0] <= scaling_ratio_range[1]  # noqa: S101
-        assert scaling_ratio_range[0] > 0  # noqa: S101
+        self._validate_parameters(max_translate_ratio, scaling_ratio_range)
 
         self.max_rotate_degree = max_rotate_degree
         self.max_translate_ratio = max_translate_ratio
@@ -1115,141 +1113,327 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         self.mask_fill_value = mask_fill_value
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
 
+    @staticmethod
+    def _validate_parameters(max_translate_ratio: float, scaling_ratio_range: tuple[float, float]) -> None:
+        """Validate input parameters."""
+        if not 0 <= max_translate_ratio <= 1:
+            msg = f"max_translate_ratio must be between 0 and 1, got {max_translate_ratio}"
+            raise ValueError(msg)
+        if scaling_ratio_range[0] > scaling_ratio_range[1]:
+            msg = f"scaling_ratio_range[0] must be <= scaling_ratio_range[1], got {scaling_ratio_range}"
+            raise ValueError(msg)
+        if scaling_ratio_range[0] <= 0:
+            msg = f"scaling_ratio_range[0] must be > 0, got {scaling_ratio_range[0]}"
+            raise ValueError(msg)
+
     @cache_randomness
     def _get_random_homography_matrix(self, height: int, width: int) -> np.ndarray:
-        # Rotation
+        """Generate random homography matrix for affine transformation.
+
+        Args:
+            height (int): Image height including border.
+            width (int): Image width including border.
+
+        Returns:
+            np.ndarray: 3x3 homography matrix.
+        """
+        # Generate transformation parameters
         rotation_degree = random.uniform(-self.max_rotate_degree, self.max_rotate_degree)
-        rotation_matrix = self._get_rotation_matrix(rotation_degree)
-
-        # Scaling
         scaling_ratio = random.uniform(self.scaling_ratio_range[0], self.scaling_ratio_range[1])
-        scaling_matrix = self._get_scaling_matrix(scaling_ratio)
-
-        # Shear
-        x_degree = random.uniform(-self.max_shear_degree, self.max_shear_degree)
-        y_degree = random.uniform(-self.max_shear_degree, self.max_shear_degree)
-        shear_matrix = self._get_shear_matrix(x_degree, y_degree)
-
-        # Translation
+        x_shear_degree = random.uniform(-self.max_shear_degree, self.max_shear_degree)
+        y_shear_degree = random.uniform(-self.max_shear_degree, self.max_shear_degree)
         trans_x = random.uniform(-self.max_translate_ratio, self.max_translate_ratio) * width
         trans_y = random.uniform(-self.max_translate_ratio, self.max_translate_ratio) * height
+
+        # Create transformation matrices
+        rotation_matrix = self._get_rotation_matrix(rotation_degree)
+        scaling_matrix = self._get_scaling_matrix(scaling_ratio)
+        shear_matrix = self._get_shear_matrix(x_shear_degree, y_shear_degree)
         translate_matrix = self._get_translation_matrix(trans_x, trans_y)
 
+        # Combine transformations: T * Sh * R * S
         return translate_matrix @ shear_matrix @ rotation_matrix @ scaling_matrix
 
-    def forward(self, *_inputs: OTXDataItem) -> OTXDataItem | None:
-        """Forward for RandomAffine."""
-        assert len(_inputs) == 1, "[tmp] Multiple entity is not supported yet."  # noqa: S101
-        inputs = _inputs[0]
+    def forward(self, inputs: OTXDataItem) -> OTXDataItem:
+        """Forward pass of RandomAffine transform.
 
-        img: np.ndarray = to_np_image(inputs.image)
-        height = img.shape[0] + self.border[0] * 2
-        width = img.shape[1] + self.border[1] * 2
+        Args:
+            inputs: Input data containing image and annotations.
 
-        warp_matrix = self._get_random_homography_matrix(height, width)
+        Returns:
+            Transformed data item or original input if no valid annotations remain.
 
-        img = cv2.warpPerspective(img, warp_matrix, dsize=(width, height), borderValue=self.border_val)
-        inputs.image = img
-        inputs.img_info = _resize_image_info(inputs.img_info, img.shape[:2])
+        Raises:
+            ValueError: If inputs format is invalid.
+        """
+        _inputs = self.extract(inputs)
+        if len(_inputs) != 1:
+            msg = f"RandomAffine can only transform single input, got {len(_inputs)}"
+            raise ValueError(msg)
 
-        # Handle bboxes first to get valid_index for filtering other annotations
-        if (bboxes := getattr(inputs, "bboxes", None)) is not None:
-            bboxes = project_bboxes(bboxes, warp_matrix)
-            if self.bbox_clip_border:
-                bboxes = clip_bboxes(bboxes, (height, width))
-            # remove outside bbox
-            valid_index = is_inside_bboxes(bboxes, (height, width))
-            inputs.bboxes = tv_tensors.BoundingBoxes(bboxes[valid_index], format="XYXY", canvas_size=(height, width))  # type: ignore[union-attr]
-            inputs.label = inputs.label[valid_index]  # type: ignore[union-attr,index]
+        data_item = _inputs[0]
 
-            # Transform masks - filter first, then transform for efficiency
-            if self.transform_mask and (masks := getattr(inputs, "masks", None)) is not None and len(masks) > 0:
-                # Filter masks using valid_index first to avoid unnecessary computation
-                masks = masks[valid_index]
-                masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
-                if isinstance(masks, np.ndarray) and masks.ndim == 3:
-                    masks = list(masks)
+        # Check if there are any transformable objects at all
+        has_bboxes = hasattr(data_item, "bboxes") and data_item.bboxes is not None and len(data_item.bboxes) > 0
+        has_masks = hasattr(data_item, "masks") and data_item.masks is not None and len(data_item.masks) > 0
+        has_polygons = hasattr(data_item, "polygons") and data_item.polygons is not None and len(data_item.polygons) > 0
 
-                # Smart mask warping: binary masks get 255/127 treatment, others use INTER_NEAREST
-                transformed_masks = []
-                for mask in masks:
-                    unique_values = np.unique(mask)
-                    if len(unique_values) <= 2 and np.max(unique_values) <= 1:
-                        # Binary mask: use 255/127 approach for cleaner results
-                        warped_mask = (
-                            cv2.warpPerspective(
-                                mask.astype(np.uint8) * 255,
-                                warp_matrix,
-                                dsize=(width, height),
-                                borderValue=0,  # Always 0 for binary masks to avoid artifacts
-                            )
-                            > 127
-                        )
-                    else:
-                        # Multi-class mask: use INTER_NEAREST to preserve discrete values
-                        warped_mask = cv2.warpPerspective(
-                            mask.astype(np.uint8),
-                            warp_matrix,
-                            dsize=(width, height),
-                            borderValue=self.mask_fill_value,  # Use configurable fill value
-                            flags=cv2.INTER_NEAREST,
-                        )
-                    transformed_masks.append(warped_mask)
-                masks = np.stack(transformed_masks).astype(np.uint8)
-                inputs.masks = tv_tensors.Mask(torch.from_numpy(masks > 0).to(torch.bool))
+        # If no transformable objects exist, skip the entire transformation
+        if not (has_bboxes or has_masks or has_polygons):
+            return self.convert(inputs)  # type: ignore[return-value]
 
-            # Transform polygons - filter first, then use project_polygons for clean implementation
-            if (
-                self.transform_polygon
-                and (polygons := getattr(inputs, "polygons", None)) is not None
-                and len(polygons) > 0
-            ):
-                # Filter polygons using valid_index first to avoid unnecessary computation
-                filtered_polygons = [p for p, keep in zip(polygons, valid_index) if keep]
-                # Use existing project_polygons function for clean, tested implementation
-                inputs.polygons = project_polygons(filtered_polygons, warp_matrix, (height, width))
+        # Get random homography matrix for affine transformation
+        height, width = data_item.img.shape[:2]
+        homography_matrix = self._get_random_homography_matrix(height, width)
+        output_shape = (height + self.border[0] * 2, width + self.border[1] * 2)
 
-        return self.convert(inputs)
+        if has_bboxes:
+            # Test transform bboxes to see if any remain valid
+            valid_index = self._transform_bboxes(data_item, homography_matrix, output_shape)
+            # If no valid annotations will remain after transformation, skip entirely
+            if not valid_index.any():
+                return self.convert(inputs)  # type: ignore[return-value]
 
-    def __repr__(self):
-        repr_str = self.__class__.__name__
-        repr_str += f"(max_rotate_degree={self.max_rotate_degree}, "
-        repr_str += f"max_translate_ratio={self.max_translate_ratio}, "
-        repr_str += f"scaling_ratio_range={self.scaling_ratio_range}, "
-        repr_str += f"max_shear_degree={self.max_shear_degree}, "
-        repr_str += f"border={self.border}, "
-        repr_str += f"border_val={self.border_val}, "
-        repr_str += f"bbox_clip_border={self.bbox_clip_border}, "
-        repr_str += f"transform_mask={self.transform_mask}, "
-        repr_str += f"transform_polygon={self.transform_polygon}, "
-        repr_str += f"mask_fill_value={self.mask_fill_value}, "
-        repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
-        return repr_str
+            # If we reach here, transformation will produce valid results, so proceed
+            # Transform image
+            transformed_img = self._warp_image(data_item.img, homography_matrix)
+            data_item.img = transformed_img
+
+            if has_masks:
+                self._transform_masks(data_item, homography_matrix, output_shape, valid_index)
+
+            if has_polygons:
+                self._transform_polygons(data_item, homography_matrix, output_shape, valid_index)
+
+        return self.convert(inputs)  # type: ignore[return-value]
+
+    def _transform_bboxes(
+        self,
+        inputs: OTXDataItem,
+        warp_matrix: np.ndarray,
+        output_shape: tuple[int, int],
+    ) -> np.ndarray:
+        """Transform bounding boxes and return valid indices.
+
+        Args:
+            inputs: Input data item.
+            warp_matrix: Transformation matrix.
+            output_shape: Output image shape (height, width).
+
+        Returns:
+            np.ndarray: Boolean array indicating valid bboxes.
+        """
+        bboxes = project_bboxes(inputs.bboxes, warp_matrix)
+
+        if self.bbox_clip_border:
+            bboxes = clip_bboxes(bboxes, output_shape)
+
+        # Get valid indices and filter
+        valid_index = is_inside_bboxes(bboxes, output_shape)
+
+        if valid_index.any():
+            inputs.bboxes = tv_tensors.BoundingBoxes(
+                bboxes[valid_index],
+                format="XYXY",
+                canvas_size=output_shape,
+            )
+            inputs.label = inputs.label[valid_index]  # type: ignore[index]
+
+        return valid_index
+
+    def _transform_masks(
+        self,
+        inputs: OTXDataItem,
+        warp_matrix: np.ndarray,
+        output_size: tuple[int, int],
+        valid_index: np.ndarray,
+    ) -> None:
+        """Transform masks using the warp matrix.
+
+        Args:
+            inputs: Input data item.
+            warp_matrix: Transformation matrix.
+            output_size: Output size (width, height).
+            valid_index: Boolean array indicating valid objects.
+        """
+        if not self.transform_mask or not hasattr(inputs, "masks") or inputs.masks is None or len(inputs.masks) == 0:
+            return
+
+        # Filter masks using valid_index first
+        masks = inputs.masks[valid_index]
+        masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
+
+        if masks.ndim == 3:
+            masks = list(masks)
+
+        transformed_masks = []
+        for mask in masks:
+            transformed_mask = self._warp_single_mask(mask, warp_matrix, output_size)
+            transformed_masks.append(transformed_mask)
+
+        if transformed_masks:
+            masks_array = np.stack(transformed_masks).astype(np.uint8)
+            inputs.masks = tv_tensors.Mask(torch.from_numpy(masks_array > 0).to(torch.bool))
+
+    def _warp_single_mask(self, mask: np.ndarray, warp_matrix: np.ndarray, output_size: tuple[int, int]) -> np.ndarray:
+        """Warp a single mask using appropriate interpolation.
+
+        Args:
+            mask: Input mask.
+            warp_matrix: Transformation matrix.
+            output_size: Output size (width, height).
+
+        Returns:
+            np.ndarray: Warped mask.
+        """
+        unique_values = np.unique(mask)
+
+        # Binary mask: use 255/127 threshold for cleaner results
+        if len(unique_values) <= 2 and np.max(unique_values) <= 1:
+            warped_mask = cv2.warpPerspective(
+                mask.astype(np.uint8) * 255,
+                warp_matrix,
+                dsize=output_size,
+                borderValue=0,
+            )
+            return warped_mask > 127
+
+        # Multi-class mask: use nearest neighbor to preserve discrete values
+        return cv2.warpPerspective(
+            mask.astype(np.uint8),
+            warp_matrix,
+            dsize=output_size,
+            borderValue=self.mask_fill_value,
+            flags=cv2.INTER_NEAREST,
+        )
+
+    def _transform_polygons(
+        self,
+        inputs: OTXDataItem,
+        warp_matrix: np.ndarray,
+        output_shape: tuple[int, int],
+        valid_index: np.ndarray,
+    ) -> None:
+        """Transform polygons using the warp matrix.
+
+        Args:
+            inputs: Input data item.
+            warp_matrix: Transformation matrix.
+            output_shape: Output shape (height, width).
+            valid_index: Boolean array indicating valid objects.
+        """
+        if (
+            not self.transform_polygon
+            or not hasattr(inputs, "polygons")
+            or inputs.polygons is None
+            or len(inputs.polygons) == 0
+        ):
+            return
+
+        # Filter polygons using valid_index
+        filtered_polygons = [p for p, keep in zip(inputs.polygons, valid_index) if keep]
+
+        if filtered_polygons:
+            inputs.polygons = project_polygons(filtered_polygons, warp_matrix, output_shape)
+
+    def __repr__(self) -> str:
+        """Return string representation of the transform."""
+        params = [
+            f"max_rotate_degree={self.max_rotate_degree}",
+            f"max_translate_ratio={self.max_translate_ratio}",
+            f"scaling_ratio_range={self.scaling_ratio_range}",
+            f"max_shear_degree={self.max_shear_degree}",
+            f"border={self.border}",
+            f"border_val={self.border_val}",
+            f"bbox_clip_border={self.bbox_clip_border}",
+            f"transform_mask={self.transform_mask}",
+            f"transform_polygon={self.transform_polygon}",
+            f"mask_fill_value={self.mask_fill_value}",
+            f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor}",
+        ]
+        return f"{self.__class__.__name__}({', '.join(params)})"
 
     @staticmethod
     def _get_rotation_matrix(rotate_degrees: float) -> np.ndarray:
+        """Create rotation transformation matrix.
+
+        Args:
+            rotate_degrees: Rotation angle in degrees.
+
+        Returns:
+            np.ndarray: 3x3 rotation matrix.
+        """
         radian = math.radians(rotate_degrees)
+        cos_val, sin_val = np.cos(radian), np.sin(radian)
         return np.array(
-            [[np.cos(radian), -np.sin(radian), 0.0], [np.sin(radian), np.cos(radian), 0.0], [0.0, 0.0, 1.0]],
+            [
+                [cos_val, -sin_val, 0.0],
+                [sin_val, cos_val, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
             dtype=np.float32,
         )
 
     @staticmethod
     def _get_scaling_matrix(scale_ratio: float) -> np.ndarray:
-        return np.array([[scale_ratio, 0.0, 0.0], [0.0, scale_ratio, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
+        """Create scaling transformation matrix.
+
+        Args:
+            scale_ratio: Scaling factor.
+
+        Returns:
+            np.ndarray: 3x3 scaling matrix.
+        """
+        return np.array(
+            [
+                [scale_ratio, 0.0, 0.0],
+                [0.0, scale_ratio, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
 
     @staticmethod
     def _get_shear_matrix(x_shear_degrees: float, y_shear_degrees: float) -> np.ndarray:
+        """Create shear transformation matrix.
+
+        Args:
+            x_shear_degrees: Shear angle in x direction (degrees).
+            y_shear_degrees: Shear angle in y direction (degrees).
+
+        Returns:
+            np.ndarray: 3x3 shear matrix.
+        """
         x_radian = math.radians(x_shear_degrees)
         y_radian = math.radians(y_shear_degrees)
         return np.array(
-            [[1, np.tan(x_radian), 0.0], [np.tan(y_radian), 1, 0.0], [0.0, 0.0, 1.0]],
+            [
+                [1, np.tan(x_radian), 0.0],
+                [np.tan(y_radian), 1, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
             dtype=np.float32,
         )
 
     @staticmethod
     def _get_translation_matrix(x: float, y: float) -> np.ndarray:
-        return np.array([[1, 0.0, x], [0.0, 1, y], [0.0, 0.0, 1.0]], dtype=np.float32)
+        """Create translation transformation matrix.
+
+        Args:
+            x: Translation in x direction.
+            y: Translation in y direction.
+
+        Returns:
+            np.ndarray: 3x3 translation matrix.
+        """
+        return np.array(
+            [
+                [1, 0.0, x],
+                [0.0, 1, y],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
 
 
 class CachedMosaic(tvt_v2.Transform, NumpytoTVTensorMixin):

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1095,6 +1095,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         bbox_clip_border: bool = True,
         transform_mask: bool = True,
         transform_polygon: bool = True,
+        recompute_bbox: bool = True,
         mask_fill_value: int = 0,
         is_numpy_to_tvtensor: bool = False,
     ) -> None:
@@ -1110,6 +1111,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         self.bbox_clip_border = bbox_clip_border
         self.transform_mask = transform_mask
         self.transform_polygon = transform_polygon
+        self.recompute_bbox = recompute_bbox
         self.mask_fill_value = mask_fill_value
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
 
@@ -1197,6 +1199,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
 
             if hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0:
                 self._transform_polygons(inputs, homography_matrix, output_shape, valid_index)
+            
+            if self.recompute_bbox:
+                self._recompute_bboxes(inputs, output_shape)
 
         return self.convert(inputs)  # type: ignore[return-value]
 
@@ -1342,6 +1347,52 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         if filtered_polygons:
             inputs.polygons = project_polygons(filtered_polygons, warp_matrix, output_shape)
+
+    def _recompute_bboxes(self, inputs: OTXDataItem, output_shape: tuple[int, int],) -> None:
+        """Recomputes the bounding boxes after tranforming from the mask or polygons if available.
+
+        Args:
+            inputs: Input data item.
+            output_shape: Output shape (height, width).
+        """
+                
+        has_polygons = hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0
+        has_masks = hasattr(inputs, "masks") and inputs.masks is not None and len(inputs.masks) > 0
+
+        if not has_polygons and not has_masks:
+            return
+        
+        # bboxes here are XYXY format
+        bboxes = inputs.bboxes
+        bboxes = bboxes.numpy() if not isinstance(bboxes, np.ndarray) else bboxes
+
+        if has_masks:
+            masks = inputs.masks
+            masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
+            for i, mask in enumerate(masks):
+                points = cv2.findNonZero(mask)
+                if points is not None:
+                    x, y, w, h = cv2.boundingRect(points)
+                    bboxXYXY = [x, y, x + w, y + h]
+                    bboxes[i] = np.array(bboxXYXY)
+
+        elif has_polygons:
+            polygons = inputs.polygons
+            for i, polygon in enumerate(polygons):
+                points_1d = np.array(polygon.points, dtype=np.float32)
+                if len(points_1d) % 2 != 0:
+                    continue
+
+                points = points_1d.reshape(-1, 2)
+                x, y, w, h = cv2.boundingRect(points)
+                bboxXYXY = [x, y, x + w, y + h]
+                bboxes[i] = np.array(bboxXYXY)
+
+        inputs.bboxes = tv_tensors.BoundingBoxes(
+            bboxes,
+            format="XYXY",
+            canvas_size=output_shape,
+        )
 
     def __repr__(self) -> str:
         """Return string representation of the transform."""

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1154,7 +1154,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         # Combine transformations: T * Sh * R * S
         return translate_matrix @ shear_matrix @ rotation_matrix @ scaling_matrix
 
-    def forward(self, inputs: OTXDataItem) -> OTXDataItem:
+    def forward(self, *_inputs: OTXDataItem) -> OTXDataItem:
         """Forward pass of RandomAffine transform.
 
         Args:
@@ -1166,46 +1166,58 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         Raises:
             ValueError: If inputs format is invalid.
         """
-        _inputs = self.extract(inputs)
         if len(_inputs) != 1:
             msg = f"RandomAffine can only transform single input, got {len(_inputs)}"
             raise ValueError(msg)
 
-        data_item = _inputs[0]
-
-        # Check if there are any transformable objects at all
-        has_bboxes = hasattr(data_item, "bboxes") and data_item.bboxes is not None and len(data_item.bboxes) > 0
-        has_masks = hasattr(data_item, "masks") and data_item.masks is not None and len(data_item.masks) > 0
-        has_polygons = hasattr(data_item, "polygons") and data_item.polygons is not None and len(data_item.polygons) > 0
-
-        # If no transformable objects exist, skip the entire transformation
-        if not (has_bboxes or has_masks or has_polygons):
-            return self.convert(inputs)  # type: ignore[return-value]
+        inputs = _inputs[0]
+        img = to_np_image(inputs.image)
 
         # Get random homography matrix for affine transformation
-        height, width = data_item.img.shape[:2]
+        height, width = img.shape[:2]  # type: ignore[union-attr]
         homography_matrix = self._get_random_homography_matrix(height, width)
         output_shape = (height + self.border[0] * 2, width + self.border[1] * 2)
 
-        if has_bboxes:
+        if hasattr(inputs, "bboxes") and inputs.bboxes is not None and len(inputs.bboxes) > 0:
             # Test transform bboxes to see if any remain valid
-            valid_index = self._transform_bboxes(data_item, homography_matrix, output_shape)
+            valid_index = self._transform_bboxes(inputs, homography_matrix, output_shape)
             # If no valid annotations will remain after transformation, skip entirely
             if not valid_index.any():
+                inputs.image = img
                 return self.convert(inputs)  # type: ignore[return-value]
 
             # If we reach here, transformation will produce valid results, so proceed
             # Transform image
-            transformed_img = self._warp_image(data_item.img, homography_matrix)
-            data_item.img = transformed_img
+            transformed_img = self._warp_image(img, homography_matrix, output_shape)
+            inputs.image = transformed_img
+            inputs.img_info = _resize_image_info(inputs.img_info, transformed_img.shape[:2])
 
-            if has_masks:
-                self._transform_masks(data_item, homography_matrix, output_shape, valid_index)
+            if hasattr(inputs, "masks") and inputs.masks is not None and len(inputs.masks) > 0:
+                self._transform_masks(inputs, homography_matrix, output_shape, valid_index)
 
-            if has_polygons:
-                self._transform_polygons(data_item, homography_matrix, output_shape, valid_index)
+            if hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0:
+                self._transform_polygons(inputs, homography_matrix, output_shape, valid_index)
 
         return self.convert(inputs)  # type: ignore[return-value]
+
+    def _warp_image(
+        self,
+        image: np.ndarray,
+        homography_matrix: np.ndarray,
+        output_shape: tuple[int, int],
+    ) -> np.ndarray:
+        """Warp image using the homography matrix.
+
+        Args:
+            image: Input image.
+            homography_matrix: Homography matrix.
+            output_shape: Output shape (height, width).
+
+        Returns:
+            np.ndarray: Warped image.
+        """
+        height, width = output_shape
+        return cv2.warpPerspective(image, homography_matrix, dsize=(width, height), borderValue=self.border_val)
 
     def _transform_bboxes(
         self,
@@ -1287,25 +1299,20 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             np.ndarray: Warped mask.
         """
         unique_values = np.unique(mask)
+        height, width = output_size
 
         # Binary mask: use 255/127 threshold for cleaner results
         if len(unique_values) <= 2 and np.max(unique_values) <= 1:
             warped_mask = cv2.warpPerspective(
                 mask.astype(np.uint8) * 255,
                 warp_matrix,
-                dsize=output_size,
+                dsize=(width, height),
                 borderValue=0,
             )
             return warped_mask > 127
 
-        # Multi-class mask: use nearest neighbor to preserve discrete values
-        return cv2.warpPerspective(
-            mask.astype(np.uint8),
-            warp_matrix,
-            dsize=output_size,
-            borderValue=self.mask_fill_value,
-            flags=cv2.INTER_NEAREST,
-        )
+        msg = "Multi-class masks are not supported yet."
+        raise NotImplementedError(msg)
 
     def _transform_polygons(
         self,

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -54,6 +54,7 @@ from otx.data.transform_libs.utils import (
     is_inside_bboxes,
     overlap_bboxes,
     project_bboxes,
+    project_polygons,
     rescale_bboxes,
     rescale_keypoints,
     rescale_masks,
@@ -1055,7 +1056,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     Reference : https://github.com/open-mmlab/mmdetection/blob/v3.2.0/mmdet/datasets/transforms/transforms.py#L2736-L2901
 
-    RandomAffine only supports images and bounding boxes in mmdetection.
+    RandomAffine supports images, bounding boxes, masks, and polygons.
 
     TODO : optimize logic to torcivision pipeline
 
@@ -1077,6 +1078,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             the border of the image. In some dataset like MOT17, the gt bboxes
             are allowed to cross the border of images. Therefore, we don't
             need to clip the gt bboxes in these cases. Defaults to True.
+        transform_mask (bool): Whether to transform the mask. Defaults to True.
+        mask_fill_value (int): Fill value for mask. Defaults to 0.
+        transform_polygon (bool): Whether to transform polygons. Defaults to True.
         is_numpy_to_tvtensor (bool): Whether convert outputs to tensor. Defaults to False.
     """
 
@@ -1089,6 +1093,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         border: tuple[int, int] = (0, 0),  # (H, W)
         border_val: tuple[int, int, int] = (114, 114, 114),
         bbox_clip_border: bool = True,
+        transform_mask: bool = True,
+        transform_polygon: bool = True,
+        mask_fill_value: int = 0,
         is_numpy_to_tvtensor: bool = False,
     ) -> None:
         super().__init__()
@@ -1103,6 +1110,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         self.border = border  # (H, W)
         self.border_val = border_val
         self.bbox_clip_border = bbox_clip_border
+        self.transform_mask = transform_mask
+        self.mask_fill_value = mask_fill_value
+        self.transform_polygon = transform_polygon
         self.is_numpy_to_tvtensor = is_numpy_to_tvtensor
 
     @cache_randomness
@@ -1153,6 +1163,27 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             inputs.bboxes = tv_tensors.BoundingBoxes(bboxes[valid_index], format="XYXY", canvas_size=(height, width))  # type: ignore[union-attr]
             inputs.label = inputs.label[valid_index]  # type: ignore[union-attr,index]
 
+        if self.transform_mask and (masks := getattr(inputs, "masks", None)) is not None and len(masks) > 0:
+            masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
+            transformed_masks = []
+            for mask in masks:
+                # Apply the same warp matrix used for the image
+                warped_mask = cv2.warpPerspective(
+                    mask,
+                    warp_matrix,
+                    dsize=(width, height),
+                    borderValue=self.mask_fill_value,
+                    flags=cv2.INTER_NEAREST,  # Use nearest neighbor for masks
+                )
+                transformed_masks.append(warped_mask)
+            inputs.masks = tv_tensors.Mask(np.stack(transformed_masks))
+
+        # Transform polygons
+        if self.transform_polygon and (polygons := getattr(inputs, "polygons", None)) is not None and len(polygons) > 0:
+            # Transform polygons using the same warp matrix
+            transformed_polygons = project_polygons(polygons, warp_matrix, (height, width))
+            inputs.polygons = transformed_polygons  # type: ignore[union-attr]
+
         return self.convert(inputs)
 
     def __repr__(self):
@@ -1164,6 +1195,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         repr_str += f"border={self.border}, "
         repr_str += f"border_val={self.border_val}, "
         repr_str += f"bbox_clip_border={self.bbox_clip_border}, "
+        repr_str += f"transform_mask={self.transform_mask}, "
+        repr_str += f"mask_fill_value={self.mask_fill_value}, "
+        repr_str += f"transform_polygon={self.transform_polygon}, "
         repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
         return repr_str
 

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -1370,7 +1370,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             masks = inputs.masks
             masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
             for i, mask in enumerate(masks):
-                points = cv2.findNonZero(mask)
+                points = cv2.findNonZero(mask.astype(np.uint8))
                 if points is not None:
                     x, y, w, h = cv2.boundingRect(points)
                     bboxXYXY = [x, y, x + w, y + h]

--- a/tests/unit/data/transform_libs/test_torchvision.py
+++ b/tests/unit/data/transform_libs/test_torchvision.py
@@ -347,24 +347,6 @@ class TestRandomAffine:
         with pytest.raises(AssertionError):
             RandomAffine(scaling_ratio_range=(0, 0.5))
 
-    def test_init_mask_parameters(self) -> None:
-        """Test initialization with mask parameters."""
-        transform = RandomAffine(transform_mask=True, mask_fill_value=128)
-        assert transform.transform_mask is True
-        assert transform.mask_fill_value == 128
-
-    def test_init_polygon_parameters(self) -> None:
-        """Test initialization with polygon parameters."""
-        transform = RandomAffine(transform_polygon=True)
-        assert transform.transform_polygon is True
-
-    def test_init_mask_and_polygon_parameters(self) -> None:
-        """Test initialization with both mask and polygon parameters."""
-        transform = RandomAffine(transform_mask=True, transform_polygon=True, mask_fill_value=64)
-        assert transform.transform_mask is True
-        assert transform.transform_polygon is True
-        assert transform.mask_fill_value == 64
-
     def test_forward(self, random_affine: RandomAffine, det_data_entity: OTXDataItem) -> None:
         """Test forward."""
         results = random_affine(deepcopy(det_data_entity))
@@ -388,7 +370,7 @@ class TestRandomAffine:
         assert hasattr(results, "masks")
         assert results.masks is not None
         assert results.masks.shape[0] > 0  # Should have masks
-        assert results.masks.shape[1:] == results.image.shape[1:]  # Same spatial dimensions as image
+        assert results.masks.shape[1:] == results.image.shape[:2]  # Same spatial dimensions as image
 
         # Check that the number of masks matches the number of remaining bboxes and labels
         assert results.masks.shape[0] == results.bboxes.shape[0]
@@ -399,7 +381,7 @@ class TestRandomAffine:
         assert len(unique_values) <= 2  # Should only have 0 and/or 255
 
         # Check data types
-        assert results.masks.dtype == torch.uint8
+        assert results.masks.dtype == torch.bool
         assert isinstance(results.masks, tv_tensors.Mask)
 
     def test_forward_with_polygons_transform_enabled(
@@ -515,7 +497,7 @@ class TestRandomAffine:
         results = random_affine_with_polygon_transform(original_entity)
 
         # Check that all polygon coordinates are within image bounds
-        height, width = results.image.shape[1:]
+        height, width = results.image.shape[:2]
 
         for polygon in results.polygons:
             points = np.array(polygon.points).reshape(-1, 2)
@@ -527,13 +509,6 @@ class TestRandomAffine:
             # Check that y coordinates are within [0, height]
             assert np.all(points[:, 1] >= 0)
             assert np.all(points[:, 1] <= height)
-
-    def test_repr_includes_polygon_params(self) -> None:
-        """Test that __repr__ includes polygon parameters."""
-        transform = RandomAffine(transform_polygon=True)
-        repr_str = repr(transform)
-
-        assert "transform_polygon=True" in repr_str
 
     @pytest.mark.parametrize("transform_polygon", [True, False])
     def test_polygon_transform_parameter_effect(
@@ -590,7 +565,7 @@ class TestRandomAffine:
         assert hasattr(results, "masks")
         assert results.masks is not None
         assert results.masks.shape[0] == 0  # Should still be empty
-        assert results.masks.shape[1:] == results.image.shape[1:]  # Same spatial dimensions
+        assert results.masks.shape[1:] == results.image.shape[:2]  # Same spatial dimensions
 
     def test_forward_without_masks(
         self,
@@ -613,29 +588,31 @@ class TestRandomAffine:
     def test_mask_fill_value_applied(
         self,
         det_data_entity_with_masks: OTXDataItem,
+        repeat: int = 10,
     ) -> None:
         """Test that mask_fill_value is applied correctly."""
         # Test with different fill values
         fill_values = [0, 128, 255]
 
-        for fill_value in fill_values:
-            transform = RandomAffine(
-                transform_mask=True,
-                mask_fill_value=fill_value,
-                max_rotate_degree=45,  # Force significant transformation
-                max_translate_ratio=0.2,
-                scaling_ratio_range=(0.8, 1.2),
-                max_shear_degree=10,
-            )
+        for _ in range(repeat):
+            for fill_value in fill_values:
+                transform = RandomAffine(
+                    transform_mask=True,
+                    mask_fill_value=fill_value,
+                    max_rotate_degree=45,  # Force significant transformation
+                    max_translate_ratio=0.2,
+                    scaling_ratio_range=(0.8, 1.2),
+                    max_shear_degree=10,
+                )
 
-            original_entity = deepcopy(det_data_entity_with_masks)
-            results = transform(original_entity)
+                original_entity = deepcopy(det_data_entity_with_masks)
+                results = transform(original_entity)
 
-            assert hasattr(results, "masks")
-            assert results.masks is not None
-            # The fill value should be used for areas outside the original mask
-            # This is hard to test directly, but we can check that the transform executed successfully
-            assert results.masks.shape[0] > 0
+                assert hasattr(results, "masks")
+                assert results.masks is not None
+                # The fill value should be used for areas outside the original mask
+                # This is hard to test directly, but we can check that the transform executed successfully
+                assert results.masks.shape[0] > 0
 
     def test_mask_consistency_with_image_transform(
         self,
@@ -656,7 +633,7 @@ class TestRandomAffine:
         results = transform(original_entity)
 
         # Check that image and masks have consistent dimensions
-        assert results.image.shape[1:] == results.masks.shape[1:]
+        assert results.image.shape[:2] == results.masks.shape[1:]
 
         # Check that masks are still properly shaped
         assert len(results.masks.shape) == 3  # (N, H, W)
@@ -689,53 +666,6 @@ class TestRandomAffine:
 
         # The number of objects might be reduced due to filtering
         assert results.masks.shape[0] <= original_num_objects
-
-    def test_repr_includes_mask_params(self) -> None:
-        """Test that __repr__ includes mask parameters."""
-        transform = RandomAffine(transform_mask=True, mask_fill_value=128)
-        repr_str = repr(transform)
-
-        assert "transform_mask=True" in repr_str
-        assert "mask_fill_value=128" in repr_str
-
-    def test_mask_dtype_preservation(
-        self,
-        random_affine_with_mask_transform: RandomAffine,
-        det_data_entity_with_masks: OTXDataItem,
-    ) -> None:
-        """Test that mask data type is preserved."""
-        original_entity = deepcopy(det_data_entity_with_masks)
-        original_dtype = original_entity.masks.dtype
-
-        results = random_affine_with_mask_transform(original_entity)
-
-        assert results.masks.dtype == original_dtype
-        assert isinstance(results.masks, tv_tensors.Mask)
-
-    @pytest.mark.parametrize("transform_mask", [True, False])
-    def test_mask_transform_parameter_effect(
-        self,
-        det_data_entity_with_masks: OTXDataItem,
-        transform_mask: bool,
-    ) -> None:
-        """Test that the transform_mask parameter controls mask transformation."""
-        transform = RandomAffine(
-            transform_mask=transform_mask,
-            mask_fill_value=0,
-            max_rotate_degree=0,
-            max_translate_ratio=0.1,
-            scaling_ratio_range=(1.0, 1.0),
-            max_shear_degree=0,
-        )
-
-        original_entity = deepcopy(det_data_entity_with_masks)
-        results = transform(original_entity)
-
-        # Regardless of transform_mask value, masks should be present and properly shaped
-        assert hasattr(results, "masks")
-        assert results.masks is not None
-        assert results.masks.shape[0] == results.bboxes.shape[0]
-        assert results.masks.shape[1:] == results.image.shape[1:]
 
 
 class TestCachedMosaic:

--- a/tests/unit/data/transform_libs/test_torchvision.py
+++ b/tests/unit/data/transform_libs/test_torchvision.py
@@ -73,9 +73,9 @@ def det_data_entity_with_masks() -> OTXDataItem:
     fake_labels = LongTensor([1, 2])
 
     # Create meaningful masks that correspond to the bounding boxes
-    masks = torch.zeros(size=(2, *img_size), dtype=torch.uint8)
-    masks[0, 10:50, 10:50] = 255  # First mask
-    masks[1, 60:100, 60:100] = 255  # Second mask
+    masks = torch.zeros(size=(2, *img_size), dtype=torch.bool)
+    masks[0, 10:50, 10:50] = True  # First mask
+    masks[1, 60:100, 60:100] = True  # Second mask
     fake_masks = tv_tensors.Mask(masks)
 
     return OTXDataItem(
@@ -122,9 +122,9 @@ def det_data_entity_with_polygons() -> OTXDataItem:
     fake_labels = LongTensor([1, 2])
 
     # Create meaningful masks that correspond to the bounding boxes
-    masks = torch.zeros(size=(2, *img_size), dtype=torch.uint8)
-    masks[0, 10:50, 10:50] = 255  # First mask
-    masks[1, 60:100, 60:100] = 255  # Second mask
+    masks = torch.zeros(size=(2, *img_size), dtype=torch.bool)
+    masks[0, 10:50, 10:50] = True  # First mask
+    masks[1, 60:100, 60:100] = True  # Second mask
     fake_masks = tv_tensors.Mask(masks)
 
     # Create corresponding polygons
@@ -336,15 +336,15 @@ class TestRandomAffine:
         return RandomAffine(transform_mask=True, transform_polygon=True, mask_fill_value=0)
 
     def test_init_invalid_translate_ratio(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):  # noqa: PT011
             RandomAffine(max_translate_ratio=1.5)
 
     def test_init_invalid_scaling_ratio_range_inverse_order(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):  # noqa: PT011
             RandomAffine(scaling_ratio_range=(1.5, 0.5))
 
     def test_init_invalid_scaling_ratio_range_zero_value(self) -> None:
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):  # noqa: PT011
             RandomAffine(scaling_ratio_range=(0, 0.5))
 
     def test_forward(self, random_affine: RandomAffine, det_data_entity: OTXDataItem) -> None:
@@ -549,8 +549,12 @@ class TestRandomAffine:
 
         # Since transform_mask is False, masks should remain unchanged
         # However, they might still be filtered based on valid bounding boxes
-        assert results.masks.shape[0] == results.bboxes.shape[0]
-        assert results.masks.shape[0] == results.label.shape[0]
+        assert (
+            results.masks.shape[0] == results.bboxes.shape[0]
+        ), f"results.masks.shape[0] = {results.masks.shape[0]}, results.bboxes.shape[0] = {results.bboxes.shape[0]}"
+        assert (
+            results.masks.shape[0] == results.label.shape[0]
+        ), f"results.masks.shape[0] = {results.masks.shape[0]}, results.label.shape[0] = {results.label.shape[0]}"
 
     def test_forward_with_empty_masks(
         self,

--- a/tests/unit/data/transform_libs/test_torchvision.py
+++ b/tests/unit/data/transform_libs/test_torchvision.py
@@ -59,6 +59,111 @@ def det_data_entity() -> OTXDataItem:
     )
 
 
+@pytest.fixture()
+def det_data_entity_with_masks() -> OTXDataItem:
+    """Create a data entity with masks for testing."""
+    img_size = (112, 224)
+    fake_image = torch.randint(low=0, high=256, size=(3, *img_size), dtype=torch.uint8)
+    fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
+    fake_bboxes = tv_tensors.BoundingBoxes(
+        data=torch.Tensor([[10, 10, 50, 50], [60, 60, 100, 100]]),
+        format="xyxy",
+        canvas_size=img_size,
+    )
+    fake_labels = LongTensor([1, 2])
+
+    # Create meaningful masks that correspond to the bounding boxes
+    masks = torch.zeros(size=(2, *img_size), dtype=torch.uint8)
+    masks[0, 10:50, 10:50] = 255  # First mask
+    masks[1, 60:100, 60:100] = 255  # Second mask
+    fake_masks = tv_tensors.Mask(masks)
+
+    return OTXDataItem(
+        image=tv_tensors.Image(fake_image),
+        img_info=fake_image_info,
+        bboxes=fake_bboxes,
+        label=fake_labels,
+        masks=fake_masks,
+    )
+
+
+@pytest.fixture()
+def det_data_entity_empty_masks() -> OTXDataItem:
+    """Create a data entity with empty masks for testing."""
+    img_size = (112, 224)
+    fake_image = torch.randint(low=0, high=256, size=(3, *img_size), dtype=torch.uint8)
+    fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
+    fake_bboxes = tv_tensors.BoundingBoxes(data=torch.Tensor([[10, 10, 50, 50]]), format="xyxy", canvas_size=img_size)
+    fake_labels = LongTensor([1])
+
+    # Create empty masks
+    fake_masks = tv_tensors.Mask(torch.zeros(size=(0, *img_size), dtype=torch.uint8))
+
+    return OTXDataItem(
+        image=tv_tensors.Image(fake_image),
+        img_info=fake_image_info,
+        bboxes=fake_bboxes,
+        label=fake_labels,
+        masks=fake_masks,
+    )
+
+
+@pytest.fixture()
+def det_data_entity_with_polygons() -> OTXDataItem:
+    """Create a data entity with polygons for testing."""
+    img_size = (112, 224)
+    fake_image = torch.randint(low=0, high=256, size=(3, *img_size), dtype=torch.uint8)
+    fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
+    fake_bboxes = tv_tensors.BoundingBoxes(
+        data=torch.Tensor([[10, 10, 50, 50], [60, 60, 100, 100]]),
+        format="xyxy",
+        canvas_size=img_size,
+    )
+    fake_labels = LongTensor([1, 2])
+
+    # Create meaningful masks that correspond to the bounding boxes
+    masks = torch.zeros(size=(2, *img_size), dtype=torch.uint8)
+    masks[0, 10:50, 10:50] = 255  # First mask
+    masks[1, 60:100, 60:100] = 255  # Second mask
+    fake_masks = tv_tensors.Mask(masks)
+
+    # Create corresponding polygons
+    fake_polygons = [
+        Polygon(points=[10, 10, 50, 10, 50, 50, 10, 50]),  # Rectangle polygon for first object
+        Polygon(points=[60, 60, 100, 60, 100, 100, 60, 100]),  # Rectangle polygon for second object
+    ]
+
+    return OTXDataItem(
+        image=tv_tensors.Image(fake_image),
+        img_info=fake_image_info,
+        bboxes=fake_bboxes,
+        label=fake_labels,
+        masks=fake_masks,
+        polygons=fake_polygons,
+    )
+
+
+@pytest.fixture()
+def det_data_entity_empty_polygons() -> OTXDataItem:
+    """Create a data entity with empty polygons for testing."""
+    img_size = (112, 224)
+    fake_image = torch.randint(low=0, high=256, size=(3, *img_size), dtype=torch.uint8)
+    fake_image_info = ImageInfo(img_idx=0, img_shape=img_size, ori_shape=img_size)
+    fake_bboxes = tv_tensors.BoundingBoxes(data=torch.Tensor([[10, 10, 50, 50]]), format="xyxy", canvas_size=img_size)
+    fake_labels = LongTensor([1])
+
+    # Create empty polygons
+    fake_polygons = []
+
+    return OTXDataItem(
+        image=tv_tensors.Image(fake_image),
+        img_info=fake_image_info,
+        bboxes=fake_bboxes,
+        label=fake_labels,
+        polygons=fake_polygons,
+    )
+
+
 class TestMinIoURandomCrop:
     @pytest.fixture()
     def min_iou_random_crop(self) -> MinIoURandomCrop:
@@ -214,6 +319,22 @@ class TestRandomAffine:
     def random_affine(self) -> RandomAffine:
         return RandomAffine()
 
+    @pytest.fixture()
+    def random_affine_with_mask_transform(self) -> RandomAffine:
+        return RandomAffine(transform_mask=True, mask_fill_value=0)
+
+    @pytest.fixture()
+    def random_affine_without_mask_transform(self) -> RandomAffine:
+        return RandomAffine(transform_mask=False)
+
+    @pytest.fixture()
+    def random_affine_with_polygon_transform(self) -> RandomAffine:
+        return RandomAffine(transform_polygon=True)
+
+    @pytest.fixture()
+    def random_affine_with_mask_and_polygon_transform(self) -> RandomAffine:
+        return RandomAffine(transform_mask=True, transform_polygon=True, mask_fill_value=0)
+
     def test_init_invalid_translate_ratio(self) -> None:
         with pytest.raises(AssertionError):
             RandomAffine(max_translate_ratio=1.5)
@@ -226,6 +347,24 @@ class TestRandomAffine:
         with pytest.raises(AssertionError):
             RandomAffine(scaling_ratio_range=(0, 0.5))
 
+    def test_init_mask_parameters(self) -> None:
+        """Test initialization with mask parameters."""
+        transform = RandomAffine(transform_mask=True, mask_fill_value=128)
+        assert transform.transform_mask is True
+        assert transform.mask_fill_value == 128
+
+    def test_init_polygon_parameters(self) -> None:
+        """Test initialization with polygon parameters."""
+        transform = RandomAffine(transform_polygon=True)
+        assert transform.transform_polygon is True
+
+    def test_init_mask_and_polygon_parameters(self) -> None:
+        """Test initialization with both mask and polygon parameters."""
+        transform = RandomAffine(transform_mask=True, transform_polygon=True, mask_fill_value=64)
+        assert transform.transform_mask is True
+        assert transform.transform_polygon is True
+        assert transform.mask_fill_value == 64
+
     def test_forward(self, random_affine: RandomAffine, det_data_entity: OTXDataItem) -> None:
         """Test forward."""
         results = random_affine(deepcopy(det_data_entity))
@@ -235,6 +374,370 @@ class TestRandomAffine:
         assert results.label.dtype == torch.long
         assert results.bboxes.dtype == torch.float32
         assert results.img_info.img_shape == results.image.shape[:2]
+
+    def test_forward_with_masks_transform_enabled(
+        self,
+        random_affine_with_mask_transform: RandomAffine,
+        det_data_entity_with_masks: OTXDataItem,
+    ) -> None:
+        """Test forward with masks when transform_mask is True."""
+        original_entity = deepcopy(det_data_entity_with_masks)
+        results = random_affine_with_mask_transform(original_entity)
+
+        # Check that masks are present and transformed
+        assert hasattr(results, "masks")
+        assert results.masks is not None
+        assert results.masks.shape[0] > 0  # Should have masks
+        assert results.masks.shape[1:] == results.image.shape[1:]  # Same spatial dimensions as image
+
+        # Check that the number of masks matches the number of remaining bboxes and labels
+        assert results.masks.shape[0] == results.bboxes.shape[0]
+        assert results.masks.shape[0] == results.label.shape[0]
+
+        # Check that masks are still binary (0 or 255)
+        unique_values = torch.unique(results.masks)
+        assert len(unique_values) <= 2  # Should only have 0 and/or 255
+
+        # Check data types
+        assert results.masks.dtype == torch.uint8
+        assert isinstance(results.masks, tv_tensors.Mask)
+
+    def test_forward_with_polygons_transform_enabled(
+        self,
+        random_affine_with_polygon_transform: RandomAffine,
+        det_data_entity_with_polygons: OTXDataItem,
+    ) -> None:
+        """Test forward with polygons when transform_polygon is True."""
+        original_entity = deepcopy(det_data_entity_with_polygons)
+        original_num_polygons = len(original_entity.polygons)
+        results = random_affine_with_polygon_transform(original_entity)
+
+        # Check that polygons are present and transformed
+        assert hasattr(results, "polygons")
+        assert results.polygons is not None
+        assert len(results.polygons) > 0  # Should have polygons
+
+        # Check that the number of polygons matches the number of remaining bboxes and labels
+        assert len(results.polygons) == results.bboxes.shape[0]
+        assert len(results.polygons) == results.label.shape[0]
+
+        # Check that polygons are still valid (even number of coordinates)
+        for polygon in results.polygons:
+            assert len(polygon.points) % 2 == 0  # Should have even number of coordinates
+            assert len(polygon.points) >= 6  # Should have at least 3 points (6 coordinates)
+
+    def test_forward_with_masks_and_polygons_transform_enabled(
+        self,
+        random_affine_with_mask_and_polygon_transform: RandomAffine,
+        det_data_entity_with_polygons: OTXDataItem,
+    ) -> None:
+        """Test forward with both masks and polygons when both transforms are enabled."""
+        original_entity = deepcopy(det_data_entity_with_polygons)
+        results = random_affine_with_mask_and_polygon_transform(original_entity)
+
+        # Check that both masks and polygons are present and transformed
+        assert hasattr(results, "masks")
+        assert hasattr(results, "polygons")
+        assert results.masks is not None
+        assert results.polygons is not None
+
+        # Check consistency between masks, polygons, bboxes, and labels
+        assert results.masks.shape[0] == results.bboxes.shape[0]
+        assert len(results.polygons) == results.bboxes.shape[0]
+        assert results.masks.shape[0] == results.label.shape[0]
+        assert len(results.polygons) == results.label.shape[0]
+
+    def test_forward_with_empty_polygons(
+        self,
+        random_affine_with_polygon_transform: RandomAffine,
+        det_data_entity_empty_polygons: OTXDataItem,
+    ) -> None:
+        """Test forward with empty polygons."""
+        original_entity = deepcopy(det_data_entity_empty_polygons)
+        results = random_affine_with_polygon_transform(original_entity)
+
+        # Check that empty polygons are handled correctly
+        assert hasattr(results, "polygons")
+        assert results.polygons is not None
+        assert len(results.polygons) == 0  # Should still be empty
+
+    def test_forward_without_polygons(
+        self,
+        random_affine_with_polygon_transform: RandomAffine,
+        det_data_entity: OTXDataItem,
+    ) -> None:
+        """Test forward when entity has no polygons attribute."""
+        original_entity = deepcopy(det_data_entity)
+        # Ensure no polygons attribute
+        if hasattr(original_entity, "polygons"):
+            delattr(original_entity, "polygons")
+
+        results = random_affine_with_polygon_transform(original_entity)
+
+        # Should work normally without polygons
+        assert results.image.shape[:2] == (112, 224)
+        assert results.label.shape[0] == results.bboxes.shape[0]
+        assert not hasattr(results, "polygons") or results.polygons is None or len(results.polygons) == 0
+
+    def test_polygon_filtering_consistency(
+        self,
+        det_data_entity_with_polygons: OTXDataItem,
+    ) -> None:
+        """Test that polygons are filtered consistently with bboxes."""
+        # Create a transform that might filter out some bboxes
+        transform = RandomAffine(
+            transform_polygon=True,
+            bbox_clip_border=True,
+            max_rotate_degree=30,
+            max_translate_ratio=0.3,
+            scaling_ratio_range=(0.5, 1.5),
+            max_shear_degree=10,
+        )
+
+        original_entity = deepcopy(det_data_entity_with_polygons)
+        original_num_polygons = len(original_entity.polygons)
+
+        results = transform(original_entity)
+
+        # Check that the number of polygons matches the number of valid bboxes and labels
+        assert len(results.polygons) == results.bboxes.shape[0]
+        assert len(results.polygons) == results.label.shape[0]
+
+        # The number of polygons might be reduced due to filtering
+        assert len(results.polygons) <= original_num_polygons
+
+    def test_polygon_coordinates_validity(
+        self,
+        random_affine_with_polygon_transform: RandomAffine,
+        det_data_entity_with_polygons: OTXDataItem,
+    ) -> None:
+        """Test that transformed polygon coordinates are valid."""
+        original_entity = deepcopy(det_data_entity_with_polygons)
+        results = random_affine_with_polygon_transform(original_entity)
+
+        # Check that all polygon coordinates are within image bounds
+        height, width = results.image.shape[1:]
+
+        for polygon in results.polygons:
+            points = np.array(polygon.points).reshape(-1, 2)
+
+            # Check that x coordinates are within [0, width]
+            assert np.all(points[:, 0] >= 0)
+            assert np.all(points[:, 0] <= width)
+
+            # Check that y coordinates are within [0, height]
+            assert np.all(points[:, 1] >= 0)
+            assert np.all(points[:, 1] <= height)
+
+    def test_repr_includes_polygon_params(self) -> None:
+        """Test that __repr__ includes polygon parameters."""
+        transform = RandomAffine(transform_polygon=True)
+        repr_str = repr(transform)
+
+        assert "transform_polygon=True" in repr_str
+
+    @pytest.mark.parametrize("transform_polygon", [True, False])
+    def test_polygon_transform_parameter_effect(
+        self,
+        det_data_entity_with_polygons: OTXDataItem,
+        transform_polygon: bool,
+    ) -> None:
+        """Test that the transform_polygon parameter controls polygon transformation."""
+        transform = RandomAffine(
+            transform_polygon=transform_polygon,
+            max_rotate_degree=0,
+            max_translate_ratio=0.1,
+            scaling_ratio_range=(1.0, 1.0),
+            max_shear_degree=0,
+        )
+
+        original_entity = deepcopy(det_data_entity_with_polygons)
+        results = transform(original_entity)
+
+        # Regardless of transform_polygon value, polygons should be present and properly managed
+        assert hasattr(results, "polygons")
+        if len(original_entity.polygons) > 0:
+            assert results.polygons is not None
+            assert len(results.polygons) == results.bboxes.shape[0]
+
+    def test_forward_with_masks_transform_disabled(
+        self,
+        random_affine_without_mask_transform: RandomAffine,
+        det_data_entity_with_masks: OTXDataItem,
+    ) -> None:
+        """Test forward with masks when transform_mask is False."""
+        original_entity = deepcopy(det_data_entity_with_masks)
+        original_masks = original_entity.masks.clone()
+        results = random_affine_without_mask_transform(original_entity)
+
+        # Check that masks are present but not transformed
+        assert hasattr(results, "masks")
+        assert results.masks is not None
+
+        # Since transform_mask is False, masks should remain unchanged
+        # However, they might still be filtered based on valid bounding boxes
+        assert results.masks.shape[0] == results.bboxes.shape[0]
+        assert results.masks.shape[0] == results.label.shape[0]
+
+    def test_forward_with_empty_masks(
+        self,
+        random_affine_with_mask_transform: RandomAffine,
+        det_data_entity_empty_masks: OTXDataItem,
+    ) -> None:
+        """Test forward with empty masks."""
+        original_entity = deepcopy(det_data_entity_empty_masks)
+        results = random_affine_with_mask_transform(original_entity)
+
+        # Check that empty masks are handled correctly
+        assert hasattr(results, "masks")
+        assert results.masks is not None
+        assert results.masks.shape[0] == 0  # Should still be empty
+        assert results.masks.shape[1:] == results.image.shape[1:]  # Same spatial dimensions
+
+    def test_forward_without_masks(
+        self,
+        random_affine_with_mask_transform: RandomAffine,
+        det_data_entity: OTXDataItem,
+    ) -> None:
+        """Test forward when entity has no masks attribute."""
+        original_entity = deepcopy(det_data_entity)
+        # Ensure no masks attribute
+        if hasattr(original_entity, "masks"):
+            delattr(original_entity, "masks")
+
+        results = random_affine_with_mask_transform(original_entity)
+
+        # Should work normally without masks
+        assert results.image.shape[:2] == (112, 224)
+        assert results.label.shape[0] == results.bboxes.shape[0]
+        assert not hasattr(results, "masks") or results.masks is None
+
+    def test_mask_fill_value_applied(
+        self,
+        det_data_entity_with_masks: OTXDataItem,
+    ) -> None:
+        """Test that mask_fill_value is applied correctly."""
+        # Test with different fill values
+        fill_values = [0, 128, 255]
+
+        for fill_value in fill_values:
+            transform = RandomAffine(
+                transform_mask=True,
+                mask_fill_value=fill_value,
+                max_rotate_degree=45,  # Force significant transformation
+                max_translate_ratio=0.2,
+                scaling_ratio_range=(0.8, 1.2),
+                max_shear_degree=10,
+            )
+
+            original_entity = deepcopy(det_data_entity_with_masks)
+            results = transform(original_entity)
+
+            assert hasattr(results, "masks")
+            assert results.masks is not None
+            # The fill value should be used for areas outside the original mask
+            # This is hard to test directly, but we can check that the transform executed successfully
+            assert results.masks.shape[0] > 0
+
+    def test_mask_consistency_with_image_transform(
+        self,
+        det_data_entity_with_masks: OTXDataItem,
+    ) -> None:
+        """Test that masks and images are transformed consistently."""
+        # Create a transform with fixed parameters for reproducibility
+        transform = RandomAffine(
+            transform_mask=True,
+            mask_fill_value=0,
+            max_rotate_degree=0,  # No rotation for simpler testing
+            max_translate_ratio=0.1,  # Small translation
+            scaling_ratio_range=(1.0, 1.0),  # No scaling
+            max_shear_degree=0,  # No shear
+        )
+
+        original_entity = deepcopy(det_data_entity_with_masks)
+        results = transform(original_entity)
+
+        # Check that image and masks have consistent dimensions
+        assert results.image.shape[1:] == results.masks.shape[1:]
+
+        # Check that masks are still properly shaped
+        assert len(results.masks.shape) == 3  # (N, H, W)
+        assert results.masks.shape[0] == results.bboxes.shape[0]
+
+    def test_mask_bbox_filtering_consistency(
+        self,
+        det_data_entity_with_masks: OTXDataItem,
+    ) -> None:
+        """Test that masks are filtered consistently with bboxes."""
+        # Create a transform that might filter out some bboxes
+        transform = RandomAffine(
+            transform_mask=True,
+            mask_fill_value=0,
+            bbox_clip_border=True,
+            max_rotate_degree=30,
+            max_translate_ratio=0.3,
+            scaling_ratio_range=(0.5, 1.5),
+            max_shear_degree=10,
+        )
+
+        original_entity = deepcopy(det_data_entity_with_masks)
+        original_num_objects = original_entity.masks.shape[0]
+
+        results = transform(original_entity)
+
+        # Check that the number of masks matches the number of valid bboxes and labels
+        assert results.masks.shape[0] == results.bboxes.shape[0]
+        assert results.masks.shape[0] == results.label.shape[0]
+
+        # The number of objects might be reduced due to filtering
+        assert results.masks.shape[0] <= original_num_objects
+
+    def test_repr_includes_mask_params(self) -> None:
+        """Test that __repr__ includes mask parameters."""
+        transform = RandomAffine(transform_mask=True, mask_fill_value=128)
+        repr_str = repr(transform)
+
+        assert "transform_mask=True" in repr_str
+        assert "mask_fill_value=128" in repr_str
+
+    def test_mask_dtype_preservation(
+        self,
+        random_affine_with_mask_transform: RandomAffine,
+        det_data_entity_with_masks: OTXDataItem,
+    ) -> None:
+        """Test that mask data type is preserved."""
+        original_entity = deepcopy(det_data_entity_with_masks)
+        original_dtype = original_entity.masks.dtype
+
+        results = random_affine_with_mask_transform(original_entity)
+
+        assert results.masks.dtype == original_dtype
+        assert isinstance(results.masks, tv_tensors.Mask)
+
+    @pytest.mark.parametrize("transform_mask", [True, False])
+    def test_mask_transform_parameter_effect(
+        self,
+        det_data_entity_with_masks: OTXDataItem,
+        transform_mask: bool,
+    ) -> None:
+        """Test that the transform_mask parameter controls mask transformation."""
+        transform = RandomAffine(
+            transform_mask=transform_mask,
+            mask_fill_value=0,
+            max_rotate_degree=0,
+            max_translate_ratio=0.1,
+            scaling_ratio_range=(1.0, 1.0),
+            max_shear_degree=0,
+        )
+
+        original_entity = deepcopy(det_data_entity_with_masks)
+        results = transform(original_entity)
+
+        # Regardless of transform_mask value, masks should be present and properly shaped
+        assert hasattr(results, "masks")
+        assert results.masks is not None
+        assert results.masks.shape[0] == results.bboxes.shape[0]
+        assert results.masks.shape[1:] == results.image.shape[1:]
 
 
 class TestCachedMosaic:

--- a/tests/unit/data/transform_libs/test_torchvision.py
+++ b/tests/unit/data/transform_libs/test_torchvision.py
@@ -409,7 +409,6 @@ class TestRandomAffine:
     ) -> None:
         """Test forward with polygons when transform_polygon is True."""
         original_entity = deepcopy(det_data_entity_with_polygons)
-        original_num_polygons = len(original_entity.polygons)
         results = random_affine_with_polygon_transform(original_entity)
 
         # Check that polygons are present and transformed
@@ -567,7 +566,6 @@ class TestRandomAffine:
     ) -> None:
         """Test forward with masks when transform_mask is False."""
         original_entity = deepcopy(det_data_entity_with_masks)
-        original_masks = original_entity.masks.clone()
         results = random_affine_without_mask_transform(original_entity)
 
         # Check that masks are present but not transformed


### PR DESCRIPTION
### Summary

This PR enhances the `RandomAffine` transform in `src/otx/data/transform_libs/torchvision.py` to support mask and polygon transformations alongside the existing image and bounding box transformations. 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
