### PR TITLE
Fix path for docker image artefact upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -215,7 +215,7 @@ jobs:
         with:
           name: docker-images
           path: |
-            docker/geti-tune-*.tar
+            application/docker/geti-tune-*.tar
           retention-days: 7
 
   required_check:

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean
 
 # Install Rust compiler
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
While inspecting workflows for issue #170 noticed that image artefact is missing after build action. This PR is intended to fix this.