### PR TITLE
fix(ci): enable semantic commits for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,9 +22,10 @@
     schedule: ["* * * * 0"], // weekly
   },
 
-  extends: ["config:base", ":gitSignOff", "helpers:pinGitHubActionDigests"],
+  extends: ["config:base", ":gitSignOff", "helpers:pinGitHubActionDigests", ":semanticCommits"],
   // https://docs.renovatebot.com/presets-default/#gitsignoff
   // https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
+  // https://docs.renovatebot.com/semantic-commits/
 
   // if necessary, add supported releases branches here
   // it is possible to enable/disable specific upgrades per branch with

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -17,4 +17,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.1.0
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1


### PR DESCRIPTION
### Summary

This PR fixes wrong version of  `actions/labeler` that caused Renovate warning and updates Renovate config to use sematic commits.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
