### PR TITLE
Fix model architecture id in demo detection model

### DIFF
--- a/application/backend/app/cli.py
+++ b/application/backend/app/cli.py
@@ -118,7 +118,7 @@ def seed(with_model: bool) -> None:
             video_path="data/media/card-video.mp4",
             sink_id=folders.id,
             model_id="977eeb18-eaac-449d-bc80-e340fbe052ad",
-            model_architecture="Object_Detection_SSD",
+            model_architecture="Custom_Object_Detection_Gen3_SSD",
             labels=detection_labels,
         )
 


### PR DESCRIPTION
### Summary

The architecture name of the seeded model now matches the [manifest id](https://github.com/open-edge-platform/training_extensions/blob/09cb758cc0d39d2a34c1dee0aae7a0e413ad5a14/application/backend/app/supported_models/manifests/detection/ssd_mobilenetv2.yaml#L1).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
