### PR TITLE
Added default source and sink

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -10,7 +10,14 @@ import click
 
 from app.db import get_db_session, migration_manager
 from app.db.schema import DatasetItemDB, LabelDB, ModelDB, PipelineDB, ProjectDB, SinkDB, SourceDB
-from app.schemas import ModelFormat, OutputFormat, SinkType, SourceType
+from app.schemas import (
+    DisconnectedSinkConfig,
+    DisconnectedSourceConfig,
+    ModelFormat,
+    OutputFormat,
+    SinkType,
+    SourceType,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -87,6 +94,24 @@ def seed(with_model: bool, model_name: str) -> None:
             exclusive_labels=True,
         )
         pipeline = PipelineDB()
+
+        # Create default disconnected source and sink
+        disconnected_source = SourceDB(
+            id="00000000-0000-0000-0000-000000000000",
+            name=DisconnectedSourceConfig().name,
+            source_type=DisconnectedSourceConfig().source_type,
+            config_data={},
+        )
+        disconnected_sink = SinkDB(
+            id="00000000-0000-0000-0000-000000000000",
+            name=DisconnectedSinkConfig().name,
+            sink_type=DisconnectedSinkConfig().sink_type,
+            output_formats=[],
+            config_data={},
+        )
+        db.add(disconnected_source)
+        db.add(disconnected_sink)
+
         project.pipeline = pipeline
         pipeline.source = SourceDB(
             id="f6b1ac22-e36c-4b36-9a23-62b0881e4223",

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -96,16 +96,18 @@ def seed(with_model: bool, model_name: str) -> None:
         pipeline = PipelineDB()
 
         # Create default disconnected source and sink
+        disconnected_source_cfg = DisconnectedSourceConfig()
         disconnected_source = SourceDB(
             id="00000000-0000-0000-0000-000000000000",
-            name=DisconnectedSourceConfig().name,
-            source_type=DisconnectedSourceConfig().source_type,
+            name=disconnected_source_cfg.name,
+            source_type=disconnected_source_cfg.source_type,
             config_data={},
         )
+        disconnected_sink_cfg = DisconnectedSinkConfig()
         disconnected_sink = SinkDB(
             id="00000000-0000-0000-0000-000000000000",
-            name=DisconnectedSinkConfig().name,
-            sink_type=DisconnectedSinkConfig().sink_type,
+            name=disconnected_sink_cfg.name,
+            sink_type=disconnected_sink_cfg.sink_type,
             output_formats=[],
             config_data={},
         )


### PR DESCRIPTION
### Summary

This PR adds the default disconnects source and sink to the DB when seeding.

<img width="1095" height="116" alt="image" src="https://github.com/user-attachments/assets/d03c855e-a681-44c2-88ef-467a3fb987c7" />

### How to test

` uv run .\app\cli.py seed --with-model=True`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
