### PR TITLE
Create skeleton for annotation endpoints

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -12,46 +12,37 @@ from app.services import ActivePipelineService, ConfigurationService, ModelServi
 from app.webrtc.manager import WebRTCManager
 
 
-def is_valid_uuid(identifier: str) -> bool:
-    """
-    Check if a given string identifier is formatted as a valid UUID
-
-    :param identifier: String to check
-    :return: True if valid UUID, False otherwise
-    """
+def validate_uuid(identifier: str, error_detail: str) -> UUID:
+    """Validates a string as UUID or raises HTTP 400 with a custom error message."""
     try:
-        UUID(identifier)
+        return UUID(identifier)
     except ValueError:
-        return False
-    return True
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_detail)
 
 
 def get_source_id(source_id: str) -> UUID:
     """Initializes and validates a source ID"""
-    if not is_valid_uuid(source_id):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid source ID")
-    return UUID(source_id)
+    return validate_uuid(source_id, "Invalid source ID")
 
 
 def get_sink_id(sink_id: str) -> UUID:
     """Initializes and validates a sink ID"""
-    if not is_valid_uuid(sink_id):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid sink ID")
-    return UUID(sink_id)
+    return validate_uuid(sink_id, "Invalid sink ID")
 
 
 def get_model_id(model_id: str) -> UUID:
     """Initializes and validates a model ID"""
-    if not is_valid_uuid(model_id):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid model ID")
-    return UUID(model_id)
+    return validate_uuid(model_id, "Invalid model ID")
 
 
 def get_pipeline_id(pipeline_id: str) -> UUID:
     """Initializes and validates a pipeline ID"""
-    if not is_valid_uuid(pipeline_id):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid pipeline ID")
-    return UUID(pipeline_id)
+    return validate_uuid(pipeline_id, "Invalid pipeline ID")
+
+
+def get_media_id(media_id: str) -> UUID:
+    """Initializes and validates a media ID"""
+    return validate_uuid(media_id, "Invalid media ID")
 
 
 @lru_cache

--- a/backend/app/api/endpoints/annotations.py
+++ b/backend/app/api/endpoints/annotations.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""API Endpoints for Media Annotations"""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Body, Depends, status
+from fastapi.openapi.models import Example
+
+from app.api.dependencies import get_media_id
+from app.api.tags import Tags
+from app.schemas.base import BaseIDModel
+
+router = APIRouter(prefix="/api/media/{media_id}/annotations", tags=[Tags.ANNOTATIONS])
+
+CREATE_ANNOTATION_BODY_DESCRIPTION = """
+Configuration for the new annotation. The exact fields depend on the type of annotation being created.
+- For `full_image` annotations, only the `label` field is required.
+- For `rectangle` annotations, the `label`, `x`, `y`, `width`, and `height` fields are required.
+- For `polygon` annotations, the `label` field is required, along with a list of `points` defining the polygon vertices.
+"""
+CREATE_ANNOTATION_BODY_EXAMPLES = {
+    "classification": Example(
+        summary="Full image annotation",
+        description="Configuration for a complete annotation of an image with label",
+        value={
+            "label": "Car",
+            "type": "full_image",
+        },
+    ),
+    "detection": Example(
+        summary="Object detection annotation",
+        description="Configuration for an object detection annotation with bounding boxes",
+        value={
+            "label": "Pedestrian",
+            "type": "rectangle",
+            "x": 100,
+            "y": 150,
+            "width": 200,
+            "height": 100,
+        },
+    ),
+    "segmentation": Example(
+        summary="Image segmentation annotation",
+        description="Configuration for an image segmentation annotation with polygon points",
+        value={
+            "label": "Car",
+            "type": "polygon",
+            "points": [
+                [50, 50],
+                [150, 50],
+                [150, 150],
+                [50, 150],
+            ],
+        },
+    ),
+}
+
+
+# TODO: Replace the model with a proper one from `app.schemas` package when defined
+class Annotation(BaseIDModel):
+    """Represents an annotation for a media item."""
+
+
+@router.get(
+    "",
+    response_model=list[Annotation],
+    responses={
+        status.HTTP_200_OK: {"description": "List of annotations for the media"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid media ID"},
+        status.HTTP_404_NOT_FOUND: {"description": "Media not found"},
+    },
+)
+async def list_annotations(media_id: Annotated[UUID, Depends(get_media_id)]) -> list[Annotation]:
+    """List all annotations for a given media item."""
+    _ = media_id
+    raise NotImplementedError
+
+
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=Annotation,
+    responses={
+        status.HTTP_201_CREATED: {"description": "Annotation created successfully"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid media ID"},
+        status.HTTP_404_NOT_FOUND: {"description": "Media not found"},
+    },
+)
+async def create_annotation(
+    media_id: Annotated[UUID, Depends(get_media_id)],
+    annotation: Annotated[
+        Annotation,
+        Body(description=CREATE_ANNOTATION_BODY_DESCRIPTION, openapi_examples=CREATE_ANNOTATION_BODY_EXAMPLES),
+    ],
+) -> Annotation:
+    """Create a new annotation for a media item."""
+    _ = annotation, media_id
+    raise NotImplementedError
+
+
+@router.delete(
+    "",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        status.HTTP_204_NO_CONTENT: {"description": "Annotations deleted successfully"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid media ID"},
+        status.HTTP_404_NOT_FOUND: {"description": "Media not found"},
+    },
+)
+async def delete_annotations(media_id: Annotated[UUID, Depends(get_media_id)]) -> None:
+    """Delete all annotations for a media item."""
+    _ = media_id
+    raise NotImplementedError

--- a/backend/app/api/endpoints/models.py
+++ b/backend/app/api/endpoints/models.py
@@ -8,10 +8,11 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 from fastapi.openapi.models import Example
 
 from app.api.dependencies import get_model_id, get_model_service
+from app.api.tags import Tags
 from app.schemas import Model
 from app.services import ModelService, ResourceInUseError, ResourceNotFoundError
 
-router = APIRouter(prefix="/api/models", tags=["Models"])
+router = APIRouter(prefix="/api/models", tags=[Tags.MODELS])
 
 
 UPDATE_MODEL_BODY_EXAMPLES = {

--- a/backend/app/api/endpoints/pipelines.py
+++ b/backend/app/api/endpoints/pipelines.py
@@ -14,11 +14,12 @@ from fastapi.responses import FileResponse
 from pydantic import ValidationError
 
 from app.api.dependencies import get_pipeline_id, get_pipeline_service
+from app.api.tags import Tags
 from app.schemas.pipeline import Pipeline, PipelineStatus
 from app.services import PipelineService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api/pipelines", tags=["Pipelines"])
+router = APIRouter(prefix="/api/pipelines", tags=[Tags.PIPELINES])
 
 CREATE_PIPELINE_BODY_DESCRIPTION = """
 Configuration for the new pipeline. Requires the IDs of a source, sink, and model to be combined into a pipeline.

