### PR TITLE
Improved error handling when loading inference model

### DIFF
--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -66,7 +66,7 @@ class ActiveModelService:
             force_reload: If True, reload the state and the model from disk. This option can be useful
             to bypass the cache after the state has been modified externally.
 
-        Returns: Model for inference or None if no model is active
+        Returns: Model for inference or None if no model is active, or if the model can't be loaded.
         """
         if force_reload:
             self._model_activation_state = self._load_state()
@@ -79,13 +79,25 @@ class ActiveModelService:
         active_model_id = self._model_activation_state.active_model_id
         if self._loaded_model is None or self._loaded_model.id != active_model_id:
             logger.info("Loading model with ID '%s'", active_model_id)
-            model_path = self._get_model_xml_path(project_id, active_model_id)
-            self._loaded_model = LoadedModel(
-                id=self._model_activation_state.active_model_id,
-                model=Model.create_model(
-                    model=str(model_path),
+            model_xml_path = self._get_model_xml_path(project_id, active_model_id)
+            model_bin_path = self._get_model_bin_path(project_id, active_model_id)
+            if not os.path.isfile(model_xml_path):
+                logger.error("Model XML file not found at path: %s", model_xml_path)
+                return None
+            if not os.path.isfile(model_bin_path):
+                logger.error("Model BIN file not found at path: %s", model_bin_path)
+                return None
+            try:
+                mapi_model = Model.create_model(
+                    model=str(model_xml_path),
                     device=MODELAPI_DEVICE,
                     nstreams=MODELAPI_NSTREAMS,
-                ),
+                )
+            except Exception:
+                logger.exception("Failed to create Model API model from '%s'", model_xml_path)
+                return None
+            self._loaded_model = LoadedModel(
+                id=self._model_activation_state.active_model_id,
+                model=mapi_model,
             )
         return self._loaded_model

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -52,11 +52,11 @@ class ActiveModelService:
                 available_models=[UUID(m.id) for m in available_models],
             )
 
-    def _get_model_xml_path(self, project_id: UUID, model_id: UUID) -> Path:
-        return self.projects_dir / f"{project_id}/models/{model_id}/model.xml"
-
-    def _get_model_bin_path(self, project_id: UUID, model_id: UUID) -> Path:
-        return self.projects_dir / f"{project_id}/models/{model_id}/model.bin"
+    def _get_model_file_path(self, project_id: UUID, model_id: UUID, extension: str = "xml") -> Path:
+        file_path = self.projects_dir / f"{project_id}/models/{model_id}/model.{extension}"
+        if not file_path.is_file():
+            raise FileNotFoundError(f"Model file not found: {file_path}")
+        return file_path
 
     def get_loaded_inference_model(self, force_reload: bool = False) -> LoadedModel | None:
         """
@@ -79,23 +79,19 @@ class ActiveModelService:
         active_model_id = self._model_activation_state.active_model_id
         if self._loaded_model is None or self._loaded_model.id != active_model_id:
             logger.info("Loading model with ID '%s'", active_model_id)
-            model_xml_path = self._get_model_xml_path(project_id, active_model_id)
-            model_bin_path = self._get_model_bin_path(project_id, active_model_id)
-            if not os.path.isfile(model_xml_path):
-                logger.error("Model XML file not found at path: %s", model_xml_path)
-                return None
-            if not os.path.isfile(model_bin_path):
-                logger.error("Model BIN file not found at path: %s", model_bin_path)
-                return None
             try:
+                # Ensure all necessary model files exist before loading the model
+                model_xml_path = self._get_model_file_path(project_id, active_model_id, "xml")
+                _ = self._get_model_file_path(project_id, active_model_id, "bin")
                 mapi_model = Model.create_model(
                     model=str(model_xml_path),
                     device=MODELAPI_DEVICE,
                     nstreams=MODELAPI_NSTREAMS,
                 )
