### PR TITLE
Update OTX classification task to use legacy converter

### DIFF
--- a/library/src/otx/data/dataset/classification_new.py
+++ b/library/src/otx/data/dataset/classification_new.py
@@ -24,7 +24,9 @@ class OTXMulticlassClsDataset(OTXDataset):
         Args:
             **kwargs: Keyword arguments to pass to OTXDataset
         """
-        super().__init__(dm_subset=dm_subset, sample_type=ClassificationSample, **kwargs)
+        sample_type = ClassificationSample
+        dm_subset = dm_subset.convert_to_schema(sample_type)
+        super().__init__(dm_subset=dm_subset, sample_type=sample_type, **kwargs)
 
         labels = dm_subset.schema.attributes["label"].categories.labels
         self.label_info = LabelInfo(

--- a/library/src/otx/data/entity/sample.py
+++ b/library/src/otx/data/entity/sample.py
@@ -11,7 +11,6 @@ import numpy as np
 import polars as pl
 import torch
 from datumaro import Mask
-from datumaro.components.media import Image
 from datumaro.experimental.dataset import Sample
 from datumaro.experimental.fields import ImageInfo as DmImageInfo
 from datumaro.experimental.fields import (
@@ -29,7 +28,6 @@ from torchvision import tv_tensors
 from otx.data.entity.base import ImageInfo
 
 if TYPE_CHECKING:
-    from datumaro import DatasetItem
     from torchvision.tv_tensors import BoundingBoxes, Mask
 
 
@@ -99,33 +97,6 @@ class ClassificationSample(OTXSample):
 
     image: np.ndarray | tv_tensors.Image = image_field(dtype=pl.UInt8)
     label: torch.Tensor = label_field(pl.Int32())
-
-    @classmethod
-    def from_dm_item(cls, item: DatasetItem) -> ClassificationSample:
-        """Create a ClassificationSample from a Datumaro DatasetItem.
-
-        Args:
-            item: Datumaro DatasetItem containing image and label
-
-        Returns:
-            ClassificationSample: Instance with image and label set
-        """
-        image = item.media_as(Image).data
-        label = item.annotations[0].label if item.annotations else None
-
-        img_shape = image.shape[:2]
-        img_info = ImageInfo(
-            img_idx=0,
-            img_shape=img_shape,
-            ori_shape=img_shape,
-        )
-
-        sample = cls(
-            image=image,
-            label=torch.as_tensor(label, dtype=torch.long) if label is not None else torch.tensor(-1, dtype=torch.long),
-        )
-        sample.img_info = img_info
-        return sample
 
 
 class DetectionSample(OTXSample):

--- a/library/src/otx/data/factory.py
+++ b/library/src/otx/data/factory.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from datumaro.components.annotation import AnnotationType
-from datumaro.experimental import Dataset as DatasetNew
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.legacy import convert_from_legacy
 
@@ -22,6 +21,7 @@ from .dataset.base_new import OTXDataset as OTXDatasetNew
 
 if TYPE_CHECKING:
     from datumaro.components.dataset import Dataset as DmDataset
+    from datumaro.experimental import Dataset as DatasetNew
 
     from otx.config.data import SubsetConfig
 
@@ -79,13 +79,9 @@ class OTXDatasetFactory:
             return OTXAnomalyDataset(task_type=task, **common_kwargs)
 
         if task == OTXTaskType.MULTI_CLASS_CLS:
-            from .dataset.classification_new import ClassificationSample, OTXMulticlassClsDataset
+            from .dataset.classification_new import OTXMulticlassClsDataset
 
-            categories = cls._get_label_categories(dm_subset, data_format)
-            dataset = DatasetNew(ClassificationSample, categories={"label": categories})
-            for item in dm_subset:
-                if len(item.media.data.shape) == 3:  # TODO(albert): Account for grayscale images
-                    dataset.append(ClassificationSample.from_dm_item(item))
+            dataset = convert_from_legacy(dm_subset)
             common_kwargs["dm_subset"] = dataset
             return OTXMulticlassClsDataset(**common_kwargs)
 
@@ -104,7 +100,6 @@ class OTXDatasetFactory:
 
             dataset = convert_from_legacy(dm_subset)
             common_kwargs["dm_subset"] = dataset
-
             return OTXDetectionDataset(**common_kwargs)
 
         if task in [OTXTaskType.ROTATED_DETECTION, OTXTaskType.INSTANCE_SEGMENTATION]:
@@ -112,7 +107,6 @@ class OTXDatasetFactory:
 
             dataset = convert_from_legacy(dm_subset)
             common_kwargs["dm_subset"] = dataset
-
             return OTXInstanceSegDataset(include_polygons=include_polygons, **common_kwargs)
 
         if task == OTXTaskType.SEMANTIC_SEGMENTATION:
@@ -120,7 +114,6 @@ class OTXDatasetFactory:
 
             dataset = convert_from_legacy(dm_subset)
             common_kwargs["dm_subset"] = dataset
-
             return OTXSegmentationDataset(**common_kwargs)
 
         if task == OTXTaskType.KEYPOINT_DETECTION:


### PR DESCRIPTION
### Summary
This pull request refactors the classification dataset pipeline to streamline the creation and conversion of classification samples and datasets. The main focus is on removing redundant code, relying more on schema-based dataset conversion, and cleaning up imports and type hints. These changes improve maintainability and consistency across the codebase.

**Refactoring and simplification of classification dataset creation:**

* The `ClassificationSample.from_dm_item` method is removed, as classification samples are now created through schema-based conversion, eliminating the need for custom sample construction logic.
* In `OTXMulticlassClsDataset.__init__`, the input `dm_subset` is explicitly converted to the `ClassificationSample` schema before passing it to the superclass, ensuring consistent sample typing.
* In the dataset factory, the classification dataset creation logic is updated to use `convert_from_legacy(dm_subset)` directly, removing the previous manual construction of `ClassificationSample` objects and reliance on `DatasetNew`.

**Cleanup of imports and type hints:**

* Unused imports are removed from `sample.py` and `factory.py`, and type hints are updated for clarity and correctness. [[1]](diffhunk://#diff-d02521df3769f12f772f40ea63dab8ce9d71937b9efae94ca39733312ec293e8L14) [[2]](diffhunk://#diff-d02521df3769f12f772f40ea63dab8ce9d71937b9efae94ca39733312ec293e8L32) [[3]](diffhunk://#diff-fc36a642b6649643ac4894740683f25935f13650cde1d26717b48932e92ed207L11) [[4]](diffhunk://#diff-fc36a642b6649643ac4894740683f25935f13650cde1d26717b48932e92ed207R24)

**Consistency improvements across dataset creation:**

* The pattern for converting datasets from legacy formats is now consistently applied across classification, detection, instance segmentation, and semantic segmentation tasks, reducing code duplication and potential errors.
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
