### PR TITLE
Update Playwright to 1.57

### DIFF
--- a/.github/workflows/ui-lint-and-test.yaml
+++ b/.github/workflows/ui-lint-and-test.yaml
@@ -304,7 +304,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.54.0-noble@sha256:18d6adb6aaccf1b0f30eba890069972e089138e4a59ddb5303d7e7290e4e38b6
+      image: mcr.microsoft.com/playwright:v1.57.0-jammy@sha256:6aca677c27a967caf7673d108ac67ffaf8fed134f27e17b27a05464ca0ace831
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -38,7 +38,7 @@
                 "@ianvs/prettier-plugin-sort-imports": "~4.4.2",
                 "@msw/playwright": "~0.4.2",
                 "@mswjs/source": "~0.4.1",
-                "@playwright/test": "~1.54.1",
+                "@playwright/test": "~1.57.0",
                 "@rsbuild/core": "~1.3.14",
                 "@rsbuild/plugin-babel": "~1.0.6",
                 "@rsbuild/plugin-react": "~1.3.0",
@@ -4008,13 +4008,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
-            "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+            "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.54.2"
+                "playwright": "1.57.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -13545,9 +13545,9 @@
             }
         },
         "node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -14531,9 +14531,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15628,13 +15628,13 @@
             "license": "MIT"
         },
         "node_modules/playwright": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-            "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+            "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.54.2"
+                "playwright-core": "1.57.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -15647,9 +15647,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-            "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+            "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -58,7 +58,7 @@
         "@ianvs/prettier-plugin-sort-imports": "~4.4.2",
         "@msw/playwright": "~0.4.2",
         "@mswjs/source": "~0.4.1",
-        "@playwright/test": "~1.54.1",
+        "@playwright/test": "~1.57.0",
         "@rsbuild/core": "~1.3.14",
         "@rsbuild/plugin-babel": "~1.0.6",
         "@rsbuild/plugin-react": "~1.3.0",


### PR DESCRIPTION
I've also ran `npm audit fix` to fix minor security vulnerabilities related to our linting tools.