### PR TITLE
Migrate OTX Keypoint detection to use the new experimental dataset

### DIFF
--- a/lib/src/otx/data/dataset/keypoint_detection_new.py
+++ b/lib/src/otx/data/dataset/keypoint_detection_new.py
@@ -29,8 +29,6 @@ class OTXKeypointDetectionDataset(OTXDataset):
         sample_type = KeypointSample
         dm_subset = dm_subset.convert_to_schema(sample_type)
         super().__init__(dm_subset=dm_subset, sample_type=sample_type, **kwargs)
-        dm_subset = dm_subset.convert_to_schema(sample_type)
-        self.dm_subset = dm_subset
         labels = dm_subset.schema.attributes["label"].categories.labels
         self.label_info = LabelInfo(
             label_names=labels,

--- a/lib/src/otx/data/dataset/keypoint_detection_new.py
+++ b/lib/src/otx/data/dataset/keypoint_detection_new.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module for OTXKeypointDetectionDataset."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, List, Union
+
+import torch
+from torchvision.transforms.v2.functional import to_dtype, to_image
+
+from otx.data.entity.sample import KeypointSample
+from otx.data.transform_libs.torchvision import Compose
+from otx.types.label import LabelInfo
+
+from .base_new import OTXDataset
+
+Transforms = Union[Compose, Callable, List[Callable], dict[str, Compose | Callable | List[Callable]]]
+
+if TYPE_CHECKING:
+    from datumaro.experimental import Dataset
+
+
+class OTXKeypointDetectionDataset(OTXDataset):
+    """OTXDataset class for keypoint detection task."""
+
+    def __init__(self, dm_subset: Dataset, **kwargs) -> None:
+        sample_type = KeypointSample
+        super().__init__(dm_subset=dm_subset, sample_type=sample_type, **kwargs)
+        dm_subset = dm_subset.convert_to_schema(sample_type)
+        self.dm_subset = dm_subset
+        labels = dm_subset.schema.attributes["label"].categories.labels
+        self.label_info = LabelInfo(
+            label_names=labels,
+            label_groups=[],
+            label_ids=[str(i) for i in range(len(labels))],
+        )
+
+    def _get_item_impl(self, index: int) -> KeypointSample | None:
+        item = self.dm_subset[index]
+        keypoints = item.keypoints
+        keypoints[:, 2] = torch.clamp(keypoints[:, 2], max=1)  # OTX represents visibility as 0 or 1
+        item.keypoints = keypoints
+        item.image = to_dtype(to_image(item.image), torch.float32)
+        return self._apply_transforms(item)  # type: ignore[return-value]

--- a/lib/src/otx/data/dataset/keypoint_detection_new.py
+++ b/lib/src/otx/data/dataset/keypoint_detection_new.py
@@ -27,6 +27,7 @@ class OTXKeypointDetectionDataset(OTXDataset):
 
     def __init__(self, dm_subset: Dataset, **kwargs) -> None:
         sample_type = KeypointSample
+        dm_subset = dm_subset.convert_to_schema(sample_type)
         super().__init__(dm_subset=dm_subset, sample_type=sample_type, **kwargs)
         dm_subset = dm_subset.convert_to_schema(sample_type)
         self.dm_subset = dm_subset

--- a/lib/src/otx/data/entity/sample.py
+++ b/lib/src/otx/data/entity/sample.py
@@ -14,7 +14,14 @@ from datumaro import Mask
 from datumaro.components.media import Image
 from datumaro.experimental.dataset import Sample
 from datumaro.experimental.fields import ImageInfo as DmImageInfo
-from datumaro.experimental.fields import bbox_field, image_field, image_info_field, label_field, mask_field
+from datumaro.experimental.fields import (
+    bbox_field,
+    image_field,
+    image_info_field,
+    keypoints_field,
+    label_field,
+    mask_field,
+)
 from torchvision import tv_tensors
 
 from otx.data.entity.base import ImageInfo
@@ -174,3 +181,11 @@ class SegmentationSample(OTXSample):
             img_shape=shape,
             ori_shape=shape,
         )
+
+
+class KeypointSample(OTXSample):
+    """KeypointSample is a base class for OTX keypoint detection items."""
+
+    image: np.ndarray | tv_tensors.Image = image_field(dtype=pl.UInt8)
+    label: torch.Tensor = label_field(pl.Int32(), is_list=True)
+    keypoints: torch.Tensor = keypoints_field()

