### PR TITLE
[GHA] Add concurrency to PR workflows

### DIFF
--- a/.github/workflows/backend-lint-and-test.yaml
+++ b/.github/workflows/backend-lint-and-test.yaml
@@ -15,6 +15,10 @@ on:
 
 permissions: {} # No permissions by default on workflow level
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   # Determines if workflow should execute based on event type and changed paths
   # If push or workflow_dispatch -> always run

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,10 @@ on:
 
 permissions: {} # No permissions by default on workflow level
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   # Determines if workflow should execute based on event type and changed paths
   # If push or workflow_dispatch -> always run

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/lib-lint-and-test.yaml
+++ b/.github/workflows/lib-lint-and-test.yaml
@@ -17,7 +17,7 @@ on:
 permissions: {} # No permissions by default
 
 concurrency:
-  group: ${{ github.workflow }}-PreMerge-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-security-scan.yaml
+++ b/.github/workflows/pr-security-scan.yaml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   zizmor-scan-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-lint-and-test.yaml
+++ b/.github/workflows/ui-lint-and-test.yaml
@@ -16,6 +16,10 @@ on:
 
 permissions: {} # No permissions by default on workflow level
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   # Determines if workflow should execute based on event type and changed paths
   # If push or workflow_dispatch -> always run


### PR DESCRIPTION
### Summary

Add concurrency configuration to all workflows that have pull_request triggers.

### How to test

Already worked for https://github.com/open-edge-platform/training_extensions/blob/develop/.github/workflows/renovate-config-validator.yml setting for other PR jobs to improve gh runners usage.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
