### PR TITLE
Fix deprecation warnings for Pydantic models

### DIFF
--- a/application/backend/app/api/serializers/configurable_parameters.py
+++ b/application/backend/app/api/serializers/configurable_parameters.py
@@ -108,7 +108,7 @@ class ConfigurableParametersConverter:
         default_config = default_config or {}
 
         json_model = configurable_parameters.model_json_schema()
-        for field_name, field_info in configurable_parameters.model_fields.items():
+        for field_name, field_info in type(configurable_parameters).model_fields.items():
             field = getattr(configurable_parameters, field_name)
             default_field = default_config.get(field_name)
 

--- a/application/backend/app/models/training_configuration/hyperparameters.py
+++ b/application/backend/app/models/training_configuration/hyperparameters.py
@@ -100,13 +100,13 @@ class TrainingHyperParameters(BaseModelNoExtra):
 
         # Update the model's json_schema to include allowed values for input_size
         # Note: existing json_schema_extra cannot be overwritten, otherwise it will absent from model_json_schema()
-        self.model_fields["input_size_width"].json_schema_extra.update(  # type: ignore[union-attr]
+        TrainingHyperParameters.model_fields["input_size_width"].json_schema_extra.update(  # type: ignore[union-attr]
             {
                 "allowed_values": self.allowed_values_input_size,  # type:ignore[dict-item]
                 "default_value": w,
             }
         )
-        self.model_fields["input_size_height"].json_schema_extra.update(  # type: ignore[union-attr]
+        TrainingHyperParameters.model_fields["input_size_height"].json_schema_extra.update(  # type: ignore[union-attr]
             {
                 "allowed_values": self.allowed_values_input_size,  # type:ignore[dict-item]
                 "default_value": h,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Addresses deprecation warnings from Pydantic model field access.

`PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0`

before
<img width="434" height="39" alt="image" src="https://github.com/user-attachments/assets/71552703-10db-46dc-b620-52216a523b5b" />


after
<img width="265" height="41" alt="image" src="https://github.com/user-attachments/assets/f41a7b4c-1d7e-48d6-aadd-e52ae36d1eb7" />


### How to test
 
`uv run pytest .\tests\unit\`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