--- a/lib/src/otx/data/factory.py
+++ b/lib/src/otx/data/factory.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from datumaro.components.annotation import AnnotationType
-from datumaro.components.dataset import Dataset as DmDataset
 from datumaro.experimental import Dataset as DatasetNew
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.legacy import convert_from_legacy
@@ -22,6 +21,8 @@ from .dataset.base import OTXDataset, Transforms
 from .dataset.base_new import OTXDataset as OTXDatasetNew
 
 if TYPE_CHECKING:
+    from datumaro.components.dataset import Dataset as DmDataset
+
     from otx.config.data import SubsetConfig
 
 
@@ -80,16 +81,12 @@ class OTXDatasetFactory:
         if task == OTXTaskType.MULTI_CLASS_CLS:
             from .dataset.classification_new import ClassificationSample, OTXMulticlassClsDataset
 
-            if isinstance(dm_subset, DmDataset):
-                categories = cls._get_label_categories(dm_subset, data_format)
-                dataset = DatasetNew(ClassificationSample, categories={"label": categories})
-                for item in dm_subset:
-                    if len(item.media.data.shape) == 3:  # TODO(albert): Account for grayscale images
-                        dataset.append(ClassificationSample.from_dm_item(item))
-                common_kwargs["dm_subset"] = dataset
-            else:
-                msg = "Dataset must be of type DmDataset."
-                raise RuntimeError(msg)
+            categories = cls._get_label_categories(dm_subset, data_format)
+            dataset = DatasetNew(ClassificationSample, categories={"label": categories})
+            for item in dm_subset:
+                if len(item.media.data.shape) == 3:  # TODO(albert): Account for grayscale images
+                    dataset.append(ClassificationSample.from_dm_item(item))
+            common_kwargs["dm_subset"] = dataset
             return OTXMulticlassClsDataset(**common_kwargs)
 
         if task == OTXTaskType.MULTI_LABEL_CLS:
@@ -105,16 +102,12 @@ class OTXDatasetFactory:
         if task == OTXTaskType.DETECTION:
             from .dataset.detection_new import DetectionSample, OTXDetectionDataset
 
-            if isinstance(dm_subset, DmDataset):
-                categories = cls._get_label_categories(dm_subset, data_format)
-                dataset = DatasetNew(DetectionSample, categories={"label": categories})
-                for item in dm_subset:
-                    if len(item.media.data.shape) == 3:
-                        dataset.append(DetectionSample.from_dm_item(item))
-                common_kwargs["dm_subset"] = dataset
-            else:
-                msg = "Dataset must be of type DmDataset."
-                raise RuntimeError(msg)
+            categories = cls._get_label_categories(dm_subset, data_format)
+            dataset = DatasetNew(DetectionSample, categories={"label": categories})
+            for item in dm_subset:
+                if len(item.media.data.shape) == 3:
+                    dataset.append(DetectionSample.from_dm_item(item))
+            common_kwargs["dm_subset"] = dataset
             return OTXDetectionDataset(**common_kwargs)
 
         if task in [OTXTaskType.ROTATED_DETECTION, OTXTaskType.INSTANCE_SEGMENTATION]:
@@ -131,8 +124,10 @@ class OTXDatasetFactory:
             return OTXSegmentationDataset(**common_kwargs)
 
         if task == OTXTaskType.KEYPOINT_DETECTION:
-            from .dataset.keypoint_detection import OTXKeypointDetectionDataset
+            from .dataset.keypoint_detection_new import OTXKeypointDetectionDataset
 
+            dataset = convert_from_legacy(dm_subset)
+            common_kwargs["dm_subset"] = dataset
             return OTXKeypointDetectionDataset(**common_kwargs)
 
         raise NotImplementedError(task)


### PR DESCRIPTION
### Summary
This pull request adds support for keypoint detection tasks using the new dataset schema, refactors the dataset factory logic to simplify type checks, and introduces a new sample type for keypoint detection. The main changes are grouped below:

### Keypoint Detection Support

* Added a new `OTXKeypointDetectionDataset` class in `keypoint_detection_new.py` for handling keypoint detection tasks, including proper conversion of legacy datasets and keypoint visibility normalization.
* Introduced a new `KeypointSample` class in `sample.py` to represent keypoint detection samples, with fields for image, label, and keypoints.

### Dataset Factory Refactor

* Updated the dataset factory logic in `factory.py` to remove unnecessary type checks for classification and detection tasks, simplifying the creation process. [[1]](diffhunk://#diff-535a232efb8b265495f79f79fe09b2dc476c6cf5b18efb25c176ba0550d9c015L83-L92) [[2]](diffhunk://#diff-535a232efb8b265495f79f79fe09b2dc476c6cf5b18efb25c176ba0550d9c015L108-L117)
* Modified the keypoint detection branch in the factory to use the new dataset class and convert legacy datasets appropriately.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