-            except Exception:
-                logger.exception("Failed to create Model API model from '%s'", model_xml_path)
+            except FileNotFoundError:
+                logger.exception("Failed to load model with ID '%s'", active_model_id)
                 return None
+
             self._loaded_model = LoadedModel(
                 id=self._model_activation_state.active_model_id,
                 model=mapi_model,

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -41,47 +41,33 @@ def fxt_active_model_service(fxt_model_activation_state, fxt_condition) -> Itera
 class TestActiveModelServiceUnit:
     """Unit tests for ActiveModelService."""
 
-    def test_get_model_xml_path(self, fxt_active_model_service):
-        """Test retrieval of model XML path."""
+    def test_get_model_file_path(self, fxt_active_model_service):
+        """Test retrieval of model file path."""
         project_id = UUID("82d20877-4dd6-4df3-b6bc-418bb300007d")
         model_id = UUID("d4992996-4d87-422b-aaf3-7427267a50df")
-        expected_path = fxt_active_model_service.projects_dir / f"{project_id}/models/{model_id}/model.xml"
-        xml_path = fxt_active_model_service._get_model_xml_path(project_id=project_id, model_id=model_id)
-        assert xml_path == expected_path
+        extension = "bin"
+        expected_path = fxt_active_model_service.projects_dir / f"{project_id}/models/{model_id}/model.{extension}"
+        expected_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_path.touch()
 
-    def test_get_model_bin_path(self, fxt_active_model_service):
-        """Test retrieval of model BIN path."""
-        project_id = UUID("82d20877-4dd6-4df3-b6bc-418bb300007d")
-        model_id = UUID("d4992996-4d87-422b-aaf3-7427267a50df")
-        expected_path = fxt_active_model_service.projects_dir / f"{project_id}/models/{model_id}/model.bin"
-        bin_path = fxt_active_model_service._get_model_bin_path(project_id=project_id, model_id=model_id)
-        assert bin_path == expected_path
+        file_path = fxt_active_model_service._get_model_file_path(
+            project_id=project_id, model_id=model_id, extension=extension
+        )
+
+        assert file_path == expected_path
 
     def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state, monkeypatch):
         """Test loading the active inference model."""
         dummy_model = Mock(spec=Model)
 
-        # Setup temp files to simulate model XML and BIN
         with (
-            tempfile.TemporaryDirectory() as tmpdir,
             patch.object(Model, "create_model", return_value=dummy_model),
             patch.object(
                 fxt_active_model_service,
-                "_get_model_xml_path",
-                new=lambda project_id, model_id: Path(tmpdir) / "model.xml",
-            ),
-            patch.object(
-                fxt_active_model_service,
-                "_get_model_bin_path",
-                new=lambda project_id, model_id: Path(tmpdir) / "model.bin",
+                "_get_model_file_path",
+                new=lambda project_id, model_id, ext: f"model.{ext}",
             ),
         ):
-            tmpdir_path = Path(tmpdir)
-            xml_path = tmpdir_path / "model.xml"
-            bin_path = tmpdir_path / "model.bin"
-            xml_path.touch()
-            bin_path.touch()
-
             loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
             assert isinstance(loaded, LoadedModel)
             assert loaded.id == fxt_model_activation_state.active_model_id

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -56,6 +56,15 @@ class TestActiveModelServiceUnit:
 
         assert file_path == expected_path
 
