### PR TITLE
Fix overriding train parameters

### DIFF
--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -134,7 +134,6 @@ class OTXEngine(Engine):
 
         self._model: OTXModel = model
         self.task = self._model.task
-
         self.checkpoint = checkpoint
         if self.checkpoint:
             if not isinstance(self.checkpoint, (Path, str)) and not Path(self.checkpoint).exists():
@@ -149,7 +148,7 @@ class OTXEngine(Engine):
 
     def train(
         self,
-        max_epochs: int | None = None,
+        max_epochs: int | None = 200,
         min_epochs: int = 1,
         seed: int | None = None,
         deterministic: bool | Literal["warn"] = False,
@@ -185,6 +184,7 @@ class OTXEngine(Engine):
             adaptive_bs (Literal["None", "Safe", "Full"]):
                 Change the actual batch size depending on the current GPU status.
                 Safe => Prevent GPU out of memory. Full => Find a batch size using most of GPU memory.
+                Defaults to "None".
             check_val_every_n_epoch (int | None, optional): How often to check validation. Defaults to 1.
             num_sanity_val_steps (int | None, optional): Number of validation steps to run before training starts.
             **kwargs: Additional keyword arguments for pl.Trainer configuration.
@@ -229,7 +229,6 @@ class OTXEngine(Engine):
                 ```
         """
         checkpoint = checkpoint if checkpoint is not None else self.checkpoint
-
         if adaptive_bs != "None":
             adapt_batch_size(engine=self, **locals(), not_increase=(adaptive_bs != "Full"))
 
@@ -756,7 +755,7 @@ class OTXEngine(Engine):
         data_root: PathLike | None = None,
         work_dir: PathLike | None = None,
         **kwargs,
-    ) -> Engine:
+    ) -> OTXEngine:
         """Builds the engine from a configuration file.
 
         Args:
@@ -774,6 +773,7 @@ class OTXEngine(Engine):
             >>> engine = OTXEngine.from_config(
             ...     config="config.yaml",
             ... )
+            ... engine.train()
         """
         from otx.cli.utils.jsonargparse import get_instantiated_classes
 
@@ -835,7 +835,7 @@ class OTXEngine(Engine):
         data_root: PathLike | None = None,
         work_dir: PathLike | None = None,
         **kwargs,
-    ) -> Engine:
+    ) -> OTXEngine:
         """Builds the engine from a model name.
 
         Args:
@@ -848,7 +848,7 @@ class OTXEngine(Engine):
             kwargs: Arguments that can override the engine's arguments.
 
         Returns:
-            Engine: An instance of the Engine class.
+            OTXEngine: An instance of the OTXEngine class.
 
         Example:
             >>> engine = OTXEngine.from_model_name(
@@ -856,6 +856,7 @@ class OTXEngine(Engine):
             ...     task="DETECTION",
             ...     data_root=<dataset/path>,
             ... )
+            ... engine.train()
 
             If you want to override configuration from default config:
                 >>> overriding = {
@@ -945,8 +946,7 @@ class OTXEngine(Engine):
     def _build_trainer(self, logger: Logger | Iterable[Logger] | bool | None = None, **kwargs) -> None:
         """Instantiate the trainer based on the model parameters."""
         if self._cache.requires_update(**kwargs) or self._trainer is None:
-            self._cache.update(**kwargs)
-
+            self._apply_param_overrides(kwargs)
             # set up xpu device
             self.configure_accelerator()
             # setup default loggers
@@ -954,11 +954,21 @@ class OTXEngine(Engine):
             # set up default callbacks
             self.configure_callbacks()
 
-            kwargs = self._cache.args
-            self._trainer = Trainer(logger=logger, **kwargs)
+            self._trainer = Trainer(logger=logger, **self._cache.args)
             self._cache.is_trainer_args_identical = True
             self._trainer.task = self.task
             self.work_dir = self._trainer.default_root_dir
+
+    def _apply_param_overrides(self, param_kwargs: dict[str, Any]) -> None:
+        """Apply parameter overrides based on the current local variables."""
+        sig = inspect.signature(self.train)
+
+        for param_name, param in sig.parameters.items():
+            if param_name not in {"self", "kwargs"} and param_name in param_kwargs:
+                current_value = param_kwargs[param_name]
+                # Apply override if current value matches default and we have an override
+                if (current_value != param.default) or (param_name not in self._cache.args):
+                    self._cache.args[param_name] = current_value
 
     def configure_accelerator(self) -> None:
         """Updates the cache arguments based on the device type."""

--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -962,9 +962,10 @@ class OTXEngine(Engine):
     def _apply_param_overrides(self, param_kwargs: dict[str, Any]) -> None:
         """Apply parameter overrides based on the current local variables."""
         sig = inspect.signature(self.train)
-
+        add_kwargs = param_kwargs.pop("kwargs", {})
+        self._cache.update(**add_kwargs)
         for param_name, param in sig.parameters.items():
-            if param_name not in {"self", "kwargs"} and param_name in param_kwargs:
+            if param_name in param_kwargs:
                 current_value = param_kwargs[param_name]
                 # Apply override if current value matches default and we have an override
                 if (current_value != param.default) or (param_name not in self._cache.args):

--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -954,7 +954,8 @@ class OTXEngine(Engine):
             # set up default callbacks
             self.configure_callbacks()
 
-            self._trainer = Trainer(logger=logger, **self._cache.args)
+            kwargs = self._cache.args
+            self._trainer = Trainer(logger=logger, **kwargs)
             self._cache.is_trainer_args_identical = True
             self._trainer.task = self.task
             self.work_dir = self._trainer.default_root_dir
@@ -1009,6 +1010,8 @@ class OTXEngine(Engine):
         """Sets up the OTX callbacks for the trainer."""
         callbacks: list[Callback] = []
         config_callbacks = self._cache.args.get("callbacks", [])
+        if config_callbacks is None:
+            return
         has_callback: Callable[[Callback], bool] = lambda callback: any(
             isinstance(c, callback) for c in config_callbacks
         )

--- a/tests/unit/backend/native/test_engine.py
+++ b/tests/unit/backend/native/test_engine.py
@@ -266,13 +266,16 @@ class TestEngine:
                 **overriding,
             )
 
-    def test_from_config(self, tmp_path) -> None:
+    def test_from_config(self, tmp_path, mocker) -> None:
         recipe_path = "src/otx/recipe/classification/multi_class_cls/tv_mobilenet_v3_small.yaml"
         data_root = "tests/assets/classification_dataset"
+        mocker.patch("pathlib.Path.symlink_to")
+        mocker.patch("otx.backend.native.engine.Trainer.fit")
 
         overriding = {
             "data.train_subset.batch_size": 3,
             "data.test_subset.subset_name": "TESTING",
+            "max_epochs": 50
         }
 
         engine = OTXEngine.from_config(
@@ -285,6 +288,16 @@ class TestEngine:
         assert engine is not None
         assert engine.datamodule.train_subset.batch_size == 3
         assert engine.datamodule.test_subset.subset_name == "TESTING"
+        # test overriding train_kwargs with config
+        engine.train()
+        assert engine._cache.args["max_epochs"] == 50
+        assert engine.trainer.max_epochs == 50
+        assert engine._cache.args["deterministic"] == False
+        engine.train(max_epochs=100, deterministic = True)
+        assert engine._cache.args["max_epochs"] == 100
+        assert engine.trainer.max_epochs == 100
+        assert engine._cache.args["deterministic"] == True
+
 
     def test_benchmark(self, fxt_engine, mocker: MockerFixture) -> None:
         checkpoint = "path/to/checkpoint.ckpt"

--- a/tests/unit/backend/native/test_engine.py
+++ b/tests/unit/backend/native/test_engine.py
@@ -275,7 +275,7 @@ class TestEngine:
         overriding = {
             "data.train_subset.batch_size": 3,
             "data.test_subset.subset_name": "TESTING",
-            "max_epochs": 50
+            "max_epochs": 50,
         }
 
         engine = OTXEngine.from_config(
@@ -292,12 +292,11 @@ class TestEngine:
         engine.train()
         assert engine._cache.args["max_epochs"] == 50
         assert engine.trainer.max_epochs == 50
-        assert engine._cache.args["deterministic"] == False
-        engine.train(max_epochs=100, deterministic = True)
+        assert not engine._cache.args["deterministic"]
+        engine.train(max_epochs=100, deterministic=True)
         assert engine._cache.args["max_epochs"] == 100
         assert engine.trainer.max_epochs == 100
-        assert engine._cache.args["deterministic"] == True
-
+        assert engine._cache.args["deterministic"]
 
     def test_benchmark(self, fxt_engine, mocker: MockerFixture) -> None:
         checkpoint = "path/to/checkpoint.ckpt"


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
