### PR TITLE
Add confidence field to prediction dataset samples

### DIFF
--- a/application/backend/app/models/dataset_item.py
+++ b/application/backend/app/models/dataset_item.py
@@ -12,11 +12,15 @@ from .shape import Shape
 
 
 class DatasetItemFormat(StrEnum):
+    """Format of the image related to the dataset item."""
+
     JPG = "jpg"
     PNG = "png"
 
 
 class DatasetItemSubset(StrEnum):
+    """Subset of the dataset item."""
+
     UNASSIGNED = "unassigned"
     TRAINING = "training"
     VALIDATION = "validation"
@@ -25,24 +29,52 @@ class DatasetItemSubset(StrEnum):
 
 class DatasetItemAnnotation(BaseModel):
     """
-    Dataset item annotation
+    DatasetItemAnnotation represents an individual annotation within a dataset item.
+
+    An annotation consists of a shape, one or more labels associated with that shape,
+    and optionally a confidence score for each label (if applicable, e.g., for model predictions).
+
+    Attributes:
+        labels: A list of references to labels associated with the annotation.
+        shape: The geometric shape defining the annotation area.
+        confidences: A list of confidence scores corresponding to each label (if applicable).
     """
 
-    labels: list[LabelReference]
     shape: Shape
-    confidence: float | None = None
+    labels: list[LabelReference]
+    confidences: list[float] | None = None
 
     model_config = {
         "json_schema_extra": {
             "example": {
-                "labels": [{"id": "d476573e-d43c-42a6-9327-199a9aa75c33"}],
                 "shape": {"type": "rectangle", "x": 10, "y": 20, "width": 100, "height": 200},
+                "labels": [{"id": "d476573e-d43c-42a6-9327-199a9aa75c33"}],
             }
         }
     }
 
 
 class DatasetItem(BaseEntity):
+    """
+    DatasetItem represents an individual item within a dataset.
+
+    Attributes:
+        id: Unique identifier for the dataset item.
+        project_id: Identifier of the project to which the dataset item belongs.
+        name: Name of the dataset item.
+        format: Format of the dataset item (e.g., JPG, PNG).
+        width: Width of the dataset item in pixels.
+        height: Height of the dataset item in pixels.
+        size: Size of the dataset item in bytes.
+        annotation_data: List of annotations associated with the dataset item.
+        user_reviewed: Indicates whether the dataset item has been reviewed by a user,
+            namely if its annotation has been created/accepted by a human or if it is just a raw model prediction.
+        prediction_model_id: Identifier of the model that generated predictions for this dataset item, if applicable.
+        source_id: Identifier of the source from which the dataset item was acquired, if applicable.
+        subset: Subset to which the dataset item belongs (e.g., training, validation, testing).
+        subset_assigned_at: Timestamp indicating when the dataset item was assigned to its subset.
+    """
+
     id: UUID
     project_id: UUID
     name: str

--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -57,7 +57,7 @@ class MultilabelClassificationSample(Sample):
 
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after datumaro/issues/1949 is solved
+    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
     label: np.ndarray = label_field(dtype=pl.Int32, multi_label=True)
     confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
@@ -76,7 +76,7 @@ class DetectionSample(Sample):
 
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after datumaro/issues/1949 is solved
+    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
     bboxes: np.ndarray = bbox_field(dtype=pl.Int32)
     label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
     confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
@@ -96,7 +96,7 @@ class InstanceSegmentationSample(Sample):
 
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after datumaro/issues/1949 is solved
+    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
     polygons: np.ndarray = polygon_field(dtype=pl.Float32)
     label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
     confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)

--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -21,7 +21,6 @@ from datumaro.experimental.fields import ImageInfo, polygon_field
 
 from app.models import DatasetItem, Label, Polygon, Rectangle, TaskType
 from app.schemas.project import ProjectBase
-from app.utils.typing import NDArrayFloat32, NDArrayInt
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +28,16 @@ CONVERSION_BATCH_SIZE = 50
 
 
 class ClassificationSample(Sample):
+    """
+    Sample for multiclass classification datasets.
+
+    Attributes:
+        image: Path to the image
+        image_info: Image information (width, height)
+        label: Class label index (0-based)
+        confidence: Confidence score for the label. Only for model predictions.
+    """
+
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     label: int = label_field(dtype=pl.Int32, is_list=False)
@@ -36,26 +45,61 @@ class ClassificationSample(Sample):
 
 
 class MultilabelClassificationSample(Sample):
