### PR TITLE
Compute Docker image size with SI units in GHA 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,7 +174,7 @@ jobs:
             IMAGE="geti-tune-${DEVICE}:${TAG}"
             if docker image inspect "$IMAGE" >/dev/null 2>&1; then
               size_bytes=$(docker image inspect "$IMAGE" --format='{{.Size}}')
-              size_readable=$(numfmt --to=iec --format "%.1f" "$size_bytes")
+              size_readable=$(numfmt --to=si --format "%.2f" "$size_bytes")
               echo "| $IMAGE | $size_readable |" >> image-sizes/${DEVICE}.md
             fi
           done


### PR DESCRIPTION
### Summary

Compute Docker image size using SI unit (GB) insted of IEC (GiB) and increase decimal precision to two digits.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
