### PR TITLE
Fix RandomAffine and RTDetr training with IoURandomCrop

### DIFF
--- a/lib/src/otx/data/transform_libs/torchvision.py
+++ b/lib/src/otx/data/transform_libs/torchvision.py
@@ -1334,7 +1334,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             return
 
         # Convert valid_index to numpy boolean array if it's a tensor
-        if valid_index and hasattr(valid_index, "numpy"):
+        if valid_index is not None and hasattr(valid_index, "numpy"):
             valid_index = valid_index.numpy()
 
         # Filter masks using valid_index first

--- a/lib/src/otx/data/transform_libs/torchvision.py
+++ b/lib/src/otx/data/transform_libs/torchvision.py
@@ -1225,7 +1225,6 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         Raises:
             ValueError: If inputs format is invalid.
         """
-
         if len(_inputs) != 1:
             msg = f"RandomAffine can only transform single input, got {len(_inputs)}"
             raise ValueError(msg)
@@ -1379,12 +1378,12 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             return warped_mask > 127
 
         return cv2.warpPerspective(
-                    mask.astype(np.uint8),
-                    warp_matrix,
-                    dsize=(width, height),
-                    flags=cv2.INTER_NEAREST,
-                    borderValue=0,
-                )
+            mask.astype(np.uint8),
+            warp_matrix,
+            dsize=(width, height),
+            flags=cv2.INTER_NEAREST,
+            borderValue=0,
+        )
 
     def _transform_polygons(
         self,
@@ -1414,7 +1413,9 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             valid_index = valid_index.numpy()
 
         # Filter polygons using valid_index if available
-        filtered_polygons = [p for p, keep in zip(inputs.polygons, valid_index) if keep] if valid_index is not None else inputs.polygons
+        filtered_polygons = (
+            [p for p, keep in zip(inputs.polygons, valid_index) if keep] if valid_index is not None else inputs.polygons
+        )
 
         if filtered_polygons:
             inputs.polygons = project_polygons(filtered_polygons, warp_matrix, output_shape)

--- a/lib/src/otx/data/transform_libs/torchvision.py
+++ b/lib/src/otx/data/transform_libs/torchvision.py
@@ -1159,7 +1159,6 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
     ) -> None:
         super().__init__()
         self._validate_parameters(max_translate_ratio, scaling_ratio_range)
-
         self.max_rotate_degree = max_rotate_degree
         self.max_translate_ratio = max_translate_ratio
         self.scaling_ratio_range = scaling_ratio_range
@@ -1226,6 +1225,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         Raises:
             ValueError: If inputs format is invalid.
         """
+
         if len(_inputs) != 1:
             msg = f"RandomAffine can only transform single input, got {len(_inputs)}"
             raise ValueError(msg)
@@ -1238,7 +1238,13 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         homography_matrix = self._get_random_homography_matrix(height, width)
         output_shape = (height + self.border[0] * 2, width + self.border[1] * 2)
 
-        if hasattr(inputs, "bboxes") and inputs.bboxes is not None and len(inputs.bboxes) > 0:
+        transformed_img = self._warp_image(img, homography_matrix, output_shape)
+        inputs.image = transformed_img
+        inputs.img_info = _resize_image_info(inputs.img_info, transformed_img.shape[:2])
+        valid_index = None
+        valid_bboxes = hasattr(inputs, "bboxes") and inputs.bboxes is not None and len(inputs.bboxes) > 0
+
+        if valid_bboxes:
             # Test transform bboxes to see if any remain valid
             valid_index = self._transform_bboxes(inputs, homography_matrix, output_shape)
             # If no valid annotations will remain after transformation, skip entirely
@@ -1246,20 +1252,14 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
                 inputs.image = img
                 return self.convert(inputs)  # type: ignore[return-value]
 
-            # If we reach here, transformation will produce valid results, so proceed
-            # Transform image
-            transformed_img = self._warp_image(img, homography_matrix, output_shape)
-            inputs.image = transformed_img
-            inputs.img_info = _resize_image_info(inputs.img_info, transformed_img.shape[:2])
+        if hasattr(inputs, "masks") and inputs.masks is not None and len(inputs.masks) > 0:
+            self._transform_masks(inputs, homography_matrix, output_shape, valid_index)
 
