### PR TITLE
Add camera access permission to fix webrtc connectivity issues

### DIFF
--- a/application/backend/app/static/webrtc.html
+++ b/application/backend/app/static/webrtc.html
@@ -360,6 +360,15 @@
       // Global client instance
       const client = new WebRTCClient();
 
+      async function requestMedia() {
+        try {
+          await navigator.mediaDevices.getUserMedia({ video: true });
+          console.log("Camera access granted.");
+        } catch (err) {
+          console.error("Access denied or error occurred:", err);
+        }
+      }
+
       function startStream() {
         client.startStream();
       }
@@ -379,6 +388,7 @@
         .addEventListener("input", (e) => {
           document.getElementById("confValue").textContent = e.target.value;
         });
+      requestMedia();
 
       // Add some initial logs
       client.log("Page loaded. Ready to connect.", "info");


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

By default Chrome uses mDNS hostnames to hide user internal IP address for WebRTC.
In case when backend application runs in docker container behind Nginx, it's not able to resolve such hostname.
As a solution, we can use STUN servers, however for now we can request Camera access on the page which uses WebRTC to switch browser to use IP address instead.

This PR addresses it for debug webrtc page, while for Web UI we need another fix.

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
