### PR TITLE
Update camera enumeration

### DIFF
--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
+import platform
 import re
+from collections import defaultdict
 
+import cv2
 import psutil
 import torch
 from cv2_enumerate_cameras import enumerate_cameras
@@ -11,6 +13,11 @@ from app.models.system import CameraInfo, DeviceInfo, DeviceType
 
 DEVICE_PATTERN = re.compile(r"^(cpu|xpu|cuda)(-(\d+))?$")
 DEFAULT_DEVICE = "cpu"
+CV2_BACKENDS = {
+    "Windows": cv2.CAP_MSMF,
+    "Linux": cv2.CAP_V4L2,
+    "Darwin": cv2.CAP_AVFOUNDATION,
+}
 
 
 class SystemService:
@@ -162,8 +169,22 @@ class SystemService:
     def get_camera_devices() -> list[CameraInfo]:
         """
         Get available camera devices.
+        If duplicate names are present, append a suffix to make them unique.
+        Example: ["camera", "camera"] -> ["camera", "camera (1)"]
 
         Returns:
             list[CameraInfo]: List of available camera devices
         """
-        return [CameraInfo(index=camera.index, name=camera.name) for camera in enumerate_cameras()]
+        if (backend := CV2_BACKENDS.get(platform.system())) is None:
+            raise RuntimeError(f"Unsupported platform: {platform.system()}")
+
+        cameras: list[CameraInfo] = []
+        name_counts: dict[str, int] = defaultdict(int)
+
+        for cam in enumerate_cameras(backend):
+            name = cam.name
+            if count := name_counts[name]:
+                name = f"{name} ({count})"
+            name_counts[cam.name] += 1
+            cameras.append(CameraInfo(index=cam.index, name=name))
+        return cameras

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -168,8 +168,7 @@ class SystemService:
     def get_camera_devices() -> list[CameraInfo]:
         """
         Get available camera devices.
-        If duplicate names are present, append a suffix to make them unique.
-        Example: ["camera", "camera"] -> ["camera", "camera (1)"]
+        Camera names are formatted as "<camera_name> [<index>]".
 
         Returns:
             list[CameraInfo]: List of available camera devices

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import platform
 import re
-from collections import defaultdict
 
 import cv2
 import psutil
@@ -178,13 +177,4 @@ class SystemService:
         if (backend := CV2_BACKENDS.get(platform.system())) is None:
             raise RuntimeError(f"Unsupported platform: {platform.system()}")
 
-        cameras: list[CameraInfo] = []
-        name_counts: dict[str, int] = defaultdict(int)
-
-        for cam in enumerate_cameras(backend):
-            name = cam.name
-            if count := name_counts[name]:
-                name = f"{name} ({count})"
-            name_counts[cam.name] += 1
-            cameras.append(CameraInfo(index=cam.index, name=name))
-        return cameras
+        return [CameraInfo(index=cam.index, name=f"{cam.name} [{cam.index}]") for cam in enumerate_cameras(backend)]

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "scikit-multilearn~=0.2.0",
     "loguru~=0.7.3",
     "sse-starlette~=3.0.3",
-    "cv2-enumerate-cameras==1.3.1",
+    "cv2-enumerate-cameras==1.3.3",
 ]
 
 [project.optional-dependencies]

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -258,5 +258,5 @@ class TestSystemService:
             camera_devices = fxt_system_service.get_camera_devices()
 
             assert len(camera_devices) == 1
-            assert camera_devices[0].name == "Integrated Camera"
+            assert camera_devices[0].name == "Integrated Camera [1400]"
             assert camera_devices[0].index == 1400

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -436,16 +436,16 @@ wheels = [
 
 [[package]]
 name = "cv2-enumerate-cameras"
-version = "1.3.1"
+version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyobjc-framework-avfoundation", marker = "sys_platform == 'darwin' or (extra == 'extra-3-otx-cpu' and extra == 'extra-3-otx-cuda') or (extra == 'extra-3-otx-cpu' and extra == 'extra-3-otx-xpu') or (extra == 'extra-3-otx-cuda' and extra == 'extra-3-otx-xpu') or (extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda') or (extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-xpu') or (extra == 'extra-9-geti-tune-cuda' and extra == 'extra-9-geti-tune-xpu')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/9a/b37be592cf3ac2d3d75a5cce13c1e9d6c642c732c1f157cbedebc709b6c7/cv2_enumerate_cameras-1.3.1.tar.gz", hash = "sha256:28f8f42df9998ff47aab65198a848f0033420dc86d858764e098ab602d745357", size = 12878, upload-time = "2025-11-29T07:15:38.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/40/6208e5ef9a0e46e9acc233c00a1b30728ca3b03b429e751c59e4d9cf5c8b/cv2_enumerate_cameras-1.3.3.tar.gz", hash = "sha256:cc09429e3fd4a2ea3449bbc0ee12420666aee6705d80a36f2235503d90fff3a2", size = 12901, upload-time = "2026-01-16T02:39:47.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/be/fde95b064dc7c15f32a748d6070350dab920527c0bceba62a0fe1bd64bd2/cv2_enumerate_cameras-1.3.1-cp32-abi3-win32.whl", hash = "sha256:3efd052be5ed3f629ff0b7a1d82e4bc109ef89dbc62fa0e9ec3b5fad2cb09ab6", size = 20873, upload-time = "2025-11-29T07:15:34.5Z" },
-    { url = "https://files.pythonhosted.org/packages/87/3d/9e9c8c7b13a61aec1dbd1ef211391ade06f4629ee0a1f4fd5404a4b45c45/cv2_enumerate_cameras-1.3.1-cp32-abi3-win_amd64.whl", hash = "sha256:e7f2e3011b63b1a7d600ec19018c34acdd4d856385f1417afa0f5f10b1a5a980", size = 21761, upload-time = "2025-11-29T07:15:35.909Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/60/da4ec76896917663009af2659864a893a243131f08a6d0fa51295d47f8bb/cv2_enumerate_cameras-1.3.1-py3-none-any.whl", hash = "sha256:7927c1c71136e2c6002b488d007d2efd237b888c65dc8bd5f9a006f5306f516d", size = 12036, upload-time = "2025-11-29T07:15:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a9/7395194e0a7ad25e14669fd499a5bf062cb9ae3dcba4d4fca8dd398b4061/cv2_enumerate_cameras-1.3.3-cp32-abi3-win32.whl", hash = "sha256:700d5d4283eb630e74d0a9e4829b9f5a3e373c3ce9a2e5bbed7959eb5bb31246", size = 20879, upload-time = "2026-01-16T02:39:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e8/197478c59e66ace7b41cbe6a5ce9cbbea42dfe6a0afba3d4dcc5d4b59df4/cv2_enumerate_cameras-1.3.3-cp32-abi3-win_amd64.whl", hash = "sha256:fb4c9cf9d3f9d1bc0e648943f6683d5dd0228c93d6ed11aae471500701009dee", size = 21768, upload-time = "2026-01-16T02:39:45.1Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b1/183463b131f6fb459186fd060ab1761aa8230f52417efc827d335c72df54/cv2_enumerate_cameras-1.3.3-py3-none-any.whl", hash = "sha256:f83c7329d85462bc27d805aa25a3cde73aa66d7e28e2f5b6cb425ccc84c965d0", size = 12043, upload-time = "2026-01-16T02:39:46.184Z" },
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ requires-dist = [
     { name = "aiofiles", specifier = "==25.1.0" },
     { name = "aiortc", specifier = "~=1.14.0" },
     { name = "alembic", specifier = "~=1.17.2" },
-    { name = "cv2-enumerate-cameras", specifier = "==1.3.1" },
+    { name = "cv2-enumerate-cameras", specifier = "==1.3.3" },
     { name = "datumaro", extras = ["experimental"], git = "https://github.com/open-edge-platform/datumaro.git?rev=develop" },
     { name = "fastapi", extras = ["standard"], specifier = "~=0.121.2" },
     { name = "faster-coco-eval", specifier = "~=1.7.0" },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Fix from https://github.com/open-edge-platform/anomalib/pull/3264
- Update `cv2-enumrate-cameras` to latest version `1.3.3` (contains a fix for MacOS).
- Use default capture backend to avoid duplicated cameras listings using different backends. For example, the library supports two backends in Linux and both results are returned if backend is not specified:
<img width="1416" height="1236" alt="image" src="https://github.com/user-attachments/assets/b3c4b72b-6df0-4a22-8581-9141d0e6b845" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
