### PR TITLE
Adds project rename endpoint

### DIFF
--- a/application/backend/.gitignore
+++ b/application/backend/.gitignore
@@ -14,6 +14,6 @@ wheels/
 TODO*
 
 data/
-docs/openapi.json
+**/openapi.json
 .idea
 .DS_Store

--- a/application/backend/.gitignore
+++ b/application/backend/.gitignore
@@ -14,5 +14,6 @@ wheels/
 TODO*
 
 data/
+docs/openapi.json
 .idea
 .DS_Store

--- a/application/backend/app/api/endpoints/projects.py
+++ b/application/backend/app/api/endpoints/projects.py
@@ -13,7 +13,7 @@ from fastapi.openapi.models import Example
 from starlette.responses import FileResponse
 
 from app.api.dependencies import get_data_collector, get_label_service, get_project_id, get_project_service
-from app.schemas import Label, PatchLabels, Project, ProjectUpdate
+from app.schemas import Label, PatchLabels, Project, ProjectUpdateName
 from app.services import (
     LabelService,
     ProjectService,
@@ -137,12 +137,12 @@ def get_project(
 )
 def rename_project(
     project_id: Annotated[UUID, Depends(get_project_id)],
-    project_update: Annotated[ProjectUpdate, Body(description="Updated project name")],
+    project_update_name: Annotated[ProjectUpdateName, Body(description="Updated project name")],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> Project:
     """Rename a project"""
     try:
-        return project_service.update_project_name(project_id, project_update.name)
+        return project_service.update_project_name(project_id, project_update_name.name)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/application/backend/app/api/endpoints/projects.py
+++ b/application/backend/app/api/endpoints/projects.py
@@ -134,12 +134,12 @@ def get_project(
         status.HTTP_404_NOT_FOUND: {"description": "Project not found"},
     },
 )
-def update_project(
+def rename_project(
     project_id: Annotated[UUID, Depends(get_project_id)],
     project_update: Annotated[ProjectUpdate, Body(description="Updated project name")],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> Project:
-    """Update project name only"""
+    """Rename a project"""
     try:
         return project_service.update_project_name(project_id, project_update.name)
     except ResourceNotFoundError as e:

--- a/application/backend/app/api/endpoints/projects.py
+++ b/application/backend/app/api/endpoints/projects.py
@@ -13,7 +13,7 @@ from fastapi.openapi.models import Example
 from starlette.responses import FileResponse
 
 from app.api.dependencies import get_label_service, get_project_id, get_project_service
-from app.schemas import Label, PatchLabels, Project
+from app.schemas import Label, PatchLabels, Project, ProjectUpdate
 from app.services import (
     LabelService,
     ProjectService,
@@ -121,6 +121,27 @@ def get_project(
     """Get info about a given project"""
     try:
         return project_service.get_project_by_id(project_id)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.patch(
+    "/{project_id}",
+    response_model=Project,
+    responses={
+        status.HTTP_200_OK: {"description": "Project name updated successfully"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID or request body"},
+        status.HTTP_404_NOT_FOUND: {"description": "Project not found"},
+    },
+)
+def update_project(
+    project_id: Annotated[UUID, Depends(get_project_id)],
+    project_update: Annotated[ProjectUpdate, Body(description="Updated project name")],
+    project_service: Annotated[ProjectService, Depends(get_project_service)],
+) -> Project:
+    """Update project name only"""
+    try:
+        return project_service.update_project_name(project_id, project_update.name)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/application/backend/app/schemas/__init__.py
+++ b/application/backend/app/schemas/__init__.py
@@ -7,7 +7,7 @@ from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetric
 from app.schemas.model import Model, ModelFormat
 from app.schemas.model_architecture import ModelArchitectures
 from app.schemas.pipeline import DataCollectionPolicy, Pipeline, PipelineStatus
-from app.schemas.project import Project
+from app.schemas.project import Project, ProjectUpdate
 from app.schemas.sink import DisconnectedSinkConfig, OutputFormat, Sink, SinkType
 from app.schemas.source import DisconnectedSourceConfig, Source, SourceType
 
@@ -29,6 +29,7 @@ __all__ = [
     "PipelineMetrics",
     "PipelineStatus",
     "Project",
+    "ProjectUpdate",
     "Sink",
     "SinkType",
     "Source",

--- a/application/backend/app/schemas/__init__.py
+++ b/application/backend/app/schemas/__init__.py
@@ -7,7 +7,7 @@ from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetric
 from app.schemas.model import Model, ModelFormat
 from app.schemas.model_architecture import ModelArchitectures
 from app.schemas.pipeline import DataCollectionPolicy, Pipeline, PipelineStatus
-from app.schemas.project import Project, ProjectUpdate
+from app.schemas.project import Project, ProjectUpdateName
 from app.schemas.sink import DisconnectedSinkConfig, OutputFormat, Sink, SinkType
 from app.schemas.source import DisconnectedSourceConfig, Source, SourceType
 
@@ -29,7 +29,7 @@ __all__ = [
     "PipelineMetrics",
     "PipelineStatus",
     "Project",
-    "ProjectUpdate",
+    "ProjectUpdateName",
     "Sink",
     "SinkType",
     "Source",

--- a/application/backend/app/schemas/project.py
+++ b/application/backend/app/schemas/project.py
@@ -20,6 +20,14 @@ class Task(BaseModel):
     labels: list[Label] = []
 
 
+class ProjectUpdate(BaseModel):
+    """Schema for updating project name"""
+
+    name: str
+
+    model_config = {"json_schema_extra": {"example": {"name": "updated_project_name"}}}
+
+
 class Project(BaseIDNameModel):
     task: Task
 

--- a/application/backend/app/schemas/project.py
+++ b/application/backend/app/schemas/project.py
@@ -20,7 +20,7 @@ class Task(BaseModel):
     labels: list[Label] = []
 
 
-class ProjectUpdate(BaseModel):
+class ProjectUpdateName(BaseModel):
     """Schema for updating project name"""
 
     name: str

--- a/application/backend/app/services/project_service.py
+++ b/application/backend/app/services/project_service.py
@@ -41,6 +41,12 @@ class ProjectService:
         return project
 
     @parent_process_only
+    def update_project_name(self, project_id: UUID, name: str) -> Project:
+        """Update only the project name"""
+        project = self.get_project_by_id(project_id)
+        return self._persistence.update(project, {"name": name})
+
+    @parent_process_only
     def delete_project_by_id(self, project_id: UUID) -> None:
         with get_db_session() as db:
             pipeline_repo = PipelineRepository(db)

--- a/application/backend/tests/integration/services/test_project_service.py
+++ b/application/backend/tests/integration/services/test_project_service.py
@@ -197,3 +197,26 @@ class TestProjectServiceIntegration:
 
         assert excinfo.value.resource_type == ResourceType.PROJECT
         assert excinfo.value.resource_id == str(non_existent_id)
+
+    def test_update_project_name(
+        self, fxt_project_service: ProjectService, fxt_db_projects: list[ProjectDB], db_session: Session
+    ):
+        """Test updating a project's name."""
+        db_project = fxt_db_projects[0]
+        db_session.add(db_project)
+        db_session.flush()
+
+        new_name = "Updated Project Name"
+        updated_project = fxt_project_service.update_project_name(UUID(db_project.id), new_name)
+
+        assert updated_project.name == new_name
+
+    def test_update_project_name_not_found(self, fxt_project_service: ProjectService):
+        """Test updating a non-existent project name raises error."""
+        non_existent_id = uuid4()
+        new_name = "New Project Name"
+        with pytest.raises(ResourceNotFoundError) as excinfo:
+            fxt_project_service.update_project_name(non_existent_id, new_name)
+
+        assert excinfo.value.resource_type == ResourceType.PROJECT
+        assert excinfo.value.resource_id == str(non_existent_id)


### PR DESCRIPTION
### Summary

This PR adds a new endpoint to be able to rename a project

### How to test
`PATCH /api/projects/3ab1bde4-288e-4309-bdc7-c54b004d17aa`

<img width="1152" height="18" alt="image" src="https://github.com/user-attachments/assets/cecdf4b8-18c8-4b6d-ad1f-08764d38fccb" />
<img width="558" height="225" alt="image" src="https://github.com/user-attachments/assets/70487ca9-2120-4a9f-a6a4-fef3e5970909" />


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
