### PR TITLE
Refine OpenAPI schema and enforce strict validation for IDs

### DIFF
--- a/application/backend/app/api/endpoints/pipelines.py
+++ b/application/backend/app/api/endpoints/pipelines.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 from app.api.dependencies import get_pipeline_service, get_project_id
 from app.schemas import DataCollectionPolicy
 from app.schemas.metrics import PipelineMetrics
-from app.schemas.pipeline import Pipeline, PipelineStatus
+from app.schemas.pipeline import PipelineStatus, PipelineView
 from app.services import PipelineService, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ UPDATE_PIPELINE_BODY_EXAMPLES = {
 
 @router.get(
     "",
-    response_model=Pipeline,
+    response_model=PipelineView,
     responses={
         status.HTTP_200_OK: {"description": "Pipeline found"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID"},
@@ -75,7 +75,7 @@ UPDATE_PIPELINE_BODY_EXAMPLES = {
 def get_pipeline(
     project_id: Annotated[UUID, Depends(get_project_id)],
     pipeline_service: Annotated[PipelineService, Depends(get_pipeline_service)],
-) -> Pipeline:
+) -> PipelineView:
     """Get info about a given pipeline"""
     try:
         return pipeline_service.get_pipeline_by_id(project_id)
@@ -85,7 +85,7 @@ def get_pipeline(
 
 @router.patch(
     "",
-    response_model=Pipeline,
+    response_model=PipelineView,
     responses={
         status.HTTP_200_OK: {"description": "Pipeline successfully reconfigured"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID or request body"},
@@ -103,7 +103,7 @@ def update_pipeline(
         ),
     ],
     pipeline_service: Annotated[PipelineService, Depends(get_pipeline_service)],
-) -> Pipeline:
+) -> PipelineView:
     """Reconfigure an existing pipeline"""
     if "status" in pipeline_config:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The 'status' field cannot be changed")

--- a/application/backend/app/api/endpoints/projects.py
+++ b/application/backend/app/api/endpoints/projects.py
@@ -13,7 +13,7 @@ from fastapi.openapi.models import Example
 from starlette.responses import FileResponse
 
 from app.api.dependencies import get_data_collector, get_label_service, get_project_id, get_project_service
-from app.schemas import Label, PatchLabels, Project, ProjectUpdateName
+from app.schemas import Label, PatchLabels, ProjectCreate, ProjectUpdateName, ProjectView
 from app.services import (
     LabelService,
     ProjectService,
@@ -74,7 +74,7 @@ CREATE_PROJECT_BODY_EXAMPLES = {
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    response_model=Project,
+    response_model=ProjectView,
     responses={
         status.HTTP_201_CREATED: {"description": "Project successfully created"},
         status.HTTP_409_CONFLICT: {"description": "Project already exists"},
@@ -83,10 +83,10 @@ CREATE_PROJECT_BODY_EXAMPLES = {
 )
 def create_project(
     project_config: Annotated[
-        Project, Body(description=CREATE_PROJECT_BODY_DESCRIPTION, openapi_examples=CREATE_PROJECT_BODY_EXAMPLES)
+        ProjectCreate, Body(description=CREATE_PROJECT_BODY_DESCRIPTION, openapi_examples=CREATE_PROJECT_BODY_EXAMPLES)
     ],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
-) -> Project:
+) -> ProjectView:
     """Create and configure a new project"""
     try:
         return project_service.create_project(project_config)
@@ -96,19 +96,19 @@ def create_project(
 
 @router.get(
     "",
-    response_model=list[Project],
+    response_model=list[ProjectView],
     responses={
         status.HTTP_200_OK: {"description": "List of available projects"},
     },
 )
-def list_projects(project_service: Annotated[ProjectService, Depends(get_project_service)]) -> list[Project]:
+def list_projects(project_service: Annotated[ProjectService, Depends(get_project_service)]) -> list[ProjectView]:
     """List the available projects"""
     return project_service.list_projects()
 
 
 @router.get(
     "/{project_id}",
-    response_model=Project,
+    response_model=ProjectView,
     responses={
         status.HTTP_200_OK: {"description": "Project found"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID"},
@@ -118,7 +118,7 @@ def list_projects(project_service: Annotated[ProjectService, Depends(get_project
 def get_project(
     project_id: Annotated[UUID, Depends(get_project_id)],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
-) -> Project:
+) -> ProjectView:
     """Get info about a given project"""
     try:
         return project_service.get_project_by_id(project_id)
@@ -128,7 +128,7 @@ def get_project(
 
 @router.patch(
     "/{project_id}",
-    response_model=Project,
+    response_model=ProjectView,
     responses={
         status.HTTP_200_OK: {"description": "Project name updated successfully"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID or request body"},
@@ -139,7 +139,7 @@ def rename_project(
     project_id: Annotated[UUID, Depends(get_project_id)],
     project_update_name: Annotated[ProjectUpdateName, Body(description="Updated project name")],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
-) -> Project:
+) -> ProjectView:
     """Rename a project"""
     try:
         return project_service.update_project_name(project_id, project_update_name.name)

--- a/application/backend/app/api/endpoints/sinks.py
+++ b/application/backend/app/api/endpoints/sinks.py
@@ -14,8 +14,8 @@ from fastapi.openapi.models import Example
 from fastapi.responses import FileResponse, Response
 
 from app.api.dependencies import get_configuration_service, get_sink_id
-from app.schemas import Sink, SinkType
-from app.schemas.sink import SinkAdapter
+from app.schemas import Sink, SinkCreate, SinkType
+from app.schemas.sink import SinkAdapter, SinkCreateAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -76,26 +76,28 @@ UPDATE_SINK_BODY_EXAMPLES = {
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
+    response_model=Sink,
     responses={
-        status.HTTP_201_CREATED: {"description": "Sink created", "model": Sink},
+        status.HTTP_201_CREATED: {"description": "Sink created"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid sink ID or request body"},
         status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
     },
 )
 async def create_sink(
-    sink_config: Annotated[
-        Sink, Body(description=CREATE_SINK_BODY_DESCRIPTION, openapi_examples=CREATE_SINK_BODY_EXAMPLES)
+    sink_create: Annotated[
+        SinkCreate, Body(description=CREATE_SINK_BODY_DESCRIPTION, openapi_examples=CREATE_SINK_BODY_EXAMPLES)
     ],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Sink:
     """Create and configure a new sink"""
-    if sink_config.sink_type == SinkType.DISCONNECTED:
+    if sink_create.sink_type == SinkType.DISCONNECTED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="The sink with sink_type=DISCONNECTED cannot be created",
         )
 
     try:
+        sink_config = SinkCreateAdapter.validate_python(sink_create.model_dump())
         return configuration_service.create_sink(sink_config)
     except ResourceAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))

--- a/application/backend/app/api/endpoints/sinks.py
+++ b/application/backend/app/api/endpoints/sinks.py
@@ -83,7 +83,7 @@ UPDATE_SINK_BODY_EXAMPLES = {
         status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
     },
 )
-async def create_sink(
+def create_sink(
     sink_create: Annotated[
         SinkCreate, Body(description=CREATE_SINK_BODY_DESCRIPTION, openapi_examples=CREATE_SINK_BODY_EXAMPLES)
     ],
@@ -109,7 +109,7 @@ async def create_sink(
         status.HTTP_200_OK: {"description": "List of available sink configurations", "model": list[Sink]},
     },
 )
-async def list_sinks(
+def list_sinks(
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> list[Sink]:
     """List the available sinks"""
@@ -124,7 +124,7 @@ async def list_sinks(
         status.HTTP_404_NOT_FOUND: {"description": "Sink not found"},
     },
 )
-async def get_sink(
+def get_sink(
     sink_id: Annotated[UUID, Depends(get_sink_id)],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Sink:
@@ -143,7 +143,7 @@ async def get_sink(
         status.HTTP_404_NOT_FOUND: {"description": "Sink not found"},
     },
 )
-async def update_sink(
+def update_sink(
     sink_id: Annotated[UUID, Depends(get_sink_id)],
     sink_config: Annotated[
         dict,
@@ -177,7 +177,7 @@ async def update_sink(
         status.HTTP_404_NOT_FOUND: {"description": "Sink not found"},
     },
 )
-async def export_sink(
+def export_sink(
     sink_id: Annotated[UUID, Depends(get_sink_id)],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Response:
@@ -204,15 +204,16 @@ async def export_sink(
     responses={
         status.HTTP_201_CREATED: {"description": "Sink imported successfully", "model": Sink},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format or sink type is DISCONNECTED"},
+        status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
     },
 )
-async def import_sink(
+def import_sink(
     yaml_file: Annotated[UploadFile, File(description="YAML file containing the sink configuration")],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Sink:
     """Import a sink from file"""
     try:
-        yaml_content = await yaml_file.read()
+        yaml_content = yaml_file.file.read()
         sink_data = yaml.safe_load(yaml_content)
 
         sink_create = SinkCreateAdapter.validate_python(sink_data)
@@ -225,6 +226,8 @@ async def import_sink(
         return configuration_service.create_sink(sink_config)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")
+    except ResourceAlreadyExistsError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
 
 @router.delete(
@@ -239,7 +242,7 @@ async def import_sink(
         status.HTTP_409_CONFLICT: {"description": "Sink is used by at least one pipeline"},
     },
 )
-async def delete_sink(
+def delete_sink(
     sink_id: Annotated[UUID, Depends(get_sink_id)],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> None:

--- a/application/backend/app/api/endpoints/sinks.py
+++ b/application/backend/app/api/endpoints/sinks.py
@@ -215,12 +215,13 @@ async def import_sink(
         yaml_content = await yaml_file.read()
         sink_data = yaml.safe_load(yaml_content)
 
-        sink_config = SinkAdapter.validate_python(sink_data)
-        if sink_config.sink_type == SinkType.DISCONNECTED:
+        sink_create = SinkCreateAdapter.validate_python(sink_data)
+        if sink_create.sink_type == SinkType.DISCONNECTED:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="The sink with sink_type=DISCONNECTED cannot be imported",
             )
+        sink_config = SinkAdapter.validate_python(sink_create.model_dump())
         return configuration_service.create_sink(sink_config)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")

--- a/application/backend/app/api/endpoints/sinks.py
+++ b/application/backend/app/api/endpoints/sinks.py
@@ -15,7 +15,7 @@ from fastapi.responses import FileResponse, Response
 
 from app.api.dependencies import get_configuration_service, get_sink_id
 from app.schemas import Sink, SinkCreate, SinkType
-from app.schemas.sink import SinkAdapter, SinkCreateAdapter
+from app.schemas.sink import SinkCreateAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -97,8 +97,7 @@ def create_sink(
         )
 
     try:
-        sink_config = SinkCreateAdapter.validate_python(sink_create.model_dump())
-        return configuration_service.create_sink(sink_config)
+        return configuration_service.create_sink(sink_create)
     except ResourceAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
@@ -222,8 +221,7 @@ def import_sink(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="The sink with sink_type=DISCONNECTED cannot be imported",
             )
-        sink_config = SinkAdapter.validate_python(sink_create.model_dump())
-        return configuration_service.create_sink(sink_config)
+        return configuration_service.create_sink(sink_create)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")
     except ResourceAlreadyExistsError as e:

--- a/application/backend/app/api/endpoints/sinks.py
+++ b/application/backend/app/api/endpoints/sinks.py
@@ -12,9 +12,10 @@ from fastapi import APIRouter, Body, Depends, File, UploadFile, status
 from fastapi.exceptions import HTTPException
 from fastapi.openapi.models import Example
 from fastapi.responses import FileResponse, Response
+from pydantic import ValidationError
 
 from app.api.dependencies import get_configuration_service, get_sink_id
-from app.schemas import Sink, SinkCreate, SinkType
+from app.schemas import Sink, SinkCreate
 from app.schemas.sink import SinkCreateAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
@@ -79,7 +80,7 @@ UPDATE_SINK_BODY_EXAMPLES = {
     response_model=Sink,
     responses={
         status.HTTP_201_CREATED: {"description": "Sink created"},
-        status.HTTP_400_BAD_REQUEST: {"description": "Invalid sink ID or request body"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid sink ID"},
         status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
     },
 )
@@ -90,12 +91,6 @@ def create_sink(
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Sink:
     """Create and configure a new sink"""
-    if sink_create.sink_type == SinkType.DISCONNECTED:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The sink with sink_type=DISCONNECTED cannot be created",
-        )
-
     try:
         return configuration_service.create_sink(sink_create)
     except ResourceAlreadyExistsError as e:
@@ -202,8 +197,9 @@ def export_sink(
     status_code=status.HTTP_201_CREATED,
     responses={
         status.HTTP_201_CREATED: {"description": "Sink imported successfully", "model": Sink},
-        status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format or sink type is DISCONNECTED"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format"},
         status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Validation error(s)"},
     },
 )
 def import_sink(
@@ -214,18 +210,14 @@ def import_sink(
     try:
         yaml_content = yaml_file.file.read()
         sink_data = yaml.safe_load(yaml_content)
-
         sink_create = SinkCreateAdapter.validate_python(sink_data)
-        if sink_create.sink_type == SinkType.DISCONNECTED:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="The sink with sink_type=DISCONNECTED cannot be imported",
-            )
         return configuration_service.create_sink(sink_create)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")
     except ResourceAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
 
 
 @router.delete(

--- a/application/backend/app/api/endpoints/sources.py
+++ b/application/backend/app/api/endpoints/sources.py
@@ -98,7 +98,7 @@ UPDATE_SOURCE_BODY_EXAMPLES = {
         status.HTTP_409_CONFLICT: {"description": "Source already exists"},
     },
 )
-async def create_source(
+def create_source(
     source_create: Annotated[
         SourceCreate, Body(description=CREATE_SOURCE_BODY_DESCRIPTION, openapi_examples=CREATE_SOURCE_BODY_EXAMPLES)
     ],
@@ -123,7 +123,7 @@ async def create_source(
         status.HTTP_200_OK: {"description": "List of available source configurations", "model": list[Source]},
     },
 )
-async def list_sources(
+def list_sources(
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> list[Source]:
     """List the available sources"""
@@ -138,7 +138,7 @@ async def list_sources(
         status.HTTP_404_NOT_FOUND: {"description": "Source not found"},
     },
 )
-async def get_source(
+def get_source(
     source_id: Annotated[UUID, Depends(get_source_id)],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Source:
@@ -157,7 +157,7 @@ async def get_source(
         status.HTTP_404_NOT_FOUND: {"description": "Source not found"},
     },
 )
-async def update_source(
+def update_source(
     source_id: Annotated[UUID, Depends(get_source_id)],
     source_config: Annotated[
         dict,
@@ -191,7 +191,7 @@ async def update_source(
         status.HTTP_404_NOT_FOUND: {"description": "Source not found"},
     },
 )
-async def export_source(
+def export_source(
     source_id: Annotated[UUID, Depends(get_source_id)],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Response:
@@ -215,15 +215,16 @@ async def export_source(
     responses={
         status.HTTP_201_CREATED: {"description": "Source imported successfully", "model": Source},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format or source type is DISCONNECTED"},
+        status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
     },
 )
-async def import_source(
+def import_source(
     yaml_file: Annotated[UploadFile, File(description="YAML file containing the source configuration")],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Source:
     """Import a source from file"""
     try:
-        yaml_content = await yaml_file.read()
+        yaml_content = yaml_file.file.read()
         source_data = yaml.safe_load(yaml_content)
 
         source_create = SourceCreateAdapter.validate_python(source_data)
@@ -236,6 +237,8 @@ async def import_source(
         return configuration_service.create_source(source_config)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")
+    except ResourceAlreadyExistsError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
 
 @router.delete(
@@ -250,7 +253,7 @@ async def import_source(
         status.HTTP_409_CONFLICT: {"description": "Source is used by at least one pipeline"},
     },
 )
-async def delete_source(
+def delete_source(
     source_id: Annotated[UUID, Depends(get_source_id)],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> None:

--- a/application/backend/app/api/endpoints/sources.py
+++ b/application/backend/app/api/endpoints/sources.py
@@ -226,12 +226,13 @@ async def import_source(
         yaml_content = await yaml_file.read()
         source_data = yaml.safe_load(yaml_content)
 
-        source_config = SourceAdapter.validate_python(source_data)
-        if source_config.source_type == SourceType.DISCONNECTED:
+        source_create = SourceCreateAdapter.validate_python(source_data)
+        if source_create.source_type == SourceType.DISCONNECTED:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="The source with source_type=DISCONNECTED cannot be imported",
             )
+        source_config = SourceAdapter.validate_python(source_create.model_dump())
         return configuration_service.create_source(source_config)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")

--- a/application/backend/app/api/endpoints/sources.py
+++ b/application/backend/app/api/endpoints/sources.py
@@ -14,8 +14,8 @@ from fastapi.openapi.models import Example
 from fastapi.responses import FileResponse, Response
 
 from app.api.dependencies import get_configuration_service, get_source_id
-from app.schemas import Source, SourceType
-from app.schemas.source import SourceAdapter
+from app.schemas import Source, SourceCreate, SourceType
+from app.schemas.source import SourceAdapter, SourceCreateAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -91,25 +91,27 @@ UPDATE_SOURCE_BODY_EXAMPLES = {
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
+    response_model=Source,
     responses={
-        status.HTTP_201_CREATED: {"description": "Source created", "model": Source},
+        status.HTTP_201_CREATED: {"description": "Source created"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid source ID or request body"},
         status.HTTP_409_CONFLICT: {"description": "Source already exists"},
     },
 )
 async def create_source(
-    source_config: Annotated[
-        Source, Body(description=CREATE_SOURCE_BODY_DESCRIPTION, openapi_examples=CREATE_SOURCE_BODY_EXAMPLES)
+    source_create: Annotated[
+        SourceCreate, Body(description=CREATE_SOURCE_BODY_DESCRIPTION, openapi_examples=CREATE_SOURCE_BODY_EXAMPLES)
     ],
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Source:
     """Create and configure a new source"""
-    if source_config.source_type == SourceType.DISCONNECTED:
+    if source_create.source_type == SourceType.DISCONNECTED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="The source with source_type=DISCONNECTED cannot be created"
         )
 
     try:
+        source_config = SourceCreateAdapter.validate_python(source_create.model_dump())
         return configuration_service.create_source(source_config)
     except ResourceAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))

--- a/application/backend/app/api/endpoints/sources.py
+++ b/application/backend/app/api/endpoints/sources.py
@@ -15,7 +15,7 @@ from fastapi.responses import FileResponse, Response
 
 from app.api.dependencies import get_configuration_service, get_source_id
 from app.schemas import Source, SourceCreate, SourceType
-from app.schemas.source import SourceAdapter, SourceCreateAdapter
+from app.schemas.source import SourceCreateAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -111,8 +111,7 @@ def create_source(
         )
 
     try:
-        source_config = SourceCreateAdapter.validate_python(source_create.model_dump())
-        return configuration_service.create_source(source_config)
+        return configuration_service.create_source(source_create)
     except ResourceAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
@@ -215,7 +214,7 @@ def export_source(
     responses={
         status.HTTP_201_CREATED: {"description": "Source imported successfully", "model": Source},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format or source type is DISCONNECTED"},
-        status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
+        status.HTTP_409_CONFLICT: {"description": "Source already exists"},
     },
 )
 def import_source(
@@ -233,8 +232,7 @@ def import_source(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="The source with source_type=DISCONNECTED cannot be imported",
             )
-        source_config = SourceAdapter.validate_python(source_create.model_dump())
-        return configuration_service.create_source(source_config)
+        return configuration_service.create_source(source_create)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")
     except ResourceAlreadyExistsError as e:

--- a/application/backend/app/api/endpoints/sources.py
+++ b/application/backend/app/api/endpoints/sources.py
@@ -12,9 +12,10 @@ from fastapi import APIRouter, Body, Depends, File, UploadFile, status
 from fastapi.exceptions import HTTPException
 from fastapi.openapi.models import Example
 from fastapi.responses import FileResponse, Response
+from pydantic import ValidationError
 
 from app.api.dependencies import get_configuration_service, get_source_id
-from app.schemas import Source, SourceCreate, SourceType
+from app.schemas import Source, SourceCreate
 from app.schemas.source import SourceCreateAdapter
 from app.services import ConfigurationService, ResourceAlreadyExistsError, ResourceInUseError, ResourceNotFoundError
 
@@ -105,11 +106,6 @@ def create_source(
     configuration_service: Annotated[ConfigurationService, Depends(get_configuration_service)],
 ) -> Source:
     """Create and configure a new source"""
-    if source_create.source_type == SourceType.DISCONNECTED:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="The source with source_type=DISCONNECTED cannot be created"
-        )
-
     try:
         return configuration_service.create_source(source_create)
     except ResourceAlreadyExistsError as e:
@@ -213,8 +209,9 @@ def export_source(
     status_code=status.HTTP_201_CREATED,
     responses={
         status.HTTP_201_CREATED: {"description": "Source imported successfully", "model": Source},
-        status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format or source type is DISCONNECTED"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format "},
         status.HTTP_409_CONFLICT: {"description": "Source already exists"},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Validation error(s)"},
     },
 )
 def import_source(
@@ -225,18 +222,14 @@ def import_source(
     try:
         yaml_content = yaml_file.file.read()
         source_data = yaml.safe_load(yaml_content)
-
         source_create = SourceCreateAdapter.validate_python(source_data)
-        if source_create.source_type == SourceType.DISCONNECTED:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="The source with source_type=DISCONNECTED cannot be imported",
-            )
         return configuration_service.create_source(source_create)
     except yaml.YAMLError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid YAML format: {str(e)}")
     except ResourceAlreadyExistsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
 
 
 @router.delete(

--- a/application/backend/app/schemas/__init__.py
+++ b/application/backend/app/schemas/__init__.py
@@ -6,8 +6,8 @@ from app.schemas.label import Label, PatchLabels
 from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, TimeWindow
 from app.schemas.model import Model, ModelFormat
 from app.schemas.model_architecture import ModelArchitectures
-from app.schemas.pipeline import DataCollectionPolicy, Pipeline, PipelineStatus
-from app.schemas.project import Project, ProjectUpdateName
+from app.schemas.pipeline import DataCollectionPolicy, PipelineStatus, PipelineView
+from app.schemas.project import ProjectCreate, ProjectUpdateName, ProjectView
 from app.schemas.sink import DisconnectedSinkConfig, OutputFormat, Sink, SinkType
 from app.schemas.source import DisconnectedSourceConfig, Source, SourceType
 
@@ -25,11 +25,12 @@ __all__ = [
     "ModelFormat",
     "OutputFormat",
     "PatchLabels",
-    "Pipeline",
     "PipelineMetrics",
     "PipelineStatus",
-    "Project",
+    "PipelineView",
+    "ProjectCreate",
     "ProjectUpdateName",
+    "ProjectView",
     "Sink",
     "SinkType",
     "Source",

--- a/application/backend/app/schemas/__init__.py
+++ b/application/backend/app/schemas/__init__.py
@@ -8,8 +8,8 @@ from app.schemas.model import Model, ModelFormat
 from app.schemas.model_architecture import ModelArchitectures
 from app.schemas.pipeline import DataCollectionPolicy, PipelineStatus, PipelineView
 from app.schemas.project import ProjectCreate, ProjectUpdateName, ProjectView
-from app.schemas.sink import DisconnectedSinkConfig, OutputFormat, Sink, SinkType
-from app.schemas.source import DisconnectedSourceConfig, Source, SourceType
+from app.schemas.sink import DisconnectedSinkConfig, OutputFormat, Sink, SinkCreate, SinkType
+from app.schemas.source import DisconnectedSourceConfig, Source, SourceCreate, SourceType
 
 __all__ = [
     "DataCollectionPolicy",
@@ -32,8 +32,10 @@ __all__ = [
     "ProjectUpdateName",
     "ProjectView",
     "Sink",
+    "SinkCreate",
     "SinkType",
     "Source",
+    "SourceCreate",
     "SourceType",
     "TimeWindow",
 ]

--- a/application/backend/app/schemas/base.py
+++ b/application/backend/app/schemas/base.py
@@ -7,17 +7,44 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel, Field
 
 
-class BaseIDModel(ABC, BaseModel):
-    """Base model with an id field."""
+class HasID(ABC, BaseModel):
+    """Mixin: Optional UUID with auto-generation."""
 
-    id: UUID = Field(default_factory=uuid4)
+    id: UUID = Field(default_factory=uuid4, description="Unique identifier")
 
 
-class BaseIDNameModel(ABC, BaseModel):
-    """Base model with id and name fields."""
+class RequiresID(ABC, BaseModel):
+    """Mixin: Required UUID field."""
 
-    id: UUID = Field(default_factory=uuid4)
-    name: str = "Default Name"
+    id: UUID = Field(..., description="Unique identifier")
+
+
+class HasName(ABC, BaseModel):
+    """Mixin: Optional name with default value."""
+
+    name: str = Field(default="Default Name", description="Name of the entity")
+
+
+class RequiresName(ABC, BaseModel):
+    """Mixin: Required name field."""
+
+    name: str = Field(..., description="Name of the entity")
+
+
+class BaseIDModel(HasID):
+    """Base model with auto-generated ID."""
+
+
+class BaseIDNameModel(HasID, HasName):
+    """Base model with auto-generated ID and default name."""
+
+
+class BaseRequiredIDModel(RequiresID):
+    """Base model with required ID."""
+
+
+class BaseRequiredIDNameModel(RequiresID, RequiresName):
+    """Base model with required ID and name."""
 
 
 class Pagination(ABC, BaseModel):

--- a/application/backend/app/schemas/label.py
+++ b/application/backend/app/schemas/label.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, StringConstraints
 
-from app.schemas.base import BaseIDModel
+from app.schemas.base import BaseIDModel, BaseRequiredIDModel
 
 COLOR_REGEX = r"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
 
@@ -104,9 +104,7 @@ class Label(BaseIDModel):
     }
 
 
-class LabelReference(BaseModel):
-    id: UUID = Field(..., description="UUID of the label")
-
+class LabelReference(BaseRequiredIDModel):
     model_config = {
         "json_schema_extra": {
             "example": {

--- a/application/backend/app/schemas/pipeline.py
+++ b/application/backend/app/schemas/pipeline.py
@@ -38,7 +38,7 @@ class FixedRateDataCollectionPolicy(DataCollectionPolicyBase):
 DataCollectionPolicy = Annotated[FixedRateDataCollectionPolicy, Field(discriminator="type")]
 
 
-class Pipeline(BaseModel):
+class PipelineView(BaseModel):
     project_id: UUID  # ID of the project this pipeline belongs to
     source: Source | None = None  # None if disconnected
     sink: Sink | None = None  # None if disconnected
@@ -107,7 +107,7 @@ class Pipeline(BaseModel):
         return data
 
     @model_validator(mode="after")
-    def validate_running_status(self) -> "Pipeline":
+    def validate_running_status(self) -> "PipelineView":
         if self.status == PipelineStatus.RUNNING and any(
             x is None for x in (self.source_id, self.sink_id, self.model_id)
         ):

--- a/application/backend/app/schemas/project.py
+++ b/application/backend/app/schemas/project.py
@@ -56,7 +56,7 @@ class ProjectBase(BaseModel):
         return {
             **({"id": "7b073838-99d3-42ff-9018-4e901eb047fc"} if view else {}),
             "name": "animals",
-            "active_pipeline": True if view else None,
+            "active_pipeline": False if view else None,
             "task": {
                 "task_type": "classification",
                 "exclusive_labels": True,

--- a/application/backend/app/schemas/project.py
+++ b/application/backend/app/schemas/project.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-from app.schemas.base import BaseIDNameModel
+from app.schemas.base import HasID, RequiresID
 from app.schemas.label import Label
 
 
@@ -15,9 +16,11 @@ class TaskType(StrEnum):
 
 
 class Task(BaseModel):
-    task_type: TaskType
-    exclusive_labels: bool = False
-    labels: list[Label] = []
+    task_type: TaskType = Field(description="Task type (classification, detection or segmentation).")
+    exclusive_labels: bool = Field(
+        default=False, description="Whether labels are exclusive (e.g. classification) or not (e.g. detection)."
+    )
+    labels: list[Label] = Field(default_factory=list, description="List of labels to use.")
 
 
 class ProjectUpdateName(BaseModel):
@@ -28,32 +31,53 @@ class ProjectUpdateName(BaseModel):
     model_config = {"json_schema_extra": {"example": {"name": "updated_project_name"}}}
 
 
-class Project(BaseIDNameModel):
+class ProjectBase(BaseModel):
+    name: str = Field(..., description="Name of the project.")
     task: Task
+
+    @classmethod
+    def example_dict(cls, view: bool = False) -> dict:
+        """Generate example with configurable ID inclusion."""
+        labels = [
+            {
+                **({"id": "a22d82ba-afa9-4d6e-bbc1-8c8e4002ec29"} if view else {}),
+                "name": "cat",
+                "color": "#FF5733",
+                "hotkey": "S",
+            },
+            {
+                **({"id": "8aa85368-11ba-4507-88f2-6a6704d78ef5"} if view else {}),
+                "name": "dog",
+                "color": "#33FF57",
+                "hotkey": "D",
+            },
+        ]
+
+        return {
+            **({"id": "7b073838-99d3-42ff-9018-4e901eb047fc"} if view else {}),
+            "name": "animals",
+            "active_pipeline": True if view else None,
+            "task": {
+                "task_type": "classification",
+                "exclusive_labels": True,
+                "labels": labels,
+            },
+        }
+
+
+class ProjectCreate(HasID, ProjectBase):
+    model_config = {
+        "json_schema_extra": {
+            "example": ProjectBase.example_dict(),
+        }
+    }
+
+
+class ProjectView(RequiresID, ProjectBase):
+    active_pipeline: bool = Field(..., description="Whether the project has an active pipeline.")
 
     model_config = {
         "json_schema_extra": {
-            "example": {
-                "id": "7b073838-99d3-42ff-9018-4e901eb047fc",
-                "name": "animals",
-                "task": {
-                    "task_type": "classification",
-                    "exclusive_labels": True,
-                    "labels": [
-                        {
-                            "id": "a22d82ba-afa9-4d6e-bbc1-8c8e4002ec29",
-                            "name": "cat",
-                            "color": "#FF5733",
-                            "hotkey": "S",
-                        },
-                        {
-                            "id": "8aa85368-11ba-4507-88f2-6a6704d78ef5",
-                            "name": "dog",
-                            "color": "#33FF57",
-                            "hotkey": "D",
-                        },
-                    ],
-                },
-            }
+            "example": ProjectBase.example_dict(view=True),
         }
     }

--- a/application/backend/app/schemas/sink.py
+++ b/application/backend/app/schemas/sink.py
@@ -4,10 +4,11 @@
 from enum import StrEnum
 from os import getenv
 from typing import Annotated, Literal
+from uuid import UUID
 
 from pydantic import Field, TypeAdapter
 
-from app.schemas.base import BaseIDNameModel
+from app.schemas.base import BaseRequiredIDNameModel, HasID
 
 MQTT_USERNAME = "MQTT_USERNAME"
 MQTT_PASSWORD = "MQTT_PASSWORD"  # noqa: S105
@@ -27,13 +28,14 @@ class OutputFormat(StrEnum):
     PREDICTIONS = "predictions"
 
 
-class BaseSinkConfig(BaseIDNameModel):
+class BaseSinkConfig(BaseRequiredIDNameModel):
     output_formats: list[OutputFormat]
     rate_limit: float | None = None  # Rate limit in Hz, None means no limit
 
 
 class DisconnectedSinkConfig(BaseSinkConfig):
     sink_type: Literal[SinkType.DISCONNECTED] = SinkType.DISCONNECTED
+    id: UUID = UUID("00000000-0000-0000-0000-000000000000")
     name: str = "No Sink"
     output_formats: list[OutputFormat] = []
 
@@ -151,3 +153,41 @@ Sink = Annotated[
 ]
 
 SinkAdapter: TypeAdapter[Sink] = TypeAdapter(Sink)
+
+# ---------------------------------
+# Creation Schemas (POST requests)
+# ---------------------------------
+# These schemas inherit from HasID first to override the required ID field with an auto-generated one (if absent) via
+# MRO (Method Resolution Order).
+
+
+class DisconnectedSinkConfigCreate(HasID, DisconnectedSinkConfig):
+    pass
+
+
+class FolderSinkConfigCreate(HasID, FolderSinkConfig):
+    pass
+
+
+class MqttSinkConfigCreate(HasID, MqttSinkConfig):
+    pass
+
+
+class RosSinkConfigCreate(HasID, RosSinkConfig):
+    pass
+
+
+class WebhookSinkConfigCreate(HasID, WebhookSinkConfig):
+    pass
+
+
+SinkCreate = Annotated[
+    FolderSinkConfigCreate
+    | MqttSinkConfigCreate
+    | RosSinkConfigCreate
+    | WebhookSinkConfigCreate
+    | DisconnectedSinkConfigCreate,
+    Field(discriminator="sink_type"),
+]
+
+SinkCreateAdapter: TypeAdapter[SinkCreate] = TypeAdapter(SinkCreate)

--- a/application/backend/app/schemas/sink.py
+++ b/application/backend/app/schemas/sink.py
@@ -161,10 +161,6 @@ SinkAdapter: TypeAdapter[Sink] = TypeAdapter(Sink)
 # MRO (Method Resolution Order).
 
 
-class DisconnectedSinkConfigCreate(HasID, DisconnectedSinkConfig):
-    pass
-
-
 class FolderSinkConfigCreate(HasID, FolderSinkConfig):
     pass
 
@@ -182,11 +178,7 @@ class WebhookSinkConfigCreate(HasID, WebhookSinkConfig):
 
 
 SinkCreate = Annotated[
-    FolderSinkConfigCreate
-    | MqttSinkConfigCreate
-    | RosSinkConfigCreate
-    | WebhookSinkConfigCreate
-    | DisconnectedSinkConfigCreate,
+    FolderSinkConfigCreate | MqttSinkConfigCreate | RosSinkConfigCreate | WebhookSinkConfigCreate,
     Field(discriminator="sink_type"),
 ]
 

--- a/application/backend/app/schemas/source.py
+++ b/application/backend/app/schemas/source.py
@@ -131,10 +131,6 @@ SourceAdapter: TypeAdapter[Source] = TypeAdapter(Source)
 # MRO (Method Resolution Order).
 
 
-class DisconnectedSourceConfigCreate(HasID, DisconnectedSourceConfig):
-    pass
-
-
 class WebcamSourceConfigCreate(HasID, WebcamSourceConfig):
     pass
 
@@ -152,8 +148,7 @@ class ImagesFolderSourceConfigCreate(HasID, ImagesFolderSourceConfig):
 
 
 SourceCreate = Annotated[
-    DisconnectedSourceConfigCreate
-    | WebcamSourceConfigCreate
+    WebcamSourceConfigCreate
     | IPCameraSourceConfigCreate
     | VideoFileSourceConfigCreate
     | ImagesFolderSourceConfigCreate,

--- a/application/backend/app/schemas/source.py
+++ b/application/backend/app/schemas/source.py
@@ -5,10 +5,11 @@ from enum import StrEnum
 from os import getenv
 from typing import Annotated, Literal
 from urllib.parse import urlparse, urlunparse
+from uuid import UUID
 
 from pydantic import Field, TypeAdapter
 
-from app.schemas.base import BaseIDNameModel
+from app.schemas.base import BaseRequiredIDNameModel, HasID
 
 IP_CAMERA_USERNAME = "IP_CAMERA_USERNAME"
 IP_CAMERA_PASSWORD = "IP_CAMERA_PASSWORD"  # noqa: S105
@@ -22,12 +23,13 @@ class SourceType(StrEnum):
     IMAGES_FOLDER = "images_folder"
 
 
-class DisconnectedSourceConfig(BaseIDNameModel):
+class DisconnectedSourceConfig(BaseRequiredIDNameModel):
     source_type: Literal[SourceType.DISCONNECTED] = SourceType.DISCONNECTED
+    id: UUID = UUID("00000000-0000-0000-0000-000000000000")
     name: str = "No Source"
 
 
-class WebcamSourceConfig(BaseIDNameModel):
+class WebcamSourceConfig(BaseRequiredIDNameModel):
     source_type: Literal[SourceType.WEBCAM]
     device_id: int
 
@@ -43,7 +45,7 @@ class WebcamSourceConfig(BaseIDNameModel):
     }
 
 
-class IPCameraSourceConfig(BaseIDNameModel):
+class IPCameraSourceConfig(BaseRequiredIDNameModel):
     source_type: Literal[SourceType.IP_CAMERA]
     stream_url: str
     auth_required: bool = False
@@ -77,7 +79,7 @@ class IPCameraSourceConfig(BaseIDNameModel):
         return urlunparse((uri.scheme, netloc, uri.path, uri.params, uri.query, uri.fragment))
 
 
-class VideoFileSourceConfig(BaseIDNameModel):
+class VideoFileSourceConfig(BaseRequiredIDNameModel):
     source_type: Literal[SourceType.VIDEO_FILE]
     video_path: str
 
@@ -93,7 +95,7 @@ class VideoFileSourceConfig(BaseIDNameModel):
     }
 
 
-class ImagesFolderSourceConfig(BaseIDNameModel):
+class ImagesFolderSourceConfig(BaseRequiredIDNameModel):
     source_type: Literal[SourceType.IMAGES_FOLDER]
     images_folder_path: str
     ignore_existing_images: bool
@@ -121,3 +123,41 @@ Source = Annotated[
 ]
 
 SourceAdapter: TypeAdapter[Source] = TypeAdapter(Source)
+
+# ---------------------------------
+# Creation Schemas (POST requests)
+# ---------------------------------
+# These schemas inherit from HasID first to override the required ID field with an auto-generated one (if absent) via
+# MRO (Method Resolution Order).
+
+
+class DisconnectedSourceConfigCreate(HasID, DisconnectedSourceConfig):
+    pass
+
+
+class WebcamSourceConfigCreate(HasID, WebcamSourceConfig):
+    pass
+
+
+class IPCameraSourceConfigCreate(HasID, IPCameraSourceConfig):
+    pass
+
+
+class VideoFileSourceConfigCreate(HasID, VideoFileSourceConfig):
+    pass
+
+
+class ImagesFolderSourceConfigCreate(HasID, ImagesFolderSourceConfig):
+    pass
+
+
+SourceCreate = Annotated[
+    DisconnectedSourceConfigCreate
+    | WebcamSourceConfigCreate
+    | IPCameraSourceConfigCreate
+    | VideoFileSourceConfigCreate
+    | ImagesFolderSourceConfigCreate,
+    Field(discriminator="source_type"),
+]
+
+SourceCreateAdapter: TypeAdapter[SourceCreate] = TypeAdapter(SourceCreate)

--- a/application/backend/app/services/active_pipeline_service.py
+++ b/application/backend/app/services/active_pipeline_service.py
@@ -8,7 +8,7 @@ from threading import Thread
 
 from app.db import get_db_session
 from app.repositories import PipelineRepository
-from app.schemas import DisconnectedSinkConfig, DisconnectedSourceConfig, Project, Sink, Source
+from app.schemas import DisconnectedSinkConfig, DisconnectedSourceConfig, ProjectView, Sink, Source
 from app.schemas.pipeline import DataCollectionPolicy
 from app.services.mappers import ProjectMapper, SinkMapper, SourceMapper
 
@@ -34,7 +34,7 @@ class ActivePipelineService:
         self.config_changed_condition = config_changed_condition
         self._source: Source = DisconnectedSourceConfig()
         self._sink: Sink = DisconnectedSinkConfig()
-        self._project: Project | None = None
+        self._project: ProjectView | None = None
         self._data_collection_policies: list[DataCollectionPolicy] = []
         self._load_app_config()
 
@@ -102,7 +102,7 @@ class ActivePipelineService:
     def get_sink_config(self) -> Sink:
         return self._sink
 
-    def get_project(self) -> Project | None:
+    def get_project(self) -> ProjectView | None:
         return self._project
 
     def get_data_collection_policies(self) -> list[DataCollectionPolicy]:

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from app.db import get_db_session
 from app.entities.stream_data import InferenceData
-from app.schemas import Project
+from app.schemas import ProjectView
 from app.schemas.dataset_item import DatasetItemFormat
 from app.schemas.pipeline import FixedRateDataCollectionPolicy
 from app.services import ActivePipelineService, DatasetService
@@ -60,7 +60,7 @@ class DataCollector:
     def collect(
         self,
         source_id: UUID,
-        project: Project,
+        project: ProjectView,
         timestamp: float,
         frame_data: np.ndarray,
         inference_data: InferenceData,

--- a/application/backend/app/services/mappers/pipeline_mapper.py
+++ b/application/backend/app/services/mappers/pipeline_mapper.py
@@ -4,18 +4,18 @@
 from uuid import UUID
 
 from app.db.schema import PipelineDB
-from app.schemas import DataCollectionPolicy, Pipeline, PipelineStatus
+from app.schemas import DataCollectionPolicy, PipelineStatus, PipelineView
 
 
 class PipelineMapper:
     """Mapper for Pipeline schema entity <-> DB entity conversions."""
 
     @staticmethod
-    def to_schema(pipeline_db: PipelineDB) -> Pipeline:
+    def to_schema(pipeline_db: PipelineDB) -> PipelineView:
         """Convert Pipeline db entity to schema."""
         from app.services.mappers import ModelRevisionMapper, SinkMapper, SourceMapper
 
-        return Pipeline(
+        return PipelineView(
             project_id=UUID(pipeline_db.project_id),
             source=SourceMapper.to_schema(pipeline_db.source) if pipeline_db.source else None,
             sink=SinkMapper.to_schema(pipeline_db.sink) if pipeline_db.sink else None,
@@ -30,7 +30,7 @@ class PipelineMapper:
         )
 
     @staticmethod
-    def from_schema(pipeline: Pipeline) -> PipelineDB:
+    def from_schema(pipeline: PipelineView) -> PipelineDB:
         """Convert Pipeline schema to db model."""
 
         return PipelineDB(

--- a/application/backend/app/services/mappers/project_mapper.py
+++ b/application/backend/app/services/mappers/project_mapper.py
@@ -3,7 +3,7 @@
 from uuid import UUID
 
 from app.db.schema import ProjectDB
-from app.schemas import Project
+from app.schemas import ProjectCreate, ProjectView
 from app.schemas.project import Task, TaskType
 from app.services.mappers.label_mapper import LabelMapper
 
@@ -12,10 +12,11 @@ class ProjectMapper:
     """Mapper for Project schema entity <-> DB entity conversions."""
 
     @staticmethod
-    def to_schema(project_db: ProjectDB) -> Project:
+    def to_schema(project_db: ProjectDB) -> ProjectView:
         """Convert Project db entity to schema."""
-        return Project(
+        return ProjectView(
             id=UUID(project_db.id),
+            active_pipeline=project_db.pipeline.is_running,
             name=project_db.name,
             task=Task(
                 task_type=TaskType(project_db.task_type),
@@ -25,7 +26,7 @@ class ProjectMapper:
         )
 
     @staticmethod
-    def from_schema(project: Project) -> ProjectDB:
+    def from_schema(project: ProjectCreate) -> ProjectDB:
         """Convert Project schema to db model."""
 
         project_db = ProjectDB(

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.repositories import PipelineRepository
-from app.schemas import Pipeline, PipelineStatus
+from app.schemas import PipelineStatus, PipelineView
 from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
 from app.services import ActivePipelineService
 from app.services.base import ResourceNotFoundError, ResourceType
@@ -48,7 +48,7 @@ class PipelineService:
         self._notify_sink_changed()
         self._data_collector.reload_policies()
 
-    def get_pipeline_by_id(self, project_id: UUID) -> Pipeline:
+    def get_pipeline_by_id(self, project_id: UUID) -> PipelineView:
         """Retrieve a pipeline by project ID."""
         pipeline_repo = PipelineRepository(self._db_session)
         pipeline = pipeline_repo.get_by_id(str(project_id))
@@ -57,7 +57,7 @@ class PipelineService:
         return PipelineMapper.to_schema(pipeline)
 
     @parent_process_only
-    def update_pipeline(self, project_id: UUID, partial_config: dict) -> Pipeline:
+    def update_pipeline(self, project_id: UUID, partial_config: dict) -> PipelineView:
         """Update an existing pipeline."""
         pipeline = self.get_pipeline_by_id(project_id)
         to_update = pipeline.model_copy(update=partial_config)

--- a/application/backend/tests/conftest.py
+++ b/application/backend/tests/conftest.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.schemas import Model, OutputFormat, Pipeline, PipelineStatus, SinkType, SourceType
+from app.schemas import Model, OutputFormat, PipelineStatus, PipelineView, SinkType, SourceType
 from app.schemas.model import TrainingInfo, TrainingStatus
 from app.schemas.sink import MqttSinkConfig
 from app.schemas.source import WebcamSourceConfig
@@ -41,9 +41,9 @@ def fxt_model() -> Model:
 
 
 @pytest.fixture
-def fxt_default_pipeline() -> Pipeline:
+def fxt_default_pipeline() -> PipelineView:
     """Sample default pipeline data."""
-    return Pipeline(
+    return PipelineView(
         project_id=uuid4(),
         source=None,
         sink=None,
@@ -53,9 +53,9 @@ def fxt_default_pipeline() -> Pipeline:
 
 
 @pytest.fixture
-def fxt_running_pipeline(fxt_webcam_source, fxt_mqtt_sink, fxt_model) -> Pipeline:
+def fxt_running_pipeline(fxt_webcam_source, fxt_mqtt_sink, fxt_model) -> PipelineView:
     """Sample default pipeline data."""
-    return Pipeline(
+    return PipelineView(
         project_id=uuid4(),
         source_id=fxt_webcam_source.id,
         sink_id=fxt_mqtt_sink.id,

--- a/application/backend/tests/conftest.py
+++ b/application/backend/tests/conftest.py
@@ -14,13 +14,14 @@ from app.schemas.source import WebcamSourceConfig
 @pytest.fixture
 def fxt_webcam_source() -> WebcamSourceConfig:
     """Sample source configuration data."""
-    return WebcamSourceConfig(source_type=SourceType.WEBCAM, name="Test Source", device_id=1)
+    return WebcamSourceConfig(id=uuid4(), source_type=SourceType.WEBCAM, name="Test Source", device_id=1)
 
 
 @pytest.fixture
 def fxt_mqtt_sink() -> MqttSinkConfig:
     """Sample sink configuration data."""
     return MqttSinkConfig(
+        id=uuid4(),
         sink_type=SinkType.MQTT,
         name="Test Sink",
         rate_limit=0.1,

--- a/application/backend/tests/integration/entities/test_ip_camera_stream.py
+++ b/application/backend/tests/integration/entities/test_ip_camera_stream.py
@@ -5,6 +5,7 @@ import re
 import time
 from collections.abc import Generator
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import cv2
 import numpy as np
@@ -47,7 +48,9 @@ class TestIPCameraStream:
 
     @pytest.fixture()
     def config(self, ip_camera: str) -> IPCameraSourceConfig:
-        return IPCameraSourceConfig(source_type=SourceType.IP_CAMERA, stream_url=ip_camera)
+        return IPCameraSourceConfig(
+            source_type=SourceType.IP_CAMERA, id=uuid4(), name="Test IP Camera", stream_url=ip_camera
+        )
 
     @pytest.fixture()
     def stream(self, config: IPCameraSourceConfig) -> Generator[IPCameraStream]:

--- a/application/backend/tests/integration/entities/test_ip_camera_stream.py
+++ b/application/backend/tests/integration/entities/test_ip_camera_stream.py
@@ -80,7 +80,9 @@ class TestIPCameraStream:
     def test_invalid_url(self):
         """Test that IPCameraStream handles invalid URLs with specific error."""
         invalid_url = "http://invalid-url:9999/stream"
-        config = IPCameraSourceConfig(source_type=SourceType.IP_CAMERA, stream_url=invalid_url)
+        config = IPCameraSourceConfig(
+            source_type=SourceType.IP_CAMERA, id=uuid4(), name="Test IP Camera", stream_url=invalid_url
+        )
 
         # Should raise exception during initialization
         with pytest.raises(RuntimeError, match=f"Could not open video source: {invalid_url}"):

--- a/application/backend/tests/integration/services/dispatchers/test_mqtt.py
+++ b/application/backend/tests/integration/services/dispatchers/test_mqtt.py
@@ -7,6 +7,7 @@ import re
 import time
 from datetime import datetime
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import cv2
 import numpy as np
@@ -52,6 +53,8 @@ def mqtt_config(mqtt_broker) -> MqttSinkConfig:
     host, port = mqtt_broker
     return MqttSinkConfig(
         sink_type=SinkType.MQTT,
+        id=uuid4(),
+        name="Test MQTT Sink",
         broker_host=host,
         broker_port=port,
         topic="topic",
@@ -65,6 +68,8 @@ def mqtt_config_with_auth(mqtt_broker) -> MqttSinkConfig:
     host, port = mqtt_broker
     return MqttSinkConfig(
         sink_type=SinkType.MQTT,
+        id=uuid4(),
+        name="Test MQTT Sink with Auth",
         broker_host=host,
         broker_port=port,
         topic="topic",

--- a/application/backend/tests/integration/services/dispatchers/test_mqtt.py
+++ b/application/backend/tests/integration/services/dispatchers/test_mqtt.py
@@ -169,6 +169,8 @@ class TestMqttDispatcher:
         """Test connection failure to invalid broker."""
         config = MqttSinkConfig(
             sink_type="mqtt",
+            id=uuid4(),
+            name="Test MQTT Sink",
             broker_host="invalid_host",
             broker_port=1883,
             topic="topic",

--- a/application/backend/tests/integration/services/test_project_service.py
+++ b/application/backend/tests/integration/services/test_project_service.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, LabelDB, PipelineDB, ProjectDB
-from app.schemas.project import Label, ProjectView, Task, TaskType
+from app.schemas.project import Label, ProjectCreate, Task, TaskType
 from app.services.base import ResourceInUseError, ResourceNotFoundError, ResourceType
 from app.services.project_service import ProjectService
 
@@ -39,7 +39,7 @@ class TestProjectServiceIntegration:
             Label(name="cat", color="#00FF00", hotkey="c"),
             Label(name="dog", color="#FF0000", hotkey="d"),
         ]
-        new_project = ProjectView(
+        new_project = ProjectCreate(
             name="Test Project",
             task=Task(
                 task_type=TaskType.CLASSIFICATION,

--- a/application/backend/tests/integration/services/test_project_service.py
+++ b/application/backend/tests/integration/services/test_project_service.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, LabelDB, PipelineDB, ProjectDB
-from app.schemas.project import Label, Project, Task, TaskType
+from app.schemas.project import Label, ProjectView, Task, TaskType
 from app.services.base import ResourceInUseError, ResourceNotFoundError, ResourceType
 from app.services.project_service import ProjectService
 
@@ -39,7 +39,7 @@ class TestProjectServiceIntegration:
             Label(name="cat", color="#00FF00", hotkey="c"),
             Label(name="dog", color="#FF0000", hotkey="d"),
         ]
-        new_project = Project(
+        new_project = ProjectView(
             name="Test Project",
             task=Task(
                 task_type=TaskType.CLASSIFICATION,

--- a/application/backend/tests/unit/endpoints/test_pipelines.py
+++ b/application/backend/tests/unit/endpoints/test_pipelines.py
@@ -11,15 +11,15 @@ from pydantic import ValidationError
 
 from app.api.dependencies import get_pipeline_service
 from app.main import app
-from app.schemas import Pipeline, PipelineStatus
+from app.schemas import PipelineStatus, PipelineView
 from app.schemas.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
 from app.schemas.pipeline import FixedRateDataCollectionPolicy
 from app.services import PipelineService, ResourceNotFoundError, ResourceType
 
 
 @pytest.fixture
-def fxt_pipeline() -> Pipeline:
-    return Pipeline(
+def fxt_pipeline() -> PipelineView:
+    return PipelineView(
         project_id=uuid4(),
         status=PipelineStatus.IDLE,
         data_collection_policies=[FixedRateDataCollectionPolicy(type="fixed_rate", rate=0.1)],

--- a/application/backend/tests/unit/endpoints/test_sources_sinks.py
+++ b/application/backend/tests/unit/endpoints/test_sources_sinks.py
@@ -115,8 +115,7 @@ class TestSourceAndSinkEndpoints:
     ):
         response = fxt_client.post(f"/api/{api_path}", json=config_data)
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "DISCONNECTED cannot be created" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         getattr(fxt_config_service, create_method).assert_not_called()
 
     @pytest.mark.parametrize(
@@ -129,7 +128,7 @@ class TestSourceAndSinkEndpoints:
     def test_create_sink_validation_error(self, api_path, create_method, fxt_config_service, fxt_client):
         response = fxt_client.post(f"/api/{api_path}", json={"name": ""})
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         getattr(fxt_config_service, create_method).assert_not_called()
 
     @pytest.mark.parametrize(
@@ -422,18 +421,20 @@ class TestSourceAndSinkEndpoints:
         assert "Invalid YAML format" in response.json()["detail"]
 
     @pytest.mark.parametrize(
-        "api_path, config_type",
+        "api_path, config_type, create_method",
         [
-            (ConfigApiPath.SOURCES, "source_type"),
-            (ConfigApiPath.SINKS, "sink_type"),
+            (ConfigApiPath.SOURCES, "source_type", "create_source"),
+            (ConfigApiPath.SINKS, "sink_type", "create_sink"),
         ],
     )
-    def test_import_disconnected_config_fails(self, api_path, config_type, fxt_client):
+    def test_import_disconnected_config_fails(
+        self, api_path, config_type, create_method, fxt_config_service, fxt_client
+    ):
         config_data = {config_type: "disconnected", "name": "Test"}
         yaml_content = yaml.safe_dump(config_data)
         files = {"yaml_file": ("test.yaml", io.BytesIO(yaml_content.encode()), "application/x-yaml")}
 
         response = fxt_client.post(f"/api/{api_path}:import", files=files)
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "DISCONNECTED cannot be imported" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        getattr(fxt_config_service, create_method).assert_not_called()

--- a/application/backend/tests/unit/endpoints/test_sources_sinks.py
+++ b/application/backend/tests/unit/endpoints/test_sources_sinks.py
@@ -388,6 +388,27 @@ class TestSourceAndSinkEndpoints:
         getattr(fxt_config_service, create_method).assert_called_once()
 
     @pytest.mark.parametrize(
+        "fixture_name, api_path, create_method",
+        [
+            ("fxt_webcam_source", ConfigApiPath.SOURCES, "create_source"),
+            ("fxt_folder_sink", ConfigApiPath.SINKS, "create_sink"),
+        ],
+    )
+    def test_import_config_exists(self, fixture_name, api_path, create_method, fxt_config_service, fxt_client, request):
+        fxt_config = request.getfixturevalue(fixture_name)
+        sink_data = fxt_config.model_dump(exclude={"id"}, mode="json")
+        yaml_content = yaml.safe_dump(sink_data)
+        getattr(fxt_config_service, create_method).side_effect = ResourceAlreadyExistsError(
+            resource_type=ResourceType(api_path[:-1].capitalize()), resource_name="New Config"
+        )
+
+        files = {"yaml_file": ("test.yaml", io.BytesIO(yaml_content.encode()), "application/x-yaml")}
+        response = fxt_client.post(f"/api/{api_path}:import", files=files)
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        getattr(fxt_config_service, create_method).assert_called_once()
+
+    @pytest.mark.parametrize(
         "api_path",
         [ConfigApiPath.SOURCES, ConfigApiPath.SINKS],
     )

--- a/application/backend/tests/unit/schemas/test_ip_camera_source_config.py
+++ b/application/backend/tests/unit/schemas/test_ip_camera_source_config.py
@@ -3,31 +3,26 @@
 
 import os
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 
 from app.schemas.source import IP_CAMERA_PASSWORD, IP_CAMERA_USERNAME, IPCameraSourceConfig, SourceType
 
 
+@pytest.fixture
+def fxt_ip_camera_source_config() -> IPCameraSourceConfig:
+    return IPCameraSourceConfig(
+        source_type=SourceType.IP_CAMERA,
+        id=uuid4(),
+        name="Test IP Camera Source",
+        stream_url="rtsp://192.168.1.100:554/stream",
+        auth_required=True,
+    )
+
+
 class TestIpCameraSourceConfig:
     """Test cases for IpCameraSourceConfig."""
-
-    def test_basic_initialization(self):
-        """Test basic config initialization without auth."""
-        config = IPCameraSourceConfig(
-            source_type=SourceType.IP_CAMERA, stream_url="rtsp://192.168.1.100:554/stream", auth_required=False
-        )
-
-        assert config.source_type == SourceType.IP_CAMERA
-        assert config.stream_url == "rtsp://192.168.1.100:554/stream"
-        assert config.get_configured_stream_url() == "rtsp://192.168.1.100:554/stream"
-        assert not config.auth_required
-
-    def test_default_auth_required_value(self):
-        """Test that auth_required defaults to False."""
-        config = IPCameraSourceConfig(source_type=SourceType.IP_CAMERA, stream_url="rtsp://192.168.1.100:554/stream")
-
-        assert not config.auth_required
 
     @pytest.mark.parametrize(
         "env_vars,description",
@@ -39,50 +34,29 @@ class TestIpCameraSourceConfig:
             ({IP_CAMERA_USERNAME: "testuser", IP_CAMERA_PASSWORD: ""}, "password is empty"),
         ],
     )
-    def test_get_configured_stream_url_invalid_credentials(self, env_vars, description):
+    def test_get_configured_stream_url_invalid_credentials(self, fxt_ip_camera_source_config, env_vars, description):
         """Test error cases for invalid or missing credentials."""
-        with patch.dict(os.environ, env_vars, clear=True):
-            config = IPCameraSourceConfig(
-                source_type=SourceType.IP_CAMERA, stream_url="rtsp://192.168.1.100:554/stream", auth_required=True
-            )
-
-            with pytest.raises(RuntimeError, match="IP camera credentials not provided"):
-                config.get_configured_stream_url()
+        with (
+            patch.dict(os.environ, env_vars, clear=True),
+            pytest.raises(RuntimeError, match="IP camera credentials not provided"),
+        ):
+            fxt_ip_camera_source_config.get_configured_stream_url()
 
     @patch.dict(os.environ, {IP_CAMERA_USERNAME: "testuser", IP_CAMERA_PASSWORD: "testpass"})
-    def test_get_configured_stream_url_with_auth_success(self):
-        """Test URL configuration with valid credentials."""
-        config = IPCameraSourceConfig(
-            source_type=SourceType.IP_CAMERA, stream_url="rtsp://192.168.1.100:554/stream", auth_required=True
-        )
-
-        result = config.get_configured_stream_url()
-        assert result == "rtsp://testuser:testpass@192.168.1.100:554/stream"
-
-    @patch.dict(os.environ, {IP_CAMERA_USERNAME: "testuser", IP_CAMERA_PASSWORD: "testpass"})
-    def test_different_url_schemes(self):
+    def test_different_url_schemes(self, fxt_ip_camera_source_config):
         """Test URL configuration with different schemes."""
         test_cases = [
             ("http://192.168.1.100/stream", "http://testuser:testpass@192.168.1.100/stream"),
             ("https://camera.local:443/video", "https://testuser:testpass@camera.local:443/video"),
             ("rtsp://10.0.0.1:554/live", "rtsp://testuser:testpass@10.0.0.1:554/live"),
+            (
+                "rtsp://192.168.1.100:554/live/stream1?quality=high&format=h264",
+                "rtsp://testuser:testpass@192.168.1.100:554/live/stream1?quality=high&format=h264",
+            ),
         ]
 
         for input_url, expected_url in test_cases:
-            config = IPCameraSourceConfig(source_type=SourceType.IP_CAMERA, stream_url=input_url, auth_required=True)
+            fxt_ip_camera_source_config.stream_url = input_url
 
-            result = config.get_configured_stream_url()
+            result = fxt_ip_camera_source_config.get_configured_stream_url()
             assert result == expected_url
-
-    @patch.dict(os.environ, {IP_CAMERA_USERNAME: "testuser", IP_CAMERA_PASSWORD: "testpass"})
-    def test_url_with_path_and_query_params(self):
-        """Test URL configuration preserves path and query parameters."""
-        config = IPCameraSourceConfig(
-            source_type=SourceType.IP_CAMERA,
-            stream_url="rtsp://192.168.1.100:554/live/stream1?quality=high&format=h264",
-            auth_required=True,
-        )
-
-        result = config.get_configured_stream_url()
-        expected = "rtsp://testuser:testpass@192.168.1.100:554/live/stream1?quality=high&format=h264"
-        assert result == expected

--- a/application/backend/tests/unit/services/dispatchers/test_webhook.py
+++ b/application/backend/tests/unit/services/dispatchers/test_webhook.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import numpy as np
 import pytest
@@ -18,6 +19,7 @@ from app.services.dispatchers.webhook import WebhookDispatcher
 def fxt_webhook_config():
     return WebhookSinkConfig(
         sink_type=SinkType.WEBHOOK,
+        id=uuid4(),
         name="Test Webhook Sink",
         rate_limit=0.2,
         output_formats=[

--- a/application/backend/tests/unit/services/mappers/test_pipeline_mapper.py
+++ b/application/backend/tests/unit/services/mappers/test_pipeline_mapper.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic_core._pydantic_core import ValidationError
 
 from app.db.schema import PipelineDB
-from app.schemas import Pipeline, PipelineStatus
+from app.schemas import PipelineStatus, PipelineView
 from app.services.mappers import PipelineMapper
 
 UUID0 = uuid4()
@@ -17,7 +17,7 @@ UUID3 = uuid4()
 
 SUPPORTED_PIPELINE_MAPPING = [
     (
-        Pipeline(
+        PipelineView(
             project_id=UUID0,
             status=PipelineStatus.IDLE,
             data_collection_policies=[],
@@ -29,7 +29,7 @@ SUPPORTED_PIPELINE_MAPPING = [
         ),
     ),
     (
-        Pipeline(
+        PipelineView(
             project_id=UUID0,
             status=PipelineStatus.RUNNING,
             source_id=UUID1,
@@ -71,4 +71,4 @@ class TestPipelineMapper:
             PipelineMapper.to_schema(PipelineDB(project_id=str(UUID0), is_running=True, data_collection_policies=[]))
 
         with pytest.raises(ValidationError):
-            Pipeline(project_id=UUID1, status=PipelineStatus.RUNNING)
+            PipelineView(project_id=UUID1, status=PipelineStatus.RUNNING)

--- a/application/backend/tests/unit/services/mappers/test_sink_mapper.py
+++ b/application/backend/tests/unit/services/mappers/test_sink_mapper.py
@@ -9,10 +9,12 @@ from app.db.schema import SinkDB
 from app.schemas.sink import FolderSinkConfig, MqttSinkConfig, OutputFormat, SinkType, WebhookSinkConfig
 from app.services.mappers.sink_mapper import SinkMapper
 
+SINK_ID = uuid4()
 SUPPORTED_SINKS_MAPPING = [
     (
         FolderSinkConfig(
             sink_type=SinkType.FOLDER,
+            id=SINK_ID,
             name="Test Folder Sink",
             rate_limit=0.2,
             output_formats=[
@@ -24,6 +26,7 @@ SUPPORTED_SINKS_MAPPING = [
         ),
         SinkDB(
             sink_type=SinkType.FOLDER,
+            id=str(SINK_ID),
             name="Test Folder Sink",
             rate_limit=0.2,
             output_formats=[
@@ -37,6 +40,7 @@ SUPPORTED_SINKS_MAPPING = [
     (
         MqttSinkConfig(
             sink_type=SinkType.MQTT,
+            id=SINK_ID,
             name="Test Mqtt Sink",
             rate_limit=0.2,
             output_formats=[
@@ -51,6 +55,7 @@ SUPPORTED_SINKS_MAPPING = [
         ),
         SinkDB(
             sink_type=SinkType.MQTT,
+            id=str(SINK_ID),
             name="Test Mqtt Sink",
             rate_limit=0.2,
             output_formats=[
@@ -64,6 +69,7 @@ SUPPORTED_SINKS_MAPPING = [
     (
         WebhookSinkConfig(
             sink_type=SinkType.WEBHOOK,
+            id=SINK_ID,
             name="Test Webhook Sink",
             rate_limit=0.2,
             output_formats=[
@@ -78,6 +84,7 @@ SUPPORTED_SINKS_MAPPING = [
         ),
         SinkDB(
             sink_type=SinkType.WEBHOOK,
+            id=str(SINK_ID),
             name="Test Webhook Sink",
             rate_limit=0.2,
             output_formats=[
@@ -102,12 +109,10 @@ class TestSinkMapper:
     @pytest.mark.parametrize("schema_instance,expected_model", SUPPORTED_SINKS_MAPPING.copy())
     def test_from_schema_valid_sink_types(self, schema_instance, expected_model):
         """Test from_schema with valid sink types."""
-        sink_id = uuid4()
-        schema_instance.id = sink_id
         result = SinkMapper.from_schema(schema_instance)
 
         assert isinstance(result, SinkDB)
-        assert result.id == str(sink_id)
+        assert result.id == expected_model.id
         assert result.name == expected_model.name
         assert result.sink_type == expected_model.sink_type
         assert result.rate_limit == expected_model.rate_limit
@@ -122,11 +127,9 @@ class TestSinkMapper:
     @pytest.mark.parametrize("db_instance,expected_schema", [(v, k) for (k, v) in SUPPORTED_SINKS_MAPPING.copy()])
     def test_to_schema_valid_sink_types(self, db_instance, expected_schema):
         """Test to_schema with valid sink types."""
-        sink_id = uuid4()
-        db_instance.id = str(sink_id)
         result = SinkMapper.to_schema(db_instance)
 
-        assert result.id == sink_id
+        assert result.id == expected_schema.id
         assert result.name == expected_schema.name
         assert result.sink_type == expected_schema.sink_type
         assert result.rate_limit == expected_schema.rate_limit

--- a/application/backend/tests/unit/services/mappers/test_source_mapper.py
+++ b/application/backend/tests/unit/services/mappers/test_source_mapper.py
@@ -15,15 +15,18 @@ from app.schemas.source import (
 )
 from app.services.mappers.source_mapper import SourceMapper
 
+SOURCE_ID = uuid4()
 SUPPORTED_SOURCES_MAPPING = [
     (
         VideoFileSourceConfig(
             source_type=SourceType.VIDEO_FILE,
+            id=SOURCE_ID,
             name="Test Video Source",
             video_path="/path/to/video.mp4",
         ),
         SourceDB(
             source_type=SourceType.VIDEO_FILE,
+            id=str(SOURCE_ID),
             name="Test Video Source",
             config_data={"video_path": "/path/to/video.mp4"},
         ),
@@ -31,11 +34,13 @@ SUPPORTED_SOURCES_MAPPING = [
     (
         WebcamSourceConfig(
             source_type=SourceType.WEBCAM,
+            id=SOURCE_ID,
             name="Test Webcam Source",
             device_id=1,
         ),
         SourceDB(
             source_type=SourceType.WEBCAM,
+            id=str(SOURCE_ID),
             name="Test Webcam Source",
             config_data={
                 "device_id": 1,
@@ -45,12 +50,14 @@ SUPPORTED_SOURCES_MAPPING = [
     (
         IPCameraSourceConfig(
             source_type=SourceType.IP_CAMERA,
+            id=SOURCE_ID,
             name="Test IPCamera Source",
             stream_url="rtsp://192.168.1.100:554/stream",
             auth_required=False,
         ),
         SourceDB(
             source_type=SourceType.IP_CAMERA,
+            id=str(SOURCE_ID),
             name="Test IPCamera Source",
             config_data={
                 "stream_url": "rtsp://192.168.1.100:554/stream",
@@ -61,12 +68,14 @@ SUPPORTED_SOURCES_MAPPING = [
     (
         ImagesFolderSourceConfig(
             source_type=SourceType.IMAGES_FOLDER,
+            id=SOURCE_ID,
             name="Test Images Folder Source",
             images_folder_path="/path/to/images",
             ignore_existing_images=True,
         ),
         SourceDB(
             source_type=SourceType.IMAGES_FOLDER,
+            id=str(SOURCE_ID),
             name="Test Images Folder Source",
             config_data={
                 "images_folder_path": "/path/to/images",
@@ -83,12 +92,10 @@ class TestSourceMapper:
     @pytest.mark.parametrize("schema_instance, expected_model", SUPPORTED_SOURCES_MAPPING.copy())
     def test_from_schema_valid_source_types(self, schema_instance, expected_model):
         """Test from_schema with valid source types."""
-        source_id = uuid4()
-        schema_instance.id = source_id
         result = SourceMapper.from_schema(schema_instance)
 
         assert isinstance(result, SourceDB)
-        assert result.id == str(source_id)
+        assert result.id == expected_model.id
         assert result.name == expected_model.name
         assert result.source_type == expected_model.source_type
         assert result.config_data == expected_model.config_data
@@ -101,11 +108,9 @@ class TestSourceMapper:
     @pytest.mark.parametrize("db_instance,expected_schema", [(v, k) for (k, v) in SUPPORTED_SOURCES_MAPPING.copy()])
     def test_to_schema_valid_source_types(self, db_instance, expected_schema):
         """Test to_schema with valid source types."""
-        source_id = uuid4()
-        db_instance.id = str(source_id)
         result = SourceMapper.to_schema(db_instance)
 
-        assert result.id == source_id
+        assert result.id == expected_schema.id
         assert result.name == expected_schema.name
         assert result.source_type == expected_schema.source_type
         match result.source_type:

--- a/application/ui/mocks/mock-project.ts
+++ b/application/ui/mocks/mock-project.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { SchemaProjectInput } from './../src/api/openapi-spec.d';
+import { SchemaProjectView } from './../src/api/openapi-spec.d';
 
-export const getMockedProject = (customProject: Partial<SchemaProjectInput>): SchemaProjectInput => {
+export const getMockedProject = (customProject: Partial<SchemaProjectView>): SchemaProjectView => {
     return {
         id: '7b073838-99d3-42ff-9018-4e901eb047fc',
         name: 'animals',
@@ -19,6 +19,7 @@ export const getMockedProject = (customProject: Partial<SchemaProjectInput>): Sc
             ],
             task_type: 'classification',
         },
+        active_pipeline: false,
         ...customProject,
     };
 };

--- a/application/ui/mocks/mocked-projects.ts
+++ b/application/ui/mocks/mocked-projects.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { SchemaProjectInput } from '../src/api/openapi-spec';
+import { SchemaProjectView } from '../src/api/openapi-spec';
 
-export const mockedProjects: SchemaProjectInput[] = [
+export const mockedProjects: SchemaProjectView[] = [
     {
         id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         name: 'Production Pipeline',
@@ -16,6 +16,7 @@ export const mockedProjects: SchemaProjectInput[] = [
                 { id: '3', name: 'Blocks', color: '#0000FF', hotkey: '3' },
             ],
         },
+        active_pipeline: true,
     },
     {
         id: 'e2f3g4h5-i6j7-8901-bcde-fg2345678901',
@@ -29,6 +30,7 @@ export const mockedProjects: SchemaProjectInput[] = [
                 { id: '3', name: 'Blocks', color: '#0000FF', hotkey: '3' },
             ],
         },
+        active_pipeline: false,
     },
     {
         id: 'i3j4k5l6-m7n8-9012-cdef-hi3456789012',
@@ -42,6 +44,7 @@ export const mockedProjects: SchemaProjectInput[] = [
                 { id: '3', name: 'Blocks', color: '#0000FF', hotkey: '3' },
             ],
         },
+        active_pipeline: false,
     },
     {
         id: 'm4n5o6p7-q8r9-0123-defg-jk4567890123',
@@ -55,6 +58,7 @@ export const mockedProjects: SchemaProjectInput[] = [
                 { id: '3', name: 'Blocks', color: '#0000FF', hotkey: '3' },
             ],
         },
+        active_pipeline: false,
     },
     {
         id: 's5t6u7v8-w9x0-1234-efgh-lm5678901234',
@@ -68,5 +72,6 @@ export const mockedProjects: SchemaProjectInput[] = [
                 { id: '3', name: 'Blocks', color: '#0000FF', hotkey: '3' },
             ],
         },
+        active_pipeline: false,
     },
 ];

--- a/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
+++ b/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
@@ -15,7 +15,7 @@ import {
     type TextFieldRef,
 } from '@geti/ui';
 import { useNavigate } from 'react-router';
-import { SchemaProjectInput } from 'src/api/openapi-spec';
+import { SchemaProjectView } from 'src/api/openapi-spec';
 
 import { paths } from '../../../constants/paths';
 
@@ -101,7 +101,7 @@ const ProjectActions = ({ onAction }: ProjectActionsProps) => {
 };
 
 interface ProjectListItemProps {
-    project: SchemaProjectInput;
+    project: SchemaProjectView;
     isInEditMode: boolean;
     onBlur: (projectId: string, newName: string) => void;
     onRename: (projectId: string) => void;

--- a/application/ui/src/components/project-panel/projects-list.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list.component.tsx
@@ -3,7 +3,7 @@
 
 import { toast } from '@geti/ui';
 import { isEmpty } from 'lodash-es';
-import { SchemaProjectInput } from 'src/api/openapi-spec';
+import { SchemaProjectView } from 'src/api/openapi-spec';
 
 import { $api } from '../../api/client';
 import { ProjectListItem } from './project-list-item/project-list-item.component';
@@ -11,7 +11,7 @@ import { ProjectListItem } from './project-list-item/project-list-item.component
 import styles from './projects-list.module.scss';
 
 interface ProjectListProps {
-    projects: SchemaProjectInput[];
+    projects: SchemaProjectView[];
     projectIdInEdition: string | null;
     setProjectInEdition: (projectId: string | null) => void;
 }

--- a/application/ui/src/features/inference/sinks/local-folder/local-folder.component.tsx
+++ b/application/ui/src/features/inference/sinks/local-folder/local-folder.component.tsx
@@ -16,6 +16,7 @@ type LocalFolderProps = {
 };
 
 const initConfig: LocalFolderSinkConfig = {
+    id: 'folder-id',
     name: '',
     sink_type: 'folder',
     rate_limit: 0,

--- a/application/ui/src/features/inference/sinks/mqtt/mqtt.component.tsx
+++ b/application/ui/src/features/inference/sinks/mqtt/mqtt.component.tsx
@@ -12,6 +12,7 @@ type MqttProps = {
     config?: MqttSinkConfig;
 };
 const initConfig: MqttSinkConfig = {
+    id: 'mqtt-id',
     name: '',
     topic: '',
     sink_type: 'mqtt',

--- a/application/ui/src/features/inference/sinks/webhook/webhook.component.tsx
+++ b/application/ui/src/features/inference/sinks/webhook/webhook.component.tsx
@@ -14,6 +14,7 @@ type WebhookProps = {
 };
 
 const initConfig: WebhookSinkConfig = {
+    id: 'webhook-id',
     name: '',
     timeout: 0,
     sink_type: 'webhook',

--- a/application/ui/src/features/inference/sources/hooks/use-source-action.test.tsx
+++ b/application/ui/src/features/inference/sources/hooks/use-source-action.test.tsx
@@ -21,6 +21,7 @@ vi.mock('react-router', async (importOriginal) => {
 });
 
 const mockedConfig: ImagesFolderSourceConfig = {
+    id: 'images_folder-id',
     name: 'Test Folder',
     source_type: 'images_folder',
     images_folder_path: '/path/to/images',

--- a/application/ui/src/features/inference/sources/hooks/use-source-mutation.hook.tsx
+++ b/application/ui/src/features/inference/sources/hooks/use-source-mutation.hook.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { omit } from 'lodash-es';
+import { v4 as uuid } from 'uuid';
 
 import { $api } from '../../../../api/client';
 import { SourceConfig } from '../util';
@@ -12,7 +13,12 @@ export const useSourceMutation = (isNewSource: boolean) => {
 
     return async (body: SourceConfig) => {
         if (isNewSource) {
-            const response = await addSource.mutateAsync({ body: omit(body, 'id') as SourceConfig });
+            const sourcePayload = {
+                ...body,
+                id: uuid(),
+            };
+
+            const response = await addSource.mutateAsync({ body: sourcePayload });
 
             return String(response.id);
         }

--- a/application/ui/src/features/inference/sources/image-folder/image-folder.component.tsx
+++ b/application/ui/src/features/inference/sources/image-folder/image-folder.component.tsx
@@ -14,6 +14,7 @@ type ImageFolderProps = {
     config?: ImagesFolderSourceConfig;
 };
 const iniConfig: ImagesFolderSourceConfig = {
+    id: 'images_folder-id',
     name: '',
     source_type: 'images_folder',
     images_folder_path: '',

--- a/application/ui/src/features/inference/sources/ip-camera/ip-camera.component.tsx
+++ b/application/ui/src/features/inference/sources/ip-camera/ip-camera.component.tsx
@@ -12,6 +12,7 @@ type IpCameraProps = {
 };
 
 const initConfig: IPCameraSourceConfig = {
+    id: 'ip_camera-id',
     name: '',
     source_type: 'ip_camera',
     stream_url: '',

--- a/application/ui/src/features/inference/sources/ip-camera/use-action-ip-camera.hook.tsx
+++ b/application/ui/src/features/inference/sources/ip-camera/use-action-ip-camera.hook.tsx
@@ -11,6 +11,7 @@ import { useSourceMutation } from '../hooks/use-source-mutation.hook';
 import { IPCameraSourceConfig } from '../util';
 
 const iniConfig: IPCameraSourceConfig = {
+    id: 'ip_camera-id',
     name: '',
     source_type: 'ip_camera',
     stream_url: '',

--- a/application/ui/src/features/inference/sources/webcam/webcam.component.tsx
+++ b/application/ui/src/features/inference/sources/webcam/webcam.component.tsx
@@ -12,6 +12,7 @@ type WebcamProps = {
 };
 
 const initConfig: WebcamSourceConfig = {
+    id: 'webcam-id',
     name: '',
     source_type: 'webcam',
     device_id: 0,

--- a/application/ui/src/features/project/details/project-details.component.test.tsx
+++ b/application/ui/src/features/project/details/project-details.component.test.tsx
@@ -28,6 +28,7 @@ describe('ProjectDetails', () => {
                         exclusive_labels: false,
                         labels: [{ name: 'person' }, { name: 'car' }],
                     },
+                    active_pipeline: true,
                 });
             }),
             http.get('/api/projects/{project_id}/pipeline', () => {
@@ -36,6 +37,7 @@ describe('ProjectDetails', () => {
                     status: 'running' as const,
                     data_collection_policies: [],
                     source: {
+                        id: 'source-id',
                         name: 'source',
                         source_type: 'video_file' as const,
                         video_path: 'video.mp4',
@@ -51,6 +53,7 @@ describe('ProjectDetails', () => {
                         files_deleted: false,
                     },
                     sink: {
+                        id: 'sink-id',
                         name: 'sink',
                         folder_path: 'data/sink',
                         output_formats: ['image_original', 'image_with_predictions', 'predictions'] as Array<

--- a/application/ui/src/features/project/details/project-details.component.tsx
+++ b/application/ui/src/features/project/details/project-details.component.tsx
@@ -56,6 +56,9 @@ export const ProjectDetails = () => {
         params: { path: { project_id: projectId } },
     });
 
+    const { name, task } = project.data;
+    const { task_type, labels = [] } = task;
+
     return (
         <View
             backgroundColor={'gray-100'}
@@ -83,9 +86,9 @@ export const ProjectDetails = () => {
                                 <Heading level={2}>Task type</Heading>
                                 <Heading level={2}>Labels</Heading>
 
-                                <Text>{project.data.name}</Text>
-                                <Text>{project.data.task.task_type}</Text>
-                                <Text>{project.data.task.labels.map((label) => label.name).join(', ')}</Text>
+                                <Text>{name}</Text>
+                                <Text>{task_type}</Text>
+                                <Text>{labels.map((label) => label.name).join(', ')}</Text>
                             </Grid>
                         </Flex>
 

--- a/application/ui/src/features/project/list/project-card.component.tsx
+++ b/application/ui/src/features/project/list/project-card.component.tsx
@@ -6,7 +6,7 @@ import { clsx } from 'clsx';
 import { NavLink } from 'react-router-dom';
 
 import { $api } from '../../../api/client';
-import { SchemaProjectInput } from '../../../api/openapi-spec';
+import { SchemaProjectView } from '../../../api/openapi-spec';
 import thumbnailUrl from '../../../assets/mocked-project-thumbnail.png';
 import { paths } from '../../../constants/paths';
 import { MenuActions } from './menu-actions.component';
@@ -14,20 +14,18 @@ import { MenuActions } from './menu-actions.component';
 import classes from './project-list.module.scss';
 
 type ProjectCardProps = {
-    item: SchemaProjectInput;
+    item: SchemaProjectView;
 };
 
 export const ProjectCard = ({ item }: ProjectCardProps) => {
     const pipeline = $api.useSuspenseQuery('get', '/api/projects/{project_id}/pipeline', {
-        params: { path: { project_id: item.id || '' } },
+        params: { path: { project_id: item.id } },
     });
 
     const isActive = pipeline.data?.status === 'running';
 
     return (
-        // TODO: remove this empty string check once
-        // https://github.com/open-edge-platform/training_extensions/issues/4721 is done
-        <NavLink to={paths.project.inference({ projectId: item.id || '' })}>
+        <NavLink to={paths.project.inference({ projectId: item.id })}>
             <Flex UNSAFE_className={clsx({ [classes.card]: true, [classes.activeCard]: isActive })}>
                 <View aria-label={'project thumbnail'}>
                     <img src={thumbnailUrl} alt={item.name} />
@@ -36,7 +34,7 @@ export const ProjectCard = ({ item }: ProjectCardProps) => {
                 <View width={'100%'} padding={'size-200'}>
                     <Flex alignItems={'center'} justifyContent={'space-between'}>
                         <Heading level={3}>{item.name}</Heading>
-                        <MenuActions projectId={item.id || ''} />
+                        <MenuActions projectId={item.id} />
                     </Flex>
 
                     <Flex marginBottom={'size-200'} gap={'size-50'}>
@@ -48,7 +46,7 @@ export const ProjectCard = ({ item }: ProjectCardProps) => {
 
                     <Flex alignItems={'center'} gap={'size-100'} direction={'row'} wrap='wrap'>
                         <Text>• Edited: 2025-08-07 06:05 AM</Text>
-                        <Text>• Labels: {item.task.labels.map((label) => label.name).join(', ')}</Text>
+                        <Text>• Labels: {(item.task.labels || []).map((label) => label.name).join(', ')}</Text>
                     </Flex>
                 </View>
             </Flex>

--- a/application/ui/src/routes/project/sink.tsx
+++ b/application/ui/src/routes/project/sink.tsx
@@ -49,17 +49,20 @@ type SinkFormRecord = {
 };
 const DEFAULT_SINK_FORMS: SinkFormRecord = {
     disconnected: {
+        id: 'disconnected-id',
         sink_type: 'disconnected',
         name: 'Disconnected',
         output_formats: [],
     },
     folder: {
+        id: 'folder-id',
         sink_type: 'folder',
         name: 'Folder',
         folder_path: '',
         output_formats: [],
     },
     mqtt: {
+        id: 'mqtt-id',
         sink_type: 'mqtt',
         auth_required: false,
         name: 'MQTT',
@@ -69,12 +72,14 @@ const DEFAULT_SINK_FORMS: SinkFormRecord = {
         output_formats: [],
     },
     ros: {
+        id: 'ros-id',
         name: 'Ros',
         sink_type: 'ros',
         topic: '',
         output_formats: [],
     },
     webhook: {
+        id: 'webhook-id',
         name: 'Webhook',
         sink_type: 'webhook',
         webhook_url: '',

--- a/application/ui/src/routes/project/sink.tsx
+++ b/application/ui/src/routes/project/sink.tsx
@@ -18,6 +18,7 @@ import {
 } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useNavigate } from 'react-router';
+import { v4 as uuid } from 'uuid';
 
 import { $api } from '../../api/client';
 import {
@@ -267,8 +268,18 @@ export const Sink = () => {
     const onSubmit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 
+        if (selectedSinkType === 'disconnected') {
+            return;
+        }
+
+        const sinkData = forms[selectedSinkType];
+        const sinkPayload = {
+            ...sinkData,
+            id: sinkData.id || uuid(),
+        };
+
         sinkMutation.mutateAsync({
-            body: forms[selectedSinkType],
+            body: sinkPayload,
         });
 
         navigate(paths.project.inference({ projectId }));

--- a/application/ui/tests/fixtures.ts
+++ b/application/ui/tests/fixtures.ts
@@ -51,6 +51,7 @@ const test = testBase.extend<Fixtures>({
                             exclusive_labels: false,
                             labels: [],
                         },
+                        active_pipeline: false,
                     },
                 ]);
             }),

--- a/application/ui/tsconfig.json
+++ b/application/ui/tsconfig.json
@@ -1,6 +1,14 @@
 {
     "extends": "@geti/config/typescript",
-    "include": ["src", "tests", "rsbuild.config.ts", "vitest.config.ts", "playwright.config.ts", "playwright.e2e.config.ts", "mocks"],
+    "include": [
+        "src",
+        "tests",
+        "rsbuild.config.ts",
+        "vitest.config.ts",
+        "playwright.config.ts",
+        "playwright.e2e.config.ts",
+        "mocks"
+    ],
     "compilerOptions": {
         "types": ["vitest/globals"],
         "baseUrl": ".",

--- a/application/ui/tsconfig.json
+++ b/application/ui/tsconfig.json
@@ -7,7 +7,7 @@
         "paths": {
             "test-utils/*": ["./src/test-utils/*"],
             "hooks/*": ["./src/hooks/*"],
-            "mocks/*": ["./mocks/*"],
+            "mocks/*": ["./mocks/*"]
         }
     }
 }


### PR DESCRIPTION
### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR splits the payloads for `POST` and `GET` requests for certain entities. In `GET` (view) requests, the payloads now require both `id` and `name` fields. In `POST` (create) requests, the `id` field is optional, allowing for more flexible entity creation while ensuring views always include the necessary identifiers.

- [x] Separate basic pydantic models with optional & required `id`, `name` attributes
- [x] Project schema: `ProjectCreate` for `POST` requests, `ProjectView` for `GET` requests:
  - [x] Added `active_pipeline` to `ProjectView` 
- [x] Configuration schemas: added `SinkCreate`, `SourceCreate` for `POST` requests

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
