### PR TITLE
Remove model /labels endpoint

### DIFF
--- a/application/backend/app/api/endpoints/models.py
+++ b/application/backend/app/api/endpoints/models.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.dependencies import get_model_id, get_model_service, get_project_id
-from app.schemas import LabelView, Model
+from app.schemas import Model
 from app.services import ModelService, ResourceInUseError, ResourceNotFoundError
 
 router = APIRouter(prefix="/api/projects/{project_id}/models", tags=["Models"])
@@ -52,24 +52,6 @@ def get_model(
         return model_service.get_model_by_id(project_id=project_id, model_id=model_id)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-
-
-@router.get(
-    "/{model_id}/labels",
-    responses={
-        status.HTTP_200_OK: {"description": "Model labels found"},
-        status.HTTP_400_BAD_REQUEST: {"description": "Invalid project or model ID"},
-        status.HTTP_404_NOT_FOUND: {"description": "Project or model not found"},
-    },
-)
-def get_model_labels(
-    project_id: Annotated[UUID, Depends(get_project_id)],
-    model_id: Annotated[UUID, Depends(get_model_id)],
-    model_service: Annotated[ModelService, Depends(get_model_service)],
-) -> list[LabelView]:
-    """Get labels for a specific model."""
-    _ = project_id, model_id, model_service
-    raise NotImplementedError("Model labels endpoint is not implemented yet")
 
 
 @router.delete(

--- a/application/backend/app/cli.py
+++ b/application/backend/app/cli.py
@@ -148,7 +148,7 @@ def seed(with_model: bool) -> None:
                 training_started_at=datetime.now() - timedelta(hours=24),
                 training_finished_at=datetime.now() - timedelta(hours=23),
                 training_configuration={},
-                label_schema_revision={},
+                label_schema_revision={"labels": [{"id": str(label.id), "name": label.name} for label in labels]},
             )
             pipeline.is_running = True
         db.add(pipeline)

--- a/application/backend/app/schemas/model.py
+++ b/application/backend/app/schemas/model.py
@@ -52,7 +52,18 @@ class Model(BaseIDModel):
                     "start_time": "2021-06-29T16:24:30.928000+00:00",
                     "end_time": "2021-06-29T16:24:30.928000+00:00",
                     "dataset_revision_id": "3c6c6d38-1cd8-4458-b759-b9880c048b78",
-                    "label_schema_revision": {},
+                    "label_schema_revision": {
+                        "labels": [
+                            {
+                                "id": "a22d82ba-afa9-4d6e-bbc1-8c8e4002ec29",
+                                "name": "cat",
+                            },
+                            {
+                                "id": "8aa85368-11ba-4507-88f2-6a6704d78ef5",
+                                "name": "dog",
+                            },
+                        ]
+                    },
                     "configuration": {},
                 },
                 "files_deleted": False,


### PR DESCRIPTION
### Summary

Changes:
- remove the `models/<id>/labels` endpoint
  - the same information can be found in `models/<id>`
- add an example of label schema revision in the REST API
- seed the label schema revision, for development purposes

Resolves #4945 

### How to test

Generate and review the OpenAPI spec: `uv run app/cli.py gen-api --target-path openapi.json`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
