### PR TITLE
Invalidate only after all items are uploaded

### DIFF
--- a/application/ui/src/features/dataset/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/toolbar/toolbar.component.tsx
@@ -55,16 +55,24 @@ export const Toolbar = ({ items }: ToolbarProps) => {
             });
         });
 
-        try {
-            await Promise.all(uploadPromises);
+        const promises = await Promise.allSettled(uploadPromises);
 
-            await queryClient.invalidateQueries({
-                queryKey: ['get', '/api/projects/{project_id}/dataset/items'],
+        const succeeded = promises.filter((result) => result.status === 'fulfilled').length;
+        const failed = promises.filter((result) => result.status === 'rejected').length;
+
+        await queryClient.invalidateQueries({
+            queryKey: ['get', '/api/projects/{project_id}/dataset/items'],
+        });
+
+        if (failed === 0) {
+            toast({ type: 'success', message: `Uploaded ${succeeded} item(s)` });
+        } else if (succeeded === 0) {
+            toast({ type: 'error', message: `Failed to upload ${failed} item(s)` });
+        } else {
+            toast({
+                type: 'warning',
+                message: `Uploaded ${succeeded} item(s), ${failed} failed`,
             });
-
-            toast({ type: 'success', message: `Uploaded ${files.length} item(s)` });
-        } catch (_error) {
-            toast({ type: 'error', message: 'Error uploading files' });
         }
     };
 

--- a/application/ui/src/features/dataset/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/toolbar/toolbar.component.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button, Divider, Flex, Heading, Text, toast } from '@geti/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../api/client';
@@ -18,13 +19,10 @@ type ToolbarProps = {
 
 export const Toolbar = ({ items }: ToolbarProps) => {
     const projectId = useProjectIdentifier();
+    const queryClient = useQueryClient();
     const { selectedKeys, setSelectedKeys, setMediaState, toggleSelectedKeys } = useSelectedData();
 
-    const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/items', {
-        meta: {
-            invalidateQueries: [['get', '/api/projects/{project_id}/dataset/items']],
-        },
-    });
+    const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/items');
 
     const totalSelectedElements = selectedKeys instanceof Set ? selectedKeys.size : 0;
     const hasSelectedElements = totalSelectedElements > 0;
@@ -45,24 +43,29 @@ export const Toolbar = ({ items }: ToolbarProps) => {
         setMediaState(updateSelectedKeysTo(selectedKeys, 'rejected'));
     };
 
-    const handleAddMediaItem = (files: File[]) => {
-        files.forEach((file) => {
+    const handleAddMediaItem = async (files: File[]) => {
+        const uploadPromises = files.map((file) => {
             const formData = new FormData();
             formData.append('file', file);
 
-            addItemMutation.mutate(
-                {
-                    params: { path: { project_id: projectId } },
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    body: formData as any,
-                },
-                {
-                    onSuccess: () => {
-                        toast({ type: 'success', message: `Uploaded ${files.length} item(s)` });
-                    },
-                }
-            );
+            return addItemMutation.mutateAsync({
+                params: { path: { project_id: projectId } },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                body: formData as any,
+            });
         });
+
+        try {
+            await Promise.all(uploadPromises);
+
+            await queryClient.invalidateQueries({
+                queryKey: ['get', '/api/projects/{project_id}/dataset/items'],
+            });
+
+            toast({ type: 'success', message: `Uploaded ${files.length} item(s)` });
+        } catch (_error) {
+            toast({ type: 'error', message: 'Error uploading files' });
+        }
     };
 
     return (

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -23,11 +23,7 @@ export const CreateProjectForm = () => {
     const [name, setName] = useState<string>('Project #1');
 
     const navigate = useNavigate();
-    const createProjectMutation = $api.useMutation('post', '/api/projects', {
-        meta: {
-            invalidateQueries: [['get', '/api/projects']],
-        },
-    });
+    const createProjectMutation = $api.useMutation('post', '/api/projects');
 
     const createProject = (e: FormEvent) => {
         e.preventDefault();


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* When adding multiple media items, we would get N-1 cancelled queries on the console. Now we wont.
* Same for /projects after creating a project.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
