### PR TITLE
Training job: prepare training weights

### DIFF
--- a/application/backend/app/core/run/runnable.py
+++ b/application/backend/app/core/run/runnable.py
@@ -49,12 +49,12 @@ class RunnableFactory(Generic[K, R]):
     """Factory protocol for creating Runnable instances."""
 
     def __init__(self) -> None:
-        self._registry: dict[K, type[R]] = {}
+        self._registry: dict[K, Callable[[], R]] = {}
 
     def __call__(self, cls_type: K) -> R:
         if cls_type not in self._registry:
             raise ValueError(f"No runnable registered for class type: {cls_type}")
         return self._registry[cls_type]()
 
-    def register(self, class_type: K, runnable_cls: type[R]) -> None:
+    def register(self, class_type: K, runnable_cls: Callable[[], R]) -> None:
         self._registry[class_type] = runnable_cls

--- a/application/backend/app/services/training/base.py
+++ b/application/backend/app/services/training/base.py
@@ -1,14 +1,34 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import ABC
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from pathlib import Path
+from uuid import UUID
 
 from app.core.run import ExecutionContext, Runnable
+from app.services.base_weights_service import BaseWeightsService
 
 from .models import TrainingParams
 
 
 class Trainer(Runnable, ABC):
+    def __init__(self, base_weights_service: BaseWeightsService):
+        self._weights_service = base_weights_service
+
     @staticmethod
-    def get_training_params(ctx: ExecutionContext) -> TrainingParams:
+    def _build_model_weights_path(data_dir: Path, project_id: UUID, model_id: UUID) -> Path:
+        return data_dir / "projects" / str(project_id) / "models" / str(model_id) / "model.pth"
+
+    @staticmethod
+    def _get_training_params(ctx: ExecutionContext) -> TrainingParams:
         return TrainingParams.model_validate_json(ctx.payload)
+
+    @abstractmethod
+    def _prepare_weights(self, data_dir: Path, training_params: TrainingParams, report_fn: Callable) -> Path: ...
+
+    @abstractmethod
+    def _train(self): ...
+
+    @abstractmethod
+    def _evaluate(self): ...

--- a/application/backend/app/services/training/models.py
+++ b/application/backend/app/services/training/models.py
@@ -9,6 +9,7 @@ from app.core.models import TaskType
 
 class TrainingParams(JobParams):
     job_id: UUID | None = None
+    project_id: UUID | None = None
     model_architecture_id: str
     parent_model_revision_id: UUID | None = None
     task_type: TaskType
@@ -24,3 +25,4 @@ class TrainingJob(ProjectJob):
 
     def model_post_init(self, _: Any) -> None:
         self.params.job_id = self.id
+        self.params.project_id = self.project_id

--- a/application/backend/app/services/training/otx.py
+++ b/application/backend/app/services/training/otx.py
@@ -3,28 +3,58 @@
 
 import logging
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from app.core.run import ExecutionContext
 
-from .base import Trainer
+from .base import Trainer, TrainingParams
 
 logger = logging.getLogger(__name__)
 
 
 class OTXTrainer(Trainer):
-    def __prepare_weights(self) -> Path | None:
+    def _prepare_weights(self, data_dir: Path, training_params: TrainingParams, report_fn: Callable) -> Path:
+        """
+        Prepare weights for training based on training parameters.
+
+        If a parent model revision ID is provided, it fetches the weights from the parent model. Otherwise, it retrieves
+        the base weights for the specified model architecture.
+
+        Args:
+            data_dir (Path): The base directory for data storage.
+            training_params (TrainingParams): The parameters for the training job.
+            report_fn (Callable): Function to report progress messages.
+        Returns:
+            Path: The path to the model weights file.
+        Raises:
+            ValueError: If project ID is not provided when parent model revision ID is specified.
+        """
+        report_fn("Preparing weights for training")
+        if training_params.parent_model_revision_id is None:
+            weights_path = self._weights_service.get_local_weights_path(
+                task=training_params.task_type, model_manifest_id=training_params.model_architecture_id
+            )
+            report_fn("Base weights preparation completed")
+            return weights_path
+        if training_params.project_id is None:
+            raise ValueError("Project ID must be provided for parent model weights preparation")
+        weights_path = self._build_model_weights_path(
+            data_dir, training_params.project_id, training_params.parent_model_revision_id
+        )
+        report_fn("Parent model weights preparation completed")
+        return weights_path
+
+    def _train(self):
         raise NotImplementedError
 
