### PR TITLE
Disable tox auto upgrade

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -35,6 +35,7 @@ updates:
       - dependency-name: "anomalib"
       - dependency-name: "torchmetrics"
       - dependency-name: "oneccl_bind_pt"
+      - dependency-name: "tox"
     groups:
       pip-mmlab:
         applies-to: version-updates


### PR DESCRIPTION
### Summary

Tox is a core dep for CI, auto upgrade can cause unexpected side-effects. See https://github.com/open-edge-platform/training_extensions/pull/4474 for an instance

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
