### PR TITLE
Bugfix: incorrect decoding of detection predictions in data collection

### DIFF
--- a/application/backend/app/services/data_collect/prediction_converter.py
+++ b/application/backend/app/services/data_collect/prediction_converter.py
@@ -23,10 +23,10 @@ def _convert_detection_prediction(labels: list[Label], prediction: DetectionResu
         if not label:
             logger.warning("Prediction label %s cannot be found in the project", label_name)
             continue
-        x, y, width, height = box.tolist()
+        x1, y1, x2, y2 = box.tolist()
         annotation = DatasetItemAnnotation(
             labels=[LabelReference(id=label.id)],
-            shape=Rectangle(x=x, y=y, width=width, height=height),
+            shape=Rectangle(x=x1, y=y1, width=(x2 - x1), height=(y2 - y1)),
             confidence=confidence,
         )
         result.append(annotation)

--- a/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
+++ b/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
@@ -42,7 +42,7 @@ def test_convert_prediction_detection() -> None:
     # Arrange
     frame_data = np.random.rand(100, 100, 3)
     label = Label(id=uuid4(), name="cat", color="#ff0000", hotkey="c")
-    coords = [12, 41, 12, 46]
+    coords = [12, 41, 30, 65]  # x1, y1, x2, y2
     raw_prediction = DetectionResult(
         bboxes=np.array([coords]),
         labels=np.array([1]),
@@ -59,7 +59,7 @@ def test_convert_prediction_detection() -> None:
     assert annotations == [
         DatasetItemAnnotation(
             labels=[LabelReference(id=label.id)],
-            shape=Rectangle(x=12, y=41, width=12, height=46),
+            shape=Rectangle(x=12, y=41, width=18, height=24),
             confidence=0.81,
         )
     ]


### PR DESCRIPTION

### Summary

The converter would interpret the result as XYWH instead of X1X2Y1Y2. Besides being incorrect, this would also lead to errors like "coordinates out of bound" when creating a DatasetItem for the collected frame.

### How to test

1. Create a project
2. Set a data collection policy, e.g. `curl -s -X PATCH localhost:7860/api/projects/9d6af8e8-6017-4ebe-9126-33aae739c5fa/pipeline -H "Content-Type: application/json" --data '{"data_collection_policies": [{"type": "fixed_rate", "enabled": true, "rate": 0.2}]}'`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​