### PR TITLE
Add query parameter to filter dataset items by annotation status

### DIFF
--- a/application/backend/app/api/endpoints/datasets.py
+++ b/application/backend/app/api/endpoints/datasets.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Optional, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
@@ -92,15 +92,19 @@ def list_dataset_items(
     offset: Annotated[int, Query(ge=0)] = 0,
     start_date: Annotated[datetime | None, Query()] = None,
     end_date: Annotated[datetime | None, Query()] = None,
+    annotation_status: Annotated[
+        Optional[Literal["unannotated", "reviewed", "to_review"]],
+        Query(description="Filter dataset items by annotation status"),
+    ] = None,
 ) -> DatasetItemsWithPagination:
     """List the available dataset items and their metadata. This endpoint supports pagination."""
     if start_date is not None and end_date is not None and start_date > end_date:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Start date must be before end date."
         )
-    total = dataset_service.count_dataset_items(project_id=project_id, start_date=start_date, end_date=end_date)
+    total = dataset_service.count_dataset_items(project_id=project_id, start_date=start_date, end_date=end_date, annotation_status=annotation_status,)
     dataset_items = dataset_service.list_dataset_items(
-        project_id=project_id, limit=limit, offset=offset, start_date=start_date, end_date=end_date
+        project_id=project_id, limit=limit, offset=offset, start_date=start_date, end_date=end_date, annotation_status=annotation_status,
     )
     return DatasetItemsWithPagination(
         items=dataset_items,

--- a/application/backend/app/api/endpoints/datasets.py
+++ b/application/backend/app/api/endpoints/datasets.py
@@ -11,7 +11,7 @@ from starlette.responses import FileResponse
 from app.api.dependencies import get_dataset_item_id, get_dataset_service, get_file_name_and_extension, get_project_id
 from app.schemas import DatasetItem, DatasetItemsWithPagination
 from app.schemas.base import Pagination
-from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemAnnotations, DatasetItemAnnotationsWithSource
+from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemAnnotations, DatasetItemAnnotationsWithSource, AnnotationStatus
 from app.services import DatasetService, ResourceNotFoundError
 from app.services.dataset_service import AnnotationValidationError, InvalidImageError
 
@@ -92,10 +92,7 @@ def list_dataset_items(
     offset: Annotated[int, Query(ge=0)] = 0,
     start_date: Annotated[datetime | None, Query()] = None,
     end_date: Annotated[datetime | None, Query()] = None,
-    annotation_status: Annotated[
-        Optional[Literal["unannotated", "reviewed", "to_review"]],
-        Query(description="Filter dataset items by annotation status"),
-    ] = None,
+    annotation_status: Annotated[Optional[AnnotationStatus], Query(description="Filter dataset items by annotation status"), ] = None,
 ) -> DatasetItemsWithPagination:
     """List the available dataset items and their metadata. This endpoint supports pagination."""
     if start_date is not None and end_date is not None and start_date > end_date:

--- a/application/backend/app/api/endpoints/datasets.py
+++ b/application/backend/app/api/endpoints/datasets.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import Annotated, Optional, Literal
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
@@ -11,7 +11,12 @@ from starlette.responses import FileResponse
 from app.api.dependencies import get_dataset_item_id, get_dataset_service, get_file_name_and_extension, get_project_id
 from app.schemas import DatasetItem, DatasetItemsWithPagination
 from app.schemas.base import Pagination
-from app.schemas.dataset_item import DatasetItemAnnotation, DatasetItemAnnotations, DatasetItemAnnotationsWithSource, AnnotationStatus
+from app.schemas.dataset_item import (
+    AnnotationStatus,
+    DatasetItemAnnotation,
+    DatasetItemAnnotations,
+    DatasetItemAnnotationsWithSource,
+)
 from app.services import DatasetService, ResourceNotFoundError
 from app.services.dataset_service import AnnotationValidationError, InvalidImageError
 
@@ -92,16 +97,40 @@ def list_dataset_items(
     offset: Annotated[int, Query(ge=0)] = 0,
     start_date: Annotated[datetime | None, Query()] = None,
     end_date: Annotated[datetime | None, Query()] = None,
-    annotation_status: Annotated[Optional[AnnotationStatus], Query(description="Filter dataset items by annotation status"), ] = None,
+    annotation_status: Annotated[
+        str | None,
+        Query(description="Filter dataset items by annotation status")
+    ] = None,
 ) -> DatasetItemsWithPagination:
     """List the available dataset items and their metadata. This endpoint supports pagination."""
     if start_date is not None and end_date is not None and start_date > end_date:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Start date must be before end date."
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Start date must be before end date."
         )