-            if hasattr(inputs, "masks") and inputs.masks is not None and len(inputs.masks) > 0:
-                self._transform_masks(inputs, homography_matrix, output_shape, valid_index)
+        if hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0:
+            self._transform_polygons(inputs, homography_matrix, output_shape, valid_index)
 
-            if hasattr(inputs, "polygons") and inputs.polygons is not None and len(inputs.polygons) > 0:
-                self._transform_polygons(inputs, homography_matrix, output_shape, valid_index)
-
-            if self.recompute_bbox:
-                self._recompute_bboxes(inputs, output_shape)
+        if valid_bboxes and self.recompute_bbox:
+            self._recompute_bboxes(inputs, output_shape)
 
         return self.convert(inputs)  # type: ignore[return-value]
 
@@ -1321,7 +1321,7 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
         inputs: OTXDataItem,
         warp_matrix: np.ndarray,
         output_size: tuple[int, int],
-        valid_index: np.ndarray,
+        valid_index: np.ndarray | None = None,
     ) -> None:
         """Transform masks using the warp matrix.
 
@@ -1335,11 +1335,11 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             return
 
         # Convert valid_index to numpy boolean array if it's a tensor
-        if hasattr(valid_index, "numpy"):
+        if valid_index and hasattr(valid_index, "numpy"):
             valid_index = valid_index.numpy()
 
         # Filter masks using valid_index first
-        masks = inputs.masks[valid_index]
+        masks = inputs.masks[valid_index] if valid_index is not None else inputs.masks
         masks = masks.numpy() if not isinstance(masks, np.ndarray) else masks
 
         if masks.ndim == 3:
@@ -1378,15 +1378,20 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             )
             return warped_mask > 127
 
-        msg = "Multi-class masks are not supported yet."
-        raise NotImplementedError(msg)
+        return cv2.warpPerspective(
+                    mask.astype(np.uint8),
+                    warp_matrix,
+                    dsize=(width, height),
+                    flags=cv2.INTER_NEAREST,
+                    borderValue=0,
+                )
 
     def _transform_polygons(
         self,
         inputs: OTXDataItem,
         warp_matrix: np.ndarray,
         output_shape: tuple[int, int],
-        valid_index: np.ndarray,
+        valid_index: np.ndarray | None = None,
     ) -> None:
         """Transform polygons using the warp matrix.
 
@@ -1405,11 +1410,11 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             return
 
         # Convert valid_index to numpy boolean array if it's a tensor
-        if hasattr(valid_index, "numpy"):
+        if valid_index is not None and hasattr(valid_index, "numpy"):
             valid_index = valid_index.numpy()
 
-        # Filter polygons using valid_index
-        filtered_polygons = [p for p, keep in zip(inputs.polygons, valid_index) if keep]
+        # Filter polygons using valid_index if available
+        filtered_polygons = [p for p, keep in zip(inputs.polygons, valid_index) if keep] if valid_index is not None else inputs.polygons
 
         if filtered_polygons:
             inputs.polygons = project_polygons(filtered_polygons, warp_matrix, output_shape)

--- a/lib/src/otx/recipe/detection/dfine_x.yaml
+++ b/lib/src/otx/recipe/detection/dfine_x.yaml
@@ -85,6 +85,22 @@ overrides:
         - class_path: otx.data.transform_libs.torchvision.RandomFlip
           init_args:
             probability: 0.5
+        - class_path: torchvision.transforms.v2.RandomPhotometricDistort
+          enable: false
+          init_args:
+            brightness:
+              - 0.875
+              - 1.125
+            contrast:
+              - 0.5
+              - 1.5
+            saturation:
+              - 0.5
+              - 1.5
+            hue:
+              - -0.05
+              - 0.05
+            p: 0.5
         - class_path: otx.data.transform_libs.torchvision.RandomAffine
           enable: false
           init_args:

--- a/lib/src/otx/recipe/detection/dfine_x.yaml
+++ b/lib/src/otx/recipe/detection/dfine_x.yaml
@@ -66,42 +66,25 @@ overrides:
       batch_size: 8
       num_workers: 4
       transforms:
-        - class_path: torchvision.transforms.v2.RandomPhotometricDistort
-          init_args:
-            p: 0.5
         - class_path: torchvision.transforms.v2.RandomZoomOut
