### PR TITLE
Custom location for data folder

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -144,18 +144,20 @@ def get_system_service() -> SystemService:
 
 @lru_cache
 def get_model_service(
+    request: Request,
     scheduler: Annotated[Scheduler, Depends(get_scheduler)],
 ) -> ModelService:
     """Provides a ModelService instance with the model reload event from the scheduler."""
     return ModelService(
+        data_dir=request.app.state.settings.data_dir,
         mp_model_reload_event=scheduler.mp_model_reload_event,
     )
 
 
 @lru_cache
-def get_dataset_service() -> DatasetService:
+def get_dataset_service(request: Request) -> DatasetService:
     """Provides a DatasetService instance."""
-    return DatasetService()
+    return DatasetService(request.app.state.settings.data_dir)
 
 
 def get_webrtc_manager(request: Request) -> WebRTCManager:

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -8,7 +8,7 @@ import sys
 
 import click
 
-from app.db import get_db_session, migration_manager
+from app.db import MigrationManager, get_db_session
 from app.db.schema import DatasetItemDB, LabelDB, ModelDB, PipelineDB, ProjectDB, SinkDB, SourceDB
 from app.schemas import (
     DisconnectedSinkConfig,
@@ -18,9 +18,12 @@ from app.schemas import (
     SinkType,
     SourceType,
 )
+from app.settings import get_settings
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+settings = get_settings()
+migration_manager = MigrationManager(settings)
 
 
 @click.group()

--- a/backend/app/core/lifecycle.py
+++ b/backend/app/core/lifecycle.py
@@ -10,7 +10,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.core.scheduler import Scheduler
-from app.db import migration_manager
+from app.db import MigrationManager
 from app.settings import get_settings
 from app.webrtc.manager import WebRTCManager
 
@@ -22,9 +22,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """FastAPI lifespan context manager"""
     # Startup
     settings = get_settings()
+    app.state.settings = settings
     logger.info("Starting %s application...", settings.app_name)
 
     # Initialize database
+    migration_manager = MigrationManager(settings)
     if not migration_manager.initialize_database():
         logger.error("Failed to initialize database. Application cannot start.")
         raise RuntimeError("Database initialization failed")

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from app.db.engine import db_engine, get_db_session
-from app.db.migration import migration_manager
+from app.db.migration import MigrationManager
 
-__all__ = ["db_engine", "get_db_session", "migration_manager"]
+__all__ = ["MigrationManager", "db_engine", "get_db_session"]

--- a/backend/app/db/migration.py
+++ b/backend/app/db/migration.py
@@ -12,7 +12,7 @@ from alembic.script import ScriptDirectory
 from sqlalchemy import text
 
 from app.db import db_engine
-from app.settings import get_settings
+from app.settings import Settings
 
 logger = logging.getLogger(__name__)
 
@@ -24,13 +24,13 @@ class RevisionNotFoundError(Exception):
 class MigrationManager:
     """Manages database connections and migrations"""
 
-    def __init__(self) -> None:
-        self.settings = get_settings()
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
         self.__ensure_data_directory()
 
     def __ensure_data_directory(self) -> None:
         """Ensure the data directory exists"""
-        db_path = self.settings.database_dir
+        db_path = self.settings.data_dir
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
@@ -118,6 +118,3 @@ class MigrationManager:
         except Exception as e:
             logger.error(f"Database initialization failed: {e}")
             return False
-
-
-migration_manager = MigrationManager()

--- a/backend/app/db/migration.py
+++ b/backend/app/db/migration.py
@@ -30,8 +30,7 @@ class MigrationManager:
 
     def __ensure_data_directory(self) -> None:
         """Ensure the data directory exists"""
-        db_path = self.settings.data_dir
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.settings.data_dir.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def check_connection() -> bool:

--- a/backend/app/services/dataset_service.py
+++ b/backend/app/services/dataset_service.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
@@ -48,8 +47,7 @@ class DatasetService:
         )
 
         dataset_dir = self.projects_dir / f"{project_id}/dataset"
-        if not os.path.exists(dataset_dir):
-            os.makedirs(dataset_dir)
+        dataset_dir.mkdir(parents=True, exist_ok=True)
         image.save(dataset_dir / f"{dataset_item_id}.{format}")
 
         try:

