### PR TITLE
(release/2.5) Remove duplicate explain() method and consolidate XAI functionality into predict()

### DIFF
--- a/docs/source/guide/explanation/additional_features/xai.rst
+++ b/docs/source/guide/explanation/additional_features/xai.rst
@@ -16,7 +16,7 @@ It looks like a heatmap, where warm-colored areas represent the areas with main 
   These images are taken from `D-RISE paper <https://arxiv.org/abs/2006.03204>`_.
 
 
-We can generate saliency maps for a certain model that was trained in OpenVINO™ Training Extensions, using ``otx explain`` command line. Learn more about its usage in  :doc:`../../tutorials/base/explain` tutorial.
+We can generate saliency maps for a certain model that was trained in OpenVINO™ Training Extensions, using ``otx predict --explain True`` command line. Learn more about its usage in  :doc:`../../tutorials/base/explain` tutorial.
 
 *********************************
 XAI algorithms for classification
@@ -109,15 +109,22 @@ For instance segmentation networks the following algorithm is used to generate s
 
         .. code-block:: python
 
-            engine.explain(
-              checkpoint="<checkpoint-path>", # .pth or .xml weights of the model
+            engine.predict(
+              checkpoint="checkpoint.pth", # Use .pth when instantiating the engine with OTXEngine
               datamodule=OTXDataModule(), # The data module to use for predictions
-              dump=True # Wherether to save saliency map images or not
+              explain=True # Enable explainability features
               )
+            
+            engine.predict(
+              checkpoint="exported_model.xml", # Use .xml when instantiating the engine with OVEngine
+              datamodule=OTXDataModule(), # The data module to use for predictions
+              explain=True # Enable explainability features
+            )
 
     .. tab-item:: CLI
 
         .. code-block:: bash
 
-            (otx) ...$ otx explain ... --checkpoint <checkpoint-path> # .pth or .xml weights of the model
-                                       --data_root <dataset_path> # Path to data folder or single image 
+            (otx) ...$ otx predict ... --checkpoint <checkpoint-path> # .pth or .xml weights of the model
+                                       --data_root <dataset_path> # Path to data folder or single image
+                                       --explain True # Enable explainability features 

--- a/docs/source/guide/get_started/api_tutorial.rst
+++ b/docs/source/guide/get_started/api_tutorial.rst
@@ -4,25 +4,21 @@
 Besides CLI functionality, The OpenVINO™ Training Extension provides APIs that help developers to integrate OpenVINO™ Training Extensions models into their projects.
 This tutorial intends to show how to create a dataset, model and use all of the CLI functionality through APIs.
 
-OTX aims to provide a unified interface for interacting with different backends, enabling seamless training and validation across both native and third-party backends. This allows users to easily adapt and integrate popular computer vision models.
-OpenVINO™ Training Extensions APIs are designed to be easy to use and flexible, allowing you to create, train, and deploy deep learning models with minimal effort.
-
-There are :doc:`dedicated tutorials <../tutorials/base/how_to_train/index>` in our documentation with life-practical examples on specific datasets for each task.
+For demonstration purposes we will use the Object Detection ATSS model with `WGISD <https://github.com/thsant/wgisd>`_ public dataset as we did for the :doc:`CLI tutorial <../tutorials/base/how_to_train/detection>`.
 
 .. note::
 
     To start with we need to `install OpenVINO™ Training Extensions <https://github.com/open-edge-platform/training_extensions/blob/develop/QUICK_START_GUIDE.md#setup-openvino-training-extensions>`_.
 
-
 *******************
 Dataset preparation
 *******************
-For the demonstration, we will use the `WGISD dataset <https://github.com/thsant/wgisd>_` and object detection model.
 
 1. Clone a repository
 with `WGISD dataset <https://github.com/thsant/wgisd>`_.
 
 .. code-block:: shell
+
     cd data
     git clone https://github.com/thsant/wgisd.git
     cd wgisd
@@ -32,75 +28,44 @@ with `WGISD dataset <https://github.com/thsant/wgisd>`_.
 be distinguished by OpenVINO™ Training Extensions Datumaro manager:
 
 .. code-block:: shell
+
     mv data images && mv coco_annotations annotations && mv annotations/train_bbox_instances.json instances_train.json && mv annotations/test_bbox_instances.json instances_val.json
+
 Now it is all set to use this dataset inside OpenVINO™ Training Extensions
 
 ************************************
-Quick Start with "create_engine"
+Quick Start with auto-configuration
 ************************************
 
-Once the dataset is ready, we can create an ``Engine`` instance using the ``create_engine`` function, providing the dataset path and the model.
-OpenVINO Training Extensions will prepare an engine based on the provided dataset and model.
+Once the dataset is ready, we can immediately start training with the model and data pipeline recommended by OpenVINO™ Training Extension through auto-configuration.
+The following code snippet demonstrates how to use the auto-configuration feature:
 
-.. tab-set::
+.. code-block:: python
 
-    .. tab-item:: with a config and dataset path
+    from otx.engine import Engine
 
-        .. code-block:: python
+    engine = Engine(data_root="data/wgisd")
+    engine.train()
 
-            from otx.engine import create_engine
 
-            engine = create_engine(data="data/wgisd", model="path/to/model/config")
-            engine.train()
+.. note::
 
-    .. tab-item:: with a datamodule and model instances
+    If dataset supports multiple Task types, this will default to the Task type detected by OpenVINO™ Training Extension.
+    If you want to specify a specific Task type, you need to specify it like below:
 
-        .. code-block:: python
+    .. code-block:: python
 
-            from otx.engine import create_engine
-            from otx.config.data import SubsetConfig
-            from otx.backend.native.models import ATSS
-            from otx.data.datamodule import OTXDataModule
+        from otx.engine import Engine
 
-            model = ATSS(model_name="atss_mobilenetv2",
-                        label_info = {"label_names": ["Chardonnay", "Cabernet Franc", "Cabernet Sauvignon", "Sauvignon Blanc", "Syrah"],
-                                     "label_id": [0, 1, 2, 3, 4],
-                                     "label_groups": [["Chardonnay", "Cabernet Franc", "Cabernet Sauvignon", "Sauvignon Blanc", "Syrah"]]},
-                        data_input_params = {"input_size": [800, 992],
-                                            "mean": [0.0, 0.0, 0.0],
-                                            "std": [255.0, 255.0, 255.0]})
-
-            train_augmentation = v2.Compose([
-                    otx.data.transform_libs.torchvision.Resize(size=(800, 992), transform_bbox=True),
-                    v2.RandomHorizontalFlip(p=0.5),
-                    v2.ToDtype(torch.float32),
-                    v2.Normalize(mean=[0.0, 0.0, 0.0], std=[255.0, 255.0, 255.0]),
-                ])
-            val_augmentation = v2.Compose([
-                    otx.data.transform_libs.torchvision.Resize(size=(800, 992), transform_bbox=True),
-                    v2.ToDtype(torch.float32),
-                    v2.Normalize(mean=[0.0, 0.0, 0.0], std=[255.0, 255.0, 255.0]),
-                ])
-            datamodule = OTXDataModule(data_root="data/wgisd", data_format="COCO", task="DETECTION",
-                                       train_subset=SubsetConfig(subset_name="train",
-                                                                augmentations=train_augmentation,
-                                                                batch_size=8,),
-                                       val_subset=SubsetConfig(subset_name="val",
-                                                                augmentations=val_augmentation,
-                                                                batch_size=8,),
-                                       test_subset=SubsetConfig(subset_name="test",
-                                                                augmentations=val_augmentation,
-                                                                batch_size=8,))
-
-            engine = create_engine(data=datamodule, model=model)
-            engine.train()
+        engine = Engine(data_root="data/wgisd", task="INSTANCE_SEGMENTATION")
+        engine.train()
 
 
 **********************************
 Check Available Model Recipes
 **********************************
 
-If you want to use other models offered by OpenVINO™ Training Extension, you can get a list of available models in OpenVINO™ Training Extension as shown below.
+If you want to use other models offered by OpenVINO™ Training Extension besides the ones provided by Auto-Configuration, you can get a list of available models in OpenVINO™ Training Extension as shown below.
 
 .. tab-set::
 
@@ -190,92 +155,74 @@ If you want to use other models offered by OpenVINO™ Training Extension, you c
 
 You can also find the available model recipes in YAML form in the folder ``otx/recipe``.
 
-*****************
-OTX Native Engine
-*****************
+*********
+Engine
+*********
 
-The ``otx.engine.Engine`` class serves as the base engine where all common entry points for various backends are defined.
-In this section, we focus on the ``otx.backend.native.engine.OTXEngine`` class — the native engine implementation provided by OpenVINO™ Training Extensions.
+The ``otx.engine.Engine`` class is the main entry point for using OpenVINO™ Training Extensions APIs.
 
-1. Setting ``work_dir``
+1. Setting ``task``
 
-Specify ``work_dir``. This is the workspace for that ``OTXEngine``, and where output is stored.
+Specify ``task``. This is the task type for that ``Engine`` usage.
+You can set the task by referencing the ``OTXTaskType`` in ``otx.types.task``.
+If no task is specified, the task is detected and used via ``datamodule`` or ``data_root``.
+
+.. code-block:: python
+
+    from otx.types.task import OTXTaskType
+    from otx.engine import Engine
+
+    engine = Engine(task=OTXTaskType.DETECTION)
+    # or
+    engine = Engine(task="DETECTION")
+
+2. Setting ``work_dir``
+
+Specify ``work_dir``. This is the workspace for that ``Engine``, and where output is stored.
 The default value is currently ``./otx-workspace``.
 
 .. code-block:: python
 
-    from otx.backend.native.engine import OTXEngine
-    from otx.backend.native.models import ATSS
+    from otx.engine import Engine
 
-    engine = OTXEngine(work_dir="work_dir",
-                       data_root="data/wgisd",
-                       model=ATSS(...))
+    engine = Engine(work_dir="work_dir")
 
 
 3. Setting device
 
 You can set the device by referencing the ``DeviceType`` in ``otx.types.device``.
-The current default setting is ``auto``. Native OTX Engine supports ``cpu``, ``gpu``, and ``xpu`` devices for training.
-
-.. note::
-
-    **XPU** is a generic term used by Intel to refer to heterogeneous compute devices, including Intel GPUs, CPUs, and certain AI accelerators.
-    However, when referring to the PyTorch device, XPU specifically denotes an **Intel GPU**.
+The current default setting is ``auto``.
 
 .. code-block:: python
 
     from otx.types.device import DeviceType
-    from otx.backend.native.engine import OTXEngine
+    from otx.engine import Engine
 
-    engine = OTXEngine(..., device=DeviceType.xpu)
-
-.. tabs::
-
-    .. tab:: CPU
-
-        .. code-block:: python
-
-            engine = OTXEngine(device=DeviceType.cpu)
-            # or
-            engine = OTXEngine(device="cpu")
-
-    .. tab:: GPU
-
-        .. code-block:: python
-
-            engine = OTXEngine(device=DeviceType.gpu)
-            # or
-            engine = OTXEngine(device="gpu")
-
-    .. tab:: XPU
-
-        .. code-block:: python
-
-            engine = OTXEngine(device=DeviceType.xpu)
-            # or
-            engine = OTXEngine(device="xpu")
+    engine = Engine(device=DeviceType.gpu)
+    # or
+    engine = Engine(device="gpu")
 
 
-In addition, the ``OTXEngine`` constructor can be associated with the Trainer's constructor arguments to control the Trainer's functionality.
+In addition, the ``Engine`` constructor can be associated with the Trainer's constructor arguments to control the Trainer's functionality.
 Refer `lightning.Trainer <https://lightning.ai/docs/pytorch/stable/common/trainer.html>`_.
 
 4. Using the OpenVINO™ Training Extension configuration we can configure the Engine.
 
 .. code-block:: python
 
-    from otx.backend.native.engine import OTXEngine
+    from otx.engine import Engine
 
     recipe = "src/otx/recipe/detection/atss_mobilenetv2.yaml"
-    engine = OTXEngine.from_config(
+    engine = Engine.from_config(
         config_path=recipe,
         data_root="data/wgisd",
         work_dir="./otx-workspace",
     )
 
 
-********
+*********
 Training
-********
+*********
 
 Create an output model and start actual training:
 
@@ -283,32 +230,20 @@ Create an output model and start actual training:
 
 .. code-block:: python
 
-    from otx.engine import create_engine
-    from otx.backend.native.models import ATSS
+    from otx.engine import Engine
 
-    model = ATSS(
-                model_name="atss_mobilenetv2",
-                label_info = {"label_names": ["Chardonnay", "Cabernet Franc", "Cabernet Sauvignon", "Sauvignon Blanc", "Syrah"],
-                                "label_id": [0, 1, 2, 3, 4],
-                                "label_groups": [["Chardonnay", "Cabernet Franc", "Cabernet Sauvignon", "Sauvignon Blanc", "Syrah"]]},
-                data_input_params = {"input_size": [800, 992],
-                                    "mean": [0.0, 0.0, 0.0],
-                                    "std": [255.0, 255.0, 255.0]}
-            )
-    engine = create_engine(data="data/wgisd",
-                           model=model)
-
+    engine = Engine(data_root="data/wgisd", model="atss_mobilenetv2")
     engine.train()
 
 2. Alternatively, we can use the configuration file.
 
 .. code-block:: python
 
-    from otx.engine import create_engine
+    from otx.engine import Engine
 
     config = "src/otx/recipe/detection/atss_mobilenetv2.yaml"
 
-    engine = create_engine(data=config, data="data/wgisd")
+    engine = Engine.from_config(config_path=config, data_root="data/wgisd")
     engine.train()
 
 .. note::
@@ -316,37 +251,34 @@ Create an output model and start actual training:
     This can use callbacks provided by OpenVINO™ Training Extension and several training techniques.
     However, in this case, no arguments are specified for train.
 
-3. You can also create a specific Engine instance using the class directly.
-
-    .. code-block:: python
-
-        from otx.backend.native.engine import OTXEngine
-
-        engine = OTXEngine(data="data/wgisd", model=config, work_dir="otx-workspace")
-        engine.train()
-
-3. If you want to customize model or optimizer, you can do so as shown below:
+3. If you want to specify the model, you can do so as shown below:
 
 The model used by the Engine is of type ``otx.model.entity.base.OTXModel``.
 
 .. tab-set::
+
+    .. tab-item:: Custom Model
+
+        .. code-block:: python
+
+            from otx.backend.native.models.detection.atss import ATSS
+            from otx.engine import Engine
+
+            model = ATSS(label_info=5, model_name="mobilenetv2", data_input_params=DataInputParams(input_size=(512, 512), mean=(123.675, 116.28, 103.53), std=(58.395, 57.12, 57.375)))
+
+            engine = Engine(data_root="data/wgisd", model=model)
+            engine.train()
 
     .. tab-item:: Custom Model with checkpoint
 
         .. code-block:: python
 
             from otx.backend.native.models.detection.atss import ATSS
-            from otx.backend.native.engine import OTXEngine
+            from otx.engine import Engine
 
-            model = ATSS(label_info = {"label_names": ["Chardonnay", "Cabernet Franc", "Cabernet Sauvignon", "Sauvignon Blanc", "Syrah"],
-                                "label_id": [0, 1, 2, 3, 4],
-                                "label_groups": [["Chardonnay", "Cabernet Franc", "Cabernet Sauvignon", "Sauvignon Blanc", "Syrah"]]},
-                         model_name="atss_mobilenetv2",
-                         data_input_params={"input_size": [800, 992],
-                                            "mean": [0.0, 0.0, 0.0],
-                                            "std": [255.0, 255.0, 255.0]})
+            model = ATSS(label_info=5, model_name="mobilenetv2")
 
-            engine = OTXEngine(data="data/wgisd", model=model, checkpoint="<path/to/checkpoint>")
+            engine = Engine(data_root="data/wgisd", model=model, checkpoint="<path/to/checkpoint>")
             engine.train()
 
     .. tab-item:: Custom Optimizer & Scheduler
@@ -356,16 +288,13 @@ The model used by the Engine is of type ``otx.model.entity.base.OTXModel``.
             from torch.optim import SGD
             from torch.optim.lr_scheduler import CosineAnnealingLR
             from otx.backend.native.models.detection.atss import ATSS
-            from otx.backend.native.engine import OTXEngine
+            from otx.engine import Engine
 
-            model = ATSS(label_info=5, model_name="atss_mobilenetv2",
-                         data_input_params={"input_size": [800, 992],
-                                            "mean": [0.0, 0.0, 0.0],
-                                            "std": [255.0, 255.0, 255.0]})
+            model = ATSS(label_info=5, model_name="mobilenetv2")
             optimizer = SGD(model.parameters(), lr=0.01, weight_decay=1e-4, momentum=0.9)
             scheduler = CosineAnnealingLR(optimizer, T_max=10000, eta_min=0)
 
-            engine = OTXEngine(
+            engine = Engine(
                 ...,
                 model=model,
                 optimizer=optimizer,
@@ -380,11 +309,11 @@ The datamodule used by the Engine is of type ``otx.data.module.OTXDataModule``.
 .. code-block:: python
 
     from otx.data.module import OTXDataModule
-    from otx.backend.native.engine import OTXEngine
+    from otx.engine import Engine
 
     datamodule = OTXDataModule(data_root="data/wgisd", ...)
 
-    engine = OTXEngine(data=datamodule, ...)
+    engine = Engine(datamodule=datamodule)
     engine.train()
 
 .. note::
@@ -462,8 +391,7 @@ For example, if you want to use the ``limit_val_batches`` feature provided by Tr
 Evaluation
 ***********
 
-1. If the training is already in place,
-we just need to use the code below:
+If the training is already in place, we just need to use the code below:
 
 .. tab-set::
 
@@ -489,7 +417,7 @@ we just need to use the code below:
 
             from otx.data.module import OTXDataModule
 
-            datamodule = OTXDataModule(data_root="data/wgisd", ...)
+            datamodule = OTXDataModule(data_root="data/wgisd")
             engine.test(datamodule=datamodule)
 
     .. tab-item:: Evaluate Model with different metrics
@@ -498,28 +426,9 @@ we just need to use the code below:
 
             from otx.metrics.fmeasure import FMeasure
 
-            metric = FMeasue(label_info=5)
+            metric = FMeasure(label_info=5)
             engine.test(metric=metric)
 
-2. If you want to validate OpenVINO IR model, you need to use OVEngine. OVEngine can be created in the same way as OTXEngine:
-
-.. tab-set::
-
-    .. code-block:: python
-
-        from otx.backend.openvino.engine import OVEngine
-        from otx.engine import create_engine
-
-        # using create_engine
-        ov_engine = create_engine(
-            data="data/wgisd",
-            model="path/to/exported_model.xml",
-        )
-
-        # or directly with OVEngine
-        ov_engine = OVEngine(model="path/to/exported_model.xml", data="data/wgisd")
-
-        ov_engine.test()
 
 ***********
 Exporting
@@ -572,15 +481,15 @@ The default value for ``export_precision`` is ``FP32``.
 XAI
 ****
 
-To run the XAI with the OTXEngine, we need to run the following code:
+To run the XAI with the OpenVINO™ IR model, we need to create an output model and run the XAI procedure:
 
 .. tab-set::
 
     .. tab-item:: Run XAI
 
         .. code-block:: python
-
-            engine.explain(checkpoint="<path/to/checkpoint>")
+            engine = OVEngine(model="exported_model.xml", ...)
+            engine.predict(explain=True)
 
     .. tab-item:: Evaluate Model with different datamodule or dataloader
 
@@ -589,20 +498,22 @@ To run the XAI with the OTXEngine, we need to run the following code:
             from otx.data.module import OTXDataModule
 
             datamodule = OTXDataModule(data_root="data/wgisd")
-            engine.explain(..., datamodule=datamodule)
+            engine.predict(..., datamodule=datamodule, explain=True)
 
-    .. tab-item:: Dump saliency_map
+    .. tab-item:: Use ExplainConfig
 
         .. code-block:: python
 
-            engine.explain(..., dump=True)
+            from otx.config.explain import ExplainConfig
+            
+            engine.predict(..., explain=True, explain_config=ExplainConfig(postprocess=True))
 
 
 ************
 Optimization
 ************
 
-To run the optimization with PTQ on the OpenVINO™ IR model, we need to use OVEngine and run the optimization procedure:
+To run the optimization with PTQ on the OpenVINO™ IR model, we need to create an output model and run the optimization procedure:
 
 .. tab-set::
 
@@ -610,34 +521,29 @@ To run the optimization with PTQ on the OpenVINO™ IR model, we need to use OVE
 
         .. code-block:: python
 
-            from otx.backend.openvino.engine import OVEngine
-            ov_engine = OVEngine(model="path/to/exported_model.xml", data="data/wgisd")
-
-            ov_engine.optimize()
+            engine.optimize(checkpoint="<path/to/ir/xml>")
 
     .. tab-item:: Evaluate Model with different datamodule or dataloader
 
         .. code-block:: python
 
             from otx.data.module import OTXDataModule
-            from otx.backend.openvino.engine import OVEngine
-            ov_engine = OVEngine(model="path/to/exported_model.xml", data="data/wgisd")
 
-            datamodule = OTXDataModule(data_root="data/wgisd", ...)
-            ov_engine.optimize(data=datamodule)
+            datamodule = OTXDataModule(data_root="data/wgisd")
+            engine.optimize(..., datamodule=datamodule)
 
 
-You can validate the optimized model as the usual model:
+You can validate the optimized model as the usual model. For example for the NNCF model it will look like this:
 
 .. code-block:: python
 
-    ov_engine.test(model="<path/to/optimized/ir/xml>")
+    engine.test(checkpoint="<path/to/optimized/ir/xml>")
 
 ************
 Benchmarking
 ************
 
-``OTXEngine`` allows to perform benchmarking of the trained model, and provide theoretical complexity information in case of torch model.
+``Engine`` allows to perform benchmarking of the trained model, and provide theoretical complexity information in case of torch model.
 The estimated by ``Engine.benchmark()`` performance may differ from the performance of the deployed model, since the measurements are conducted
 via OTX inference API, which can introduce additional burden.
 
@@ -647,8 +553,17 @@ via OTX inference API, which can introduce additional burden.
 
         .. code-block:: python
 
-            engine = OTXEngine(data="data/wgisd", model="src/otx/recipe/detection/atss_mobilenetv2.yaml", work_dir="otx-workspace")
             engine.benchmark()
+
+    .. tab-item:: Benchmark OpenVINO™ IR model
+
+        .. code-block:: python
+
+            engine.benchmark(checkpoint="<path/to/exported_model.xml>")
+
+        .. note::
+
+            Specifying a checkpoint only makes sense for OpenVINO™ IR models.
 
 Conclusion
 """""""""""

--- a/docs/source/guide/get_started/cli_commands.rst
+++ b/docs/source/guide/get_started/cli_commands.rst
@@ -9,10 +9,6 @@ All possible OpenVINO™ Training Extensions CLI commands are presented below al
     Also, by default, the OpenVINO™ Training Extensions CLI is written using jsonargparse, see jsonargparse or LightningCLI.
     Please refer `Jsonargparse Documentation <https://jsonargparse.readthedocs.io/en/v4.27.4/#configuration-files>`_
 
-.. note::
-
-    Since OTX v2.5, a new concept of multiple backends has been introduced. Currently, only the native OTX backend supports CLI functionality. Support for additional backends will be added in future releases.
-
 |
 
 .. figure:: ../../../utils/images/cli.png
@@ -31,7 +27,7 @@ Help
 
     (otx) ...$ otx --help
     ╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────╮
-    │ Usage: otx [-h] [-v] {find,train,test,predict,export,optimize,explain} ...                              │
+    │ Usage: otx [-h] [-v] {find,train,test,predict,export,optimize} ...                                      │
     │                                                                                                                 │
     │                                                                                                                 │
     │ OpenVINO Training-Extension command line tool                                                                   │
@@ -52,7 +48,6 @@ Help
     │     predict             Run predictions using the specified model and data.                                     │
     │     export              Export the trained model to OpenVINO Intermediate Representation (IR) or ONNX formats.  │
     │     optimize            Applies NNCF.PTQ to the underlying models (now works only for OV models).               │
-    │     explain             Run XAI using the specified model and data (test subset).                               │
     |     benchmark           Executes model micro benchmarking on random data.                                       |
     │                                                                                                                 │
     ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
@@ -73,15 +68,23 @@ For basic subcommand help, the Verbosity Level is 0. In this case, the CLI provi
     A better guide is provided by the documentation.
     ╭─ Quick-Start ─────────────────────────────────────────────────────────╮
     │                                                                       │
-    │  1 you can pick a model or datamodule as Config file or Class.        │
+    │  1 you can train with data_root only. then OTX will provide default   │
+    │    model.                                                             │
+    │                                                                       │
+    │                                                                       │
+    │  otx train --data_root <DATASET_PATH>                                 │
+    │                                                                       │
+    │                                                                       │
+    │  2 you can pick a model or datamodule as Config file or Class.        │
     │                                                                       │
     │                                                                       │
     │  otx train                                                            │
     │  --data_root <DATASET_PATH>                                           │
-    │  --config <CONFIG | CLASS_PATH_OR_NAME>                               │
+    │  --model <CONFIG | CLASS_PATH_OR_NAME> --data <CONFIG |               │
+    │  CLASS_PATH_OR_NAME>                                                  │
     │                                                                       │
     │                                                                       │
-    │  2 Of course, you can override the various values with commands.      │
+    │  3 Of course, you can override the various values with commands.      │
     │                                                                       │
     │                                                                       │
     │  otx train                                                            │
@@ -89,29 +92,20 @@ For basic subcommand help, the Verbosity Level is 0. In this case, the CLI provi
     │  --max_epochs <EPOCHS, int> --checkpoint <CKPT_PATH, str>             │
     │                                                                       │
     │                                                                       │
-    │  3 To reproduce the existing training with work_dir, run              │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │  otx train --work_dir <WORK_DIR_PATH, str>                            │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │  4 To resume training, run                                            │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │  otx train \                                                          │                                                                                                                                                                                                                                                                                                                    │
-    │  ...     --config <CONFIG, str> \                                     │                                                                                                                                                                                                                                                                                                                    │
-    │  ...     --data_root <DATASET_PATH, str> \                            │                                                                                                                                                                                                                                                                                                                    │
-    │  ...     --checkpoint <CKPT_PATH, str>                                │                                                                                                                                                                                                                                                                                                                    │
-    │  ...     --resume True                                                │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │ To get more overridable argument information, run the command below.  │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │                                                                       │                                                                                                                                                                                                                                                                                                                    │
-    │  # Verbosity Level 1                                                  │                                                                                                                                                                                                                                                                                                                    │
-    │  >>> otx train [optional_arguments] -h -v                             │                                                                                                                                                                                                                                                                                                                    │
-    │  # Verbosity Level 2                                                  │                                                                                                                                                                                                                                                                                                                    │
-    │  >>> otx train [optional_arguments] -h -vv                            │
+    │  4 If you have a complete configuration file, run it like this.       │
+    │                                                                       │
+    │                                                                       │
+    │  otx train --data_root <DATASET_PATH> --config <CONFIG_PATH, str>     │
+    │                                                                       │
+    │                                                                       │
+    │ To get more overridable argument information, run the command below.  │
+    │                                                                       │
+    │                                                                       │
+    │  # Verbosity Level 1                                                  │
+    │  otx train [optional_arguments] -h -v                                 │
+    │  # Verbosity Level 2                                                  │
+    │  otx train [optional_arguments] -h -vv                                │
+    │                                                                       │
     ╰───────────────────────────────────────────────────────────────────────╯
 
 For Verbosity Level 1, it shows Quick-Guide & the essential arguments.
@@ -137,7 +131,11 @@ For Verbosity Level 1, it shows Quick-Guide & the essential arguments.
     │                            [--work_dir WORK_DIR]                                                │
     │                            [--engine.checkpoint CHECKPOINT]                                     │
     │                            [--engine.device {auto,gpu,cpu,tpu,ipu,hpu,mps}]                     │
+    │                            [--model.help CLASS_PATH_OR_NAME]                                    │
+    │                            [--model CONFIG | CLASS_PATH_OR_NAME | .INIT_ARG_NAME VALUE]         │
     │                            [--data CONFIG]                                                      │
+    │                            [--optimizer CONFIG | CLASS_PATH_OR_NAME | .INIT_ARG_NAME VALUE]     │
+    │                            [--scheduler CONFIG | CLASS_PATH_OR_NAME | .INIT_ARG_NAME VALUE]     │
     │                                                                                                 │
     ...
 
@@ -321,6 +319,14 @@ The results will be saved in ``./otx-workspace/`` folder by default. The output 
 
 .. tab-set::
 
+    .. tab-item:: Auto-Configuration
+
+        Example of the command line to start training using Auto-Configuration:
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train --data_root <dataset-root> --task <TASK>
+
     .. tab-item:: With Configuration
 
         You can use the recipe configuration provided by OpenVINO™ Training Extensions. The corresponding configuration file can be found via ``otx find``.
@@ -329,8 +335,32 @@ The results will be saved in ``./otx-workspace/`` folder by default. The output 
 
             (otx) ...$ otx train --config <config-file-path> --data_root <dataset-root>
 
+    .. tab-item:: With Custom Model
+
+        You can also use a custom model and data module. The model and data module can be passed as a class path or a configuration file.
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train --model <model-class-path-or-name> --task <task-type> --data_root <dataset-root>
+
+        For example, if you want to use the ``otx.algo.classification.torchvision_model.TVModelForMulticlassCls`` model class, you can train it as shown below.
+
+        .. code-block:: shell
+
+            (otx) ...$ otx train --model otx.algo.classification.torchvision_model.TVModelForMulticlassCls --model.backbone mobilenet_v3_small ...
+
 .. note::
     You also can visualize the training using ``Tensorboard`` as these logs are located in ``<work_dir>/tensorboard``.
+
+.. note::
+    ``--data.mem_cache_size`` provides in-memory caching for decoded images in main memory.
+    If the batch size is large, such as for classification tasks, or if your dataset contains high-resolution images,
+    image decoding can account for a non-negligible overhead in data pre-processing.
+    This option can be useful for maximizing GPU utilization and reducing model training time in those cases.
+    If your machine has enough main memory, we recommend increasing this value as much as possible.
+    For example, you can cache approximately 10,000 of ``500x375~500x439`` sized images with ``--data.mem_cache_size 8GB``.
+
+It is also possible to start training by omitting the recipe and just passing the paths to dataset roots, then the :doc:`auto-configuration <../explanation/additional_features/auto_configuration>` will be enabled. Based on the dataset, OpenVINO™ Training Extensions will choose the task type and recipe with the best accuracy/speed trade-off.
 
 You can override the configurable arguments.
 For example, that is how you can change the max epochs and the batch size for the training:
@@ -354,11 +384,11 @@ The command below performs exporting to the ``{work_dir}/`` path.
 
 .. code-block:: shell
 
-    (otx) ...$ otx export --config <config-file-path> --data_root <dataset-root> --checkpoint <path/to/trained/weights.ckpt>
+    (otx) ...$ otx export ... --checkpoint <path/to/trained/weights.ckpt>
 
 The command results in ``exported_model.xml``, ``exported_model.bin``.
 
-To use the exported model as an input for ``otx explain``, please dump additional outputs with internal information, using ``--explain``:
+To use the exported model for explainable AI (XAI), please dump additional outputs with internal information, using ``--explain``:
 
 .. code-block:: shell
 
@@ -376,6 +406,36 @@ To use the exported model as an input for ``otx explain``, please dump additiona
         # OR if you are in the workspace root
         (otx) ...$ otx export
 
+
+************
+Optimization
+************
+
+``otx optimize`` optimizes a model using `PTQ <https://github.com/openvinotoolkit/nncf#post-training-quantization>`_ depending on the model and transforms it to ``INT8`` format.
+
+- PTQ optimization used for models exported in the OpenVINO™ IR format
+
+Command example for optimizing OpenVINO™ model (.xml) with OpenVINO™ PTQ:
+
+.. code-block:: shell
+
+    (otx) ...$ otx optimize ... --checkpoint <path/to/exported_model.xml> \
+                                --data_root <path/to/val/root>
+
+
+Thus, to use PTQ pass the path to exported IR (.xml) model.
+
+.. note::
+    If ``.latest`` exists in work_dir, you can omit checkpoint and config.
+    You can also omit ``--work_dir`` if you run from the root of the workspace that contains ``.latest``.
+
+    .. code-block:: shell
+
+        (otx) ...$ otx optimize --work_dir <workspace-path>
+
+        # OR if you are in the workspace root
+        (otx) ...$ otx optimize
+
 ***********
 Evaluation
 ***********
@@ -391,7 +451,7 @@ The command below will evaluate the trained model on the provided dataset:
 
 .. note::
 
-    OpenVINO™ IR model validation is not supported for now in CLI.
+    It is possible to pass both PyTorch weights ``.ckpt`` or OpenVINO™ IR ``exported_model.xml`` to ``--checkpoint`` option.
 
 
 .. note::
@@ -405,27 +465,35 @@ The command below will evaluate the trained model on the provided dataset:
         # OR if you are in the workspace root
         (otx) ...$ otx test
 
-***********
-Explanation
-***********
+**********
+Prediction
+**********
 
-``otx explain`` runs the explainable AI (XAI) algorithm on a specific model-dataset pair. It helps explain the model's decision-making process in a way that is easily understood by humans.
+``otx predict`` runs inference on a dataset and optionally generates explainable AI (XAI) saliency maps.
 
-
-The command below will generate saliency maps (heatmaps with red colored areas of focus) of the trained model on the provided dataset and save the resulting images to ``output`` path:
-
-.. code-block:: shell
-
-    (otx) ...$ otx explain --config <path/to/config> \
-                           --checkpoint <path/to/pytorch_model_weights>
-
-
-By default, the model is exported to the OpenVINO™ IR format without extra feature information needed for the ``explain`` functionality. To use OpenVINO™ IR model with feature information, you need to export the model with ``--explain True`` option.
+The command below will run predictions on the provided dataset:
 
 .. code-block:: shell
 
-    (otx) ...$ otx export ... --checkpoint <path/to/trained/weights.ckpt> \
-                              --explain True
+    (otx) ...$ otx predict ... --data_root <path/to/test/root> \
+                               --checkpoint <path/to/model_weights>
+
+To generate saliency maps for explainability (XAI), use the ``--explain True`` parameter:
+
+.. code-block:: shell
+
+    (otx) ...$ otx predict ... --data_root <path/to/test/root> \
+                               --checkpoint <path/to/model_weights> \
+                               --explain True \
+                               --explain_config.postprocess True
+
+.. note::
+
+    For exported OpenVINO™ IR models, make sure the model was exported with ``otx export --explain True`` to include the necessary outputs for XAI functionality.
+
+.. note::
+
+    It is possible to pass both PyTorch weights ``.ckpt`` or OpenVINO™ IR ``exported_model.xml`` to ``--checkpoint`` option.
 
 *******************
 Micro-benchmarking
@@ -444,7 +512,7 @@ It worth noticing that the latency and throughput are depend on batch size. Vary
 
 .. note::
 
-    OTX benchmark works only with PyTorch model. To benchmark OpenVINO™ IR models, use `OpenVINO benchmark app <https://docs.openvino.ai/nightly/get-started/learn-openvino/openvino-samples/benchmark-tool.html>_`.
+    It is possible to pass both PyTorch weights ``.ckpt`` or OpenVINO™ IR ``exported_model.xml`` to ``--checkpoint`` option.
 
 ***********
 Workspace

--- a/docs/source/guide/tutorials/base/explain.rst
+++ b/docs/source/guide/tutorials/base/explain.rst
@@ -12,7 +12,7 @@ To be specific, this tutorial uses as an example of the ATSS model trained throu
 
 For visualization we use images from WGISD dataset from the :doc:`object detection tutorial <how_to_train/detection>` together with trained model.
 
-1. Activate the virtual environment
+1. Activate the virtual environment 
 created in the previous step.
 
 .. code-block:: shell
@@ -21,7 +21,7 @@ created in the previous step.
   # or by this line, if you created an environment, using tox
   . venv/otx/bin/activate
 
-2. ``otx explain`` command returns saliency maps,
+2. ``otx predict`` with the ``--explain True`` parameter returns saliency maps, 
 which are heatmaps with red-colored areas indicating focus. Here's an example how to generate saliency maps from trained checkpoint:
 
 .. tab-set::
@@ -30,31 +30,33 @@ which are heatmaps with red-colored areas indicating focus. Here's an example ho
 
         .. code-block:: shell
 
-            (otx) ...$ otx explain --work_dir otx-workspace \
+            (otx) ...$ otx predict --work_dir otx-workspace \
+                                   --explain True \
                                    --explain_config.postprocess True # Resizes and applies colormap to the saliency map
 
     .. tab-item:: CLI (with config)
 
         .. code-block:: shell
 
-            (otx) ...$ otx explain --config  src/otx/recipe/detection/atss_mobilenetv2.yaml \
+            (otx) ...$ otx predict --config src/otx/recipe/detection/atss_mobilenetv2.yaml \
                                    --data_root data/wgisd \
-                                   --checkpoint otx-workspace/20240312_051135/checkpoints/epoch_033.ckpt \
+                                   --checkpoint otx-workspace/.latest/train/best_checkpoint.ckpt \
+                                   --explain True \
                                    --explain_config.postprocess True # Resizes and applies colormap to the saliency map
 
     .. tab-item:: API
 
         .. code-block:: python
 
-            engine.explain(
-                checkpoint="<checkpoint-path>",
+            engine.predict(
+                checkpoint="otx-workspace/.latest/train/best_checkpoint.ckpt",
                 datamodule=OTXDataModule(...), # The data module to use for predictions
+                explain=True,
                 explain_config=ExplainConfig(postprocess=True), # Resizes and applies colormap to the saliency map
-                dump=True # Wherether to save saliency map images or not
               )
 
-3. The generated saliency maps will appear in  ``otx-workspace/.latest/explain/saliency_maps`` folder.
-It will contain a pair of generated images with saliency maps for each image used for the explanation process:
+3. The generated saliency maps will appear in  ``otx-workspace/.latest/explain/saliency_maps`` folder. 
+It will contain a pair of generated images with saliency maps for each image used for the explanation process: 
 
 - saliency map - where red color means more attention of the model
 - overlay - where the saliency map is combined with the original image:
@@ -64,7 +66,31 @@ It will contain a pair of generated images with saliency maps for each image use
 
 |
 
-4. We can parametrize the explanation process by specifying
+4. To use the exported OpenVINO IR model for explanation, PyTorch weights should be converted to OpenVINO IR model with additional outputs ``saliency_map`` and ``feature_map``.
+To do that we should use ``otx export --explain True`` parameter during export.
+
+.. tab-set::
+
+    .. tab-item:: CLI
+
+        .. code-block:: shell
+
+            (otx) ...$ otx export ... --explain True
+            (otx) ...$ otx predict ... --checkpoint otx-workspace/20240312_052847/exported_model.xml --explain True
+
+    .. tab-item:: API
+
+        .. code-block:: python
+            # Use .pth when instantiating the engine with OTXEngine
+            engine = OTXEngine(model="checkpoint.pth", ...)
+            engine.export(..., explain=True)
+            engine.predict(..., explain=True)
+
+  
+            engine = OVEngine(model="exported_model.xml", ...)
+            engine.predict(..., explain=True)
+
+5. We can parametrize the explanation process by specifying 
 the following parameters in ``ExplainConfig``:
 
 - ``target_explain_group`` - for which target saliency maps will be generated:
@@ -84,21 +110,23 @@ the following parameters in ``ExplainConfig``:
 
         .. code-block:: shell
 
-            (otx) ...$ otx explain ... --explain_config.postprocess True
+            (otx) ...$ otx predict ... --explain True \
+                                       --explain_config.postprocess True \
                                        --explain_config.target_explain_group PREDICTIONS
 
     .. tab-item:: API
 
         .. code-block:: python
 
-            engine.explain(...,
+            engine.predict(...,
+                           explain=True,
                            explain_config=ExplainConfig(
                              postprocess=True,
                              target_explain_group=TargetExplainGroup.PREDICTIONS
                            )
               )
 
-5. The explanation algorithm is chosen automatically
+6. The explanation algorithm is chosen automatically 
 based on the used model:
 
 - ``Recipro-CAM`` - for CNN classification models

--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -421,10 +421,7 @@ class OTXEngine(Engine):
                 ...     --checkpoint <CKPT_PATH, str>
                 ```
         """
-        from otx.backend.native.models.utils.xai_utils import (
-            process_saliency_maps_in_pred_entity,
-            set_crop_padded_map_flag,
-        )
+        from otx.backend.native.models.utils.xai_utils import process_saliency_maps_in_pred_entity
 
         model = self.model
 
@@ -462,7 +459,6 @@ class OTXEngine(Engine):
         if explain:
             if explain_config is None:
                 explain_config = ExplainConfig()
-            explain_config = set_crop_padded_map_flag(explain_config, datamodule)
 
             predict_result = process_saliency_maps_in_pred_entity(predict_result, explain_config, datamodule.label_info)
 
@@ -547,91 +543,6 @@ class OTXEngine(Engine):
 
         self.model.explain_mode = False
         return exported_model_path
-
-    def explain(
-        self,
-        checkpoint: PathLike | None = None,
-        datamodule: EVAL_DATALOADERS | OTXDataModule | None = None,
-        explain_config: ExplainConfig | None = None,
-        **kwargs,
-    ) -> list | None:
-        r"""Run XAI using the specified model and data (test subset).
-
-        Args:
-            checkpoint (PathLike | None, optional): The path to the checkpoint file to load the model from.
-            datamodule (EVAL_DATALOADERS | OTXDataModule | None, optional): The data module to use for predictions.
-            explain_config (ExplainConfig | None, optional): Config used to handle saliency maps.
-            **kwargs: Additional keyword arguments for pl.Trainer configuration.
-
-        Returns:
-            list: Saliency maps.
-
-        Example:
-            >>> engine.explain(
-            ...     datamodule=OTXDataModule(),
-            ...     checkpoint=<checkpoint/path>,
-            ...     explain_config=ExplainConfig(),
-            ... )
-
-        CLI Usage:
-            1. To run XAI with the torch model in work_dir, run
-                ```shell
-                >>> otx explain \
-                ...     --work_dir <WORK_DIR_PATH, str>
-                ```
-            2. To run XAI using the specified model (torch or IR), run
-                ```shell
-                >>> otx explain \
-                ...     --work_dir <WORK_DIR_PATH, str> \
-                ...     --checkpoint <CKPT_PATH, str>
-                ```
-            3. To run XAI using the configuration, run
-                ```shell
-                >>> otx explain \
-                ...     --config <CONFIG_PATH> --data_root <DATASET_PATH, str> \
-                ...     --checkpoint <CKPT_PATH, str>
-                ```
-        """
-        from otx.backend.native.models.utils.xai_utils import (
-            process_saliency_maps_in_pred_entity,
-            set_crop_padded_map_flag,
-        )
-
-        model = self.model
-
-        checkpoint = checkpoint if checkpoint is not None else self.checkpoint
-        datamodule = datamodule if datamodule is not None else self.datamodule
-
-        if checkpoint is not None:
-            ckpt = self._load_model_checkpoint(checkpoint, map_location="cpu")
-            model.load_state_dict(ckpt)
-
-        if model.label_info != self.datamodule.label_info:
-            msg = (
-                "To launch a explain pipeline, the label information should be same "
-                "between the training and testing datasets. "
-                "Please check whether you use the same dataset: "
-                f"model.label_info={model.label_info}, "
-                f"datamodule.label_info={self.datamodule.label_info}"
-            )
-            raise ValueError(msg)
-
-        model.explain_mode = True
-
-        self._build_trainer(**kwargs)
-
-        predict_result = self.trainer.predict(
-            model=model,
-            datamodule=datamodule,
-        )
-
-        if explain_config is None:
-            explain_config = ExplainConfig()
-        explain_config = set_crop_padded_map_flag(explain_config, datamodule)
-
-        predict_result = process_saliency_maps_in_pred_entity(predict_result, explain_config, datamodule.label_info)
-        model.explain_mode = False
-        return predict_result
 
     def benchmark(
         self,

--- a/src/otx/backend/native/models/detection/base.py
+++ b/src/otx/backend/native/models/detection/base.py
@@ -211,7 +211,7 @@ class OTXDetectionModel(OTXModel):
                 scores=scores,
                 bboxes=bboxes,
                 labels=labels,
-                saliency_map=[saliency_map.detach().to(torch.float32) for saliency_map in outputs["saliency_map"]],
+                saliency_map=outputs["saliency_map"],
                 feature_vector=[
                     feature_vector.detach().unsqueeze(0).to(torch.float32)
                     for feature_vector in outputs["feature_vector"]

--- a/src/otx/backend/native/tools/explain/explain_algo.py
+++ b/src/otx/backend/native/tools/explain/explain_algo.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Callable
 
 import torch
@@ -267,6 +268,14 @@ class DetClassProbabilityMap(BaseExplainAlgo):
         self._num_classes = num_classes
         self._num_anchors = num_anchors
         # Should be switched off for tiling
+        if num_classes == 1 and use_cls_softmax:
+            # softmax would result in all 1.0 values if there's only 1 class
+            warnings.warn(
+                "use_cls_softmax is automatically disabled when num_classes=1 to prevent degenerate softmax behavior",
+                UserWarning,
+                stacklevel=2,
+            )
+            use_cls_softmax = False
         self.use_cls_softmax = use_cls_softmax
 
     def func(

--- a/src/otx/backend/native/tools/explain/explain_algo.py
+++ b/src/otx/backend/native/tools/explain/explain_algo.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Algorithms for calculcalating XAI branch for Explainable AI."""

--- a/src/otx/backend/openvino/engine.py
+++ b/src/otx/backend/openvino/engine.py
@@ -269,10 +269,7 @@ class OVEngine(Engine):
             ValueError: If input data is invalid or label information does not match.
             TypeError: If input data type is unsupported.
         """
-        from otx.backend.native.models.utils.xai_utils import (
-            process_saliency_maps_in_pred_entity,
-            set_crop_padded_map_flag,
-        )
+        from otx.backend.native.models.utils.xai_utils import process_saliency_maps_in_pred_entity
 
         model = self._update_checkpoint(checkpoint)
         if isinstance(data, (str, os.PathLike)):
@@ -328,7 +325,6 @@ class OVEngine(Engine):
         if explain and isinstance(datamodule, OTXDataModule):
             if explain_config is None:
                 explain_config = ExplainConfig()
-            explain_config = set_crop_padded_map_flag(explain_config, datamodule)
             predict_result = process_saliency_maps_in_pred_entity(predict_result, explain_config, datamodule.label_info)
 
         return predict_result

--- a/src/otx/cli/cli.py
+++ b/src/otx/cli/cli.py
@@ -213,7 +213,6 @@ class OTXCLI:
             "test": {"datamodule"}.union(device_kwargs),
             "predict": {"datamodule"}.union(device_kwargs),
             "export": device_kwargs,
-            "explain": {"datamodule"}.union(device_kwargs),
             "benchmark": device_kwargs,
         }
 

--- a/src/otx/data/entity/base.py
+++ b/src/otx/data/entity/base.py
@@ -69,6 +69,7 @@ class ImageInfo(tv_tensors.TVTensor):
         norm_std: Standard deviation vector used to normalize this image
         image_color_channel: Color channel type of this image, RGB or BGR.
         ignored_labels: Label that should be ignored in this image. Default to None.
+        keep_ratio: If true, the image is resized while keeping the aspect ratio. Default to False.
     """
 
     img_idx: int
@@ -81,6 +82,7 @@ class ImageInfo(tv_tensors.TVTensor):
     norm_std: tuple[float, float, float] = (1.0, 1.0, 1.0)
     image_color_channel: ImageColorChannel = ImageColorChannel.RGB
     ignored_labels: list[int]
+    keep_ratio: bool = False
 
     @classmethod
     def _wrap(
@@ -97,6 +99,7 @@ class ImageInfo(tv_tensors.TVTensor):
         norm_std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         image_color_channel: ImageColorChannel = ImageColorChannel.RGB,
         ignored_labels: list[int] | None = None,
+        keep_ratio: bool = False,
     ) -> ImageInfo:
         image_info = dummy_tensor.as_subclass(cls)
         image_info.img_idx = img_idx
@@ -109,6 +112,7 @@ class ImageInfo(tv_tensors.TVTensor):
         image_info.norm_std = norm_std
         image_info.image_color_channel = image_color_channel
         image_info.ignored_labels = ignored_labels if ignored_labels else []
+        image_info.keep_ratio = keep_ratio
         return image_info
 
     def __new__(  # noqa: D102
@@ -123,6 +127,7 @@ class ImageInfo(tv_tensors.TVTensor):
         norm_std: tuple[float, float, float] = (1.0, 1.0, 1.0),
         image_color_channel: ImageColorChannel = ImageColorChannel.RGB,
         ignored_labels: list[int] | None = None,
+        keep_ratio: bool = False,
     ) -> ImageInfo:
         return cls._wrap(
             dummy_tensor=Tensor(),
@@ -136,6 +141,7 @@ class ImageInfo(tv_tensors.TVTensor):
             norm_std=norm_std,
             image_color_channel=image_color_channel,
             ignored_labels=ignored_labels,
+            keep_ratio=keep_ratio,
         )
 
     @classmethod
@@ -169,6 +175,7 @@ class ImageInfo(tv_tensors.TVTensor):
                 norm_std=image_info.norm_std,
                 image_color_channel=image_info.image_color_channel,
                 ignored_labels=image_info.ignored_labels,
+                keep_ratio=image_info.keep_ratio,
             )
         elif isinstance(output, (tuple, list)):
             image_infos = [x for x in flat_params if isinstance(x, ImageInfo)]
@@ -185,6 +192,7 @@ class ImageInfo(tv_tensors.TVTensor):
                     norm_std=image_info.norm_std,
                     image_color_channel=image_info.image_color_channel,
                     ignored_labels=image_info.ignored_labels,
+                    keep_ratio=image_info.keep_ratio,
                 )
                 for dummy_tensor, image_info in zip(output, image_infos)
             )
@@ -202,7 +210,8 @@ class ImageInfo(tv_tensors.TVTensor):
             f"norm_mean={self.norm_mean}, "
             f"norm_std={self.norm_std}, "
             f"image_color_channel={self.image_color_channel}, "
-            f"ignored_labels={self.ignored_labels})"
+            f"ignored_labels={self.ignored_labels}, "
+            f"keep_ratio={self.keep_ratio})"
         )
 
 

--- a/src/otx/data/entity/torch/validations.py
+++ b/src/otx/data/entity/torch/validations.py
@@ -310,17 +310,6 @@ class ValidateBatchMixin:
         """
         if all(saliency_map is None for saliency_map in saliency_map_batch):
             return []
-        # TODO(ashwinvaidya17): use only one dtype. Kept for OV Classification compatibility
-        if not isinstance(saliency_map_batch, list) or not isinstance(
-            saliency_map_batch[0],
-            (torch.Tensor, np.ndarray),
-        ):
-            msg = f"Saliency map batch must be a list of torch tensors. Got {type(saliency_map_batch)}"
-            raise TypeError(msg)
-        # assumes homogeneous data so validation is done only for the first element
-        if isinstance(saliency_map_batch[0], torch.Tensor) and not saliency_map_batch[0].dtype.is_floating_point:
-            msg = f"Saliency map must have a floating point dtype. Got {saliency_map_batch[0].dtype}"
-            raise ValueError(msg)
         return saliency_map_batch
 
     @staticmethod

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -28,7 +28,7 @@ from torchvision import tv_tensors
 from torchvision._utils import sequence_to_str
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
-from otx.backend.native.utils.utils import import_object_from_module
+from otx.data.utils.utils import import_object_from_module
 from otx.data.entity.base import (
     Points,
     _crop_image_info,

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -28,7 +28,6 @@ from torchvision import tv_tensors
 from torchvision._utils import sequence_to_str
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
-from otx.data.utils.utils import import_object_from_module
 from otx.data.entity.base import (
     Points,
     _crop_image_info,
@@ -64,6 +63,7 @@ from otx.data.transform_libs.utils import (
     translate_masks,
     translate_polygons,
 )
+from otx.data.utils.utils import import_object_from_module
 
 if TYPE_CHECKING:
     from otx.config.data import SubsetConfig

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -63,7 +63,7 @@ from otx.data.transform_libs.utils import (
     translate_masks,
     translate_polygons,
 )
-from otx.data.utils.utils import import_object_from_module
+from otx.data.utils import import_object_from_module
 
 if TYPE_CHECKING:
     from otx.config.data import SubsetConfig

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -28,6 +28,7 @@ from torchvision import tv_tensors
 from torchvision._utils import sequence_to_str
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
+from otx.backend.native.utils.utils import import_object_from_module
 from otx.data.entity.base import (
     Points,
     _crop_image_info,
@@ -63,7 +64,6 @@ from otx.data.transform_libs.utils import (
     translate_masks,
     translate_polygons,
 )
-from otx.data.utils import import_object_from_module
 
 if TYPE_CHECKING:
     from otx.config.data import SubsetConfig
@@ -332,6 +332,7 @@ class Resize(tvt_v2.Transform, NumpytoTVTensorMixin):
 
             inputs.image = img
             inputs.img_info = _resize_image_info(inputs.img_info, img.shape[:2])
+            inputs.img_info.keep_ratio = self.keep_ratio  # type: ignore[union-attr]
             scale_factor = (scale[0] / img_shape[0], scale[1] / img_shape[1])
         return inputs, scale_factor
 

--- a/tests/unit/backend/native/test_engine.py
+++ b/tests/unit/backend/native/test_engine.py
@@ -230,7 +230,7 @@ class TestEngine:
 
         # Correct label_info from the checkpoint
         mock_model.label_info = fxt_engine.datamodule.label_info
-        fxt_engine.explain(checkpoint=checkpoint)
+        fxt_engine.predict(checkpoint=checkpoint, explain=True)
         mock_predict.assert_called_once()
 
         mock_process_saliency_maps.assert_called_once()

--- a/tests/unit/backend/native/tools/explain/test_saliency_map_processing.py
+++ b/tests/unit/backend/native/tools/explain/test_saliency_map_processing.py
@@ -39,6 +39,7 @@ def test_process_all(postprocess) -> None:
             ORI_IMG_SHAPES,
             IMAGE_SHAPE,
             PADDINDS,
+            keep_ratio=False,
         )
 
     processed_saliency_maps = process_saliency_maps(
@@ -48,6 +49,7 @@ def test_process_all(postprocess) -> None:
         ORI_IMG_SHAPES,
         IMAGE_SHAPE,
         PADDINDS,
+        keep_ratio=False,
     )
 
     assert len(processed_saliency_maps) == BATCH_SIZE
@@ -75,6 +77,7 @@ def test_process_predictions(postprocess) -> None:
             ORI_IMG_SHAPES,
             IMAGE_SHAPE,
             PADDINDS,
+            keep_ratio=False,
         )
 
     processed_saliency_maps = process_saliency_maps(
@@ -84,6 +87,7 @@ def test_process_predictions(postprocess) -> None:
         ORI_IMG_SHAPES,
         IMAGE_SHAPE,
         PADDINDS,
+        keep_ratio=False,
     )
 
     assert len(processed_saliency_maps) == BATCH_SIZE
@@ -115,6 +119,7 @@ def test_process_image(postprocess) -> None:
             ORI_IMG_SHAPES,
             IMAGE_SHAPE,
             PADDINDS,
+            keep_ratio=False,
         )
 
     processed_saliency_maps = process_saliency_maps(
@@ -124,6 +129,7 @@ def test_process_image(postprocess) -> None:
         ORI_IMG_SHAPES,
         IMAGE_SHAPE,
         PADDINDS,
+        keep_ratio=False,
     )
     assert len(processed_saliency_maps) == BATCH_SIZE
     assert all(len(s_map_dict) == 1 for s_map_dict in processed_saliency_maps)
@@ -244,6 +250,7 @@ def test_process_crop_padded_map() -> None:
         ORI_IMG_SHAPES,
         IMAGE_SHAPE,
         paddings,
+        keep_ratio=True,
     )
 
     assert len(processed_saliency_maps) == BATCH_SIZE


### PR DESCRIPTION
### Summary

Remove duplicate `explain()` method and move XAI functionality into `predict()`

The codebase had significant code duplication between `OTXEngine.explain()` and `OTXEngine.predict(explain=True)` methods. Both methods performed nearly identical operations:
- Same checkpoint loading logic
- Same label validation 
- Same trainer building
- Same saliency map processing via `process_saliency_maps_in_pred_entity()`

### 🔧 **Changes Made**

#### Code Changes
- **Removed** `OTXEngine.explain()` method entirely
- **Keep** `OTXEngine.predict(explain=True)` to be the single source for XAI functionality

#### Documentation Updates
- **Updated** `docs/source/guide/tutorials/base/explain.rst` - Main XAI tutorial
- **Updated** `docs/source/guide/get_started/api_tutorial.rst` - API examples
- **Updated** `docs/source/guide/get_started/cli_commands.rst` - CLI documentation  
- **Updated** `docs/source/guide/explanation/additional_features/xai.rst` - XAI feature docs

#### CLI Changes
- **Removed** `otx explain` command from CLI help and documentation
- **Added** comprehensive `otx predict --explain True` documentation

#### 🚨 **Breaking Changes**

### Python API
```python
# Before (deprecated)
engine.explain(checkpoint="model.pth", explain_config=ExplainConfig())

# After (new approach)  
engine.predict(checkpoint="model.pth", explain=True, explain_config=ExplainConfig())
```

#### CLI Usage
```bash
# Before (deprecated)
otx explain --work_dir workspace --checkpoint model.pth

# After (new approach)
otx predict --work_dir workspace --checkpoint model.pth --explain True
```

#### 📖 **Migration Guide**
For Python API Users
Replace all `engine.explain()` calls with `engine.predict(explain=True)`:

```python
# Old code
results = engine.explain(
    checkpoint="model.pth",
    datamodule=datamodule,
    explain_config=ExplainConfig(postprocess=True)
)

# New code  
results = engine.predict(
    checkpoint="model.pth", 
    datamodule=datamodule,
    explain=True,
    explain_config=ExplainConfig(postprocess=True)
)
```

#### For CLI Users
Replace `otx explain` with `otx predict --explain True`:

```bash
# Old command
otx explain --work_dir workspace --checkpoint model.pth --explain_config.postprocess True

# New command
otx predict --work_dir workspace --checkpoint model.pth --explain True --explain_config.postprocess True
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
