### PR TITLE
Set annotations submitted via API as user reviewed

### DIFF
--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -257,7 +257,11 @@ def set_dataset_item_annotations(
     """Set dataset item annotations"""
     try:
         dataset_item = dataset_service.set_dataset_item_annotations(
-            project=project, dataset_item_id=dataset_item_id, annotations=dataset_item_annotations.annotations
+            project=project,
+            dataset_item_id=dataset_item_id,
+            annotations=dataset_item_annotations.annotations,
+            # Annotations submitted via API are considered user-reviewed, unlike auto-generated predictions
+            user_reviewed=True,
         )
         return DatasetItemAnnotations(
             annotations=dataset_item.annotation_data,  # type: ignore[arg-type]

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -128,7 +128,9 @@ class DatasetItemRepository:
         result = cast(CursorResult, self.db.execute(stmt))
         return result.rowcount > 0
 
-    def set_annotation_data(self, obj_id: str, annotation_data: list) -> UpdateDatasetItemAnnotation | None:
+    def set_annotation_data(
+        self, obj_id: str, annotation_data: list, user_reviewed: bool
+    ) -> UpdateDatasetItemAnnotation | None:
         stmt = (
             update(DatasetItemDB)
             .returning(
@@ -142,6 +144,7 @@ class DatasetItemRepository:
             )
             .values(
                 annotation_data=annotation_data,
+                user_reviewed=user_reviewed,
                 updated_at=datetime.now(UTC),
             )
         )

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -312,9 +312,20 @@ class DatasetService(BaseSessionManagedService):
                         raise AnnotationValidationError("Polygon points are out of bounds")
 
     def set_dataset_item_annotations(
-        self, project: Project, dataset_item_id: UUID, annotations: list[DatasetItemAnnotation]
+        self, project: Project, dataset_item_id: UUID, annotations: list[DatasetItemAnnotation], user_reviewed: bool
     ) -> DatasetItem:
-        """Set dataset item annotations"""
+        """
+        Set dataset item annotations
+
+        Args:
+            project: The project to which the dataset item belongs.
+            dataset_item_id: The ID of the dataset item.
+            annotations: The list of annotations to set. Overwrites existing annotations, if any.
+            user_reviewed: Whether the annotations have been reviewed by a user.
+
+        Returns:
+            The updated dataset item.
+        """
         labels = self._label_service.list_all(project_id=project.id)
         DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
         DatasetService._validate_annotations(annotations=annotations, project=project)
@@ -327,6 +338,7 @@ class DatasetService(BaseSessionManagedService):
         result = repo.set_annotation_data(
             obj_id=str(dataset_item_id),
             annotation_data=[annotation.model_dump(mode="json") for annotation in annotations],
+            user_reviewed=user_reviewed,
         )
         if not result:
             raise ResourceNotFoundError(ResourceType.DATASET_ITEM, str(dataset_item_id))

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -419,6 +419,7 @@ class TestDatasetItemEndpoints:
             project=fxt_get_project,
             dataset_item_id=dataset_item_id,
             annotations=annotations,
+            user_reviewed=True,
         )
 
     def test_set_dataset_item_annotations_label_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
@@ -442,6 +443,7 @@ class TestDatasetItemEndpoints:
             project=fxt_get_project,
             dataset_item_id=dataset_item_id,
             annotations=annotations,
+            user_reviewed=True,
         )
 
     def test_set_dataset_item_annotations_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
@@ -467,6 +469,7 @@ class TestDatasetItemEndpoints:
             project=fxt_get_project,
             dataset_item_id=dataset_item_id,
             annotations=annotations,
