### PR TITLE
Save initial model revision in a training job

### DIFF
--- a/application/backend/app/lifecycle.py
+++ b/application/backend/app/lifecycle.py
@@ -19,7 +19,7 @@ from app.core.run import Runnable, RunnableFactory
 from app.db import MigrationManager, get_db_session
 from app.scheduler import Scheduler
 from app.schemas.job import JobType
-from app.services import DatasetService, LabelService
+from app.services import DatasetService, LabelService, ModelService
 from app.services.base_weights_service import BaseWeightsService
 from app.services.data_collect import DataCollector
 from app.services.event.event_bus import EventBus
@@ -50,6 +50,7 @@ def setup_job_controller(data_dir: Path, max_parallel_jobs: int) -> tuple[JobQue
     subset_service = SubsetService()
     subset_assigner = SubsetAssigner()
     label_service = LabelService()
+    model_service = ModelService()
     dataset_service = DatasetService(data_dir=data_dir, label_service=label_service)
     job_runnable_factory.register(
         JobType.TRAIN,
@@ -59,6 +60,7 @@ def setup_job_controller(data_dir: Path, max_parallel_jobs: int) -> tuple[JobQue
             subset_service=subset_service,
             subset_assigner=subset_assigner,
             dataset_service=dataset_service,
+            model_service=model_service,
             data_dir=data_dir,
             db_session_factory=get_db_session,
         ),

--- a/application/backend/app/services/__init__.py
+++ b/application/backend/app/services/__init__.py
@@ -15,7 +15,7 @@ from .dataset_service import DatasetService
 from .dispatch_service import DispatchService
 from .label_service import LabelService
 from .metrics_service import MetricsService
-from .model_service import ModelService
+from .model_service import ModelMetadata, ModelService
 from .pipeline_metrics_service import PipelineMetricsService
 from .pipeline_service import PipelineService
 from .project_service import ProjectService
@@ -32,6 +32,7 @@ __all__ = [
     "DispatchService",
     "LabelService",
     "MetricsService",
+    "ModelMetadata",
     "ModelService",
     "PipelineMetricsService",
     "PipelineService",

--- a/application/backend/app/services/__init__.py
+++ b/application/backend/app/services/__init__.py
@@ -15,7 +15,7 @@ from .dataset_service import DatasetService
 from .dispatch_service import DispatchService
 from .label_service import LabelService
 from .metrics_service import MetricsService
-from .model_service import ModelMetadata, ModelService
+from .model_service import ModelRevisionMetadata, ModelService
 from .pipeline_metrics_service import PipelineMetricsService
 from .pipeline_service import PipelineService
 from .project_service import ProjectService
@@ -32,7 +32,7 @@ __all__ = [
     "DispatchService",
     "LabelService",
     "MetricsService",
-    "ModelMetadata",
+    "ModelRevisionMetadata",
     "ModelService",
     "PipelineMetricsService",
     "PipelineService",

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -375,7 +375,7 @@ class DatasetService(BaseSessionManagedService):
             get_image_path=_get_image_path,
         )
 
-    def save_revision(self, project_id: UUID, dataset: dm.Dataset) -> None:
+    def save_revision(self, project_id: UUID, dataset: dm.Dataset) -> UUID:
         """
         Saves the dataset as a new revision.
 
@@ -387,7 +387,7 @@ class DatasetService(BaseSessionManagedService):
             dataset: The Datumaro dataset to export.
 
         Returns:
-            None
+            UUID: The UUID of the newly created dataset revision.
         """
         revision_repo = DatasetRevisionRepository(db=self.db_session)
         revision_db = revision_repo.save(
@@ -403,3 +403,4 @@ class DatasetService(BaseSessionManagedService):
             export_images=True,
             as_zip=True,
         )
+        return UUID(revision_db.id)

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -1,24 +1,35 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
 
-from app.repositories import ModelRevisionRepository, ProjectRepository
+from app.db.schema import ModelRevisionDB
+from app.models.training_configuration.configuration import TrainingConfiguration
+from app.repositories import LabelRepository, ModelRevisionRepository, ProjectRepository
 from app.schemas.model import Model as ModelSchema
+from app.schemas.model import TrainingStatus
 
-from .base import ResourceInUseError, ResourceNotFoundError, ResourceType
+from .base import BaseSessionManagedService, ResourceInUseError, ResourceNotFoundError, ResourceType
 from .mappers.model_revision_mapper import ModelRevisionMapper
 from .parent_process_guard import parent_process_only
 
 
-class ModelService:
-    """Service to register and activate models"""
+@dataclass(frozen=True)
+class ModelMetadata:
+    model_id: UUID
+    project_id: UUID
+    architecture_id: str
+    parent_revision_id: UUID | None
+    dataset_revision_id: UUID | None
+    training_status: TrainingStatus
+    training_configuration: TrainingConfiguration | None = None
 
-    def __init__(self, db_session: Session) -> None:
-        self._db_session = db_session
+
+class ModelService(BaseSessionManagedService):
+    """Service to register and activate models"""
 
     def get_model_by_id(self, project_id: UUID, model_id: UUID) -> ModelSchema:
         """
@@ -39,7 +50,7 @@ class ModelService:
             ResourceNotFoundError: If the project with the given project_id does not exist,
                 or if no model with the given model_id is found within the project.
         """
-        project_repo = ProjectRepository(self._db_session)
+        project_repo = ProjectRepository(self.db_session)
         # Prefer using a JOIN here since the list of model revisions per project is not large,
         # and it allows us to check for project existence and fetch the model in a single query.
         project = project_repo.get_by_id(str(project_id))
@@ -72,10 +83,10 @@ class ModelService:
             ResourceInUseError: If the model cannot be deleted due to integrity constraints
                 (e.g., the model is referenced by other entities).
         """
-        project_repo = ProjectRepository(self._db_session)
+        project_repo = ProjectRepository(self.db_session)
         if not project_repo.exists(str(project_id)):
             raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
-        model_rev_repo = ModelRevisionRepository(self._db_session)
+        model_rev_repo = ModelRevisionRepository(self.db_session)
         try:
             # TODO: delete model artifacts from filesystem when implemented
             deleted = model_rev_repo.delete(str(model_id))
@@ -102,8 +113,40 @@ class ModelService:
         Raises:
             ResourceNotFoundError: If the project with the given project_id does not exist.
         """
-        project_repo = ProjectRepository(self._db_session)
+        project_repo = ProjectRepository(self.db_session)
         project = project_repo.get_by_id(str(project_id))
         if not project:
             raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
         return [ModelRevisionMapper.to_schema(model_rev_db) for model_rev_db in project.model_revisions]
+
+    def create_revision(self, metadata: ModelMetadata) -> None:
+        """
+        Create and persist a new model revision for the given project metadata.
+
+        Reads the project's label definitions, serializes them into a dict format,
+        combines them with the provided metadata into a new model revision record,
+        and saves it to the database.
+
+        Args:
+            metadata (ModelMetadata): Metadata used to create the new model revision
+                including project id, architecture, optional parent revision id,
+                dataset revision id, training status and optional training
+                configuration.
+        """
+        label_repo = LabelRepository(project_id=str(metadata.project_id), db=self.db_session)
+        labels_schema_rev = {"labels": [{"name": label.name, "id": label.id} for label in label_repo.list_all()]}
+        model_revision_repo = ModelRevisionRepository(self.db_session)
+        model_revision_repo.save(
+            ModelRevisionDB(
+                id=str(metadata.model_id),
+                project_id=str(metadata.project_id),
+                architecture=metadata.architecture_id,
+                parent_revision=str(metadata.parent_revision_id) if metadata.parent_revision_id else None,
+                training_status=metadata.training_status,
+                training_configuration=metadata.training_configuration.model_dump()
+                if metadata.training_configuration
+                else {},
+                training_dataset_id=str(metadata.dataset_revision_id),
+                label_schema_revision=labels_schema_rev,
+            )
+        )

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -18,7 +18,7 @@ from .parent_process_guard import parent_process_only
 
 
 @dataclass(frozen=True)
-class ModelMetadata:
+class ModelRevisionMetadata:
     model_id: UUID
     project_id: UUID
     architecture_id: str
@@ -119,7 +119,7 @@ class ModelService(BaseSessionManagedService):
             raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
         return [ModelRevisionMapper.to_schema(model_rev_db) for model_rev_db in project.model_revisions]
 
-    def create_revision(self, metadata: ModelMetadata) -> None:
+    def create_revision(self, metadata: ModelRevisionMetadata) -> None:
         """
         Create and persist a new model revision for the given project metadata.
 
@@ -128,7 +128,7 @@ class ModelService(BaseSessionManagedService):
         and saves it to the database.
 
         Args:
-            metadata (ModelMetadata): Metadata used to create the new model revision
+            metadata (ModelRevisionMetadata): Metadata used to create the new model revision
                 including project id, architecture, optional parent revision id,
                 dataset revision id, training status and optional training
                 configuration.

--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -17,7 +17,7 @@ from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus
 from app.schemas.model import TrainingStatus
 from app.schemas.project import TaskBase
-from app.services import BaseWeightsService, DatasetService, ModelMetadata, ModelService
+from app.services import BaseWeightsService, DatasetService, ModelRevisionMetadata, ModelService
 
 from .base import Trainer, step
 from .models import TrainingParams
@@ -134,7 +134,7 @@ class OTXTrainer(Trainer):
         with self._db_session_factory() as db:
             self._model_service.set_db_session(db)
             self._model_service.create_revision(
-                ModelMetadata(
+                ModelRevisionMetadata(
                     model_id=training_params.model_id,
                     project_id=training_params.project_id,
                     architecture_id=training_params.model_architecture_id,

--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -139,7 +139,7 @@ class OTXTrainer(Trainer):
                     project_id=training_params.project_id,
                     architecture_id=training_params.model_architecture_id,
                     parent_revision_id=training_params.parent_model_revision_id,
-                    training_configuration=None,  # todo: to be set when config is added
+                    training_configuration=None,  # TODO: to be set when config is added
                     dataset_revision_id=dataset_revision_id,
                     training_status=TrainingStatus.NOT_STARTED,
                 )
@@ -161,6 +161,8 @@ class OTXTrainer(Trainer):
         self._ctx = ctx
         training_params = self._get_training_params(ctx)
         project_id = training_params.project_id
+        if project_id is None:
+            raise ValueError("Project ID must be provided in training parameters")
         task = training_params.task
 
         self.prepare_weights(training_params)

--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -4,6 +4,7 @@
 import time
 from collections.abc import Callable
 from contextlib import AbstractContextManager
+from dataclasses import dataclass
 from pathlib import Path
 from uuid import UUID
 
@@ -14,12 +15,23 @@ from sqlalchemy.orm import Session
 
 from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus
-from app.services import BaseWeightsService, DatasetService
+from app.schemas.model import TrainingStatus
+from app.schemas.project import TaskBase
+from app.services import BaseWeightsService, DatasetService, ModelMetadata, ModelService
 
 from .base import Trainer, step
+from .models import TrainingParams
 from .subset_assignment import SplitRatios, SubsetAssigner, SubsetService
 
 MODEL_WEIGHTS_PATH = "model_weights_path"
+
+
+@dataclass(frozen=True)
+class DatasetInfo:
+    training: Dataset
+    validation: Dataset
+    testing: Dataset
+    revision_id: UUID
 
 
 class OTXTrainer(Trainer):
@@ -31,6 +43,7 @@ class OTXTrainer(Trainer):
         base_weights_service: BaseWeightsService,
         subset_service: SubsetService,
         dataset_service: DatasetService,
+        model_service: ModelService,
         subset_assigner: SubsetAssigner,
         db_session_factory: Callable[[], AbstractContextManager[Session]],
     ):
@@ -39,26 +52,22 @@ class OTXTrainer(Trainer):
         self._base_weights_service = base_weights_service
         self._subset_service = subset_service
         self._dataset_service = dataset_service
+        self._model_service = model_service
         self._subset_assigner = subset_assigner
         self._db_session_factory = db_session_factory
-        self._training_dataset: Dataset | None = None
-        self._validation_dataset: Dataset | None = None
-        self._testing_dataset: Dataset | None = None
 
     @step("Prepare Model Weights")
-    def prepare_weights(self) -> Path:
+    def prepare_weights(self, training_params: TrainingParams) -> Path:
         """
         Prepare weights for training based on training parameters.
 
         If a parent model revision ID is provided, it fetches the weights from the parent model.
         Otherwise, it retrieves the base weights for the specified model architecture.
         """
-        if self._training_params is None:
-            raise ValueError("Training parameters not set")
-        parent_model_revision_id = self._training_params.parent_model_revision_id
-        task = self._training_params.task
-        model_architecture_id = self._training_params.model_architecture_id
-        project_id = self._training_params.project_id
+        parent_model_revision_id = training_params.parent_model_revision_id
+        task = training_params.task
+        model_architecture_id = training_params.model_architecture_id
+        project_id = training_params.project_id
         if parent_model_revision_id is None:
             return self._base_weights_service.get_local_weights_path(
                 task=task.task_type, model_manifest_id=model_architecture_id
@@ -74,17 +83,11 @@ class OTXTrainer(Trainer):
         return weights_path
 
     @step("Assign Dataset Subsets")
-    def assign_subsets(self) -> None:
+    def assign_subsets(self, project_id: UUID) -> None:
         """Assigning subsets to all unassigned dataset items in the project dataset."""
-        if self._training_params is None:
-            raise ValueError("Training parameters not set")
-        project_id = self._training_params.project_id
-        self.report_progress("Retrieving unassigned items")
-        if project_id is None:
-            raise ValueError("Project ID must be provided for subset assignment")
-
         with self._db_session_factory() as db:
             self._subset_service.set_db_session(db)
+            self.report_progress("Retrieving unassigned items")
             unassigned_items = self._subset_service.get_unassigned_items_with_labels(project_id)
 
             if not unassigned_items:
@@ -112,30 +115,41 @@ class OTXTrainer(Trainer):
         self.report_progress(f"Successfully assigned {len(assignments)} items to subsets")
 
     @step("Create Training Dataset")
-    def create_training_dataset(self) -> None:
+    def create_training_dataset(self, project_id: UUID, task: TaskBase) -> DatasetInfo:
         """Create datasets for training, validation, and testing."""
-        if self._training_params is None:
-            raise ValueError("Training parameters not set")
-        project_id = self._training_params.project_id
-        if project_id is None:
-            raise ValueError("Project ID must be provided")
-        task = self._training_params.task
-
         with self._db_session_factory() as db:
             self._dataset_service.set_db_session(db)
             dm_dataset = self._dataset_service.get_dm_dataset(project_id, task, DatasetItemAnnotationStatus.REVIEWED)
-            self._training_dataset = dm_dataset.filter_by_subset(Subset.TRAINING)
-            self._validation_dataset = dm_dataset.filter_by_subset(Subset.VALIDATION)
-            self._testing_dataset = dm_dataset.filter_by_subset(Subset.TESTING)
-            self._dataset_service.save_revision(project_id, dm_dataset)
+            return DatasetInfo(
+                training=dm_dataset.filter_by_subset(Subset.TRAINING),
+                validation=dm_dataset.filter_by_subset(Subset.VALIDATION),
+                testing=dm_dataset.filter_by_subset(Subset.TESTING),
+                revision_id=self._dataset_service.save_revision(project_id, dm_dataset),
+            )
+
+    @step("Prepare Model Metadata")
+    def prepare_model(self, training_params: TrainingParams, dataset_revision_id: UUID) -> None:
+        if training_params.project_id is None:
+            raise ValueError("Project ID must be provided for model preparation")
+        with self._db_session_factory() as db:
+            self._model_service.set_db_session(db)
+            self._model_service.create_revision(
+                ModelMetadata(
+                    model_id=training_params.model_id,
+                    project_id=training_params.project_id,
+                    architecture_id=training_params.model_architecture_id,
+                    parent_revision_id=training_params.parent_model_revision_id,
+                    training_configuration=None,  # todo: to be set when config is added
+                    dataset_revision_id=dataset_revision_id,
+                    training_status=TrainingStatus.NOT_STARTED,
+                )
+            )
 
     @step("Train Model with OTX")
-    def train_model(self) -> None:
+    def train_model(self, training_params: TrainingParams) -> None:
         """Execute OTX model training."""
-        if self._training_params is None:
-            raise ValueError("Training parameters not set")
         # Simulate training with progress reporting
-        job_id = self._training_params.job_id
+        job_id = training_params.job_id
         step_count = 20
         for i in range(step_count):
             time.sleep(1)
@@ -145,12 +159,15 @@ class OTXTrainer(Trainer):
 
     def run(self, ctx: ExecutionContext) -> None:
         self._ctx = ctx
-        self._training_params = self._get_training_params(ctx)
+        training_params = self._get_training_params(ctx)
+        project_id = training_params.project_id
+        task = training_params.task
 
-        self.prepare_weights()
-        self.assign_subsets()
-        self.create_training_dataset()
-        self.train_model()
+        self.prepare_weights(training_params)
+        self.assign_subsets(project_id)
+        dataset_info = self.create_training_dataset(project_id, task)
+        self.prepare_model(training_params, dataset_info.revision_id)
+        self.train_model(training_params)
 
     @staticmethod
     def __build_model_weights_path(data_dir: Path, project_id: UUID, model_id: UUID) -> Path:

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -1385,13 +1385,11 @@ class TestDatasetServiceIntegration:
         project, db_dataset_items = fxt_project_with_subset_items
         dataset = fxt_dataset_service.get_dm_dataset(project.id, project.task, DatasetItemAnnotationStatus.REVIEWED)
 
-        fxt_dataset_service.save_revision(
+        revision_id = fxt_dataset_service.save_revision(
             project_id=project.id,
             dataset=dataset,
         )
 
         # Verify that a revision entry was created
-        db_revisions = db_session.query(DatasetRevisionDB).all()
-        assert len(db_revisions) == 1
-        revision_id = db_revisions[0].id
-        assert (fxt_projects_dir / str(project.id) / "dataset_revisions" / revision_id / "dataset.zip").exists()
+        assert db_session.get(DatasetRevisionDB, str(revision_id)) is not None
+        assert (fxt_projects_dir / str(project.id) / "dataset_revisions" / str(revision_id) / "dataset.zip").exists()

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -10,8 +10,9 @@ import pytest
 
 from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, TaskType
+from app.schemas.model import TrainingStatus
 from app.schemas.project import TaskBase
-from app.services import DatasetService
+from app.services import DatasetService, ModelMetadata, ModelService
 from app.services.base_weights_service import BaseWeightsService
 from app.services.training.models import TrainingParams
 from app.services.training.otx_trainer import OTXTrainer
@@ -49,30 +50,37 @@ def fxt_dataset_service() -> Mock:
 
 
 @pytest.fixture
+def fxt_model_service() -> Mock:
+    """Mock ModelService for testing."""
+    return Mock(spec=ModelService)
+
+
+@pytest.fixture
 def fxt_otx_trainer(
     tmp_path: Path,
     fxt_weights_service: Mock,
     fxt_subset_service: Mock,
     fxt_assigner: Mock,
     fxt_dataset_service: Mock,
+    fxt_model_service: Mock,
     fxt_db_session_factory: Callable,
-) -> Callable[[TrainingParams], OTXTrainer]:
+) -> Callable[[], OTXTrainer]:
     """Create an OTXTrainer instance."""
 
-    def create_otx_trainer(params: TrainingParams) -> OTXTrainer:
+    def create_otx_trainer() -> OTXTrainer:
         otx_trainer = OTXTrainer(
             data_dir=tmp_path,
             base_weights_service=fxt_weights_service,
             subset_service=fxt_subset_service,
             subset_assigner=fxt_assigner,
             dataset_service=fxt_dataset_service,
+            model_service=fxt_model_service,
             db_session_factory=fxt_db_session_factory,
         )
         execution_ctx = Mock(spec=ExecutionContext)
         execution_ctx.report = Mock()
         execution_ctx.heartbeat = Mock()
         otx_trainer._ctx = execution_ctx
-        otx_trainer._training_params = params
         return otx_trainer
 
     return create_otx_trainer
@@ -84,7 +92,7 @@ class TestOTXTrainerPrepareWeights:
     def test_prepare_weights_without_parent_model(
         self,
         fxt_weights_service: Mock,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
     ):
         """Test preparing weights when no parent model revision ID is provided."""
         # Arrange
@@ -93,13 +101,13 @@ class TestOTXTrainerPrepareWeights:
             task=TaskBase(task_type=TaskType.DETECTION),
             parent_model_revision_id=None,
         )
-        otx_trainer = fxt_otx_trainer(training_params)
+        otx_trainer = fxt_otx_trainer()
 
         expected_weights_path = Path("/path/to/weights.pth")
         fxt_weights_service.get_local_weights_path.return_value = expected_weights_path
 
         # Act
-        weights_path = otx_trainer.prepare_weights()
+        weights_path = otx_trainer.prepare_weights(training_params)
 
         # Assert
         assert weights_path == expected_weights_path
@@ -110,7 +118,7 @@ class TestOTXTrainerPrepareWeights:
     def test_prepare_weights_with_parent_model(
         self,
         tmp_path: Path,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
     ):
         """Test preparing weights when parent model revision ID is provided."""
         # Arrange
@@ -127,10 +135,10 @@ class TestOTXTrainerPrepareWeights:
         )
         expected_weights_path.parent.mkdir(parents=True, exist_ok=True)
         expected_weights_path.touch()
-        otx_trainer = fxt_otx_trainer(training_params)
+        otx_trainer = fxt_otx_trainer()
 
         # Act
-        weights_path = otx_trainer.prepare_weights()
+        weights_path = otx_trainer.prepare_weights(training_params)
 
         # Assert
         assert weights_path == expected_weights_path
@@ -138,7 +146,7 @@ class TestOTXTrainerPrepareWeights:
     def test_prepare_weights_with_parent_model_no_file_raises_error(
         self,
         tmp_path: Path,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
     ):
         """Test that FileNotFoundError is raised when parent model weights file is missing."""
         # Arrange
@@ -153,15 +161,15 @@ class TestOTXTrainerPrepareWeights:
         expected_weights_path = (
             tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.pth"
         )
-        otx_trainer = fxt_otx_trainer(training_params)
+        otx_trainer = fxt_otx_trainer()
 
         # Act
         with pytest.raises(FileNotFoundError, match=f"Parent model weights not found at {expected_weights_path}"):
-            otx_trainer.prepare_weights()
+            otx_trainer.prepare_weights(training_params)
 
     def test_prepare_weights_with_parent_model_no_project_id_raises_error(
         self,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
     ):
         """Test that ValueError is raised when parent model revision ID is provided without project ID."""
         # Arrange
@@ -171,11 +179,11 @@ class TestOTXTrainerPrepareWeights:
             parent_model_revision_id=uuid4(),
             project_id=None,
         )
-        otx_trainer = fxt_otx_trainer(training_params)
+        otx_trainer = fxt_otx_trainer()
 
         # Act & Assert
         with pytest.raises(ValueError, match="Project ID must be provided for parent model weights preparation"):
-            otx_trainer.prepare_weights()
+            otx_trainer.prepare_weights(training_params)
 
 
 class TestOTXTrainerAssignSubsets:
@@ -183,19 +191,13 @@ class TestOTXTrainerAssignSubsets:
 
     def test_assign_subsets_with_unassigned_items(
         self,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
         fxt_subset_service: Mock,
         fxt_assigner: Mock,
     ):
         """Test assigning subsets when unassigned items exist."""
         # Arrange
-        project_id = uuid4()
-        training_params = TrainingParams(
-            project_id=project_id,
-            model_architecture_id="Object_Detection_YOLOX_S",
-            task=TaskBase(task_type=TaskType.DETECTION),
-        )
-        otx_trainer = fxt_otx_trainer(training_params)
+        otx_trainer = fxt_otx_trainer()
 
         # Create mock unassigned items
         unassigned_items = [
@@ -222,9 +224,10 @@ class TestOTXTrainerAssignSubsets:
             SubsetAssignment(item_id=unassigned_items[2].item_id, subset=DatasetItemSubset.TESTING),
         ]
         fxt_assigner.assign.return_value = expected_assignments
+        project_id = uuid4()
 
         # Act
-        otx_trainer.assign_subsets()
+        otx_trainer.assign_subsets(project_id)
 
         # Assert
         fxt_subset_service.get_unassigned_items_with_labels.assert_called_once_with(project_id)
@@ -234,23 +237,18 @@ class TestOTXTrainerAssignSubsets:
 
     def test_assign_subsets_with_no_unassigned_items(
         self,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
         fxt_subset_service: Mock,
         fxt_assigner: Mock,
     ):
         """Test assigning subsets when no unassigned items exist."""
         # Arrange
         project_id = uuid4()
-        training_params = TrainingParams(
-            project_id=project_id,
-            model_architecture_id="Object_Detection_YOLOX_S",
-            task=TaskBase(task_type=TaskType.DETECTION),
-        )
         fxt_subset_service.get_unassigned_items_with_labels.return_value = []
-        otx_trainer = fxt_otx_trainer(training_params)
+        otx_trainer = fxt_otx_trainer()
 
         # Act
-        otx_trainer.assign_subsets()
+        otx_trainer.assign_subsets(project_id)
 
         # Assert
         fxt_subset_service.get_unassigned_items_with_labels.assert_called_once_with(project_id)
@@ -258,41 +256,20 @@ class TestOTXTrainerAssignSubsets:
         fxt_assigner.assign.assert_not_called()
         fxt_subset_service.update_subset_assignments.assert_not_called()
 
-    def test_assign_subsets_without_project_id_raises_error(
-        self,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
-    ):
-        """Test that ValueError is raised when no project ID is provided."""
-        # Arrange
-        training_params = TrainingParams(
-            project_id=None,
-            model_architecture_id="Object_Detection_YOLOX_S",
-            task=TaskBase(task_type=TaskType.DETECTION),
-        )
-        otx_trainer = fxt_otx_trainer(training_params)
-
-        # Act & Assert
-        with pytest.raises(ValueError, match="Project ID must be provided for subset assignment"):
-            otx_trainer.assign_subsets()
-
 
 class TestOTXTrainerCreateTrainingDataset:
     """Tests for the OTXTrainer.create_training_dataset method."""
 
     def test_create_training_dataset_success(
         self,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
         fxt_dataset_service: Mock,
     ):
         """Test successful creation of training, validation, and testing datasets."""
         # Arrange
         project_id = uuid4()
-        training_params = TrainingParams(
-            project_id=project_id,
-            model_architecture_id="Object_Detection_YOLOX_S",
-            task=TaskBase(task_type=TaskType.DETECTION, exclusive_labels=True),
-        )
-        otx_trainer = fxt_otx_trainer(training_params)
+        task = TaskBase(task_type=TaskType.DETECTION, exclusive_labels=True)
+        otx_trainer = fxt_otx_trainer()
 
         mock_dm_dataset = Mock()
         fxt_dataset_service.get_dm_dataset.return_value = mock_dm_dataset
@@ -308,7 +285,7 @@ class TestOTXTrainerCreateTrainingDataset:
         ]
 
         # Act
-        otx_trainer.create_training_dataset()
+        datasets_info = otx_trainer.create_training_dataset(project_id, task)
 
         # Assert
         fxt_dataset_service.get_dm_dataset.assert_called_once_with(
@@ -316,24 +293,65 @@ class TestOTXTrainerCreateTrainingDataset:
             TaskBase(task_type=TaskType.DETECTION, exclusive_labels=True),
             DatasetItemAnnotationStatus.REVIEWED,
         )
-        assert otx_trainer._training_dataset == mock_training_dataset
-        assert otx_trainer._validation_dataset == mock_validation_dataset
-        assert otx_trainer._testing_dataset == mock_testing_dataset
+        assert datasets_info.training == mock_training_dataset
+        assert datasets_info.validation == mock_validation_dataset
+        assert datasets_info.testing == mock_testing_dataset
         fxt_dataset_service.save_revision.assert_called_once_with(project_id, mock_dm_dataset)
 
-    def test_create_training_dataset_without_project_id_raises_error(
+
+class TestOTXTrainerPrepareModel:
+    """Tests for the OTXTrainer.prepare_model method."""
+
+    def test_prepare_model_success(
         self,
-        fxt_otx_trainer: Callable[[TrainingParams], OTXTrainer],
+        fxt_otx_trainer: Callable[[], OTXTrainer],
+        fxt_model_service: Mock,
     ):
-        """Test that ValueError is raised when no project ID is provided."""
+        """Test successful preparation of model metadata."""
+        # Arrange
+        project_id = uuid4()
+        model_id = uuid4()
+        training_params = TrainingParams(
+            model_id=model_id,
+            project_id=project_id,
+            model_architecture_id="Object_Detection_YOLOX_S",
+            task=TaskBase(task_type=TaskType.DETECTION),
+            parent_model_revision_id=None,
+        )
+        dataset_revision_id = uuid4()
+        otx_trainer = fxt_otx_trainer()
+
+        # Act
+        otx_trainer.prepare_model(training_params, dataset_revision_id)
+
+        # Assert
+        fxt_model_service.create_revision.assert_called_once_with(
+            ModelMetadata(
+                model_id=model_id,
+                project_id=project_id,
+                architecture_id="Object_Detection_YOLOX_S",
+                parent_revision_id=None,
+                training_status=TrainingStatus.NOT_STARTED,
+                dataset_revision_id=dataset_revision_id,
+            )
+        )
+
+    def test_prepare_model_no_project_id_raises_error(
+        self,
+        fxt_otx_trainer: Callable[[], OTXTrainer],
+    ):
+        """Test that ValueError is raised when project ID is not provided."""
         # Arrange
         training_params = TrainingParams(
+            model_id=uuid4(),
             project_id=None,
             model_architecture_id="Object_Detection_YOLOX_S",
-            task=TaskBase(task_type=TaskType.DETECTION, exclusive_labels=True),
+            task=TaskBase(task_type=TaskType.DETECTION),
+            parent_model_revision_id=None,
         )
-        otx_trainer = fxt_otx_trainer(training_params)
+        dataset_revision_id = uuid4()
+        otx_trainer = fxt_otx_trainer()
 
         # Act & Assert
-        with pytest.raises(ValueError, match="Project ID must be provided"):
-            otx_trainer.create_training_dataset()
+        with pytest.raises(ValueError, match="Project ID must be provided for model preparation"):
+            otx_trainer.prepare_model(training_params, dataset_revision_id)

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -12,7 +12,7 @@ from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, TaskType
 from app.schemas.model import TrainingStatus
 from app.schemas.project import TaskBase
-from app.services import DatasetService, ModelMetadata, ModelService
+from app.services import DatasetService, ModelRevisionMetadata, ModelService
 from app.services.base_weights_service import BaseWeightsService
 from app.services.training.models import TrainingParams
 from app.services.training.otx_trainer import OTXTrainer
@@ -326,7 +326,7 @@ class TestOTXTrainerPrepareModel:
 
         # Assert
         fxt_model_service.create_revision.assert_called_once_with(
-            ModelMetadata(
+            ModelRevisionMetadata(
                 model_id=model_id,
                 project_id=project_id,
                 architecture_id="Object_Detection_YOLOX_S",


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Added step to save the model revision in a database

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

1. Start the server with `./run.sh`
2. Run the training job:
  ```bash
  curl -X POST -H "Content-Type: application/json" http://localhost:7860/api/jobs -d '{"job_type": "train", "project_id": "9d6af8e8-6017-4ebe-9126-33aae739c5fa", "parameters": { "model_architecture_id": "Custom_Object_Detection_YOLOX" }}
  ```
3. A new record should be added in `model_revisions` table
  

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
