### PR TITLE
Incorrect response for unannotated dataset items

### DIFF
--- a/application/backend/app/db/schema.py
+++ b/application/backend/app/db/schema.py
@@ -98,7 +98,7 @@ class DatasetItemDB(BaseID):
     width: Mapped[int] = mapped_column(Integer, nullable=False)
     height: Mapped[int] = mapped_column(Integer, nullable=False)
     size: Mapped[int] = mapped_column(Integer, nullable=False)
-    annotation_data: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    annotation_data: Mapped[list | None] = mapped_column(JSON, nullable=True, default=None)
     user_reviewed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     prediction_model_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("model_revisions.id", ondelete="SET NULL"), nullable=True

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -100,3 +100,18 @@ class DatasetItemRepository:
         result = self.db.execute(stmt)
         row = result.mappings().first()
         return UpdateDatasetItemAnnotation(**row) if row else None
+
+    def delete_annotation_data(self, obj_id: str) -> bool:
+        stmt = (
+            update(DatasetItemDB)
+            .where(
+                DatasetItemDB.project_id == self.project_id,
+                DatasetItemDB.id == obj_id,
+            )
+            .values(
+                annotation_data=None,
+                updated_at=datetime.now(UTC),
+            )
+        )
+        result = self.db.execute(stmt)
+        return result.rowcount > 0  # type: ignore[union-attr]

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -94,7 +94,7 @@ class DatasetItemAnnotationsWithSource(BaseModel):
     Dataset item annotations with information about source
     """
 
-    annotations: list[DatasetItemAnnotation] | None
+    annotations: list[DatasetItemAnnotation]
     user_reviewed: bool
     prediction_model_id: str | None = None
 

--- a/application/backend/app/schemas/dataset_item.py
+++ b/application/backend/app/schemas/dataset_item.py
@@ -70,10 +70,8 @@ class DatasetItemAnnotation(BaseModel):
     }
 
 
-class DatasetItemAnnotations(BaseModel):
-    """
-    Dataset item annotations
-    """
+class SetDatasetItemAnnotations(BaseModel):
+    """Schema for setting dataset item annotations"""
 
     annotations: list[DatasetItemAnnotation]
 
@@ -91,11 +89,12 @@ class DatasetItemAnnotations(BaseModel):
     }
 
 
-class DatasetItemAnnotationsWithSource(DatasetItemAnnotations):
+class DatasetItemAnnotationsWithSource(BaseModel):
     """
     Dataset item annotations with information about source
     """
 
+    annotations: list[DatasetItemAnnotation] | None
     user_reviewed: bool
     prediction_model_id: str | None = None
 

--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -117,6 +117,8 @@ def convert_detection_dataset(
     def _convert_sample(
         dataset_item: DatasetItemDB, image_path: str, project_labels_ids: list[UUID]
     ) -> DetectionSample | None:
+        if dataset_item.annotation_data is None:
+            return None
         annotations = [DatasetItemAnnotation.model_validate(annotation) for annotation in dataset_item.annotation_data]
         coords = [
             convert_rectangle(annotation.shape)
@@ -167,6 +169,8 @@ def convert_classification_dataset(
     def _convert_sample(
         dataset_item: DatasetItemDB, image_path: str, project_labels_ids: list[UUID]
     ) -> ClassificationSample | None:
+        if dataset_item.annotation_data is None:
+            return None
         annotation = next(
             DatasetItemAnnotation.model_validate(annotation) for annotation in dataset_item.annotation_data
         )
@@ -205,6 +209,8 @@ def convert_multiclass_classification_dataset(
     def _convert_sample(
         dataset_item: DatasetItemDB, image_path: str, project_labels_ids: list[UUID]
     ) -> MultilabelClassificationSample | None:
+        if dataset_item.annotation_data is None:
+            return None
         annotation = next(
             DatasetItemAnnotation.model_validate(annotation) for annotation in dataset_item.annotation_data
         )
@@ -244,6 +250,8 @@ def convert_instance_segmentation_dataset(
     def _convert_sample(
         dataset_item: DatasetItemDB, image_path: str, project_labels_ids: list[UUID]
     ) -> InstanceSegmentationSample | None:
+        if dataset_item.annotation_data is None:
+            return None
         annotations = [DatasetItemAnnotation.model_validate(annotation) for annotation in dataset_item.annotation_data]
         polygons = [
             convert_polygon(annotation.shape) for annotation in annotations if (isinstance(annotation.shape, Polygon))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

Resolves #4890

This PR changes default `annotation_data` value to None instead of empty list and adds all required handlings.

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
