### PR TITLE
fix pattern for release branches in GHA workflows

### DIFF
--- a/.github/workflows/backend-lint-and-test.yaml
+++ b/.github/workflows/backend-lint-and-test.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - develop
-      - releases/**
+      - release/**
     tags:
       - "v*"
   pull_request:
   merge_group:
     branches:
       - develop
-      - releases/**
+      - release/**
 
 permissions: {} # No permissions by default on workflow level
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
       - develop
-      - releases/**
+      - release/**
     tags:
       - "v*"
   pull_request:
   merge_group:
     branches:
       - develop
-      - releases/**
+      - release/**
 
 permissions: {} # No permissions by default on workflow level
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,9 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   push:
-    branches: ["develop", "releases/**"]
+    branches: ["develop", "release/**"]
   pull_request:
-    branches: ["develop", "releases/**"]
+    branches: ["develop", "release/**"]
 
 permissions: {}
 

--- a/.github/workflows/lib-lint-and-test.yaml
+++ b/.github/workflows/lib-lint-and-test.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - develop
-      - releases/**
+      - release/**
     tags:
       - "v*"
   pull_request:
   merge_group:
     branches:
       - develop
-      - releases/**
+      - release/**
   workflow_dispatch: # run on request (no need for PR)
 
 permissions: {} # No permissions by default

--- a/.github/workflows/pr-security-scan.yaml
+++ b/.github/workflows/pr-security-scan.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - develop
-      - releases/**
+      - release/**
 
 permissions: {}
 

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - develop
-      - "releases/**"
+      - "release/**"
 
 permissions: {} # No permissions by default
 

--- a/.github/workflows/ui-lint-and-test.yaml
+++ b/.github/workflows/ui-lint-and-test.yaml
@@ -5,14 +5,14 @@ on:
   push:
     branches:
       - develop
-      - releases/**
+      - release/**
     tags:
       - "v*"
   pull_request:
   merge_group:
     branches:
       - develop
-      - releases/**
+      - release/**
 
 permissions: {} # No permissions by default on workflow level
 


### PR DESCRIPTION
### Summary

Fix the pattern since the release branches are called `release/*`, not  `releases/*`.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
