### PR TITLE
Upgrade OpenVINO to 2025.3 in OTX

### DIFF
--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "torchmetrics==1.6.0",
     "pytorchcv==0.0.67",
     "timm==1.0.3",
-    "openvino==2025.2",
+    "openvino==2025.3",
     "openvino-model-api==0.3.0.4",
     "onnx==1.19.1",
     "onnxconverter-common==1.16.0",


### PR DESCRIPTION
### Summary

Upgrade OpenVINO to latest `2025.3` release.

Release notes: https://github.com/openvinotoolkit/openvino/releases

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
