### PR TITLE
CPU-only installation mode for OTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,37 +73,35 @@ If you want to make changes to the library, then a local installation is recomme
 
 <details>
 <summary>Install from PyPI</summary>
-Installing the library with uv tool is the easiest way to get started with otx.
+Installing the library with pip or uv is the easiest way to get started with otx.
 
 ```bash
-uv pip install otx[cuda]
-```
+# Without GPU support (CPU only)
+pip install otx[cpu]
 
-For Intel GPUs users:
+# With Intel GPU support (XPU)
+pip install otx[xpu]
 
-```bash
-uv pip install otx[xpu]
+# With NVIDIA GPU support (CUDA)
+pip install otx[cuda]
 ```
 
 </details>
 
 <details>
 <summary>Install from source</summary>
-To install from source, you need to clone the repository and install the library using uv pip via editable mode.
+To install from source, you need to clone the repository and install the library with pip or uv.
+It is recommended to use a virtual environment to avoid conflicts with other packages.
 
 ```bash
-# Create a new virtual environment using uv (Python 3.11)
-uv venv .otx --python 3.11
-source .otx/bin/activate
-
 # Clone the repository
 git clone https://github.com/open-edge-platform/training_extensions.git
 cd training_extensions
 
-# Install in editable mode
-uv pip install -e .[cuda]
-# For Intel GPUs users
-uv pip install -e .[xpu]
+# Install (optional: pass the '-e' flag for editable mode
+# If you have an Intel GPU, use 'xpu' to enable support.
+# If you have an NVIDIA GPU, use 'cuda' to enable support.
+pip install -e .[cpu]
 ```
 
 </details>

--- a/library/docs/source/guide/get_started/installation.rst
+++ b/library/docs/source/guide/get_started/installation.rst
@@ -16,139 +16,95 @@ The current version of OpenVINO™ Training Extensions was tested in the followi
     To enable efficient execution of multiple models, we increase the ONEDNN_PRIMITIVE_CACHE_CAPACITY environment variable from its default value to 10000.
     For more information, refer to the `Primitive cache <https://www.intel.com/content/www/us/en/docs/onednn/developer-guide-reference/2024-1/primitive-cache-002.html>`_.
 
-***************
-Installing ``uv``
-***************
+*****************
+Install from pypi
+*****************
 
-To use OpenVINO™ Training Extensions with ``uv``, you first need to install the ``uv`` tool.
+The easiest way to install OpenVINO™ Training Extensions is via PyPI (`otx <https://pypi.org/project/otx>`_ package).
 
-You can install it in one of the following ways:
-
-.. tab-set::
-
-    .. tab-item:: Recommended (Standalone Binary)
-
-        .. code-block:: shell
-
-            curl -LsSf https://astral.sh/uv/install.sh | sh
-
-        This method installs ``uv`` globally as a fast and portable binary.
-        After installation, make sure ``uv`` is available in your ``PATH``.
-
-    .. tab-item:: Via pip (Python-based)
-
-        .. code-block:: shell
-
-            pip install uv
-
-        This installs ``uv`` inside the currently active Python environment.
-
-    .. tab-item:: Verify Installation
-
-        After installation, confirm it works:
-
-        .. code-block:: shell
-
-            uv --version
-
-
-**********************************************************
-Install OpenVINO™ Training Extensions for users (CUDA/CPU)
-**********************************************************
-
-1. Install OpenVINO™ Training Extensions package:
-
-* A local source in development mode
+Select the extra dependencies according to your hardware:
 
 .. tab-set::
 
-    .. tab-item:: PyPI
+    .. tab-item:: CPU only
 
         .. code-block:: shell
 
-            # Create a virtual environment using uv
-            uv venv .otx --python 3.12 # or 3.11
-            source .otx/bin/activate
+            pip install otx[cpu]
 
-            # Install from PyPI
-            uv pip install otx[cuda]
-
-    .. tab-item:: Source
+    .. tab-item:: Intel GPU (XPU)
 
         .. code-block:: shell
 
