### PR TITLE
bugfix: use brackets in Samples dtype

### DIFF
--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -40,8 +40,8 @@ class ClassificationSample(Sample):
 
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
-    label: int = label_field(dtype=pl.Int32, is_list=False)
-    confidence: float | None = score_field(dtype=pl.Float32)
+    label: int = label_field(dtype=pl.Int32(), is_list=False)
+    confidence: float | None = score_field(dtype=pl.Float32())
 
 
 class MultilabelClassificationSample(Sample):
@@ -58,8 +58,8 @@ class MultilabelClassificationSample(Sample):
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
-    label: np.ndarray = label_field(dtype=pl.Int32, multi_label=True)
-    confidence: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
+    label: np.ndarray = label_field(dtype=pl.Int32(), multi_label=True)
+    confidence: np.ndarray | None = score_field(dtype=pl.Float32(), is_list=True)
 
 
 class DetectionSample(Sample):
@@ -77,9 +77,9 @@ class DetectionSample(Sample):
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
-    bboxes: np.ndarray = bbox_field(dtype=pl.Int32)
-    label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
-    confidence: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
+    bboxes: np.ndarray = bbox_field(dtype=pl.Int32())
+    label: np.ndarray = label_field(dtype=pl.Int32(), is_list=True)
+    confidence: np.ndarray | None = score_field(dtype=pl.Float32(), is_list=True)
 
 
 class InstanceSegmentationSample(Sample):
@@ -97,9 +97,9 @@ class InstanceSegmentationSample(Sample):
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     # TODO: Use NDArrayFloat32 and NDArrayInt instead of np.ndarray after open-edge-platform/datumaro#1949 is solved
-    polygons: np.ndarray = polygon_field(dtype=pl.Float32)
-    label: np.ndarray = label_field(dtype=pl.Int32, is_list=True)
-    confidence: np.ndarray | None = score_field(dtype=pl.Float32, is_list=True)
+    polygons: np.ndarray = polygon_field(dtype=pl.Float32())
+    label: np.ndarray = label_field(dtype=pl.Int32(), is_list=True)
+    confidence: np.ndarray | None = score_field(dtype=pl.Float32(), is_list=True)
 
 
 def convert_rectangle(r: Rectangle) -> list[int]:

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -509,7 +509,7 @@ wheels = [
 [[package]]
 name = "datumaro"
 version = "1.12.0"
-source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#ed1e5944ffcdc4ec06dd4476c3efc62fe57dcf81" }
+source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#e7e3b42f76ccd4c6bdfc5330e8d4d6bb71f9ed2a" }
 dependencies = [
     { name = "attrs" },
     { name = "defusedxml" },


### PR DESCRIPTION
### Summary

In the definition of `Sample` classes, the `dtype` should be passed with brackets (e.g. `pl.Float32()` instead of `pl.Float32`), as mentioned in https://github.com/open-edge-platform/datumaro/issues/1855#issue-3359351248. This prevents issues like https://github.com/open-edge-platform/datumaro/issues/1951.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
