### PR TITLE
 Extend EfficientNet pretrained support to B2-B8

### DIFF
--- a/library/src/otx/backend/native/models/classification/backbones/efficientnet.py
+++ b/library/src/otx/backend/native/models/classification/backbones/efficientnet.py
@@ -672,6 +672,6 @@ class EfficientNetBackbone:
 
         if pretrained:
             cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
-            download_model(net=model, model_name=f"{model_name}", local_model_store_dir_path=str(cache_dir))
+            download_model(net=model, model_name=f"{model_name}c", local_model_store_dir_path=str(cache_dir))
             print(f"Download model weight in {cache_dir!s}")
         return model

--- a/library/tests/unit/backend/native/models/classification/backbones/test_otx_efficientnet.py
+++ b/library/tests/unit/backend/native/models/classification/backbones/test_otx_efficientnet.py
@@ -23,8 +23,9 @@ class TestOTXEfficientNet:
             "efficientnet_b8",
         ],
     )
-    def test_forward(self, model_name):
-        model = EfficientNetBackbone(model_name, pretrained=None)
+    @pytest.mark.parametrize("pretrained", [True, False])
+    def test_forward(self, model_name, pretrained):
+        model = EfficientNetBackbone(model_name, pretrained=pretrained)
         assert model(torch.randn(1, 3, 244, 244))[0].shape[-1] == 8
         assert model(torch.randn(1, 3, 244, 244))[0].shape[-2] == 8
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds support for downloading and using pretrained EfficientNet weights for models larger than B1 (B2-B8).

In pytorchcv, the “c” denotes the community re-trained EfficientNet variants (ported via https://www.github.com/rwightman/timm) that use PyTorch-native ops and shapes, distinct from the original TF-trained baselines.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)


> [!WARNING]  
> This PR may increase test runtime because it involves downloading large models.