-            # Clone the training_extensions repository:
+            pip install otx[xpu]
+
+    .. tab-item:: Nvidia GPU (CUDA)
+
+        .. code-block:: shell
+
+            pip install otx[cuda]
+
+.. note::
+
+    It is always recommended to use a virtual environment to avoid conflicts with other packages.
+
+After the installation, you can verify it works with:
+
+.. code-block:: shell
+
+    otx --help
+
+
+*******************
+Install from source
+*******************
+
+If you want to install OpenVINO™ Training Extensions from source, you have to first clone the repository,
+then install the package.
+
+.. tab-set::
+
+    .. tab-item:: CPU only
+
+        .. code-block:: shell
+
             git clone https://github.com/open-edge-platform/training_extensions.git
-            cd training_extensions
+            cd training_extensions/library
+            pip install .[cpu]
 
-            # Create a virtual environment with uv
-            uv venv .otx --python 3.12 # or 3.11
-            source .otx/bin/activate
+    .. tab-item:: Intel GPU (XPU)
 
-            # Install the package in editable mode with base dependencies
-            uv pip install -e .[cuda]
+        .. code-block:: shell
 
-            # Install OTX in development mode
-            uv pip install -e .[dev,cuda]
+            git clone https://github.com/open-edge-platform/training_extensions.git
+            cd training_extensions/library
+            pip install .[xpu]
 
-2. Once the package is installed in the virtual environment, you can use the full
-OpenVINO™ Training Extensions command line functionality.
+    .. tab-item:: Nvidia GPU (CUDA)
 
-.. code-block:: shell
+        .. code-block:: shell
 
-    otx --help
+            git clone https://github.com/open-edge-platform/training_extensions.git
+            cd training_extensions/library
+            pip install .[gpu]
 
-*************************************************************
-Install OpenVINO™ Training Extensions for users (Intel GPUs)
-*************************************************************
 
-1. Install OpenVINO™ Training Extensions from source to use Intel XPU functionality:
+**************
+For developers
+**************
 
-.. code-block:: shell
+For developers, it is recommended to use `uv` to automatically manage virtual environments and dependencies.
 
+.. code-block::
+
+    # Clone the repo
     git clone https://github.com/open-edge-platform/training_extensions.git
-    cd training_extensions
+    cd training_extensions/library
 
-    uv venv .otx --python 3.12 # or 3.11
-    source .otx/bin/activate
+    # Create a virtual environment with uv and sync dependencies
+    uv sync --extra cpu  # or 'xpu' or 'cuda', depending on your hardware
 
-    uv pip install -e .[xpu]
-
-.. note::
-
-    Please refer to the `PyTorch XPU installation guide <https://pytorch.org/docs/stable/notes/get_start_xpu.html>`_
-    to install prerequisites and resolve any potential issues.
-
-2. Once installed, use the command-line interface:
-
-.. code-block:: shell
-
-    otx --help
-
-****************************************************
-Install OpenVINO™ Training Extensions for developers
-****************************************************
-
-1. Install ``tox`` with the ``tox-uv`` plugin using uv's tool system:
-
-.. code-block:: shell
-
-    uv tool install tox --with tox-uv
-
-2. Create a development environment using ``tox``:
-
-.. code-block:: shell
-
-    # Replace '312' with '311' if using Python 3.11
-    tox devenv venv/otx -e unit-test-py312
-    source venv/otx/bin/activate
-
-Now you're ready to develop, test, and make changes — all reflected live in the editable install.
-
-.. note::
-
-    By installing ``tox`` with ``uv tool``, you ensure it runs in a reproducible and isolated environment,
-    with ``uv`` used internally to manage dependencies for each test environment.
+If you plan to edit the documentation, also install the `docs` extra.
 
 
 *****************************************************

--- a/library/docs/source/guide/get_started/installation.rst
+++ b/library/docs/source/guide/get_started/installation.rst
@@ -86,7 +86,7 @@ then install the package.
 
             git clone https://github.com/open-edge-platform/training_extensions.git
             cd training_extensions/library