+          enable: true
           init_args:
             fill: 0
         - class_path: otx.data.transform_libs.torchvision.RandomIoUCrop
+          enable: true
           init_args:
             probability: 0.8
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
           init_args:
             min_size: 1
-        - class_path: otx.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            probability: 0.5
         - class_path: otx.data.transform_libs.torchvision.Resize
           init_args:
             scale: $(input_size)
             transform_bbox: true
             keep_ratio: false
-        - class_path: torchvision.transforms.v2.RandomPhotometricDistort
-          enable: false
+        - class_path: otx.data.transform_libs.torchvision.RandomFlip
           init_args:
-            brightness:
-              - 0.875
-              - 1.125
-            contrast:
-              - 0.5
-              - 1.5
-            saturation:
-              - 0.5
-              - 1.5
-            hue:
-              - -0.05
-              - 0.05
-            p: 0.5
+            probability: 0.5
         - class_path: otx.data.transform_libs.torchvision.RandomAffine
           enable: false
           init_args:

--- a/lib/src/otx/recipe/detection/dfine_x_tile.yaml
+++ b/lib/src/otx/recipe/detection/dfine_x_tile.yaml
@@ -68,26 +68,25 @@ overrides:
       num_workers: 4
       to_tv_image: true
       transforms:
-        - class_path: torchvision.transforms.v2.RandomPhotometricDistort
-          init_args:
-            p: 0.5
         - class_path: torchvision.transforms.v2.RandomZoomOut
+          enable: true
           init_args:
             fill: 0
         - class_path: otx.data.transform_libs.torchvision.RandomIoUCrop
+          enable: true
           init_args:
             probability: 0.8
         - class_path: torchvision.transforms.v2.SanitizeBoundingBoxes
           init_args:
             min_size: 1
-        - class_path: otx.data.transform_libs.torchvision.RandomFlip
-          init_args:
-            probability: 0.5
         - class_path: otx.data.transform_libs.torchvision.Resize
           init_args:
             scale: $(input_size)
             transform_bbox: true
             keep_ratio: false
+        - class_path: otx.data.transform_libs.torchvision.RandomFlip
+          init_args:
+            probability: 0.5
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           enable: false
           init_args:

--- a/lib/src/otx/recipe/detection/rtdetr_101.yaml
+++ b/lib/src/otx/recipe/detection/rtdetr_101.yaml
@@ -63,6 +63,13 @@ overrides:
     train_subset:
       batch_size: 4
       transforms:
+        - class_path: otx.data.transform_libs.torchvision.MinIoURandomCrop
+          enable: false
+        - class_path: otx.data.transform_libs.torchvision.Resize
+          init_args:
+            scale: $(input_size)
+            keep_ratio: false
+            transform_bbox: true
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           enable: false
           init_args:
@@ -79,11 +86,6 @@ overrides:
               - -0.05
               - 0.05
             p: 0.5
-        - class_path: otx.data.transform_libs.torchvision.Resize
-          init_args:
-            scale: $(input_size)
-            keep_ratio: false
-            transform_bbox: true
         - class_path: otx.data.transform_libs.torchvision.RandomAffine
           enable: false
           init_args:
@@ -94,6 +96,7 @@ overrides:
               - 1.5
             max_shear_degree: 2.0
         - class_path: otx.data.transform_libs.torchvision.RandomFlip
+          enable: true
           init_args:
             probability: 0.5
         - class_path: torchvision.transforms.v2.RandomVerticalFlip

--- a/lib/src/otx/recipe/detection/rtdetr_18.yaml
+++ b/lib/src/otx/recipe/detection/rtdetr_18.yaml
@@ -62,6 +62,13 @@ overrides:
     train_subset:
       batch_size: 4
       transforms:
+        - class_path: otx.data.transform_libs.torchvision.MinIoURandomCrop
+          enable: false
+        - class_path: otx.data.transform_libs.torchvision.Resize
+          init_args:
+            scale: $(input_size)
+            keep_ratio: false
+            transform_bbox: true
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           enable: false
           init_args:
@@ -78,11 +85,6 @@ overrides:
               - -0.05
               - 0.05
             p: 0.5