--- a/backend/app/services/dataset_service.py
+++ b/backend/app/services/dataset_service.py
@@ -24,8 +24,9 @@ DEFAULT_THUMBNAIL_SIZE = 256
 
 
 class DatasetService:
-    def __init__(self) -> None:
+    def __init__(self, data_dir: Path) -> None:
         self.mapper = DatasetItemMapper()
+        self.projects_dir = data_dir / "projects"
 
     def create_dataset_item(self, project_id: UUID, name: str, format: str, size: int, file: BinaryIO) -> DatasetItem:
         """Creates a new dataset item"""
@@ -46,10 +47,10 @@ class DatasetService:
             subset=DatasetItemSubset.UNASSIGNED,
         )
 
-        dataset_dir = Path(f"data/projects/{str(project_id)}/dataset")
+        dataset_dir = self.projects_dir / f"{project_id}/dataset"
         if not os.path.exists(dataset_dir):
             os.makedirs(dataset_dir)
-        image.save(dataset_dir / f"{str(dataset_item_id)}.{format}")
+        image.save(dataset_dir / f"{dataset_item_id}.{format}")
 
         try:
             thumbnail_image = crop_to_thumbnail(
@@ -57,7 +58,7 @@ class DatasetService:
             )
             if thumbnail_image.mode in ("RGBA", "P"):
                 thumbnail_image = thumbnail_image.convert("RGB")
-            thumbnail_image.save(dataset_dir / f"{str(dataset_item_id)}-thumb.jpg")
+            thumbnail_image.save(dataset_dir / f"{dataset_item_id}-thumb.jpg")
         except Exception as e:
             logger.exception("Failed to generate thumbnail image %s", e)
 
@@ -110,7 +111,7 @@ class DatasetService:
             dataset_item = repo.get_by_id(str(dataset_item_id))
             if not dataset_item:
                 raise ResourceNotFoundError(ResourceType.DATASET_ITEM, str(dataset_item_id))
-        return Path(f"data/projects/{str(project_id)}/dataset/{dataset_item.id}.{dataset_item.format}")
+        return self.projects_dir / f"{project_id}/dataset/{dataset_item.id}.{dataset_item.format}"
 
     def get_dataset_item_thumbnail_path_by_id(self, project_id: UUID, dataset_item_id: UUID) -> Path | str:
         """Get a dataset item thumbnail binary content by its ID"""
@@ -119,7 +120,7 @@ class DatasetService:
             dataset_item = repo.get_by_id(str(dataset_item_id))
             if not dataset_item:
                 raise ResourceNotFoundError(ResourceType.DATASET_ITEM, str(dataset_item_id))
-        return Path(f"data/projects/{str(project_id)}/dataset/{str(dataset_item.id)}-thumb.jpg")
+        return self.projects_dir / f"{project_id}/dataset/{dataset_item.id}-thumb.jpg"
 
     def delete_dataset_item(self, project_id: UUID, dataset_item_id: UUID) -> None:
         """Delete a dataset item by its ID"""

--- a/backend/app/services/model_service.py
+++ b/backend/app/services/model_service.py
@@ -45,8 +45,8 @@ class LoadedModel:
 class ModelService:
     """Service to register and activate models"""
 
