### PR TITLE
Bugfixes in OTXDataModule

### DIFF
--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging as log
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Sequence
 
 from datumaro import Dataset as DmDataset
 from lightning import LightningDataModule
@@ -18,7 +18,7 @@ from torchvision.transforms.v2 import Normalize
 from otx.config.data import SubsetConfig, TileConfig
 from otx.data.dataset.tile import OTXTileDatasetFactory
 from otx.data.factory import OTXDatasetFactory
-from otx.data.transform_libs.torchvision import TorchVisionTransformLib
+from otx.data.transform_libs.torchvision import Compose, TorchVisionTransformLib
 from otx.data.utils import adapt_tile_config, get_adaptive_num_workers, instantiate_sampler
 from otx.data.utils.pre_filtering import pre_filtering
 from otx.types.device import DeviceType
@@ -191,13 +191,19 @@ class OTXDataModule(LightningDataModule):
 
         self.label_info = next(iter(label_infos))
 
+    @classmethod
     def extract_normalization_params(
-        self, transforms_source: list | None
+        cls, transforms_source: Sequence[dict[str, Any]] | Compose | None
     ) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
-        """Extract mean and std from transforms.
+        """Extract mean and std from the dataset transforms.
+
+        Specifically, this method looks for a Normalize transform in the provided transforms, and extracts
+        the mean and std values used for normalization.
+        If not found, it returns default values of mean=(0.0, 0.0, 0.0) and std=(1.0, 1.0, 1.0).
 
         Args:
-            transforms_source: List of transforms or None.
+            transforms_source: Transforms applied to the dataset.
+                Should be specified as an iterable of transform descriptors (jsonargparse-like) or a Compose object
 
         Returns:
             Tuple of (mean, std) tuples.
@@ -205,21 +211,34 @@ class OTXDataModule(LightningDataModule):
         mean = (0.0, 0.0, 0.0)
         std = (1.0, 1.0, 1.0)
 
-        if transforms_source is not None:
-            for transform in transforms_source:
-                if isinstance(transform, dict) and "Normalize" in transform.get("class_path", ""):
-                    # CLI case with jsonargparse
-                    mean = transform["init_args"].get("mean", (0.0, 0.0, 0.0))
-                    std = transform["init_args"].get("std", (1.0, 1.0, 1.0))
-                    break
+        if transforms_source is None:
+            return mean, std
+        if hasattr(transforms_source, "__iter__"):
+            transforms_iterable = transforms_source
+        elif isinstance(transforms_source, Compose):
+            transforms_iterable = transforms_source.transforms
+        else:
+            msg = f"Transforms should be given as an iterable or a Compose object, got {type(transforms_source)}"
+            raise TypeError(msg)
 
-                if isinstance(transform, Normalize):
-                    # torchvision.transforms case
-                    mean = transform.mean
-                    std = transform.std
-                    break
+        for transform in transforms_iterable:
+            if isinstance(transform, dict) and "Normalize" in transform.get("class_path", ""):
+                # CLI case with jsonargparse
+                mean = transform["init_args"].get("mean", (0.0, 0.0, 0.0))
+                std = transform["init_args"].get("std", (1.0, 1.0, 1.0))
+                break
 
