### PR TITLE
apply copyright header to all .py, .ts, .tsx and .js files

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/app/alembic/env.py
+++ b/backend/app/alembic/env.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from logging.config import fileConfig
 
 from alembic import context

--- a/backend/app/alembic/versions/cb68fa7db781_schema.py
+++ b/backend/app/alembic/versions/cb68fa7db781_schema.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """schema
 
 Revision ID: cb68fa7db781

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from functools import lru_cache
 from typing import Annotated
 from uuid import UUID

--- a/backend/app/api/endpoints/__init__.py
+++ b/backend/app/api/endpoints/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/app/api/endpoints/models.py
+++ b/backend/app/api/endpoints/models.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Annotated
 from uuid import UUID
 

--- a/backend/app/api/endpoints/pipelines.py
+++ b/backend/app/api/endpoints/pipelines.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Endpoints for managing pipelines"""
 
 import logging

--- a/backend/app/api/endpoints/sinks.py
+++ b/backend/app/api/endpoints/sinks.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Endpoints for managing pipeline sinks"""
 
 import logging

--- a/backend/app/api/endpoints/sources.py
+++ b/backend/app/api/endpoints/sources.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Endpoints for managing pipeline sources"""
 
 import logging

--- a/backend/app/api/endpoints/system.py
+++ b/backend/app/api/endpoints/system.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """System API Endpoints"""
 
 import logging

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Command line interface for interacting with the Geti Tune application."""
 
 import logging

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.core.lifecycle import lifespan
 from app.core.scheduler import Scheduler
 

--- a/backend/app/core/lifecycle.py
+++ b/backend/app/core/lifecycle.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Application lifecycle management"""
 
 import logging

--- a/backend/app/core/scheduler.py
+++ b/backend/app/core/scheduler.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import multiprocessing as mp
 import os

--- a/backend/app/create_openapi.py
+++ b/backend/app/create_openapi.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """This script generates an OpenAPI JSON file for the FastAPI application."""
 
 import json

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.db.engine import db_engine, get_db_session
 from app.db.migration import migration_manager
 

--- a/backend/app/db/engine.py
+++ b/backend/app/db/engine.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import Iterator
 from contextlib import contextmanager
 from sqlite3 import Connection