-    def __init__(self, mp_model_reload_event: EventClass | None = None) -> None:
-        self.models_dir = Path("data/models")
+    def __init__(self, data_dir: Path, mp_model_reload_event: EventClass | None = None) -> None:
+        self.models_dir = data_dir / "models"
         self._mp_model_reload_event = mp_model_reload_event
 
         self._persistence: GenericPersistenceService[Model, ModelRepository] = GenericPersistenceService(

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -28,15 +28,14 @@ class Settings(BaseSettings):
     openapi_url: str = "/api/openapi.json"
     debug: bool = Field(default=False, alias="DEBUG")
     environment: Literal["dev", "prod"] = "dev"
+    data_dir: Path = Field(default="data", alias="DATA_DIR")
 
     # Server
     host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104
     port: int = Field(default=7860, alias="PORT")
 
     # Database
-    database_url: str = Field(
-        default="sqlite:///./data/geti_tune.db", alias="DATABASE_URL", description="Database connection URL"
-    )
+    database_file: str = Field(default="geti_tune.db", alias="DATABASE_FILE", description="Database filename")
     db_echo: bool = Field(default=False, alias="DB_ECHO")
 
     # Alembic
@@ -47,12 +46,9 @@ class Settings(BaseSettings):
     no_proxy: str = Field(default="localhost,127.0.0.1,::1", alias="no_proxy")
 
     @property
-    def database_dir(self) -> Path:
-        """Get database directory path"""
-        if self.database_url.startswith("sqlite:///"):
-            db_path = Path(self.database_url.replace("sqlite:///", ""))
-            return db_path.parent
-        return Path("./data")
+    def database_url(self) -> str:
+        """Get database URL"""
+        return f"sqlite:///{self.data_dir / self.database_file}"
 
 
 @lru_cache

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     openapi_url: str = "/api/openapi.json"
     debug: bool = Field(default=False, alias="DEBUG")
     environment: Literal["dev", "prod"] = "dev"
-    data_dir: Path = Field(default="data", alias="DATA_DIR")
+    data_dir: Path = Field(default=Path("data"), alias="DATA_DIR")
 
     # Server
     host: str = Field(default="0.0.0.0", alias="HOST")  # noqa: S104

--- a/backend/app/workers/inference.py
+++ b/backend/app/workers/inference.py
@@ -12,9 +12,9 @@ from uuid import UUID
 from model_api.models import DetectionResult, Model
 
 from app.entities.stream_data import InferenceData, StreamData
-from app.services import ModelService
-from app.services.metrics_service import MetricsService
+from app.services import MetricsService, ModelService
 from app.services.model_service import LoadedModel
+from app.settings import get_settings
 from app.utils import Visualizer
 from app.workers.base import BaseProcessWorker
 
@@ -49,7 +49,7 @@ class InferenceWorker(BaseProcessWorker):
 
     def setup(self) -> None:
         self._metrics_service = MetricsService(self._shm_name, self._shm_lock)
-        self._model_service = ModelService()
+        self._model_service = ModelService(get_settings().data_dir)
 
     def _on_inference_completed(self, inf_result: DetectionResult, userdata: dict[str, Any]) -> None:
         start_time = float(userdata["inference_start_time"])

--- a/backend/tests/integration/services/test_dataset_service.py
+++ b/backend/tests/integration/services/test_dataset_service.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 import os.path
+import shutil
+from collections.abc import Generator
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -19,6 +21,16 @@ from app.services.dataset_service import DatasetService
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def projects_dir() -> Generator[Path]:
+    """Setup a temporary data directory for tests."""
+    projects_dir = Path("data/projects")
+    if not projects_dir.exists():
+        projects_dir.mkdir(parents=True)
+    yield projects_dir
+    shutil.rmtree(projects_dir)
+
+
 @pytest.fixture(autouse=True)
 def mock_get_db_session(db_session):
     """Mock the get_db_session to use test database."""
@@ -29,9 +41,9 @@ def mock_get_db_session(db_session):
 
 
 @pytest.fixture
-def fxt_dataset_service() -> DatasetService:
+def fxt_dataset_service(projects_dir: Path) -> DatasetService:
     """Fixture to create a DatasetService instance."""
-    return DatasetService()
+    return DatasetService(projects_dir.parent)
 
 
 @pytest.fixture

--- a/backend/tests/integration/services/test_model_service.py
+++ b/backend/tests/integration/services/test_model_service.py
@@ -49,8 +49,7 @@ def fxt_model_service(fxt_db_projects, db_session):
     db_session.add(db_project)
     db_session.flush()
     with TemporaryDirectory(suffix="models") as tmpdir:
-        service = ModelService()
-        service.models_dir = Path(tmpdir)
+        service = ModelService(Path(tmpdir).parent)
         service._model_activation_state = ModelActivationState(
             active_model=None, active_model_id=None, available_models=[]
         )


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR introduces support for customizing the `DATA_DIR` via environment variable in the backend application. The following changes were made:

- The `Settings` class now reads the `DATA_DIR` environment variable to set the application's data directory, defaulting to `data` if not provided.
- All services that previously used hardcoded values for the data directory have been updated to use the value from `Settings.data_dir` instead.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

**Default Behavior:**
1. Start the backend without setting `DATA_DIR`. 

```bash
SEED_DB=true ./run.sh
```

2. Verify db file is created in default location.

**Custom Data Directory:**
1. Start the backend with env variable.

```bash
DATA_DIR=../resources SEED_DB=true ./run.sh
```
2. Verify db file is created in the new location.