### PR TITLE
Fix gaussian noise augmentation and add random gaussian blur

### DIFF
--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -26,6 +26,7 @@ from omegaconf import DictConfig
 from scipy.stats import truncnorm
 from torchvision import tv_tensors
 from torchvision._utils import sequence_to_str
+from torchvision.transforms.v2 import GaussianNoise
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
 from otx.data.entity.base import (
@@ -901,6 +902,36 @@ class RandomFlip(tvt_v2.Transform, NumpytoTVTensorMixin):
         repr_str += f"direction={self.direction}, "
         repr_str += f"is_numpy_to_tvtensor={self.is_numpy_to_tvtensor})"
         return repr_str
+
+
+class UnscaledGaussianNoise(GaussianNoise):
+    """Modified version of the torchvision GaussianNoise.
+
+    This augmentation allows to add gaussian noise to unscaled image.
+    Only float32 images are supported for this augmentation.
+    """
+
+    def _is_scaled(self, tensor: torch.Tensor) -> bool:
+        return torch.all((tensor >= 0) & (tensor <= 1))
+
+    def forward(self, *_inputs: OTXDataItem) -> OTXDataItem:
+        """Main transform function."""
+        assert len(_inputs) == 1, "[tmp] Multiple entity is not supported yet."  # noqa: S101
+        inputs = _inputs[0]
+
+        if (img := getattr(inputs, "image", None)) is not None:
+            scaled = self._is_scaled(img)
+            sigma = self.sigma * 255 if not scaled else self.sigma
+            mean = self.mean * 255 if not scaled else self.mean
+            clip = False if not scaled else self.clip
+
+            img = self._call_kernel(F.gaussian_noise, img, mean=mean, sigma=sigma, clip=clip)
+            if not scaled:
+                img = torch.clamp(img, 0, 255)
+
+            inputs.image = img
+
+        return inputs
 
 
 class PhotoMetricDistortion(tvt_v2.Transform, NumpytoTVTensorMixin):

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -26,7 +26,7 @@ from omegaconf import DictConfig
 from scipy.stats import truncnorm
 from torchvision import tv_tensors
 from torchvision._utils import sequence_to_str
-from torchvision.transforms.v2 import GaussianNoise
+from torchvision.transforms.v2 import GaussianBlur, GaussianNoise
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
 from otx.data.entity.base import (
@@ -904,12 +904,35 @@ class RandomFlip(tvt_v2.Transform, NumpytoTVTensorMixin):
         return repr_str
 
 
-class UnscaledGaussianNoise(GaussianNoise):
+class RandomGaussianBlur(GaussianBlur):
+    """Modified version of the torchvision GaussianBlur."""
+
+    def __init__(
+        self,
+        kernel_size: int | Sequence[int],
+        sigma: int | tuple[float, float] = (0.1, 2.0),
+        prob: float = 0.5,
+    ) -> None:
+        super().__init__(kernel_size=kernel_size, sigma=sigma)
+        self.prob = prob
+
+    def transform(self, inpt: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
+        """Main transform function."""
+        if self.prob >= np.random.rand():
+            return super().transform(inpt, params)
+        return inpt
+
+
+class RandomGaussianNoise(GaussianNoise):
     """Modified version of the torchvision GaussianNoise.
 
     This augmentation allows to add gaussian noise to unscaled image.
     Only float32 images are supported for this augmentation.
     """
+
+    def __init__(self, mean: float = 0.0, sigma: float = 0.1, clip: bool = True, prob: float = 0.5) -> None:
+        super().__init__(mean=mean, sigma=sigma, clip=clip)
+        self.prob = prob
 
     def _is_scaled(self, tensor: torch.Tensor) -> bool:
         return torch.all((tensor >= 0) & (tensor <= 1))
@@ -918,8 +941,7 @@ class UnscaledGaussianNoise(GaussianNoise):
         """Main transform function."""
         assert len(_inputs) == 1, "[tmp] Multiple entity is not supported yet."  # noqa: S101
         inputs = _inputs[0]
-
-        if (img := getattr(inputs, "image", None)) is not None:
+        if (img := getattr(inputs, "image", None)) is not None and self.prob >= np.random.rand():
             scaled = self._is_scaled(img)
             sigma = self.sigma * 255 if not scaled else self.sigma
             mean = self.mean * 255 if not scaled else self.mean

--- a/src/otx/data/transform_libs/torchvision.py
+++ b/src/otx/data/transform_libs/torchvision.py
@@ -935,7 +935,7 @@ class RandomGaussianNoise(GaussianNoise):
         self.prob = prob
 
     def _is_scaled(self, tensor: torch.Tensor) -> bool:
-        return torch.all((tensor >= 0) & (tensor <= 1))
+        return torch.max(tensor) <= 1 + 1e-5
 
     def forward(self, *_inputs: OTXDataItem) -> OTXDataItem:
         """Main transform function."""

--- a/src/otx/recipe/_base_/data/classification.yaml
+++ b/src/otx/recipe/_base_/data/classification.yaml
@@ -34,12 +34,13 @@ train_subset:
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
         scale: false
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [123.675, 116.28, 103.53]
         std: [58.395, 57.12, 57.375]
-    - class_path: torchvision.transforms.v2.GaussianNoise
-      enable: false
+
   sampler:
     class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/_base_/data/classification.yaml
+++ b/src/otx/recipe/_base_/data/classification.yaml
@@ -26,7 +26,7 @@ train_subset:
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.RandomVerticalFlip
       enable: false
-    - class_path: torchvision.transforms.v2.GaussianBlur
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
       enable: false
       init_args:
         kernel_size: 5
@@ -34,7 +34,7 @@ train_subset:
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
         scale: false
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/_base_/data/detection.yaml
+++ b/src/otx/recipe/_base_/data/detection.yaml
@@ -34,12 +34,13 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [0.0, 0.0, 0.0]
         std: [255.0, 255.0, 255.0]
-    - class_path: torchvision.transforms.v2.GaussianNoise
-      enable: false
+
   sampler:
     class_path: torch.utils.data.RandomSampler
 

--- a/src/otx/recipe/_base_/data/detection.yaml
+++ b/src/otx/recipe/_base_/data/detection.yaml
@@ -27,14 +27,14 @@ train_subset:
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.RandomVerticalFlip
       enable: false
-    - class_path: torchvision.transforms.v2.GaussianBlur
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
       enable: false
       init_args:
         kernel_size: 5
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/_base_/data/detection_tile.yaml
+++ b/src/otx/recipe/_base_/data/detection_tile.yaml
@@ -30,14 +30,14 @@ train_subset:
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.RandomVerticalFlip
       enable: false
-    - class_path: torchvision.transforms.v2.GaussianBlur
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
       enable: false
       init_args:
         kernel_size: 5
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/_base_/data/detection_tile.yaml
+++ b/src/otx/recipe/_base_/data/detection_tile.yaml
@@ -37,12 +37,13 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [0.0, 0.0, 0.0]
         std: [255.0, 255.0, 255.0]
-    - class_path: torchvision.transforms.v2.GaussianNoise
-      enable: false
+
   sampler:
     class_path: torch.utils.data.RandomSampler
 

--- a/src/otx/recipe/_base_/data/instance_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/instance_segmentation.yaml
@@ -40,12 +40,13 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [123.675, 116.28, 103.53]
         std: [58.395, 57.12, 57.375]
-    - class_path: torchvision.transforms.v2.GaussianNoise
-      enable: false
+
   sampler:
     class_path: torch.utils.data.RandomSampler
 

--- a/src/otx/recipe/_base_/data/instance_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/instance_segmentation.yaml
@@ -33,14 +33,14 @@ train_subset:
         is_numpy_to_tvtensor: true
     - class_path: torchvision.transforms.v2.RandomVerticalFlip
       enable: false
-    - class_path: torchvision.transforms.v2.GaussianBlur
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
       enable: false
       init_args:
         kernel_size: 5
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/_base_/data/keypoint_detection.yaml
+++ b/src/otx/recipe/_base_/data/keypoint_detection.yaml
@@ -18,7 +18,7 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/_base_/data/keypoint_detection.yaml
+++ b/src/otx/recipe/_base_/data/keypoint_detection.yaml
@@ -18,6 +18,8 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/_base_/data/semantic_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/semantic_segmentation.yaml
@@ -32,6 +32,8 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/_base_/data/semantic_segmentation.yaml
+++ b/src/otx/recipe/_base_/data/semantic_segmentation.yaml
@@ -32,7 +32,7 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/_base_/data/semantic_segmentation_tile.yaml
+++ b/src/otx/recipe/_base_/data/semantic_segmentation_tile.yaml
@@ -34,6 +34,8 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
+    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+      enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:
         mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/_base_/data/semantic_segmentation_tile.yaml
+++ b/src/otx/recipe/_base_/data/semantic_segmentation_tile.yaml
@@ -34,7 +34,7 @@ train_subset:
     - class_path: torchvision.transforms.v2.ToDtype
       init_args:
         dtype: ${as_torch_dtype:torch.float32}
-    - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+    - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
       enable: false
     - class_path: torchvision.transforms.v2.Normalize
       init_args:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
@@ -68,7 +68,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -76,7 +76,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_b0.yaml
@@ -72,12 +72,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -72,7 +72,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -80,7 +80,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/h_label_cls/efficientnet_v2.yaml
@@ -76,12 +76,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
@@ -67,7 +67,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -75,7 +75,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_b3.yaml
@@ -71,12 +71,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
@@ -67,7 +67,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -75,7 +75,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/h_label_cls/tv_efficientnet_v2_l.yaml
@@ -71,12 +71,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -68,7 +68,7 @@ overrides:
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
         - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
-          enable: true
+          enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -67,15 +67,15 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
-          enable: false
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
+          enable: true
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_b0.yaml
@@ -71,12 +71,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
@@ -68,7 +68,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -76,7 +76,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/efficientnet_v2.yaml
@@ -72,12 +72,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
@@ -69,12 +69,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_class_cls/tv_efficientnet_v2_l.yaml
@@ -65,7 +65,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -73,7 +73,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
@@ -69,7 +69,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -77,7 +77,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_b0.yaml
@@ -73,12 +73,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
@@ -69,7 +69,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -77,7 +77,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/efficientnet_v2.yaml
@@ -73,12 +73,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
@@ -70,12 +70,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_b3.yaml
@@ -66,7 +66,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -74,7 +74,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
@@ -69,12 +69,12 @@ overrides:
           enable: false
           init_args:
             kernel_size: 5
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]

--- a/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
+++ b/src/otx/recipe/classification/multi_label_cls/tv_efficientnet_v2_l.yaml
@@ -65,7 +65,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -73,7 +73,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/dfine_x.yaml
+++ b/src/otx/recipe/detection/dfine_x.yaml
@@ -93,7 +93,7 @@ overrides:
           enable: false
           init_args:
             is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -103,12 +103,12 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
           init_args:
             min_size: 1

--- a/src/otx/recipe/detection/dfine_x.yaml
+++ b/src/otx/recipe/detection/dfine_x.yaml
@@ -107,7 +107,7 @@ overrides:
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
           init_args:

--- a/src/otx/recipe/detection/dfine_x_tile.yaml
+++ b/src/otx/recipe/detection/dfine_x_tile.yaml
@@ -97,7 +97,7 @@ overrides:
           enable: false
           init_args:
             is_numpy_to_tvtensor: true
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -107,7 +107,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/dfine_x_tile.yaml
+++ b/src/otx/recipe/detection/dfine_x_tile.yaml
@@ -107,12 +107,12 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
           init_args:
             min_size: 1

--- a/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/src/otx/recipe/detection/rtdetr_101.yaml
@@ -81,7 +81,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -89,7 +89,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/src/otx/recipe/detection/rtdetr_101.yaml
@@ -89,13 +89,14 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
+
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/src/otx/recipe/detection/rtdetr_18.yaml
@@ -80,7 +80,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -88,7 +88,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/src/otx/recipe/detection/rtdetr_18.yaml
@@ -88,13 +88,14 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
+
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/src/otx/recipe/detection/rtdetr_50.yaml
@@ -81,7 +81,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -89,7 +89,7 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/src/otx/recipe/detection/rtdetr_50.yaml
@@ -89,13 +89,14 @@ overrides:
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
             scale: false
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
+
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -92,7 +92,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -113,7 +113,7 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -113,12 +113,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [103.53, 116.28, 123.675]
             std: [57.375, 57.12, 58.395]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
 
     val_subset:
       batch_size: 8

--- a/src/otx/recipe/detection/ssd_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2.yaml
@@ -84,12 +84,13 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [255.0, 255.0, 255.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
+
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/ssd_mobilenetv2.yaml
+++ b/src/otx/recipe/detection/ssd_mobilenetv2.yaml
@@ -77,14 +77,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -104,14 +104,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_l.yaml
+++ b/src/otx/recipe/detection/yolox_l.yaml
@@ -111,12 +111,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -88,12 +88,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
 
     val_subset:
       num_workers: 4

--- a/src/otx/recipe/detection/yolox_l_tile.yaml
+++ b/src/otx/recipe/detection/yolox_l_tile.yaml
@@ -81,14 +81,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -102,14 +102,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_s.yaml
+++ b/src/otx/recipe/detection/yolox_s.yaml
@@ -109,12 +109,13 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
+
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -80,14 +80,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_s_tile.yaml
+++ b/src/otx/recipe/detection/yolox_s_tile.yaml
@@ -87,12 +87,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
 
     val_subset:
       num_workers: 4

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -94,12 +94,13 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
+
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/yolox_tiny.yaml
+++ b/src/otx/recipe/detection/yolox_tiny.yaml
@@ -87,14 +87,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -80,14 +80,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_tiny_tile.yaml
+++ b/src/otx/recipe/detection/yolox_tiny_tile.yaml
@@ -87,12 +87,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
 
     val_subset:
       num_workers: 4

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -99,14 +99,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_x.yaml
+++ b/src/otx/recipe/detection/yolox_x.yaml
@@ -106,12 +106,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
       sampler:
         class_path: otx.data.samplers.balanced_sampler.BalancedSampler
 

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -80,14 +80,14 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:

--- a/src/otx/recipe/detection/yolox_x_tile.yaml
+++ b/src/otx/recipe/detection/yolox_x_tile.yaml
@@ -87,12 +87,12 @@ overrides:
         - class_path: torchvision.transforms.v2.ToDtype
           init_args:
             dtype: ${as_torch_dtype:torch.float32}
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+          enable: false
         - class_path: torchvision.transforms.v2.Normalize
           init_args:
             mean: [0.0, 0.0, 0.0]
             std: [1.0, 1.0, 1.0]
-        - class_path: torchvision.transforms.v2.GaussianNoise
-          enable: false
 
     val_subset:
       num_workers: 4

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -119,7 +119,7 @@ overrides:
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
-        - class_path: torchvision.transforms.v2.GaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
           enable: false
 
     val_subset:

--- a/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/src/otx/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -108,7 +108,7 @@ overrides:
             is_numpy_to_tvtensor: true
         - class_path: torchvision.transforms.v2.RandomVerticalFlip
           enable: false
-        - class_path: torchvision.transforms.v2.GaussianBlur
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianBlur
           enable: false
           init_args:
             kernel_size: 5
@@ -119,7 +119,7 @@ overrides:
           init_args:
             mean: [123.675, 116.28, 103.53]
             std: [58.395, 57.12, 57.375]
-        - class_path: otx.data.transform_libs.torchvision.UnscaledGaussianNoise
+        - class_path: otx.data.transform_libs.torchvision.RandomGaussianNoise
           enable: false
 
     val_subset:

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -382,7 +382,7 @@ class GetiConfigConverter:
                 "random_horizontal_flip": "otx.data.transform_libs.torchvision.RandomFlip",
                 "random_vertical_flip": "torchvision.transforms.v2.RandomVerticalFlip",
                 "gaussian_blur": "torchvision.transforms.v2.GaussianBlur",
-                "gaussian_noise": "torchvision.transforms.v2.GaussianNoise",
+                "gaussian_noise": "otx.data.transform_libs.torchvision.UnscaledGaussianNoise",
                 "color_jitter": "otx.data.transform_libs.torchvision.PhotoMetricDistortion",
             }
 

--- a/src/otx/tools/converter.py
+++ b/src/otx/tools/converter.py
@@ -381,17 +381,22 @@ class GetiConfigConverter:
                 "random_affine": "otx.data.transform_libs.torchvision.RandomAffine",
                 "random_horizontal_flip": "otx.data.transform_libs.torchvision.RandomFlip",
                 "random_vertical_flip": "torchvision.transforms.v2.RandomVerticalFlip",
-                "gaussian_blur": "torchvision.transforms.v2.GaussianBlur",
-                "gaussian_noise": "otx.data.transform_libs.torchvision.UnscaledGaussianNoise",
+                "gaussian_blur": "otx.data.transform_libs.torchvision.RandomGaussianBlur",
+                "gaussian_noise": "otx.data.transform_libs.torchvision.RandomGaussianNoise",
                 "color_jitter": "otx.data.transform_libs.torchvision.PhotoMetricDistortion",
             }
 
             for aug_name, aug_value in augmentation_params.items():
                 aug_class = augs_mapping_list[aug_name]
+                found = False
                 for aug_config in config["data"]["train_subset"]["transforms"]:
                     if aug_class == aug_config["class_path"]:
+                        found = True
                         aug_config["enable"] = aug_value["enable"]
                         break
+                if not found:
+                    msg = f"augmentation {aug_class} is not found for this model"
+                    raise ValueError(msg)
 
         augmentation_params = param_dict.get("dataset_preparation", {}).get("augmentation", {})
         tiling = augmentation_params.pop("tiling", None)

--- a/tests/unit/data/transform_libs/test_torchvision.py
+++ b/tests/unit/data/transform_libs/test_torchvision.py
@@ -13,6 +13,7 @@ import torch
 from datumaro import Polygon
 from torch import LongTensor
 from torchvision import tv_tensors
+from torchvision.transforms.v2 import ToDtype
 from torchvision.transforms.v2 import functional as F  # noqa: N812
 
 from otx.data.entity.base import ImageInfo
@@ -30,6 +31,7 @@ from otx.data.transform_libs.torchvision import (
     RandomResize,
     Resize,
     TopdownAffine,
+    UnscaledGaussianNoise,
     YOLOXHSVRandomAug,
 )
 from otx.data.transform_libs.utils import overlap_bboxes
@@ -686,3 +688,25 @@ class TestTopdownAffine:
         )
         results = transform(deepcopy(keypoint_det_entity))
         assert results.keypoints.shape == (4, 3)