-    total = dataset_service.count_dataset_items(project_id=project_id, start_date=start_date, end_date=end_date, annotation_status=annotation_status,)
+    if annotation_status is not None:
+        try:
+            annotation_status = AnnotationStatus(annotation_status)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid annotation_status value: {annotation_status}"
+            )
+    else:
+        annotation_status = None
+    total = dataset_service.count_dataset_items(
+        project_id=project_id,
+        start_date=start_date,
+        end_date=end_date,
+        annotation_status=annotation_status
+    )
     dataset_items = dataset_service.list_dataset_items(
-        project_id=project_id, limit=limit, offset=offset, start_date=start_date, end_date=end_date, annotation_status=annotation_status,
+        project_id=project_id,
+        limit=limit,
+        offset=offset,
+        start_date=start_date,
+        end_date=end_date,
+        annotation_status=annotation_status,
     )
     return DatasetItemsWithPagination(
         items=dataset_items,

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import UTC, datetime
-from typing import NamedTuple, Literal
+from typing import NamedTuple
 
 from sqlalchemy import Select, delete, func, select, update
 from sqlalchemy.orm import Session
@@ -37,9 +37,7 @@ class DatasetItemRepository:
             stmt = stmt.where(DatasetItemDB.created_at < end_date)
         return stmt
 
-    def _apply_annotation_status_filter(
-        self, stmt: Select, annotation_status: AnnotationStatus | None
-    ) -> Select:
+    def _apply_annotation_status_filter(self, stmt: Select, annotation_status: str | None) -> Select:
         """Apply annotation status filter to SQL query statement.
 
         Args:
@@ -82,7 +80,10 @@ class DatasetItemRepository:
         return dataset_item_db
 
     def count(
-        self, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: AnnotationStatus | None = None,
+        self,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        annotation_status: AnnotationStatus | None = None,
     ) -> int:
         """Count dataset items matching specified filters.
 
@@ -94,13 +95,20 @@ class DatasetItemRepository:
         Returns:
             int: Count of dataset items matching the specified filters.
         """
-        stmt = select(func.count()).select_from(DatasetItemDB).where(DatasetItemDB.project_id == self.project_id)
+        stmt = select(func.count()) \
+                .select_from(DatasetItemDB) \
+                .where(DatasetItemDB.project_id == self.project_id)
         stmt = self._apply_date_filters(stmt, start_date, end_date)
         stmt = self._apply_annotation_status_filter(stmt, annotation_status)
         return self.db.scalar(stmt) or 0
 
     def list_items(
-        self, limit: int, offset: int, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: AnnotationStatus | None = None,
+        self,
+        limit: int,
+        offset: int,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        annotation_status: AnnotationStatus | None = None,
     ) -> list[DatasetItemDB]:
         """Retrieve paginated list of dataset items with optional filtering.
 
@@ -112,7 +120,8 @@ class DatasetItemRepository:
             annotation_status: Optional annotation status filter.
 
         Returns:
-            list[DatasetItemDB]: List of DatasetItemDB instances ordered by creation date (descending).
+            list[DatasetItemDB]: List of DatasetItemDB instances
+                        ordered by creation date (descending).
         """
         stmt = self._base_select()
         stmt = self._apply_date_filters(stmt, start_date, end_date)

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import UTC, datetime
-from typing import NamedTuple
+from typing import NamedTuple, Literal
 
 from sqlalchemy import Select, delete, func, select, update
 from sqlalchemy.orm import Session
@@ -36,22 +36,86 @@ class DatasetItemRepository:
             stmt = stmt.where(DatasetItemDB.created_at < end_date)
         return stmt
 
+    def _apply_annotation_status_filter(
+        self, stmt: Select, annotation_status: Literal["unannotated", "reviewed", "to_review"] | None
+    ) -> Select:
+        """Apply annotation status filter to SQL query statement.
+
+        Args:
+            stmt: Select statement to apply filters to.
+            annotation_status: Filter criteria for annotation status. Valid values are:
+                - "unannotated": Items with no annotation data
+                - "reviewed": Items with annotation data that have been user reviewed
+                - "to_review": Items with annotation data pending user review
+                - None: No filtering applied
+
+        Returns:
+            Select: Modified SQLAlchemy Select statement with annotation status filters applied.
+        """
+        if annotation_status == "unannotated":
+            stmt = stmt.where(DatasetItemDB.annotation_data.is_(None))
+        elif annotation_status == "reviewed":
+            stmt = stmt.where(
+                DatasetItemDB.annotation_data.is_not(None),
+                DatasetItemDB.user_reviewed.is_(True),
+            )
+        elif annotation_status == "to_review":
+            stmt = stmt.where(
+                DatasetItemDB.annotation_data.is_not(None),
+                DatasetItemDB.user_reviewed.is_(False),
+            )
+        return stmt
+
     def save(self, dataset_item_db: DatasetItemDB) -> DatasetItemDB:
+        """Save dataset item to database with updated timestamp.
+
+        Args:
+            dataset_item_db: DatasetItemDB instance to be saved.
+
+        Returns:
+            DatasetItemDB: The saved DatasetItemDB instance.
+        """
         dataset_item_db.updated_at = datetime.now(UTC)
         self.db.add(dataset_item_db)
         self.db.flush()
         return dataset_item_db
 
-    def count(self, start_date: datetime | None = None, end_date: datetime | None = None) -> int:
+    def count(
+        self, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: Literal["unannotated", "reviewed", "to_review"] | None = None,
+    ) -> int:
+        """Count dataset items matching specified filters.
+
+        Args:
+            start_date: Optional start date for filtering items by creation date.
+            end_date: Optional end date for filtering items by creation date.
+            annotation_status: Optional annotation status filter.
+
+        Returns:
+            int: Count of dataset items matching the specified filters.
+        """
         stmt = select(func.count()).select_from(DatasetItemDB).where(DatasetItemDB.project_id == self.project_id)
         stmt = self._apply_date_filters(stmt, start_date, end_date)
+        stmt = self._apply_annotation_status_filter(stmt, annotation_status)
         return self.db.scalar(stmt) or 0
 
     def list_items(
-        self, limit: int, offset: int, start_date: datetime | None = None, end_date: datetime | None = None
+        self, limit: int, offset: int, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: Literal["unannotated", "reviewed", "to_review"] | None = None,
     ) -> list[DatasetItemDB]:
+        """Retrieve paginated list of dataset items with optional filtering.
+
+        Args:
+            limit: Maximum number of items to return.
+            offset: Number of items to skip for pagination.
+            start_date: Optional start date for creation date filtering.
+            end_date: Optional end date for creation date filtering.
+            annotation_status: Optional annotation status filter.
+
+        Returns:
+            list[DatasetItemDB]: List of DatasetItemDB instances ordered by creation date (descending).
+        """
         stmt = self._base_select()
         stmt = self._apply_date_filters(stmt, start_date, end_date)
+        stmt = self._apply_annotation_status_filter(stmt, annotation_status)
         stmt = stmt.order_by(DatasetItemDB.created_at.desc()).offset(offset).limit(limit)
         return list(self.db.scalars(stmt).all())
 

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -7,6 +7,7 @@ from sqlalchemy import Select, delete, func, select, update
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB
+from app.schemas.dataset_item import AnnotationStatus
 
 
 class UpdateDatasetItemAnnotation(NamedTuple):
@@ -37,7 +38,7 @@ class DatasetItemRepository:
         return stmt
 
     def _apply_annotation_status_filter(
-        self, stmt: Select, annotation_status: Literal["unannotated", "reviewed", "to_review"] | None
+        self, stmt: Select, annotation_status: AnnotationStatus | None
     ) -> Select:
         """Apply annotation status filter to SQL query statement.
 
@@ -52,14 +53,14 @@ class DatasetItemRepository:
         Returns:
             Select: Modified SQLAlchemy Select statement with annotation status filters applied.
         """
-        if annotation_status == "unannotated":
+        if annotation_status == AnnotationStatus.UNANNOTATED:
             stmt = stmt.where(DatasetItemDB.annotation_data.is_(None))
-        elif annotation_status == "reviewed":
+        elif annotation_status == AnnotationStatus.REVIEWED:
             stmt = stmt.where(
                 DatasetItemDB.annotation_data.is_not(None),
                 DatasetItemDB.user_reviewed.is_(True),
             )
-        elif annotation_status == "to_review":
+        elif annotation_status == AnnotationStatus.TO_REVIEW:
             stmt = stmt.where(
                 DatasetItemDB.annotation_data.is_not(None),
                 DatasetItemDB.user_reviewed.is_(False),
@@ -81,7 +82,7 @@ class DatasetItemRepository:
         return dataset_item_db
 
     def count(
-        self, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: Literal["unannotated", "reviewed", "to_review"] | None = None,
+        self, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: AnnotationStatus | None = None,
     ) -> int:
         """Count dataset items matching specified filters.
 
@@ -99,7 +100,7 @@ class DatasetItemRepository:
         return self.db.scalar(stmt) or 0
 
     def list_items(
-        self, limit: int, offset: int, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: Literal["unannotated", "reviewed", "to_review"] | None = None,
+        self, limit: int, offset: int, start_date: datetime | None = None, end_date: datetime | None = None, annotation_status: AnnotationStatus | None = None,
     ) -> list[DatasetItemDB]:
         """Retrieve paginated list of dataset items with optional filtering.
 

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -122,3 +122,8 @@ class DatasetItemsWithPagination(BaseModel):
 
     items: list[DatasetItem]
     pagination: Pagination
+
+class AnnotationStatus(StrEnum):
+    UNANNOTATED = "unannotated"
+    REVIEWED = "reviewed"
+    TO_REVIEW = "to_review"

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -123,6 +123,7 @@ class DatasetItemsWithPagination(BaseModel):
     items: list[DatasetItem]
     pagination: Pagination
 
+
 class AnnotationStatus(StrEnum):
     UNANNOTATED = "unannotated"
     REVIEWED = "reviewed"

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -140,10 +140,11 @@ class DatasetService:
         project_id: UUID,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        annotation_status: str | None = None,
     ) -> int:
         """Get number of available dataset items (within date range if specified)"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)
-        return repo.count(start_date=start_date, end_date=end_date)
+        return repo.count(start_date=start_date, end_date=end_date, annotation_status=annotation_status)
 
     def list_dataset_items(
         self,
@@ -152,14 +153,14 @@ class DatasetService:
         offset: int = 0,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        annotation_status: str | None = None,
     ) -> list[DatasetItem]:
         """Get information about available dataset items"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)
         return [
             self.mapper.to_schema(db)
-            for db in repo.list_items(limit=limit, offset=offset, start_date=start_date, end_date=end_date)
+            for db in repo.list_items(limit=limit, offset=offset, start_date=start_date, end_date=end_date, annotation_status=annotation_status)
         ]
-
     def get_dataset_item_by_id(self, project_id: UUID, dataset_item_id: UUID) -> DatasetItem:
         """Get a dataset item by its ID"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -21,6 +21,7 @@ from app.schemas.dataset_item import (
     DatasetItemAnnotation,
     DatasetItemAnnotationsWithSource,
     DatasetItemSubset,
+    AnnotationStatus
 )
 from app.schemas.project import TaskType
 from app.schemas.shape import FullImage, Polygon, Rectangle
