### PR TITLE
Workaround for batch size search on xpu devices

### DIFF
--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -159,7 +159,7 @@ class OTXEngine(Engine):
         resume: bool = False,
         metric: MetricCallable | None = None,
         checkpoint: PathLike | None = None,
-        adaptive_bs: Literal["None", "Safe", "Full"] = "Safe",
+        adaptive_bs: Literal["None", "Safe", "Full"] = "None",
         check_val_every_n_epoch: int | None = 1,
         num_sanity_val_steps: int | None = 0,
         log_every_n_steps: int | None = 1,

--- a/src/otx/backend/native/engine.py
+++ b/src/otx/backend/native/engine.py
@@ -159,9 +159,10 @@ class OTXEngine(Engine):
         resume: bool = False,
         metric: MetricCallable | None = None,
         checkpoint: PathLike | None = None,
-        adaptive_bs: Literal["None", "Safe", "Full"] = "None",
+        adaptive_bs: Literal["None", "Safe", "Full"] = "Safe",
         check_val_every_n_epoch: int | None = 1,
         num_sanity_val_steps: int | None = 0,
+        log_every_n_steps: int | None = 1,
         **kwargs,
     ) -> dict[str, Any]:
         r"""Trains the model using the provided LightningModule and OTXDataModule.
@@ -245,6 +246,7 @@ class OTXEngine(Engine):
             val_check_interval=val_check_interval,
             check_val_every_n_epoch=check_val_every_n_epoch,
             num_sanity_val_steps=num_sanity_val_steps,
+            log_every_n_steps=log_every_n_steps,
             **kwargs,
         )
         fit_kwargs: dict[str, Any] = {}

--- a/src/otx/backend/native/tools/adaptive_bs/algorithm.py
+++ b/src/otx/backend/native/tools/adaptive_bs/algorithm.py
@@ -269,6 +269,7 @@ def _run_trial(train_func: Callable[[int], Any], bs: int, trial_queue: mp.Queue)
             or "XPU out of memory" in str(e)
             or "UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY" in str(e)
             or "UR error" in str(e)
+            or "UR_RESULT_ERROR_UNKNOWN" in str(e)
         ):  # XPU OOM
             oom = True
         else:

--- a/src/otx/backend/native/tools/adaptive_bs/runner.py
+++ b/src/otx/backend/native/tools/adaptive_bs/runner.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 def adapt_batch_size(
     engine: OTXEngine,
     not_increase: bool = True,
-    callbacks: list[Callback] | Callback | None = None,
     **train_args,
 ) -> None:
     """Change the actual batch size depending on the current GPU status.