+    def test_get_model_file_path_not_found(self, fxt_active_model_service):
+        """Test error when model file is not found."""
+        project_id = UUID("82d20877-4dd6-4df3-b6bc-418bb300007d")
+        model_id = UUID("d4992996-4d87-422b-aaf3-7427267a50df")
+        extension = "bin"
+
+        with pytest.raises(FileNotFoundError, match="Model file not found"):
+            fxt_active_model_service._get_model_file_path(project_id=project_id, model_id=model_id, extension=extension)
+
     def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state, monkeypatch):
         """Test loading the active inference model."""
         dummy_model = Mock(spec=Model)

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2022-2025 Intel Corporation
+# LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import Mock, patch
+from uuid import UUID
+
+import pytest
+from model_api.models import Model
+
+from app.schemas.model_activation import ModelActivationState
+from app.services import ActiveModelService
+from app.services.active_model_service import LoadedModel
+
+
+@pytest.fixture
+def fxt_model_activation_state() -> ModelActivationState:
+    """Fixture to create a default ModelActivationState."""
+    project_id = UUID("82d20877-4dd6-4df3-b6bc-418bb300007d")
+    active_model_id = UUID("d4992996-4d87-422b-aaf3-7427267a50df")
+    other_model_id = UUID("da21744f-990c-4b95-aa2a-70da8d46fdcf")
+    available_models = [active_model_id, other_model_id]
+    return ModelActivationState(
+        project_id=project_id,
+        active_model_id=active_model_id,
+        available_models=available_models,
+    )
+
+
+@pytest.fixture
+def fxt_active_model_service(fxt_model_activation_state, fxt_condition) -> Iterator[ActiveModelService]:
+    """Fixture to create an ActiveModelService instance with mocked dependencies and a temporary data directory."""
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        patch.object(ActiveModelService, "_load_state", return_value=fxt_model_activation_state),
+    ):
+        yield ActiveModelService(data_dir=Path(tmpdir), mp_model_reload_event=fxt_condition)
+
+
+class TestActiveModelServiceUnit:
+    """Unit tests for ActiveModelService."""
+
+    def test_get_model_xml_path(self, fxt_active_model_service):
+        """Test retrieval of model XML path."""
+        project_id = UUID("82d20877-4dd6-4df3-b6bc-418bb300007d")
+        model_id = UUID("d4992996-4d87-422b-aaf3-7427267a50df")
+        expected_path = fxt_active_model_service.projects_dir / f"{project_id}/models/{model_id}/model.xml"
+        xml_path = fxt_active_model_service._get_model_xml_path(project_id=project_id, model_id=model_id)
+        assert xml_path == expected_path
+
+    def test_get_model_bin_path(self, fxt_active_model_service):
+        """Test retrieval of model BIN path."""
+        project_id = UUID("82d20877-4dd6-4df3-b6bc-418bb300007d")
+        model_id = UUID("d4992996-4d87-422b-aaf3-7427267a50df")
+        expected_path = fxt_active_model_service.projects_dir / f"{project_id}/models/{model_id}/model.bin"
+        bin_path = fxt_active_model_service._get_model_bin_path(project_id=project_id, model_id=model_id)
+        assert bin_path == expected_path
+
+    def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state, monkeypatch):
+        """Test loading the active inference model."""
+        dummy_model = Mock(spec=Model)
+
+        # Setup temp files to simulate model XML and BIN
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.object(Model, "create_model", return_value=dummy_model),
+            patch.object(
+                fxt_active_model_service,
+                "_get_model_xml_path",
+                new=lambda project_id, model_id: Path(tmpdir) / "model.xml",
+            ),
+            patch.object(
+                fxt_active_model_service,
+                "_get_model_bin_path",
+                new=lambda project_id, model_id: Path(tmpdir) / "model.bin",
+            ),
+        ):
+            tmpdir_path = Path(tmpdir)
+            xml_path = tmpdir_path / "model.xml"
+            bin_path = tmpdir_path / "model.bin"
+            xml_path.touch()
+            bin_path.touch()
+
+            loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
+            assert isinstance(loaded, LoadedModel)
+            assert loaded.id == fxt_model_activation_state.active_model_id
+            assert loaded.model is dummy_model


### PR DESCRIPTION

### Summary

- The `ActiveModelService` now verifies that model files (xml and bin) exist before loading the inference `Model`
  - If the model cannot be loaded, an error is raised instead of crashing the inference process
- Added unit tests for `ActiveModelService`

### How to test

Remove/rename the model files, then launch the server.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
