### PR TITLE
Fix loading checkpoint after 1st round of training for DFine-X model

### DIFF
--- a/lib/src/otx/backend/native/models/detection/d_fine.py
+++ b/lib/src/otx/backend/native/models/detection/d_fine.py
@@ -162,8 +162,8 @@ class DFine(RTDETR):
     def load_state_dict(self, ckpt: dict[str, Any], *args, **kwargs) -> None:
         """Load state dictionary from checkpoint state dictionary.
 
-        If checkpoint's label_info and OTXLitModule's label_info are different,
-        load_state_pre_hook for smart weight loading will be registered.
+        If a RuntimeError occurs due to size mismatch, non-trainable anchors and valid_mask
+        are removed from the checkpoint before loading.
         """
         try:
             return super().load_state_dict(ckpt, *args, **kwargs)

--- a/lib/src/otx/backend/native/models/detection/d_fine.py
+++ b/lib/src/otx/backend/native/models/detection/d_fine.py
@@ -158,3 +158,17 @@ class DFine(RTDETR):
                 },
             },
         }
+
+    def load_state_dict(self, ckpt: dict[str, Any], *args, **kwargs) -> None:
+        """Load state dictionary from checkpoint state dictionary.
+
+        If checkpoint's label_info and OTXLitModule's label_info are different,
+        load_state_pre_hook for smart weight loading will be registered.
+        """
+        try:
+            return super().load_state_dict(ckpt, *args, **kwargs)
+        except RuntimeError:
+            # Remove non-trainable anchors and valid_mask from the checkpoint to avoid size mismatch
+            ckpt.pop("model.decoder.anchors")
+            ckpt.pop("model.decoder.valid_mask")
+            return super().load_state_dict(ckpt, *args, strict=False, **kwargs)


### PR DESCRIPTION
### Summary
resolves: https://github.com/open-edge-platform/geti/issues/1316

see: https://github.com/Peterande/D-FINE/issues/280
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