@@ -140,7 +141,7 @@ class DatasetService:
         project_id: UUID,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
-        annotation_status: str | None = None,
+        annotation_status: AnnotationStatus | None = None,
     ) -> int:
         """Get number of available dataset items (within date range if specified)"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)
@@ -153,14 +154,20 @@ class DatasetService:
         offset: int = 0,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
-        annotation_status: str | None = None,
+        annotation_status: AnnotationStatus | None = None,
     ) -> list[DatasetItem]:
         """Get information about available dataset items"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)
         return [
             self.mapper.to_schema(db)
-            for db in repo.list_items(limit=limit, offset=offset, start_date=start_date, end_date=end_date, annotation_status=annotation_status)
+            for db in repo.list_items(
+                        limit=limit,
+                        offset=offset,
+                        start_date=start_date,
+                        end_date=end_date,
+                        annotation_status=annotation_status)
         ]
+
     def get_dataset_item_by_id(self, project_id: UUID, dataset_item_id: UUID) -> DatasetItem:
         """Get a dataset item by its ID"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self._db_session)

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -234,6 +234,7 @@ class TestDatasetServiceIntegration:
             offset=offset,
             start_date=start_date,
             end_date=end_date,
+            annotation_status=None,
         )
         assert (
             len(dataset_items) == 0

--- a/application/backend/tests/unit/endpoints/test_datasets.py
+++ b/application/backend/tests/unit/endpoints/test_datasets.py
@@ -83,10 +83,10 @@ class TestDatasetItemEndpoints:
 
         assert response.status_code == status.HTTP_200_OK
         fxt_dataset_service.count_dataset_items.assert_called_once_with(
-            project_id=project_id, start_date=None, end_date=None
+            project_id=project_id, start_date=None, end_date=None, annotation_status='reviewed'
         )
         fxt_dataset_service.list_dataset_items.assert_called_once_with(
-            project_id=project_id, limit=10, offset=0, start_date=None, end_date=None
+            project_id=project_id, limit=10, offset=0, start_date=None, end_date=None, annotation_status='reviewed'
         )
 
     def test_list_dataset_items_filtering_and_pagination(self, fxt_dataset_item, fxt_dataset_service, fxt_client):

--- a/application/backend/tests/unit/endpoints/test_datasets.py
+++ b/application/backend/tests/unit/endpoints/test_datasets.py
@@ -95,7 +95,7 @@ class TestDatasetItemEndpoints:
         fxt_dataset_service.list_dataset_items.return_value = [fxt_dataset_item]
 
         response = fxt_client.get(
-            f"/api/projects/{str(project_id)}/dataset/items?limit=50&offset=2&start_date=2025-01-09T00:00:00Z&end_date=2025-12-31T23:59:59Z"
+            f"/api/projects/{str(project_id)}/dataset/items?limit=50&offset=2&start_date=2025-01-09T00:00:00Z&end_date=2025-12-31T23:59:59Z&annotation_status=reviewed"
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -103,6 +103,7 @@ class TestDatasetItemEndpoints:
             project_id=project_id,
             start_date=datetime(2025, 1, 9, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
             end_date=datetime(2025, 12, 31, 23, 59, 59, tzinfo=ZoneInfo("UTC")),
+            annotation_status='reviewed',
         )
         fxt_dataset_service.list_dataset_items.assert_called_once_with(
             project_id=project_id,
@@ -110,11 +111,14 @@ class TestDatasetItemEndpoints:
             offset=2,
             start_date=datetime(2025, 1, 9, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
             end_date=datetime(2025, 12, 31, 23, 59, 59, tzinfo=ZoneInfo("UTC")),
+            annotation_status='reviewed',
         )
 
     @pytest.mark.parametrize("limit", [1000, 0, -20])
     def test_list_dataset_items_wrong_limit(self, fxt_dataset_service, fxt_client, limit):
-        response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/items?limit=${limit}")
+        response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/items?limit={limit}&annotation_status=None")
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        fxt_dataset_service.list_dataset_items.assert_not_called()
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         fxt_dataset_service.list_dataset_items.assert_not_called()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

This PR enhances the `GET /api/projects/{project_id}/dataset/items` endpoint by introducing an **annotation_status** query parameter that allows filtering dataset items by their annotation state.  

#### Key Additions
- **annotation_status filter** → supports:  
  - **unannotated** → items with no annotations  
  - **reviewed** → items with user-reviewed annotations  
  - **to_review** → items with model-generated predictions pending review  
  - **null/omitted** → no filtering (default behaviour)

#### Backward Compatibility  

- Fully backward-compatible: existing clients that do not use `annotation_status` will continue to receive unfiltered results.  