### PR TITLE
Fix unit tests for Windows

### DIFF
--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import os
 import tempfile
 from datetime import datetime
 from io import BytesIO
@@ -324,7 +325,7 @@ class TestDatasetItemEndpoints:
     def test_get_dataset_item_binary_success(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp_file:
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             fxt_dataset_service.get_dataset_item_binary_path_by_id.return_value = tmp_file.name
             response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/binary")
 
@@ -332,6 +333,9 @@ class TestDatasetItemEndpoints:
         fxt_dataset_service.get_dataset_item_binary_path_by_id.assert_called_once_with(
             project_id=fxt_get_project.id, dataset_item_id=dataset_item_id
         )
+
+        if os.path.exists(tmp_file.name):
+            os.unlink(tmp_file.name)
 
     def test_get_dataset_item_thumbnail_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
@@ -349,7 +353,7 @@ class TestDatasetItemEndpoints:
     def test_get_dataset_item_thumbnail_success(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp_file:
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.return_value = tmp_file.name
             response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail")
 
@@ -357,6 +361,9 @@ class TestDatasetItemEndpoints:
         fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.assert_called_once_with(
             project=fxt_get_project, dataset_item_id=dataset_item_id
         )
+
+        if os.path.exists(tmp_file.name):
+            os.unlink(tmp_file.name)
 
     def test_delete_dataset_item_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -325,17 +325,20 @@ class TestDatasetItemEndpoints:
     def test_get_dataset_item_binary_success(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-            fxt_dataset_service.get_dataset_item_binary_path_by_id.return_value = tmp_file.name
-            response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/binary")
+        tmp_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+                temp_file_path = tmp_file.name
+                fxt_dataset_service.get_dataset_item_binary_path_by_id.return_value = temp_file_path
+                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/binary")
 
-        assert response.status_code == status.HTTP_200_OK
-        fxt_dataset_service.get_dataset_item_binary_path_by_id.assert_called_once_with(
-            project_id=fxt_get_project.id, dataset_item_id=dataset_item_id
-        )
-
-        if os.path.exists(tmp_file.name):
-            os.unlink(tmp_file.name)
+            assert response.status_code == status.HTTP_200_OK
+            fxt_dataset_service.get_dataset_item_binary_path_by_id.assert_called_once_with(
+                project_id=fxt_get_project.id, dataset_item_id=dataset_item_id
+            )
+        finally:
+            if tmp_file_path and os.path.exists(tmp_file_path):
+                os.unlink(tmp_file_path)
 
     def test_get_dataset_item_thumbnail_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
@@ -353,17 +356,22 @@ class TestDatasetItemEndpoints:
     def test_get_dataset_item_thumbnail_success(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-            fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.return_value = tmp_file.name
-            response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail")
+        tmp_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+                temp_file_path = tmp_file.name
+                fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.return_value = temp_file_path
+                response = fxt_client.get(
+                    f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail"
+                )
 
-        assert response.status_code == status.HTTP_200_OK
-        fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.assert_called_once_with(
-            project=fxt_get_project, dataset_item_id=dataset_item_id
-        )
-
-        if os.path.exists(tmp_file.name):
-            os.unlink(tmp_file.name)
+            assert response.status_code == status.HTTP_200_OK
+            fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.assert_called_once_with(
+                project=fxt_get_project, dataset_item_id=dataset_item_id
+            )
+        finally:
+            if tmp_file_path and os.path.exists(tmp_file_path):
+                os.unlink(tmp_file_path)
 
     def test_delete_dataset_item_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()

--- a/application/backend/tests/unit/routers/test_projects.py
+++ b/application/backend/tests/unit/routers/test_projects.py
@@ -291,15 +291,18 @@ class TestProjectEndpoints:
         fxt_project_service.get_project_by_id.assert_not_called()
 
     def test_get_project_thumbnail(self, fxt_project, fxt_project_service, fxt_client):
-        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-            fxt_project_service.get_project_thumbnail_path.return_value = tmp_file.name
-            response = fxt_client.get(f"/api/projects/{str(fxt_project.id)}/thumbnail")
+        tmp_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+                tmp_file_path = tmp_file.name
+                fxt_project_service.get_project_thumbnail_path.return_value = tmp_file_path
+                response = fxt_client.get(f"/api/projects/{str(fxt_project.id)}/thumbnail")
 
-        assert response.status_code == status.HTTP_200_OK
-        fxt_project_service.get_project_thumbnail_path.assert_called_once()
-
-        if os.path.exists(tmp_file.name):
-            os.unlink(tmp_file.name)
+            assert response.status_code == status.HTTP_200_OK
+            fxt_project_service.get_project_thumbnail_path.assert_called_once()
+        finally:
+            if tmp_file_path and os.path.exists(tmp_file_path):
+                os.unlink(tmp_file_path)
 
     def test_get_project_thumbnail_none(self, fxt_project, fxt_project_service, fxt_client):
         fxt_project_service.get_project_thumbnail_path.return_value = None

--- a/application/backend/tests/unit/routers/test_projects.py
+++ b/application/backend/tests/unit/routers/test_projects.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import os
 import tempfile
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -290,12 +291,15 @@ class TestProjectEndpoints:
         fxt_project_service.get_project_by_id.assert_not_called()
 
     def test_get_project_thumbnail(self, fxt_project, fxt_project_service, fxt_client):
-        with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp_file:
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             fxt_project_service.get_project_thumbnail_path.return_value = tmp_file.name
             response = fxt_client.get(f"/api/projects/{str(fxt_project.id)}/thumbnail")
 
         assert response.status_code == status.HTTP_200_OK
         fxt_project_service.get_project_thumbnail_path.assert_called_once()
+
+        if os.path.exists(tmp_file.name):
+            os.unlink(tmp_file.name)
 
     def test_get_project_thumbnail_none(self, fxt_project, fxt_project_service, fxt_client):
         fxt_project_service.get_project_thumbnail_path.return_value = None

--- a/application/backend/tests/unit/stream/test_images_folder_stream.py
+++ b/application/backend/tests/unit/stream/test_images_folder_stream.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 from app.stream.images_folder_stream import ImagesFolderStream
@@ -28,10 +29,12 @@ class TestImagesFolderStream:
     @patch("os.listdir", return_value=["file1", "file2"])
     def test_init_do_not_ignore_existing_images(self, mock_listdir, mock_isfile, mock_getmtime, mock_init_watchdog):
         stream = ImagesFolderStream(folder_path="folder_path", ignore_existing_images=False)
-        assert stream.files == ["folder_path/file1", "folder_path/file2"]
+        file_1 = str(Path("folder_path", "file1"))
+        file_2 = str(Path("folder_path", "file2"))
+        assert stream.files == [file_1, file_2]
         mock_listdir.assert_called_once_with("folder_path")
-        mock_isfile.assert_has_calls([call("folder_path/file1"), call("folder_path/file2")])
-        mock_getmtime.assert_has_calls([call("folder_path/file1"), call("folder_path/file2")])
+        mock_isfile.assert_has_calls([call(file_1), call(file_2)])
+        mock_getmtime.assert_has_calls([call(file_1), call(file_2)])
         mock_init_watchdog.assert_called_once_with("folder_path")
 
     @patch.object(ImagesFolderStream, "_init_watchdog")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Windows has different path behaviour than Unix, this PR adapts the test so they work on both systems.

### How to test

`uv run pytest .\tests\unit\`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
