### PR TITLE
Improve error and suspense handling in router

### DIFF
--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -4,7 +4,7 @@
 import { Suspense } from 'react';
 
 import { Loading } from '@geti/ui';
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 
 import { $api } from './api/client';
 import { ZoomProvider } from './components/zoom/zoom';
@@ -50,59 +50,57 @@ export const router = createBrowserRouter([
     {
         path: paths.root.pattern,
         element: (
-            <Suspense fallback={<Loading />}>
-                <Redirect />
-            </Suspense>
-        ),
-    },
-    {
-        path: paths.project.index.pattern,
-        element: (
             <Suspense fallback={<Loading mode='fullscreen' />}>
-                <ProjectList />
-            </Suspense>
-        ),
-    },
-    {
-        path: paths.project.new.pattern,
-        element: <CreateProject />,
-    },
-    {
-        path: paths.project.details.pattern,
-        element: (
-            <Suspense fallback={<Loading mode='fullscreen' />}>
-                <Layout />
+                <Outlet />
             </Suspense>
         ),
         errorElement: <ErrorPage />,
         children: [
             {
                 index: true,
-                element: <ViewProject />,
+                element: <Redirect />,
             },
             {
-                path: paths.project.inference.pattern,
-                element: (
-                    <WebRTCConnectionProvider>
-                        <ZoomProvider>
-                            <Inference />
-                        </ZoomProvider>
-                    </WebRTCConnectionProvider>
-                ),
+                path: paths.project.index.pattern,
+                element: <ProjectList />,
             },
             {
-                path: paths.project.dataset.pattern,
-                element: (
-                    <ZoomProvider>
-                        <SelectedDataProvider>
-                            <Dataset />
-                        </SelectedDataProvider>
-                    </ZoomProvider>
-                ),
+                path: paths.project.new.pattern,
+                element: <CreateProject />,
             },
             {
-                path: paths.project.models.pattern,
-                element: <Models />,
+                path: paths.project.details.pattern,
+                element: <Layout />,
+                children: [
+                    {
+                        index: true,
+                        element: <ViewProject />,
+                    },
+                    {
+                        path: paths.project.inference.pattern,
+                        element: (
+                            <WebRTCConnectionProvider>
+                                <ZoomProvider>
+                                    <Inference />
+                                </ZoomProvider>
+                            </WebRTCConnectionProvider>
+                        ),
+                    },
+                    {
+                        path: paths.project.dataset.pattern,
+                        element: (
+                            <ZoomProvider>
+                                <SelectedDataProvider>
+                                    <Dataset />
+                                </SelectedDataProvider>
+                            </ZoomProvider>
+                        ),
+                    },
+                    {
+                        path: paths.project.models.pattern,
+                        element: <Models />,
+                    },
+                ],
             },
         ],
     },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

By moving all of the routes into a single root route we can make sure that all routes are rendered inside of an layout that has a suspense and error boundary.

### How to test

Trigger an `useSuspenseQuery` to test the suspense layout and an API failure to test the error element.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