+
+
+class TestUnscaledGaussianNoise:
+    def test_transform(self, det_data_entity) -> None:
+        transform = Compose(
+            [
+                ToDtype(torch.float32),
+                UnscaledGaussianNoise(mean=0.1, sigma=0.2, clip=True),
+            ],
+        )
+
+        new_det_data_entity = deepcopy(det_data_entity)
+        # test unscaled image in range [0, 255]
+        result = transform(new_det_data_entity)
+        assert not torch.all((result.image >= 0) & (result.image <= 1))
+        assert torch.all((result.image >= 0) & (result.image <= 255))
+
+        # test scaled image in range [0, 1]
+        new_image = torch.rand((3, 100, 100))
+        new_det_data_entity.image = new_image
+        result = transform(new_det_data_entity)
+        assert torch.all((result.image >= 0) & (result.image <= 1))

--- a/tests/unit/data/transform_libs/test_torchvision.py
+++ b/tests/unit/data/transform_libs/test_torchvision.py
@@ -28,10 +28,10 @@ from otx.data.transform_libs.torchvision import (
     RandomAffine,
     RandomCrop,
     RandomFlip,
+    RandomGaussianNoise,
     RandomResize,
     Resize,
     TopdownAffine,
-    UnscaledGaussianNoise,
     YOLOXHSVRandomAug,
 )
 from otx.data.transform_libs.utils import overlap_bboxes
