### PR TITLE
Improve db session mgmt & upgrade sqlalchemy API

### DIFF
--- a/application/backend/app/core/lifecycle.py
+++ b/application/backend/app/core/lifecycle.py
@@ -24,7 +24,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """FastAPI lifespan context manager"""
     # Startup
     settings = get_settings()
-    app.state.settings = settings
     logger.info("Starting %s application...", settings.app_name)
 
     # Initialize database
@@ -36,7 +35,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     active_pipeline_service = ActivePipelineService()
     app.state.active_pipeline_service = active_pipeline_service
 
-    data_collector = DataCollector(active_pipeline_service=active_pipeline_service)
+    data_collector = DataCollector(data_dir=settings.data_dir, active_pipeline_service=active_pipeline_service)
     app.state.data_collector = data_collector
 
     # Initialize Scheduler

--- a/application/backend/app/core/lifecycle.py
+++ b/application/backend/app/core/lifecycle.py
@@ -24,6 +24,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """FastAPI lifespan context manager"""
     # Startup
     settings = get_settings()
+    app.state.settings = settings
     logger.info("Starting %s application...", settings.app_name)
 
     # Initialize database

--- a/application/backend/app/db/engine.py
+++ b/application/backend/app/db/engine.py
@@ -34,7 +34,7 @@ def set_sqlite_pragma(dbapi_connection: Connection, _: Any) -> None:
     cursor.close()
 
 
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+SessionLocal = sessionmaker(bind=db_engine)
 Base = declarative_base()
 
 
@@ -47,5 +47,7 @@ def get_db_session() -> Iterator[Session]:
     except Exception:
         db.rollback()
         raise
+    else:
+        db.commit()
     finally:
         db.close()

--- a/application/backend/app/db/schema.py
+++ b/application/backend/app/db/schema.py
@@ -10,29 +10,29 @@ from sqlalchemy.sql import func
 
 
 class Base(DeclarativeBase):
-    pass
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
 
-class SourceDB(Base):
+class BaseID(Base):
+    __abstract__ = True
+    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
+
+
+class SourceDB(BaseID):
     __tablename__ = "sources"
 
