### PR TITLE
Make id required for DatasetItem

### DIFF
--- a/application/backend/app/api/endpoints/datasets.py
+++ b/application/backend/app/api/endpoints/datasets.py
@@ -57,7 +57,11 @@ SET_DATASET_ITEM_ANNOTATIONS_BODY_EXAMPLES = {
 @router.post(
     "",
     status_code=status.HTTP_201_CREATED,
-    responses={status.HTTP_201_CREATED: {"description": "Dataset item created", "model": DatasetItem}},
+    response_model=DatasetItem,
+    responses={
+        status.HTTP_201_CREATED: {"description": "Dataset item created"},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid image has been uploaded"},
+    },
 )
 def add_dataset_item(
     project_id: Annotated[UUID, Depends(get_project_id)],

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from app.schemas.base import BaseIDNameModel, Pagination
+from app.schemas.base import BaseRequiredIDNameModel, Pagination
 from app.schemas.label import LabelReference
 from app.schemas.shape import Shape
 
@@ -23,7 +23,7 @@ class DatasetItemSubset(StrEnum):
     TESTING = "testing"
 
 
-class DatasetItem(BaseIDNameModel):
+class DatasetItem(BaseRequiredIDNameModel):
     """
     Dataset item
     """

--- a/application/backend/tests/unit/services/mappers/test_dataset_item_mapper.py
+++ b/application/backend/tests/unit/services/mappers/test_dataset_item_mapper.py
@@ -11,25 +11,28 @@ from app.schemas.dataset_item import DatasetItemFormat, DatasetItemSubset
 from app.services.mappers import DatasetItemMapper
 
 UUID0 = uuid4()
+UUID1 = uuid4()
 
 SUPPORTED_DATASET_ITEM_MAPPING = [
     (
         DatasetItem(
+            id=UUID0,
             name="DatasetItem1",
             format=DatasetItemFormat.JPG,
             width=1024,
             height=768,
             size=1024,
-            source_id=UUID0,
+            source_id=UUID1,
             subset=DatasetItemSubset.TRAINING,
         ),
         DatasetItemDB(
+            id=str(UUID0),
             name="DatasetItem1",
             format="jpg",
             width=1024,
             height=768,
             size=1024,
-            source_id=str(UUID0),
+            source_id=str(UUID1),
             subset="training",
         ),
     )
@@ -42,6 +45,7 @@ class TestDatasetItemMapper:
     @pytest.mark.parametrize("schema_instance,expected_db", SUPPORTED_DATASET_ITEM_MAPPING.copy())
     def test_from_schema(self, schema_instance, expected_db):
         actual_db = DatasetItemMapper.from_schema(schema_instance)
+        assert actual_db.id == expected_db.id
         assert actual_db.project_id == expected_db.project_id
         assert actual_db.name == expected_db.name
         assert actual_db.format == expected_db.format


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Makes DatasetItem `id` field required.
Resolves #4839

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
