### PR TITLE
Upgrade datumaro dependency in Geti Tune backend

### DIFF
--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 [[package]]
 name = "datumaro"
 version = "1.12.0"
-source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#4f3bed0245348abf49bd542283c4500a00846626" }
+source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#04948e73d3e55a797d6bbeb6d964ff24e7bdf848" }
 dependencies = [
     { name = "attrs" },
     { name = "defusedxml" },


### PR DESCRIPTION
### Summary

Upgrade `datumaro` to include the latest experimental changes, including subset field and support to multilabel cls, h-cls and tiling.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