-        - class_path: otx.data.transform_libs.torchvision.Resize
-          init_args:
-            scale: $(input_size)
-            keep_ratio: false
-            transform_bbox: true
         - class_path: otx.data.transform_libs.torchvision.RandomAffine
           enable: false
           init_args:
@@ -93,6 +95,7 @@ overrides:
               - 1.5
             max_shear_degree: 2.0
         - class_path: otx.data.transform_libs.torchvision.RandomFlip
+          enable: true
           init_args:
             probability: 0.5
         - class_path: torchvision.transforms.v2.RandomVerticalFlip

--- a/lib/src/otx/recipe/detection/rtdetr_50.yaml
+++ b/lib/src/otx/recipe/detection/rtdetr_50.yaml
@@ -63,6 +63,13 @@ overrides:
     train_subset:
       batch_size: 4
       transforms:
+        - class_path: otx.data.transform_libs.torchvision.MinIoURandomCrop
+          enable: false
+        - class_path: otx.data.transform_libs.torchvision.Resize
+          init_args:
+            scale: $(input_size)
+            keep_ratio: false
+            transform_bbox: true
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           enable: false
           init_args:
@@ -79,11 +86,6 @@ overrides:
               - -0.05
               - 0.05
             p: 0.5
-        - class_path: otx.data.transform_libs.torchvision.Resize
-          init_args:
-            scale: $(input_size)
-            keep_ratio: false
-            transform_bbox: true
         - class_path: otx.data.transform_libs.torchvision.RandomAffine
           enable: false
           init_args:
@@ -94,6 +96,7 @@ overrides:
               - 1.5
             max_shear_degree: 2.0
         - class_path: otx.data.transform_libs.torchvision.RandomFlip
+          enable: true
           init_args:
             probability: 0.5
         - class_path: torchvision.transforms.v2.RandomVerticalFlip

--- a/lib/src/otx/recipe/detection/rtmdet_tiny.yaml
+++ b/lib/src/otx/recipe/detection/rtmdet_tiny.yaml
@@ -81,15 +81,6 @@ overrides:
         - class_path: otx.data.transform_libs.torchvision.RandomCrop
           init_args:
             crop_size: $(input_size)
-        - class_path: otx.data.transform_libs.torchvision.RandomAffine
-          enable: false
-          init_args:
-            max_rotate_degree: 10.0
-            max_translate_ratio: 0.1
-            scaling_ratio_range:
-              - 0.5
-              - 1.5
-            max_shear_degree: 2.0
         - class_path: torchvision.transforms.v2.RandomPhotometricDistort
           enable: false
           init_args:
@@ -106,6 +97,15 @@ overrides:
               - -0.05
               - 0.05
             p: 0.5
+        - class_path: otx.data.transform_libs.torchvision.RandomAffine
+          enable: false
+          init_args:
+            max_rotate_degree: 10.0
+            max_translate_ratio: 0.1
+            scaling_ratio_range:
+              - 0.5
+              - 1.5
+            max_shear_degree: 2.0
         - class_path: otx.data.transform_libs.torchvision.YOLOXHSVRandomAug
         - class_path: otx.data.transform_libs.torchvision.RandomFlip
           init_args:

--- a/lib/src/otx/tools/converter.py
+++ b/lib/src/otx/tools/converter.py
@@ -360,6 +360,7 @@ def update_augmentations(augmentation_params: dict, config: dict) -> None:
         "mosaic": ["otx.data.transform_libs.torchvision.CachedMosaic"],
     }
 
+    breakpoint()
     for aug_name, aug_value in augmentation_params.items():
         aug_classes = augs_mapping_list[aug_name]
         found = False

--- a/lib/src/otx/tools/converter.py
+++ b/lib/src/otx/tools/converter.py
@@ -360,7 +360,6 @@ def update_augmentations(augmentation_params: dict, config: dict) -> None:
         "mosaic": ["otx.data.transform_libs.torchvision.CachedMosaic"],
     }
 
-    breakpoint()
     for aug_name, aug_value in augmentation_params.items():
         aug_classes = augs_mapping_list[aug_name]
         found = False


### PR DESCRIPTION
### Summary
resolves https://github.com/open-edge-platform/geti/issues/1312
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
