### PR TITLE
Fix semantic segmentation annotation handling for ExtractedMask type

### DIFF
--- a/src/otx/data/utils/utils.py
+++ b/src/otx/data/utils/utils.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 import cv2
 import numpy as np
 import torch
-from datumaro.components.annotation import AnnotationType, Bbox, LabelCategories, Polygon
+from datumaro.components.annotation import AnnotationType, Bbox, ExtractedMask, LabelCategories, Polygon
 from datumaro.components.annotation import Shape as _Shape
 
 from otx.types import OTXTaskType
@@ -145,7 +145,7 @@ def compute_robust_dataset_statistics(
         data = dataset.get(id=idx, subset=dataset.name)
         annotations: dict[str, list] = defaultdict(list)
         for ann in data.annotations:
-            if task is OTXTaskType.SEMANTIC_SEGMENTATION:
+            if task is OTXTaskType.SEMANTIC_SEGMENTATION and isinstance(ann, ExtractedMask):
                 # Skip background class
                 if label_names and label_names[AnnotationType.label][ann.label].name == "background":
                     continue


### PR DESCRIPTION
### Summary
Fixed an issue in `compute_robust_dataset_statistics` function where semantic segmentation annotations of type `ExtractedMask` were not being properly handled, causing errors in dataset statistics computation.

- Modified the annotation processing logic in `compute_robust_dataset_statistics` to properly handle `ExtractedMask` annotations for semantic segmentation tasks

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
