### PR TITLE
Extend model deletion endpoint for files only

### DIFF
--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -171,10 +171,14 @@ def delete_model(
     project: Annotated[ProjectView, Depends(get_project)],
     model_id: ModelID,
     model_service: Annotated[ModelService, Depends(get_model_service)],
+    files_only: Annotated[bool, Query()] = False,
 ) -> None:
     """Delete a model from a project."""
     try:
-        model_service.delete_model(project_id=project.id, model_id=model_id)
+        if files_only:
+            model_service.delete_model_files(project_id=project.id, model_id=model_id)
+        else:
+            model_service.delete_model(project_id=project.id, model_id=model_id)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ResourceInUseError as e:

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -116,6 +116,33 @@ class ModelService(BaseSessionManagedService):
         except IntegrityError:
             raise ResourceInUseError(ResourceType.MODEL, str(model_id))
 
+    @parent_process_only
+    def delete_model_files(self, project_id: UUID, model_id: UUID) -> None:
+        """
+        Delete only the model files from disk, keeping the model revision record in the database and setting its
+        files_deleted flag to True.
+
+        Args:
+            project_id (UUID): The unique identifier of the project.
+            model_id (UUID): The unique identifier of the model.
+        """
+        try:
+            model_files_path = self.get_model_files_path(project_id=project_id, model_id=model_id)
+        except FileNotFoundError:
+            return
+        except ResourceNotFoundError:
+            return
+
+        # Delete model files from disk
+        shutil.rmtree(model_files_path)
+        logger.info("Deleted model files at '{}'", model_files_path)
+
+        # Mark as deleted in the database
+        model_rev_repo = ModelRevisionRepository(project_id=str(project_id), db=self.db_session)
+        model_rev_db = model_rev_repo.get_by_id(str(model_id))  # model_revision is present as model_files_path exists
+        model_rev_db.files_deleted = True  # type: ignore[union-attr]
+        model_rev_repo.update(model_rev_db)  # type: ignore[arg-type]
+
     def list_models(self, project_id: UUID) -> list[ModelRevision]:
         """
         Get information about all available model revisions in a project.

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -4,6 +4,7 @@
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 from uuid import UUID
 
 from loguru import logger
@@ -139,9 +140,9 @@ class ModelService(BaseSessionManagedService):
 
         # Mark as deleted in the database
         model_rev_repo = ModelRevisionRepository(project_id=str(project_id), db=self.db_session)
-        model_rev_db = model_rev_repo.get_by_id(str(model_id))  # model_revision is present as model_files_path exists
-        model_rev_db.files_deleted = True  # type: ignore[union-attr]
-        model_rev_repo.update(model_rev_db)  # type: ignore[arg-type]
+        model_rev_db = cast(ModelRevisionDB, model_rev_repo.get_by_id(str(model_id)))
+        model_rev_db.files_deleted = True
+        model_rev_repo.update(model_rev_db)
 
     def list_models(self, project_id: UUID) -> list[ModelRevision]:
         """

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -115,6 +115,27 @@ class TestModelServiceIntegration:
         assert db_session.get(ModelRevisionDB, str(fxt_model_id)) is None
         assert not model_rev_path.exists()
 
+    def test_delete_model_only_files(
+        self,
+        tmp_path: Path,
+        fxt_project_id: UUID,
+        fxt_model_id: UUID,
+        fxt_model_service: ModelService,
+        db_session: Session,
+    ):
+        """Test that deleting only model files removes only filesystem artifacts."""
+        model_rev_path = tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id)
+        model_rev_path.mkdir(parents=True, exist_ok=True)
+        (model_rev_path / "model.xml").touch()
+        (model_rev_path / "model.bin").touch()
+
+        fxt_model_service.delete_model_files(project_id=fxt_project_id, model_id=fxt_model_id)
+
+        model_db = db_session.get(ModelRevisionDB, str(fxt_model_id))
+        assert model_db is not None
+        assert model_db.files_deleted is True
+        assert not model_rev_path.exists()
+
     def test_delete_model_with_files_no_permission(
         self,
         tmp_path: Path,

--- a/application/backend/tests/unit/routers/test_models.py
+++ b/application/backend/tests/unit/routers/test_models.py
@@ -93,6 +93,14 @@ class TestModelEndpoints:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         fxt_model_service.delete_model.assert_called_once_with(project_id=fxt_get_project.id, model_id=fxt_model.id)
 
+    def test_delete_model_files_only_success(self, fxt_get_project, fxt_model, fxt_model_service, fxt_client):
+        response = fxt_client.delete(f"/api/projects/{fxt_get_project.id}/models/{fxt_model.id}?files_only=true")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        fxt_model_service.delete_model_files.assert_called_once_with(
+            project_id=fxt_get_project.id, model_id=fxt_model.id
+        )
+
     def test_delete_model_not_found(self, fxt_get_project, fxt_model_service, fxt_client):
         model_id = uuid4()
         fxt_model_service.delete_model.side_effect = ResourceNotFoundError(ResourceType.MODEL, str(model_id))


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Extend the delete model endpoint with a new query `files_only=False` which when set to `True` will delete only the model files from disk to save space, but persist the db document with `files_deleted=True`.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