+            user_reviewed=True,
         )
 
     def test_get_dataset_item_annotations(self, fxt_get_project, fxt_dataset_service, fxt_client):

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -1,11 +1,14 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB
 from app.models import (
+    DatasetItem,
     DatasetItemAnnotation,
     FullImage,
     Label,
@@ -17,14 +20,64 @@ from app.models import (
     Task,
     TaskType,
 )
-from app.services import DatasetService
+from app.repositories import DatasetItemRepository
+from app.services import DatasetService, LabelService
 from app.services.dataset_service import AnnotationValidationError
 
 
 class TestDatasetServiceUnit:
     """Unit tests for DatasetService."""
 
-    def test_validate_annotations_labels(self):
+    @pytest.fixture
+    def fxt_dataset_service(self, tmp_path):
+        db_session = MagicMock(spec=Session)
+        label_service = MagicMock(spec=LabelService)
+        return DatasetService(
+            data_dir=tmp_path,
+            label_service=label_service,
+            db_session=db_session,
+        )
+
+    @pytest.fixture
+    def fxt_multiclass_classification_project(self):
+        return Project(
+            id=uuid4(),
+            name="Test Multiclass Classification Project",
+            task=Task(
+                task_type=TaskType.CLASSIFICATION,
+                exclusive_labels=True,
+            ),
+            active_pipeline=False,
+        )
+
+    @pytest.fixture
+    def fxt_multilabel_classification_project(self):
+        return Project(
+            id=uuid4(),
+            name="Test Multilabel Classification Project",
+            task=Task(task_type=TaskType.CLASSIFICATION, exclusive_labels=False),
+            active_pipeline=False,
+        )
+
+    @pytest.fixture
+    def fxt_detection_project(self):
+        return Project(
+            id=uuid4(),
+            name="Test Detection Project",
+            task=Task(task_type=TaskType.DETECTION),
+            active_pipeline=False,
+        )
+
+    @pytest.fixture
+    def fxt_segmentation_project(self):
+        return Project(
+            id=uuid4(),
+            name="Test Instance Segmentation Project",
+            task=Task(task_type=TaskType.INSTANCE_SEGMENTATION),
+            active_pipeline=False,
+        )
+
+    def test_validate_annotations_labels(self) -> None:
         label_id = uuid4()
         labels = [Label(id=label_id, project_id=uuid4(), name="cat", color="#00FF00", hotkey="c")]
         annotations = [
@@ -35,7 +88,7 @@ class TestDatasetServiceUnit:
         ]
         DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
 
-    def test_validate_annotations_labels_not_found(self):
+    def test_validate_annotations_labels_not_found(self) -> None:
         label_id = uuid4()
         labels = [Label(id=label_id, project_id=uuid4(), name="cat", color="#00FF00", hotkey="c")]
         annotations = [
@@ -47,7 +100,7 @@ class TestDatasetServiceUnit:
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
 
-    def test_validate_annotations_coordinates_rectangle(self):
+    def test_validate_annotations_coordinates_rectangle(self) -> None:
         dataset_item = DatasetItemDB(name="test", format="jpg", width=100, height=50, size=1024)
         annotations = [
             DatasetItemAnnotation(
@@ -77,7 +130,7 @@ class TestDatasetServiceUnit:
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations_coordinates(annotations=annotations, dataset_item=dataset_item)
 
-    def test_validate_annotations_coordinates_polygon(self):
+    def test_validate_annotations_coordinates_polygon(self) -> None:
         dataset_item = DatasetItemDB(name="test", format="jpg", width=100, height=50, size=1024)
         annotations = [
             DatasetItemAnnotation(
@@ -105,28 +158,18 @@ class TestDatasetServiceUnit:
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations_coordinates(annotations=annotations, dataset_item=dataset_item)
 
-    def test_validate_annotations_multilabel_classification(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Classification Project",
-            task=Task(task_type=TaskType.CLASSIFICATION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_multilabel_classification(self, fxt_multilabel_classification_project) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4()), LabelReference(id=uuid4())],
                 shape=FullImage(type="full_image"),
             )
         ]
-        DatasetService._validate_annotations(annotations=annotations, project=project)
+        DatasetService._validate_annotations(annotations=annotations, project=fxt_multilabel_classification_project)
 
-    def test_validate_annotations_multilabel_classification_multi_annotations(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Classification Project",
-            task=Task(task_type=TaskType.CLASSIFICATION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_multilabel_classification_multi_annotations(
+        self, fxt_multilabel_classification_project
+    ) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4()), LabelReference(id=uuid4())],
@@ -138,7 +181,7 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_multilabel_classification_project)
 
     @pytest.mark.parametrize(
         "shape",
@@ -147,13 +190,9 @@ class TestDatasetServiceUnit:
             Polygon(type="polygon", points=[Point(x=0, y=0), Point(x=10, y=10)]),
         ],
     )
-    def test_validate_annotations_multilabel_classification_wrong_shape(self, shape):
-        project = Project(
-            id=uuid4(),
-            name="Test Classification Project",
-            task=Task(task_type=TaskType.CLASSIFICATION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_multilabel_classification_wrong_shape(
+        self, shape, fxt_multilabel_classification_project
+    ):
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4()), LabelReference(id=uuid4())],
@@ -161,18 +200,11 @@ class TestDatasetServiceUnit:
             )
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_multilabel_classification_project)
 
-    def test_validate_annotations_multiclass_classification_multiple_labels(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Classification Project",
-            task=Task(
-                task_type=TaskType.CLASSIFICATION,
-                exclusive_labels=True,
-            ),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_multiclass_classification_multiple_labels(
+        self, fxt_multiclass_classification_project
+    ) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4()), LabelReference(id=uuid4())],
@@ -180,15 +212,9 @@ class TestDatasetServiceUnit:
             )
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_multiclass_classification_project)
 
-    def test_validate_annotations_detection(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Detection Project",
-            task=Task(task_type=TaskType.DETECTION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_detection(self, fxt_detection_project) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4())],
@@ -199,7 +225,7 @@ class TestDatasetServiceUnit:
                 shape=Rectangle(type="rectangle", x=10, y=10, width=10, height=10),
             ),
         ]
