### PR TITLE
Upgrade numpy to 2.x in OTX 

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "onnxscript==0.5.3",
     "nncf==2.17.0",
     "anomalib[core]==1.1.3",
+    "imgaug==0.4.0",  # for anomalib
     "numpy>2.0",
     "tensorboardx==2.6.4"
 ]
@@ -114,6 +115,14 @@ otx = "otx.cli:main"
 Documentation = "https://open-edge-platform.github.io/training_extensions/"
 Repository = "https://github.com/open-edge-platform/training_extensions/"
 
+[tool.uv]
+conflicts = [
+    [
+        { extra = "xpu" },
+        { extra = "cuda" },
+    ],
+]
+
 [tool.uv.sources]
 torch = [
     { index = "torch-xpu", extra = "xpu"},
@@ -126,6 +135,10 @@ torchvision = [
     { index = "torch-xpu", extra = "xpu"},
     { index = "torch-cuda", extra = "cuda"},
 ]
+# Anomalib depends on imgaug, which is abandoned and depends on an old version of numpy.
+# To avoid dependency resolution issues, we install imgaug from a maintained fork.
+# For details: https://github.com/aleju/imgaug/issues/859
+imgaug = { git = "https://github.com/imaug/imaug/", rev = "a7ca1b04d44700d075a23f14a97f86285ba3b33f" }
 
 [[tool.uv.index]]
 name = "torch-cuda"

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "onnxscript==0.5.3",
     "nncf==2.17.0",
     "anomalib[core]==1.1.3",
-    "numpy<2.0",
+    "numpy>2.0",
     "tensorboardx==2.6.4"
 ]
 
@@ -285,12 +285,6 @@ ignore = [
 
     "E731",     # Do not assign a `lambda` expression, use a `def`
     "TD003",    # Missing issue link on the line following this TODO
-
-    # TODO (someone): Update legacy np.random.{method_name} call with np.random.Generator
-    # Legacy (MT19964) and new (PCG64) random generators use different pseudo-random number generators.
-    # (https://numpy.org/doc/stable/reference/random/legacy.html#legacy)
-    # For now, remaining legacy random methods is required until numpy version is explicitly updated in OTX.
-    "NPY002",   # Replace legacy np.random.{method_name} call with np.random.Generator
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/library/src/otx/backend/native/exporter/exportable_code/demo/demo_package/visualizers/visualizer.py
+++ b/library/src/otx/backend/native/exporter/exportable_code/demo/demo_package/visualizers/visualizer.py
@@ -202,13 +202,14 @@ class SemanticSegmentationVisualizer(BaseVisualizer):
         super().__init__(window_name, no_show, delay, output)
         self.color_palette = ColorPalette(len(labels)).to_numpy_array()
         self.color_map = self._create_color_map()
+        self.rng = np.random.default_rng(42)
 
     def _create_color_map(self) -> np.ndarray:
         classes = self.color_palette[:, ::-1]  # RGB to BGR
         color_map = np.zeros((256, 1, 3), dtype=np.uint8)
         classes_num = len(classes)
         color_map[:classes_num, 0, :] = classes
-        color_map[classes_num:, 0, :] = np.random.uniform(0, 255, size=(256 - classes_num, 3))
+        color_map[classes_num:, 0, :] = self.rng.uniform(0, 255, size=(256 - classes_num, 3))
         return color_map
 
     def _apply_color_map(self, input_2d_mask: np.ndarray) -> np.ndarray:

--- a/library/src/otx/backend/native/exporter/exportable_code/demo/demo_package/visualizers/visualizer.py
+++ b/library/src/otx/backend/native/exporter/exportable_code/demo/demo_package/visualizers/visualizer.py
@@ -202,14 +202,14 @@ class SemanticSegmentationVisualizer(BaseVisualizer):
         super().__init__(window_name, no_show, delay, output)
         self.color_palette = ColorPalette(len(labels)).to_numpy_array()
         self.color_map = self._create_color_map()
-        self.rng = np.random.default_rng(42)
 
     def _create_color_map(self) -> np.ndarray:
+        rng = np.random.default_rng(42)
         classes = self.color_palette[:, ::-1]  # RGB to BGR
         color_map = np.zeros((256, 1, 3), dtype=np.uint8)
         classes_num = len(classes)
         color_map[:classes_num, 0, :] = classes
-        color_map[classes_num:, 0, :] = self.rng.uniform(0, 255, size=(256 - classes_num, 3))
+        color_map[classes_num:, 0, :] = rng.uniform(0, 255, size=(256 - classes_num, 3))
         return color_map
 
     def _apply_color_map(self, input_2d_mask: np.ndarray) -> np.ndarray:

--- a/library/src/otx/backend/native/models/detection/detectors/detection_transformer.py
+++ b/library/src/otx/backend/native/models/detection/detectors/detection_transformer.py
@@ -67,6 +67,7 @@ class DETR(BaseModule):
             )
         )
         self.optimizer_configuration = optimizer_configuration
