### PR TITLE
Replace deprecated 422 Unproccessable Entity

### DIFF
--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -38,22 +38,22 @@ from app.webrtc.manager import WebRTCManager
 def get_file_name_and_extension(file: UploadFile) -> tuple[str, str]:
     """Return the file name and extension"""
     if not file.filename:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="File name cannot be empty.")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="File name cannot be empty.")
     full_name = file.filename.strip()
     if not full_name:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="File name cannot be empty.")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="File name cannot be empty.")
     file_name, file_ext = os.path.splitext(full_name)
     file_name = file_name.strip()  # remove whitespace characters between the basename and the extension
     file_ext = file_ext[1:]  # remove leading dot in the extension
     if not file_ext:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="File extension cannot be empty.")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="File extension cannot be empty.")
     return file_name, file_ext
 
 
 def get_file_size(file: UploadFile) -> int:
     """Return the file size in bytes"""
     if not file.size:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="File size should be defined.")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="File size should be defined.")
     return file.size
 
 

--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -72,7 +72,7 @@ SET_DATASET_ITEM_ANNOTATIONS_BODY_EXAMPLES = {
     response_model=DatasetItemView,
     responses={
         status.HTTP_201_CREATED: {"description": "Dataset item created"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid image has been uploaded"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid image has been uploaded"},
     },
 )
 def add_dataset_item(
@@ -93,7 +93,9 @@ def add_dataset_item(
         )
         return DatasetItemView.model_validate(dataset_item, from_attributes=True)
     except InvalidImageError:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid image has been uploaded.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Invalid image has been uploaded."
+        )
 
 
 @router.get(
@@ -116,7 +118,7 @@ def list_dataset_items(  # noqa: PLR0913
     """List the available dataset items and their metadata. This endpoint supports pagination."""
     if start_date is not None and end_date is not None and start_date > end_date:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Start date must be before end date."
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Start date must be before end date."
         )
     total = dataset_service.count_dataset_items(
         project=project,
@@ -335,7 +337,7 @@ def delete_dataset_item_annotation(
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid dataset item ID or project ID"},
         status.HTTP_404_NOT_FOUND: {"description": "Dataset item or project not found"},
         status.HTTP_409_CONFLICT: {"description": "Dataset item already has a subset assigned"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid subset"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid subset"},
     },
 )
 def assign_dataset_item_subset(

--- a/application/backend/app/api/routers/projects.py
+++ b/application/backend/app/api/routers/projects.py
@@ -78,7 +78,7 @@ CREATE_PROJECT_BODY_EXAMPLES = {
     responses={
         status.HTTP_201_CREATED: {"description": "Project successfully created"},
         status.HTTP_409_CONFLICT: {"description": "Project already exists or labels have duplicated names or hotkeys"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Invalid request body"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Invalid request body"},
     },
 )
 def create_project(

--- a/application/backend/app/api/routers/sinks.py
+++ b/application/backend/app/api/routers/sinks.py
@@ -207,7 +207,7 @@ def export_sink(sink: Annotated[Sink, Depends(get_sink)]) -> Response:
         status.HTTP_201_CREATED: {"description": "Sink imported successfully", "model": SinkView},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format"},
         status.HTTP_409_CONFLICT: {"description": "Sink already exists"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Validation error(s)"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Validation error(s)"},
     },
 )
 def import_sink(
@@ -233,7 +233,7 @@ def import_sink(
     except (ResourceWithNameAlreadyExistsError, ResourceWithIdAlreadyExistsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     except ValidationError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
 @router.delete(

--- a/application/backend/app/api/routers/sources.py
+++ b/application/backend/app/api/routers/sources.py
@@ -219,7 +219,7 @@ def export_source(source: Annotated[Source, Depends(get_source)]) -> Response:
         status.HTTP_201_CREATED: {"description": "Source imported successfully", "model": SourceView},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid YAML format "},
         status.HTTP_409_CONFLICT: {"description": "Source already exists"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Validation error(s)"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Validation error(s)"},
     },
 )
 def import_source(
@@ -243,7 +243,7 @@ def import_source(
     except (ResourceWithNameAlreadyExistsError, ResourceWithIdAlreadyExistsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
     except ValidationError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
 
 @router.delete(

--- a/application/backend/tests/unit/routers/test_dataset_revisions.py
+++ b/application/backend/tests/unit/routers/test_dataset_revisions.py
@@ -178,7 +178,7 @@ class TestDatasetRevisionItemEndpoints:
             f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items?limit={limit}"
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_revision_service.list_dataset_revision_items.assert_not_called()
 
     @pytest.mark.parametrize("offset", [-1, -20])
@@ -189,7 +189,7 @@ class TestDatasetRevisionItemEndpoints:
             f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items?offset={offset}"
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_revision_service.list_dataset_revision_items.assert_not_called()
 
     def test_list_dataset_revision_items_invalid_revision_id(

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -70,7 +70,7 @@ class TestDatasetItemEndpoints:
 
         response = fxt_client.post(f"/api/projects/{uuid4()}/dataset/items")
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.create_dataset_item.assert_not_called()
 
     def test_create_dataset_item_success(self, fxt_get_project, fxt_dataset_item, fxt_dataset_service, fxt_client):
@@ -158,14 +158,14 @@ class TestDatasetItemEndpoints:
     def test_list_dataset_items_wrong_limit(self, fxt_get_project, fxt_dataset_service, fxt_client, limit):
         response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/items?limit=${limit}")
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.list_dataset_items.assert_not_called()
 
     @pytest.mark.parametrize("offset", [-20])
     def test_list_dataset_items_wrong_offset(self, fxt_get_project, fxt_dataset_service, fxt_client, offset):
         response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/items?offset=${offset}")
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.list_dataset_items.assert_not_called()
 
     @pytest.mark.parametrize("offset", [-20])
@@ -174,7 +174,7 @@ class TestDatasetItemEndpoints:
             f"/api/projects/{str(uuid4())}/dataset/items?start_date=2025-12-31T23:59:59Z&end_date=2025-01-09T00:00:00Z"
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.list_dataset_items.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -631,5 +631,5 @@ class TestDatasetItemEndpoints:
             json='{"subset": "' + subset + '"}',
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.assign_dataset_item_subset.assert_not_called()

--- a/application/backend/tests/unit/routers/test_projects.py
+++ b/application/backend/tests/unit/routers/test_projects.py
@@ -101,7 +101,7 @@ class TestProjectEndpoints:
     def test_create_project_invalid(self, fxt_project_service, fxt_client):
         response = fxt_client.post("/api/projects", json={"name": "New Pipeline", "attr": "invalid"})
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_project_service.create_project.assert_not_called()
 
     def test_delete_project_success(self, fxt_project, fxt_project_service, fxt_client):

--- a/application/backend/tests/unit/routers/test_sinks.py
+++ b/application/backend/tests/unit/routers/test_sinks.py
@@ -93,13 +93,13 @@ class TestSinkEndpoints:
     def test_create_sink_disconnected_fails(self, fxt_sink_service, fxt_client):
         response = fxt_client.post("/api/sinks", json={"sink_type": SinkType.DISCONNECTED, "name": "Disconnected Sink"})
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_sink_service.create_sink.assert_not_called()
 
     def test_create_sink_validation_error(self, fxt_sink_service, fxt_client):
         response = fxt_client.post("/api/sinks", json={"name": ""})
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_sink_service.create_sink.assert_not_called()
 
     def test_create_sink_exists(self, fxt_folder_sink_create, fxt_sink_service, fxt_client):
@@ -264,5 +264,5 @@ class TestSinkEndpoints:
 
         response = fxt_client.post("/api/sinks:import", files=files)
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_sink_service.create_sink.assert_not_called()

--- a/application/backend/tests/unit/routers/test_sources.py
+++ b/application/backend/tests/unit/routers/test_sources.py
@@ -82,13 +82,13 @@ class TestSourceEndpoints:
             "/api/sources", json={"source_type": SourceType.DISCONNECTED, "name": "Disconnected Source"}
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_source_update_service.create_source.assert_not_called()
 
     def test_create_source_validation_error(self, fxt_source_update_service, fxt_client):
         response = fxt_client.post("/api/sources", json={"name": ""})
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_source_update_service.create_source.assert_not_called()
 
     def test_create_source_exists(self, fxt_webcam_source_create, fxt_source_update_service, fxt_client):
@@ -258,5 +258,5 @@ class TestSourceEndpoints:
 
         response = fxt_client.post("/api/sources:import", files=files)
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_source_update_service.create_source.assert_not_called()

--- a/application/backend/tests/unit/routers/test_webrtc.py
+++ b/application/backend/tests/unit/routers/test_webrtc.py
@@ -51,7 +51,7 @@ class TestWebRTCEndpoints:
 
     def test_create_webrtc_offer_invalid_payload(self, fxt_client):
         resp = fxt_client.post("/api/webrtc/offer", json={"sdp": 123})
-        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     def test_webrtc_input_hook_success(self, fxt_client, fxt_webrtc_manager, fxt_input_data):
         resp = fxt_client.post("/api/webrtc/input_hook", json=fxt_input_data.model_dump(mode="json"))
@@ -60,4 +60,4 @@ class TestWebRTCEndpoints:
 
     def test_webrtc_input_hook_invalid_payload(self, fxt_client, fxt_webrtc_manager):
         resp = fxt_client.post("/api/webrtc/input_hook", json={"wrong": "field"})
-        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Replace deprecated `HTTP_422_UNPROCCESSABLE_ENTITY` with `HTTP_422_UNPROCESSABLE_CONTENT`.

Before and after:

<img width="1813" height="581" alt="image" src="https://github.com/user-attachments/assets/b16be3d0-5994-455c-ba1b-79d841b3d4db" />


### How to test


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