-        DatasetService._validate_annotations(annotations=annotations, project=project)
+        DatasetService._validate_annotations(annotations=annotations, project=fxt_detection_project)
 
     @pytest.mark.parametrize(
         "shape",
@@ -208,13 +234,7 @@ class TestDatasetServiceUnit:
             Polygon(type="polygon", points=[Point(x=0, y=0), Point(x=10, y=10)]),
         ],
     )
-    def test_validate_annotations_detection_wrong_shape(self, shape):
-        project = Project(
-            id=uuid4(),
-            name="Test Detection Project",
-            task=Task(task_type=TaskType.DETECTION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_detection_wrong_shape(self, shape, fxt_detection_project):
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4())],
@@ -226,15 +246,9 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_detection_project)
 
-    def test_validate_annotations_detection_wrong_shape_multiple_labels(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Detection Project",
-            task=Task(task_type=TaskType.DETECTION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_detection_wrong_shape_multiple_labels(self, fxt_detection_project) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4()), LabelReference(id=uuid4())],
@@ -246,15 +260,9 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_detection_project)
 
-    def test_validate_annotations_segmentation(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Instance Segmentation Project",
-            task=Task(task_type=TaskType.INSTANCE_SEGMENTATION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_segmentation(self, fxt_segmentation_project) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4())],
@@ -265,7 +273,7 @@ class TestDatasetServiceUnit:
                 shape=Polygon(type="polygon", points=[Point(x=10, y=10), Point(x=20, y=20)]),
             ),
         ]
-        DatasetService._validate_annotations(annotations=annotations, project=project)
+        DatasetService._validate_annotations(annotations=annotations, project=fxt_segmentation_project)
 
     @pytest.mark.parametrize(
         "shape",
@@ -274,13 +282,7 @@ class TestDatasetServiceUnit:
             Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
         ],
     )
-    def test_validate_annotations_segmentation_wrong_shape(self, shape):
-        project = Project(
-            id=uuid4(),
-            name="Test Instance Segmentation Project",
-            task=Task(task_type=TaskType.INSTANCE_SEGMENTATION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_segmentation_wrong_shape(self, shape, fxt_segmentation_project):
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4())],
@@ -292,15 +294,9 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_segmentation_project)
 
-    def test_validate_annotations_segmentation_wrong_shape_multiple_labels(self):
-        project = Project(
-            id=uuid4(),
-            name="Test Instance Segmentation Project",
-            task=Task(task_type=TaskType.INSTANCE_SEGMENTATION),
-            active_pipeline=False,
-        )
+    def test_validate_annotations_segmentation_wrong_shape_multiple_labels(self, fxt_segmentation_project) -> None:
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=uuid4()), LabelReference(id=uuid4())],
@@ -312,4 +308,51 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, project=fxt_segmentation_project)
+
+    def test_set_dataset_item_annotations(self, fxt_dataset_service, fxt_detection_project) -> None:
+        dataset_service = fxt_dataset_service
+        dataset_item_id = uuid4()
+        dataset_item = MagicMock(spec=DatasetItem)
+        label_id = uuid4()
+        dataset_item_annotations = [
+            DatasetItemAnnotation(
+                labels=[LabelReference(id=label_id)],
+                shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
+            )
+        ]
+
+        with (
+            patch.object(DatasetService, "_validate_annotations_labels") as mock_validate_labels,
+            patch.object(DatasetService, "_validate_annotations") as mock_validate_annotations,
+            patch.object(DatasetService, "_validate_annotations_coordinates") as mock_validate_coordinates,
+            patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
+            patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,
+            patch.object(DatasetItemRepository, "set_labels") as mock_repo_set_labels,
+        ):
+            result = dataset_service.set_dataset_item_annotations(
+                project=fxt_detection_project,
+                dataset_item_id=dataset_item_id,
+                annotations=dataset_item_annotations,
+                user_reviewed=True,
+            )
+
+        mock_validate_labels.assert_called_once()
+        mock_validate_annotations.assert_called_once()
+        mock_validate_coordinates.assert_called_once()
+        mock_repo_set_annotation_data.assert_called_once_with(
+            obj_id=str(dataset_item_id),
+            annotation_data=[
+                {
+                    "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10},
+                    "labels": [{"id": str(label_id)}],
+                    "confidences": None,
+                }
+            ],
+            user_reviewed=True,
+        )
+        mock_repo_set_labels.assert_called_once_with(
+            dataset_item_id=str(dataset_item_id),
+            label_ids={str(label_id)},
+        )
+        assert result == dataset_item


### PR DESCRIPTION
### Summary

`DatasetItem` has a field `user_reviewed` to distinguish between raw auto-generated model predictions and annotations that have been created/reviewed by a user.

The `POST /annotations` endpoint should always set `user_reviewed=True`, because such annotations come from a request initiated by the client (user).

Resolves #5068 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