--- a/backend/app/db/migration.py
+++ b/backend/app/db/migration.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Database migration management"""
 
 import logging

--- a/backend/app/db/schema.py
+++ b/backend/app/db/schema.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime
 from uuid import uuid4
 

--- a/backend/app/entities/__init__.py
+++ b/backend/app/entities/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/app/entities/base_opencv_stream.py
+++ b/backend/app/entities/base_opencv_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 from abc import ABC
 from typing import Any

--- a/backend/app/entities/images_folder_stream.py
+++ b/backend/app/entities/images_folder_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 import threading

--- a/backend/app/entities/ip_camera_stream.py
+++ b/backend/app/entities/ip_camera_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import time
 

--- a/backend/app/entities/stream_data.py
+++ b/backend/app/entities/stream_data.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/backend/app/entities/video_file_stream.py
+++ b/backend/app/entities/video_file_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import cv2
 import numpy as np
 

--- a/backend/app/entities/video_stream.py
+++ b/backend/app/entities/video_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 

--- a/backend/app/entities/webcam_stream.py
+++ b/backend/app/entities/webcam_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.entities.base_opencv_stream import BaseOpenCVStream
 from app.schemas import SourceType
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 # export no_proxy="localhost, 127.0.0.1, ::1"
 # Start with:
 #  - uv run app/main.py

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from .model_repo import ModelRepository
 from .pipeline_repo import PipelineRepository
 from .sink_repo import SinkRepository

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime
 from typing import TypeVar
 

--- a/backend/app/repositories/model_repo.py
+++ b/backend/app/repositories/model_repo.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime
 
 from sqlalchemy.orm import Session

--- a/backend/app/repositories/pipeline_repo.py
+++ b/backend/app/repositories/pipeline_repo.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime
 
 from sqlalchemy.orm import Session

--- a/backend/app/repositories/sink_repo.py
+++ b/backend/app/repositories/sink_repo.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from sqlalchemy.orm import Session
 
 from app.db.schema import SinkDB

--- a/backend/app/repositories/source_repo.py
+++ b/backend/app/repositories/source_repo.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from sqlalchemy.orm import Session
 
 from app.db.schema import SourceDB

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.schemas.model import Model, ModelFormat
 from app.schemas.pipeline import Pipeline, PipelineStatus
 from app.schemas.sink import DisconnectedSinkConfig, OutputFormat, Sink, SinkType

--- a/backend/app/schemas/base.py
+++ b/backend/app/schemas/base.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC
 from uuid import UUID, uuid4
 

--- a/backend/app/schemas/model.py
+++ b/backend/app/schemas/model.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 from app.schemas.base import BaseIDNameModel

--- a/backend/app/schemas/model_activation.py
+++ b/backend/app/schemas/model_activation.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import BaseModel, Field, field_validator
 
 

--- a/backend/app/schemas/pipeline.py
+++ b/backend/app/schemas/pipeline.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 from typing import Any
 from uuid import UUID

--- a/backend/app/schemas/sink.py
+++ b/backend/app/schemas/sink.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 from typing import Annotated, Literal
 

--- a/backend/app/schemas/source.py
+++ b/backend/app/schemas/source.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 from os import getenv
 from typing import Annotated, Literal

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from .active_pipeline_service import ActivePipelineService
 from .base import ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError, ResourceType
 from .configuration_service import ConfigurationService

--- a/backend/app/services/active_pipeline_service.py
+++ b/backend/app/services/active_pipeline_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import multiprocessing as mp
 from multiprocessing.synchronize import Condition as ConditionClass

--- a/backend/app/services/base.py
+++ b/backend/app/services/base.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass

--- a/backend/app/services/configuration_service.py
+++ b/backend/app/services/configuration_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from collections.abc import Callable
 from enum import StrEnum

--- a/backend/app/services/dispatch_service.py
+++ b/backend/app/services/dispatch_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import Callable, Sequence
 
 from app.schemas import Sink, SinkType

--- a/backend/app/services/dispatchers/__init__.py
+++ b/backend/app/services/dispatchers/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from .filesystem import FolderDispatcher
 from .mqtt import MqttDispatcher
 

--- a/backend/app/services/dispatchers/base.py
+++ b/backend/app/services/dispatchers/base.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 from abc import ABCMeta, abstractmethod
 

--- a/backend/app/services/dispatchers/filesystem.py
+++ b/backend/app/services/dispatchers/filesystem.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 from datetime import datetime

--- a/backend/app/services/dispatchers/mqtt.py
+++ b/backend/app/services/dispatchers/mqtt.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import base64
 import json
 import logging

--- a/backend/app/services/mappers/__init__.py
+++ b/backend/app/services/mappers/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from .model_mapper import ModelMapper
 from .pipeline_mapper import PipelineMapper
 from .sink_mapper import SinkMapper

--- a/backend/app/services/mappers/model_mapper.py
+++ b/backend/app/services/mappers/model_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.db.schema import ModelDB
 from app.schemas.model import Model
 

--- a/backend/app/services/mappers/pipeline_mapper.py
+++ b/backend/app/services/mappers/pipeline_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.db.schema import PipelineDB
 from app.schemas import Pipeline, PipelineStatus
 

--- a/backend/app/services/mappers/sink_mapper.py
+++ b/backend/app/services/mappers/sink_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.db.schema import SinkDB
 from app.schemas.sink import Sink, SinkAdapter, SinkType
 

--- a/backend/app/services/mappers/source_mapper.py
+++ b/backend/app/services/mappers/source_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.db.schema import SourceDB
 from app.schemas.source import Source, SourceAdapter, SourceType
 

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import logging
 import os

--- a/backend/app/services/parent_process_guard.py
+++ b/backend/app/services/parent_process_guard.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import multiprocessing as mp
 from collections.abc import Callable
 from functools import wraps

--- a/backend/app/services/pipeline_service.py
+++ b/backend/app/services/pipeline_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from multiprocessing.synchronize import Condition
 from uuid import UUID
 

--- a/backend/app/services/system_service.py
+++ b/backend/app/services/system_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import psutil
 
 

--- a/backend/app/services/video_stream_service.py
+++ b/backend/app/services/video_stream_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 
 from app.entities.images_folder_stream import ImagesFolderStream

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 """Application configuration management"""
 
 from functools import lru_cache

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from app.utils.diagnostics import log_threads
 from app.utils.queue import flush_queue
 from app.utils.singleton import Singleton

--- a/backend/app/utils/diagnostics.py
+++ b/backend/app/utils/diagnostics.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import multiprocessing as mp
 import os

--- a/backend/app/utils/queue.py
+++ b/backend/app/utils/queue.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import multiprocessing as mp
 import queue

--- a/backend/app/utils/singleton.py
+++ b/backend/app/utils/singleton.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from threading import Lock
 
 

--- a/backend/app/utils/visualization.py
+++ b/backend/app/utils/visualization.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from abc import ABC, abstractmethod
 

--- a/backend/app/workers/__init__.py
+++ b/backend/app/workers/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from .dispatching import dispatching_routine
 from .inference import inference_routine
 from .stream_loading import frame_acquisition_routine

--- a/backend/app/workers/dispatching.py
+++ b/backend/app/workers/dispatching.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import copy
 import logging
 import multiprocessing as mp

--- a/backend/app/workers/inference.py
+++ b/backend/app/workers/inference.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import multiprocessing as mp
 import queue

--- a/backend/app/workers/stream_loading.py
+++ b/backend/app/workers/stream_loading.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import copy
 import logging
 import multiprocessing as mp

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/tests/integration/__init__.py
+++ b/backend/tests/integration/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/tests/integration/alembic/test_initial_schema_migration.py
+++ b/backend/tests/integration/alembic/test_initial_schema_migration.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import tempfile
 
 import pytest

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import Generator
 from multiprocessing.synchronize import Condition
 from unittest.mock import MagicMock

--- a/backend/tests/integration/entities/test_ip_camera_stream.py
+++ b/backend/tests/integration/entities/test_ip_camera_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 import time
 from collections.abc import Generator

--- a/backend/tests/integration/services/__init__.py
+++ b/backend/tests/integration/services/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/tests/integration/services/dispatchers/__init__.py
+++ b/backend/tests/integration/services/dispatchers/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/tests/integration/services/dispatchers/test_mqtt.py
+++ b/backend/tests/integration/services/dispatchers/test_mqtt.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import re
 import time

--- a/backend/tests/integration/services/test_active_pipeline_service.py
+++ b/backend/tests/integration/services/test_active_pipeline_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import patch
 
 import pytest

--- a/backend/tests/integration/services/test_configuration_service.py
+++ b/backend/tests/integration/services/test_configuration_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import patch
 from uuid import uuid4
 

--- a/backend/tests/integration/services/test_model_service.py
+++ b/backend/tests/integration/services/test_model_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import io
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/backend/tests/integration/services/test_pipeline_service.py
+++ b/backend/tests/integration/services/test_pipeline_service.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import patch
 from uuid import UUID, uuid4
 

--- a/backend/tests/unit/__init__.py
+++ b/backend/tests/unit/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import multiprocessing as mp
 
 import pytest

--- a/backend/tests/unit/endpoints/conftest.py
+++ b/backend/tests/unit/endpoints/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 from fastapi.testclient import TestClient
 

--- a/backend/tests/unit/endpoints/test_models.py
+++ b/backend/tests/unit/endpoints/test_models.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import MagicMock
 from uuid import uuid4
 

--- a/backend/tests/unit/endpoints/test_pipelines.py
+++ b/backend/tests/unit/endpoints/test_pipelines.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import MagicMock
 from uuid import uuid4
 

--- a/backend/tests/unit/endpoints/test_sources_sinks.py
+++ b/backend/tests/unit/endpoints/test_sources_sinks.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import io
 from enum import StrEnum
 from unittest.mock import MagicMock

--- a/backend/tests/unit/entities/test_images_folder_stream.py
+++ b/backend/tests/unit/entities/test_images_folder_stream.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 from unittest.mock import MagicMock, call, patch
 

--- a/backend/tests/unit/schemas/test_ip_camera_source_config.py
+++ b/backend/tests/unit/schemas/test_ip_camera_source_config.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from unittest.mock import patch
 

--- a/backend/tests/unit/services/mappers/test_pipeline_mapper.py
+++ b/backend/tests/unit/services/mappers/test_pipeline_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import uuid4
 
 import pytest

--- a/backend/tests/unit/services/mappers/test_sink_mapper.py
+++ b/backend/tests/unit/services/mappers/test_sink_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import uuid4
 
 import pytest

--- a/backend/tests/unit/services/mappers/test_source_mapper.py
+++ b/backend/tests/unit/services/mappers/test_source_mapper.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import uuid4
 
 import pytest

--- a/backend/tests/unit/test_visualization.py
+++ b/backend/tests/unit/test_visualization.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import unittest
 
 import numpy as np

--- a/backend/tests/unit/workers/test_stream_loading.py
+++ b/backend/tests/unit/workers/test_stream_loading.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 import multiprocessing as mp
 import queue
 import time

--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -1,5 +1,5 @@
-// Copyright (C) 2022-2025 Intel Corporation
-// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig, devices } from '@playwright/test';
 
 const CI = !!process.env.CI;

--- a/ui/rsbuild.config.ts
+++ b/ui/rsbuild.config.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig, loadEnv } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import createFetchClient from 'openapi-fetch';
 import createClient from 'openapi-react-query';
 

--- a/ui/src/api/utils.ts
+++ b/ui/src/api/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { fromOpenApi } from '@mswjs/source/open-api';
 import { createOpenApiHttp, OpenApiHttpHandlers } from 'openapi-msw';
 

--- a/ui/src/components/notification/notification.component.tsx
+++ b/ui/src/components/notification/notification.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { toast, Toaster } from 'sonner';
 
 import { ReactComponent as ErrorIcon } from '../../assets/icons/error-icon.svg';

--- a/ui/src/components/radio-disclosure-group/radio-disclosure-group.tsx
+++ b/ui/src/components/radio-disclosure-group/radio-disclosure-group.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { ReactNode } from 'react';
 
 import { Disclosure, DisclosurePanel, DisclosureTitle, Flex, Radio, RadioGroup, View } from '@geti/ui';

--- a/ui/src/components/stream/stream.tsx
+++ b/ui/src/components/stream/stream.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef } from 'react';
 
 import { useWebRTCConnection } from '../../components/stream/web-rtc-connection-provider';

--- a/ui/src/components/stream/web-rtc-connection-provider.test.tsx
+++ b/ui/src/components/stream/web-rtc-connection-provider.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { fireEvent, render } from '@testing-library/react';
 import { vi } from 'vitest';
 

--- a/ui/src/components/stream/web-rtc-connection-provider.tsx
+++ b/ui/src/components/stream/web-rtc-connection-provider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext, ReactNode, RefObject, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 import { WebRTCConnection, WebRTCConnectionStatus } from './web-rtc-connection';

--- a/ui/src/components/stream/web-rtc-connection.ts
+++ b/ui/src/components/stream/web-rtc-connection.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { fetchClient } from '../../api/client';
 
 export type WebRTCConnectionStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'failed';

--- a/ui/src/components/wizard-steps/interfaces.ts
+++ b/ui/src/components/wizard-steps/interfaces.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 export type WizardStep = {
     href: string;
     name: string;

--- a/ui/src/components/wizard-steps/wizard-steps.test.tsx
+++ b/ui/src/components/wizard-steps/wizard-steps.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { render, screen } from '@testing-library/react';
 import { TabPanel } from 'react-aria-components';
 

--- a/ui/src/components/wizard-steps/wizard-steps.tsx
+++ b/ui/src/components/wizard-steps/wizard-steps.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { ComponentProps, ReactNode } from 'react';
 
 import { Text } from '@geti/ui';

--- a/ui/src/components/wizard-tabs/interfaces.ts
+++ b/ui/src/components/wizard-tabs/interfaces.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 export type WizardTab = {
     href: string;
     name: string;

--- a/ui/src/components/wizard-tabs/wizard-tabs.tsx
+++ b/ui/src/components/wizard-tabs/wizard-tabs.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { ComponentProps } from 'react';
 
 import { Tab as AriaTab, TabList, Tabs } from 'react-aria-components';

--- a/ui/src/components/zoom/use-container-size.ts
+++ b/ui/src/components/zoom/use-container-size.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { RefObject, useState } from 'react';
 
 import { useResizeObserver } from '@react-aria/utils';

--- a/ui/src/components/zoom/zoom-transform.tsx
+++ b/ui/src/components/zoom/zoom-transform.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { ReactNode, useEffect, useMemo, useRef } from 'react';
 
 import { useContainerSize } from './use-container-size';

--- a/ui/src/components/zoom/zoom.test.tsx
+++ b/ui/src/components/zoom/zoom.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 

--- a/ui/src/components/zoom/zoom.tsx
+++ b/ui/src/components/zoom/zoom.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
 
 export type ZoomState = { scale: number; translate: { x: number; y: number } };

--- a/ui/src/env.d.ts
+++ b/ui/src/env.d.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="@rsbuild/core/types" />
 
 // We need these two to be able to import/export svgs as ReactComponent,

--- a/ui/src/features/data-collection/checkbox-input.tsx
+++ b/ui/src/features/data-collection/checkbox-input.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { noop } from 'lodash-es';
 
 import classes from './checkbox-input.module.scss';

--- a/ui/src/features/data-collection/data-collection.component.tsx
+++ b/ui/src/features/data-collection/data-collection.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { View } from '@geti/ui';
 
 import { Gallery } from './gallery/gallery.component';

--- a/ui/src/features/data-collection/gallery/annotation-state-icon.component.tsx
+++ b/ui/src/features/data-collection/gallery/annotation-state-icon.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { CanceledIcon, CheckCircleOutlined } from '@geti/ui/icons';
 
 import { AnnotationState } from '../../../routes/data-collection/provider';

--- a/ui/src/features/data-collection/gallery/gallery.component.tsx
+++ b/ui/src/features/data-collection/gallery/gallery.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { AriaComponentsListBox, GridLayout, ListBoxItem, Size, View, Virtualizer } from '@geti/ui';
 
 import { useSelectedData } from '../../../routes/data-collection/provider';

--- a/ui/src/features/data-collection/gallery/media-item.component.tsx
+++ b/ui/src/features/data-collection/gallery/media-item.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { ReactNode } from 'react';
 
 import { View } from '@geti/ui';

--- a/ui/src/features/data-collection/gallery/utils.ts
+++ b/ui/src/features/data-collection/gallery/utils.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { API_BASE_URL } from '../../../api/client';
 
 const getBaseUrl = (src: string) => `${API_BASE_URL}/api/data-collection/${src}`;

--- a/ui/src/features/data-collection/mock-response.ts
+++ b/ui/src/features/data-collection/mock-response.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 export const response = {
     page: 1,
     page_size: 1500,

--- a/ui/src/features/data-collection/toolbar/toolbar.component.tsx
+++ b/ui/src/features/data-collection/toolbar/toolbar.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Button, Divider, Flex, Heading, Text } from '@geti/ui';
 
 import { useSelectedData } from '../../../routes/data-collection/provider';

--- a/ui/src/features/data-collection/toolbar/util.test.ts
+++ b/ui/src/features/data-collection/toolbar/util.test.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, expect, it } from 'vitest';
 
 import { MediaState } from '../../../routes/data-collection/provider';

--- a/ui/src/features/data-collection/toolbar/util.ts
+++ b/ui/src/features/data-collection/toolbar/util.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Key, Selection } from '@geti/ui';
 
 import { AnnotationState, MediaState } from '../../../routes/data-collection/provider';

--- a/ui/src/features/pipelines/models/label-selection.component.test.tsx
+++ b/ui/src/features/pipelines/models/label-selection.component.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { LabelSelection } from './label-selection.component';

--- a/ui/src/features/pipelines/models/label-selection.component.tsx
+++ b/ui/src/features/pipelines/models/label-selection.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState } from 'react';
 
 import {

--- a/ui/src/features/pipelines/models/model-selection-group.component.test.tsx
+++ b/ui/src/features/pipelines/models/model-selection-group.component.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { ModelSelectionGroup } from './model-selection-group.component';

--- a/ui/src/features/pipelines/models/model-selection-group.component.tsx
+++ b/ui/src/features/pipelines/models/model-selection-group.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState } from 'react';
 
 import { Flex, Heading, Image, Radio, RadioGroup, Text, View } from '@geti/ui';

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="@rsbuild/core/types" />
 
 import 'react';

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 
 import ReactDOM from 'react-dom/client';

--- a/ui/src/layout.tsx
+++ b/ui/src/layout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Flex, Grid, Item, TabList, TabPanels, Tabs, View } from '@geti/ui';
 import { Outlet, useLocation } from 'react-router';
 

--- a/ui/src/msw-node-setup.ts
+++ b/ui/src/msw-node-setup.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { setupServer } from 'msw/node';
 
 import { handlers } from './api/utils';

--- a/ui/src/providers.tsx
+++ b/ui/src/providers.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { ReactNode } from 'react';
 
 import { ThemeProvider } from '@geti/ui/theme';

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Suspense } from 'react';
 
 import { Loading } from '@geti/ui';

--- a/ui/src/routes/data-collection/data-collection.component.tsx
+++ b/ui/src/routes/data-collection/data-collection.component.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { dimensionValue, Flex } from '@geti/ui';
 
 import { Gallery } from '../../features/data-collection/gallery/gallery.component';

--- a/ui/src/routes/data-collection/provider.tsx
+++ b/ui/src/routes/data-collection/provider.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext, Dispatch, ReactNode, SetStateAction, useContext, useState } from 'react';
 
 import { Selection } from '@geti/ui';

--- a/ui/src/routes/live-feed/aside.tsx
+++ b/ui/src/routes/live-feed/aside.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useRef, useState } from 'react';
 
 import { ActionButton, Flex, Grid, Heading, View } from '@geti/ui';

--- a/ui/src/routes/live-feed/debug-trigger.tsx
+++ b/ui/src/routes/live-feed/debug-trigger.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Suspense } from 'react';
 
 import { Content, Dialog, DialogTrigger } from '@adobe/react-spectrum';

--- a/ui/src/routes/live-feed/live-feed.tsx
+++ b/ui/src/routes/live-feed/live-feed.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useState } from 'react';
 
 import { Button, Flex, Grid, Loading, View } from '@geti/ui';

--- a/ui/src/routes/live-feed/toolbar.tsx
+++ b/ui/src/routes/live-feed/toolbar.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Suspense } from 'react';
 
 import { StatusLight } from '@adobe/react-spectrum';

--- a/ui/src/routes/pipeline/edit-pipeline-layout.tsx
+++ b/ui/src/routes/pipeline/edit-pipeline-layout.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { CSSProperties, Suspense } from 'react';
 
 import { Loading, View } from '@geti/ui';

--- a/ui/src/routes/pipeline/index.test.tsx
+++ b/ui/src/routes/pipeline/index.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { render, screen } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 

--- a/ui/src/routes/pipeline/index.tsx
+++ b/ui/src/routes/pipeline/index.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Button, ButtonGroup, Divider, Flex, Grid, Heading, repeat, Text, View } from '@geti/ui';
 import { capitalize, isArray, startsWith } from 'lodash-es';
 

--- a/ui/src/routes/pipeline/model.tsx
+++ b/ui/src/routes/pipeline/model.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Button, ButtonGroup, Divider, Flex, Text } from '@geti/ui';
 
 import { LabelSelection } from '../../features/pipelines/models/label-selection.component';

--- a/ui/src/routes/pipeline/sink.tsx
+++ b/ui/src/routes/pipeline/sink.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { Dispatch, FormEvent, SetStateAction, useState } from 'react';
 
 import {

--- a/ui/src/routes/pipeline/source.tsx
+++ b/ui/src/routes/pipeline/source.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { FormEvent, useState } from 'react';
 
 import { Button, ButtonGroup, Divider, Flex, Form, Grid, Loading, NumberField, Text, TextField, View } from '@geti/ui';

--- a/ui/src/setup-tests.ts
+++ b/ui/src/setup-tests.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import '@testing-library/jest-dom';
 
 import fetchPolyfill, { Request as RequestPolyfill } from 'node-fetch';

--- a/ui/tests/data-collection.spec.ts
+++ b/ui/tests/data-collection.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { expect, test } from './fixtures';
 
 test.describe('data collection', () => {

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { createNetworkFixture, NetworkFixture } from '@msw/playwright';
 import { expect, test as testBase } from '@playwright/test';
 

--- a/ui/tests/main.spec.ts
+++ b/ui/tests/main.spec.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import { expect, test } from './fixtures';
 
 test.describe('livefeed', () => {

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';


### PR DESCRIPTION
### Summary

Apply copyright header to the new Geti Tune files

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