+        self.rng = np.random.default_rng(42)
 
     def generate_scales(self, input_size: int, base_size_repeat: int = 3) -> list[int]:
         """Generates scales for multi-scale training."""
@@ -84,7 +85,7 @@ class DETR(BaseModule):
     def forward(self, images: Tensor, targets: dict[str, Any] | None = None) -> dict[str, Tensor] | Tensor:
         """Forward pass of the model."""
         if self.multi_scale and self.training:
-            sz = int(np.random.choice(self.multi_scale))
+            sz = int(self.rng.choice(self.multi_scale))
             images = nn.functional.interpolate(images, size=[sz, sz])
 
         output = self._forward_features(images, targets)

--- a/library/src/otx/data/transform_libs/torchvision.py
+++ b/library/src/otx/data/transform_libs/torchvision.py
@@ -2447,7 +2447,7 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
         assert len(scale) == 2  # noqa: S101
         min_ratio, max_ratio = ratio_range
         assert min_ratio <= max_ratio  # noqa: S101
-        ratio = RNG.randomom_sample() * (max_ratio - min_ratio) + min_ratio
+        ratio = RNG.random() * (max_ratio - min_ratio) + min_ratio
         return int(scale[0] * ratio), int(scale[1] * ratio)
 
     @cache_randomness

--- a/library/src/otx/data/transform_libs/torchvision.py
+++ b/library/src/otx/data/transform_libs/torchvision.py
@@ -21,7 +21,6 @@ import torch
 import torchvision.transforms.v2 as tvt_v2
 import typeguard
 from lightning.pytorch.cli import instantiate_class
-from numpy import random
 from omegaconf import DictConfig
 from scipy.stats import truncnorm
 from torchvision import tv_tensors
@@ -72,6 +71,8 @@ if TYPE_CHECKING:
 
 
 # mypy: disable-error-code="attr-defined"
+
+RNG = np.random.default_rng(42)
 
 
 def custom_query_size(flat_inputs: list[Any]) -> tuple[int, int]:  # noqa: D103
@@ -151,7 +152,7 @@ class MinIoURandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     @cache_randomness
     def _random_mode(self) -> int | float:
-        return random.choice(self.sample_mode)
+        return RNG.choice(self.sample_mode)
 
     def forward(self, *_inputs: OTXDataItem) -> OTXDataItem | None:
         """Forward for MinIoURandomCrop."""
@@ -172,15 +173,15 @@ class MinIoURandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
 
             min_iou = self.mode
             for _ in range(50):
-                new_w = random.uniform(self.min_crop_size * w, w)
-                new_h = random.uniform(self.min_crop_size * h, h)
+                new_w = RNG.uniform(self.min_crop_size * w, w)
+                new_h = RNG.uniform(self.min_crop_size * h, h)
 
                 # h / w in [0.5, 2]
                 if new_h / new_w < 0.5 or new_h / new_w > 2:
                     continue
 
-                left = random.uniform(w - new_w)
-                top = random.uniform(h - new_h)
+                left = RNG.uniform(w - new_w)
+                top = RNG.uniform(h - new_h)
 
                 patch = np.array((int(left), int(top), int(left + new_w), int(top + new_h)))
                 # Line or point crop is not allowed
@@ -484,15 +485,15 @@ class RandomResizedCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
         area = h * w
 
         for _ in range(self.max_attempts):
-            target_area = np.random.uniform(*self.crop_ratio_range) * area
+            target_area = RNG.uniform(*self.crop_ratio_range) * area
             log_ratio = (math.log(self.aspect_ratio_range[0]), math.log(self.aspect_ratio_range[1]))
-            aspect_ratio = math.exp(np.random.uniform(*log_ratio))
+            aspect_ratio = math.exp(RNG.uniform(*log_ratio))
             target_w = int(round(math.sqrt(target_area * aspect_ratio)))
             target_h = int(round(math.sqrt(target_area / aspect_ratio)))
 
             if 0 < target_w <= w and 0 < target_h <= h:
