### PR TITLE
Available devices endpoint

### DIFF
--- a/application/backend/app/api/routers/system.py
+++ b/application/backend/app/api/routers/system.py
@@ -8,9 +8,18 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from app.api.dependencies import get_system_service
+from app.schemas.system import DeviceInfo
 from app.services import SystemService
 
 router = APIRouter(prefix="/api")
+
+
+@router.get("/system/devices")
+async def get_devices(
+    system_service: Annotated[SystemService, Depends(get_system_service)],
+) -> list[DeviceInfo]:
+    """Returns the list of available compute devices (CPU, Intel XPU, NVIDIA CUDA)."""
+    return system_service.get_devices()
 
 
 @router.get("/system/metrics/memory")

--- a/application/backend/app/schemas/system.py
+++ b/application/backend/app/schemas/system.py
@@ -3,22 +3,32 @@
 
 """System schemas"""
 
+from enum import StrEnum, auto
+
 from pydantic import BaseModel, Field
+
+
+class DeviceType(StrEnum):
+    """Enumeration of device types"""
+
+    CPU = auto()
+    XPU = auto()
+    CUDA = auto()
 
 
 class DeviceInfo(BaseModel):
     """Device information schema"""
 
-    type: str = Field(..., description="Device type (cpu, xpu, or cuda)")
+    type: DeviceType = Field(..., description="Device type (cpu, xpu, or cuda)")
     name: str = Field(..., description="Device name")
-    memory: int | None = Field(None, description="Total device memory in bytes (null for CPU)")
-    index: int | None = Field(None, description="Device index (null for CPU)")
+    memory: int | None = Field(None, description="Total memory available to the device, in bytes (null for CPU)")
+    index: int | None = Field(None, description="Device index among those of the same type (null for CPU)")
 
     model_config = {
         "json_schema_extra": {
             "examples": [
                 {"type": "cpu", "name": "CPU"},
-                {"type": "xpu", "name": "Intel(R) Graphics [0x7d41]", "memory": 36022263808, "index": 0},
+                {"type": "xpu", "name": "Intel Arc B580", "memory": 12884901888, "index": 0},
                 {"type": "cuda", "name": "NVIDIA GeForce RTX 4090", "memory": 25769803776, "index": 0},
             ]
         }

--- a/application/backend/app/schemas/system.py
+++ b/application/backend/app/schemas/system.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""System schemas"""
+
+from pydantic import BaseModel, Field
+
+
+class DeviceInfo(BaseModel):
+    """Device information schema"""
+
+    type: str = Field(..., description="Device type (cpu, xpu, or cuda)")
+    name: str = Field(..., description="Device name")
+    memory: int | None = Field(None, description="Total device memory in bytes (null for CPU)")
+    index: int | None = Field(None, description="Device index (null for CPU)")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"type": "cpu", "name": "CPU"},
+                {"type": "xpu", "name": "Intel(R) Graphics [0x7d41]", "memory": 36022263808, "index": 0},
+                {"type": "cuda", "name": "NVIDIA GeForce RTX 4090", "memory": 25769803776, "index": 0},
+            ]
+        }
+    }

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -3,6 +3,8 @@
 
 import psutil
 
+from app.schemas.system import DeviceInfo
+
 
 class SystemService:
     """Service to get system information"""
@@ -28,3 +30,54 @@ class SystemService:
             float: CPU usage in percentage
         """
         return self.process.cpu_percent(interval=None)
+
+    @staticmethod
+    def get_devices() -> list[DeviceInfo]:
+        """
+        Get available compute devices (CPU, Intel XPU, NVIDIA CUDA)
+
+        Returns:
+            list[DeviceInfo]: List of available devices
+        """
+        # CPU is always available
+        devices: list[DeviceInfo] = [DeviceInfo(type="cpu", name="CPU", memory=None, index=None)]
+
+        # Check for Intel XPU devices
+        try:
+            import torch
+
+            if torch.xpu.is_available():
+                for device_idx in range(torch.xpu.device_count()):
+                    dp = torch.xpu.get_device_properties(device_idx)
+                    devices.append(
+                        DeviceInfo(
+                            type="xpu",
+                            name=dp.name,
+                            memory=dp.total_memory,
+                            index=device_idx,
+                        )
+                    )
+        except (ImportError, AttributeError, RuntimeError):
+            # torch not available, or XPU not supported
+            pass
+
+        # Check for NVIDIA CUDA devices
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                for device_idx in range(torch.cuda.device_count()):
+                    dp = torch.cuda.get_device_properties(device_idx)
+                    devices.append(
+                        DeviceInfo(
+                            type="cuda",
+                            name=dp.name,
+                            memory=dp.total_memory,
+                            index=device_idx,
+                        )
+                    )
+        except (ImportError, AttributeError, RuntimeError):
+            # torch not available, or CUDA not supported
+            pass
+
+        return devices

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -46,12 +46,12 @@ class SystemService:
         # Check for Intel XPU devices
         if torch.xpu.is_available():
             for device_idx in range(torch.xpu.device_count()):
-                dp = torch.xpu.get_device_properties(device_idx)
+                xpu_dp = torch.xpu.get_device_properties(device_idx)
                 devices.append(
                     DeviceInfo(
                         type=DeviceType.XPU,
-                        name=dp.name,
-                        memory=dp.total_memory,
+                        name=xpu_dp.name,
+                        memory=xpu_dp.total_memory,
                         index=device_idx,
                     )
                 )
@@ -59,12 +59,12 @@ class SystemService:
         # Check for NVIDIA CUDA devices
         if torch.cuda.is_available():
             for device_idx in range(torch.cuda.device_count()):
-                dp = torch.cuda.get_device_properties(device_idx)
+                cuda_dp = torch.cuda.get_device_properties(device_idx)
                 devices.append(
                     DeviceInfo(
                         type=DeviceType.CUDA,
-                        name=dp.name,
-                        memory=dp.total_memory,
+                        name=cuda_dp.name,
+                        memory=cuda_dp.total_memory,
                         index=device_idx,
                     )
                 )

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -4,7 +4,7 @@
 import psutil
 import torch
 
-from app.schemas.system import DeviceInfo
+from app.schemas.system import DeviceInfo, DeviceType
 
 
 class SystemService:
@@ -35,46 +35,38 @@ class SystemService:
     @staticmethod
     def get_devices() -> list[DeviceInfo]:
         """
-        Get available compute devices (CPU, Intel XPU, NVIDIA CUDA)
+        Get available compute devices (CPU,GPUs, ...)
 
         Returns:
             list[DeviceInfo]: List of available devices
         """
         # CPU is always available
-        devices: list[DeviceInfo] = [DeviceInfo(type="cpu", name="CPU", memory=None, index=None)]
+        devices: list[DeviceInfo] = [DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)]
 
         # Check for Intel XPU devices
