### PR TITLE
Use selected device for OTX training

### DIFF
--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -133,10 +133,10 @@ class SystemService:
             raise ValueError(f"Device '{device_str}' is not available on the system.")
 
         device_type, device_index = self._parse_device(device_str)
+        if device_type == DeviceType.CPU:
+            return DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
         return next(
-            device
-            for device in self.get_devices()
-            if device.type == device_type and (device.index or 0) == device_index
+            device for device in self.get_devices() if device.type == device_type and device.index == device_index
         )
 
     @staticmethod

--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -321,7 +321,7 @@ class OTXTrainer(Trainer):
         otx_engine = OTXEngine(
             model=otx_model,
             data=otx_datamodule,
-            device=device.type,
+            device=f"{device.type}:{device.index if device.index else 0}",
             work_dir=f"./otx-workspace-{model_id}",
         )
 

--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -26,7 +26,6 @@ from otx.data.dataset.base import OTXDataset
 from otx.data.module import OTXDataModule
 from otx.data.transform_libs.torchvision import TorchVisionTransformLib
 from otx.tools.converter import GetiConfigConverter
-from otx.types.device import DeviceType
 from otx.types.export import OTXExportFormatType
 from otx.types.precision import OTXPrecisionType
 from otx.types.task import OTXTaskType
@@ -36,6 +35,7 @@ from app.core.jobs.models import TrainingJobParams
 from app.core.run import ExecutionContext
 from app.models import DatasetItemAnnotationStatus, Task, TaskType, TrainingStatus
 from app.models.training_configuration.configuration import TrainingConfiguration
+from app.schemas.system import DeviceInfo
 from app.services import (
     BaseWeightsService,
     DatasetRevisionService,
@@ -279,7 +279,7 @@ class OTXTrainer(Trainer):
 
     @step("Train Model")
     def train_model(
-        self, training_config: dict, dataset_info: DatasetInfo, weights_path: Path, model_id: UUID
+        self, training_config: dict, dataset_info: DatasetInfo, weights_path: Path, model_id: UUID, device: DeviceInfo
     ) -> tuple[Path, OTXEngine]:
         """Execute model training."""
         # TODO use weights path to initialize model from pre-downloaded weights
@@ -321,7 +321,7 @@ class OTXTrainer(Trainer):
         otx_engine = OTXEngine(
             model=otx_model,
             data=otx_datamodule,
-            device=DeviceType.cpu,  # TODO make device configurable (#5040)
+            device=device.type,
             work_dir=f"./otx-workspace-{model_id}",
         )
 
@@ -426,6 +426,7 @@ class OTXTrainer(Trainer):
             dataset_info=dataset_info,
             weights_path=weights_path,
             model_id=training_params.model_id,
+            device=training_params.device,
         )
         self.evaluate_model(otx_engine=otx_engine, model_checkpoint_path=trained_model_path)
         exported_model_path = self.export_model(otx_engine=otx_engine, model_checkpoint_path=trained_model_path)

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -226,6 +226,13 @@ class TestSystemService:
             # CUDA not available
             mock_torch.cuda.is_available.return_value = False
 
+            device_info = fxt_system_service.get_device_info("cpu")
+
+            assert device_info.type == "cpu"
+            assert device_info.name == "CPU"
+            assert device_info.memory is None
+            assert device_info.index is None
+
             device_info = fxt_system_service.get_device_info("xpu-0")
 
             assert device_info.type == "xpu"

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -200,8 +200,9 @@ class TestOTXTrainerPrepareWeights:
         otx_trainer = fxt_otx_trainer()
 
         # Act
-        with pytest.raises(FileNotFoundError, match=f"Parent model weights not found at {expected_weights_path}"):
+        with pytest.raises(FileNotFoundError) as excinfo:
             otx_trainer.prepare_weights(training_params)
+        assert excinfo.value.args[0] == f"Parent model weights not found at {expected_weights_path}"
 
     def test_prepare_weights_with_parent_model_no_project_id_raises_error(
         self,
@@ -630,6 +631,7 @@ class TestOTXTrainerTrainModel:
                         dataset_info=mock_dataset_info,
                         weights_path=weights_path,
                         model_id=model_id,
+                        device=DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
                     )
 
         # Assert


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

OTX training uses the requested device for training

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