-                offset_h = np.random.randint(0, h - target_h + 1)
-                offset_w = np.random.randint(0, w - target_w + 1)
+                offset_h = RNG.integers(0, h - target_h + 1)
+                offset_w = RNG.integers(0, w - target_w + 1)
 
                 return offset_h, offset_w, target_h, target_w
 
@@ -725,7 +726,7 @@ class EfficientNetRandomCrop(RandomResizedCrop):
         max_target_area = self.crop_ratio_range[1] * area
 
         for _ in range(self.max_attempts):
-            aspect_ratio = np.random.uniform(*self.aspect_ratio_range)
+            aspect_ratio = RNG.uniform(*self.aspect_ratio_range)
             min_target_h = int(round(math.sqrt(min_target_area / aspect_ratio)))
             max_target_h = int(round(math.sqrt(max_target_area / aspect_ratio)))
 
@@ -738,7 +739,7 @@ class EfficientNetRandomCrop(RandomResizedCrop):
             min_target_h = min(max_target_h, min_target_h)
 
             # slightly differs from tf implementation
-            target_h = int(round(np.random.uniform(min_target_h, max_target_h)))
+            target_h = int(round(RNG.uniform(min_target_h, max_target_h)))
             target_w = int(round(target_h * aspect_ratio))
             target_area = target_h * target_w
 
@@ -753,8 +754,8 @@ class EfficientNetRandomCrop(RandomResizedCrop):
             ):
                 continue
 
-            offset_h = np.random.randint(0, h - target_h + 1)
-            offset_w = np.random.randint(0, w - target_w + 1)
+            offset_h = RNG.integers(0, h - target_h + 1)
+            offset_w = RNG.integers(0, w - target_w + 1)
 
             return offset_h, offset_w, target_h, target_w
 
@@ -865,7 +866,7 @@ class RandomFlip(tvt_v2.Transform, NumpytoTVTensorMixin):
             single_ratio = self.prob / (len(direction_list) - 1)
             prob_list = [single_ratio] * (len(direction_list) - 1) + [non_prob]
 
-        return np.random.choice(direction_list, p=prob_list)
+        return RNG.choice(direction_list, p=prob_list)
 
     def forward(self, *_inputs: OTXDataItem) -> OTXDataItem | None:
         """Flip images, bounding boxes, and semantic segmentation map."""
