### PR TITLE
Remove duplicate `explain()` method and consolidate XAI functionality into `predict()`

### DIFF
--- a/docs/source/guide/explanation/additional_features/xai.rst
+++ b/docs/source/guide/explanation/additional_features/xai.rst
@@ -16,7 +16,7 @@ It looks like a heatmap, where warm-colored areas represent the areas with main 
   These images are taken from `D-RISE paper <https://arxiv.org/abs/2006.03204>`_.
 
 
-We can generate saliency maps for a certain model that was trained in OpenVINO™ Training Extensions, using ``otx explain`` command line. Learn more about its usage in  :doc:`../../tutorials/base/explain` tutorial.
+We can generate saliency maps for a certain model that was trained in OpenVINO™ Training Extensions, using ``otx predict --explain True`` command line. Learn more about its usage in  :doc:`../../tutorials/base/explain` tutorial.
 
 *********************************
 XAI algorithms for classification
@@ -109,15 +109,22 @@ For instance segmentation networks the following algorithm is used to generate s
 
         .. code-block:: python
 
-            engine.explain(
-              checkpoint="<checkpoint-path>", # .pth or .xml weights of the model
+            engine.predict(
+              checkpoint="checkpoint.pth", # Use .pth when instantiating the engine with OTXEngine
               datamodule=OTXDataModule(), # The data module to use for predictions
-              dump=True # Wherether to save saliency map images or not
+              explain=True # Enable explainability features
               )
+            
+            engine.predict(
+              checkpoint="exported_model.xml", # Use .xml when instantiating the engine with OVEngine
+              datamodule=OTXDataModule(), # The data module to use for predictions
+              explain=True # Enable explainability features
+            )
 
     .. tab-item:: CLI
 
         .. code-block:: bash
 
-            (otx) ...$ otx explain ... --checkpoint <checkpoint-path> # .pth or .xml weights of the model
-                                       --data_root <dataset_path> # Path to data folder or single image 
+            (otx) ...$ otx predict ... --checkpoint <checkpoint-path> # .pth or .xml weights of the model
+                                       --data_root <dataset_path> # Path to data folder or single image
+                                       --explain True # Enable explainability features 

--- a/docs/source/guide/get_started/api_tutorial.rst
+++ b/docs/source/guide/get_started/api_tutorial.rst
@@ -426,7 +426,7 @@ If the training is already in place, we just need to use the code below:
 
             from otx.metrics.fmeasure import FMeasure
 
-            metric = FMeasue(label_info=5)
+            metric = FMeasure(label_info=5)
             engine.test(metric=metric)
 
 
@@ -488,8 +488,8 @@ To run the XAI with the OpenVINO™ IR model, we need to create an output model 
     .. tab-item:: Run XAI
 
         .. code-block:: python
-
-            engine.explain(checkpoint="<path/to/ir/xml>")
+            engine = OVEngine(model="exported_model.xml", ...)
+            engine.predict(explain=True)
 
     .. tab-item:: Evaluate Model with different datamodule or dataloader
 
@@ -498,13 +498,15 @@ To run the XAI with the OpenVINO™ IR model, we need to create an output model 
             from otx.data.module import OTXDataModule
 
             datamodule = OTXDataModule(data_root="data/wgisd")
-            engine.explain(..., datamodule=datamodule)
+            engine.predict(..., datamodule=datamodule, explain=True)
 
-    .. tab-item:: Dump saliency_map
+    .. tab-item:: Use ExplainConfig
 
         .. code-block:: python
 
-            engine.explain(..., dump=True)
+            from otx.config.explain import ExplainConfig
+            
+            engine.predict(..., explain=True, explain_config=ExplainConfig(postprocess=True))
 
 
 ************

--- a/docs/source/guide/get_started/cli_commands.rst
+++ b/docs/source/guide/get_started/cli_commands.rst
@@ -27,7 +27,7 @@ Help
 
     (otx) ...$ otx --help
     ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │ Usage: otx [-h] [-v] {find,train,test,predict,export,optimize,explain} ...                              │
+    │ Usage: otx [-h] [-v] {find,train,test,predict,export,optimize} ...                                      │
     │                                                                                                                 │
     │                                                                                                                 │
     │ OpenVINO Training-Extension command line tool                                                                   │
@@ -48,7 +48,6 @@ Help
     │     predict             Run predictions using the specified model and data.                                     │
     │     export              Export the trained model to OpenVINO Intermediate Representation (IR) or ONNX formats.  │
     │     optimize            Applies NNCF.PTQ to the underlying models (now works only for OV models).               │
-    │     explain             Run XAI using the specified model and data (test subset).                               │
     |     benchmark           Executes model micro benchmarking on random data.                                       |
     │                                                                                                                 │
     ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -389,7 +388,7 @@ The command below performs exporting to the ``{work_dir}/`` path.
 
 The command results in ``exported_model.xml``, ``exported_model.bin``.
 
-To use the exported model as an input for ``otx explain``, please dump additional outputs with internal information, using ``--explain``:
+To use the exported model for explainable AI (XAI), please dump additional outputs with internal information, using ``--explain``:
 
 .. code-block:: shell
 
@@ -466,31 +465,35 @@ The command below will evaluate the trained model on the provided dataset:
         # OR if you are in the workspace root
         (otx) ...$ otx test
 
-***********
-Explanation
-***********
+**********
+Prediction
+**********
 
-``otx explain`` runs the explainable AI (XAI) algorithm on a specific model-dataset pair. It helps explain the model's decision-making process in a way that is easily understood by humans.
+``otx predict`` runs inference on a dataset and optionally generates explainable AI (XAI) saliency maps.
 
-
-The command below will generate saliency maps (heatmaps with red colored areas of focus) of the trained model on the provided dataset and save the resulting images to ``output`` path:
+The command below will run predictions on the provided dataset:
 
 .. code-block:: shell
 
-    (otx) ...$ otx explain --config <path/to/config> \
-                           --checkpoint <path/to/model_weights>
+    (otx) ...$ otx predict ... --data_root <path/to/test/root> \
+                               --checkpoint <path/to/model_weights>
+
+To generate saliency maps for explainability (XAI), use the ``--explain True`` parameter:
+
+.. code-block:: shell
+
+    (otx) ...$ otx predict ... --data_root <path/to/test/root> \
+                               --checkpoint <path/to/model_weights> \
+                               --explain True \
+                               --explain_config.postprocess True
+
+.. note::
+
+    For exported OpenVINO™ IR models, make sure the model was exported with ``otx export --explain True`` to include the necessary outputs for XAI functionality.
 
 .. note::
 
     It is possible to pass both PyTorch weights ``.ckpt`` or OpenVINO™ IR ``exported_model.xml`` to ``--checkpoint`` option.
-
-By default, the model is exported to the OpenVINO™ IR format without extra feature information needed for the ``explain`` function. To use OpenVINO™ IR model in ``otx explain``, please first export it with ``--explain`` parameter:
-
-.. code-block:: shell
-
-    (otx) ...$ otx export ... --checkpoint <path/to/trained/weights.ckpt> \
-                              --explain True
-    (otx) ...$ otx explain ... --checkpoint outputs/openvino/with_features \
 
 *******************
 Micro-benchmarking

--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -431,10 +431,7 @@ class OTXEngine(Engine):
                 ...     --checkpoint <CKPT_PATH, str>
                 ```
         """
-        from otx.backend.native.models.utils.xai_utils import (
-            process_saliency_maps_in_pred_entity,
-            set_crop_padded_map_flag,
-        )
+        from otx.backend.native.models.utils.xai_utils import process_saliency_maps_in_pred_entity
 
         model = self.model
 
@@ -474,7 +471,6 @@ class OTXEngine(Engine):
         if explain:
             if explain_config is None:
                 explain_config = ExplainConfig()
-            explain_config = set_crop_padded_map_flag(explain_config, datamodule)
 
             predict_result = process_saliency_maps_in_pred_entity(predict_result, explain_config, datamodule.label_info)
 
@@ -569,93 +565,6 @@ class OTXEngine(Engine):
 
         self.model.explain_mode = False
         return exported_model_path
-
-    def explain(
-        self,
-        checkpoint: PathLike | None = None,
-        datamodule: EVAL_DATALOADERS | OTXDataModule | None = None,
-        explain_config: ExplainConfig | None = None,
-        **kwargs,
-    ) -> list | None:
-        r"""Run XAI using the specified model and data (test subset).
-
-        Args:
-            checkpoint (PathLike | None, optional): The path to the checkpoint file to load the model from.
-            datamodule (EVAL_DATALOADERS | OTXDataModule | None, optional): The data module to use for predictions.
-            explain_config (ExplainConfig | None, optional): Config used to handle saliency maps.
-            **kwargs: Additional keyword arguments for pl.Trainer configuration.
-
-        Returns:
-            list: Saliency maps.
-
-        Example:
-            >>> engine.explain(
-            ...     datamodule=OTXDataModule(),
-            ...     checkpoint=<checkpoint/path>,
-            ...     explain_config=ExplainConfig(),
-            ... )
-
-        CLI Usage:
-            1. To run XAI with the torch model in work_dir, run
-                ```shell
-                >>> otx explain \
-                ...     --work_dir <WORK_DIR_PATH, str>
-                ```
-            2. To run XAI using the specified model (torch or IR), run
-                ```shell
-                >>> otx explain \
-                ...     --work_dir <WORK_DIR_PATH, str> \
-                ...     --checkpoint <CKPT_PATH, str>
-                ```
-            3. To run XAI using the configuration, run
-                ```shell
-                >>> otx explain \
-                ...     --config <CONFIG_PATH> --data_root <DATASET_PATH, str> \
-                ...     --checkpoint <CKPT_PATH, str>
-                ```
-        """
-        from otx.backend.native.models.utils.xai_utils import (
-            process_saliency_maps_in_pred_entity,
-            set_crop_padded_map_flag,
-        )
-
-        model = self.model
-
-        checkpoint = checkpoint if checkpoint is not None else self.checkpoint
-        datamodule = datamodule if datamodule is not None else self.datamodule
-
-        if checkpoint is not None:
-            kwargs_user_input: dict[str, Any] = {}
-
-            model_cls = model.__class__
-            model = model_cls.load_from_checkpoint(checkpoint_path=checkpoint, **kwargs_user_input)
-
-        if model.label_info != self.datamodule.label_info:
-            msg = (
-                "To launch a explain pipeline, the label information should be same "
-                "between the training and testing datasets. "
-                "Please check whether you use the same dataset: "
-                f"model.label_info={model.label_info}, "
-                f"datamodule.label_info={self.datamodule.label_info}"
-            )
-            raise ValueError(msg)
-
-        model.explain_mode = True
-
-        self._build_trainer(**kwargs)
-
-        predict_result = self.trainer.predict(
-            model=model,
-            datamodule=datamodule,
-        )
-
-        if explain_config is None:
-            explain_config = ExplainConfig()
-        explain_config = set_crop_padded_map_flag(explain_config, datamodule)
-
-        predict_result = process_saliency_maps_in_pred_entity(predict_result, explain_config, datamodule.label_info)
-        model.explain_mode = False
-        return predict_result
 
     def benchmark(
         self,

--- a/src/otx/backend/native/models/detection/base.py
+++ b/src/otx/backend/native/models/detection/base.py
@@ -209,7 +209,7 @@ class OTXDetectionModel(OTXModel):
                 scores=scores,
                 bboxes=bboxes,
                 labels=labels,
-                saliency_map=[saliency_map.detach().to(torch.float32) for saliency_map in outputs["saliency_map"]],
+                saliency_map=outputs["saliency_map"],
                 feature_vector=[
                     feature_vector.detach().unsqueeze(0).to(torch.float32)
                     for feature_vector in outputs["feature_vector"]

--- a/src/otx/backend/native/tools/explain/explain_algo.py
+++ b/src/otx/backend/native/tools/explain/explain_algo.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Callable
 
 import torch
@@ -267,6 +268,14 @@ class DetClassProbabilityMap(BaseExplainAlgo):
         self._num_classes = num_classes
         self._num_anchors = num_anchors
         # Should be switched off for tiling
+        if num_classes == 1 and use_cls_softmax:
+            # softmax would result in all 1.0 values if there's only 1 class
+            warnings.warn(
+                "use_cls_softmax is automatically disabled when num_classes=1 to prevent degenerate softmax behavior",
+                UserWarning,
+                stacklevel=2,
+            )
+            use_cls_softmax = False
         self.use_cls_softmax = use_cls_softmax
 
     def func(

--- a/src/otx/backend/openvino/engine.py
+++ b/src/otx/backend/openvino/engine.py
@@ -270,10 +270,7 @@ class OVEngine(Engine):
             ValueError: If input data is invalid or label information does not match.
             TypeError: If input data type is unsupported.
         """
-        from otx.backend.native.models.utils.xai_utils import (
-            process_saliency_maps_in_pred_entity,
-            set_crop_padded_map_flag,
-        )
+        from otx.backend.native.models.utils.xai_utils import process_saliency_maps_in_pred_entity
 
         model = self._update_checkpoint(checkpoint)
         if isinstance(data, (str, os.PathLike)):
@@ -329,7 +326,6 @@ class OVEngine(Engine):
         if explain and isinstance(datamodule, OTXDataModule):
             if explain_config is None:
                 explain_config = ExplainConfig()
-            explain_config = set_crop_padded_map_flag(explain_config, datamodule)
             predict_result = process_saliency_maps_in_pred_entity(predict_result, explain_config, datamodule.label_info)
 
         return predict_result

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -213,7 +213,6 @@ class OTXCLI:
             "test": {"datamodule"}.union(device_kwargs),
             "predict": {"datamodule"}.union(device_kwargs),
             "export": device_kwargs,
-            "explain": {"datamodule"}.union(device_kwargs),
             "benchmark": device_kwargs,
         }
 

--- a/src/otx/data/entity/base.py
+++ b/src/otx/data/entity/base.py
@@ -69,6 +69,7 @@ class ImageInfo(tv_tensors.TVTensor):
         norm_std: Standard deviation vector used to normalize this image
         image_color_channel: Color channel type of this image, RGB or BGR.
         ignored_labels: Label that should be ignored in this image. Default to None.
+        keep_ratio: If true, the image is resized while keeping the aspect ratio. Default to False.
     """
 
     img_idx: int
@@ -81,6 +82,7 @@ class ImageInfo(tv_tensors.TVTensor):
     norm_std: tuple[float, float, float] = (1.0, 1.0, 1.0)
     image_color_channel: ImageColorChannel = ImageColorChannel.RGB
     ignored_labels: list[int]
+    keep_ratio: bool = False
 
     @classmethod
     def _wrap(
@@ -97,6 +99,7 @@ class ImageInfo(tv_tensors.TVTensor):
         norm_std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         image_color_channel: ImageColorChannel = ImageColorChannel.RGB,
         ignored_labels: list[int] | None = None,
+        keep_ratio: bool = False,
     ) -> ImageInfo:
         image_info = dummy_tensor.as_subclass(cls)
         image_info.img_idx = img_idx
@@ -109,6 +112,7 @@ class ImageInfo(tv_tensors.TVTensor):
         image_info.norm_std = norm_std
         image_info.image_color_channel = image_color_channel
         image_info.ignored_labels = ignored_labels if ignored_labels else []
+        image_info.keep_ratio = keep_ratio
         return image_info
 
     def __new__(  # noqa: D102
@@ -123,6 +127,7 @@ class ImageInfo(tv_tensors.TVTensor):
         norm_std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         image_color_channel: ImageColorChannel = ImageColorChannel.RGB,
         ignored_labels: list[int] | None = None,
+        keep_ratio: bool = False,
     ) -> ImageInfo:
         return cls._wrap(
             dummy_tensor=Tensor(),
@@ -136,6 +141,7 @@ class ImageInfo(tv_tensors.TVTensor):
             norm_std=norm_std,
             image_color_channel=image_color_channel,
             ignored_labels=ignored_labels,
+            keep_ratio=keep_ratio,
         )
 
     @classmethod
@@ -169,6 +175,7 @@ class ImageInfo(tv_tensors.TVTensor):
                 norm_std=image_info.norm_std,
                 image_color_channel=image_info.image_color_channel,
                 ignored_labels=image_info.ignored_labels,
+                keep_ratio=image_info.keep_ratio,
             )
         elif isinstance(output, (tuple, list)):
             image_infos = [x for x in flat_params if isinstance(x, ImageInfo)]
@@ -185,6 +192,7 @@ class ImageInfo(tv_tensors.TVTensor):
                     norm_std=image_info.norm_std,
                     image_color_channel=image_info.image_color_channel,
                     ignored_labels=image_info.ignored_labels,
+                    keep_ratio=image_info.keep_ratio,
                 )
                 for dummy_tensor, image_info in zip(output, image_infos)
             )
@@ -202,7 +210,8 @@ class ImageInfo(tv_tensors.TVTensor):
             f"norm_mean={self.norm_mean}, "
             f"norm_std={self.norm_std}, "
             f"image_color_channel={self.image_color_channel}, "
-            f"ignored_labels={self.ignored_labels})"
+            f"ignored_labels={self.ignored_labels}, "
+            f"keep_ratio={self.keep_ratio})"
         )
 
 

--- a/src/otx/data/entity/torch/validations.py
+++ b/src/otx/data/entity/torch/validations.py
@@ -310,17 +310,6 @@ class ValidateBatchMixin:
         """
         if all(saliency_map is None for saliency_map in saliency_map_batch):
             return []
-        # TODO(ashwinvaidya17): use only one dtype. Kept for OV Classification compatibility
-        if not isinstance(saliency_map_batch, list) or not isinstance(
-            saliency_map_batch[0],
-            (torch.Tensor, np.ndarray),
-        ):
-            msg = f"Saliency map batch must be a list of torch tensors. Got {type(saliency_map_batch)}"
-            raise TypeError(msg)
-        # assumes homogeneous data so validation is done only for the first element
-        if isinstance(saliency_map_batch[0], torch.Tensor) and not saliency_map_batch[0].dtype.is_floating_point:
-            msg = f"Saliency map must have a floating point dtype. Got {saliency_map_batch[0].dtype}"
-            raise ValueError(msg)
         return saliency_map_batch
 
     @staticmethod

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -332,6 +332,7 @@ class Resize(tvt_v2.Transform, NumpytoTVTensorMixin):
 
             inputs.image = img
             inputs.img_info = _resize_image_info(inputs.img_info, img.shape[:2])
+            inputs.img_info.keep_ratio = self.keep_ratio  # type: ignore[union-attr]
             scale_factor = (scale[0] / img_shape[0], scale[1] / img_shape[1])
         return inputs, scale_factor
 


### PR DESCRIPTION
### Summary

Remove duplicate `explain()` method and move XAI functionality into `predict()`

The codebase had significant code duplication between `OTXEngine.explain()` and `OTXEngine.predict(explain=True)` methods. Both methods performed nearly identical operations:
- Same checkpoint loading logic
- Same label validation 
- Same trainer building
- Same saliency map processing via `process_saliency_maps_in_pred_entity()`

### 🔧 **Changes Made**

#### Code Changes
- **Removed** `OTXEngine.explain()` method entirely
- **Keep** `OTXEngine.predict(explain=True)` to be the single source for XAI functionality

#### Documentation Updates
- **Updated** `docs/source/guide/tutorials/base/explain.rst` - Main XAI tutorial
- **Updated** `docs/source/guide/get_started/api_tutorial.rst` - API examples
- **Updated** `docs/source/guide/get_started/cli_commands.rst` - CLI documentation  
- **Updated** `docs/source/guide/explanation/additional_features/xai.rst` - XAI feature docs

#### CLI Changes
- **Removed** `otx explain` command from CLI help and documentation
- **Added** comprehensive `otx predict --explain True` documentation

#### 🚨 **Breaking Changes**

### Python API
```python
# Before (deprecated)
engine.explain(checkpoint="model.pth", explain_config=ExplainConfig())

# After (new approach)  
engine.predict(checkpoint="model.pth", explain=True, explain_config=ExplainConfig())
```

#### CLI Usage
```bash
# Before (deprecated)
otx explain --work_dir workspace --checkpoint model.pth

# After (new approach)
otx predict --work_dir workspace --checkpoint model.pth --explain True
```

#### 📖 **Migration Guide**
For Python API Users
Replace all `engine.explain()` calls with `engine.predict(explain=True)`:

```python
# Old code
results = engine.explain(
    checkpoint="model.pth",
    datamodule=datamodule,
    explain_config=ExplainConfig(postprocess=True)
)

# New code  
results = engine.predict(
    checkpoint="model.pth", 
    datamodule=datamodule,
    explain=True,
    explain_config=ExplainConfig(postprocess=True)
)
```

#### For CLI Users
Replace `otx explain` with `otx predict --explain True`:

```bash
# Old command
otx explain --work_dir workspace --checkpoint model.pth --explain_config.postprocess True

# New command
otx predict --work_dir workspace --checkpoint model.pth --explain True --explain_config.postprocess True
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