@@ -39,7 +38,6 @@ def adapt_batch_size(
     Args:
         engine (OTXEngine): engine instnace.
         not_increase (bool) : Whether adapting batch size to larger value than default value or not.
-        callbacks (list[Callback] | Callback | None, optional): callbacks used during training. Defaults to None.
     """
     if not (is_cuda_available() or is_xpu_available()):
         msg = "Adaptive batch size supports CUDA or XPU."
@@ -54,7 +52,7 @@ def adapt_batch_size(
             _apply_new_batch_size(engine, new_batch_size)
         return
 
-    train_func = partial(_train_model, engine=engine, callbacks=callbacks, **_adjust_train_args(train_args))
+    train_func = partial(_train_model, engine=engine, **_adjust_train_args(train_args))
     bs_search_algo = BsSearchAlgo(
         train_func=train_func,
         default_bs=default_bs,
@@ -85,10 +83,11 @@ def _adjust_train_args(train_args: dict[str, Any]) -> dict[str, Any]:
     train_args.update(train_args.pop("kwargs", {}))
     train_args.pop("self", None)
     train_args.pop("adaptive_bs")
+    train_args.pop("callbacks")
     return train_args
 
 
-def _train_model(bs: int, engine: OTXEngine, callbacks: list[Callback] | Callback | None = None, **train_args) -> None:
+def _train_model(bs: int, engine: OTXEngine, **train_args) -> None:
     if bs <= 0:
         msg = f"Batch size should be greater than 0, but {bs} is given."
         raise ValueError(msg)
@@ -99,7 +98,8 @@ def _train_model(bs: int, engine: OTXEngine, callbacks: list[Callback] | Callbac
     engine.datamodule.val_subset.batch_size = bs
     engine.datamodule.test_subset.batch_size = bs
     train_args["adaptive_bs"] = "None"
-    engine.train(callbacks=_register_callback(callbacks), **train_args)
+    print(f"Runnning training trial with bs = {bs} ...")
+    engine.train(callbacks=_register_callback(), **train_args)
 
 
 def _register_callback(callbacks: list[Callback] | Callback | None = None) -> list[Callback]:
@@ -113,9 +113,13 @@ def _register_callback(callbacks: list[Callback] | Callback | None = None) -> li
 
 def _apply_new_batch_size(engine: OTXEngine, new_batch_size: int) -> None:
     origin_bs = engine.datamodule.train_subset.batch_size
+    if is_xpu_available() and new_batch_size != 1:
+        new_batch_size -= 1  # for safety reasons
     if new_batch_size == origin_bs:
         return
     engine.datamodule.train_subset.batch_size = new_batch_size
     engine.datamodule.val_subset.batch_size = new_batch_size
     engine.datamodule.test_subset.batch_size = new_batch_size
-    engine.model.optimizer_callable.optimizer_kwargs["lr"] *= sqrt(new_batch_size / origin_bs)  # type: ignore[attr-defined]
+    new_lr = engine.model.optimizer_callable.optimizer_kwargs["lr"] * sqrt(new_batch_size / origin_bs)  # type: ignore[attr-defined]
+    print(f"new batch size = {new_batch_size} with learning rate = {new_lr} is set for the training and validation.")
+    engine.model.optimizer_callable.optimizer_kwargs["lr"] = new_lr  # type: ignore[attr-defined]

--- a/src/otx/backend/native/tools/adaptive_bs/runner.py
+++ b/src/otx/backend/native/tools/adaptive_bs/runner.py
@@ -82,8 +82,8 @@ def adapt_batch_size(
 def _adjust_train_args(train_args: dict[str, Any]) -> dict[str, Any]:
     train_args.update(train_args.pop("kwargs", {}))
     train_args.pop("self", None)
-    train_args.pop("adaptive_bs")
-    train_args.pop("callbacks")
+    train_args.pop("adaptive_bs", None)
+    train_args.pop("callbacks", None)
     return train_args
 
 

--- a/src/otx/backend/native/utils/utils.py
+++ b/src/otx/backend/native/utils/utils.py
@@ -85,7 +85,7 @@ def mock_modules_for_chkpt() -> Iterator[None]:
         sys.modules["otx.core.types"] = otx.types
         sys.modules["otx.core.types.task"] = otx.types.task
         sys.modules["otx.core.types.label"] = otx.types.label
-        sys.modules["otx.core.model"] = otx.backend.native.models
+        sys.modules["otx.core.model"] = otx.backend.native.models  # type: ignore[attr-defined]
         sys.modules["otx.core.metrics"] = otx.metrics
 
         yield

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
@@ -57,10 +57,12 @@ overrides:
   data:
     train_subset:
       batch_size: 4
-      num_workers: 8
+      num_workers: 4
 
     val_subset:
+      batch_size: 4
       num_workers: 4
 
     test_subset:
+      batch_size: 4
       num_workers: 4

--- a/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
+++ b/src/otx/recipe/instance_segmentation/maskrcnn_r50_tv.yaml
@@ -60,9 +60,7 @@ overrides:
       num_workers: 4
 
     val_subset:
-      batch_size: 4
       num_workers: 4
 
     test_subset:
-      batch_size: 4
       num_workers: 4

--- a/tests/unit/backend/native/tools/adaptive_bs/test_adaptive_bs_api.py
+++ b/tests/unit/backend/native/tools/adaptive_bs/test_adaptive_bs_api.py
@@ -17,6 +17,7 @@ from otx.backend.native.tools.adaptive_bs.runner import (
     _train_model,
     adapt_batch_size,
 )
+from otx.utils.device import is_xpu_available
 
 
 @pytest.fixture()
@@ -260,7 +261,7 @@ class TestBatchSizeFinder:
         # check steps_per_trial is set well
         assert mock_trainer.limit_val_batches == steps_per_trial
         assert mock_trainer.fit_loop.epoch_loop.max_steps == -1
-        assert mock_trainer.fit_loop.max_epochs == 1
+        assert mock_trainer.fit_loop.max_epochs == 1 if not is_xpu_available() else 2
         assert mock_trainer.limit_train_batches == steps_per_trial
         # check active_loop is run
         assert mock_active_loop.restarting is False
@@ -278,7 +279,7 @@ class TestBatchSizeFinder:
         # check steps_per_trial is set well
         assert mock_trainer.limit_val_batches == 0
         assert mock_trainer.fit_loop.epoch_loop.max_steps == -1
-        assert mock_trainer.fit_loop.max_epochs == 1
+        assert mock_trainer.fit_loop.max_epochs == 1 if not is_xpu_available() else 2
         assert mock_trainer.limit_train_batches == steps_per_trial
         # check active_loop is run
         assert mock_active_loop.restarting is False

--- a/tests/unit/tools/test_converter.py
+++ b/tests/unit/tools/test_converter.py
@@ -114,3 +114,5 @@ class TestGetiConfigConverter:
         if "logger" in train_kwargs and train_kwargs["logger"] is not None:
             assert len(train_kwargs["logger"]) == len(config["logger"])
         assert train_kwargs["max_epochs"] == 100
+        assert "adaptive_bs" in train_kwargs
+        assert train_kwargs["adaptive_bs"] == "Safe"


### PR DESCRIPTION
### Summary

Currently, XPU may fail even after a successful batch size search. XPU accumulates operations and uses a cache for primitives, causing memory consumption to grow during training. This PR is not a reliable solution, but rather an attempt to mitigate failures in Geti.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