-        return mean, std
+            if isinstance(transform, Normalize):
+                # torchvision.transforms case
+                mean = transform.mean
+                std = transform.std
+                break
+
+        if len(mean) != 3 or len(std) != 3:
+            msg = f"Expected mean and std to have length 3, got mean={mean}, std={std}"
+            raise ValueError(msg)
+
+        return tuple(mean), tuple(std)  # type: ignore[return-value]
 
     @classmethod
     def from_otx_datasets(

--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import logging
-import logging as log
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -151,13 +150,13 @@ class OTXDataModule(LightningDataModule):
 
         if self.auto_num_workers:
             if self.device not in [DeviceType.gpu, DeviceType.auto]:
-                log.warning(
+                logger.warning(
                     "Only GPU device type support auto_num_workers. "
                     f"Current deveice type is {self.device!s}. auto_num_workers is skipped.",
                 )
             elif (num_workers := get_adaptive_num_workers()) is not None:
                 for subset_name, subset_config in config_mapping.items():
-                    log.info(
+                    logger.info(
                         f"num_workers of {subset_name} subset is changed : "
                         f"{subset_config.num_workers} -> {num_workers}",
                     )
@@ -166,7 +165,7 @@ class OTXDataModule(LightningDataModule):
         label_infos: list[LabelInfo] = []
         for name, dm_subset in dataset.subsets().items():
             if name not in config_mapping:
-                log.warning(f"{name} is not available. Skip it")
+                logger.warning(f"{name} is not available. Skip it")
                 continue
 
             otx_dataset = OTXDatasetFactory.create(
@@ -186,7 +185,7 @@ class OTXDataModule(LightningDataModule):
                 )
             self.subsets[name] = otx_dataset
             label_infos += [self.subsets[name].label_info]
-            log.info(f"Add name: {name}, self.subsets: {self.subsets}")
+            logger.info(f"Add name: {name}, self.subsets: {self.subsets}")
 
         if self._is_meta_info_valid(label_infos) is False:
             msg = "All data meta infos of subsets should be the same."
@@ -478,7 +477,7 @@ class OTXDataModule(LightningDataModule):
         tile_config = self.tile_config
         if tile_config.enable_tiler and tile_config.sampling_ratio < 1:
             num_samples = max(1, int(len(dataset) * tile_config.sampling_ratio))
-            log.info(f"Using tiled sampling with {num_samples} samples")
+            logger.info(f"Using tiled sampling with {num_samples} samples")
             common_args.update(
                 {
                     "shuffle": False,

--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -335,16 +335,15 @@ class OTXDataModule(LightningDataModule):
         # Store datasets and label info
         instance.label_info = train_dataset.label_info
 
-        # derive image_size from dataset
-        # assume that data uses fixed size during transforms
+        # Derive the image size from the dataset, assuming layout CHW and that all dataset items have
+        # the same size after transforms.
         try:
             example_item = next(iter(train_dataset))
         except StopIteration:
             msg = "train_dataset is empty; cannot infer input_size"
             raise ValueError(msg) from None
-        input_size = example_item.img_info.img_shape
-        instance.input_size = input_size
-        default_subset_configs = instance.get_default_subset_configs(input_size)
+        instance.input_size = example_item.image.shape[1:]
+        default_subset_configs = instance.get_default_subset_configs(instance.input_size)
 
         # merge default configs with provided subsets
         for name, subset in zip(["train", "val", "test"], [train_subset, val_subset, test_subset]):

--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -369,9 +369,8 @@ class OTXDataModule(LightningDataModule):
             # Override transforms with the ones from the pre-constructed dataset
             subset_to_assign.transforms = instance.subsets[name].transforms  # type: ignore[assignment]
 
-            # Assign subset config and transforms to subset dataset
+            # Set the 'train_subset', 'val_subset', 'test_subset' attributes
             setattr(instance, f"{name}_subset", subset_to_assign)
-            instance.subsets[name].transforms = subset_to_assign.transforms  # type: ignore[assignment]
 
         # Extract normalization parameters from train dataset transforms if available
         instance.input_mean, instance.input_std = instance.extract_normalization_params(

--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 import logging as log
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     from lightning.pytorch.utilities.parsing import AttributeDict
 
     from otx.data.dataset.base import OTXDataset
+
+logger = logging.getLogger(__name__)
 
 
 class OTXDataModule(LightningDataModule):
@@ -264,10 +267,13 @@ class OTXDataModule(LightningDataModule):
             test_dataset (OTXDataset | None, optional): Pre-constructed test dataset. Defaults to None.
             train_subset (SubsetConfig | None, optional): Configuration for the training dataloader.
                 If None, default configuration will be used. Defaults to None.
+                Transforms should be left unspecified as they will be taken from the provided train_dataset.
             val_subset (SubsetConfig | None, optional): Configuration for the validation dataloader.
                 If None, default configuration will be used. Defaults to None.
+                Transforms should be left unspecified as they will be taken from the provided val_dataset.
             test_subset (SubsetConfig | None, optional): Configuration for the test dataloader.
                 If None, default configuration will be used. Defaults to None.
+                Transforms should be left unspecified as they will be taken from the provided test_dataset.
             auto_num_workers (bool, optional): Whether to automatically determine the number of workers.
                 Defaults to False.
             device (DeviceType, optional): Device type to use (e.g., 'cpu', 'gpu').
@@ -294,7 +300,6 @@ class OTXDataModule(LightningDataModule):
             >>> from otx.config.data import SubsetConfig
             >>> train_config = SubsetConfig(
             ...     batch_size=64,
-            ...     transforms=[],
             ...     num_workers=8,
             ... )
             >>> datamodule = OTXDataModule.from_otx_datasets(
@@ -343,18 +348,27 @@ class OTXDataModule(LightningDataModule):
             msg = "train_dataset is empty; cannot infer input_size"
             raise ValueError(msg) from None
         instance.input_size = example_item.image.shape[1:]
-        default_subset_configs = instance.get_default_subset_configs(instance.input_size)
 
         # merge default configs with provided subsets
+        default_subset_configs: dict[str, SubsetConfig] = {}  # Initialize lazily if needed)
         for name, subset in zip(["train", "val", "test"], [train_subset, val_subset, test_subset]):
             if subset is not None:
                 # Use provided subset config
                 subset_to_assign = subset
+                if subset.transforms:
+                    logger.warning(
+                        f"The provided {name} SubsetConfig contains transforms which will be overridden "
+                        "by the transforms of the provided OTXDataset. When building OTXDataModule from "
+                        "pre-constructed datasets, developers should set up the transforms when creating the datasets.",
+                    )
             else:
                 # Use default config but get transforms from the dataset
+                if not default_subset_configs:
+                    default_subset_configs = instance.get_default_subset_configs(instance.input_size)
                 subset_to_assign = default_subset_configs[f"{name}_subset"]
-                # Override transforms with the ones from the pre-constructed dataset
-                subset_to_assign.transforms = instance.subsets[name].transforms  # type: ignore[assignment]
+
+            # Override transforms with the ones from the pre-constructed dataset
+            subset_to_assign.transforms = instance.subsets[name].transforms  # type: ignore[assignment]
 
             # Assign subset config and transforms to subset dataset
             setattr(instance, f"{name}_subset", subset_to_assign)

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -11,6 +11,7 @@ import pytest
 from importlib_resources import files
 from lightning.pytorch.loggers import CSVLogger
 from omegaconf import DictConfig, OmegaConf
+from torchvision.transforms.v2 import Normalize
 
 from otx.config.data import (
     SubsetConfig,
@@ -22,12 +23,13 @@ from otx.data.module import (
     OTXDataModule,
     OTXTaskType,
 )
+from otx.data.transform_libs.torchvision import Compose, RandomFlip
 
 if TYPE_CHECKING:
     from datumaro.components.dataset import Dataset as DmDataset
 
 
-class TestModule:
+class TestOTXDataModule:
     @pytest.fixture
     def fxt_config(self) -> DictConfig:
         train_subset = MagicMock(spec=SubsetConfig)
@@ -394,8 +396,8 @@ class TestModule:
         )
 
         # Assertions - normalization params should be extracted
-        assert module.input_mean == normalize_transform.mean
-        assert module.input_std == normalize_transform.std
+        assert module.input_mean == tuple(normalize_transform.mean)
+        assert module.input_std == tuple(normalize_transform.std)
 
     def test_from_otx_datasets_with_auto_num_workers(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset) -> None:
         """Test from_otx_datasets with auto_num_workers enabled."""
@@ -428,3 +430,39 @@ class TestModule:
         # Assertions
         assert module.auto_num_workers is True
         assert module.device == DeviceType.auto  # Default value
+
+    @pytest.mark.parametrize(
+        "transforms_source",
+        [
+            None,
+            [
+                {"class_path": "otx.data.transform_libs.torchvision.RandomFlip", "init_args": {"probability": 0.5}},
+                {
+                    "class_path": "otx.data.transform_libs.torchvision.Normalize",
+                    "init_args": {"mean": [123.675, 116.28, 103.53], "std": [58.395, 57.12, 57.375]},
+                },
+            ],
+            [
+                RandomFlip(probability=0.5),
+                Normalize(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375]),
+            ],
+            Compose(
+                [
+                    RandomFlip(probability=0.5),
+                    Normalize(mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375]),
+                ]
+            ),
+        ],
+        ids=["from None", "from list of configs", "from list of objects", "from compose"],
+    )
+    def test_extract_normalization_params(self, transforms_source) -> None:
+        """Test _extract_normalization_params with various transform sources."""
+        mean, std = OTXDataModule.extract_normalization_params(transforms_source)
+
+        # Assertions based on expected values
+        if transforms_source is None:
+            assert mean == (0.0, 0.0, 0.0)
+            assert std == (1.0, 1.0, 1.0)
+        else:
+            assert mean == (123.675, 116.28, 103.53)
+            assert std == (58.395, 57.12, 57.375)

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -240,7 +240,11 @@ class TestOTXDataModule:
             mock_dataset.data_format = "coco"
             mock_dataset.image_color_channel = "RGB"
             mock_dataset.transforms = transforms or []
-            mock_dataset.__iter__ = lambda _: iter([MagicMock(img_info=MagicMock(img_shape=img_shape))])
+            mock_dataset_item = MagicMock(
+                image=MagicMock(shape=(3, *img_shape)),
+                img_info=MagicMock(img_shape=img_shape),
+            )
+            mock_dataset.__iter__ = lambda _: iter([mock_dataset_item])
             return mock_dataset
 
         return _create_mock_dataset


### PR DESCRIPTION
### Summary

This PR addresses a bunch of issues that I encountered when working with `OTXDataModule`.

Changes:
- Bugfix: `extract_normalization_params` no longer throws an error if the transforms are given in the form of a `Compose` object rather than a list. It now works fine with both `Compose` and iterables.
- Bugfix: the `image_size` attribute would assume an incorrect value when `OTXDataModule` is initialized from the new Datumaro datasets, because the deprecated `img_info.shape` attribute is not updated by the transforms (always refers to the original image size)
- Fix an issue where the transforms provided through the input dataset would be silently overridden by default transforms in the SubsetConfig
  - For clarify, transforms are now _always_ taken from the dataset; if the user attempts to pass them through SubsetConfig, they are ignored and a warning is raised.

### How to test

Manually instantiate a data module and train.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