@@ -920,7 +921,7 @@ class RandomGaussianBlur(GaussianBlur):
 
     def transform(self, inpt: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
         """Main transform function."""
-        if self.prob >= np.random.rand():
+        if self.prob >= RNG.random():
             return super().transform(inpt, params)
         return inpt
 
@@ -943,7 +944,7 @@ class RandomGaussianNoise(GaussianNoise):
         """Main transform function."""
         assert len(_inputs) == 1, "[tmp] Multiple entity is not supported yet."  # noqa: S101
         inputs = _inputs[0]
-        if (img := getattr(inputs, "image", None)) is not None and self.prob >= np.random.rand():
+        if (img := getattr(inputs, "image", None)) is not None and self.prob >= RNG.random():
             scaled = self._is_scaled(img)
             sigma = self.sigma * 255 if not scaled else self.sigma
             mean = self.mean * 255 if not scaled else self.mean
@@ -1007,17 +1008,17 @@ class PhotoMetricDistortion(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     @cache_randomness
     def _random_flags(self) -> Sequence[int | float]:
-        mode = random.rand() > self.prob
-        brightness_flag = random.rand() > self.prob
-        contrast_flag = random.rand() > self.prob
-        saturation_flag = random.rand() > self.prob
-        hue_flag = random.rand() > self.prob
-        swap_flag = random.rand() > self.prob
-        delta_value = random.uniform(-self.brightness_delta, self.brightness_delta)
-        alpha_value = random.uniform(self.contrast_lower, self.contrast_upper)
-        saturation_value = random.uniform(self.saturation_lower, self.saturation_upper)
-        hue_value = random.uniform(-self.hue_delta, self.hue_delta)
-        swap_value = random.permutation(3)
+        mode = RNG.random() > self.prob
+        brightness_flag = RNG.random() > self.prob
+        contrast_flag = RNG.random() > self.prob
+        saturation_flag = RNG.random() > self.prob
+        hue_flag = RNG.random() > self.prob
+        swap_flag = RNG.random() > self.prob
+        delta_value = RNG.uniform(-self.brightness_delta, self.brightness_delta)
+        alpha_value = RNG.uniform(self.contrast_lower, self.contrast_upper)
+        saturation_value = RNG.uniform(self.saturation_lower, self.saturation_upper)
+        hue_value = RNG.uniform(-self.hue_delta, self.hue_delta)
+        swap_value = RNG.permutation(3)
 
         return (
             mode,
@@ -1197,12 +1198,12 @@ class RandomAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
             np.ndarray: 3x3 homography matrix.
         """
         # Generate transformation parameters
-        rotation_degree = random.uniform(-self.max_rotate_degree, self.max_rotate_degree)
-        scaling_ratio = random.uniform(self.scaling_ratio_range[0], self.scaling_ratio_range[1])
-        x_shear_degree = random.uniform(-self.max_shear_degree, self.max_shear_degree)
-        y_shear_degree = random.uniform(-self.max_shear_degree, self.max_shear_degree)
-        trans_x = random.uniform(-self.max_translate_ratio, self.max_translate_ratio) * width
-        trans_y = random.uniform(-self.max_translate_ratio, self.max_translate_ratio) * height
+        rotation_degree = RNG.uniform(-self.max_rotate_degree, self.max_rotate_degree)
+        scaling_ratio = RNG.uniform(self.scaling_ratio_range[0], self.scaling_ratio_range[1])
+        x_shear_degree = RNG.uniform(-self.max_shear_degree, self.max_shear_degree)
+        y_shear_degree = RNG.uniform(-self.max_shear_degree, self.max_shear_degree)
+        trans_x = RNG.uniform(-self.max_translate_ratio, self.max_translate_ratio) * width
+        trans_y = RNG.uniform(-self.max_translate_ratio, self.max_translate_ratio) * height
 
         # Create transformation matrices
         rotation_matrix = self._get_rotation_matrix(rotation_degree)
@@ -1633,7 +1634,7 @@ class CachedMosaic(tvt_v2.Transform, NumpytoTVTensorMixin):
         Returns:
             list: indexes.
         """
-        return [random.randint(0, len(cache) - 1) for _ in range(3)]
+        return [RNG.integers(0, len(cache) - 1) for _ in range(3)]
 
     @typing.no_type_check  # TODO(ashwinvaidya17): temporary
     def forward(self, *_inputs: OTXDataItem) -> OTXDataItem | None:
@@ -1643,13 +1644,13 @@ class CachedMosaic(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         self.results_cache.append(copy.deepcopy(inputs))
         if len(self.results_cache) > self.max_cached_images:
-            index = random.randint(0, len(self.results_cache) - 1) if self.random_pop else 0
+            index = RNG.integers(0, len(self.results_cache) - 1) if self.random_pop else 0
             self.results_cache.pop(index)
 
         if len(self.results_cache) <= 4:
             return self.convert(inputs)
 
-        if random.uniform(0, 1) > self.prob:
+        if RNG.uniform(0, 1) > self.prob:
             return self.convert(inputs)
 
         indices = self.get_indexes(self.results_cache)
@@ -1678,8 +1679,8 @@ class CachedMosaic(tvt_v2.Transform, NumpytoTVTensorMixin):
             )
 
         # mosaic center x, y
-        center_x = int(random.uniform(*self.center_ratio_range) * self.img_scale[1])
-        center_y = int(random.uniform(*self.center_ratio_range) * self.img_scale[0])
+        center_x = int(RNG.uniform(*self.center_ratio_range) * self.img_scale[1])
+        center_y = int(RNG.uniform(*self.center_ratio_range) * self.img_scale[0])
         center_position = (center_x, center_y)
 
         loc_strs = ("top_left", "top_right", "bottom_left", "bottom_right")
@@ -1941,7 +1942,7 @@ class CachedMixUp(tvt_v2.Transform, NumpytoTVTensorMixin):
             int: index.
         """
         for _ in range(self.max_iters):
-            index = random.randint(0, len(cache) - 1)
+            index = RNG.integers(0, len(cache) - 1)
             gt_bboxes_i = cache[index].bboxes
             if len(gt_bboxes_i) != 0:
                 break
@@ -1956,13 +1957,13 @@ class CachedMixUp(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         self.results_cache.append(copy.deepcopy(inputs))
         if len(self.results_cache) > self.max_cached_images:
-            index = random.randint(0, len(self.results_cache) - 1) if self.random_pop else 0
+            index = RNG.integers(0, len(self.results_cache) - 1) if self.random_pop else 0
             self.results_cache.pop(index)
 
         if len(self.results_cache) <= 1:
             return self.convert(inputs)
 
-        if random.uniform(0, 1) > self.prob:
+        if RNG.uniform(0, 1) > self.prob:
             return self.convert(inputs)
 
         index = self.get_indexes(self.results_cache)
@@ -1977,8 +1978,8 @@ class CachedMixUp(tvt_v2.Transform, NumpytoTVTensorMixin):
         retrieve_img: np.ndarray = to_np_image(retrieve_results.image)
         with_mask = bool(hasattr(inputs, "masks") or hasattr(inputs, "polygons"))
 
-        jit_factor = random.uniform(*self.ratio_range)
-        is_flip = random.uniform(0, 1) > self.flip_ratio
+        jit_factor = RNG.uniform(*self.ratio_range)
+        is_flip = RNG.uniform(0, 1) > self.flip_ratio
 
         if len(retrieve_img.shape) == 3:
             out_img = (
@@ -2019,9 +2020,9 @@ class CachedMixUp(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         x_offset, y_offset = 0, 0
         if padded_img.shape[0] > target_h:
-            y_offset = random.randint(0, padded_img.shape[0] - target_h)
+            y_offset = RNG.integers(0, padded_img.shape[0] - target_h)
         if padded_img.shape[1] > target_w:
-            x_offset = random.randint(0, padded_img.shape[1] - target_w)
+            x_offset = RNG.integers(0, padded_img.shape[1] - target_w)
         padded_cropped_img = padded_img[y_offset : y_offset + target_h, x_offset : x_offset + target_w]
 
         # 6. adjust bbox
@@ -2170,13 +2171,13 @@ class YOLOXHSVRandomAug(tvt_v2.Transform, NumpytoTVTensorMixin):
 
     @cache_randomness
     def _get_hsv_gains(self) -> np.ndarray:
-        hsv_gains = np.random.uniform(-1, 1, 3) * [
+        hsv_gains = RNG.uniform(-1, 1, 3) * [
             self.hue_delta,
             self.saturation_delta,
             self.value_delta,
         ]
         # random selection of h, s, v
-        hsv_gains *= random.randint(0, 2, 3)
+        hsv_gains *= RNG.integers(0, 2, 3)
         # prevent overflow
         return hsv_gains.astype(np.int16)
 
@@ -2422,8 +2423,8 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
         assert len(scales) == 2  # noqa: S101
         scale_0 = [scales[0][0], scales[1][0]]
         scale_1 = [scales[0][1], scales[1][1]]
-        edge_0 = np.random.randint(min(scale_0), max(scale_0) + 1)
-        edge_1 = np.random.randint(min(scale_1), max(scale_1) + 1)
+        edge_0 = RNG.integers(min(scale_0), max(scale_0) + 1)
+        edge_1 = RNG.integers(min(scale_1), max(scale_1) + 1)
         return (edge_0, edge_1)
 
     @staticmethod
@@ -2446,7 +2447,7 @@ class RandomResize(tvt_v2.Transform, NumpytoTVTensorMixin):
         assert len(scale) == 2  # noqa: S101
         min_ratio, max_ratio = ratio_range
         assert min_ratio <= max_ratio  # noqa: S101
-        ratio = np.random.random_sample() * (max_ratio - min_ratio) + min_ratio
+        ratio = RNG.randomom_sample() * (max_ratio - min_ratio) + min_ratio
         return int(scale[0] * ratio), int(scale[1] * ratio)
 
     @cache_randomness
@@ -2664,8 +2665,8 @@ class RandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
             tuple[int, int]: The random offset for the crop.
         """
         margin_h, margin_w = margin
-        offset_h = np.random.randint(0, margin_h + 1)
-        offset_w = np.random.randint(0, margin_w + 1)
+        offset_h = RNG.integers(0, margin_h + 1)
+        offset_w = RNG.integers(0, margin_w + 1)
 
         return offset_h, offset_w
 
@@ -2685,8 +2686,8 @@ class RandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         if self.crop_type == "absolute_range":
             # `self.crop_size` is used as range, not absolute value
-            crop_h = np.random.randint(min(h, self.crop_size[0]), min(h, self.crop_size[1]) + 1)
-            crop_w = np.random.randint(min(w, self.crop_size[0]), min(w, self.crop_size[1]) + 1)
+            crop_h = RNG.integers(min(h, self.crop_size[0]), min(h, self.crop_size[1]) + 1)
+            crop_w = RNG.integers(min(w, self.crop_size[0]), min(w, self.crop_size[1]) + 1)
             return crop_h, crop_w
 
         if self.crop_type == "relative":
@@ -2695,7 +2696,7 @@ class RandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         # 'relative_range'
         crop_size = np.asarray(self.crop_size, dtype=np.float32)
-        crop_h, crop_w = crop_size + np.random.rand(2) * (1 - crop_size)
+        crop_h, crop_w = crop_size + RNG.random(2) * (1 - crop_size)
         return int(h * crop_h + 0.5), int(w * crop_w + 0.5)
 
     @typing.no_type_check  # TODO(ashwinvaidya17): temporary
@@ -2821,18 +2822,18 @@ class TopdownAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         # Get shift parameters
         offset = offset_v * self.shift_factor
-        offset = np.where(np.random.rand(1) < self.shift_prob, offset, 0.0)
+        offset = np.where(RNG.random(1) < self.shift_prob, offset, 0.0)
 
         # Get scaling parameters
         scale_min, scale_max = self.scale_factor
         mu = (scale_max + scale_min) * 0.5
         sigma = (scale_max - scale_min) * 0.5
         scale = scale_v * sigma + mu
-        scale = np.where(np.random.rand(1) < self.scale_prob, scale, 1.0)
+        scale = np.where(RNG.random(1) < self.scale_prob, scale, 1.0)
 
         # Get rotation parameters
         rotate = rotate_v * self.rotate_factor
-        rotate = np.where(np.random.rand() < self.rotate_prob, rotate, 0.0)
+        rotate = np.where(RNG.random() < self.rotate_prob, rotate, 0.0)
 
         return offset, scale, rotate
 
@@ -2935,7 +2936,7 @@ class TopdownAffine(tvt_v2.Transform, NumpytoTVTensorMixin):
 
         h, w = self.input_size
         warp_size = (int(w), int(h))
-        apply_transforms = np.random.rand()
+        apply_transforms = RNG.random()
         ori_img_shape = inputs.img_info.ori_shape
 
         if apply_transforms <= self.affine_transforms_prob:

--- a/library/src/otx/data/transform_libs/torchvision.py
+++ b/library/src/otx/data/transform_libs/torchvision.py
@@ -180,8 +180,8 @@ class MinIoURandomCrop(tvt_v2.Transform, NumpytoTVTensorMixin):
                 if new_h / new_w < 0.5 or new_h / new_w > 2:
                     continue
 
-                left = RNG.uniform(w - new_w)
-                top = RNG.uniform(h - new_h)
+                left = RNG.uniform(0, w - new_w)
+                top = RNG.uniform(0, h - new_h)
 
                 patch = np.array((int(left), int(top), int(left + new_w), int(top + new_h)))
                 # Line or point crop is not allowed

--- a/library/tests/unit/backend/native/exporter/exportable_code/demo/demo_package/streamer/test_streamer.py
+++ b/library/tests/unit/backend/native/exporter/exportable_code/demo/demo_package/streamer/test_streamer.py
@@ -17,6 +17,8 @@ ThreadedStreamer = None
 VideoStreamer = None
 get_streamer = None
 
+RNG = np.random.default_rng(42)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def fxt_import_module():
@@ -133,7 +135,7 @@ def random_single_video(tmp_path, width: int = 480, height: int = 360, number_of
 
 
 def _write_random_image(width: int, height: int, filename: str) -> None:
-    img = np.uint8(np.random.random((height, width, 3)) * 255)
+    img = np.uint8(RNG.random((height, width, 3)) * 255)
     cv2.imwrite(filename, img)
 
 
@@ -143,7 +145,7 @@ def _write_random_video(width: int, height: int, number_of_frames: int, filename
     videowriter = cv2.VideoWriter(f, fourcc, 30, (width, height))
 
     for _ in range(number_of_frames):
-        img = np.uint8(np.random.random((height, width, 3)) * 255)
+        img = np.uint8(RNG.random((height, width, 3)) * 255)
         videowriter.write(img)
 
     videowriter.release()

--- a/library/tests/unit/backend/native/models/common/test_iou2d_calculator.py
+++ b/library/tests/unit/backend/native/models/common/test_iou2d_calculator.py
@@ -10,13 +10,15 @@ import torch
 from otx.backend.native.models.common.utils.assigners.iou2d_calculator import BboxOverlaps2D
 from otx.backend.native.models.common.utils.bbox_overlaps import bbox_overlaps
 
+RNG = np.random.default_rng(42)
+
 
 def test_bbox_overlaps_2d(eps: float = 1e-7):
     def _construct_bbox(num_bbox: int | None = None) -> tuple[torch.Tensor, int]:
-        img_h = int(np.random.randint(3, 1000))
-        img_w = int(np.random.randint(3, 1000))
+        img_h = int(RNG.integers(3, 1000))
+        img_w = int(RNG.integers(3, 1000))
         if num_bbox is None:
-            num_bbox = np.random.randint(1, 10)
+            num_bbox = RNG.integers(1, 10)
         x1y1 = torch.rand((num_bbox, 2))
         x2y2 = torch.max(torch.rand((num_bbox, 2)), x1y1)
         bboxes = torch.cat((x1y1, x2y2), -1)

--- a/library/tests/unit/backend/native/models/keypoint_detection/utils/test_simcc_label.py
+++ b/library/tests/unit/backend/native/models/keypoint_detection/utils/test_simcc_label.py
@@ -7,11 +7,13 @@ import pytest
 
 from otx.backend.native.models.keypoint_detection.utils.simcc_label import SimCCLabel
 
+RNG = np.random.default_rng(42)
+
 
 class TestSimCCLabel:
     @pytest.fixture()
     def fxt_keypoints(self):
-        return (0.1 + 0.8 * np.random.rand(1, 17, 2)) * [192, 256]
+        return (0.1 + 0.8 * RNG.random((1, 17, 2))) * [192, 256]
 
     @pytest.fixture()
     def fxt_keypoints_visible(self):
@@ -57,8 +59,8 @@ class TestSimCCLabel:
     )
     def test_decode(self, fxt_codec, request):
         codec = request.getfixturevalue(fxt_codec)
-        simcc_x = np.random.rand(1, 17, int(192 * codec.simcc_split_ratio))
-        simcc_y = np.random.rand(1, 17, int(256 * codec.simcc_split_ratio))
+        simcc_x = RNG.random((1, 17, int(192 * codec.simcc_split_ratio)))
+        simcc_y = RNG.random((1, 17, int(256 * codec.simcc_split_ratio)))
 
         keypoints, scores = codec.decode(simcc_x, simcc_y)
         assert keypoints.shape == (1, 17, 2)
@@ -66,8 +68,8 @@ class TestSimCCLabel:
 
         codec.decode_scores = True
 
-        simcc_x = np.random.rand(1, 17, int(192 * codec.simcc_split_ratio)) * 10
-        simcc_y = np.random.rand(1, 17, int(256 * codec.simcc_split_ratio)) * 10
+        simcc_x = RNG.random((1, 17, int(192 * codec.simcc_split_ratio))) * 10
+        simcc_y = RNG.random((1, 17, int(256 * codec.simcc_split_ratio))) * 10
         keypoints, scores = codec.decode(simcc_x, simcc_y)
 
         assert len(scores) == 1

--- a/library/tests/unit/data/dataset/test_base.py
+++ b/library/tests/unit/data/dataset/test_base.py
@@ -9,12 +9,14 @@ from datumaro.components.media import Image
 
 from otx.data.dataset.base import OTXDataset
 
+RNG = np.random.default_rng(42)
+
 
 class TestOTXDataset:
     @pytest.fixture()
     def mock_image(self) -> Image:
         img = mock.Mock(spec=Image)
-        img.data = np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8)
+        img.data = RNG.integers(0, 256, (10, 10, 3), dtype=np.uint8)
         img.path = "test_path"
         return img
 

--- a/library/tests/unit/data/test_tiling.py
+++ b/library/tests/unit/data/test_tiling.py
@@ -36,6 +36,8 @@ from otx.types.task import OTXTaskType
 from otx.types.transformer_libs import TransformLibType
 from tests.test_helpers import generate_random_bboxes
 
+RNG = np.random.default_rng(42)
+
 
 class TestOTXTiling:
     @pytest.fixture()
@@ -250,11 +252,10 @@ class TestOTXTiling:
         data_root = str(fxt_data_roots[task])
         dataset = DmDataset.import_from(data_root, format=dataset_format)
 
-        rng = np.random.default_rng()
-        tile_size = rng.integers(low=50, high=128, size=(2,))
-        overlap = rng.random(2)
+        tile_size = RNG.integers(low=50, high=128, size=(2,))
+        overlap = RNG.random(2)
         overlap = overlap.clip(0, 0.9)
-        threshold_drop_ann = rng.random()
+        threshold_drop_ann = RNG.random()
         tiled_dataset = DmDataset.import_from(data_root, format=dataset_format)
         tiled_dataset.transform(
             OTXTileTransform,
@@ -348,8 +349,7 @@ class TestOTXTiling:
 
     def test_tile_sampler(self, fxt_data_config):
         for task, data_config in fxt_data_config.items():
-            rng = np.random.default_rng()
-            sampling_ratio = rng.random()
+            sampling_ratio = RNG.random()
             data_config["tile_config"] = TileConfig(
                 enable_tiler=True,
                 enable_adaptive_tiling=False,
@@ -539,17 +539,16 @@ class TestOTXTiling:
             model.forward_tiles(batch)
 
     def test_seg_tiler(self, mocker):
-        rng = np.random.default_rng()
-        rnd_tile_size = rng.integers(low=100, high=500)
-        rnd_tile_overlap = rng.random() * 0.75
-        image_size = rng.integers(low=1000, high=5000)
+        rnd_tile_size = RNG.integers(low=100, high=500)
+        rnd_tile_overlap = RNG.random() * 0.75
+        image_size = RNG.integers(low=1000, high=5000)
         np_image = np.zeros((image_size, image_size, 3), dtype=np.uint8)
 
         mock_model = MagicMock(spec=Model)
         mocker.patch("model_api.tilers.tiler.Tiler.__init__", return_value=None)
         mocker.patch.multiple(SemanticSegmentationTiler, __abstractmethods__=set())
 
-        num_labels = rng.integers(low=1, high=10)
+        num_labels = RNG.integers(low=1, high=10)
 
         tiler = SemanticSegmentationTiler(model=mock_model)
         tiler.model = mock_model
@@ -564,7 +563,7 @@ class TestOTXTiling:
             h, w = y2 - y1, x2 - x1
             tile_predictions = ImageResultWithSoftPrediction(
                 resultImage=np.zeros((h, w), dtype=np.uint8),
-                soft_prediction=np.random.rand(h, w, num_labels),
+                soft_prediction=RNG.random((h, w, num_labels)),
                 feature_vector=np.array([]),
                 saliency_map=np.array([]),
             )

--- a/library/tests/unit/data/transform_libs/test_torchvision.py
+++ b/library/tests/unit/data/transform_libs/test_torchvision.py
@@ -36,6 +36,8 @@ from otx.data.transform_libs.torchvision import (
 )
 from otx.data.transform_libs.utils import overlap_bboxes
 
+RNG = np.random.default_rng(42)
+
 
 class MockFrame:
     data = np.ndarray([10, 10, 3], dtype=np.uint8)
@@ -1123,7 +1125,7 @@ class TestRandomCrop:
     @pytest.mark.parametrize("allow_negative_crop", [True, False])
     def test_forward_allow_negative_crop(self, det_entity, allow_negative_crop: bool) -> None:
         # test the crop does not contain any gt-bbox allow_negative_crop = False
-        det_entity.image = np.random.randint(0, 255, size=(10, 10), dtype=np.uint8)
+        det_entity.image = RNG.integers(0, 255, size=(10, 10), dtype=np.uint8)
         det_entity.bboxes = tv_tensors.wrap(torch.zeros((0, 4)), like=det_entity.bboxes)
         det_entity.label = torch.LongTensor()
         transform = RandomCrop(crop_size=(5, 3), allow_negative_crop=allow_negative_crop, is_numpy_to_tvtensor=False)

--- a/library/tests/unit/data/utils/test_utils.py
+++ b/library/tests/unit/data/utils/test_utils.py
@@ -25,6 +25,8 @@ from otx.data.utils.utils import (
     import_object_from_module,
 )
 
+RNG = np.random.default_rng(42)
+
 
 def test_compute_robust_statistics():
     values = np.array([])
@@ -37,7 +39,7 @@ def test_compute_robust_statistics():
     assert np.isclose(stat["min"], 0.5)
     assert np.isclose(stat["max"], 1.5)
 
-    values = np.random.rand(10)
+    values = RNG.random(10)
     stat = compute_robust_statistics(values)
     assert np.isclose(stat["min"], np.min(values))
     assert np.isclose(stat["max"], np.max(values))
@@ -56,7 +58,7 @@ def test_compute_robust_scale_statistics():
     assert np.isclose(stat["min"], 0.5)
     assert np.isclose(stat["max"], 2.0)
 
-    scales = np.random.rand(10)
+    scales = RNG.random(10)
     stat = compute_robust_scale_statistics(scales)
     assert np.isclose(stat["min"], np.min(scales))
     assert np.isclose(stat["max"], np.max(scales))


### PR DESCRIPTION
### Summary

Changes:
- Upgrade numpy to 2.x in `library/` (OTX)
  - The upgrade is necessary because numpy 1.x is now quite old and leads to dependency conflicts
- Resolve all NPY issues reported by ruff
- Source `imgaug` (dependency of `anomalib`) from a fork to avoid runtime errors due to obsolete numpy code

### How to test

Verify that the requirements have no conflicts: `uv lock --check`

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
