### PR TITLE
Update label fetching

### DIFF
--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -22,7 +22,7 @@ const mapServerAnnotationsToLocal = (serverAnnotations: ServerAnnotation[], proj
         // We only get the ids of the labels
         const labels = annotation.labels
             .map((labelRef) => labelMap.get(labelRef.id))
-            .filter((label) => label !== undefined);
+            .filter((label): label is Label => label !== undefined);
 
         return {
             ...annotation,

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -8,25 +8,34 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { get, isEmpty, isObject } from 'lodash-es';
 import { $api } from 'src/api/client';
 import type { components } from 'src/api/openapi-spec';
-import type { DatasetItem } from 'src/constants/shared-types';
+import type { DatasetItem, Label } from 'src/constants/shared-types';
 import { v4 as uuid } from 'uuid';
 
 import type { Annotation, Shape } from '../../features/annotator/types';
 
 type ServerAnnotation = components['schemas']['DatasetItemAnnotation-Input'];
 
-const mapServerAnnotationsToLocal = (serverAnnotations: ServerAnnotation[]): Annotation[] => {
+const mapServerAnnotationsToLocal = (serverAnnotations: ServerAnnotation[], projectLabels: Label[]): Annotation[] => {
+    const labelMap = new Map(projectLabels.map((label) => [label.id, label]));
+
     return serverAnnotations.map((annotation) => {
+        // We only get the ids of the labels
+        const labels = annotation.labels
+            .map((labelRef) => labelMap.get(labelRef.id))
+            .filter((label) => label !== undefined);
+
         return {
             ...annotation,
             id: uuid(),
+            labels,
         } as Annotation;
     });
 };
 
 const mapLocalAnnotationsToServer = (localAnnotations: Annotation[]): ServerAnnotation[] => {
     return localAnnotations.map((annotation) => ({
-        labels: annotation.labels,
+        // We only want to send the ids of the labels
+        labels: annotation.labels.map((label) => ({ id: label.id })),
         shape: annotation.shape,
         ...(annotation.confidence !== undefined && { confidence: annotation.confidence }),
     }));
@@ -123,9 +132,10 @@ export const AnnotationActionsProvider = ({ children, mediaItem }: AnnotationAct
         if (!project || !serverAnnotations) return;
 
         const annotations = get(serverAnnotations, 'annotations', []);
+        const projectLabels = project.task?.labels || [];
 
         if (annotations.length > 0) {
-            const localFormattedAnnotations = mapServerAnnotationsToLocal(annotations);
+            const localFormattedAnnotations = mapServerAnnotationsToLocal(annotations, projectLabels);
 
             setLocalAnnotations(localFormattedAnnotations);
             isDirty.current = false;


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* From the server side the annotations only contain an array of label ids, and not the actual labels, so we need to cross reference those with the project labels to display them properly.

Before:
<img width="1336" height="917" alt="Screenshot 2025-10-23 at 08 24 19" src="https://github.com/user-attachments/assets/b7d37363-7de1-402f-bd52-d5a34096fa53" />

After:
<img width="1280" height="820" alt="Screenshot 2025-10-23 at 08 34 10" src="https://github.com/user-attachments/assets/ad03ac1f-008e-47ec-b255-e43bd9bec0c0" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
