### PR TITLE
Add endpoint for updating model name

### DIFF
--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -123,7 +123,7 @@ UPDATE_MODEL_BODY_EXAMPLES = {
         status.HTTP_404_NOT_FOUND: {"description": "Project or model not found"},
     },
 )
-def update_model(
+def rename_model(
     project: Annotated[ProjectView, Depends(get_project)],
     model_id: ModelID,
     model_metadata: Annotated[
@@ -135,9 +135,9 @@ def update_model(
     ],
     model_service: Annotated[ModelService, Depends(get_model_service)],
 ) -> ModelView:
-    """Rename a model by ID."""
+    """Rename a model"""
     try:
-        model_revision = model_service.update_model(
+        model_revision = model_service.rename_model(
             project_id=project.id, model_id=model_id, model_metadata=model_metadata
         )
         return ModelView.model_validate(model_revision, from_attributes=True)

--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -5,7 +5,8 @@ import io
 import zipfile
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+from fastapi.openapi.models import Example
 from fastapi.responses import StreamingResponse
 
 from app.api.dependencies import get_model_service, get_project
@@ -95,6 +96,51 @@ def download_model_binary(
             media_type="application/zip",
             headers={"Content-Disposition": f'attachment; filename="{filename}"'},
         )
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+UPDATE_MODEL_BODY_DESCRIPTION = """
+Update name of model revision.
+"""
+UPDATE_MODEL_BODY_EXAMPLES = {
+    "name": Example(
+        summary="Update model name",
+        description="Change the name of the model",
+        value={
+            "name": "new_model_name",
+        },
+    ),
+}
+
+
+@router.patch(
+    "/{model_id}",
+    response_model=ModelView,
+    responses={
+        status.HTTP_200_OK: {"description": "Model successfully renamed"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid project or model ID"},
+        status.HTTP_404_NOT_FOUND: {"description": "Project or model not found"},
+    },
+)
+def rename_model(
+    project: Annotated[ProjectView, Depends(get_project)],
+    model_id: ModelID,
+    model_metadata: Annotated[
+        dict,
+        Body(
+            description=UPDATE_MODEL_BODY_DESCRIPTION,
+            openapi_examples=UPDATE_MODEL_BODY_EXAMPLES,
+        ),
+    ],
+    model_service: Annotated[ModelService, Depends(get_model_service)],
+) -> ModelView:
+    """Rename a model by ID."""
+    try:
+        model_revision = model_service.update_model(
+            project_id=project.id, model_id=model_id, model_metadata=model_metadata
+        )
+        return ModelView.model_validate(model_revision, from_attributes=True)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -123,7 +123,7 @@ UPDATE_MODEL_BODY_EXAMPLES = {
         status.HTTP_404_NOT_FOUND: {"description": "Project or model not found"},
     },
 )
-def rename_model(
+def update_model(
     project: Annotated[ProjectView, Depends(get_project)],
     model_id: ModelID,
     model_metadata: Annotated[

--- a/application/backend/app/api/schemas/model.py
+++ b/application/backend/app/api/schemas/model.py
@@ -12,6 +12,7 @@ from app.models import TrainingInfo
 class ModelView(BaseIDModel):
     """Represents a model revision with its architecture, parent revision, training info, and file status."""
 
+    name: str = Field(..., description="User friendly model name")
     architecture: str = Field(..., description="Model architecture name")
     parent_revision: UUID | None = Field(None, description="Parent model revision ID")
     training_info: TrainingInfo = Field(..., description="Information about the training process")
@@ -21,6 +22,7 @@ class ModelView(BaseIDModel):
         "json_schema_extra": {
             "example": {
                 "id": "76e07d18-196e-4e33-bf98-ac1d35dca4cb",
+                "name": "Object_Detection_YOLOX_X (76e07d18)",
                 "architecture": "Object_Detection_YOLOX_X",
                 "parent_revision": "06091f82-5506-41b9-b97f-c761380df870",
                 "training_info": {

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -57,16 +57,14 @@ class ModelService(BaseSessionManagedService):
             raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
         return ModelRevision.model_validate(model_rev_db)
 
-    def update_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
+    def rename_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
         """
-        Update a model revision.
-
-        Currently supports updating a model revision's name.
+        Rename a model revision.
 
         Args:
             project_id (UUID): The unique identifier of the project whose models to get.
             model_id (UUID): The unique identifier of the model to retrieve.
-            model_metadata: Dict containing updated model revision metadata
+            model_metadata: Dict containing updated model revision name
 
         Returns:
             ModelRevision: The model revision object containing the model's updated information.

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -57,6 +57,34 @@ class ModelService(BaseSessionManagedService):
             raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
         return ModelRevision.model_validate(model_rev_db)
 
+    def update_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
+        """
+        Update a model revision.
+
+        Currently supports updating a model revision's name.
+
+        Args:
+            project_id (UUID): The unique identifier of the project whose models to get.
+            model_id (UUID): The unique identifier of the model to retrieve.
+            model_metadata: Dict containing updated model revision metadata
+
+        Returns:
+            ModelRevision: The model revision object containing the model's updated information.
+
+        Raises:
+            ResourceNotFoundError: If no model with the given model_id is found.
+        """
+        model_rev_repo = ModelRevisionRepository(project_id=str(project_id), db=self.db_session)
+        model_rev_db = model_rev_repo.get_by_id(str(model_id))
+        if not model_rev_db:
+            raise ResourceNotFoundError(ResourceType.MODEL, str(model_id))
+
+        new_name = model_metadata.get("name")
+        if new_name is not None:
+            model_rev_db.name = new_name
+            model_rev_repo.update(model_rev_db)
+        return ModelRevision.model_validate(model_rev_db)
+
     @parent_process_only
     def delete_model(self, project_id: UUID, model_id: UUID) -> None:
         """

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -56,6 +56,20 @@ class TestModelServiceIntegration:
         assert model is not None
         assert model.id == fxt_model_id
 
+    def test_update_model(self, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService):
+        """Test updating name of a model by ID."""
+        new_model_name = "This is a new model name"
+        model_metadata = {"name": new_model_name}
+        model_from_get_before_update = fxt_model_service.get_model(fxt_project_id, fxt_model_id)
+        model_from_update = fxt_model_service.update_model(
+            project_id=fxt_project_id, model_id=fxt_model_id, model_metadata=model_metadata
+        )
+        model_from_get_after_update = fxt_model_service.get_model(fxt_project_id, fxt_model_id)
+
+        assert model_from_update.name == new_model_name
+        assert model_from_get_before_update.name != new_model_name
+        assert model_from_get_after_update.name == new_model_name
+
     @pytest.mark.parametrize("model_operation", ["get_model", "delete_model"])
     def test_non_existent_model(self, model_operation, fxt_project_id, fxt_db_projects, fxt_model_service, db_session):
         """Test retrieving a non-existent model raises error."""

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -61,7 +61,7 @@ class TestModelServiceIntegration:
         new_model_name = "This is a new model name"
         model_metadata = {"name": new_model_name}
         model_from_get_before_update = fxt_model_service.get_model(fxt_project_id, fxt_model_id)
-        model_from_update = fxt_model_service.update_model(
+        model_from_update = fxt_model_service.rename_model(
             project_id=fxt_project_id, model_id=fxt_model_id, model_metadata=model_metadata
         )
         model_from_get_after_update = fxt_model_service.get_model(fxt_project_id, fxt_model_id)

--- a/application/backend/tests/unit/routers/test_models.py
+++ b/application/backend/tests/unit/routers/test_models.py
@@ -18,6 +18,7 @@ from app.services import ModelService, ResourceInUseError, ResourceNotFoundError
 def fxt_model() -> ModelView:
     return ModelView(
         id=uuid4(),
+        name="Object_Detection_YOLOX (id-short)",
         architecture="Object_Detection_YOLOX",
         training_info=TrainingInfo(status=TrainingStatus.NOT_STARTED, label_schema_revision={}, configuration={}),  # type: ignore
     )  # type: ignore

--- a/application/ui/mocks/mock-model.ts
+++ b/application/ui/mocks/mock-model.ts
@@ -5,6 +5,7 @@ import type { SchemaModelView } from '../src/api/openapi-spec';
 
 export const getMockedModel = (overrides: Partial<SchemaModelView> = {}): SchemaModelView => ({
     id: 'model-1',
+    name: 'Mocked Model',
     architecture: 'YOLOX',
     parent_revision: null,
     training_info: {


### PR DESCRIPTION
This pull request adds support for renaming a model revision by its ID through a new PATCH endpoint, updates the service layer to handle model name updates, and introduces an integration test to verify this new functionality.

**API Enhancements:**

* Added a new PATCH endpoint (`/{model_id}`) to `routers/models.py` allowing clients to rename a model revision, including OpenAPI documentation and request body examples. [[1]](diffhunk://#diff-ef85386976609785b98cca7904421ac6fd51ac32a71d731777efccda4c3d938cL8-R9) [[2]](diffhunk://#diff-ef85386976609785b98cca7904421ac6fd51ac32a71d731777efccda4c3d938cR103-R147)

**Service Layer Updates:**

* Implemented the `rename_model` method in `ModelService` to update a model revision's name, with proper error handling if the model is not found.

**Testing:**

* Added an integration test `test_update_model` to ensure the model name update functionality works as expected.

Resolves #5057 

### How to test

Added integration test for update_model

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
