### PR TITLE
Add name to dataset revision

### DIFF
--- a/application/backend/app/db/schema.py
+++ b/application/backend/app/db/schema.py
@@ -93,6 +93,7 @@ class DatasetRevisionDB(BaseID):
     __table_args__ = (Index("idx_dataset_revisions_project", "project_id"),)
 
     project_id: Mapped[str] = mapped_column(Text, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
     files_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
 

--- a/application/backend/app/models/dataset_revision.py
+++ b/application/backend/app/models/dataset_revision.py
@@ -20,4 +20,5 @@ class DatasetRevision(BaseEntity):
 
     id: UUID
     project_id: UUID
+    name: str
     files_deleted: bool

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -3,7 +3,7 @@
 
 import shutil
 from pathlib import Path
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import datumaro.experimental as dm
 import polars as pl
@@ -40,9 +40,14 @@ class DatasetRevisionService(BaseSessionManagedService):
             UUID: The UUID of the newly created dataset revision.
         """
         revision_repo = DatasetRevisionRepository(db=self.db_session)
+        dataset_revision_id = str(uuid4())
+        short_id = dataset_revision_id.split("-")[0]
+        dataset_name = f"Dataset ({short_id})"
         revision_db = revision_repo.save(
             DatasetRevisionDB(
+                id=dataset_revision_id,
                 project_id=str(project_id),
+                name=dataset_name,
             )
         )
         revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / revision_db.id
@@ -87,6 +92,7 @@ class DatasetRevisionService(BaseSessionManagedService):
             DatasetRevisionDB(
                 id=str(dataset_revision.id),
                 project_id=str(dataset_revision.project_id),
+                name=dataset_revision.name,
                 files_deleted=dataset_revision.files_deleted,
             )
         )

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -279,6 +279,7 @@ class TestDatasetRevisionServiceIntegration:
         assert revision is not None
         assert revision.id == revision_id
         assert revision.project_id == project.id
+        assert revision.name == f"Dataset ({str(revision.id).split('-')[0]})"
         assert revision.files_deleted is False
 
     def test_get_dataset_revision_not_found(
@@ -418,6 +419,7 @@ class TestDatasetRevisionServiceIntegration:
         db_revision = DatasetRevisionDB(
             id=str(revision_id),
             project_id=str(project.id),
+            name=f"Dataset ({str(revision_id).split('-')[0]})",
             files_deleted=False,
         )
         db_session.add(db_revision)


### PR DESCRIPTION
This pull request introduces a new required `name` field for dataset revisions, ensuring each revision has a human-readable identifier. The name is automatically generated based on a short form of the revision UUID. The changes span the database schema, data models, service logic, and tests to support this new field.

Schema and Model Updates:
- Added a new non-nullable `name` column to the `DatasetRevisionDB` database model, and a corresponding `name` attribute to the `DatasetRevision` entity model. [[1]](diffhunk://#diff-8a5fe51e36428f9d874a68decf7a22fc42235143b5fc708756be7fadd4ebb528R96) [[2]](diffhunk://#diff-9e159e0c61cf600e499e28580f0f95dc272e194f19d229e10b8834bcc46a6781R23)

Service Logic Enhancements:
- Updated the dataset revision creation logic in `save_revision` to generate a UUID, derive a short ID, and set the `name` field in the new revision.
- Updated the revision update logic to include the `name` field when persisting changes.

Testing Improvements:
- Updated integration tests to check that the `name` field is set correctly when retrieving or creating a dataset revision. [[1]](diffhunk://#diff-17859d947cf4a4178c0b812e9543641723ee7985811ead6c8b966533b7811b21R282) [[2]](diffhunk://#diff-17859d947cf4a4178c0b812e9543641723ee7985811ead6c8b966533b7811b21R422)

Dependency Update:
- Added import of `uuid4` in the service file to support UUID generation for dataset revisions.

Resolves #5154 
### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