+    """
+    Sample for multilabel classification datasets.
+
+    Attributes:
+        image: Path to the image
+        image_info: Image information (width, height)
+        label: Array of class label indices (0-based)
+        confidences: Array of confidence scores for each label. Only for model predictions.
+    """
+
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    label: NDArrayInt = label_field(dtype=pl.Int32, multi_label=True)
-    confidences: NDArrayFloat32 | None = score_field(dtype=pl.Float32, is_list=True)
+    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after datumaro/issues/1949 is solved
+    label: np.ndarray = label_field(dtype=pl.Int32, multi_label=True)
+    confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 class DetectionSample(Sample):
+    """
+    Sample for object detection datasets.
+
+    Attributes:
+        image: Path to the image
+        image_info: Image information (width, height)
+        bboxes: Array of bounding boxes in x1y1x2y2 format
+        label: Array of class label indices (0-based) for each bounding box
+        confidences: Array of confidence scores for each bounding box. Only for model predictions.
+    """
+
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    bboxes: NDArrayInt = bbox_field(dtype=pl.Int32)
-    label: NDArrayInt = label_field(dtype=pl.Int32, is_list=True)
-    confidences: NDArrayFloat32 | None = score_field(dtype=pl.Float32, is_list=True)
+    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after datumaro/issues/1949 is solved
+    bboxes: np.ndarray = bbox_field(dtype=pl.Int32)
+    label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
+    confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 class InstanceSegmentationSample(Sample):
+    """
+    Sample for instance segmentation datasets.
+
+    Attributes:
+        image: Path to the image
+        image_info: Image information (width, height)
+        polygons: Array of polygons, each represented as a list of points in xy format
+        label: Array of class label indices (0-based) for each polygon
+        confidences: Array of confidence scores for each polygon. Only for model predictions.
+    """
+
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    polygons: NDArrayFloat32 = polygon_field(dtype=pl.Float32)
-    label: NDArrayInt = label_field(dtype=pl.Int32, is_list=True)
-    confidences: NDArrayFloat32 | None = score_field(dtype=pl.Float32, is_list=True)
+    # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after datumaro/issues/1949 is solved
+    polygons: np.ndarray = polygon_field(dtype=pl.Float32)
+    label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
+    confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 def convert_rectangle(r: Rectangle) -> list[int]:
@@ -111,68 +155,6 @@ def _convert_dataset(
     return dataset
 
 
-def convert_detection_dataset(
-    project_labels: Sequence[Label],
-    get_dataset_items: Callable[[int, int], list[DatasetItem]],
-    get_image_path: Callable[[DatasetItem], str],
-) -> Dataset[DetectionSample]:
-    """
-    Convert detection dataset to Datumaro format
-
-    Args:
-        project_labels: List of project labels
-        get_dataset_items: Function to get a batch of dataset items
-        get_image_path: Function to get image path for a dataset item
-
-    Returns:
-        Dataset[DetectionSample]: Datumaro dataset
-    """
-
-    def _convert_sample(
-        dataset_item: DatasetItem, image_path: str, project_labels_ids: list[UUID]
-    ) -> DetectionSample | None:
-        if dataset_item.annotation_data is None:
-            return None
-        coords = [
-            convert_rectangle(annotation.shape)
-            for annotation in dataset_item.annotation_data
-            if (isinstance(annotation.shape, Rectangle))
-        ]
-        try:
-            labels_indexes = [
-                project_labels_ids.index(annotation.labels[0].id)
-                for annotation in dataset_item.annotation_data
-                if len(annotation.labels) == 1
-            ]
-        except ValueError:
-            logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
-            return None
-        # Every item must be either a model prediction (with confidence score) or a user annotation (without)
-        any_with_confidence = any(annotation.confidence is not None for annotation in annotations)
-        all_with_confidence = all(annotation.confidence is not None for annotation in annotations)
-        if any_with_confidence and not all_with_confidence:
-            logger.error(
-                f"Dataset item {dataset_item.id} contains shapes with and without confidence scores: {annotations}"
-            )
-            raise ValueError("Either all or none of the annotations must have confidence scores")
-        confidences = [annotation.confidence for annotation in annotations] if all_with_confidence else []
-        return DetectionSample(
-            image=image_path,
-            image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
-            bboxes=np.array(coords),
-            label=np.array(labels_indexes),
-            confidences=np.array(confidences) if confidences else None,
-        )
-
-    return _convert_dataset(
-        sample_type=DetectionSample,
-        project_labels=project_labels,
-        get_dataset_items=get_dataset_items,
-        get_image_path=get_image_path,
-        convert_sample=_convert_sample,
-    )
-
-
 def convert_classification_dataset(
     project_labels: Sequence[Label],
     get_dataset_items: Callable[[int, int], list[DatasetItem]],
@@ -196,11 +178,12 @@ def convert_classification_dataset(
         if dataset_item.annotation_data is None:
             return None
         try:
+            annotation = dataset_item.annotation_data[0]  # classification -> only one shape (annotation)
             return ClassificationSample(
                 image=image_path,
                 image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
-                label=project_labels_ids.index(dataset_item.annotation_data[0].labels[0].id),
-                confidence=dataset_item.annotation_data[0].confidence,
+                label=project_labels_ids.index(annotation.labels[0].id),  # multiclass -> only one label
+                confidence=annotation.confidences[0] if annotation.confidences else None,
             )
         except ValueError:
             logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
@@ -238,7 +221,8 @@ def convert_multilabel_classification_dataset(
         if dataset_item.annotation_data is None:
             return None
         try:
-            labels_indexes = [project_labels_ids.index(label.id) for label in dataset_item.annotation_data[0].labels]
+            annotation = dataset_item.annotation_data[0]  # classification -> only one shape (annotation)
+            labels_indexes = [project_labels_ids.index(label.id) for label in annotation.labels]
         except ValueError:
             logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
             return None
@@ -246,11 +230,81 @@ def convert_multilabel_classification_dataset(
             image=image_path,
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             label=np.array(labels_indexes),
-            confidences=None,  # TODO fix DatasetItemAnnotation definition to support confidences for multilabel
+            confidences=np.array(annotation.confidences) if annotation.confidences else None,
         )
 
     return _convert_dataset(
         sample_type=MultilabelClassificationSample,
+        project_labels=project_labels,
+        get_dataset_items=get_dataset_items,
+        get_image_path=get_image_path,
+        convert_sample=_convert_sample,
+    )
+
+
+def convert_detection_dataset(
+    project_labels: Sequence[Label],
+    get_dataset_items: Callable[[int, int], list[DatasetItem]],
+    get_image_path: Callable[[DatasetItem], str],
+) -> Dataset[DetectionSample]:
+    """
+    Convert detection dataset to Datumaro format
+
+    Args:
+        project_labels: List of project labels
+        get_dataset_items: Function to get a batch of dataset items
+        get_image_path: Function to get image path for a dataset item
+
+    Returns:
+        Dataset[DetectionSample]: Datumaro dataset
+    """
+
+    def _convert_sample(
+        dataset_item: DatasetItem, image_path: str, project_labels_ids: list[UUID]
+    ) -> DetectionSample | None:
+        if dataset_item.annotation_data is None:
+            return None
+        coords = [
+            convert_rectangle(annotation.shape)
+            for annotation in dataset_item.annotation_data
+            if (isinstance(annotation.shape, Rectangle))
+        ]
+        try:
+            labels_indexes = [
+                project_labels_ids.index(annotation.labels[0].id)
+                for annotation in dataset_item.annotation_data
+                if len(annotation.labels) == 1
+            ]
+        except ValueError:
+            logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
+            return None
+        # Every item must be either a model prediction (with confidence score) or a user annotation (without)
+        any_with_confidence = any(annotation.confidences is not None for annotation in dataset_item.annotation_data)
+        all_with_confidence = all(annotation.confidences is not None for annotation in dataset_item.annotation_data)
+        if any_with_confidence and not all_with_confidence:
+            logger.error(
+                f"Dataset item {dataset_item.id} contains shapes with and without "
+                f"confidence scores: {dataset_item.annotation_data}"
+            )
+            raise ValueError("Either all or none of the annotations must have confidence scores")
+        confidences = (
+            [  # list of confidence scores, one per bbox
+                annotation.confidences[0]  # type: ignore[index]
+                for annotation in dataset_item.annotation_data
+            ]
+            if all_with_confidence
+            else []
+        )
+        return DetectionSample(
+            image=image_path,
+            image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
+            bboxes=np.array(coords),
+            label=np.array(labels_indexes),
+            confidences=np.array(confidences) if confidences else None,
+        )
+
+    return _convert_dataset(
+        sample_type=DetectionSample,
         project_labels=project_labels,
         get_dataset_items=get_dataset_items,
         get_image_path=get_image_path,
@@ -295,14 +349,22 @@ def convert_instance_segmentation_dataset(
             logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
             return None
         # Every item must be either a model prediction (with confidence score) or a user annotation (without)
-        any_with_confidence = any(annotation.confidence is not None for annotation in annotations)
-        all_with_confidence = all(annotation.confidence is not None for annotation in annotations)
+        any_with_confidence = any(annotation.confidences is not None for annotation in dataset_item.annotation_data)
+        all_with_confidence = all(annotation.confidences is not None for annotation in dataset_item.annotation_data)
         if any_with_confidence and not all_with_confidence:
             logger.error(
-                f"Dataset item {dataset_item.id} contains shapes with and without confidence scores: {annotations}"
+                f"Dataset item {dataset_item.id} contains shapes with and without "
+                f"confidence scores: {dataset_item.annotation_data}"
             )
             raise ValueError("Either all or none of the annotations must have confidence scores")
-        confidences = [annotation.confidence for annotation in annotations] if all_with_confidence else []
+        confidences = (
+            [  # list of confidence scores, one per polygon
+                annotation.confidences[0]  # type: ignore[index]
+                for annotation in dataset_item.annotation_data
+            ]
+            if all_with_confidence
+            else []
+        )
         return InstanceSegmentationSample(
             image=image_path,
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),

--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -52,14 +52,14 @@ class MultilabelClassificationSample(Sample):
         image: Path to the image
         image_info: Image information (width, height)
         label: Array of class label indices (0-based)
-        confidences: Array of confidence scores for each label. Only for model predictions.
+        confidence: Array of confidence scores for each label. Only for model predictions.
     """
 
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
     label: np.ndarray = label_field(dtype=pl.Int32, multi_label=True)
-    confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
+    confidence: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 class DetectionSample(Sample):
@@ -71,7 +71,7 @@ class DetectionSample(Sample):
         image_info: Image information (width, height)
         bboxes: Array of bounding boxes in x1y1x2y2 format
         label: Array of class label indices (0-based) for each bounding box
-        confidences: Array of confidence scores for each bounding box. Only for model predictions.
+        confidence: Array of confidence scores for each bounding box. Only for model predictions.
     """
 
     image: str = image_path_field()
@@ -79,7 +79,7 @@ class DetectionSample(Sample):
     # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
     bboxes: np.ndarray = bbox_field(dtype=pl.Int32)
     label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
-    confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
+    confidence: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 class InstanceSegmentationSample(Sample):
@@ -91,7 +91,7 @@ class InstanceSegmentationSample(Sample):
         image_info: Image information (width, height)
         polygons: Array of polygons, each represented as a list of points in xy format
         label: Array of class label indices (0-based) for each polygon
-        confidences: Array of confidence scores for each polygon. Only for model predictions.
+        confidence: Array of confidence scores for each polygon. Only for model predictions.
     """
 
     image: str = image_path_field()
@@ -99,7 +99,7 @@ class InstanceSegmentationSample(Sample):
     # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
     polygons: np.ndarray = polygon_field(dtype=pl.Float32)
     label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
-    confidences: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
+    confidence: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 def convert_rectangle(r: Rectangle) -> list[int]:
@@ -230,7 +230,7 @@ def convert_multilabel_classification_dataset(
             image=image_path,
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             label=np.array(labels_indexes),
-            confidences=np.array(annotation.confidences) if annotation.confidences else None,
+            confidence=np.array(annotation.confidences) if annotation.confidences else None,
         )
 
     return _convert_dataset(
@@ -300,7 +300,7 @@ def convert_detection_dataset(
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             bboxes=np.array(coords),
             label=np.array(labels_indexes),
-            confidences=np.array(confidences) if confidences else None,
+            confidence=np.array(confidences) if confidences else None,
         )
 
     return _convert_dataset(
@@ -370,7 +370,7 @@ def convert_instance_segmentation_dataset(
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             polygons=np.array(polygons, dtype=np.float32),
             label=np.array(labels_indexes),
-            confidences=np.array(confidences) if confidences else None,
+            confidence=np.array(confidences) if confidences else None,
         )
 
     return _convert_dataset(

--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -2,47 +2,60 @@
 # SPDX-License-Identifier: Apache-2.0
 import logging
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from typing import TypeVar
 from uuid import UUID
 
 import numpy as np
 import polars as pl
-from datumaro.experimental import Dataset, Sample, bbox_field, image_info_field, image_path_field, label_field
+from datumaro.experimental import (
+    Dataset,
+    Sample,
+    bbox_field,
+    image_info_field,
+    image_path_field,
+    label_field,
+    score_field,
+)
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.fields import ImageInfo, polygon_field
 
 from app.models import DatasetItem, Label, Polygon, Rectangle, TaskType
 from app.schemas.project import ProjectBase
+from app.utils.typing import NDArrayFloat32, NDArrayInt
 
 logger = logging.getLogger(__name__)
 
 CONVERSION_BATCH_SIZE = 50
 
 
-class DetectionSample(Sample):
-    image: str = image_path_field()
-    image_info: ImageInfo = image_info_field()
-    bboxes: np.ndarray[Any, Any] = bbox_field(dtype=pl.Int32)
-    label: np.ndarray[Any, Any] = label_field(dtype=pl.Int32, is_list=True)
-
-
 class ClassificationSample(Sample):
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     label: int = label_field(dtype=pl.Int32, is_list=False)
+    confidence: float | None = score_field(dtype=pl.Float32)
 
 
 class MultilabelClassificationSample(Sample):
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    label: np.ndarray[Any, Any] = label_field(dtype=pl.Int32, multi_label=True)
+    label: NDArrayInt = label_field(dtype=pl.Int32, multi_label=True)
+    confidences: NDArrayFloat32 | None = score_field(dtype=pl.Float32, is_list=True)
+
+
+class DetectionSample(Sample):
+    image: str = image_path_field()
+    image_info: ImageInfo = image_info_field()
+    bboxes: NDArrayInt = bbox_field(dtype=pl.Int32)
+    label: NDArrayInt = label_field(dtype=pl.Int32, is_list=True)
+    confidences: NDArrayFloat32 | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 class InstanceSegmentationSample(Sample):
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    polygons: np.ndarray[Any, Any] = polygon_field(dtype=pl.Float32)
-    label: np.ndarray[Any, Any] = label_field(dtype=pl.Int32, is_list=True)
+    polygons: NDArrayFloat32 = polygon_field(dtype=pl.Float32)
+    label: NDArrayInt = label_field(dtype=pl.Int32, is_list=True)
+    confidences: NDArrayFloat32 | None = score_field(dtype=pl.Float32, is_list=True)
 
 
 def convert_rectangle(r: Rectangle) -> list[int]:
@@ -134,11 +147,21 @@ def convert_detection_dataset(
         except ValueError:
             logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
             return None
+        # Every item must be either a model prediction (with confidence score) or a user annotation (without)
+        any_with_confidence = any(annotation.confidence is not None for annotation in annotations)
+        all_with_confidence = all(annotation.confidence is not None for annotation in annotations)
+        if any_with_confidence and not all_with_confidence:
+            logger.error(
+                f"Dataset item {dataset_item.id} contains shapes with and without confidence scores: {annotations}"
+            )
+            raise ValueError("Either all or none of the annotations must have confidence scores")
+        confidences = [annotation.confidence for annotation in annotations] if all_with_confidence else []
         return DetectionSample(
             image=image_path,
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             bboxes=np.array(coords),
             label=np.array(labels_indexes),
+            confidences=np.array(confidences) if confidences else None,
         )
 
     return _convert_dataset(
@@ -177,6 +200,7 @@ def convert_classification_dataset(
                 image=image_path,
                 image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
                 label=project_labels_ids.index(dataset_item.annotation_data[0].labels[0].id),
+                confidence=dataset_item.annotation_data[0].confidence,
             )
         except ValueError:
             logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
@@ -191,13 +215,13 @@ def convert_classification_dataset(
     )
 
 
-def convert_multiclass_classification_dataset(
+def convert_multilabel_classification_dataset(
     project_labels: Sequence[Label],
     get_dataset_items: Callable[[int, int], list[DatasetItem]],
     get_image_path: Callable[[DatasetItem], str],
 ) -> Dataset[MultilabelClassificationSample]:
     """
-    Convert multiclass classification dataset to Datumaro format
+    Convert multilabel classification dataset to Datumaro format
 
     Args:
         project_labels: List of project labels
@@ -222,6 +246,7 @@ def convert_multiclass_classification_dataset(
             image=image_path,
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             label=np.array(labels_indexes),
+            confidences=None,  # TODO fix DatasetItemAnnotation definition to support confidences for multilabel
         )
 
     return _convert_dataset(
@@ -269,11 +294,21 @@ def convert_instance_segmentation_dataset(
         except ValueError:
             logger.error("Unable to find one of dataset item %s labels in project", dataset_item.id)
             return None
+        # Every item must be either a model prediction (with confidence score) or a user annotation (without)
+        any_with_confidence = any(annotation.confidence is not None for annotation in annotations)
+        all_with_confidence = all(annotation.confidence is not None for annotation in annotations)
+        if any_with_confidence and not all_with_confidence:
+            logger.error(
+                f"Dataset item {dataset_item.id} contains shapes with and without confidence scores: {annotations}"
+            )
+            raise ValueError("Either all or none of the annotations must have confidence scores")
+        confidences = [annotation.confidence for annotation in annotations] if all_with_confidence else []
         return InstanceSegmentationSample(
             image=image_path,
             image_info=ImageInfo(width=dataset_item.width, height=dataset_item.height),
             polygons=np.array(polygons, dtype=np.float32),
             label=np.array(labels_indexes),
+            confidences=np.array(confidences) if confidences else None,
         )
 
     return _convert_dataset(
@@ -313,7 +348,7 @@ def convert_dataset(
                 return convert_classification_dataset(
                     project_labels=labels, get_dataset_items=get_dataset_items, get_image_path=get_image_path
                 )
-            return convert_multiclass_classification_dataset(
+            return convert_multilabel_classification_dataset(
                 project_labels=labels, get_dataset_items=get_dataset_items, get_image_path=get_image_path
             )
         case TaskType.INSTANCE_SEGMENTATION:

--- a/application/backend/app/services/evaluation/evaluators.py
+++ b/application/backend/app/services/evaluation/evaluators.py
@@ -50,7 +50,7 @@ def datumaro_dataset_to_coco(dataset: Dataset) -> dict:
 
         # Detection
         if hasattr(sample, "bboxes") and sample.bboxes is not None:
-            confidences = sample.confidences if sample.confidences is not None else [None] * len(sample.bboxes)
+            confidences = sample.confidence if sample.confidence is not None else [None] * len(sample.bboxes)
             for bbox, label_idx, confidence in zip(sample.bboxes, sample.label, confidences, strict=True):
                 x1, y1, x2, y2 = bbox
                 width = x2 - x1
@@ -68,7 +68,7 @@ def datumaro_dataset_to_coco(dataset: Dataset) -> dict:
 
         # Instance Segmentation
         if hasattr(sample, "polygons") and sample.polygons is not None:
-            confidences = sample.confidences if sample.confidences is not None else [None] * len(sample.polygons)
+            confidences = sample.confidence if sample.confidence is not None else [None] * len(sample.polygons)
             for polygon, label_idx, confidence in zip(sample.polygons, sample.label, confidences, strict=True):
                 flattened_polygon = [coord for point in polygon for coord in point]
                 x_coords = [point[0] for point in polygon]

--- a/application/backend/app/services/evaluation/evaluators.py
+++ b/application/backend/app/services/evaluation/evaluators.py
@@ -50,24 +50,26 @@ def datumaro_dataset_to_coco(dataset: Dataset) -> dict:
 
         # Detection
         if hasattr(sample, "bboxes") and sample.bboxes is not None:
-            for bbox, label_idx in zip(sample.bboxes, sample.label):
+            confidences = sample.confidences if sample.confidences is not None else [None] * len(sample.bboxes)
+            for bbox, label_idx, confidence in zip(sample.bboxes, sample.label, confidences, strict=True):
                 x1, y1, x2, y2 = bbox
                 width = x2 - x1
                 height = y2 - y1
-                coco_dataset_dict["annotations"].append(
-                    {
-                        "id": annotation_id,
-                        "image_id": image_id,
-                        "category_id": int(label_idx),
-                        "bbox": [float(x1), float(y1), float(width), float(height)],
-                        "score": 1.0,
-                    }
-                )
+                annotation = {
+                    "id": annotation_id,
+                    "image_id": image_id,
+                    "category_id": int(label_idx),
+                    "bbox": [float(x1), float(y1), float(width), float(height)],
+                }
+                if confidence is not None:
+                    annotation["score"] = float(confidence)
+                coco_dataset_dict["annotations"].append(annotation)
                 annotation_id += 1
 
         # Instance Segmentation
         if hasattr(sample, "polygons") and sample.polygons is not None:
-            for polygon, label_idx in zip(sample.polygons, sample.label):
+            confidences = sample.confidences if sample.confidences is not None else [None] * len(sample.polygons)
+            for polygon, label_idx, confidence in zip(sample.polygons, sample.label, confidences, strict=True):
                 flattened_polygon = [coord for point in polygon for coord in point]
                 x_coords = [point[0] for point in polygon]
                 y_coords = [point[1] for point in polygon]
@@ -75,16 +77,16 @@ def datumaro_dataset_to_coco(dataset: Dataset) -> dict:
                 y_min, y_max = min(y_coords), max(y_coords)
                 width = x_max - x_min
                 height = y_max - y_min
-                coco_dataset_dict["annotations"].append(
-                    {
-                        "id": annotation_id,
-                        "image_id": image_id,
-                        "category_id": int(label_idx),
-                        "segmentation": [flattened_polygon],
-                        "bbox": [float(x_min), float(y_min), float(width), float(height)],
-                        "score": 1.0,
-                    }
-                )
+                annotation = {
+                    "id": annotation_id,
+                    "image_id": image_id,
+                    "category_id": int(label_idx),
+                    "segmentation": [flattened_polygon],
+                    "bbox": [float(x_min), float(y_min), float(width), float(height)],
+                }
+                if confidence is not None:
+                    annotation["score"] = float(confidence)
+                coco_dataset_dict["annotations"].append(annotation)
                 annotation_id += 1
 
     return coco_dataset_dict

--- a/application/backend/app/utils/typing.py
+++ b/application/backend/app/utils/typing.py
@@ -1,0 +1,12 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for type-hinting"""
+
+import numpy as np
+import numpy.typing as npt
+
+NDArrayBool = npt.NDArray[np.bool_]  # numpy array of booleans
+NDArrayInt = npt.NDArray[np.int_]  # numpy array of integers
+NDArrayFloat32 = npt.NDArray[np.float32]  # numpy array of 32-bit floats
+NDArrayFloat64 = npt.NDArray[np.float64]  # numpy array of 64-bit floats

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -205,9 +205,9 @@ class TestDatasetServiceIntegration:
         if not user_reviewed:
             assert dataset_item.annotation_data == [
                 {
-                    "labels": [{"id": str(label_id)}],
                     "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10},
-                    "confidence": None,
+                    "labels": [{"id": str(label_id)}],
+                    "confidences": None,
                 }
             ]
             assert db_session.get(DatasetItemLabelDB, (str(created_dataset_item.id), str(label_id))) is not None

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -322,7 +322,7 @@ class TestDatasetItemEndpoints:
         assert response.json() == {
             "annotations": [
                 {
-                    "confidence": None,
+                    "confidences": None,
                     "labels": [{"id": str(label_id)}],
                     "shape": {"height": 10, "type": "rectangle", "width": 10, "x": 0, "y": 0},
                 }
@@ -406,7 +406,7 @@ class TestDatasetItemEndpoints:
         assert response.json() == {
             "annotations": [
                 {
-                    "confidence": None,
+                    "confidences": None,
                     "labels": [{"id": str(label_id)}],
                     "shape": {"height": 10, "type": "rectangle", "width": 10, "x": 0, "y": 0},
                 }

--- a/application/backend/tests/unit/services/evaluation/conftest.py
+++ b/application/backend/tests/unit/services/evaluation/conftest.py
@@ -21,11 +21,11 @@ def fxt_multiclass_classification_dataset_gt() -> Dataset:
     dataset = Dataset(ClassificationSample, categories={"label": LabelCategories(labels=("cat", "dog", "bird"))})
     img_info = ImageInfo(width=100, height=100)
     samples = (
-        ClassificationSample(image="/dummy/path/A.jpg", image_info=img_info, label=0),
-        ClassificationSample(image="/dummy/path/B.jpg", image_info=img_info, label=1),
-        ClassificationSample(image="/dummy/path/C.jpg", image_info=img_info, label=2),
-        ClassificationSample(image="/dummy/path/D.jpg", image_info=img_info, label=1),
-        ClassificationSample(image="/dummy/path/E.jpg", image_info=img_info, label=2),
+        ClassificationSample(image="/dummy/path/A.jpg", image_info=img_info, label=0, confidence=None),
+        ClassificationSample(image="/dummy/path/B.jpg", image_info=img_info, label=1, confidence=None),
+        ClassificationSample(image="/dummy/path/C.jpg", image_info=img_info, label=2, confidence=None),
+        ClassificationSample(image="/dummy/path/D.jpg", image_info=img_info, label=1, confidence=None),
+        ClassificationSample(image="/dummy/path/E.jpg", image_info=img_info, label=2, confidence=None),
     )
     for sample in samples:
         dataset.append(sample)
@@ -38,11 +38,11 @@ def fxt_multiclass_classification_dataset_pred() -> Dataset:
     dataset = Dataset(ClassificationSample, categories={"label": LabelCategories(labels=("cat", "dog", "bird"))})
     img_info = ImageInfo(width=100, height=100)
     samples = (
-        ClassificationSample(image="/dummy/path/A.jpg", image_info=img_info, label=0),  # correct
-        ClassificationSample(image="/dummy/path/B.jpg", image_info=img_info, label=2),  # wrong
-        ClassificationSample(image="/dummy/path/C.jpg", image_info=img_info, label=1),  # wrong
-        ClassificationSample(image="/dummy/path/D.jpg", image_info=img_info, label=1),  # correct
-        ClassificationSample(image="/dummy/path/E.jpg", image_info=img_info, label=2),  # correct
+        ClassificationSample(image="/dummy/path/A.jpg", image_info=img_info, label=0, confidence=0.9),  # correct
+        ClassificationSample(image="/dummy/path/B.jpg", image_info=img_info, label=2, confidence=0.6),  # wrong
+        ClassificationSample(image="/dummy/path/C.jpg", image_info=img_info, label=1, confidence=0.5),  # wrong
+        ClassificationSample(image="/dummy/path/D.jpg", image_info=img_info, label=1, confidence=0.8),  # correct
+        ClassificationSample(image="/dummy/path/E.jpg", image_info=img_info, label=2, confidence=0.9),  # correct
     )
     for sample in samples:
         dataset.append(sample)
@@ -57,9 +57,15 @@ def fxt_multilabel_classification_dataset_gt() -> Dataset:
     )
     img_info = ImageInfo(width=100, height=100)
     samples = (
-        MultilabelClassificationSample(image="/dummy/path/A.jpg", image_info=img_info, label=np.array([0, 1])),
-        MultilabelClassificationSample(image="/dummy/path/B.jpg", image_info=img_info, label=np.array([1])),
-        MultilabelClassificationSample(image="/dummy/path/C.jpg", image_info=img_info, label=np.array([2, 0])),
+        MultilabelClassificationSample(
+            image="/dummy/path/A.jpg", image_info=img_info, label=np.array([0, 1]), confidences=None
+        ),
+        MultilabelClassificationSample(
+            image="/dummy/path/B.jpg", image_info=img_info, label=np.array([1]), confidences=None
+        ),
+        MultilabelClassificationSample(
+            image="/dummy/path/C.jpg", image_info=img_info, label=np.array([2, 0]), confidences=None
+        ),
     )
     for sample in samples:
         dataset.append(sample)
@@ -75,13 +81,22 @@ def fxt_multilabel_classification_dataset_pred() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         MultilabelClassificationSample(
-            image="/dummy/path/A.jpg", image_info=img_info, label=np.array([0])
+            image="/dummy/path/A.jpg",
+            image_info=img_info,
+            label=np.array([0]),
+            confidences=np.array([0.85]),
         ),  # missing one label
         MultilabelClassificationSample(
-            image="/dummy/path/B.jpg", image_info=img_info, label=np.array([1, 2])
+            image="/dummy/path/B.jpg",
+            image_info=img_info,
+            label=np.array([1, 2]),
+            confidences=np.array([0.8, 0.6]),
         ),  # one extra label
         MultilabelClassificationSample(
-            image="/dummy/path/C.jpg", image_info=img_info, label=np.array([2, 0])
+            image="/dummy/path/C.jpg",
+            image_info=img_info,
+            label=np.array([2, 0]),
+            confidences=np.array([0.9, 0.7]),
         ),  # correct
     )
     for sample in samples:
@@ -100,18 +115,21 @@ def fxt_detection_dataset_gt() -> Dataset:
             image_info=img_info,
             bboxes=np.array([[10, 15, 30, 35]]),
             label=np.array([1]),
+            confidences=None,
         ),
         DetectionSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]]),
             label=np.array([0, 1]),
+            confidences=None,
         ),
         DetectionSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             bboxes=np.array([[0, 0, 15, 15]]),
             label=np.array([0]),
+            confidences=None,
         ),
     )
     for sample in samples:
@@ -130,18 +148,21 @@ def fxt_detection_dataset_pred() -> Dataset:
             image_info=img_info,
             bboxes=np.array([[10, 20, 30, 40]]),  # partial overlap (IoU = 0.6)
             label=np.array([1]),  # correct
+            confidences=np.array([0.8]),
         ),
         DetectionSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]]),  # correct
             label=np.array([0, 1]),  # correct
+            confidences=np.array([0.9, 0.7]),
         ),
         DetectionSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             bboxes=np.array([[0, 0, 15, 15]]),  # correct
             label=np.array([1]),  # wrong
+            confidences=np.array([0.6]),
         ),
     )
     for sample in samples:
@@ -160,18 +181,21 @@ def fxt_instance_segmentation_dataset_gt() -> Dataset:
             image_info=img_info,
             polygons=np.array([[[10, 20], [30, 40], [40, 70], [10, 60]], [[10, 20], [30, 40], [50, 40]]], dtype=object),
             label=np.array([0, 1]),
+            confidences=None,
         ),
         InstanceSegmentationSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             polygons=np.array([[[50, 50], [90, 50], [50, 80]]]),
             label=np.array([0]),
+            confidences=None,
         ),
         InstanceSegmentationSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             polygons=np.array([[[15, 15], [25, 15], [25, 25], [15, 25]]]),
             label=np.array([1]),
+            confidences=None,
         ),
     )
     for sample in samples:
@@ -192,18 +216,21 @@ def fxt_instance_segmentation_dataset_pred() -> Dataset:
                 [[[10, 20], [30, 40], [40, 70], [10, 60]], [[10, 20], [30, 40], [50, 40]]], dtype=object
             ),  # correct
             label=np.array([0, 1]),  # correct
+            confidences=np.array([0.9, 0.75]),
         ),
         InstanceSegmentationSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             polygons=np.array([[[50, 50], [82, 50], [50, 74]]]),  # partial overlap (64% IoU)
             label=np.array([0]),  # correct
+            confidences=np.array([0.8]),
         ),
         InstanceSegmentationSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             polygons=np.array([[[15, 15], [25, 15], [25, 25], [15, 25]]]),  # correct
             label=np.array([0]),  # wrong
+            confidences=np.array([0.6]),
         ),
     )
     for sample in samples:

--- a/application/backend/tests/unit/services/evaluation/conftest.py
+++ b/application/backend/tests/unit/services/evaluation/conftest.py
@@ -58,13 +58,13 @@ def fxt_multilabel_classification_dataset_gt() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         MultilabelClassificationSample(
-            image="/dummy/path/A.jpg", image_info=img_info, label=np.array([0, 1]), confidences=None
+            image="/dummy/path/A.jpg", image_info=img_info, label=np.array([0, 1]), confidence=None
         ),
         MultilabelClassificationSample(
-            image="/dummy/path/B.jpg", image_info=img_info, label=np.array([1]), confidences=None
+            image="/dummy/path/B.jpg", image_info=img_info, label=np.array([1]), confidence=None
         ),
         MultilabelClassificationSample(
-            image="/dummy/path/C.jpg", image_info=img_info, label=np.array([2, 0]), confidences=None
+            image="/dummy/path/C.jpg", image_info=img_info, label=np.array([2, 0]), confidence=None
         ),
     )
     for sample in samples:
@@ -84,19 +84,19 @@ def fxt_multilabel_classification_dataset_pred() -> Dataset:
             image="/dummy/path/A.jpg",
             image_info=img_info,
             label=np.array([0]),
-            confidences=np.array([0.85]),
+            confidence=np.array([0.85]),
         ),  # missing one label
         MultilabelClassificationSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             label=np.array([1, 2]),
-            confidences=np.array([0.8, 0.6]),
+            confidence=np.array([0.8, 0.6]),
         ),  # one extra label
         MultilabelClassificationSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             label=np.array([2, 0]),
-            confidences=np.array([0.9, 0.7]),
+            confidence=np.array([0.9, 0.7]),
         ),  # correct
     )
     for sample in samples:
@@ -115,21 +115,21 @@ def fxt_detection_dataset_gt() -> Dataset:
             image_info=img_info,
             bboxes=np.array([[10, 15, 30, 35]]),
             label=np.array([1]),
-            confidences=None,
+            confidence=None,
         ),
         DetectionSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]]),
             label=np.array([0, 1]),
-            confidences=None,
+            confidence=None,
         ),
         DetectionSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             bboxes=np.array([[0, 0, 15, 15]]),
             label=np.array([0]),
-            confidences=None,
+            confidence=None,
         ),
     )
     for sample in samples:
@@ -148,21 +148,21 @@ def fxt_detection_dataset_pred() -> Dataset:
             image_info=img_info,
             bboxes=np.array([[10, 20, 30, 40]]),  # partial overlap (IoU = 0.6)
             label=np.array([1]),  # correct
-            confidences=np.array([0.8]),
+            confidence=np.array([0.8]),
         ),
         DetectionSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]]),  # correct
             label=np.array([0, 1]),  # correct
-            confidences=np.array([0.9, 0.7]),
+            confidence=np.array([0.9, 0.7]),
         ),
         DetectionSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             bboxes=np.array([[0, 0, 15, 15]]),  # correct
             label=np.array([1]),  # wrong
-            confidences=np.array([0.6]),
+            confidence=np.array([0.6]),
         ),
     )
     for sample in samples:
@@ -181,21 +181,21 @@ def fxt_instance_segmentation_dataset_gt() -> Dataset:
             image_info=img_info,
             polygons=np.array([[[10, 20], [30, 40], [40, 70], [10, 60]], [[10, 20], [30, 40], [50, 40]]], dtype=object),
             label=np.array([0, 1]),
-            confidences=None,
+            confidence=None,
         ),
         InstanceSegmentationSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             polygons=np.array([[[50, 50], [90, 50], [50, 80]]]),
             label=np.array([0]),
-            confidences=None,
+            confidence=None,
         ),
         InstanceSegmentationSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             polygons=np.array([[[15, 15], [25, 15], [25, 25], [15, 25]]]),
             label=np.array([1]),
-            confidences=None,
+            confidence=None,
         ),
     )
     for sample in samples:
@@ -216,21 +216,21 @@ def fxt_instance_segmentation_dataset_pred() -> Dataset:
                 [[[10, 20], [30, 40], [40, 70], [10, 60]], [[10, 20], [30, 40], [50, 40]]], dtype=object
             ),  # correct
             label=np.array([0, 1]),  # correct
-            confidences=np.array([0.9, 0.75]),
+            confidence=np.array([0.9, 0.75]),
         ),
         InstanceSegmentationSample(
             image="/dummy/path/B.jpg",
             image_info=img_info,
             polygons=np.array([[[50, 50], [82, 50], [50, 74]]]),  # partial overlap (64% IoU)
             label=np.array([0]),  # correct
-            confidences=np.array([0.8]),
+            confidence=np.array([0.8]),
         ),
         InstanceSegmentationSample(
             image="/dummy/path/C.jpg",
             image_info=img_info,
             polygons=np.array([[[15, 15], [25, 15], [25, 25], [15, 25]]]),  # correct
             label=np.array([0]),  # wrong
-            confidences=np.array([0.6]),
+            confidence=np.array([0.6]),
         ),
     )
     for sample in samples:

--- a/application/backend/tests/unit/services/evaluation/test_evaluators.py
+++ b/application/backend/tests/unit/services/evaluation/test_evaluators.py
@@ -49,10 +49,11 @@ class TestMultiClassClassificationEvaluator:
         assert f1_score_weighted == pytest.approx(3 / 5)
         assert (confusion_matrix == np.array([[1, 0, 0], [0, 1, 1], [0, 1, 1]])).all()
 
-    def test_evaluate_with_perfect_predictions(self, fxt_multiclass_classification_dataset_gt) -> None:
+    def test_evaluate_with_perfect_predictions(self, fxt_multiclass_classification_dataset_pred) -> None:
+        # Using the same dataset for GT and predictions to simulate perfect predictions
         evaluator = MultiClassClassificationEvaluator(
-            predictions_dataset=fxt_multiclass_classification_dataset_gt,  # using GT as predictions, hence perfect
-            ground_truth_dataset=fxt_multiclass_classification_dataset_gt,
+            predictions_dataset=fxt_multiclass_classification_dataset_pred,
+            ground_truth_dataset=fxt_multiclass_classification_dataset_pred,
         )
 
         precision_micro = evaluator.precision(averaging_method=AveragingMethod.MICRO)
@@ -105,10 +106,11 @@ class TestMultiLabelClassificationEvaluator:
         assert f1_score_macro == pytest.approx(7 / 9)  # harmonic mean of macro precision and recall
         assert f1_score_weighted == pytest.approx(4 / 5)  # harmonic mean of weighted precision and recall
 
-    def test_evaluate_with_perfect_predictions(self, fxt_multilabel_classification_dataset_gt) -> None:
+    def test_evaluate_with_perfect_predictions(self, fxt_multilabel_classification_dataset_pred) -> None:
+        # Using the same dataset for GT and predictions to simulate perfect predictions
         evaluator = MultiLabelClassificationEvaluator(
-            predictions_dataset=fxt_multilabel_classification_dataset_gt,  # using GT as predictions, hence perfect
-            ground_truth_dataset=fxt_multilabel_classification_dataset_gt,
+            predictions_dataset=fxt_multilabel_classification_dataset_pred,
+            ground_truth_dataset=fxt_multilabel_classification_dataset_pred,
         )
 
         precision_micro = evaluator.precision(averaging_method=AveragingMethod.MICRO)
@@ -142,11 +144,12 @@ class TestDetectionEvaluator:
         assert 0 < map_dict["AP_75"] < map_dict["AP_50"] < 1
         assert 0 < map_dict["AP_all"] < 1
 
-    def test_evaluate_with_perfect_predictions(self, fxt_detection_dataset_gt) -> None:
+    def test_evaluate_with_perfect_predictions(self, fxt_detection_dataset_pred) -> None:
         """Evaluate on a scenario where all predictions are correct."""
+        # Using the same dataset for GT and predictions to simulate perfect predictions
         evaluator = DetectionEvaluator(
-            predictions_dataset=fxt_detection_dataset_gt,  # using GT as predictions, hence perfect
-            ground_truth_dataset=fxt_detection_dataset_gt,
+            predictions_dataset=fxt_detection_dataset_pred,
+            ground_truth_dataset=fxt_detection_dataset_pred,
         )
 
         map_dict = evaluator.mean_average_precision()
@@ -170,11 +173,12 @@ class TestInstanceSegmentationEvaluator:
         assert 0 < map_dict["AP_75"] < map_dict["AP_50"] < 1
         assert 0 < map_dict["AP_all"] < 1
 
-    def test_evaluate_with_perfect_predictions(self, fxt_instance_segmentation_dataset_gt) -> None:
+    def test_evaluate_with_perfect_predictions(self, fxt_instance_segmentation_dataset_pred) -> None:
         """Evaluate on a scenario where all predictions are correct."""
+        # Using the same dataset for GT and predictions to simulate perfect predictions
         evaluator = InstanceSegmentationEvaluator(
-            predictions_dataset=fxt_instance_segmentation_dataset_gt,  # using GT as predictions, hence perfect
-            ground_truth_dataset=fxt_instance_segmentation_dataset_gt,
+            predictions_dataset=fxt_instance_segmentation_dataset_pred,
+            ground_truth_dataset=fxt_instance_segmentation_dataset_pred,
         )
 
         map_dict = evaluator.mean_average_precision()

--- a/application/backend/tests/unit/services/test_datumaro_converter.py
+++ b/application/backend/tests/unit/services/test_datumaro_converter.py
@@ -109,7 +109,7 @@ def fxt_classification_dataset_item(fxt_dataset_item, fxt_dataset_item_annotatio
 
 
 @pytest.fixture
-def fxt_multiclass_classification_dataset_item(fxt_dataset_item, fxt_dataset_item_annotation):
+def fxt_multilabel_classification_dataset_item(fxt_dataset_item, fxt_dataset_item_annotation):
     def _create_classification_dataset_item(project_id: UUID, name: str, labels: list[str]) -> DatasetItem:
         return fxt_dataset_item(
             project_id=project_id,
@@ -222,10 +222,10 @@ def test_convert_multiclass_classification_dataset(fxt_project_labels, fxt_class
 
 
 def test_convert_multilabel_classification_dataset_item(
-    fxt_project_labels, fxt_multiclass_classification_dataset_item
+    fxt_project_labels, fxt_multilabel_classification_dataset_item
 ) -> None:
     project_id = uuid4()
-    dataset_item = fxt_multiclass_classification_dataset_item(
+    dataset_item = fxt_multilabel_classification_dataset_item(
         project_id, "1", [str(fxt_project_labels[0].id), str(fxt_project_labels[1].id)]
     )
     get_dataset_items = MagicMock(side_effect=[[dataset_item], []])

--- a/application/backend/tests/unit/services/test_datumaro_converter.py
+++ b/application/backend/tests/unit/services/test_datumaro_converter.py
@@ -27,7 +27,7 @@ from app.services.datumaro_converter import (
     convert_classification_dataset,
     convert_detection_dataset,
     convert_instance_segmentation_dataset,
-    convert_multiclass_classification_dataset,
+    convert_multilabel_classification_dataset,
     convert_polygon,
     convert_rectangle,
 )
@@ -186,7 +186,7 @@ def test_convert_detection_dataset(fxt_project_labels, fxt_detection_dataset_ite
     )
 
 
-def test_convert_classification_dataset(fxt_project_labels, fxt_classification_dataset_item) -> None:
+def test_convert_multiclass_classification_dataset(fxt_project_labels, fxt_classification_dataset_item) -> None:
     project_id = uuid4()
     dataset_item_1 = fxt_classification_dataset_item(project_id, "cat", str(fxt_project_labels[0].id))
     dataset_item_2 = fxt_classification_dataset_item(project_id, "dog", str(fxt_project_labels[1].id))
@@ -221,7 +221,7 @@ def test_convert_classification_dataset(fxt_project_labels, fxt_classification_d
     )
 
 
-def test_convert_multiclass_classification_dataset_item(
+def test_convert_multilabel_classification_dataset_item(
     fxt_project_labels, fxt_multiclass_classification_dataset_item
 ) -> None:
     project_id = uuid4()
@@ -231,7 +231,7 @@ def test_convert_multiclass_classification_dataset_item(
     get_dataset_items = MagicMock(side_effect=[[dataset_item], []])
     get_image_path = MagicMock(side_effect=["path1"])
 
-    dataset = convert_multiclass_classification_dataset(
+    dataset = convert_multilabel_classification_dataset(
         project_labels=fxt_project_labels, get_dataset_items=get_dataset_items, get_image_path=get_image_path
     )
 

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -509,7 +509,7 @@ wheels = [
 [[package]]
 name = "datumaro"
 version = "1.12.0"
-source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#04948e73d3e55a797d6bbeb6d964ff24e7bdf848" }
+source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#ed1e5944ffcdc4ec06dd4476c3efc62fe57dcf81" }
 dependencies = [
     { name = "attrs" },
     { name = "defusedxml" },

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -37,7 +37,7 @@ const mapLocalAnnotationsToServer = (localAnnotations: Annotation[]): ServerAnno
         // We only want to send the ids of the labels
         labels: annotation.labels.map((label) => ({ id: label.id })),
         shape: annotation.shape,
-        ...(annotation.confidence !== undefined && { confidence: annotation.confidence }),
+        ...(annotation.confidences !== undefined && { confidences: annotation.confidences }),
     }));
 };
 


### PR DESCRIPTION
### Summary

Changes:
- Add optional `confidence` field to `Sample` classes, to model the confidence score associated to each predicted label. The value can be `None` for user annotations.
- Update `DatasetItemAnnotation` to support a list of confidence scores (one per label)
- Update COCO converters in the evaluation code to take into account the prediction confidence

Resolves #4962 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