-    def __train(self):
-        raise NotImplementedError
-
-    def __evaluate(self):
+    def _evaluate(self):
         raise NotImplementedError
 
     def run(self, ctx: ExecutionContext) -> None:
-        training_params = self.get_training_params(ctx)
+        training_params = self._get_training_params(ctx)
         logger.info("Training job started with params: %s", training_params)
+        self._prepare_weights(ctx.data_dir, training_params, ctx.report_progress)
         ctx.report_progress("Training job started")
         job_id = training_params.job_id
         # Simulate training with progress reporting

--- a/application/backend/app/services/training/otx.py
+++ b/application/backend/app/services/training/otx.py
@@ -44,6 +44,8 @@ class OTXTrainer(Trainer):
         weights_path = self._build_model_weights_path(
             data_dir, training_params.project_id, training_params.parent_model_revision_id
         )
+        if not weights_path.exists():
+            raise FileNotFoundError(f"Parent model weights not found at {weights_path}")
         report_fn("Parent model weights preparation completed")
         return weights_path
 

--- a/application/backend/app/services/training/otx.py
+++ b/application/backend/app/services/training/otx.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class OTXTrainer(Trainer):
-    def _prepare_weights(self, data_dir: Path, training_params: TrainingParams, report_fn: Callable) -> Path:
+    def _prepare_weights(
+        self, data_dir: Path, training_params: TrainingParams, report_fn: Callable[[str], None]
+    ) -> Path:
         """
         Prepare weights for training based on training parameters.
 
@@ -55,7 +57,7 @@ class OTXTrainer(Trainer):
         training_params = self._get_training_params(ctx)
         logger.info("Training job started with params: %s", training_params)
         self._prepare_weights(ctx.data_dir, training_params, ctx.report_progress)
-        ctx.report_progress("Training job started")
+        ctx.report_progress("Started model training")
         job_id = training_params.job_id
         # Simulate training with progress reporting
         step_count = 20

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import Mock, call
+from uuid import uuid4
+
+import pytest
+
+from app.core.models import TaskType
+from app.services.base_weights_service import BaseWeightsService
+from app.services.training.models import TrainingParams
+from app.services.training.otx import OTXTrainer
+
+
+@pytest.fixture
+def fxt_base_weights_service() -> Mock:
+    """Mock BaseWeightsService for testing."""
+    return Mock(spec=BaseWeightsService)
+
+
+@pytest.fixture
+def fxt_otx_trainer(fxt_base_weights_service: Mock) -> OTXTrainer:
+    """Create an OTXTrainer instance for testing."""
+    return OTXTrainer(fxt_base_weights_service)
+
+
+class TestOTXTrainerPrepareWeights:
+    """Test cases for the _prepare_weights method."""
+
+    def test_prepare_weights_without_parent_model(
+        self, fxt_otx_trainer: OTXTrainer, fxt_base_weights_service: Mock, tmp_path: Path
+    ):
+        """Test preparing weights when no parent model revision ID is provided."""
+        # Arrange
+        training_params = TrainingParams(
+            model_architecture_id="Object_Detection_YOLOX_S",
+            task_type=TaskType.DETECTION,
+            parent_model_revision_id=None,
+        )
+        expected_weights_path = tmp_path / "model.pth"
+        fxt_base_weights_service.get_local_weights_path.return_value = expected_weights_path
+        report_fn = Mock()
+
+        # Act
+        result = fxt_otx_trainer._prepare_weights(tmp_path, training_params, report_fn)
+
+        # Assert
+        assert result == expected_weights_path
+        fxt_base_weights_service.get_local_weights_path.assert_called_once_with(
+            task=TaskType.DETECTION, model_manifest_id="Object_Detection_YOLOX_S"
+        )
+        report_fn.assert_has_calls([call("Preparing weights for training"), call("Base weights preparation completed")])
+
+    def test_prepare_weights_with_parent_model(self, fxt_otx_trainer: OTXTrainer, tmp_path: Path):
+        """Test preparing weights when parent model revision ID is provided."""
+        # Arrange
+        project_id = uuid4()
+        parent_model_revision_id = uuid4()
+        training_params = TrainingParams(
+            project_id=project_id,
+            model_architecture_id="Object_Detection_YOLOX_S",
+            task_type=TaskType.DETECTION,
+            parent_model_revision_id=parent_model_revision_id,
+        )
+        report_fn = Mock()
+        expected_weights_path = (
+            tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.pth"
+        )
+
+        # Act
+        result = fxt_otx_trainer._prepare_weights(tmp_path, training_params, report_fn)
+
+        # Assert
+        assert result == expected_weights_path
+        report_fn.assert_has_calls(
+            [call("Preparing weights for training"), call("Parent model weights preparation completed")]
+        )
+
+    def test_prepare_weights_with_parent_model_no_project_id_raises_error(
+        self, fxt_otx_trainer: OTXTrainer, tmp_path: Path
+    ):
+        """Test that ValueError is raised when parent model revision ID is provided without project ID."""
+        # Arrange
+        training_params = TrainingParams(
+            model_architecture_id="Object_Detection_YOLOX_S",
+            task_type=TaskType.DETECTION,
+            parent_model_revision_id=uuid4(),
+            project_id=None,
+        )
+        report_fn = Mock()
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="Project ID must be provided for parent model weights preparation"):
+            fxt_otx_trainer._prepare_weights(tmp_path, training_params, report_fn)

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -67,6 +67,8 @@ class TestOTXTrainerPrepareWeights:
         expected_weights_path = (
             tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.pth"
         )
+        expected_weights_path.parent.mkdir(parents=True, exist_ok=True)
+        expected_weights_path.touch()
 
         # Act
         result = fxt_otx_trainer._prepare_weights(tmp_path, training_params, report_fn)
@@ -76,6 +78,29 @@ class TestOTXTrainerPrepareWeights:
         report_fn.assert_has_calls(
             [call("Preparing weights for training"), call("Parent model weights preparation completed")]
         )
+
+    def test_prepare_weights_with_parent_model_no_file_raises_error(self, fxt_otx_trainer: OTXTrainer, tmp_path: Path):
+        """Test that FileNotFoundError is raised when parent model weights file is missing."""
+        # Arrange
+        project_id = uuid4()
+        parent_model_revision_id = uuid4()
+        training_params = TrainingParams(
+            project_id=project_id,
+            model_architecture_id="Object_Detection_YOLOX_S",
+            task_type=TaskType.DETECTION,
+            parent_model_revision_id=parent_model_revision_id,
+        )
+        report_fn = Mock()
+        expected_weights_path = (
+            tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.pth"
+        )
+
+        # Act
+        with pytest.raises(FileNotFoundError, match=f"Parent model weights not found at {expected_weights_path}"):
+            fxt_otx_trainer._prepare_weights(tmp_path, training_params, report_fn)
+
+        # Assert
+        report_fn.assert_called_once_with("Preparing weights for training")
 
     def test_prepare_weights_with_parent_model_no_project_id_raises_error(
         self, fxt_otx_trainer: OTXTrainer, tmp_path: Path


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Implement weight preparation phase in `OTXTrainer` with support for both base model weights and parent model weights:

- [x] Implemented `_prepare_weights` method in `OTXTrainer` class with support of two scenarios: 
  - [x] Base weights: When no parent model is specified, the method checks for and downloads weights based on the model architecture
  - [x] Parent weights: When a parent model revision ID is provided, the method constructs and returns the appropriate path to the parent model weights
- [x] Unit tests

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

```bash
curl -X POST -H "Content-Type: application/json" localhost:7860/api/jobs -d '{"job_type": "train", "project_id": "9d6af8e8-6017-4ebe-9126-33aae739c5fa", "parameters": { "model_architecture_id": "Object_Detection_YOLOX_S" }}'
```

Weights will be downloaded and added under `/data/pretrained_weights/detection/yolox_s_8x8_300e_coco_20211121_095711-4592a793.pth`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
