### PR TITLE
fix(inference): Wrap StreamContainer with ZoomProvider

### DIFF
--- a/application/ui/src/routes/inference/inference.tsx
+++ b/application/ui/src/routes/inference/inference.tsx
@@ -3,6 +3,7 @@
 
 import { Grid } from '@geti/ui';
 
+import { ZoomProvider } from '../../components/zoom/zoom.provider';
 import { Sidebar } from '../../features/inference/aside/sidebar-tabs.component';
 import { StreamContainer } from '../../features/inference/stream/stream-container';
 import { Toolbar } from '../../features/inference/toolbar/toolbar.component';
@@ -20,7 +21,9 @@ export const Inference = () => {
             }}
         >
             <Toolbar />
-            <StreamContainer />
+            <ZoomProvider>
+                <StreamContainer />
+            </ZoomProvider>
             <Sidebar />
         </Grid>
     );


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add ZoomProvider import and wrap StreamContainer to provide zoom context for the stream view in the inference route.

This fixes the error:

> Error: useSetZoom must be used within "SetZoom.Provider"

when starting a stream in the inference route.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