-    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
     name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     source_type: Mapped[str] = mapped_column(String(50), nullable=False)
     config_data: Mapped[dict] = mapped_column(JSON, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
 
-class ProjectDB(Base):
+class ProjectDB(BaseID):
     __tablename__ = "projects"
 
-    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     task_type: Mapped[str] = mapped_column(String(50), nullable=False)
     exclusive_labels: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
     pipeline = relationship("PipelineDB", back_populates="project", uselist=False)
     labels = relationship("LabelDB", back_populates="project")
@@ -48,8 +48,6 @@ class PipelineDB(Base):
     model_revision_id: Mapped[str | None] = mapped_column(Text, ForeignKey("model_revisions.id", ondelete="RESTRICT"))
     is_running: Mapped[bool] = mapped_column(Boolean, default=False)
     data_collection_policies: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
     project = relationship("ProjectDB", back_populates="pipeline")
     sink = relationship("SinkDB", uselist=False)
@@ -57,7 +55,7 @@ class PipelineDB(Base):
     model_revision = relationship("ModelRevisionDB", uselist=False)
 
 
-class SinkDB(Base):
+class SinkDB(BaseID):
     __tablename__ = "sinks"
 
     id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
@@ -66,14 +64,11 @@ class SinkDB(Base):
     rate_limit: Mapped[float | None] = mapped_column(Float, nullable=True)
     config_data: Mapped[dict] = mapped_column(JSON, nullable=False)
     output_formats: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
 
-class ModelRevisionDB(Base):
+class ModelRevisionDB(BaseID):
     __tablename__ = "model_revisions"
 
-    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
     project_id: Mapped[str] = mapped_column(Text, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
     architecture: Mapped[str] = mapped_column(String(100), nullable=False)
     parent_revision: Mapped[str | None] = mapped_column(Text, ForeignKey("model_revisions.id"), nullable=True)
@@ -84,26 +79,20 @@ class ModelRevisionDB(Base):
     training_started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     training_finished_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     files_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
     project = relationship("ProjectDB", back_populates="model_revisions")
 
 
-class DatasetRevisionDB(Base):
+class DatasetRevisionDB(BaseID):
     __tablename__ = "dataset_revisions"
 
-    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
     project_id: Mapped[str] = mapped_column(Text, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
     files_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
 
-class DatasetItemDB(Base):
+class DatasetItemDB(BaseID):
     __tablename__ = "dataset_items"
 
-    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
     project_id: Mapped[str] = mapped_column(Text, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     format: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -118,22 +107,17 @@ class DatasetItemDB(Base):
     source_id: Mapped[str | None] = mapped_column(Text, ForeignKey("sources.id", ondelete="SET NULL"), nullable=True)
     subset: Mapped[str | None] = mapped_column(String(20), nullable=False)
     subset_assigned_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
 
 
-class LabelDB(Base):
+class LabelDB(BaseID):
     __tablename__ = "labels"
     __table_args__ = (
         UniqueConstraint("project_id", "name", name="uq_project_label_name"),
         UniqueConstraint("project_id", "hotkey", name="uq_project_label_hotkey"),
     )
 
-    id: Mapped[str] = mapped_column(Text, primary_key=True, default=lambda: str(uuid4()))
     project_id: Mapped[str] = mapped_column(Text, ForeignKey("projects.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.current_timestamp())
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)
     hotkey: Mapped[str | None] = mapped_column(String(10), nullable=True)
 

--- a/application/backend/app/repositories/base.py
+++ b/application/backend/app/repositories/base.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime
+from collections.abc import Sequence
+from datetime import UTC, datetime
 from typing import TypeVar
 
-from sqlalchemy import exists
+from sqlalchemy import delete, exists, select
 from sqlalchemy.orm import Session
 
 from app.db.schema import Base
@@ -23,40 +24,46 @@ class BaseRepository[ModelType]:
         return self.db.get(self.model, obj_id)
 
     def exists(self, obj_id: str) -> bool:
-        return self.db.query(exists().where(self.model.id == obj_id)).scalar()  # type: ignore[attr-defined]
+        stmt = select(exists().where(self.model.id == obj_id))  # type: ignore[attr-defined]
+        return self.db.execute(stmt).scalar() or False
 
-    def list_all(self) -> list[ModelType]:
-        return self.db.query(self.model).all()
+    def list_all(self) -> Sequence[ModelType]:
+        return self.db.execute(select(self.model)).scalars().all()
 
     def save(self, item: ModelType) -> ModelType:
-        item.updated_at = datetime.now()  # type: ignore[attr-defined]
+        item.updated_at = datetime.now(UTC)  # type: ignore[attr-defined]
         self.db.add(item)
         self.db.flush()
         return item
 
     def update(self, item: ModelType) -> ModelType:
-        item.updated_at = datetime.now()  # type: ignore[attr-defined]
+        item.updated_at = datetime.now(UTC)  # type: ignore[attr-defined]
         updated = self.db.merge(item)
         self.db.flush()
         self.db.refresh(updated)
         return updated
 
     def delete(self, obj_id: str) -> bool:
-        return self.db.query(self.model).filter(self.model.id == obj_id).delete() > 0  # type: ignore[attr-defined]
+        stmt = delete(self.model).where(self.model.id == obj_id)  # type: ignore[attr-defined]
+        result = self.db.execute(stmt)
+        return result.rowcount > 0  # type: ignore[union-attr]
 
     def save_batch(self, items: list[ModelType]) -> list[ModelType]:
+        now = datetime.now(UTC)
         for item in items:
-            item.updated_at = datetime.now()  # type: ignore[attr-defined]
+            item.updated_at = now  # type: ignore[attr-defined]
         self.db.add_all(items)
         self.db.flush()
         return items
 
     def update_batch(self, updates: list[ModelType]) -> None:
+        now = datetime.now(UTC)
         for update in updates:
-            update.updated_at = datetime.now()  # type: ignore[attr-defined]
+            update.updated_at = now  # type: ignore[attr-defined]
             self.db.merge(update)
         self.db.flush()
 
-    def delete_batch(self, obj_ids: list[str]) -> None:
-        self.db.query(self.model).filter(self.model.id.in_(obj_ids)).delete(synchronize_session=False)  # type: ignore[attr-defined]
-        self.db.flush()
+    def delete_batch(self, obj_ids: list[str]) -> int:
+        stmt = delete(self.model).where(self.model.id.in_(obj_ids))  # type: ignore[attr-defined]
+        result = self.db.execute(stmt)
+        return result.rowcount  # type: ignore[union-attr]

--- a/application/backend/app/repositories/base.py
+++ b/application/backend/app/repositories/base.py
@@ -3,17 +3,17 @@
 
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import TypeVar
+from typing import Generic, TypeVar
 
 from sqlalchemy import delete, exists, select
 from sqlalchemy.orm import Session
 
-from app.db.schema import Base
+from app.db.schema import BaseID
 
-ModelType = TypeVar("ModelType", bound=Base)
+ModelType = TypeVar("ModelType", bound=BaseID)
 
 
-class BaseRepository[ModelType]:
+class BaseRepository(Generic[ModelType]):
     """Base repository class for database operations."""
 
     def __init__(self, db: Session, model: type[ModelType]) -> None:
@@ -24,34 +24,34 @@ class BaseRepository[ModelType]:
         return self.db.get(self.model, obj_id)
 
     def exists(self, obj_id: str) -> bool:
-        stmt = select(exists().where(self.model.id == obj_id))  # type: ignore[attr-defined]
+        stmt = select(exists().where(self.model.id == obj_id))
         return self.db.execute(stmt).scalar() or False
 
     def list_all(self) -> Sequence[ModelType]:
         return self.db.execute(select(self.model)).scalars().all()
 
     def save(self, item: ModelType) -> ModelType:
-        item.updated_at = datetime.now(UTC)  # type: ignore[attr-defined]
+        item.updated_at = datetime.now(UTC)
         self.db.add(item)
         self.db.flush()
         return item
 
     def update(self, item: ModelType) -> ModelType:
-        item.updated_at = datetime.now(UTC)  # type: ignore[attr-defined]
+        item.updated_at = datetime.now(UTC)
         updated = self.db.merge(item)
         self.db.flush()
         self.db.refresh(updated)
         return updated
 
     def delete(self, obj_id: str) -> bool:
-        stmt = delete(self.model).where(self.model.id == obj_id)  # type: ignore[attr-defined]
+        stmt = delete(self.model).where(self.model.id == obj_id)
         result = self.db.execute(stmt)
         return result.rowcount > 0  # type: ignore[union-attr]
 
     def save_batch(self, items: list[ModelType]) -> list[ModelType]:
         now = datetime.now(UTC)
         for item in items:
-            item.updated_at = now  # type: ignore[attr-defined]
+            item.updated_at = now
         self.db.add_all(items)
         self.db.flush()
         return items
@@ -59,11 +59,11 @@ class BaseRepository[ModelType]:
     def update_batch(self, updates: list[ModelType]) -> None:
         now = datetime.now(UTC)
         for update in updates:
-            update.updated_at = now  # type: ignore[attr-defined]
+            update.updated_at = now
             self.db.merge(update)
         self.db.flush()
 
     def delete_batch(self, obj_ids: list[str]) -> int:
-        stmt = delete(self.model).where(self.model.id.in_(obj_ids))  # type: ignore[attr-defined]
+        stmt = delete(self.model).where(self.model.id.in_(obj_ids))
         result = self.db.execute(stmt)
         return result.rowcount  # type: ignore[union-attr]

--- a/application/backend/app/repositories/pipeline_repo.py
+++ b/application/backend/app/repositories/pipeline_repo.py
@@ -1,19 +1,29 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db.schema import PipelineDB
-from app.repositories.base import BaseRepository
 
 
-class PipelineRepository(BaseRepository[PipelineDB]):
+class PipelineRepository:
     """Repository for pipeline-related database operations."""
 
     def __init__(self, db: Session):
-        super().__init__(db, PipelineDB)
+        self.db = db
+
+    def get_by_id(self, obj_id: str) -> PipelineDB | None:
+        return self.db.get(PipelineDB, obj_id)
+
+    def update(self, item: PipelineDB) -> PipelineDB:
+        item.updated_at = datetime.now(UTC)
+        updated = self.db.merge(item)
+        # Explicit early commit to ensure changes are visible to other transactions before the session is closed
+        self.db.commit()
+        return updated
 
     def get_active_pipeline(self) -> PipelineDB | None:
         """Get the active pipeline from database."""

--- a/application/backend/app/repositories/pipeline_repo.py
+++ b/application/backend/app/repositories/pipeline_repo.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db.schema import PipelineDB
@@ -16,4 +17,5 @@ class PipelineRepository(BaseRepository[PipelineDB]):
 
     def get_active_pipeline(self) -> PipelineDB | None:
         """Get the active pipeline from database."""
-        return self.db.query(PipelineDB).filter(PipelineDB.is_running).first()
+        stmt = select(PipelineDB).where(PipelineDB.is_running)
+        return self.db.execute(stmt).scalar_one_or_none()

--- a/application/backend/app/services/__init__.py
+++ b/application/backend/app/services/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
+from .active_model_service import ActiveModelService
 from .active_pipeline_service import ActivePipelineService
 from .base import ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError, ResourceType
 from .configuration_service import ConfigurationService
@@ -15,6 +15,7 @@ from .system_service import SystemService
 from .video_stream_service import VideoStreamService
 
 __all__ = [
+    "ActiveModelService",
     "ActivePipelineService",
     "ConfigurationService",
     "DatasetService",

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+from dataclasses import dataclass
+from multiprocessing.synchronize import Event as EventClass
+from pathlib import Path
+from uuid import UUID
+
+from model_api.models import Model
+
+from app.db.engine import get_db_session
+from app.repositories import ModelRevisionRepository
+from app.schemas.model_activation import ModelActivationState
+
+logger = logging.getLogger(__name__)
+
+MODELAPI_DEVICE = os.getenv("MODELAPI_DEVICE", "AUTO")
+MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
+
+
+@dataclass(frozen=True)
+class LoadedModel:
+    id: UUID
+    model: Model
+
+
+class ActiveModelService:
+    """
+    Service to fetch the currently active model for inference.
+
+    Used exclusively by the InferenceWorker process.
+    """
+
+    def __init__(self, data_dir: Path, mp_model_reload_event: EventClass) -> None:
+        self.projects_dir = data_dir / "projects"
+        self._mp_model_reload_event = mp_model_reload_event
+        self._model_activation_state: ModelActivationState = self._load_state()
+        self._loaded_model: LoadedModel | None = None
+
+    @staticmethod
+    def _load_state() -> ModelActivationState:
+        """Load the state from the file if it exists, otherwise initialize an empty state"""
+        with get_db_session() as db:
+            repo = ModelRevisionRepository(db)
+            active_model = repo.get_active_revision()
+            available_models = repo.list_all()
+            return ModelActivationState(
+                project_id=UUID(active_model.project_id) if active_model is not None else None,
+                active_model_id=UUID(active_model.id) if active_model is not None else None,
+                available_models=[UUID(m.id) for m in available_models],
+            )
+
+    def _get_model_xml_path(self, project_id: UUID, model_id: UUID) -> Path:
+        return self.projects_dir / f"{project_id}/models/{model_id}/model.xml"
+
+    def _get_model_bin_path(self, project_id: UUID, model_id: UUID) -> Path:
+        return self.projects_dir / f"{project_id}/models/{model_id}/model.bin"
+
+    def get_loaded_inference_model(self, force_reload: bool = False) -> LoadedModel | None:
+        """
+        Get the currently active model for inference.
+
+        Args:
+            force_reload: If True, reload the state and the model from disk. This option can be useful
+            to bypass the cache after the state has been modified externally.
+
+        Returns: Model for inference or None if no model is active
+        """
+        if force_reload:
+            self._model_activation_state = self._load_state()
+            self._loaded_model = None
+
+        if self._model_activation_state.active_model_id is None:
+            return None
+
+        project_id = self._model_activation_state.project_id
+        active_model_id = self._model_activation_state.active_model_id
+        if self._loaded_model is None or self._loaded_model.id != active_model_id:
+            logger.info("Loading model with ID '%s'", active_model_id)
+            model_path = self._get_model_xml_path(project_id, active_model_id)
+            self._loaded_model = LoadedModel(
+                id=self._model_activation_state.active_model_id,
+                model=Model.create_model(
+                    model=str(model_path),
+                    device=MODELAPI_DEVICE,
+                    nstreams=MODELAPI_NSTREAMS,
+                ),
+            )
+        return self._loaded_model

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -72,7 +72,7 @@ class ActiveModelService:
             self._model_activation_state = self._load_state()
             self._loaded_model = None
 
-        if self._model_activation_state.active_model_id is None:
+        if self._model_activation_state.active_model_id is None or self._model_activation_state.project_id is None:
             return None
 
         project_id = self._model_activation_state.project_id

--- a/application/backend/app/services/base.py
+++ b/application/backend/app/services/base.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.db import get_db_session
 from app.db.schema import Base
 from app.repositories.base import BaseRepository
 
@@ -87,32 +86,27 @@ class ServiceConfig(Generic[R]):
 class GenericPersistenceService(Generic[S, R]):
     """Generic service for CRUD operations on a repository."""
 
-    def __init__(self, config: ServiceConfig[R]) -> None:
+    def __init__(self, config: ServiceConfig[R], db: Session) -> None:
         self.config = config
+        self.db = db
 
     @contextmanager
-    def _get_repo(self, db: Session | None = None) -> Generator[R]:
-        if db is None:
-            with get_db_session() as db_session:
-                repo = self.config.repository_class(db_session)  # type: ignore[call-arg]
-                yield repo
-                db_session.commit()
-        else:
-            repo = self.config.repository_class(db)  # type: ignore[call-arg]
-            yield repo
+    def _get_repo(self) -> Generator[R]:
+        repo = self.config.repository_class(self.db)  # type: ignore[call-arg]
+        yield repo
 
-    def list_all(self, db: Session | None = None) -> list[S]:
-        with self._get_repo(db) as repo:
+    def list_all(self) -> list[S]:
+        with self._get_repo() as repo:
             return [self.config.mapper_class.to_schema(o) for o in repo.list_all()]
 
-    def get_by_id(self, item_id: UUID, db: Session | None = None) -> S | None:
-        with self._get_repo(db) as repo:
+    def get_by_id(self, item_id: UUID) -> S | None:
+        with self._get_repo() as repo:
             item_db = repo.get_by_id(str(item_id))
             return self.config.mapper_class.to_schema(item_db) if item_db else None
 
-    def create(self, item: S, db: Session | None = None) -> S:
+    def create(self, item: S) -> S:
         try:
-            with self._get_repo(db) as repo:
+            with self._get_repo() as repo:
                 item_db = self.config.mapper_class.from_schema(item)
                 repo.save(item_db)
                 return self.config.mapper_class.to_schema(item_db)
@@ -121,17 +115,17 @@ class GenericPersistenceService(Generic[S, R]):
                 raise ResourceAlreadyExistsError(self.config.resource_type, getattr(item, "name", str(item.id)))  # type: ignore[attr-defined]
             raise
 
-    def update(self, item: S, partial_config: dict, db: Session | None = None) -> S:
-        with self._get_repo(db) as repo:
+    def update(self, item: S, partial_config: dict) -> S:
+        with self._get_repo() as repo:
             to_update = item.model_copy(update=partial_config)
             updated = repo.update(self.config.mapper_class.from_schema(to_update))
-            if db:
-                db.commit()  # Ensure changes are committed for notification purposes
+            # Explicit early commit to ensure changes are visible to other transactions before the session is closed
+            self.db.commit()
             return self.config.mapper_class.to_schema(updated)
 
-    def delete_by_id(self, item_id: UUID, db: Session | None = None) -> None:
+    def delete_by_id(self, item_id: UUID) -> None:
         try:
-            with self._get_repo(db) as repo:
+            with self._get_repo() as repo:
                 deleted = repo.delete(str(item_id))
             if not deleted:
                 raise ResourceNotFoundError(self.config.resource_type, str(item_id))

--- a/application/backend/app/services/base.py
+++ b/application/backend/app/services/base.py
@@ -125,6 +125,8 @@ class GenericPersistenceService(Generic[S, R]):
         with self._get_repo(db) as repo:
             to_update = item.model_copy(update=partial_config)
             updated = repo.update(self.config.mapper_class.from_schema(to_update))
+            if db:
+                db.commit()  # Ensure changes are committed for notification purposes
             return self.config.mapper_class.to_schema(updated)
 
     def delete_by_id(self, item_id: UUID, db: Session | None = None) -> None:

--- a/application/backend/app/services/configuration_service.py
+++ b/application/backend/app/services/configuration_service.py
@@ -31,10 +31,10 @@ class ConfigurationService:
         self, active_pipeline_service: ActivePipelineService, db_session: Session, config_changed_condition: Condition
     ) -> None:
         self._source_service: GenericPersistenceService[Source, SourceRepository] = GenericPersistenceService(
-            ServiceConfig(SourceRepository, SourceMapper, ResourceType.SOURCE)
+            ServiceConfig(SourceRepository, SourceMapper, ResourceType.SOURCE), db_session
         )
         self._sink_service: GenericPersistenceService[Sink, SinkRepository] = GenericPersistenceService(
-            ServiceConfig(SinkRepository, SinkMapper, ResourceType.SINK)
+            ServiceConfig(SinkRepository, SinkMapper, ResourceType.SINK), db_session
         )
         self._db_session = db_session
         self._active_pipeline_service: ActivePipelineService = active_pipeline_service
@@ -56,51 +56,51 @@ class ConfigurationService:
             notify_fn()
 
     def list_sources(self) -> list[Source]:
-        return self._source_service.list_all(self._db_session)
+        return self._source_service.list_all()
 
     def list_sinks(self) -> list[Sink]:
-        return self._sink_service.list_all(self._db_session)
+        return self._sink_service.list_all()
 
     def get_source_by_id(self, source_id: UUID) -> Source:
-        source = self._source_service.get_by_id(source_id, self._db_session)
+        source = self._source_service.get_by_id(source_id)
         if not source:
             raise ResourceNotFoundError(ResourceType.SOURCE, str(source_id))
         return source
 
     def get_sink_by_id(self, sink_id: UUID) -> Sink:
-        sink = self._sink_service.get_by_id(sink_id, self._db_session)
+        sink = self._sink_service.get_by_id(sink_id)
         if not sink:
             raise ResourceNotFoundError(ResourceType.SINK, str(sink_id))
         return sink
 
     @parent_process_only
     def create_source(self, source: Source) -> Source:
-        return self._source_service.create(source, self._db_session)
+        return self._source_service.create(source)
 
     @parent_process_only
     def create_sink(self, sink: Sink) -> Sink:
-        return self._sink_service.create(sink, self._db_session)
+        return self._sink_service.create(sink)
 
     @parent_process_only
     def update_source(self, source_id: UUID, partial_config: dict) -> Source:
         source = self.get_source_by_id(source_id)
-        updated = self._source_service.update(source, partial_config, self._db_session)
+        updated = self._source_service.update(source, partial_config)
         self._on_config_changed(updated.id, PipelineField.SOURCE_ID, self._notify_source_changed)
         return updated
 
     @parent_process_only
     def update_sink(self, sink_id: UUID, partial_config: dict) -> Sink:
         sink = self.get_sink_by_id(sink_id)
-        updated = self._sink_service.update(sink, partial_config, self._db_session)
+        updated = self._sink_service.update(sink, partial_config)
         self._on_config_changed(updated.id, PipelineField.SINK_ID, self._notify_sink_changed)
         return updated
 
     @parent_process_only
     def delete_source_by_id(self, source_id: UUID) -> None:
         source = self.get_source_by_id(source_id)
-        self._source_service.delete_by_id(source.id, self._db_session)
+        self._source_service.delete_by_id(source.id)
 
     @parent_process_only
     def delete_sink_by_id(self, sink_id: UUID) -> None:
         sink = self.get_sink_by_id(sink_id)
-        self._sink_service.delete_by_id(sink.id, self._db_session)
+        self._sink_service.delete_by_id(sink.id)

--- a/application/backend/app/services/configuration_service.py
+++ b/application/backend/app/services/configuration_service.py
@@ -9,7 +9,6 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.db import get_db_session
 from app.repositories import PipelineRepository, SinkRepository, SourceRepository
 from app.schemas import Sink, Source
 from app.services import ActivePipelineService
@@ -28,13 +27,16 @@ class PipelineField(StrEnum):
 
 
 class ConfigurationService:
-    def __init__(self, active_pipeline_service: ActivePipelineService, config_changed_condition: Condition) -> None:
+    def __init__(
+        self, active_pipeline_service: ActivePipelineService, db_session: Session, config_changed_condition: Condition
+    ) -> None:
         self._source_service: GenericPersistenceService[Source, SourceRepository] = GenericPersistenceService(
             ServiceConfig(SourceRepository, SourceMapper, ResourceType.SOURCE)
         )
         self._sink_service: GenericPersistenceService[Sink, SinkRepository] = GenericPersistenceService(
             ServiceConfig(SinkRepository, SinkMapper, ResourceType.SINK)
         )
+        self._db_session = db_session
         self._active_pipeline_service: ActivePipelineService = active_pipeline_service
         self._config_changed_condition: Condition = config_changed_condition
 
@@ -45,69 +47,60 @@ class ConfigurationService:
         with self._config_changed_condition:
             self._config_changed_condition.notify_all()
 
-    @staticmethod
-    def _on_config_changed(config_id: UUID, field: PipelineField, db: Session, notify_fn: Callable[[], None]) -> None:
+    def _on_config_changed(self, config_id: UUID, field: PipelineField, notify_fn: Callable[[], None]) -> None:
         """Notify threads or child processes that the configuration has changed.
         Notification triggered only when the configuration is used by the active pipeline."""
-        pipeline_repo = PipelineRepository(db)
+        pipeline_repo = PipelineRepository(self._db_session)
         active_pipeline = pipeline_repo.get_active_pipeline()
         if active_pipeline and getattr(active_pipeline, field) == str(config_id):
             notify_fn()
 
     def list_sources(self) -> list[Source]:
-        return self._source_service.list_all()
+        return self._source_service.list_all(self._db_session)
 
     def list_sinks(self) -> list[Sink]:
-        return self._sink_service.list_all()
+        return self._sink_service.list_all(self._db_session)
 
-    def get_source_by_id(self, source_id: UUID, db: Session | None = None) -> Source:
-        source = self._source_service.get_by_id(source_id, db)
+    def get_source_by_id(self, source_id: UUID) -> Source:
+        source = self._source_service.get_by_id(source_id, self._db_session)
         if not source:
             raise ResourceNotFoundError(ResourceType.SOURCE, str(source_id))
         return source
 
-    def get_sink_by_id(self, sink_id: UUID, db: Session | None = None) -> Sink:
-        sink = self._sink_service.get_by_id(sink_id, db)
+    def get_sink_by_id(self, sink_id: UUID) -> Sink:
+        sink = self._sink_service.get_by_id(sink_id, self._db_session)
         if not sink:
             raise ResourceNotFoundError(ResourceType.SINK, str(sink_id))
         return sink
 
     @parent_process_only
     def create_source(self, source: Source) -> Source:
-        return self._source_service.create(source)
+        return self._source_service.create(source, self._db_session)
 
     @parent_process_only
     def create_sink(self, sink: Sink) -> Sink:
-        return self._sink_service.create(sink)
+        return self._sink_service.create(sink, self._db_session)
 
     @parent_process_only
     def update_source(self, source_id: UUID, partial_config: dict) -> Source:
-        with get_db_session() as db:
-            source = self.get_source_by_id(source_id, db)
-            updated = self._source_service.update(source, partial_config, db)
-            db.commit()
-            self._on_config_changed(updated.id, PipelineField.SOURCE_ID, db, self._notify_source_changed)
-            return updated
+        source = self.get_source_by_id(source_id)
+        updated = self._source_service.update(source, partial_config, self._db_session)
+        self._on_config_changed(updated.id, PipelineField.SOURCE_ID, self._notify_source_changed)
+        return updated
 
     @parent_process_only
     def update_sink(self, sink_id: UUID, partial_config: dict) -> Sink:
-        with get_db_session() as db:
-            sink = self.get_sink_by_id(sink_id, db)
-            updated = self._sink_service.update(sink, partial_config, db)
-            db.commit()
-            self._on_config_changed(updated.id, PipelineField.SINK_ID, db, self._notify_sink_changed)
-            return updated
+        sink = self.get_sink_by_id(sink_id)
+        updated = self._sink_service.update(sink, partial_config, self._db_session)
+        self._on_config_changed(updated.id, PipelineField.SINK_ID, self._notify_sink_changed)
+        return updated
 
     @parent_process_only
     def delete_source_by_id(self, source_id: UUID) -> None:
-        with get_db_session() as db:
-            source = self.get_source_by_id(source_id, db)
-            self._source_service.delete_by_id(source.id, db)
-            db.commit()
+        source = self.get_source_by_id(source_id)
+        self._source_service.delete_by_id(source.id, self._db_session)
 
     @parent_process_only
     def delete_sink_by_id(self, sink_id: UUID) -> None:
-        with get_db_session() as db:
-            sink = self.get_sink_by_id(sink_id, db)
-            self._sink_service.delete_by_id(sink.id, db)
-            db.commit()
+        sink = self.get_sink_by_id(sink_id)
+        self._sink_service.delete_by_id(sink.id, self._db_session)

--- a/application/backend/app/services/dispatchers/base.py
+++ b/application/backend/app/services/dispatchers/base.py
@@ -4,7 +4,7 @@
 import base64
 import time
 from abc import ABCMeta, abstractmethod
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import cv2
@@ -68,7 +68,7 @@ class BaseDispatcher(metaclass=ABCMeta):
     ) -> dict[str, Any]:
         """Create a JSON payload with the requested output formats."""
         result: dict[str, Any] = {}
-        payload = {"timestamp": datetime.now().isoformat(), "result": result}
+        payload = {"timestamp": datetime.now(UTC).isoformat(), "result": result}
 
         if OutputFormat.IMAGE_ORIGINAL in self.output_formats:
             result[OutputFormat.IMAGE_ORIGINAL] = {

--- a/application/backend/app/services/dispatchers/filesystem.py
+++ b/application/backend/app/services/dispatchers/filesystem.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 
 import cv2
 import numpy as np
@@ -49,7 +49,7 @@ class FolderDispatcher(BaseDispatcher):
         image_with_visualization: np.ndarray,
         predictions: Result,
     ) -> None:
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]  # up to milliseconds
+        timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")[:-3]  # up to milliseconds
         image_orig_file = os.path.join(self.output_folder, f"{timestamp}-original.jpg")
         image_viz_file = os.path.join(self.output_folder, f"{timestamp}-pred.jpg")
         pred_txt_file = os.path.join(self.output_folder, f"{timestamp}-pred.txt")

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -2,95 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-import os
-from dataclasses import dataclass
-from multiprocessing.synchronize import Event as EventClass
-from pathlib import Path
 from uuid import UUID
 
-from model_api.models import Model
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
-from app.db import get_db_session
 from app.repositories import ModelRevisionRepository, ProjectRepository
 from app.schemas.model import Model as ModelSchema
-from app.schemas.model_activation import ModelActivationState
 from app.services.base import ResourceInUseError, ResourceNotFoundError, ResourceType
 from app.services.mappers.model_revision_mapper import ModelRevisionMapper
 from app.services.parent_process_guard import parent_process_only
 
 logger = logging.getLogger(__name__)
 
-MODELAPI_DEVICE = os.getenv("MODELAPI_DEVICE", "AUTO")
-MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
-
-
-@dataclass(frozen=True)
-class LoadedModel:
-    id: UUID
-    model: Model
-
 
 class ModelService:
     """Service to register and activate models"""
 
-    def __init__(self, data_dir: Path, mp_model_reload_event: EventClass | None = None) -> None:
-        self.projects_dir = data_dir / "projects"
-        self._mp_model_reload_event = mp_model_reload_event
-        self._model_activation_state: ModelActivationState = self._load_state()
-        self._loaded_model: LoadedModel | None = None
-        self._mapper = ModelRevisionMapper()
-
-    @staticmethod
-    def _load_state() -> ModelActivationState:
-        """Load the state from the file if it exists, otherwise initialize an empty state"""
-        with get_db_session() as db:
-            repo = ModelRevisionRepository(db)
-            active_model = repo.get_active_revision()
-            available_models = repo.list_all()
-            return ModelActivationState(
-                project_id=UUID(active_model.project_id) if active_model is not None else None,
-                active_model_id=UUID(active_model.id) if active_model is not None else None,
-                available_models=[UUID(m.id) for m in available_models],
-            )
-
-    def _get_model_xml_path(self, project_id: UUID, model_id: UUID) -> Path:
-        return self.projects_dir / f"{project_id}/models/{model_id}/model.xml"
-
-    def _get_model_bin_path(self, project_id: UUID, model_id: UUID) -> Path:
-        return self.projects_dir / f"{project_id}/models/{model_id}/model.bin"
-
-    def get_loaded_inference_model(self, force_reload: bool = False) -> LoadedModel | None:
-        """
-        Get the currently active model for inference.
-
-        Args:
-            force_reload: If True, reload the state and the model from disk. This option can be useful
-            to bypass the cache after the state has been modified externally.
-
-        Returns: Model for inference or None if no model is active
-        """
-        if force_reload:
-            self._model_activation_state = self._load_state()
-            self._loaded_model = None
-
-        if self._model_activation_state.active_model_id is None or self._model_activation_state.project_id is None:
-            return None
-
-        project_id = self._model_activation_state.project_id
-        active_model_id = self._model_activation_state.active_model_id
-        if self._loaded_model is None or self._loaded_model.id != active_model_id:
-            logger.info("Loading model with ID '%s'", active_model_id)
-            model_path = self._get_model_xml_path(project_id=project_id, model_id=active_model_id)
-            self._loaded_model = LoadedModel(
-                id=self._model_activation_state.active_model_id,
-                model=Model.create_model(
-                    model=str(model_path),
-                    device=MODELAPI_DEVICE,
-                    nstreams=MODELAPI_NSTREAMS,
-                ),
-            )
-        return self._loaded_model
+    def __init__(self, db_session: Session) -> None:
+        self._db_session = db_session
 
     def get_model_by_id(self, project_id: UUID, model_id: UUID) -> ModelSchema:
         """
@@ -111,17 +41,16 @@ class ModelService:
             ResourceNotFoundError: If the project with the given project_id does not exist,
                 or if no model with the given model_id is found within the project.
         """
-        with get_db_session() as db:
-            project_repo = ProjectRepository(db)
-            # Prefer using a JOIN here since the list of model revisions per project is not large,
-            # and it allows us to check for project existence and fetch the model in a single query.
-            project = project_repo.get_by_id(str(project_id))
-            if not project:
-                raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
-            model = next((self._mapper.to_schema(m) for m in project.model_revisions if m.id == str(model_id)), None)
-            if not model:
-                raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
-            return model
+        project_repo = ProjectRepository(self._db_session)
+        # Prefer using a JOIN here since the list of model revisions per project is not large,
+        # and it allows us to check for project existence and fetch the model in a single query.
+        project = project_repo.get_by_id(str(project_id))
+        if not project:
+            raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
+        model = next((ModelRevisionMapper.to_schema(m) for m in project.model_revisions if m.id == str(model_id)), None)
+        if not model:
+            raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
+        return model
 
     @parent_process_only
     def delete_model_by_id(self, project_id: UUID, model_id: UUID) -> None:
@@ -145,18 +74,17 @@ class ModelService:
             ResourceInUseError: If the model cannot be deleted due to integrity constraints
                 (e.g., the model is referenced by other entities).
         """
-        with get_db_session() as db:
-            project_repo = ProjectRepository(db)
-            if not project_repo.exists(str(project_id)):
-                raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
-            model_rev_repo = ModelRevisionRepository(db)
-            try:
-                # TODO: delete model artifacts from filesystem when implemented
-                deleted = model_rev_repo.delete(str(model_id))
-                if not deleted:
-                    raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
-            except IntegrityError:
-                raise ResourceInUseError(ResourceType.MODEL, str(model_id))
+        project_repo = ProjectRepository(self._db_session)
+        if not project_repo.exists(str(project_id)):
+            raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
+        model_rev_repo = ModelRevisionRepository(self._db_session)
+        try:
+            # TODO: delete model artifacts from filesystem when implemented
+            deleted = model_rev_repo.delete(str(model_id))
+            if not deleted:
+                raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
+        except IntegrityError:
+            raise ResourceInUseError(ResourceType.MODEL, str(model_id))
 
     def list_models(self, project_id: UUID) -> list[ModelSchema]:
         """
@@ -176,9 +104,8 @@ class ModelService:
         Raises:
             ResourceNotFoundError: If the project with the given project_id does not exist.
         """
-        with get_db_session() as db:
-            project_repo = ProjectRepository(db)
-            project = project_repo.get_by_id(str(project_id))
-            if not project:
-                raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
-            return [self._mapper.to_schema(model_rev_db) for model_rev_db in project.model_revisions]
+        project_repo = ProjectRepository(self._db_session)
+        project = project_repo.get_by_id(str(project_id))
+        if not project:
+            raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
+        return [ModelRevisionMapper.to_schema(model_rev_db) for model_rev_db in project.model_revisions]

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -31,7 +31,7 @@ class PipelineService:
         db_session: Session,
     ) -> None:
         self._persistence: GenericPersistenceService[Pipeline, PipelineRepository] = GenericPersistenceService(
-            ServiceConfig(PipelineRepository, PipelineMapper, ResourceType.PIPELINE)
+            ServiceConfig(PipelineRepository, PipelineMapper, ResourceType.PIPELINE), db_session
         )
         self._active_pipeline_service: ActivePipelineService = active_pipeline_service
         self._data_collector: DataCollector = data_collector
@@ -53,7 +53,7 @@ class PipelineService:
 
     def get_pipeline_by_id(self, project_id: UUID) -> Pipeline:
         """Retrieve a pipeline by project ID."""
-        pipeline = self._persistence.get_by_id(project_id, db=self._db_session)
+        pipeline = self._persistence.get_by_id(project_id)
         if not pipeline:
             raise ResourceNotFoundError(ResourceType.PIPELINE, str(project_id))
         return pipeline
@@ -62,7 +62,7 @@ class PipelineService:
     def update_pipeline(self, project_id: UUID, partial_config: dict) -> Pipeline:
         """Update an existing pipeline."""
         pipeline = self.get_pipeline_by_id(project_id)
-        updated = self._persistence.update(pipeline, partial_config, self._db_session)
+        updated = self._persistence.update(pipeline, partial_config)
         if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:
             # If the pipeline source_id or sink_id is being updated while running
             if pipeline.source.id != updated.source.id:  # type: ignore[union-attr] # source is always there for running pipeline

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -8,7 +8,6 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.db import get_db_session
 from app.repositories import PipelineRepository
 from app.schemas import Pipeline, PipelineStatus
 from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
@@ -29,6 +28,7 @@ class PipelineService:
         data_collector: DataCollector,
         metrics_service: MetricsService,
         config_changed_condition: Condition,
+        db_session: Session,
     ) -> None:
         self._persistence: GenericPersistenceService[Pipeline, PipelineRepository] = GenericPersistenceService(
             ServiceConfig(PipelineRepository, PipelineMapper, ResourceType.PIPELINE)
@@ -37,6 +37,7 @@ class PipelineService:
         self._data_collector: DataCollector = data_collector
         self._config_changed_condition: Condition = config_changed_condition
         self._metrics_service: MetricsService = metrics_service
+        self._db_session: Session = db_session
 
     def _notify_source_changed(self) -> None:
         with self._config_changed_condition:
@@ -50,9 +51,9 @@ class PipelineService:
         self._notify_sink_changed()
         self._data_collector.reload_policies()
 
-    def get_pipeline_by_id(self, project_id: UUID, db: Session | None = None) -> Pipeline:
+    def get_pipeline_by_id(self, project_id: UUID) -> Pipeline:
         """Retrieve a pipeline by project ID."""
-        pipeline = self._persistence.get_by_id(project_id, db)
+        pipeline = self._persistence.get_by_id(project_id, db=self._db_session)
         if not pipeline:
             raise ResourceNotFoundError(ResourceType.PIPELINE, str(project_id))
         return pipeline
@@ -60,23 +61,21 @@ class PipelineService:
     @parent_process_only
     def update_pipeline(self, project_id: UUID, partial_config: dict) -> Pipeline:
         """Update an existing pipeline."""
-        with get_db_session() as db:
-            pipeline = self.get_pipeline_by_id(project_id, db)
-            updated = self._persistence.update(pipeline, partial_config, db)
-            db.commit()
-            if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:
-                # If the pipeline source_id or sink_id is being updated while running
-                if pipeline.source.id != updated.source.id:  # type: ignore[union-attr] # source is always there for running pipeline
-                    self._notify_source_changed()
-                if pipeline.sink.id != updated.sink.id:  # type: ignore[union-attr] # sink is always there for running pipeline
-                    self._notify_sink_changed()
-                if pipeline.data_collection_policies != updated.data_collection_policies:
-                    self._active_pipeline_service.reload()
-                    self._data_collector.reload_policies()
-            elif pipeline.status != updated.status:
-                # If the pipeline is being activated or stopped
-                self._notify_pipeline_changed()
-            return updated
+        pipeline = self.get_pipeline_by_id(project_id)
+        updated = self._persistence.update(pipeline, partial_config, self._db_session)
+        if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:
+            # If the pipeline source_id or sink_id is being updated while running
+            if pipeline.source.id != updated.source.id:  # type: ignore[union-attr] # source is always there for running pipeline
+                self._notify_source_changed()
+            if pipeline.sink.id != updated.sink.id:  # type: ignore[union-attr] # sink is always there for running pipeline
+                self._notify_sink_changed()
+            if pipeline.data_collection_policies != updated.data_collection_policies:
+                self._active_pipeline_service.reload()
+                self._data_collector.reload_policies()
+        elif pipeline.status != updated.status:
+            # If the pipeline is being activated or stopped
+            self._notify_pipeline_changed()
+        return updated
 
     def get_pipeline_metrics(self, pipeline_id: UUID, time_window: int = 60) -> PipelineMetrics:
         """Calculate metrics for a pipeline over a specified time window."""

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -12,7 +12,7 @@ from app.repositories import PipelineRepository
 from app.schemas import Pipeline, PipelineStatus
 from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
 from app.services import ActivePipelineService
-from app.services.base import GenericPersistenceService, ResourceNotFoundError, ResourceType, ServiceConfig
+from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.data_collect import DataCollector
 from app.services.mappers import PipelineMapper
 from app.services.metrics_service import MetricsService
@@ -30,9 +30,6 @@ class PipelineService:
         config_changed_condition: Condition,
         db_session: Session,
     ) -> None:
-        self._persistence: GenericPersistenceService[Pipeline, PipelineRepository] = GenericPersistenceService(
-            ServiceConfig(PipelineRepository, PipelineMapper, ResourceType.PIPELINE), db_session
-        )
         self._active_pipeline_service: ActivePipelineService = active_pipeline_service
         self._data_collector: DataCollector = data_collector
         self._config_changed_condition: Condition = config_changed_condition
@@ -53,16 +50,19 @@ class PipelineService:
 
     def get_pipeline_by_id(self, project_id: UUID) -> Pipeline:
         """Retrieve a pipeline by project ID."""
-        pipeline = self._persistence.get_by_id(project_id)
+        pipeline_repo = PipelineRepository(self._db_session)
+        pipeline = pipeline_repo.get_by_id(str(project_id))
         if not pipeline:
             raise ResourceNotFoundError(ResourceType.PIPELINE, str(project_id))
-        return pipeline
+        return PipelineMapper.to_schema(pipeline)
 
     @parent_process_only
     def update_pipeline(self, project_id: UUID, partial_config: dict) -> Pipeline:
         """Update an existing pipeline."""
         pipeline = self.get_pipeline_by_id(project_id)
-        updated = self._persistence.update(pipeline, partial_config)
+        to_update = pipeline.model_copy(update=partial_config)
+        pipeline_repo = PipelineRepository(self._db_session)
+        updated = PipelineMapper.to_schema(pipeline_repo.update(PipelineMapper.from_schema(to_update)))
         if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:
             # If the pipeline source_id or sink_id is being updated while running
             if pipeline.source.id != updated.source.id:  # type: ignore[union-attr] # source is always there for running pipeline

--- a/application/backend/app/services/project_service.py
+++ b/application/backend/app/services/project_service.py
@@ -4,7 +4,8 @@
 from pathlib import Path
 from uuid import UUID
 
-from app.db import get_db_session
+from sqlalchemy.orm import Session
+
 from app.repositories import DatasetItemRepository, PipelineRepository, ProjectRepository
 from app.schemas import Project
 from app.services.base import (
@@ -21,21 +22,22 @@ MSG_ERR_DELETE_ACTIVE_PROJECT = "Cannot delete a project with a running pipeline
 
 
 class ProjectService:
-    def __init__(self, data_dir: Path) -> None:
+    def __init__(self, data_dir: Path, db_session: Session) -> None:
         self._persistence: GenericPersistenceService[Project, ProjectRepository] = GenericPersistenceService(
             ServiceConfig(ProjectRepository, ProjectMapper, ResourceType.PROJECT)
         )
         self.projects_dir = data_dir / "projects"
+        self._db_session: Session = db_session
 
     @parent_process_only
     def create_project(self, project: Project) -> Project:
-        return self._persistence.create(project)
+        return self._persistence.create(project, self._db_session)
 
     def list_projects(self) -> list[Project]:
-        return self._persistence.list_all()
+        return self._persistence.list_all(self._db_session)
 
     def get_project_by_id(self, project_id: UUID) -> Project:
-        project = self._persistence.get_by_id(project_id)
+        project = self._persistence.get_by_id(project_id, self._db_session)
         if not project:
             raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
         return project
@@ -48,19 +50,16 @@ class ProjectService:
 
     @parent_process_only
     def delete_project_by_id(self, project_id: UUID) -> None:
-        with get_db_session() as db:
-            pipeline_repo = PipelineRepository(db)
-            pipeline_db = pipeline_repo.get_by_id(str(project_id))
-            if pipeline_db and pipeline_db.is_running:
-                raise ResourceInUseError(ResourceType.PROJECT, str(project_id), MSG_ERR_DELETE_ACTIVE_PROJECT)
-            self._persistence.delete_by_id(project_id, db)
-            db.commit()
+        pipeline_repo = PipelineRepository(self._db_session)
+        pipeline_db = pipeline_repo.get_by_id(str(project_id))
+        if pipeline_db and pipeline_db.is_running:
+            raise ResourceInUseError(ResourceType.PROJECT, str(project_id), MSG_ERR_DELETE_ACTIVE_PROJECT)
+        self._persistence.delete_by_id(project_id, self._db_session)
 
     def get_project_thumbnail_path(self, project_id: UUID) -> Path | None:
         """Get the path to the project's thumbnail image, as determined by the earliest dataset item"""
-        with get_db_session() as db:
-            dataset_repo = DatasetItemRepository(str(project_id), db)
-            earliest_dataset_item = dataset_repo.get_earliest()
+        dataset_repo = DatasetItemRepository(str(project_id), self._db_session)
+        earliest_dataset_item = dataset_repo.get_earliest()
 
         if earliest_dataset_item:
             return self.projects_dir / f"{project_id}/dataset/{earliest_dataset_item.id}-thumb.jpg"

--- a/application/backend/app/services/project_service.py
+++ b/application/backend/app/services/project_service.py
@@ -4,17 +4,12 @@
 from pathlib import Path
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.repositories import DatasetItemRepository, PipelineRepository, ProjectRepository
 from app.schemas import Project
-from app.services.base import (
-    GenericPersistenceService,
-    ResourceInUseError,
-    ResourceNotFoundError,
-    ResourceType,
-    ServiceConfig,
-)
+from app.services.base import ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError, ResourceType
 from app.services.mappers.project_mapper import ProjectMapper
 from app.services.parent_process_guard import parent_process_only
 
@@ -23,24 +18,30 @@ MSG_ERR_DELETE_ACTIVE_PROJECT = "Cannot delete a project with a running pipeline
 
 class ProjectService:
     def __init__(self, data_dir: Path, db_session: Session) -> None:
-        self._persistence: GenericPersistenceService[Project, ProjectRepository] = GenericPersistenceService(
-            ServiceConfig(ProjectRepository, ProjectMapper, ResourceType.PROJECT)
-        )
-        self.projects_dir = data_dir / "projects"
+        self._projects_dir = data_dir / "projects"
         self._db_session: Session = db_session
 
     @parent_process_only
     def create_project(self, project: Project) -> Project:
-        return self._persistence.create(project, self._db_session)
+        try:
+            project_repo = ProjectRepository(self._db_session)
+            saved = project_repo.save(ProjectMapper.from_schema(project))
+            return ProjectMapper.to_schema(saved)
+        except IntegrityError as e:
+            if "unique constraint failed" in str(e).lower():
+                raise ResourceAlreadyExistsError(ResourceType.PROJECT, str(project.id))
+            raise
 
     def list_projects(self) -> list[Project]:
-        return self._persistence.list_all(self._db_session)
+        project_repo = ProjectRepository(self._db_session)
+        return [ProjectMapper.to_schema(p) for p in project_repo.list_all()]
 
     def get_project_by_id(self, project_id: UUID) -> Project:
-        project = self._persistence.get_by_id(project_id, self._db_session)
-        if not project:
+        project_repo = ProjectRepository(self._db_session)
+        project_db = project_repo.get_by_id(str(project_id))
+        if not project_db:
             raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
-        return project
+        return ProjectMapper.to_schema(project_db)
 
     @parent_process_only
     def update_project_name(self, project_id: UUID, name: str) -> Project:
@@ -54,13 +55,15 @@ class ProjectService:
         pipeline_db = pipeline_repo.get_by_id(str(project_id))
         if pipeline_db and pipeline_db.is_running:
             raise ResourceInUseError(ResourceType.PROJECT, str(project_id), MSG_ERR_DELETE_ACTIVE_PROJECT)
-        self._persistence.delete_by_id(project_id, self._db_session)
+        project_repo = ProjectRepository(self._db_session)
+        if not project_repo.delete(str(project_id)):
+            raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
 
     def get_project_thumbnail_path(self, project_id: UUID) -> Path | None:
         """Get the path to the project's thumbnail image, as determined by the earliest dataset item"""
-        dataset_repo = DatasetItemRepository(str(project_id), self._db_session)
-        earliest_dataset_item = dataset_repo.get_earliest()
+        dataset_item_repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)
+        earliest_dataset_item = dataset_item_repo.get_earliest()
 
         if earliest_dataset_item:
-            return self.projects_dir / f"{project_id}/dataset/{earliest_dataset_item.id}-thumb.jpg"
+            return self._projects_dir / f"{project_id}/dataset/{earliest_dataset_item.id}-thumb.jpg"
         return None

--- a/application/backend/app/services/project_service.py
+++ b/application/backend/app/services/project_service.py
@@ -46,8 +46,12 @@ class ProjectService:
     @parent_process_only
     def update_project_name(self, project_id: UUID, name: str) -> Project:
         """Update only the project name"""
-        project = self.get_project_by_id(project_id)
-        return self._persistence.update(project, {"name": name})
+        project_repo = ProjectRepository(self._db_session)
+        project_db = project_repo.get_by_id(str(project_id))
+        if not project_db:
+            raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
+        project_db.name = name
+        return ProjectMapper.to_schema(project_repo.update(project_db))
 
     @parent_process_only
     def delete_project_by_id(self, project_id: UUID) -> None:

--- a/application/backend/tests/integration/services/test_configuration_service.py
+++ b/application/backend/tests/integration/services/test_configuration_service.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -11,24 +10,10 @@ from app.services import ConfigurationService, ResourceInUseError, ResourceNotFo
 from app.services.base import ResourceAlreadyExistsError
 
 
-@pytest.fixture(autouse=True)
-def mock_get_db_session(db_session):
-    """Mock the get_db_session to use test database."""
-    with (
-        patch("app.services.configuration_service.get_db_session") as mock,
-        patch("app.services.base.get_db_session") as mock_base,
-    ):
-        mock.return_value.__enter__.return_value = db_session
-        mock.return_value.__exit__.return_value = None
-        mock_base.return_value.__enter__.return_value = db_session
-        mock_base.return_value.__exit__.return_value = None
-        yield
-
-
 @pytest.fixture
-def fxt_config_service(fxt_active_pipeline_service, fxt_condition) -> ConfigurationService:
+def fxt_config_service(fxt_active_pipeline_service, fxt_condition, db_session) -> ConfigurationService:
     """Fixture to provide a ConfigurationService instance with mocked dependencies."""
-    return ConfigurationService(fxt_active_pipeline_service, fxt_condition)
+    return ConfigurationService(fxt_active_pipeline_service, db_session, fxt_condition)
 
 
 class TestConfigurationServiceIntegration:

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -7,7 +7,6 @@ from collections.abc import Callable, Generator
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -34,19 +33,10 @@ def fxt_projects_dir() -> Generator[Path]:
     shutil.rmtree(projects_dir)
 
 
-@pytest.fixture(autouse=True)
-def mock_get_db_session(db_session):
-    """Mock the get_db_session to use test database."""
-    with patch("app.services.dataset_service.get_db_session") as mock:
-        mock.return_value.__enter__.return_value = db_session
-        mock.return_value.__exit__.return_value = None
-        yield
-
-
 @pytest.fixture
-def fxt_dataset_service(fxt_projects_dir: Path) -> DatasetService:
+def fxt_dataset_service(fxt_projects_dir: Path, db_session: Session) -> DatasetService:
     """Fixture to create a DatasetService instance."""
-    return DatasetService(fxt_projects_dir.parent)
+    return DatasetService(fxt_projects_dir.parent, db_session=db_session)
 
 
 @pytest.fixture

--- a/application/backend/tests/integration/services/test_label_service.py
+++ b/application/backend/tests/integration/services/test_label_service.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import patch
 from uuid import UUID
 
 import pytest
@@ -13,15 +12,9 @@ from app.services import ResourceAlreadyExistsError
 from app.services.label_service import LabelService
 
 
-@pytest.fixture(autouse=True)
-def mock_get_db_session(db_session):
-    """Mock the get_db_session to use test database."""
-    with (
-        patch("app.services.label_service.get_db_session") as mock,
-    ):
-        mock.return_value.__enter__.return_value = db_session
-        mock.return_value.__exit__.return_value = None
-        yield
+@pytest.fixture
+def fxt_label_service(db_session):
+    return LabelService(db_session)
 
 
 class TestLabelServiceIntegration:
@@ -38,7 +31,9 @@ class TestLabelServiceIntegration:
     - Execution order compliance (update → remove → add)
     """
 
-    def test_add_labels_to_project(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_add_labels_to_project(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test adding new labels to a project without conflicts.
 
@@ -53,7 +48,7 @@ class TestLabelServiceIntegration:
             Label(name="mouse", color="#0000FF", hotkey="r"),
             Label(name="bird", color="#FFFF00", hotkey="b"),
         ]
-        labels = LabelService.update_labels_in_project(UUID(fxt_db_projects[0].id), new_labels, None, None)
+        labels = fxt_label_service.update_labels_in_project(UUID(fxt_db_projects[0].id), new_labels, None, None)
 
         assert len(labels) == 4
         assert new_labels[0] in labels
@@ -61,7 +56,7 @@ class TestLabelServiceIntegration:
 
     @pytest.mark.parametrize("new_label_attrs", [{"name": "cat"}, {"hotkey": "c"}])
     def test_add_existing_label_to_project(
-        self, new_label_attrs, fxt_db_projects: list[ProjectDB], db_session: Session
+        self, new_label_attrs, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
     ):
         """
         Test that adding labels with duplicate attributes raises ResourceAlreadyExistsError.
@@ -78,11 +73,13 @@ class TestLabelServiceIntegration:
         new_label = Label(name="mouse", color="#0000FF", hotkey="r")
         new_label = new_label.model_copy(update=new_label_attrs)
         with pytest.raises(ResourceAlreadyExistsError) as exc_info:
-            LabelService.update_labels_in_project(UUID(fxt_db_projects[0].id), [new_label], None, None)
+            fxt_label_service.update_labels_in_project(UUID(fxt_db_projects[0].id), [new_label], None, None)
 
         assert str(exc_info.value) == "Label with the same name or hotkey already exists in this project."
 
-    def test_remove_labels_from_project(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_remove_labels_from_project(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test removing all labels from a project.
 
@@ -95,13 +92,15 @@ class TestLabelServiceIntegration:
         db_session.add(db_project)
         db_session.flush()
 
-        labels = LabelService.update_labels_in_project(
+        labels = fxt_label_service.update_labels_in_project(
             UUID(db_project.id), None, None, [label.id for label in db_project.labels]
         )
 
         assert len(labels) == 0
 
-    def test_edit_labels_in_project(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_edit_labels_in_project(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test updating existing labels' properties.
 
@@ -121,12 +120,14 @@ class TestLabelServiceIntegration:
             )  # type: ignore[call-arg]
             for db_label in db_project.labels
         ]
-        labels = LabelService.update_labels_in_project(UUID(db_project.id), None, labels_to_edit, None)
+        labels = fxt_label_service.update_labels_in_project(UUID(db_project.id), None, labels_to_edit, None)
 
         assert len(labels) == 2
         assert {label.name for label in labels} == {labels_to_edit.name for labels_to_edit in labels_to_edit}
 
-    def test_update_and_add_existing_label_in_project(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_update_and_add_existing_label_in_project(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test that updating and adding conflicting labels in same operation raises error.
 
@@ -138,7 +139,7 @@ class TestLabelServiceIntegration:
         db_session.flush()
 
         with pytest.raises(ResourceAlreadyExistsError) as exc_info:
-            LabelService.update_labels_in_project(
+            fxt_label_service.update_labels_in_project(
                 UUID(db_project.id),
                 [Label(name="mouse", color="#0000FF", hotkey="r")],
                 [Label(id=db_project.labels[0].id, name="mouse")],  # type: ignore[call-arg]
@@ -147,7 +148,9 @@ class TestLabelServiceIntegration:
 
         assert str(exc_info.value) == "Label with the same name or hotkey already exists in this project."
 
-    def test_remove_update_add_combined_operation(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_remove_update_add_combined_operation(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test complex operation combining removal, update, and addition.
 
@@ -163,7 +166,7 @@ class TestLabelServiceIntegration:
         label_to_update = Label(id=db_project.labels[1].id, name="updated_name")  # type: ignore[call-arg]
         new_label = Label(name="new_label", color="#123456", hotkey="x")
 
-        labels = LabelService.update_labels_in_project(
+        labels = fxt_label_service.update_labels_in_project(
             UUID(db_project.id), [new_label], [label_to_update], [label_to_remove_id]
         )
 
@@ -172,7 +175,9 @@ class TestLabelServiceIntegration:
         assert any(label.name == "new_label" for label in labels)
         assert not any(label.id == label_to_remove_id for label in labels)
 
-    def test_remove_update_same_label_operation(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_remove_update_same_label_operation(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test that updating and removing conflicting labels in same operation works.
 
@@ -186,7 +191,7 @@ class TestLabelServiceIntegration:
         label_to_update = Label(id=db_project.labels[0].id, name="updated_name")  # type: ignore[call-arg]
         label_to_remove_id = db_project.labels[0].id
 
-        labels = LabelService.update_labels_in_project(
+        labels = fxt_label_service.update_labels_in_project(
             UUID(db_project.id), None, [label_to_update], [label_to_remove_id]
         )
 
@@ -194,7 +199,9 @@ class TestLabelServiceIntegration:
         assert labels[0].name != "updated_name"
         assert not any(label.id == label_to_remove_id for label in labels)
 
-    def test_empty_operations(self, fxt_db_projects: list[ProjectDB], db_session: Session):
+    def test_empty_operations(
+        self, fxt_db_projects: list[ProjectDB], fxt_label_service: LabelService, db_session: Session
+    ):
         """
         Test that calling with all None parameters returns current labels unchanged.
 
@@ -206,7 +213,7 @@ class TestLabelServiceIntegration:
 
         original_labels = db_project.labels.copy()
 
-        labels = LabelService.update_labels_in_project(UUID(db_project.id), None, None, None)
+        labels = fxt_label_service.update_labels_in_project(UUID(db_project.id), None, None, None)
 
         assert len(labels) == len(original_labels)
         assert {str(label.id) for label in labels} == {label.id for label in original_labels}

--- a/application/backend/tests/integration/services/test_label_service.py
+++ b/application/backend/tests/integration/services/test_label_service.py
@@ -13,7 +13,7 @@ from app.services.label_service import LabelService
 
 
 @pytest.fixture
-def fxt_label_service(db_session):
+def fxt_label_service(db_session: Session) -> LabelService:
     return LabelService(db_session)
 
 

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable
-from unittest.mock import patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -15,32 +15,13 @@ from app.services.configuration_service import PipelineField
 from app.services.data_collect import DataCollector
 
 
-@pytest.fixture(autouse=True)
-def mock_get_db_session(db_session):
-    """Mock the get_db_session to use test database."""
-    with (
-        patch("app.services.pipeline_service.get_db_session") as mock,
-        patch("app.services.base.get_db_session") as mock_base,
-    ):
-        mock.return_value.__enter__.return_value = db_session
-        mock.return_value.__exit__.return_value = None
-        mock_base.return_value.__enter__.return_value = db_session
-        mock_base.return_value.__exit__.return_value = None
-        yield
-
-
-@pytest.fixture
-def fxt_data_collector(fxt_active_pipeline_service) -> DataCollector:
-    """Fixture to create a DataCollector instance with mocked dependencies."""
-    return DataCollector(fxt_active_pipeline_service)
-
-
 @pytest.fixture
 def fxt_pipeline_service(
-    fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition
+    fxt_active_pipeline_service, fxt_metrics_service, fxt_condition, db_session
 ) -> PipelineService:
     """Fixture to create a PipelineService instance with mocked dependencies."""
-    return PipelineService(fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition)
+    collector = MagicMock(spec=DataCollector)
+    return PipelineService(fxt_active_pipeline_service, collector, fxt_metrics_service, fxt_condition, db_session)
 
 
 @pytest.fixture

--- a/application/backend/tests/integration/services/test_project_service.py
+++ b/application/backend/tests/integration/services/test_project_service.py
@@ -125,7 +125,7 @@ class TestProjectServiceIntegration:
         fetched_thumbnail_path = fxt_project_service.get_project_thumbnail_path(UUID(db_project.id))
         assert (
             fetched_thumbnail_path
-            == fxt_project_service.projects_dir / f"{db_project.id}/dataset/{db_dataset_item.id}-thumb.jpg"
+            == fxt_project_service._projects_dir / f"{db_project.id}/dataset/{db_dataset_item.id}-thumb.jpg"
         )
 
     def test_get_project_by_id_not_found(self, fxt_project_service: ProjectService):

--- a/application/backend/tests/integration/services/test_project_service.py
+++ b/application/backend/tests/integration/services/test_project_service.py
@@ -3,7 +3,6 @@
 import shutil
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -25,24 +24,10 @@ def fxt_projects_dir() -> Generator[Path]:
     shutil.rmtree(projects_dir)
 
 
-@pytest.fixture(autouse=True)
-def mock_get_db_session(db_session):
-    """Mock the get_db_session to use test database."""
-    with (
-        patch("app.services.project_service.get_db_session") as mock,
-        patch("app.services.base.get_db_session") as mock_base,
-    ):
-        mock.return_value.__enter__.return_value = db_session
-        mock.return_value.__exit__.return_value = None
-        mock_base.return_value.__enter__.return_value = db_session
-        mock_base.return_value.__exit__.return_value = None
-        yield
-
-
 @pytest.fixture
-def fxt_project_service(fxt_projects_dir: Path) -> ProjectService:
+def fxt_project_service(fxt_projects_dir: Path, db_session: Session) -> ProjectService:
     """Fixture to create a ProjectService instance."""
-    return ProjectService(fxt_projects_dir.parent)
+    return ProjectService(data_dir=fxt_projects_dir.parent, db_session=db_session)
 
 
 class TestProjectServiceIntegration:
@@ -161,10 +146,11 @@ class TestProjectServiceIntegration:
         db_session.flush()
 
         fxt_project_service.delete_project_by_id(UUID(db_project.id))
+        db_session.expire_all()  # Clear the session cache
 
         assert db_session.get(ProjectDB, db_project.id) is None
         # Ensure the associated pipeline is deleted
-        assert db_session.get(PipelineDB, str(db_project.id)) is None
+        assert db_session.get(PipelineDB, db_project.id) is None
 
     def test_delete_active_project(
         self,

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 from uuid import uuid4
 
@@ -43,7 +44,7 @@ class TestFixedRatePolicyCheckerUnit:
 @pytest.fixture
 def fxt_data_collector(fxt_active_pipeline_service) -> DataCollector:
     """Fixture to create a DataCollector instance with mocked dependencies."""
-    return DataCollector(fxt_active_pipeline_service)
+    return DataCollector(Path("data"), fxt_active_pipeline_service)
 
 
 class TestDataCollectorUnit:

--- a/application/backend/tests/unit/services/dispatchers/test_webhook.py
+++ b/application/backend/tests/unit/services/dispatchers/test_webhook.py
@@ -99,7 +99,7 @@ class TestWebhookDispatcher:
                 fxt_webhook_config.webhook_url,
                 headers=fxt_webhook_config.headers,
                 json={
-                    "timestamp": "2025-01-01T12:00:00",
+                    "timestamp": "2025-01-01T12:00:00+00:00",
                     "result": expected_result,
                 },
                 timeout=fxt_webhook_config.timeout,

--- a/application/backend/tests/unit/services/test_pipeline_service.py
+++ b/application/backend/tests/unit/services/test_pipeline_service.py
@@ -1,31 +1,28 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
+from sqlalchemy.orm import Session
 
 from app.services import MetricsService, PipelineService
 from app.services.data_collect import DataCollector
 
 
 @pytest.fixture
-def fxt_data_collector(fxt_active_pipeline_service) -> DataCollector:
-    """Fixture to create a DataCollector instance with mocked dependencies."""
-    return DataCollector(fxt_active_pipeline_service)
-
-
-@pytest.fixture
-def fxt_pipeline_service(
-    fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition
-) -> PipelineService:
+def fxt_pipeline_service(fxt_active_pipeline_service, fxt_metrics_service, fxt_condition) -> PipelineService:
     """Fixture to create a PipelineService instance with mocked dependencies."""
-    return PipelineService(fxt_active_pipeline_service, fxt_data_collector, fxt_metrics_service, fxt_condition)
+    mock_collector = Mock(spec=DataCollector)
+    mock_db_session = Mock(spec=Session)
+    return PipelineService(
+        fxt_active_pipeline_service, mock_collector, fxt_metrics_service, fxt_condition, mock_db_session
+    )
 
 
 @pytest.fixture
-def fxt_metrics_service() -> MagicMock:
-    return MagicMock(spec=MetricsService)
+def fxt_metrics_service() -> Mock:
+    return Mock(spec=MetricsService)
 
 
 class TestPipelineServiceUnit:


### PR DESCRIPTION
### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

This PR modernizes database session handling, upgrades to SQLAlchemy 2.0 API, and refactors `ModelService` to better separate stateful and stateless concerns:

- [x] Database sessions are now managed through FastAPI's dependency injection system, eliminating manual session handling
- [x] Sessions automatically commit on successful request completion
- [x] `SQLAlchemy`: Migrated from legacy `query()` API to modern `select()`, `update()`, and `delete()` constructs
- [x] Extracted `ActiveModelService` to separate stateful model operations from the stateless `ModelService`
- [x] Removed `@lru_cache` from stateless services
- [x] All datetime operations now explicitly use UTC to eliminate timezone-related bugs and ambiguity

*Note! Keeping repository instantiation in the service layer to avoid an already-large changeset from growing further. Ideally, services shouldn't know about the DB at all and should receive fully-configured repositories via DI. We can address this in a follow-up ticket.*

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

- [x] Inference pipeline from seed setup should work as expected. 

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] I have added unit tests to cover my changes.​
- [ ] I have added integration tests to cover my changes.​
- [ ] I have ran e2e tests and there is no issues.
- [ ] I have added the description of my changes into CHANGELOG in my target branch (e.g., [CHANGELOG](https://github.com/open-edge-platform/training_extensions/blob/develop/CHANGELOG.md) in develop).​
- [ ] I have updated the documentation in my target branch accordingly (e.g., [documentation](https://github.com/open-edge-platform/training_extensions/tree/develop/docs) in develop).
- [ ] I have [linked related issues](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/training_extensions/blob/develop/LICENSE) that covers the project.
      Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0
```
