### PR TITLE
Fix logger level initialization

### DIFF
--- a/application/backend/app/lifecycle.py
+++ b/application/backend/app/lifecycle.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI
 from loguru import logger
 
 from app.core.jobs import JobController, JobQueue, ProcessRunnerFactory
-from app.core.logging import setup_logging, setup_uvicorn_logging
+from app.core.logging import LogConfig, setup_logging, setup_uvicorn_logging
 from app.core.run import Runnable, RunnableFactory
 from app.db import MigrationManager, get_db_session
 from app.scheduler import Scheduler
@@ -80,7 +80,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     logger.info("Starting {} application...", settings.app_name)
 
     # Setup logging
-    setup_logging()
+    setup_logging(config=LogConfig(level=settings.log_level))
     setup_uvicorn_logging(settings.log_level)
 
     # Initialize database

--- a/application/backend/app/services/event/event_bus.py
+++ b/application/backend/app/services/event/event_bus.py
@@ -6,6 +6,8 @@ from enum import StrEnum
 from multiprocessing.synchronize import Condition
 from threading import RLock
 
+from loguru import logger
+
 
 class EventType(StrEnum):
     SOURCE_CHANGED = "SOURCE_CHANGED"
@@ -37,8 +39,10 @@ class EventBus:
         with self._lock:
             for event_type in event_types:
                 self._event_handlers[event_type].append(handler)
+                logger.debug(f"registered event handler for event '{event_type}'")
 
     def emit_event(self, event_type: EventType) -> None:
+        logger.debug(f"Emitting event '{event_type}' to {len(self._event_handlers[event_type])} handlers")
         with self._lock:
             for handler in self._event_handlers[event_type]:
                 handler()

--- a/application/backend/app/workers/base.py
+++ b/application/backend/app/workers/base.py
@@ -78,9 +78,11 @@ class BaseProcessWorker(mp.Process, StoppableMixin, ABC):
         """Allocate resources. Called once in the child process."""
         from app.core.logging import setup_logging
 
+        settings = get_settings()
         log_config = LogConfig(
             log_file=f"{self.ROLE.lower()}.log",
-            log_folder=str(get_settings().worker_dir),
+            log_folder=str(settings.worker_dir),
+            level=settings.log_level,
         )
         setup_logging(log_config)
 


### PR DESCRIPTION
### Summary

Changes: 
- When initializing the logger, always read the level (severity) from the settings
- Add some debug logging in the `EventBus` class

### How to test

Create a `.env` with `LOG_LEVEL=DEBUG`, run the application and verify that debug records are shown.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
