### PR TITLE
Extend job view with job dependent metadata

### DIFF
--- a/application/backend/app/api/routers/jobs.py
+++ b/application/backend/app/api/routers/jobs.py
@@ -14,11 +14,10 @@ from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 from app.api.dependencies import get_data_dir, get_job_dir, get_job_queue, get_project_service
 from app.api.validators import JobID
 from app.core.jobs.control_plane import CancellationResult, JobQueue
-from app.core.jobs.models import JobStatus
+from app.core.jobs.models import JobStatus, TrainingJob, TrainingJobParams
 from app.schemas import JobRequest, JobView
 from app.schemas.job import JobType
 from app.services import ProjectService, ResourceNotFoundError
-from app.services.training.models import TrainingJob, TrainingParams
 
 router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
 
@@ -50,7 +49,7 @@ async def submit_job(
                     project_id=job_request.project_id,
                     log_dir=job_dir,
                     data_dir=data_dir,
-                    params=TrainingParams(
+                    params=TrainingJobParams(
                         model_architecture_id=job_request.parameters.model_architecture_id,
                         parent_model_revision_id=job_request.parameters.parent_model_revision_id,
                         task=project.task,

--- a/application/backend/app/core/jobs/__init__.py
+++ b/application/backend/app/core/jobs/__init__.py
@@ -3,16 +3,10 @@
 
 from .control_plane import CancellationResult, JobController, JobQueue
 from .exec import ProcessRunnerFactory
-from .models import Job, JobParams, JobStatus, JobType, now_utc_ts
 
 __all__ = [
     "CancellationResult",
-    "Job",
     "JobController",
-    "JobParams",
     "JobQueue",
-    "JobStatus",
-    "JobType",
     "ProcessRunnerFactory",
-    "now_utc_ts",
 ]

--- a/application/backend/app/core/jobs/models/__init__.py
+++ b/application/backend/app/core/jobs/models/__init__.py
@@ -3,6 +3,7 @@
 
 from .events import Cancelled, Done, ExecutionEvent, Failed, Progress, Started
 from .job import Job, JobParams, JobStatus, JobType, now_utc_ts
+from .training_job import TrainingJob, TrainingJobParams
 
 __all__ = [
     "Cancelled",
@@ -15,5 +16,7 @@ __all__ = [
     "JobType",
     "Progress",
     "Started",
+    "TrainingJob",
+    "TrainingJobParams",
     "now_utc_ts",
 ]

--- a/application/backend/app/core/jobs/models/training_job.py
+++ b/application/backend/app/core/jobs/models/training_job.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 from loguru import logger
 from pydantic import Field
 
-from app.core.jobs import Job, JobParams, JobType
+from app.core.jobs.models import Job, JobParams, JobType
 from app.models import Task
 
 

--- a/application/backend/app/core/jobs/models/training_job.py
+++ b/application/backend/app/core/jobs/models/training_job.py
@@ -12,7 +12,7 @@ from app.core.jobs import Job, JobParams, JobType
 from app.models import Task
 
 
-class TrainingParams(JobParams):
+class TrainingJobParams(JobParams):
     job_id: UUID | None = None
     project_id: UUID | None = None
     model_architecture_id: str
@@ -29,7 +29,7 @@ class TrainingJob(ProjectJob):
     job_type: Literal[JobType.TRAIN] = JobType.TRAIN
     log_dir: Path
     data_dir: Path
-    params: TrainingParams
+    params: TrainingJobParams
 
     def model_post_init(self, _: Any) -> None:
         self.params.job_id = self.id

--- a/application/backend/app/schemas/job.py
+++ b/application/backend/app/schemas/job.py
@@ -8,7 +8,6 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 from app.core.jobs.models import Job, JobStatus, JobType
-from app.services.training.models import TrainingJob
 
 
 class TrainingRequestParams(BaseModel):
@@ -79,7 +78,7 @@ class TrainingMetadata(BaseModel):
     model: ModelMetadata = Field(..., description="Model being trained")
 
     @staticmethod
-    def of(job: TrainingJob) -> "TrainingMetadata":
+    def of(job: Job) -> "TrainingMetadata":
         return TrainingMetadata(
             project=ProjectMetadata(id=job.project_id),
             model=ModelMetadata(
@@ -91,12 +90,15 @@ class TrainingMetadata(BaseModel):
         )
 
 
+JobMetadata = Annotated[TrainingMetadata, Field(..., description="Metadata associated with the job")]
+
+
 class JobView(BaseModel):
     """Response schema for job creation."""
 
     job_id: UUID = Field(..., description="Job identifier")
     job_type: JobType = Field(..., description="Type of the job")
-    metadata: TrainingMetadata = Field(..., description="Metadata associated with the job")  # | InferenceMetadata | ...
+    metadata: JobMetadata = Field(..., description="Metadata associated with the job")
     status: str = Field(..., description="Job status")
     progress: float = Field(..., description="Job progress percentage (0-100)")
     message: str | None = Field(None, description="Additional information about the job status")
@@ -129,9 +131,9 @@ class JobView(BaseModel):
     }
 
     @staticmethod
-    def of(job: Job | TrainingJob) -> "JobView":
-        match job:
-            case TrainingJob():
+    def of(job: Job) -> "JobView":
+        match job.job_type:
+            case JobType.TRAIN:
                 metadata = TrainingMetadata.of(job)
             case _:
                 raise NotImplementedError("JobView is not implemented for this job type")

--- a/application/backend/app/schemas/job.py
+++ b/application/backend/app/schemas/job.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from app.core.jobs.models import Job, JobStatus, JobType
+from app.core.jobs.models import Job, JobStatus, JobType, TrainingJob
 
 
 class TrainingRequestParams(BaseModel):
@@ -78,7 +78,7 @@ class TrainingMetadata(BaseModel):
     model: ModelMetadata = Field(..., description="Model being trained")
 
     @staticmethod
-    def of(job: Job) -> "TrainingMetadata":
+    def of(job: TrainingJob) -> "TrainingMetadata":
         return TrainingMetadata(
             project=ProjectMetadata(id=job.project_id),
             model=ModelMetadata(

--- a/application/backend/app/schemas/job.py
+++ b/application/backend/app/schemas/job.py
@@ -134,7 +134,7 @@ class JobView(BaseModel):
     def of(job: Job) -> "JobView":
         match job.job_type:
             case JobType.TRAIN:
-                metadata = TrainingMetadata.of(job)
+                metadata = TrainingMetadata.of(job)  # type: ignore[arg-type]
             case _:
                 raise NotImplementedError("JobView is not implemented for this job type")
 

--- a/application/backend/app/schemas/job.py
+++ b/application/backend/app/schemas/job.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 from app.core.jobs.models import Job, JobStatus, JobType
+from app.services.training.models import TrainingJob
 
 
 class TrainingRequestParams(BaseModel):
@@ -54,10 +55,48 @@ class TrainingRequest(BaseJobRequest):
 JobRequest = Annotated[TrainingRequest, Field(discriminator="job_type")]
 
 
+class ProjectMetadata(BaseModel):
+    """Metadata about a project."""
+
+    id: UUID = Field(..., description="Project identifier")
+
+
+class ModelMetadata(BaseModel):
+    """Metadata about a model."""
+
+    id: UUID = Field(..., description="Model identifier")
+    architecture: str = Field(..., description="Model architecture identifier")
+    parent_revision_id: UUID | None = Field(
+        None, description="Parent model revision ID for fine-tuning, null if trained from scratch"
+    )
+    dataset_revision_id: UUID = Field(..., description="Dataset revision ID used for training")
+
+
+class TrainingMetadata(BaseModel):
+    """Metadata associated with a training job."""
+
+    project: ProjectMetadata = Field(..., description="Project associated with the training job")
+    model: ModelMetadata = Field(..., description="Model being trained")
+
+    @staticmethod
+    def of(job: TrainingJob) -> "TrainingMetadata":
+        return TrainingMetadata(
+            project=ProjectMetadata(id=job.project_id),
+            model=ModelMetadata(
+                id=job.params.model_id,
+                architecture=job.params.model_architecture_id,
+                parent_revision_id=job.params.parent_model_revision_id,
+                dataset_revision_id=UUID("00000000-0000-0000-0000-000000000000"),  # TODO set correct value
+            ),
+        )
+
+
 class JobView(BaseModel):
     """Response schema for job creation."""
 
     job_id: UUID = Field(..., description="Job identifier")
+    job_type: JobType = Field(..., description="Type of the job")
+    metadata: TrainingMetadata = Field(..., description="Metadata associated with the job")  # | InferenceMetadata | ...
     status: str = Field(..., description="Job status")
     progress: float = Field(..., description="Job progress percentage (0-100)")
     message: str | None = Field(None, description="Additional information about the job status")
@@ -69,6 +108,16 @@ class JobView(BaseModel):
         "json_schema_extra": {
             "example": {
                 "job_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                "job_type": "train",
+                "metadata": {
+                    "project": {"id": "7b073838-99d3-42ff-9018-4e901eb047fc"},
+                    "model": {
+                        "id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+                        "architecture": "Custom_Object_Detection_Gen3_ATSS",
+                        "parent_revision_id": "ef3983f1-cef0-4ebe-91db-7330f1dd6e27",
+                        "dataset_revision_id": "2b073838-99d3-42ff-9018-4e901eb047fc",
+                    },
+                },
                 "status": "done",
                 "progress": 100.0,
                 "message": "Training completed successfully",
@@ -80,9 +129,17 @@ class JobView(BaseModel):
     }
 
     @staticmethod
-    def of(job: Job) -> "JobView":
+    def of(job: Job | TrainingJob) -> "JobView":
+        match job:
+            case TrainingJob():
+                metadata = TrainingMetadata.of(job)
+            case _:
+                raise NotImplementedError("JobView is not implemented for this job type")
+
         return JobView(
             job_id=job.id,
+            job_type=job.job_type,
+            metadata=metadata,
             status=job.status.name,
             progress=job.progress,
             message=job.message,

--- a/application/backend/app/services/training/base.py
+++ b/application/backend/app/services/training/base.py
@@ -8,9 +8,8 @@ from typing import Any, TypeVar
 
 from loguru import logger
 
+from app.core.jobs.models import TrainingJobParams
 from app.core.run import ExecutionContext, Runnable
-
-from .models import TrainingParams
 
 T = TypeVar("T")
 
@@ -59,14 +58,14 @@ class Trainer(Runnable, ABC):
 
     def __init__(self) -> None:
         self._ctx: ExecutionContext | None = None
-        self._training_params: TrainingParams | None = None
+        self._training_params: TrainingJobParams | None = None
 
     @abstractmethod
     def run(self, ctx: ExecutionContext) -> None: ...
 
     @staticmethod
-    def _get_training_params(ctx: ExecutionContext) -> TrainingParams:
-        return TrainingParams.model_validate_json(ctx.payload)
+    def _get_training_params(ctx: ExecutionContext) -> TrainingJobParams:
+        return TrainingJobParams.model_validate_json(ctx.payload)
 
     def report_progress(self, msg: str = "", percent: float = 0.0) -> None:
         if self._ctx is not None:

--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -32,6 +32,7 @@ from otx.types.precision import OTXPrecisionType
 from otx.types.task import OTXTaskType
 from sqlalchemy.orm import Session
 
+from app.core.jobs.models import TrainingJobParams
 from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus, Task, TaskType, TrainingStatus
 from app.models.training_configuration.configuration import TrainingConfiguration
@@ -45,7 +46,6 @@ from app.services import (
 )
 
 from .base import Trainer, step
-from .models import TrainingParams
 from .subset_assignment import SplitRatios, SubsetAssigner, SubsetService
 
 MODEL_WEIGHTS_PATH = "model_weights_path"
@@ -99,7 +99,7 @@ class OTXTrainer(Trainer):
         self._db_session_factory = training_deps.db_session_factory
 
     @step("Prepare Model Weights")
-    def prepare_weights(self, training_params: TrainingParams) -> Path:
+    def prepare_weights(self, training_params: TrainingJobParams) -> Path:
         """
         Prepare weights for training based on training parameters.
 
@@ -161,7 +161,7 @@ class OTXTrainer(Trainer):
 
     @step("Prepare Training Configuration")
     def prepare_training_configuration(
-        self, training_params: TrainingParams, task: Task
+        self, training_params: TrainingJobParams, task: Task
     ) -> tuple[TrainingConfiguration, dict]:
         project_id = cast(UUID, training_params.project_id)
         with self._db_session_factory() as db:
@@ -259,7 +259,7 @@ class OTXTrainer(Trainer):
 
     @step("Prepare Model")
     def prepare_model(
-        self, training_params: TrainingParams, dataset_revision_id: UUID, configuration: TrainingConfiguration
+        self, training_params: TrainingJobParams, dataset_revision_id: UUID, configuration: TrainingConfiguration
     ) -> None:
         project_id = cast(UUID, training_params.project_id)  # In 'run' we already check that project_id is not None
         logger.info("Preparing model revision (model_id={}, project_id={})", training_params.model_id, project_id)
@@ -368,7 +368,7 @@ class OTXTrainer(Trainer):
     @step("Store Model Artifacts")
     def store_model_artifacts(
         self,
-        training_params: TrainingParams,
+        training_params: TrainingJobParams,
         otx_work_dir: Path,
         trained_model_path: Path,
         exported_model_path: Path,

--- a/application/backend/tests/conftest.py
+++ b/application/backend/tests/conftest.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.core.jobs import Job, JobParams, JobType
+from app.core.jobs.models import Job, JobParams, JobType
 from app.models import (
     ModelRevision,
     MqttSinkConfig,

--- a/application/backend/tests/unit/routers/test_jobs.py
+++ b/application/backend/tests/unit/routers/test_jobs.py
@@ -9,8 +9,9 @@ import pytest
 from starlette import status
 
 from app.api.dependencies import get_data_dir, get_job_dir, get_job_queue
-from app.core.jobs import Job, JobParams, JobQueue, JobStatus
+from app.core.jobs import JobQueue
 from app.core.jobs.control_plane import CancellationResult
+from app.core.jobs.models import Job, JobParams, JobStatus
 from app.main import app
 from app.models import Project, Task, TaskType
 from app.schemas.job import JobRequest, JobType, TrainingRequestParams

--- a/application/backend/tests/unit/routers/test_jobs.py
+++ b/application/backend/tests/unit/routers/test_jobs.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 from collections.abc import Callable
+from pathlib import Path
 from unittest.mock import Mock
 from uuid import UUID, uuid4
 
@@ -11,7 +12,7 @@ from starlette import status
 from app.api.dependencies import get_data_dir, get_job_dir, get_job_queue
 from app.core.jobs import JobQueue
 from app.core.jobs.control_plane import CancellationResult
-from app.core.jobs.models import Job, JobParams, JobStatus
+from app.core.jobs.models import Job, JobStatus, TrainingJob, TrainingJobParams
 from app.main import app
 from app.models import Project, Task, TaskType
 from app.schemas.job import JobRequest, JobType, TrainingRequestParams
@@ -29,12 +30,22 @@ def fxt_job() -> Callable[[UUID | None, JobStatus, float], Job]:
     def job_factory(
         job_id: UUID | None = None, job_status: JobStatus = JobStatus.RUNNING, progress: float = 50.0
     ) -> Job:
-        return Job(
-            id=job_id or uuid4(),
+        job_id_ = job_id or uuid4()
+        project_id_ = uuid4()
+        return TrainingJob(
+            id=job_id_,
+            project_id=project_id_,
+            log_dir=Path(""),
+            data_dir=Path(""),
             status=job_status,
             progress=100.0 if job_status >= JobStatus.DONE else progress,
             job_type=JobType.TRAIN,
-            params=JobParams(),
+            params=TrainingJobParams(
+                job_id=job_id_,
+                project_id=project_id_,
+                model_architecture_id="TestArch",
+                task=Task(task_type=TaskType.CLASSIFICATION, exclusive_labels=True),
+            ),
         )
 
     return job_factory

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -11,6 +11,7 @@ from otx.tools.converter import GetiConfigConverter
 from otx.types.export import OTXExportFormatType
 from otx.types.precision import OTXPrecisionType
 
+from app.core.jobs.models import TrainingJobParams
 from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Task, TaskType, TrainingStatus
 from app.models.training_configuration.configuration import (
@@ -28,7 +29,6 @@ from app.services import (
     TrainingConfigurationService,
 )
 from app.services.base_weights_service import BaseWeightsService
-from app.services.training.models import TrainingParams
 from app.services.training.otx_trainer import OTXTrainer, TrainingDependencies
 from app.services.training.subset_assignment import (
     DatasetItemWithLabels,
@@ -128,7 +128,7 @@ class TestOTXTrainerPrepareWeights:
     ):
         """Test preparing weights when no parent model revision ID is provided."""
         # Arrange
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             model_architecture_id="Object_Detection_YOLOX_S",
             task=Task(task_type=TaskType.DETECTION),
             parent_model_revision_id=None,
@@ -156,7 +156,7 @@ class TestOTXTrainerPrepareWeights:
         # Arrange
         project_id = uuid4()
         parent_model_revision_id = uuid4()
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             project_id=project_id,
             model_architecture_id="Object_Detection_YOLOX_S",
             task=Task(task_type=TaskType.DETECTION),
@@ -184,7 +184,7 @@ class TestOTXTrainerPrepareWeights:
         # Arrange
         project_id = uuid4()
         parent_model_revision_id = uuid4()
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             project_id=project_id,
             model_architecture_id="Object_Detection_YOLOX_S",
             task=Task(task_type=TaskType.DETECTION),
@@ -205,7 +205,7 @@ class TestOTXTrainerPrepareWeights:
     ):
         """Test that ValueError is raised when parent model revision ID is provided without project ID."""
         # Arrange
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             model_architecture_id="Object_Detection_YOLOX_S",
             task=Task(task_type=TaskType.DETECTION),
             parent_model_revision_id=uuid4(),
@@ -225,7 +225,7 @@ class TestOTXTrainerPrepareTrainingConfiguration:
         # Arrange
         project_id = uuid4()
         parent_model_revision_id = uuid4()
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             project_id=project_id,
             model_architecture_id="Object_Detection_YOLOX_S",
             task=Task(task_type=TaskType.DETECTION),
@@ -499,7 +499,7 @@ class TestOTXTrainerPrepareModel:
         project_id = uuid4()
         model_id = uuid4()
         model_architecture_id = "Custom_Image_Classification_EfficientNet-B0"
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             model_id=model_id,
             project_id=project_id,
             model_architecture_id=model_architecture_id,
@@ -724,7 +724,7 @@ class TestOTXTrainerStoreModelArtifacts:
         project_id = uuid4()
         model_id = uuid4()
 
-        training_params = TrainingParams(
+        training_params = TrainingJobParams(
             model_id=model_id,
             project_id=project_id,
             model_architecture_id="Object_Detection_YOLOX_S",

--- a/application/backend/tests/unit/services/training/test_training_job.py
+++ b/application/backend/tests/unit/services/training/test_training_job.py
@@ -6,13 +6,13 @@ from uuid import uuid4
 
 import pytest
 
+from app.core.jobs.models import TrainingJob, TrainingJobParams
 from app.models import Task, TaskType
-from app.services.training.models import TrainingJob, TrainingParams
 
 
 @pytest.fixture
 def fxt_training_params():
-    return TrainingParams(model_architecture_id="test_arch", task=Task(task_type=TaskType.CLASSIFICATION))
+    return TrainingJobParams(model_architecture_id="test_arch", task=Task(task_type=TaskType.CLASSIFICATION))
 
 
 @pytest.fixture

--- a/application/backend/tests/unit/services/training/test_training_job.py
+++ b/application/backend/tests/unit/services/training/test_training_job.py
@@ -54,7 +54,7 @@ class TestTrainingJob:
         assert expected_path.exists()
         assert expected_path.read_text() == "Training log content"
 
-    @patch("app.services.training.models.logger")
+    @patch("app.core.jobs.models.training_job.logger")
     def test_on_finish_logs_warning(self, mock_logger, fxt_training_job):
         """Test that a warning is logged and no file copied when the source log file doesn't exist."""
         # Don't create the log file


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Adds additional fields to the JobView.
The additional fields includes metadata that are dependent on its JobType, for now it is only `train`.
Includes a small refactor of moving the training the job model and relevant files.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