-            pip install .[gpu]
+            pip install .[cuda]
 
 
 **************

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "docstring_parser==0.16", # CLI help-formatter
     "rich_argparse==1.7.0", # CLI help-formatter
     "einops==0.8.1",
-    "decord==0.6.0",
     "typeguard>=4.3,<4.5",
     "setuptools==78.1.1",
     "lightning==2.4.0",
@@ -45,14 +44,14 @@ dependencies = [
     "pytorchcv==0.0.67",
     "timm==1.0.3",
     "openvino==2025.2",
-    "openvino-model-api==0.3.0.2",
+    "openvino-model-api==0.3.0.4",
     "onnx==1.17.0",
     "onnxconverter-common==1.16.0",
     "onnxscript==0.5.3",
     "nncf==2.17.0",
     "anomalib[core]==1.1.3",
     "imgaug==0.4.0",  # for anomalib
-    "numpy>2.0",
+    "numpy>=2.0",
     "tensorboardx==2.6.4"
 ]
 
@@ -71,8 +70,13 @@ dev = [
     "onnxruntime==1.21.1",
 ]
 
-cuda = ["torch==2.8.0",
-        "torchvision==0.23.0"
+cpu = [
+    "torch==2.8.0",
+    "torchvision==0.23.0"
+]
+cuda = [
+    "torch==2.8.0",
+    "torchvision==0.23.0"
 ]
 xpu = [
     "torch==2.8.0+xpu",
@@ -118,6 +122,7 @@ Repository = "https://github.com/open-edge-platform/training_extensions/"
 [tool.uv]
 conflicts = [
     [
+        { extra = "cpu" },
         { extra = "xpu" },
         { extra = "cuda" },
     ],
@@ -125,6 +130,7 @@ conflicts = [
 
 [tool.uv.sources]
 torch = [
+    { index = "torch-cpu", extra = "cpu"},
     { index = "torch-xpu", extra = "xpu"},
     { index = "torch-cuda", extra = "cuda"},
 ]
@@ -132,6 +138,7 @@ pytorch-triton-xpu = [
     { index = "torch-xpu", extra = "xpu"},
 ]
 torchvision = [
+    { index = "torch-cpu", extra = "cpu"},
     { index = "torch-xpu", extra = "xpu"},
     { index = "torch-cuda", extra = "cuda"},
 ]
@@ -139,6 +146,11 @@ torchvision = [
 # To avoid dependency resolution issues, we install imgaug from a maintained fork.
 # For details: https://github.com/aleju/imgaug/issues/859
 imgaug = { git = "https://github.com/imaug/imaug/", rev = "a7ca1b04d44700d075a23f14a97f86285ba3b33f" }
+
+[[tool.uv.index]]
+name = "torch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [[tool.uv.index]]
 name = "torch-cuda"

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -2,7 +2,7 @@
 # SETUP CONFIGURATION.                                                        #
 [build-system]
 requires = [
-    "setuptools>=61",
+    "setuptools>=77.0.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
@@ -13,13 +13,12 @@ dynamic = ["version"]
 description = "OpenVINO™ Training Extensions: Train, Evaluate, Optimize, Deploy Computer Vision Models via OpenVINO™"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
 authors = [
     { name = "OpenVINO™ Training Extensions Contributors" },
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "timm==1.0.3",
     "openvino==2025.2",
     "openvino-model-api==0.3.0.4",
-    "onnx==1.17.0",
+    "onnx==1.19.1",
     "onnxconverter-common==1.16.0",
     "onnxscript==0.5.3",
     "nncf==2.17.0",


### PR DESCRIPTION
### Summary

Resolves #4971 

Changes:
- Add 'cpu' extra dependency to install OTX in CPU-only mode
    - CPU is the most lightweight installation option as it doesn't include GPU/XPU drivers
    - It can be useful for platforms that don't have a GPU (embedded devices, laptops, CI workers, ...)
- Update documentation to install OTX
- Upgrade `onnx` dependency to solve build problems
- Upgrade `openvino-model-api` dependency
- Remove unnecessary `decord` dependency

### How to test

In `library/`, run `uv sync --extra cpu` to create a venv with CPU-only OTX.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