-        try:
-            if torch.xpu.is_available():
-                for device_idx in range(torch.xpu.device_count()):
-                    dp = torch.xpu.get_device_properties(device_idx)
-                    devices.append(
-                        DeviceInfo(
-                            type="xpu",
-                            name=dp.name,
-                            memory=dp.total_memory,
-                            index=device_idx,
-                        )
+        if torch.xpu.is_available():
+            for device_idx in range(torch.xpu.device_count()):
+                dp = torch.xpu.get_device_properties(device_idx)
+                devices.append(
+                    DeviceInfo(
+                        type=DeviceType.XPU,
+                        name=dp.name,
+                        memory=dp.total_memory,
+                        index=device_idx,
                     )
-        except (ImportError, AttributeError, RuntimeError):
-            # torch not available, or XPU not supported
-            pass
+                )
 
         # Check for NVIDIA CUDA devices
-        try:
-            if torch.cuda.is_available():
-                for device_idx in range(torch.cuda.device_count()):
-                    dp = torch.cuda.get_device_properties(device_idx)
-                    devices.append(
-                        DeviceInfo(
-                            type="cuda",
-                            name=dp.name,
-                            memory=dp.total_memory,
-                            index=device_idx,
-                        )
+        if torch.cuda.is_available():
+            for device_idx in range(torch.cuda.device_count()):
+                dp = torch.cuda.get_device_properties(device_idx)
+                devices.append(
+                    DeviceInfo(
+                        type=DeviceType.CUDA,
+                        name=dp.name,
+                        memory=dp.total_memory,
+                        index=device_idx,
                     )
-        except (ImportError, AttributeError, RuntimeError):
-            # torch not available, or CUDA not supported
-            pass
+                )
 
         return devices

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -35,7 +35,7 @@ class SystemService:
     @staticmethod
     def get_devices() -> list[DeviceInfo]:
         """
-        Get available compute devices (CPU,GPUs, ...)
+        Get available compute devices (CPU, GPUs, ...)
 
         Returns:
             list[DeviceInfo]: List of available devices

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import psutil
+import torch
 
 from app.schemas.system import DeviceInfo
 
@@ -44,8 +45,6 @@ class SystemService:
 
         # Check for Intel XPU devices
         try:
-            import torch
-
             if torch.xpu.is_available():
                 for device_idx in range(torch.xpu.device_count()):
                     dp = torch.xpu.get_device_properties(device_idx)
@@ -63,8 +62,6 @@ class SystemService:
 
         # Check for NVIDIA CUDA devices
         try:
-            import torch
-
             if torch.cuda.is_available():
                 for device_idx in range(torch.cuda.device_count()):
                     dp = torch.cuda.get_device_properties(device_idx)

--- a/application/backend/tests/unit/routers/test_system.py
+++ b/application/backend/tests/unit/routers/test_system.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_system_service
+from app.main import app
+from app.schemas.system import DeviceInfo
+from app.services import SystemService
+
+
+@pytest.fixture
+def fxt_client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def fxt_system_service() -> Mock:
+    system_service = Mock(spec=SystemService)
+    app.dependency_overrides[get_system_service] = lambda: system_service
+    return system_service
+
+
+class TestSystemEndpoints:
+    def test_get_devices_cpu_only(self, fxt_system_service: Mock, fxt_client: TestClient):
+        """Test GET /api/system/devices with CPU only"""
+        fxt_system_service.get_devices.return_value = [
+            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
+        ]
+
+        response = fxt_client.get("/api/system/devices")
+
+        assert response.status_code == status.HTTP_200_OK
+        devices = response.json()
+        assert len(devices) == 1
+        assert devices[0]["type"] == "cpu"
+        assert devices[0]["name"] == "CPU"
+        assert devices[0]["memory"] is None
+        assert devices[0]["index"] is None
+
+    def test_get_devices_with_xpu(self, fxt_system_service: Mock, fxt_client: TestClient):
+        """Test GET /api/system/devices with Intel XPU"""
+        fxt_system_service.get_devices.return_value = [
+            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
+            DeviceInfo(type="xpu", name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
+        ]
+
+        response = fxt_client.get("/api/system/devices")
+
+        assert response.status_code == status.HTTP_200_OK
+        devices = response.json()
+        assert len(devices) == 2
+        assert devices[0]["type"] == "cpu"
+        assert devices[1]["type"] == "xpu"
+        assert devices[1]["name"] == "Intel(R) Graphics [0x7d41]"
+        assert devices[1]["memory"] == 36022263808
+        assert devices[1]["index"] == 0
+
+    def test_get_devices_with_cuda(self, fxt_system_service: Mock, fxt_client: TestClient):
+        """Test GET /api/system/devices with NVIDIA CUDA"""
+        fxt_system_service.get_devices.return_value = [
+            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
+            DeviceInfo(type="cuda", name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
+        ]
+
+        response = fxt_client.get("/api/system/devices")
+
+        assert response.status_code == status.HTTP_200_OK
+        devices = response.json()
+        assert len(devices) == 2
+        assert devices[0]["type"] == "cpu"
+        assert devices[1]["type"] == "cuda"
+        assert devices[1]["name"] == "NVIDIA GeForce RTX 4090"
+        assert devices[1]["memory"] == 25769803776
+        assert devices[1]["index"] == 0
+
+    def test_get_devices_with_all_devices(self, fxt_system_service: Mock, fxt_client: TestClient):
+        """Test GET /api/system/devices with all device types"""
+        fxt_system_service.get_devices.return_value = [
+            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
+            DeviceInfo(type="xpu", name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
+            DeviceInfo(type="cuda", name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
+        ]
+
+        response = fxt_client.get("/api/system/devices")
+
+        assert response.status_code == status.HTTP_200_OK
+        devices = response.json()
+        assert len(devices) == 3
+        assert devices[0]["type"] == "cpu"
+        assert devices[1]["type"] == "xpu"
+        assert devices[2]["type"] == "cuda"
+
+    def test_get_memory(self, fxt_system_service: Mock, fxt_client: TestClient):
+        """Test GET /api/system/metrics/memory"""
+        fxt_system_service.get_memory_usage.return_value = (1024.5, 8192.0)
+
+        response = fxt_client.get("/api/system/metrics/memory")
+
+        assert response.status_code == status.HTTP_200_OK
+        memory = response.json()
+        assert memory["used"] == 1024
+        assert memory["total"] == 8192

--- a/application/backend/tests/unit/routers/test_system.py
+++ b/application/backend/tests/unit/routers/test_system.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.api.dependencies import get_system_service
 from app.main import app
-from app.schemas.system import DeviceInfo
+from app.schemas.system import DeviceInfo, DeviceType
 from app.services import SystemService
 
 
@@ -29,7 +29,7 @@ class TestSystemEndpoints:
     def test_get_devices_cpu_only(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices with CPU only"""
         fxt_system_service.get_devices.return_value = [
-            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
+            DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
         ]
 
         response = fxt_client.get("/api/system/devices")
@@ -45,8 +45,8 @@ class TestSystemEndpoints:
     def test_get_devices_with_xpu(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices with Intel XPU"""
         fxt_system_service.get_devices.return_value = [
-            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
-            DeviceInfo(type="xpu", name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
+            DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
+            DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
         ]
 
         response = fxt_client.get("/api/system/devices")
@@ -63,8 +63,8 @@ class TestSystemEndpoints:
     def test_get_devices_with_cuda(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices with NVIDIA CUDA"""
         fxt_system_service.get_devices.return_value = [
-            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
-            DeviceInfo(type="cuda", name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
+            DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
+            DeviceInfo(type=DeviceType.CUDA, name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
         ]
 
         response = fxt_client.get("/api/system/devices")
@@ -81,9 +81,9 @@ class TestSystemEndpoints:
     def test_get_devices_with_all_devices(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices with all device types"""
         fxt_system_service.get_devices.return_value = [
-            DeviceInfo(type="cpu", name="CPU", memory=None, index=None),
-            DeviceInfo(type="xpu", name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
-            DeviceInfo(type="cuda", name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
+            DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
+            DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
+            DeviceInfo(type=DeviceType.CUDA, name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
         ]
 
         response = fxt_client.get("/api/system/devices")

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.system_service import SystemService
+
+
+class TestSystemService:
+    """Test cases for SystemService"""
+
+    @pytest.fixture
+    def fxt_system_service(self) -> SystemService:
+        return SystemService()
+
+    def test_get_memory_usage(self, fxt_system_service: SystemService):
+        """Test getting memory usage"""
+        used, total = fxt_system_service.get_memory_usage()
+
+        assert used > 0
+        assert total > 0
+        assert used <= total
+
+    def test_get_cpu_usage(self, fxt_system_service: SystemService):
+        """Test getting CPU usage"""
+        cpu_usage = fxt_system_service.get_cpu_usage()
+
+        assert cpu_usage >= 0.0
+
+    def test_get_devices_cpu_only(self, fxt_system_service: SystemService):
+        """Test getting devices when only CPU is available"""
+        mock_torch = MagicMock()
+        # Simulate torch not being available
+        mock_torch.xpu.is_available.side_effect = AttributeError()
+        mock_torch.cuda.is_available.side_effect = AttributeError()
+
+        with patch.dict(sys.modules, {"torch": mock_torch}):
+            devices = fxt_system_service.get_devices()
+
+            assert len(devices) == 1
+            assert devices[0].type == "cpu"
+            assert devices[0].name == "CPU"
+            assert devices[0].memory is None
+            assert devices[0].index is None
+
+    def test_get_devices_with_xpu(self, fxt_system_service: SystemService):
+        """Test getting devices when Intel XPU is available"""
+        mock_torch = MagicMock()
+        # Mock XPU device
+        mock_dp = MagicMock()
+        mock_dp.name = "Intel(R) Graphics [0x7d41]"
+        mock_dp.total_memory = 36022263808
+
+        mock_torch.xpu.is_available.return_value = True
+        mock_torch.xpu.device_count.return_value = 1
+        mock_torch.xpu.get_device_properties.return_value = mock_dp
+
+        # CUDA not available
+        mock_torch.cuda.is_available.return_value = False
+
+        with patch.dict(sys.modules, {"torch": mock_torch}):
+            devices = fxt_system_service.get_devices()
+
+            assert len(devices) == 2
+            assert devices[0].type == "cpu"
+            assert devices[1].type == "xpu"
+            assert devices[1].name == "Intel(R) Graphics [0x7d41]"
+            assert devices[1].memory == 36022263808
+            assert devices[1].index == 0
+
+    def test_get_devices_with_cuda(self, fxt_system_service: SystemService):
+        """Test getting devices when NVIDIA CUDA is available"""
+        mock_torch = MagicMock()
+        # XPU not available
+        mock_torch.xpu.is_available.return_value = False
+
+        # Mock CUDA device
+        mock_dp = MagicMock()
+        mock_dp.name = "NVIDIA GeForce RTX 4090"
+        mock_dp.total_memory = 25769803776
+
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.device_count.return_value = 1
+        mock_torch.cuda.get_device_properties.return_value = mock_dp
+
+        with patch.dict(sys.modules, {"torch": mock_torch}):
+            devices = fxt_system_service.get_devices()
+
+            assert len(devices) == 2
+            assert devices[0].type == "cpu"
+            assert devices[1].type == "cuda"
+            assert devices[1].name == "NVIDIA GeForce RTX 4090"
+            assert devices[1].memory == 25769803776
+            assert devices[1].index == 0
+
+    def test_get_devices_with_multiple_devices(self, fxt_system_service: SystemService):
+        """Test getting devices when multiple GPUs are available"""
+        mock_torch = MagicMock()
+        # Mock XPU device
+        mock_xpu_dp = MagicMock()
+        mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
+        mock_xpu_dp.total_memory = 36022263808
+
+        mock_torch.xpu.is_available.return_value = True
+        mock_torch.xpu.device_count.return_value = 1
+        mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+
+        # Mock CUDA device
+        mock_cuda_dp = MagicMock()
+        mock_cuda_dp.name = "NVIDIA GeForce RTX 4090"
+        mock_cuda_dp.total_memory = 25769803776
+
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.device_count.return_value = 1
+        mock_torch.cuda.get_device_properties.return_value = mock_cuda_dp
+
+        with patch.dict(sys.modules, {"torch": mock_torch}):
+            devices = fxt_system_service.get_devices()
+
+            assert len(devices) == 3
+            assert devices[0].type == "cpu"
+            assert devices[1].type == "xpu"
+            assert devices[2].type == "cuda"
+
+    def test_get_devices_torch_not_available(self, fxt_system_service: SystemService):
+        """Test getting devices when torch is not available"""
+        # Remove torch from sys.modules to simulate ImportError
+        original_torch = sys.modules.get("torch")
+        if "torch" in sys.modules:
+            del sys.modules["torch"]
+
+        try:
+            devices = fxt_system_service.get_devices()
+
+            assert len(devices) == 1
+            assert devices[0].type == "cpu"
+        finally:
+            # Restore torch if it was present
+            if original_torch is not None:
+                sys.modules["torch"] = original_torch

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,112 +31,83 @@ class TestSystemService:
 
     def test_get_devices_cpu_only(self, fxt_system_service: SystemService):
         """Test getting devices when only CPU is available"""
-        mock_torch = MagicMock()
-        # Simulate torch not being available
-        mock_torch.xpu.is_available.side_effect = AttributeError()
-        mock_torch.cuda.is_available.side_effect = AttributeError()
+        with patch("app.services.system_service.torch") as mock_torch:
+            # Simulate torch not being available
+            mock_torch.xpu.is_available.return_value = False
+            mock_torch.cuda.is_available.return_value = False
 
-        with patch.dict(sys.modules, {"torch": mock_torch}):
             devices = fxt_system_service.get_devices()
 
             assert len(devices) == 1
-            assert devices[0].type == "cpu"
             assert devices[0].name == "CPU"
             assert devices[0].memory is None
             assert devices[0].index is None
 
     def test_get_devices_with_xpu(self, fxt_system_service: SystemService):
         """Test getting devices when Intel XPU is available"""
-        mock_torch = MagicMock()
-        # Mock XPU device
-        mock_dp = MagicMock()
-        mock_dp.name = "Intel(R) Graphics [0x7d41]"
-        mock_dp.total_memory = 36022263808
+        with patch("app.services.system_service.torch") as mock_torch:
+            # Mock XPU device
+            mock_dp = MagicMock()
+            mock_dp.name = "Intel(R) Graphics [0x7d41]"
+            mock_dp.total_memory = 36022263808
 
-        mock_torch.xpu.is_available.return_value = True
-        mock_torch.xpu.device_count.return_value = 1
-        mock_torch.xpu.get_device_properties.return_value = mock_dp
+            mock_torch.xpu.is_available.return_value = True
+            mock_torch.xpu.device_count.return_value = 1
+            mock_torch.xpu.get_device_properties.return_value = mock_dp
 
-        # CUDA not available
-        mock_torch.cuda.is_available.return_value = False
+            # CUDA not available
+            mock_torch.cuda.is_available.return_value = False
 
-        with patch.dict(sys.modules, {"torch": mock_torch}):
             devices = fxt_system_service.get_devices()
 
             assert len(devices) == 2
-            assert devices[0].type == "cpu"
-            assert devices[1].type == "xpu"
             assert devices[1].name == "Intel(R) Graphics [0x7d41]"
             assert devices[1].memory == 36022263808
             assert devices[1].index == 0
 
     def test_get_devices_with_cuda(self, fxt_system_service: SystemService):
         """Test getting devices when NVIDIA CUDA is available"""
-        mock_torch = MagicMock()
-        # XPU not available
-        mock_torch.xpu.is_available.return_value = False
+        with patch("app.services.system_service.torch") as mock_torch:
+            # XPU not available
+            mock_torch.xpu.is_available.return_value = False
 
-        # Mock CUDA device
-        mock_dp = MagicMock()
-        mock_dp.name = "NVIDIA GeForce RTX 4090"
-        mock_dp.total_memory = 25769803776
+            # Mock CUDA device
+            mock_dp = MagicMock()
+            mock_dp.name = "NVIDIA GeForce RTX 4090"
+            mock_dp.total_memory = 25769803776
 
-        mock_torch.cuda.is_available.return_value = True
-        mock_torch.cuda.device_count.return_value = 1
-        mock_torch.cuda.get_device_properties.return_value = mock_dp
+            mock_torch.cuda.is_available.return_value = True
+            mock_torch.cuda.device_count.return_value = 1
+            mock_torch.cuda.get_device_properties.return_value = mock_dp
 
-        with patch.dict(sys.modules, {"torch": mock_torch}):
             devices = fxt_system_service.get_devices()
 
             assert len(devices) == 2
-            assert devices[0].type == "cpu"
-            assert devices[1].type == "cuda"
             assert devices[1].name == "NVIDIA GeForce RTX 4090"
             assert devices[1].memory == 25769803776
             assert devices[1].index == 0
 
     def test_get_devices_with_multiple_devices(self, fxt_system_service: SystemService):
         """Test getting devices when multiple GPUs are available"""
-        mock_torch = MagicMock()
-        # Mock XPU device
-        mock_xpu_dp = MagicMock()
-        mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
-        mock_xpu_dp.total_memory = 36022263808
+        with patch("app.services.system_service.torch") as mock_torch:
+            # Mock XPU device
+            mock_xpu_dp = MagicMock()
+            mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
+            mock_xpu_dp.total_memory = 36022263808
 
-        mock_torch.xpu.is_available.return_value = True
-        mock_torch.xpu.device_count.return_value = 1
-        mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+            mock_torch.xpu.is_available.return_value = True
+            mock_torch.xpu.device_count.return_value = 1
+            mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
 
-        # Mock CUDA device
-        mock_cuda_dp = MagicMock()
-        mock_cuda_dp.name = "NVIDIA GeForce RTX 4090"
-        mock_cuda_dp.total_memory = 25769803776
+            # Mock CUDA device
+            mock_cuda_dp = MagicMock()
+            mock_cuda_dp.name = "NVIDIA GeForce RTX 4090"
+            mock_cuda_dp.total_memory = 25769803776
 
-        mock_torch.cuda.is_available.return_value = True
-        mock_torch.cuda.device_count.return_value = 1
-        mock_torch.cuda.get_device_properties.return_value = mock_cuda_dp
+            mock_torch.cuda.is_available.return_value = True
+            mock_torch.cuda.device_count.return_value = 1
+            mock_torch.cuda.get_device_properties.return_value = mock_cuda_dp
 
-        with patch.dict(sys.modules, {"torch": mock_torch}):
             devices = fxt_system_service.get_devices()
 
             assert len(devices) == 3
-            assert devices[0].type == "cpu"
-            assert devices[1].type == "xpu"
-            assert devices[2].type == "cuda"
-
-    def test_get_devices_torch_not_available(self, fxt_system_service: SystemService):
-        """Test getting devices when torch is not available"""
-        # Remove torch from sys.modules to simulate ImportError
-        original_torch = sys.modules.get("torch")
-        if "torch" in sys.modules:
-            del sys.modules["torch"]
-
-        try:
-            devices = fxt_system_service.get_devices()
-
-            assert len(devices) == 1
-            assert devices[0].type == "cpu"
-        finally:
-            # Restore torch if it was present
-            if original_torch is not None:
-                sys.modules["torch"] = original_torch


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds endpoint to retrieve available compute devices, split by type
- CPU
- XPU
- CUDA


### How to test

`GET /api/system/devices`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
