### PR TITLE
Update renovate config for release/2.6 branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -199,9 +199,9 @@
 
     // Disable lockFileMaintenance for release/2.6 branch
     {
-      "matchBaseBranches": ["release/2.6"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "enabled": false
+      enabled: false,
+      matchUpdateTypes: ["lockFileMaintenance"],
+      matchBaseBranches: ["release/2.6"],
     },
   ],
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,7 +35,7 @@
   // if necessary, add supported releases branches here
   // it is possible to enable/disable specific upgrades per branch with
   // `matchBaseBranches` in specific rule
-  baseBranches: ["develop"],
+  baseBranches: ["develop", "release/2.6"],
 
   // https://docs.renovatebot.com/modules/manager/#disabling-managers
   pip_requirements: {
@@ -147,6 +147,13 @@
       matchDepNames: ["docker/dockerfile"],
     },
 
+    // Disable images upgrades for release/2.6 branch
+    {
+      enabled: false,
+      matchDatasources: ["docker"],
+      matchBaseBranches: ["release/2.6"],
+    },
+
     // Group GitHub Actions updates
     {
       enabled: true,
@@ -155,6 +162,14 @@
       matchManagers: ["github-actions"],
       matchPackagePatterns: ["*"],
       schedule: ["* * 1,15 * *"], // twice a month
+      matchBaseBranches: ["main"],
+    },
+
+    // Disable upgrades for non-main branches
+    {
+      enabled: false,
+      matchManagers: ["github-actions"],
+      matchBaseBranches: ["!main"],
     },
 
     // uv version used in GitHub Actions is updated manually
@@ -180,6 +195,13 @@
       matchDepTypes: ["container"],
       matchDepNames: ["mcr.microsoft.com/playwright"],
       matchUpdateTypes: ["major", "minor", "patch"],
+    },
+
+    // Disable lockFileMaintenance for release/2.6 branch
+    {
+      "matchBaseBranches": ["release/2.6"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "enabled": false
     },
   ],
 


### PR DESCRIPTION
### Summary

Intention is to allow renovate bot to create PRs with security upgrades only in release/2.6 branch

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
