### PR TITLE
Fix enabling misconfigured pipeline

### DIFF
--- a/application/backend/app/schemas/pipeline.py
+++ b/application/backend/app/schemas/pipeline.py
@@ -126,5 +126,5 @@ class PipelineView(BaseModel):
         if self.status == PipelineStatus.RUNNING and any(
             x is None for x in (self.source_id, self.sink_id, self.model_id)
         ):
-            raise ValueError("Pipeline cannot be in 'running' status when source, sink, or model is not configured.")
+            raise ValueError("Pipeline cannot be in 'running' state when source, sink, or model is not configured.")
         return self

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -61,7 +61,7 @@ class PipelineService:
     def update_pipeline(self, project_id: UUID, partial_config: dict) -> PipelineView:
         """Update an existing pipeline."""
         pipeline = self.get_pipeline_by_id(project_id)
-        to_update = pipeline.model_copy(update=partial_config)
+        to_update = type(pipeline).model_validate(pipeline.model_copy(update=partial_config))
         pipeline_repo = PipelineRepository(self._db_session)
         updated = PipelineMapper.to_schema(pipeline_repo.update(PipelineMapper.from_schema(to_update)))
         if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR fixes the error where, despite a `409` response from the API, the pipeline record was still updated in the database with a running status. The issue occurred because `model_copy` does not run model validators by itself.

Changes:

- Added an explicit call to `model_validate` after `model_copy` to ensure model validation is performed before updating the pipeline.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

1. Create new project
2. Try to enable the pipeline

Expected: Action is failed and pipeline status is not updated in the DB (server can be restarted)

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
