### PR TITLE
Pass model checkpoint to OTXEngine

### DIFF
--- a/application/backend/app/services/training/otx_trainer.py
+++ b/application/backend/app/services/training/otx_trainer.py
@@ -281,7 +281,13 @@ class OTXTrainer(Trainer):
 
     @step("Train Model")
     def train_model(
-        self, training_config: dict, dataset_info: DatasetInfo, weights_path: Path, model_id: UUID, device: DeviceInfo
+        self,
+        training_config: dict,
+        dataset_info: DatasetInfo,
+        weights_path: Path,
+        model_id: UUID,
+        device: DeviceInfo,
+        has_parent_revision: bool,
     ) -> tuple[Path, OTXEngine]:
         """Execute model training."""
         # TODO use weights path to initialize model from pre-downloaded weights
@@ -324,6 +330,7 @@ class OTXTrainer(Trainer):
         otx_engine = OTXEngine(
             model=otx_model,
             data=otx_datamodule,
+            checkpoint=weights_path if has_parent_revision else None,
             work_dir=f"./otx-workspace-{model_id}",
             device=otx_device_type,
         )
@@ -432,6 +439,7 @@ class OTXTrainer(Trainer):
             weights_path=weights_path,
             model_id=training_params.model_id,
             device=training_params.device,
+            has_parent_revision=training_params.parent_model_revision_id is not None,
         )
         self.evaluate_model(otx_engine=otx_engine, model_checkpoint_path=trained_model_path)
         exported_model_path = self.export_model(otx_engine=otx_engine, model_checkpoint_path=trained_model_path)
@@ -448,7 +456,7 @@ class OTXTrainer(Trainer):
 
     @classmethod
     def __build_model_weights_path(cls, data_dir: Path, project_id: UUID, model_id: UUID) -> Path:
-        return cls.__base_model_path(data_dir, project_id, model_id) / "model.pth"
+        return cls.__base_model_path(data_dir, project_id, model_id) / "model.ckpt"
 
     @classmethod
     def __build_model_config_path(cls, data_dir: Path, project_id: UUID, model_id: UUID) -> Path:

--- a/application/backend/tests/unit/services/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/services/training/test_otx_trainer.py
@@ -166,7 +166,7 @@ class TestOTXTrainerPrepareWeights:
             parent_model_revision_id=parent_model_revision_id,
         )
         expected_weights_path = (
-            tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.pth"
+            tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.ckpt"
         )
         expected_weights_path.parent.mkdir(parents=True, exist_ok=True)
         expected_weights_path.touch()
@@ -195,7 +195,7 @@ class TestOTXTrainerPrepareWeights:
             parent_model_revision_id=parent_model_revision_id,
         )
         expected_weights_path = (
-            tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.pth"
+            tmp_path / "projects" / str(project_id) / "models" / str(parent_model_revision_id) / "model.ckpt"
         )
         otx_trainer = fxt_otx_trainer()
 
@@ -643,6 +643,7 @@ class TestOTXTrainerTrainModel:
                         weights_path=weights_path,
                         model_id=model_id,
                         device=geti_device,
+                        has_parent_revision=True,
                     )
 
         # Assert
@@ -663,6 +664,7 @@ class TestOTXTrainerTrainModel:
         assert engine_call_kwargs["data"] == mock_datamodule
         assert engine_call_kwargs["work_dir"] == f"./otx-workspace-{model_id}"
         assert engine_call_kwargs["device"] == otx_device
+        assert engine_call_kwargs["checkpoint"] == weights_path
 
         # Verify training was started
         mock_otx_engine.train.assert_called_once()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

When training is requested from a parent revision, the trainer passes the checkpoint (`.ckpt`) file from the parent model revision's folder to the OTX engine to initialize training from that checkpoint.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
