### PR TITLE
Implement fixed rate data collection policy

### DIFF
--- a/application/backend/app/api/endpoints/datasets.py
+++ b/application/backend/app/api/endpoints/datasets.py
@@ -8,13 +8,7 @@ from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, Upload
 from fastapi.openapi.models import Example
 from starlette.responses import FileResponse
 
-from app.api.dependencies import (
-    get_dataset_item_id,
-    get_dataset_service,
-    get_file_name_and_extension,
-    get_file_size,
-    get_project_id,
-)
+from app.api.dependencies import get_dataset_item_id, get_dataset_service, get_file_name_and_extension, get_project_id
 from app.schemas import DatasetItem, DatasetItemsWithPagination
 from app.schemas.base import Pagination
 from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemAnnotations, DatasetItemAnnotationsWithSource
@@ -69,7 +63,6 @@ def add_dataset_item(
     project_id: Annotated[UUID, Depends(get_project_id)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
     file_name_and_extension: Annotated[tuple[str, str], Depends(get_file_name_and_extension)],
-    size: Annotated[int, Depends(get_file_size)],
     file: Annotated[UploadFile, File()],
 ) -> DatasetItem:
     """Add a new item to the dataset by uploading an image"""
@@ -77,10 +70,9 @@ def add_dataset_item(
     try:
         return dataset_service.create_dataset_item(
             project_id=project_id,
-            file=file.file,
+            data=file.file,
             name=name,
             format=format,
-            size=size,
             user_reviewed=True,
         )
     except InvalidImageError:

--- a/application/backend/app/cli.py
+++ b/application/backend/app/cli.py
@@ -92,8 +92,11 @@ def seed(with_model: bool) -> None:
             exclusive_labels=True,
         )
         project.labels = [
-            LabelDB(name="card", color="#FF0000", hotkey="c"),
-            LabelDB(name="person", color="#00FF00", hotkey="p"),
+            LabelDB(name="Clubs", color="#2d6311", hotkey="c"),
+            LabelDB(name="Diamonds", color="#baa3b3", hotkey="d"),
+            LabelDB(name="Spades", color="#000702", hotkey="s"),
+            LabelDB(name="Hearts", color="#1f016b", hotkey="h"),
+            LabelDB(name="No_object", color="#565a84", hotkey="n"),
         ]
         db.add(project)
         db.flush()

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -58,6 +58,7 @@ class DatasetItemAnnotation(BaseModel):
 
     labels: list[LabelReference]
     shape: Shape
+    probability: float | None = None
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -58,7 +58,7 @@ class DatasetItemAnnotation(BaseModel):
 
     labels: list[LabelReference]
     shape: Shape
-    probability: float | None = None
+    confidence: float | None = None
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/schemas/shape.py
+++ b/application/backend/app/schemas/shape.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 
 
 class Point(BaseModel):
-    x: float = Field(..., description="Point x coordinate", ge=0)
-    y: float = Field(..., description="Point y coordinate", ge=0)
+    x: int = Field(..., description="Point x coordinate", ge=0)
+    y: int = Field(..., description="Point y coordinate", ge=0)
 
 
 # Base class with discriminator field
@@ -17,10 +17,10 @@ class ShapeBase(BaseModel):
 
 class Rectangle(ShapeBase):
     type: Literal["rectangle"] = "rectangle"
-    x: float = Field(..., description="Rectangle x coordinate", ge=0)
-    y: float = Field(..., description="Rectangle y coordinate", ge=0)
-    width: float = Field(..., description="Rectangle width", ge=0)
-    height: float = Field(..., description="Rectangle height", ge=0)
+    x: int = Field(..., description="Rectangle x coordinate", ge=0)
+    y: int = Field(..., description="Rectangle y coordinate", ge=0)
+    width: int = Field(..., description="Rectangle width", ge=0)
+    height: int = Field(..., description="Rectangle height", ge=0)
 
     model_config = {
         "json_schema_extra": {"example": {"type": "rectangle", "x": 10, "y": 20, "width": 100, "height": 200}}

--- a/application/backend/app/schemas/shape.py
+++ b/application/backend/app/schemas/shape.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 
 
 class Point(BaseModel):
-    x: int = Field(..., description="Point x coordinate", ge=0)
-    y: int = Field(..., description="Point y coordinate", ge=0)
+    x: float = Field(..., description="Point x coordinate", ge=0)
+    y: float = Field(..., description="Point y coordinate", ge=0)
 
 
 # Base class with discriminator field
@@ -16,11 +16,11 @@ class ShapeBase(BaseModel):
 
 
 class Rectangle(ShapeBase):
-    type: Literal["rectangle"]
-    x: int = Field(..., description="Rectangle x coordinate", ge=0)
-    y: int = Field(..., description="Rectangle y coordinate", ge=0)
-    width: int = Field(..., description="Rectangle width", ge=0)
-    height: int = Field(..., description="Rectangle height", ge=0)
+    type: Literal["rectangle"] = "rectangle"
+    x: float = Field(..., description="Rectangle x coordinate", ge=0)
+    y: float = Field(..., description="Rectangle y coordinate", ge=0)
+    width: float = Field(..., description="Rectangle width", ge=0)
+    height: float = Field(..., description="Rectangle height", ge=0)
 
     model_config = {
         "json_schema_extra": {"example": {"type": "rectangle", "x": 10, "y": 20, "width": 100, "height": 200}}
@@ -28,14 +28,14 @@ class Rectangle(ShapeBase):
 
 
 class Polygon(ShapeBase):
-    type: Literal["polygon"]
+    type: Literal["polygon"] = "polygon"
     points: list[Point] = Field(..., description="Polygon points")
 
     model_config = {"json_schema_extra": {"example": {"type": "polygon", "points": [[10, 20], [20, 60], [30, 40]]}}}
 
 
 class FullImage(ShapeBase):
-    type: Literal["full_image"]
+    type: Literal["full_image"] = "full_image"
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/services/data_collect/__init__.py
+++ b/application/backend/app/services/data_collect/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .data_collector import DataCollector
+
+__all__ = ["DataCollector"]

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -81,7 +81,7 @@ class DataCollector(metaclass=Singleton):
         )
         self.dataset_service.create_dataset_item(
             project_id=project.id,
-            name=str(int(timestamp)),
+            name=f"{timestamp:.4f}".replace(".", "_"),
             format=DatasetItemFormat.JPG,
             data=frame_data,
             user_reviewed=False,

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from abc import ABCMeta, abstractmethod
+from uuid import UUID
+
+import numpy as np
+
+from app.entities.stream_data import InferenceData
+from app.schemas import Project
+from app.schemas.dataset_item import DatasetItemFormat
+from app.schemas.pipeline import FixedRateDataCollectionPolicy
+from app.services import ActivePipelineService, DatasetService
+from app.services.data_collect.prediction_converter import convert_prediction
+from app.settings import get_settings
+from app.utils import Singleton
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyChecker(metaclass=ABCMeta):
+    @abstractmethod
+    def should_collect(self, timestamp: float) -> bool:
+        """
+        Checks if certain dispatched image should be collected to the project dataset
+        :param timestamp: dispatched image timestamp
+        :return: True if image should be collected, False otherwise
+        """
+
+
+class FixedRatePolicyChecker(PolicyChecker):
+    """
+    Fixed rate data collection policy checker.
+    Checks when the last image has been collected against collection rate.
+    """
+
+    def __init__(self, policy: FixedRateDataCollectionPolicy):
+        self.min_interval = 1.0 / policy.rate
+        self.last_collect_time = 0.0
+
+    def should_collect(self, timestamp: float) -> bool:
+        time_since_last = timestamp - self.last_collect_time
+        if time_since_last < self.min_interval:
+            return False
+        self.last_collect_time = timestamp
+        return True
+
+
+class DataCollector(metaclass=Singleton):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dataset_service = DatasetService(get_settings().data_dir)
+        self.policy_checkers: list[PolicyChecker] = []
+        self.reload_policies()
+
+    def collect(
+        self,
+        source_id: UUID,
+        project: Project,
+        timestamp: float,
+        frame_data: np.ndarray,
+        inference_data: InferenceData,
+    ) -> None:
+        """
+        Collects the dispatched image if any of the policy checkers indicate that it should be collected.
+        :param source_id: ID of the pipeline source
+        :param project: Pipeline project
+        :param timestamp: Timestamp of the image
+        :param frame_data: Image binary data in ndarray format
+        :param inference_data: Inference data including predictions
+        :return:
+        """
+        should_collect = any(checker.should_collect(timestamp) for checker in self.policy_checkers)
+        if not should_collect:
+            return
+        annotations = convert_prediction(
+            labels=project.task.labels, frame_data=frame_data, prediction=inference_data.prediction
+        )
+        self.dataset_service.create_dataset_item(
+            project_id=project.id,
+            name=str(int(timestamp)),
+            format=DatasetItemFormat.JPG,
+            data=frame_data,
+            user_reviewed=False,
+            source_id=source_id,
+            prediction_model_id=inference_data.model_id,
+            annotations=annotations,
+        )
+
+    def reload_policies(self) -> None:
+        """
+        Reloads data collection policies from active pipeline and re-initialize policy checkers.
+        """
+        policies = [policy for policy in ActivePipelineService().get_data_collection_policies() if policy.enabled]
+        self.policy_checkers = []
+        for policy in policies:
+            manager = None
+            match policy:
+                case FixedRateDataCollectionPolicy():
+                    manager = FixedRatePolicyChecker(policy)
+            if manager is not None:
+                self.policy_checkers.append(manager)

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -47,8 +47,9 @@ class FixedRatePolicyChecker(PolicyChecker):
 
 
 class DataCollector(metaclass=Singleton):
-    def __init__(self) -> None:
+    def __init__(self, active_pipeline_service: ActivePipelineService) -> None:
         super().__init__()
+        self.active_pipeline_service = active_pipeline_service
         self.dataset_service = DatasetService(get_settings().data_dir)
         self.policy_checkers: list[PolicyChecker] = []
         self.reload_policies()
@@ -91,7 +92,7 @@ class DataCollector(metaclass=Singleton):
         """
         Reloads data collection policies from active pipeline and re-initialize policy checkers.
         """
-        policies = [policy for policy in ActivePipelineService().get_data_collection_policies() if policy.enabled]
+        policies = [policy for policy in self.active_pipeline_service.get_data_collection_policies() if policy.enabled]
         self.policy_checkers = []
         for policy in policies:
             manager = None

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -23,6 +23,7 @@ class PolicyChecker(metaclass=ABCMeta):
     def should_collect(self, timestamp: float) -> bool:
         """
         Checks if certain dispatched image should be collected to the project dataset
+
         :param timestamp: dispatched image timestamp
         :return: True if image should be collected, False otherwise
         """
@@ -64,6 +65,7 @@ class DataCollector(metaclass=Singleton):
     ) -> None:
         """
         Collects the dispatched image if any of the policy checkers indicate that it should be collected.
+
         :param source_id: ID of the pipeline source
         :param project: Pipeline project
         :param timestamp: Timestamp of the image

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -13,7 +13,6 @@ from app.schemas.pipeline import FixedRateDataCollectionPolicy
 from app.services import ActivePipelineService, DatasetService
 from app.services.data_collect.prediction_converter import convert_prediction
 from app.settings import get_settings
-from app.utils import Singleton
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ class FixedRatePolicyChecker(PolicyChecker):
         return True
 
 
-class DataCollector(metaclass=Singleton):
+class DataCollector:
     def __init__(self, active_pipeline_service: ActivePipelineService) -> None:
         super().__init__()
         self.active_pipeline_service = active_pipeline_service

--- a/application/backend/app/services/data_collect/prediction_converter.py
+++ b/application/backend/app/services/data_collect/prediction_converter.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import logging
+
+import cv2
+import numpy as np
+from model_api.models import ClassificationResult, DetectionResult, InstanceSegmentationResult
+from model_api.models.result import Result
+
+from app.schemas.dataset_item import DatasetItemAnnotation
+from app.schemas.label import Label, LabelReference
+from app.schemas.shape import FullImage, Point, Polygon, Rectangle
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_detection_prediction(labels: list[Label], prediction: DetectionResult) -> list[DatasetItemAnnotation]:
+    result = []
+    for idx, box in enumerate(prediction.bboxes):
+        label_name = prediction.label_names[idx]
+        probability = prediction.scores.tolist()[idx]
+        label = next((label for label in labels if label.name == label_name), None)
+        if not label:
+            logger.warning(f"Prediction label {label_name} cannot be found in the project")
+            continue
+        x, y, width, height = box.tolist()
+        annotation = DatasetItemAnnotation(
+            labels=[LabelReference(id=label.id)],
+            shape=Rectangle(x=x, y=y, width=width, height=height),
+            probability=probability,
+        )
+        result.append(annotation)
+    return result
+
+
+def _convert_classification_prediction(
+    labels: list[Label], prediction: ClassificationResult
+) -> list[DatasetItemAnnotation]:
+    annotation_labels: list[LabelReference] = []
+    probability = 0
+    for predicted_label in prediction.top_labels:
+        label_name = predicted_label.name
+        probability = predicted_label.confidence
+        label = next((label for label in labels if label.name == label_name), None)
+        if not label:
+            logger.warning(f"Prediction label {label_name} cannot be found in the project")
+            continue
+        annotation_labels.append(LabelReference(id=label.id))
+    return [DatasetItemAnnotation(labels=annotation_labels, shape=FullImage(), probability=probability)]
+
+
+def _convert_segmentation_prediction(
+    labels: list[Label],
+    frame_data: np.ndarray,
+    prediction: InstanceSegmentationResult,
+) -> list[DatasetItemAnnotation]:
+    height, width, _ = frame_data.shape
+    result = []
+    for idx, box in enumerate(prediction.bboxes):
+        label_name = prediction.label_names[idx]
+        probability = prediction.scores.tolist()[idx]
+        label = next((label for label in labels if label.name == label_name), None)
+        if not label:
+            logger.warning(f"Prediction label {label_name} cannot be found in the project")
+            continue
+        mask = prediction.masks[idx].astype(np.uint8)
+        contours, hierarchies = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
+        if hierarchies is None:
+            continue
+        for contour, hierarchy in zip(contours, hierarchies[0]):
+            if hierarchy[3] != -1:
+                continue
+            if len(contour) <= 2 or cv2.contourArea(contour) < 1.0:
+                continue
+            points = [
+                Point(
+                    x=point[0][0] / width,
+                    y=point[0][1] / height,
+                )
+                for point in list(contour)
+            ]
+            polygon = Polygon(points=points)
+            annotation = DatasetItemAnnotation(
+                labels=[LabelReference(id=label.id)], shape=polygon, probability=probability
+            )
+            result.append(annotation)
+    return result
+
+
+def convert_prediction(labels: list[Label], frame_data: np.ndarray, prediction: Result) -> list[DatasetItemAnnotation]:
+    """
+    Converts an image prediction to dataset item annotations depending on the prediction type.
+    :param labels: project labels list
+    :param frame_data: image binary data
+    :param prediction: prediction result
+    :return: list of dataset item annotations
+    """
+    match prediction:
+        case InstanceSegmentationResult():
+            return _convert_segmentation_prediction(labels=labels, frame_data=frame_data, prediction=prediction)
+        case DetectionResult():
+            return _convert_detection_prediction(labels=labels, prediction=prediction)
+        case ClassificationResult():
+            return _convert_classification_prediction(labels=labels, prediction=prediction)
+    return []

--- a/application/backend/app/services/data_collect/prediction_converter.py
+++ b/application/backend/app/services/data_collect/prediction_converter.py
@@ -18,7 +18,7 @@ def _convert_detection_prediction(labels: list[Label], prediction: DetectionResu
     result = []
     for idx, box in enumerate(prediction.bboxes):
         label_name = prediction.label_names[idx]
-        probability = prediction.scores.tolist()[idx]
+        confidence = prediction.scores.tolist()[idx]
         label = next((label for label in labels if label.name == label_name), None)
         if not label:
             logger.warning(f"Prediction label {label_name} cannot be found in the project")
@@ -27,7 +27,7 @@ def _convert_detection_prediction(labels: list[Label], prediction: DetectionResu
         annotation = DatasetItemAnnotation(
             labels=[LabelReference(id=label.id)],
             shape=Rectangle(x=x, y=y, width=width, height=height),
-            probability=probability,
+            confidence=confidence,
         )
         result.append(annotation)
     return result
@@ -37,16 +37,16 @@ def _convert_classification_prediction(
     labels: list[Label], prediction: ClassificationResult
 ) -> list[DatasetItemAnnotation]:
     annotation_labels: list[LabelReference] = []
-    probability = 0
+    confidence = 0
     for predicted_label in prediction.top_labels:
         label_name = predicted_label.name
-        probability = predicted_label.confidence
+        confidence = predicted_label.confidence
         label = next((label for label in labels if label.name == label_name), None)
         if not label:
             logger.warning(f"Prediction label {label_name} cannot be found in the project")
             continue
         annotation_labels.append(LabelReference(id=label.id))
-    return [DatasetItemAnnotation(labels=annotation_labels, shape=FullImage(), probability=probability)]
+    return [DatasetItemAnnotation(labels=annotation_labels, shape=FullImage(), confidence=confidence)]
 
 
 def _convert_segmentation_prediction(
@@ -58,7 +58,7 @@ def _convert_segmentation_prediction(
     result = []
     for idx, box in enumerate(prediction.bboxes):
         label_name = prediction.label_names[idx]
-        probability = prediction.scores.tolist()[idx]
+        confidence = prediction.scores.tolist()[idx]
         label = next((label for label in labels if label.name == label_name), None)
         if not label:
             logger.warning(f"Prediction label {label_name} cannot be found in the project")
@@ -72,16 +72,9 @@ def _convert_segmentation_prediction(
                 continue
             if len(contour) <= 2 or cv2.contourArea(contour) < 1.0:
                 continue
-            points = [
-                Point(
-                    x=point[0][0] / width,
-                    y=point[0][1] / height,
-                )
-                for point in list(contour)
-            ]
-            polygon = Polygon(points=points)
+            polygon = Polygon(points=[Point(x=point[0][0], y=point[0][1]) for point in list(contour)])
             annotation = DatasetItemAnnotation(
-                labels=[LabelReference(id=label.id)], shape=polygon, probability=probability
+                labels=[LabelReference(id=label.id)], shape=polygon, confidence=confidence
             )
             result.append(annotation)
     return result

--- a/application/backend/app/services/data_collect/prediction_converter.py
+++ b/application/backend/app/services/data_collect/prediction_converter.py
@@ -21,7 +21,7 @@ def _convert_detection_prediction(labels: list[Label], prediction: DetectionResu
         confidence = prediction.scores.tolist()[idx]
         label = next((label for label in labels if label.name == label_name), None)
         if not label:
-            logger.warning(f"Prediction label {label_name} cannot be found in the project")
+            logger.warning("Prediction label %s cannot be found in the project", label_name)
             continue
         x, y, width, height = box.tolist()
         annotation = DatasetItemAnnotation(
@@ -43,7 +43,7 @@ def _convert_classification_prediction(
         confidence = predicted_label.confidence
         label = next((label for label in labels if label.name == label_name), None)
         if not label:
-            logger.warning(f"Prediction label {label_name} cannot be found in the project")
+            logger.warning("Prediction label %s cannot be found in the project", label_name)
             continue
         annotation_labels.append(LabelReference(id=label.id))
     return [DatasetItemAnnotation(labels=annotation_labels, shape=FullImage(), confidence=confidence)]
@@ -61,7 +61,7 @@ def _convert_segmentation_prediction(
         confidence = prediction.scores.tolist()[idx]
         label = next((label for label in labels if label.name == label_name), None)
         if not label:
-            logger.warning(f"Prediction label {label_name} cannot be found in the project")
+            logger.warning("Prediction label %s cannot be found in the project", label_name)
             continue
         mask = prediction.masks[idx].astype(np.uint8)
         contours, hierarchies = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -14,6 +14,7 @@ from app.schemas import Pipeline, PipelineStatus
 from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
 from app.services import ActivePipelineService
 from app.services.base import GenericPersistenceService, ResourceNotFoundError, ResourceType, ServiceConfig
+from app.services.data_collect import DataCollector
 from app.services.mappers import PipelineMapper
 from app.services.metrics_service import MetricsService
 from app.services.parent_process_guard import parent_process_only
@@ -45,6 +46,7 @@ class PipelineService:
     def _notify_pipeline_changed(self) -> None:
         self._notify_source_changed()
         self._notify_sink_changed()
+        DataCollector().reload_policies()
 
     def get_pipeline_by_id(self, project_id: UUID, db: Session | None = None) -> Pipeline:
         """Retrieve a pipeline by project ID."""
@@ -66,6 +68,9 @@ class PipelineService:
                     self._notify_source_changed()
                 if pipeline.sink.id != updated.sink.id:  # type: ignore[union-attr] # sink is always there for running pipeline
                     self._notify_sink_changed()
+                if pipeline.data_collection_policies != updated.data_collection_policies:
+                    self._active_pipeline_service.reload()
+                    DataCollector().reload_policies()
             elif pipeline.status != updated.status:
                 # If the pipeline is being activated or stopped
                 self._notify_pipeline_changed()

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -46,7 +46,7 @@ class PipelineService:
     def _notify_pipeline_changed(self) -> None:
         self._notify_source_changed()
         self._notify_sink_changed()
-        DataCollector().reload_policies()
+        DataCollector(self._active_pipeline_service).reload_policies()
 
     def get_pipeline_by_id(self, project_id: UUID, db: Session | None = None) -> Pipeline:
         """Retrieve a pipeline by project ID."""
@@ -70,7 +70,7 @@ class PipelineService:
                     self._notify_sink_changed()
                 if pipeline.data_collection_policies != updated.data_collection_policies:
                     self._active_pipeline_service.reload()
-                    DataCollector().reload_policies()
+                    DataCollector(self._active_pipeline_service).reload_policies()
             elif pipeline.status != updated.status:
                 # If the pipeline is being activated or stopped
                 self._notify_pipeline_changed()

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -26,6 +26,7 @@ class PipelineService:
     def __init__(
         self,
         active_pipeline_service: ActivePipelineService,
+        data_collector: DataCollector,
         metrics_service: MetricsService,
         config_changed_condition: Condition,
     ) -> None:
@@ -33,6 +34,7 @@ class PipelineService:
             ServiceConfig(PipelineRepository, PipelineMapper, ResourceType.PIPELINE)
         )
         self._active_pipeline_service: ActivePipelineService = active_pipeline_service
+        self._data_collector: DataCollector = data_collector
         self._config_changed_condition: Condition = config_changed_condition
         self._metrics_service: MetricsService = metrics_service
 
@@ -46,7 +48,7 @@ class PipelineService:
     def _notify_pipeline_changed(self) -> None:
         self._notify_source_changed()
         self._notify_sink_changed()
-        DataCollector(self._active_pipeline_service).reload_policies()
+        self._data_collector.reload_policies()
 
     def get_pipeline_by_id(self, project_id: UUID, db: Session | None = None) -> Pipeline:
         """Retrieve a pipeline by project ID."""
@@ -70,7 +72,7 @@ class PipelineService:
                     self._notify_sink_changed()
                 if pipeline.data_collection_policies != updated.data_collection_policies:
                     self._active_pipeline_service.reload()
-                    DataCollector(self._active_pipeline_service).reload_policies()
+                    self._data_collector.reload_policies()
             elif pipeline.status != updated.status:
                 # If the pipeline is being activated or stopped
                 self._notify_pipeline_changed()

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -96,7 +96,7 @@ class DispatchingWorker(BaseThreadWorker):
 
             # Collect the image to project dataset if needed
             source_config = self._active_pipeline_service.get_source_config()  # type: ignore
-            DataCollector().collect(
+            DataCollector(self._active_pipeline_service).collect(  # type: ignore
                 source_id=source_config.id,
                 project=project,
                 timestamp=stream_data.timestamp,

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -10,6 +10,7 @@ from multiprocessing.synchronize import Event as EventClass
 from app.entities.stream_data import StreamData
 from app.schemas import Sink, SinkType
 from app.services import ActivePipelineService, DispatchService
+from app.services.data_collect import DataCollector
 from app.services.dispatchers import Dispatcher
 from app.workers.base import BaseThreadWorker
 
@@ -47,9 +48,15 @@ class DispatchingWorker(BaseThreadWorker):
     def run_loop(self) -> None:
         while not self.should_stop():
             sink_config = self._active_pipeline_service.get_sink_config()  # type: ignore
+            project = self._active_pipeline_service.get_project()  # type: ignore
 
             if sink_config.sink_type == SinkType.DISCONNECTED:
                 logger.debug("No sink available... retrying in 1 second")
+                self.stop_aware_sleep(1)
+                continue
+
+            if project is None:
+                logger.debug("No project available... retrying in 1 second")
                 self.stop_aware_sleep(1)
                 continue
 
@@ -86,3 +93,13 @@ class DispatchingWorker(BaseThreadWorker):
                 self._rtc_stream_queue.put(image_with_visualization, block=False)
             except queue.Full:
                 logger.debug("Visualization queue is full; skipping")
+
+            # Collect the image to project dataset if needed
+            source_config = self._active_pipeline_service.get_source_config()  # type: ignore
+            DataCollector().collect(
+                source_id=source_config.id,
+                project=project,
+                timestamp=stream_data.timestamp,
+                frame_data=stream_data.frame_data,
+                inference_data=inference_data,
+            )

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -31,13 +31,15 @@ class DispatchingWorker(BaseThreadWorker):
         self._rtc_stream_queue = rtc_stream_queue
 
         self._active_pipeline_service: ActivePipelineService | None = None
+        self._data_collector: DataCollector | None = None
         self._prev_sink_config: Sink | None = None
         self._destinations: list[Dispatcher] = []
 
     def setup(self) -> None:
-        from app.api.dependencies import get_active_pipeline_service  # Avoid circular import
+        from app.api.dependencies import get_active_pipeline_service, get_data_collector  # Avoid circular import
 
         self._active_pipeline_service = get_active_pipeline_service()
+        self._data_collector = get_data_collector(self._active_pipeline_service)
 
     def _reset_sink_if_needed(self, sink_config: Sink) -> None:
         if not self._prev_sink_config or sink_config != self._prev_sink_config:
@@ -96,7 +98,7 @@ class DispatchingWorker(BaseThreadWorker):
 
             # Collect the image to project dataset if needed
             source_config = self._active_pipeline_service.get_source_config()  # type: ignore
-            DataCollector(self._active_pipeline_service).collect(  # type: ignore
+            self._data_collector.collect(  # type: ignore
                 source_id=source_config.id,
                 project=project,
                 timestamp=stream_data.timestamp,

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -14,8 +14,8 @@ import pytest
 from PIL import Image
 from sqlalchemy.orm import Session
 
-from app.db.schema import DatasetItemDB, ProjectDB
-from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemAnnotationsWithSource
+from app.db.schema import DatasetItemDB, ModelRevisionDB, ProjectDB, SourceDB
+from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemAnnotationsWithSource, DatasetItemSubset
 from app.schemas.label import LabelReference
 from app.schemas.shape import FullImage, Rectangle
 from app.services.base import ResourceNotFoundError, ResourceType
@@ -82,43 +82,71 @@ def fxt_annotations():
 class TestDatasetServiceIntegration:
     """Integration tests for DatasetService."""
 
+    @pytest.mark.parametrize("use_pipeline_model", [True, False])
+    @pytest.mark.parametrize("use_pipeline_source", [True, False])
     @pytest.mark.parametrize("user_reviewed", [True, False])
     @pytest.mark.parametrize("format", ["jpg", "png"])
     def test_create_dataset_item(
         self,
         fxt_dataset_service: DatasetService,
+        fxt_db_models: list[ModelRevisionDB],
+        fxt_db_sources: list[SourceDB],
         fxt_stored_projects: list[ProjectDB],
         db_session: Session,
-        format: str,
+        format: DatasetItemSubset,
         user_reviewed: bool,
+        use_pipeline_source: bool,
+        use_pipeline_model: bool,
     ):
         """Test creating a dataset item."""
-        img_byte_arr = BytesIO()
-        img = Image.new("RGB", (1024, 768))
-        img.save(img_byte_arr, "PNG")
+        project_id = fxt_stored_projects[0].id
+        image = Image.new("RGB", (1024, 768))
+        fxt_db_models[0].project_id = project_id
+        db_session.add_all([fxt_db_sources[0], fxt_db_models[0]])
+        db_session.flush()
+        stored_source_id = fxt_db_sources[0].id
+        model_revision_id = fxt_db_models[0].id
+        db_session.commit()
 
         created_dataset_item = fxt_dataset_service.create_dataset_item(
-            project_id=UUID(fxt_stored_projects[0].id),
+            project_id=UUID(project_id),
             name="test",
             format=format,
-            size=2048,
-            file=img_byte_arr,
+            data=image,
             user_reviewed=user_reviewed,
+            source_id=UUID(stored_source_id) if use_pipeline_source else None,
+            prediction_model_id=UUID(model_revision_id) if use_pipeline_model else None,
         )
         logger.info(f"Created dataset item: {created_dataset_item}")
-        assert created_dataset_item.id is not None
-        assert created_dataset_item.name == "test"
-        assert created_dataset_item.format == format
-        assert created_dataset_item.size == 2048
-        assert created_dataset_item.width == 1024
-        assert created_dataset_item.height == 768
 
-        binary_file_path = Path(f"data/projects/{fxt_stored_projects[0].id}/dataset/{created_dataset_item.id}.{format}")
-        assert os.path.exists(binary_file_path)
-
-        thumbnail_file_path = Path(
-            f"data/projects/{fxt_stored_projects[0].id}/dataset/{created_dataset_item.id}-thumb.jpg"
+        dataset_item = db_session.get(DatasetItemDB, str(created_dataset_item.id))
+        assert dataset_item is not None
+        assert (
+            dataset_item.id == str(created_dataset_item.id)
+            and dataset_item.project_id == project_id
+            and dataset_item.name == "test"
+            and dataset_item.format == format
+            and dataset_item.width == 1024
+            and dataset_item.height == 768
+            and dataset_item.annotation_data == []
+            and dataset_item.user_reviewed == user_reviewed
+            and dataset_item.subset == DatasetItemSubset.UNASSIGNED
+            and dataset_item.subset_assigned_at is None
         )
+        if use_pipeline_source:
+            assert dataset_item.source_id == stored_source_id
+        else:
+            assert dataset_item.source_id is None
+        if use_pipeline_model:
+            assert dataset_item.prediction_model_id == model_revision_id
+        else:
+            assert dataset_item.prediction_model_id is None
+
+        binary_file_path = Path(f"data/projects/{project_id}/dataset/{created_dataset_item.id}.{format}")
+        assert os.path.exists(binary_file_path)
+        assert created_dataset_item.size == os.path.getsize(binary_file_path)
+
+        thumbnail_file_path = Path(f"data/projects/{project_id}/dataset/{created_dataset_item.id}-thumb.jpg")
         assert os.path.exists(thumbnail_file_path)
 
     def test_create_dataset_item_invalid_image(
@@ -130,8 +158,7 @@ class TestDatasetServiceIntegration:
                 project_id=UUID(fxt_stored_projects[0].id),
                 name="test",
                 format="jpg",
-                size=1024,
-                file=BytesIO(b"123"),
+                data=BytesIO(b"123"),
                 user_reviewed=True,
             )
 
@@ -202,7 +229,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
         limit,
         limit_out_of_range,
         offset,
@@ -231,7 +257,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test retrieving a dataset item by ID."""
         fetched_dataset_item = fxt_dataset_service.get_dataset_item_by_id(
@@ -258,7 +283,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test retrieving a dataset item with wrong project ID raises error."""
         with pytest.raises(ResourceNotFoundError) as excinfo:
@@ -274,7 +298,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test retrieving a dataset item binary path by ID."""
         dataset_item_binary_path = fxt_dataset_service.get_dataset_item_binary_path_by_id(
@@ -302,7 +325,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test retrieving a dataset item binary path with wrong project ID raises error."""
         with pytest.raises(ResourceNotFoundError) as excinfo:
@@ -318,7 +340,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test retrieving a dataset item thumbnail path by ID."""
         dataset_item_binary_path = fxt_dataset_service.get_dataset_item_thumbnail_path_by_id(
@@ -346,7 +367,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test retrieving a dataset item thumbnail path with wrong project ID raises error."""
         with pytest.raises(ResourceNotFoundError) as excinfo:
@@ -403,7 +423,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test deleting a dataset item."""
         with pytest.raises(ResourceNotFoundError) as excinfo:
@@ -483,7 +502,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test getting a dataset item annotation and it's missing."""
         annotations = fxt_dataset_service.get_dataset_item_annotations(
@@ -500,7 +518,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test getting a dataset item annotation."""
         annotations = fxt_dataset_service.get_dataset_item_annotations(
@@ -524,7 +541,6 @@ class TestDatasetServiceIntegration:
         fxt_dataset_service: DatasetService,
         fxt_stored_projects: list[ProjectDB],
         fxt_stored_dataset_items: list[DatasetItemDB],
-        db_session: Session,
     ):
         """Test getting a dataset item annotation."""
         non_existent_id = uuid4()

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -106,7 +106,6 @@ class TestDatasetServiceIntegration:
         db_session.flush()
         stored_source_id = fxt_db_sources[0].id
         model_revision_id = fxt_db_models[0].id
-        db_session.commit()
 
         created_dataset_item = fxt_dataset_service.create_dataset_item(
             project_id=UUID(project_id),

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -12,6 +12,7 @@ from app.schemas import PipelineStatus
 from app.schemas.pipeline import FixedRateDataCollectionPolicy
 from app.services import PipelineService, ResourceNotFoundError, ResourceType
 from app.services.configuration_service import PipelineField
+from app.services.data_collect import DataCollector
 
 
 @pytest.fixture(autouse=True)
@@ -29,9 +30,17 @@ def mock_get_db_session(db_session):
 
 
 @pytest.fixture
-def fxt_pipeline_service(fxt_active_pipeline_service, fxt_metrics_service, fxt_condition) -> PipelineService:
+def fxt_data_collector(fxt_active_pipeline_service) -> DataCollector:
+    """Fixture to create a DataCollector instance with mocked dependencies."""
+    return DataCollector(fxt_active_pipeline_service)
+
+
+@pytest.fixture
+def fxt_pipeline_service(
+    fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition
+) -> PipelineService:
     """Fixture to create a PipelineService instance with mocked dependencies."""
-    return PipelineService(fxt_active_pipeline_service, fxt_metrics_service, fxt_condition)
+    return PipelineService(fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition)
 
 
 @pytest.fixture

--- a/application/backend/tests/unit/endpoints/test_datasets.py
+++ b/application/backend/tests/unit/endpoints/test_datasets.py
@@ -68,10 +68,9 @@ class TestDatasetItemEndpoints:
         assert response.status_code == status.HTTP_201_CREATED
         fxt_dataset_service.create_dataset_item.assert_called_once_with(
             project_id=project_id,
-            file=ANY,
+            data=ANY,
             name="test_file",
             format="jpg",
-            size=3,
             user_reviewed=True,
         )
 

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import numpy as np
+
+from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemFormat
+from app.schemas.label import LabelReference
+from app.schemas.pipeline import FixedRateDataCollectionPolicy
+from app.schemas.shape import FullImage
+from app.services import DatasetService
+from app.services.data_collect.data_collector import DataCollector, FixedRatePolicyChecker
+
+
+class TestFixedRatePolicyCheckerUnit:
+    """Unit tests for FixedRatePolicyChecker."""
+
+    def test_should_collect_true(self):
+        # Arrange
+        policy = FixedRateDataCollectionPolicy(rate=0.1)
+
+        # Act
+        should_collect = FixedRatePolicyChecker(policy).should_collect(100)
+
+        # Assert
+        assert should_collect is True
+
+    def test_should_collect_false(self):
+        # Arrange
+        policy = FixedRateDataCollectionPolicy(rate=0.1)
+
+        # Act
+        should_collect = FixedRatePolicyChecker(policy).should_collect(9)
+
+        # Assert
+        assert should_collect is False
+
+
+class TestDataCollectorUnit:
+    """Unit tests for DataCollector."""
+
+    def test_collect_no(self):
+        """
+        No images should be collected if policy conditions aren't met
+        """
+        # Arrange
+        source_id = uuid4()
+        project = MagicMock()
+        frame_data = np.random.rand(100, 100, 3)
+        inference_data = MagicMock()
+
+        now = datetime.timestamp(datetime.now())
+
+        data_collector = DataCollector()
+        policy_checker = MagicMock()
+        policy_checker.should_collect.return_value = False
+        data_collector.policy_checkers = [policy_checker]
+
+        # Act
+        with (
+            patch.object(DatasetService, "create_dataset_item") as mock_create_dataset_item,
+            patch("app.services.data_collect.data_collector.convert_prediction") as mock_convert_prediction,
+        ):
+            data_collector.collect(
+                source_id=source_id,
+                project=project,
+                timestamp=now + 1,
+                frame_data=frame_data,
+                inference_data=inference_data,
+            )
+
+        # Assert
+        mock_convert_prediction.assert_not_called()
+        mock_create_dataset_item.assert_not_called()
+
+    def test_collect(self):
+        """
+        Image should be collected if policy conditions are met
+        """
+        # Arrange
+        source_id = uuid4()
+        project = MagicMock()
+        frame_data = np.random.rand(100, 100, 3)
+        inference_data = MagicMock()
+
+        now = datetime.timestamp(datetime.now())
+
+        data_collector = DataCollector()
+        policy_checker = MagicMock()
+        policy_checker.should_collect.return_value = True
+        data_collector.policy_checkers = [policy_checker]
+
+        annotations = [DatasetItemAnnotation(labels=[LabelReference(id=uuid4())], shape=FullImage())]
+
+        # Act
+        with (
+            patch.object(DatasetService, "create_dataset_item") as mock_create_dataset_item,
+            patch(
+                "app.services.data_collect.data_collector.convert_prediction", return_value=annotations
+            ) as mock_convert_prediction,
+        ):
+            data_collector.collect(
+                source_id=source_id,
+                project=project,
+                timestamp=now + 1,
+                frame_data=frame_data,
+                inference_data=inference_data,
+            )
+
+        # Assert
+        mock_convert_prediction.assert_called_once_with(
+            labels=project.task.labels, frame_data=frame_data, prediction=inference_data.prediction
+        )
+        mock_create_dataset_item.assert_called_once_with(
+            project_id=project.id,
+            name=str(int(now + 1)),
+            format=DatasetItemFormat.JPG,
+            data=frame_data,
+            user_reviewed=False,
+            source_id=source_id,
+            prediction_model_id=inference_data.model_id,
+            annotations=annotations,
+        )

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -38,11 +38,10 @@ class TestFixedRatePolicyCheckerUnit:
         assert should_collect is False
 
 
-@patch.object(DataCollector, "reload_policies")
 class TestDataCollectorUnit:
     """Unit tests for DataCollector."""
 
-    def test_collect_no(self, mock_reload_policies):
+    def test_collect_no(self, fxt_active_pipeline_service):
         """
         No images should be collected if policy conditions aren't met
         """
@@ -54,7 +53,7 @@ class TestDataCollectorUnit:
 
         now = datetime.timestamp(datetime.now())
 
-        data_collector = DataCollector()
+        data_collector = DataCollector(fxt_active_pipeline_service)
         policy_checker = MagicMock()
         policy_checker.should_collect.return_value = False
         data_collector.policy_checkers = [policy_checker]
@@ -76,7 +75,7 @@ class TestDataCollectorUnit:
         mock_convert_prediction.assert_not_called()
         mock_create_dataset_item.assert_not_called()
 
-    def test_collect(self, mock_reload_policies):
+    def test_collect(self, fxt_active_pipeline_service):
         """
         Image should be collected if policy conditions are met
         """
@@ -88,7 +87,7 @@ class TestDataCollectorUnit:
 
         now = datetime.timestamp(datetime.now())
 
-        data_collector = DataCollector()
+        data_collector = DataCollector(fxt_active_pipeline_service)
         policy_checker = MagicMock()
         policy_checker.should_collect.return_value = True
         data_collector.policy_checkers = [policy_checker]

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import numpy as np
+from freezegun import freeze_time
 
 from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemFormat
 from app.schemas.label import LabelReference
@@ -75,6 +76,7 @@ class TestDataCollectorUnit:
         mock_convert_prediction.assert_not_called()
         mock_create_dataset_item.assert_not_called()
 
+    @freeze_time("2025-01-01 00:00:01")
     def test_collect(self, fxt_active_pipeline_service):
         """
         Image should be collected if policy conditions are met
@@ -104,7 +106,7 @@ class TestDataCollectorUnit:
             data_collector.collect(
                 source_id=source_id,
                 project=project,
-                timestamp=now + 1,
+                timestamp=now,
                 frame_data=frame_data,
                 inference_data=inference_data,
             )
@@ -115,7 +117,7 @@ class TestDataCollectorUnit:
         )
         mock_create_dataset_item.assert_called_once_with(
             project_id=project.id,
-            name=str(int(now + 1)),
+            name="1735689601_0000",
             format=DatasetItemFormat.JPG,
             data=frame_data,
             user_reviewed=False,

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -38,10 +38,11 @@ class TestFixedRatePolicyCheckerUnit:
         assert should_collect is False
 
 
+@patch.object(DataCollector, "reload_policies")
 class TestDataCollectorUnit:
     """Unit tests for DataCollector."""
 
-    def test_collect_no(self):
+    def test_collect_no(self, mock_reload_policies):
         """
         No images should be collected if policy conditions aren't met
         """
@@ -75,7 +76,7 @@ class TestDataCollectorUnit:
         mock_convert_prediction.assert_not_called()
         mock_create_dataset_item.assert_not_called()
 
-    def test_collect(self):
+    def test_collect(self, mock_reload_policies):
         """
         Image should be collected if policy conditions are met
         """

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import numpy as np
+import pytest
 from freezegun import freeze_time
 
 from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemFormat
@@ -39,10 +40,16 @@ class TestFixedRatePolicyCheckerUnit:
         assert should_collect is False
 
 
+@pytest.fixture
+def fxt_data_collector(fxt_active_pipeline_service) -> DataCollector:
+    """Fixture to create a DataCollector instance with mocked dependencies."""
+    return DataCollector(fxt_active_pipeline_service)
+
+
 class TestDataCollectorUnit:
     """Unit tests for DataCollector."""
 
-    def test_collect_no(self, fxt_active_pipeline_service):
+    def test_collect_no(self, fxt_data_collector):
         """
         No images should be collected if policy conditions aren't met
         """
@@ -54,17 +61,16 @@ class TestDataCollectorUnit:
 
         now = datetime.timestamp(datetime.now())
 
-        data_collector = DataCollector(fxt_active_pipeline_service)
         policy_checker = MagicMock()
         policy_checker.should_collect.return_value = False
-        data_collector.policy_checkers = [policy_checker]
+        fxt_data_collector.policy_checkers = [policy_checker]
 
         # Act
         with (
             patch.object(DatasetService, "create_dataset_item") as mock_create_dataset_item,
             patch("app.services.data_collect.data_collector.convert_prediction") as mock_convert_prediction,
         ):
-            data_collector.collect(
+            fxt_data_collector.collect(
                 source_id=source_id,
                 project=project,
                 timestamp=now + 1,
@@ -77,7 +83,7 @@ class TestDataCollectorUnit:
         mock_create_dataset_item.assert_not_called()
 
     @freeze_time("2025-01-01 00:00:01")
-    def test_collect(self, fxt_active_pipeline_service):
+    def test_collect(self, fxt_data_collector):
         """
         Image should be collected if policy conditions are met
         """
@@ -89,10 +95,9 @@ class TestDataCollectorUnit:
 
         now = datetime.timestamp(datetime.now())
 
-        data_collector = DataCollector(fxt_active_pipeline_service)
         policy_checker = MagicMock()
         policy_checker.should_collect.return_value = True
-        data_collector.policy_checkers = [policy_checker]
+        fxt_data_collector.policy_checkers = [policy_checker]
 
         annotations = [DatasetItemAnnotation(labels=[LabelReference(id=uuid4())], shape=FullImage())]
 
@@ -103,7 +108,7 @@ class TestDataCollectorUnit:
                 "app.services.data_collect.data_collector.convert_prediction", return_value=annotations
             ) as mock_convert_prediction,
         ):
-            data_collector.collect(
+            fxt_data_collector.collect(
                 source_id=source_id,
                 project=project,
                 timestamp=now,

--- a/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
+++ b/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
@@ -33,7 +33,7 @@ def test_convert_prediction_classification() -> None:
         DatasetItemAnnotation(
             labels=[LabelReference(id=label.id)],
             shape=FullImage(),
-            probability=0.81,
+            confidence=0.81,
         )
     ]
 
@@ -42,7 +42,7 @@ def test_convert_prediction_detection() -> None:
     # Arrange
     frame_data = np.random.rand(100, 100, 3)
     label = Label(id=uuid4(), name="cat", color="#ff0000", hotkey="c")
-    coords = [12.0, 41.0, 12.5, 45.5]
+    coords = [12, 41, 12, 46]
     raw_prediction = DetectionResult(
         bboxes=np.array([coords]),
         labels=np.array([1]),
@@ -59,8 +59,8 @@ def test_convert_prediction_detection() -> None:
     assert annotations == [
         DatasetItemAnnotation(
             labels=[LabelReference(id=label.id)],
-            shape=Rectangle(x=12.0, y=41.0, width=12.5, height=45.5),
-            probability=0.81,
+            shape=Rectangle(x=12, y=41, width=12, height=46),
+            confidence=0.81,
         )
     ]
 
@@ -72,7 +72,7 @@ def test_convert_prediction_segmentation() -> None:
     cv2.rectangle(mask, (0, 0), (100, 100), 255, -1)
 
     label = Label(id=uuid4(), name="cat", color="#ff0000", hotkey="c")
-    coords = [12.0, 41.0, 12.5, 45.5]
+    coords = [12, 41, 12, 46]
     raw_prediction = InstanceSegmentationResult(
         bboxes=np.array([coords]),
         labels=np.array([1]),
@@ -90,9 +90,7 @@ def test_convert_prediction_segmentation() -> None:
     assert annotations == [
         DatasetItemAnnotation(
             labels=[LabelReference(id=label.id)],
-            shape=Polygon(
-                points=[Point(x=0.0, y=0.0), Point(x=0.0, y=0.99), Point(x=0.5, y=0.99), Point(x=0.5, y=0.0)]
-            ),
-            probability=0.81,
+            shape=Polygon(points=[Point(x=0, y=0), Point(x=0, y=99), Point(x=100, y=99), Point(x=100, y=0)]),
+            confidence=0.81,
         )
     ]

--- a/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
+++ b/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+from uuid import uuid4
+
+import cv2
+import model_api.models.result
+import numpy as np
+from model_api.models import ClassificationResult, DetectionResult, InstanceSegmentationResult
+
+from app.schemas import Label
+from app.schemas.dataset_item import DatasetItemAnnotation
+from app.schemas.label import LabelReference
+from app.schemas.shape import FullImage, Point, Polygon, Rectangle
+from app.services.data_collect.prediction_converter import convert_prediction
+
+
+def test_convert_prediction_classification() -> None:
+    # Arrange
+    frame_data = np.random.rand(100, 100, 3)
+    label = Label(id=uuid4(), name="cat", color="#ff0000", hotkey="c")
+    raw_prediction = ClassificationResult(
+        top_labels=[model_api.models.result.Label(id=1, name=label.name, confidence=0.81)],
+        raw_scores=[0.19, 0.81],
+        saliency_map=None,
+        feature_vector=None,
+    )
+
+    # Act
+    annotations = convert_prediction(labels=[label], frame_data=frame_data, prediction=raw_prediction)
+
+    # Assert
+    assert annotations == [
+        DatasetItemAnnotation(
+            labels=[LabelReference(id=label.id)],
+            shape=FullImage(),
+            probability=0.81,
+        )
+    ]
+
+
+def test_convert_prediction_detection() -> None:
+    # Arrange
+    frame_data = np.random.rand(100, 100, 3)
+    label = Label(id=uuid4(), name="cat", color="#ff0000", hotkey="c")
+    coords = [12.0, 41.0, 12.5, 45.5]
+    raw_prediction = DetectionResult(
+        bboxes=np.array([coords]),
+        labels=np.array([1]),
+        scores=np.array([0.81]),
+        label_names=["cat"],
+        saliency_map=None,
+        feature_vector=None,
+    )
+
+    # Act
+    annotations = convert_prediction(labels=[label], frame_data=frame_data, prediction=raw_prediction)
+
+    # Assert
+    assert annotations == [
+        DatasetItemAnnotation(
+            labels=[LabelReference(id=label.id)],
+            shape=Rectangle(x=12.0, y=41.0, width=12.5, height=45.5),
+            probability=0.81,
+        )
+    ]
+
+
+def test_convert_prediction_segmentation() -> None:
+    # Arrange
+    frame_data = np.zeros((100, 200, 3), dtype=np.uint8)
+    mask = np.zeros((100, 200), dtype=np.uint8)
+    cv2.rectangle(mask, (0, 0), (100, 100), 255, -1)
+
+    label = Label(id=uuid4(), name="cat", color="#ff0000", hotkey="c")
+    coords = [12.0, 41.0, 12.5, 45.5]
+    raw_prediction = InstanceSegmentationResult(
+        bboxes=np.array([coords]),
+        labels=np.array([1]),
+        masks=np.array([mask]),
+        scores=np.array([0.81]),
+        label_names=["cat"],
+        saliency_map=None,
+        feature_vector=None,
+    )
+
+    # Act
+    annotations = convert_prediction(labels=[label], frame_data=frame_data, prediction=raw_prediction)
+
+    # Assert
+    assert annotations == [
+        DatasetItemAnnotation(
+            labels=[LabelReference(id=label.id)],
+            shape=Polygon(
+                points=[Point(x=0.0, y=0.0), Point(x=0.0, y=0.99), Point(x=0.5, y=0.99), Point(x=0.5, y=0.0)]
+            ),
+            probability=0.81,
+        )
+    ]

--- a/application/backend/tests/unit/services/test_pipeline_service.py
+++ b/application/backend/tests/unit/services/test_pipeline_service.py
@@ -6,12 +6,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services import MetricsService, PipelineService
+from app.services.data_collect import DataCollector
 
 
 @pytest.fixture
-def fxt_pipeline_service(fxt_active_pipeline_service, fxt_metrics_service, fxt_condition) -> PipelineService:
+def fxt_data_collector(fxt_active_pipeline_service) -> DataCollector:
+    """Fixture to create a DataCollector instance with mocked dependencies."""
+    return DataCollector(fxt_active_pipeline_service)
+
+
+@pytest.fixture
+def fxt_pipeline_service(
+    fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition
+) -> PipelineService:
     """Fixture to create a PipelineService instance with mocked dependencies."""
-    return PipelineService(fxt_active_pipeline_service, fxt_metrics_service, fxt_condition)
+    return PipelineService(fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Summary

Resolves #4690

This PR introduces data collector module which is responsible for data collection and adding it to a project dataset based on the pipeline policies.
The only policy implemented at the moment is Fixed rate policy which allows to collect images with predefined frequency.

In case if pipeline is changed, policies are automatically reloaded.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