@@ -690,12 +690,12 @@ class TestTopdownAffine:
         assert results.keypoints.shape == (4, 3)
 
 
-class TestUnscaledGaussianNoise:
+class TestRandomGaussianNoise:
     def test_transform(self, det_data_entity) -> None:
         transform = Compose(
             [
                 ToDtype(torch.float32),
-                UnscaledGaussianNoise(mean=0.1, sigma=0.2, clip=True),
+                RandomGaussianNoise(mean=0.1, sigma=0.2, clip=True),
             ],
         )
 

--- a/tests/unit/tools/test_converter.py
+++ b/tests/unit/tools/test_converter.py
@@ -49,8 +49,8 @@ class TestGetiConfigConverter:
         supported_augs_list_for_configuration = [
             "otx.data.transform_libs.torchvision.RandomAffine",
             "torchvision.transforms.v2.RandomVerticalFlip",
-            "torchvision.transforms.v2.GaussianBlur",
-            "torchvision.transforms.v2.GaussianNoise",
+            "otx.data.transform_libs.torchvision.RandomGaussianBlur",
+            "otx.data.transform_libs.torchvision.RandomGaussianNoise",
             "otx.data.transform_libs.torchvision.PhotoMetricDistortion",
         ]
         otx_config = OTXConfig.from_yaml_file("tests/assets/geti/model_configs/classification.yaml")


### PR DESCRIPTION
### Summary

Problem:

1. The Gaussian Noise augmentation from TorchVision can only be applied to images scaled to the [0, 1] range. This is not feasible for some of our models. Additionally, applying augmentations after normalization is generally discouraged.
2. Both Gaussian Noise and Gaussian Blur are always applied without any probability control, making it impossible to adjust the frequency of these augmentations.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
