### PR TITLE
Fix issues during shutdown

### DIFF
--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -3,7 +3,8 @@
 
 from app.utils.diagnostics import log_threads
 from app.utils.queue import flush_queue
+from app.utils.signal import suppress_child_shutdown_signals
 from app.utils.singleton import Singleton
 from app.utils.visualization import Visualizer
 
-__all__ = ["Singleton", "Visualizer", "flush_queue", "log_threads"]
+__all__ = ["Singleton", "Visualizer", "flush_queue", "log_threads", "suppress_child_shutdown_signals"]

--- a/backend/app/utils/signal.py
+++ b/backend/app/utils/signal.py
@@ -7,7 +7,7 @@ import signal
 
 def suppress_child_shutdown_signals() -> None:
     """
-    Ignore shutdown signals (SIGINT, SIGTERM) in child processes.
+    Ignore shutdown signals (SIGINT) in child processes.
 
     This function prevents child processes from handling shutdown signals directly,
     ensuring that cleanup is coordinated through the parent process via the stop_event
@@ -38,4 +38,3 @@ def suppress_child_shutdown_signals() -> None:
     """
     if mp.get_start_method(allow_none=True) == "spawn" and mp.parent_process() is not None:
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        signal.signal(signal.SIGTERM, signal.SIG_IGN)

--- a/backend/app/utils/signal.py
+++ b/backend/app/utils/signal.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import multiprocessing as mp
+import signal
+
+
+def suppress_child_shutdown_signals() -> None:
+    """
+    Ignore shutdown signals (SIGINT, SIGTERM) in child processes.
+
+    This function prevents child processes from handling shutdown signals directly,
+    ensuring that cleanup is coordinated through the parent process via the stop_event
+    mechanism. This avoids race conditions and ensures consistent cleanup behavior.
+
+    Notes:
+        - Only applies when using 'spawn' start method (macOS, Windows)
+        - Child processes should perform resource cleanup via stop_event notification
+        - Parent process remains responsible for signal handling and process termination
+
+    Implementation:
+        Child processes should call this function at startup to ignore signals
+        and rely on stop_event.is_set() for graceful shutdown coordination.
+
+    Returns:
+        None
+
+    Example:
+        >>> def worker_process(stop_event, resource):
+        ...     suppress_child_shutdown_signals()
+        ...     try:
+        ...         while not stop_event.is_set():
+        ...             # perform work
+        ...             pass
+        ...     finally:
+        ...         # Cleanup resources when stop_event is set
+        ...         resource.cleanup()
+    """
+    if mp.get_start_method(allow_none=True) == "spawn" and mp.parent_process() is not None:
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)

--- a/backend/app/workers/inference.py
+++ b/backend/app/workers/inference.py
@@ -12,7 +12,7 @@ from model_api.models import DetectionResult, Model
 
 from app.entities.stream_data import InferenceData, StreamData
 from app.services import ModelService
-from app.utils import Visualizer, flush_queue, log_threads
+from app.utils import Visualizer, flush_queue, log_threads, suppress_child_shutdown_signals
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ def inference_routine(  # noqa: C901
     frame_queue: mp.Queue, pred_queue: mp.Queue, stop_event: EventClass, model_reload_event: EventClass
 ) -> None:
     """Load frames from the frame queue, run inference then inject the result into the predictions queue"""
+    suppress_child_shutdown_signals()
 
     def on_inference_completed(inf_result: DetectionResult, userdata: dict[str, Any]) -> None:
         stream_data: StreamData = userdata["stream_data"]

--- a/backend/app/workers/stream_loading.py
+++ b/backend/app/workers/stream_loading.py
@@ -13,7 +13,7 @@ from app.entities.stream_data import StreamData
 from app.entities.video_stream import VideoStream
 from app.schemas import Source, SourceType
 from app.services import ActivePipelineService, VideoStreamService
-from app.utils import flush_queue, log_threads
+from app.utils import flush_queue, log_threads, suppress_child_shutdown_signals
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +22,8 @@ def frame_acquisition_routine(
     frame_queue: mp.Queue, stop_event: EventClass, config_changed_condition: ConditionClass, cleanup: bool = True
 ) -> None:
     """Load frames from the video stream and inject them into the frame queue"""
+    suppress_child_shutdown_signals()
+
     active_pipeline_service = ActivePipelineService(config_changed_condition=config_changed_condition)
     prev_source_config: Source | None = None
     video_stream: VideoStream | None = None


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR introduces the `suppress_child_shutdown_signals()` utility function in `signal.py`. The function ensures that child processes spawned using the 'spawn' start method (macOS, Windows) ignore shutdown signals `SIGINT`, `SIGTERM`. This prevents child processes from handling these signals directly:

- [x] Child processes should call `suppress_child_shutdown_signals()`
- [x] Signals are ignored only if the process is a child and the 'spawn' method is used.
- [x] The parent process remains responsible for signal handling and process termination. 
- [x] Code review has been done

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

1. Run the server with `./run.sh`
2. Try to trigger shutdown either with `kill -SIGINT <process_id>` or using `Ctrl+C`
3. Server stack trace should be clean and the process is finished

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