--- a/backend/app/api/endpoints/sinks.py
+++ b/backend/app/api/endpoints/sinks.py
@@ -14,12 +14,13 @@ from fastapi.openapi.models import Example
 from fastapi.responses import FileResponse, Response
 
 from app.api.dependencies import get_configuration_service, get_sink_id
+from app.api.tags import Tags
 from app.schemas import Sink, SinkType
 from app.schemas.sink import SinkAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api/sinks", tags=["Sinks"])
+router = APIRouter(prefix="/api/sinks", tags=[Tags.SINKS])
 
 CREATE_SINK_BODY_DESCRIPTION = """
 Configuration for the new sink. The exact list of fields that can be configured depends on the sink type.

--- a/backend/app/api/endpoints/sources.py
+++ b/backend/app/api/endpoints/sources.py
@@ -14,12 +14,13 @@ from fastapi.openapi.models import Example
 from fastapi.responses import FileResponse, Response
 
 from app.api.dependencies import get_configuration_service, get_source_id
+from app.api.tags import Tags
 from app.schemas import Source, SourceType
 from app.schemas.source import SourceAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api/sources", tags=["Sources"])
+router = APIRouter(prefix="/api/sources", tags=[Tags.SOURCES])
 
 CREATE_SOURCE_BODY_DESCRIPTION = """
 Configuration for the new source. The exact list of fields that can be configured depends on the source type.

--- a/backend/app/api/tags.py
+++ b/backend/app/api/tags.py
@@ -1,0 +1,11 @@
+from enum import StrEnum
+
+
+class Tags(StrEnum):
+    """Enum for API tags."""
+
+    MODELS = "Models"
+    SINKS = "Sinks"
+    SOURCES = "Sources"
+    PIPELINES = "Pipelines"
+    ANNOTATIONS = "Annotations"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,9 @@
 #  - docker compose up
 #  - docker compose -f docker-compose.dev.yaml up
 
+import importlib
 import logging
+import pkgutil
 from pathlib import Path
 
 import uvicorn
@@ -16,7 +18,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 
-from app.api.endpoints import models, pipelines, sinks, sources, system, webrtc
+from app.api import endpoints
 from app.core import lifespan
 from app.settings import get_settings
 
@@ -48,12 +50,12 @@ app.add_middleware(  # TODO restrict settings in production
     allow_headers=["*"],
 )
 
-app.include_router(sources.router)
-app.include_router(sinks.router)
-app.include_router(pipelines.router)
-app.include_router(models.router)
-app.include_router(system.router)
-app.include_router(webrtc.router)
+# Include all API routers from the endpoints package
+for module_info in pkgutil.iter_modules(endpoints.__path__):
+    module_name = module_info.name
+    module = importlib.import_module(f"app.api.endpoints.{module_name}")
+    if hasattr(module, "router"):
+        app.include_router(module.router)
 
 cur_dir = Path(__file__).parent
 


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->
This PR adds API skeleton for annotations

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->
```bash
 curl -H "Content-Type: application/json" http://localhost:7860/api/media/721080f9-17e5-44d5-84d3-302245ec4ed/annotations
```
More curl examples can be found in api spec via http://localhost:7860/api/docs after running the server with default settings.

### Checklist

- [x] 3 new annotation endpoints
- [x] Added `Tags` enum
- [x] Automatically configure FastAPI router based on the base package name
- [ ] Code review has been done

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
