### PR TITLE
Improve the API docs of the jobs endpoints

### DIFF
--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -69,12 +69,12 @@ def get_scheduler(request: Request) -> Scheduler:
 
 
 def get_data_dir(request: Request) -> Path:
-    """Provides the data directory path from settings."""
+    """Provides the path to the folder that stores the projects data. This path is defined in the app settings."""
     return request.app.state.settings.data_dir
 
 
 def get_job_dir(request: Request) -> Path:
-    """Provides the job log directory path from settings."""
+    """Provides the path to the folder where the jobs logs are saved. This path is defined in the app settings."""
     return request.app.state.settings.job_dir
 
 
@@ -218,7 +218,10 @@ def get_base_weights_service(data_dir: Annotated[Path, Depends(get_data_dir)]) -
 
 
 def get_job_queue(request: Request) -> JobQueue:
-    """Provides the global JobQueue instance from FastAPI application's state."""
+    """
+    Provides the global JobQueue instance from FastAPI application's state.
+    The JobQueue is responsible for managing job submissions and tracking job statuses.
+    """
     return request.app.state.job_queue
 
 


### PR DESCRIPTION
### Summary

Swagger uses the routers docstrings as descriptions of the respective endpoints, but it can't render the Args/Returns sections. Therefore these docstrings should be minimal and clean; parameters must be documented through FastAPI / Pydantic features.

This PR cleans the descriptions of the jobs endpoints.

### How to test

Generate the docs with: `uv run app/cli.py gen-api --target-path openapi.json`

View with `docker run -p 8080:8080 -v $(pwd):/tmp -e SWAGGER_JSON=/tmp/openapi.json swaggerapi/swagger-ui`

<img width="980" height="184" alt="image" src="https://github.com/user-attachments/assets/76e646ea-cf15-4bb7-b130-957abba00d05" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
