### PR TITLE
Improve annotation endpoint examples

### DIFF
--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -33,34 +33,62 @@ DEFAULT_DATASET_ITEMS_NUMBER_RETURNED = 10
 MAX_DATASET_ITEMS_NUMBER_RETURNED = 100
 
 SET_DATASET_ITEM_ANNOTATIONS_BODY_EXAMPLES = {
-    "full_image": Example(
-        summary="Full image annotation",
+    "single_label": Example(
+        summary="Single label (multiclass classification)",
         value={
             "annotations": [
                 {"labels": [{"id": "d476573e-d43c-42a6-9327-199a9aa75c33"}], "shape": {"type": "full_image"}}
             ],
         },
     ),
-    "rectangle": Example(
-        summary="Rectangle annotation",
+    "multi_label": Example(
+        summary="Multiple labels (multilabel classification)",
+        value={
+            "annotations": [
+                {
+                    "labels": [
+                        {"id": "d476573e-d43c-42a6-9327-199a9aa75c33"},
+                        {"id": "bbb782b7-8322-44e8-b6a9-90a5c9ee4bad"},
+                    ],
+                    "shape": {"type": "full_image"},
+                },
+            ],
+        },
+    ),
+    "bounding_boxes": Example(
+        summary="Bounding boxes (detection)",
         value={
             "annotations": [
                 {
                     "labels": [{"id": "d476573e-d43c-42a6-9327-199a9aa75c33"}],
                     "shape": {"type": "rectangle", "x": 10, "y": 20, "width": 100, "height": 200},
-                }
+                },
+                {
+                    "labels": [{"id": "bbb782b7-8322-44e8-b6a9-90a5c9ee4bad"}],
+                    "shape": {"type": "rectangle", "x": 150, "y": 250, "width": 80, "height": 120},
+                },
             ],
         },
     ),
-    "polygon": Example(
-        summary="Polygon annotation",
+    "polygons": Example(
+        summary="Polygons (segmentation)",
         value={
             "annotations": [
                 {
                     "labels": [{"id": "d476573e-d43c-42a6-9327-199a9aa75c33"}],
                     "shape": {"type": "polygon", "points": [[10, 20], [20, 60], [30, 40]]},
-                }
+                },
+                {
+                    "labels": [{"id": "bbb782b7-8322-44e8-b6a9-90a5c9ee4bad"}],
+                    "shape": {"type": "polygon", "points": [[150, 250], [180, 300], [200, 280]]},
+                },
             ],
+        },
+    ),
+    "empty": Example(
+        summary="No objects (detection / segmentation)",
+        value={
+            "annotations": [],
         },
     ),
 }

--- a/application/backend/app/db_seeder.py
+++ b/application/backend/app/db_seeder.py
@@ -91,7 +91,6 @@ def _create_detection_labels(project_id: str | UUID) -> list[LabelDB]:
         LabelDB(project_id=project_id, name="Diamonds", color="#baa3b3", hotkey="d"),
         LabelDB(project_id=project_id, name="Spades", color="#000702", hotkey="s"),
         LabelDB(project_id=project_id, name="Hearts", color="#1f016b", hotkey="h"),
-        LabelDB(project_id=project_id, name="No_object", color="#565a84", hotkey="n"),
     ]
 
 
@@ -107,7 +106,6 @@ def _create_segmentation_labels(project_id: str | UUID) -> list[LabelDB]:
     """
     return [
         LabelDB(project_id=project_id, name="Fish", color="#2d6311", hotkey="f"),
-        LabelDB(project_id=project_id, name="Empty", color="#565a84", hotkey="e"),
     ]
 
 


### PR DESCRIPTION
### Summary

Changes:
- Improve the examples in the OpenAPI docs for the `POST /annotations` endpoint
  - Add comprehensive examples for all type tasks
  - Add an example for empty annotations
- Remove the empty label from the demo models (DB seeding)
  - In the server, the empty label is represented implicitly by an empty list of annotations (`[]`), not with an explicit label

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
