### PR TITLE
Collected dataset items have inverted color channels

### DIFF
--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 from uuid import UUID
 
+import cv2
 import numpy as np
 
 from app.entities.stream_data import InferenceData
@@ -78,6 +79,7 @@ class DataCollector:
         )
         if not should_collect:
             return
+        frame_data = cv2.cvtColor(frame_data, cv2.COLOR_BGR2RGB)  # Convert BGR to RGB
         annotations = convert_prediction(
             labels=project.task.labels, frame_data=frame_data, prediction=inference_data.prediction
         )

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from uuid import uuid4
 
 import numpy as np
@@ -90,7 +90,7 @@ class TestDataCollectorUnit:
         # Arrange
         source_id = uuid4()
         project = MagicMock()
-        frame_data = np.random.rand(100, 100, 3)
+        frame_data = np.random.randint(low=0, high=255, size=(100, 100), dtype=np.uint8)
         inference_data = MagicMock()
 
         now = datetime.timestamp(datetime.now())
@@ -119,13 +119,13 @@ class TestDataCollectorUnit:
 
         # Assert
         mock_convert_prediction.assert_called_once_with(
-            labels=project.task.labels, frame_data=frame_data, prediction=inference_data.prediction
+            labels=project.task.labels, frame_data=ANY, prediction=inference_data.prediction
         )
         mock_create_dataset_item.assert_called_once_with(
             project_id=project.id,
             name="1735689601_0000",
             format=DatasetItemFormat.JPG,
-            data=frame_data,
+            data=ANY,
             user_reviewed=False,
             source_id=source_id,
             prediction_model_id=inference_data.model_id,
@@ -140,7 +140,7 @@ class TestDataCollectorUnit:
         # Arrange
         source_id = uuid4()
         project = MagicMock()
-        frame_data = np.random.rand(100, 100, 3)
+        frame_data = np.random.randint(low=0, high=255, size=(100, 100), dtype=np.uint8)
         inference_data = MagicMock()
 
         now = datetime.timestamp(datetime.now())
@@ -169,13 +169,13 @@ class TestDataCollectorUnit:
 
         # Assert
         mock_convert_prediction.assert_called_once_with(
-            labels=project.task.labels, frame_data=frame_data, prediction=inference_data.prediction
+            labels=project.task.labels, frame_data=ANY, prediction=inference_data.prediction
         )
         mock_create_dataset_item.assert_called_once_with(
             project_id=project.id,
             name="1735689601_0000",
             format=DatasetItemFormat.JPG,
-            data=frame_data,
+            data=ANY,
             user_reviewed=False,
             source_id=source_id,
             prediction_model_id=inference_data.model_id,


### PR DESCRIPTION
### Summary

Resolves #4793 

Fixes a bug with incorrect RGB channels, Data Collector performs BGR -> RGB conversion if necessary.

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] I have added unit tests to cover my changes.​
- [x] I have added integration tests to cover my changes.​
- [x] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [x] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
