### PR TITLE
Fix default ice servers

### DIFF
--- a/application/docker/docker-compose.yaml
+++ b/application/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
     working_dir: /application/backend
     environment:
       - AI_DEVICE=${AI_DEVICE} # choose between 'cpu' (default), 'xpu', 'gpu'
-      - ICE_SERVERS=${ICE_SERVERS} # JSON array of STUN/TURN servers for WebRTC, e.g. '[{"urls":"stun:stun.l.google.com:19302"},{"urls": "turn:' + COTURN-EXTERNAL-IP + ':' + COTURN-PORT + '?transport=tcp", "username": "user", "credential": "password"}]'
+      - ICE_SERVERS=${ICE_SERVERS:-[]} # JSON array of STUN/TURN servers for WebRTC, e.g. '[{"urls":"stun:stun.l.google.com:19302"},{"urls": "turn:' + COTURN-EXTERNAL-IP + ':' + COTURN-PORT + '?transport=tcp", "username": "user", "credential": "password"}]'
       - WEBRTC_ADVERTISE_IP=${WEBRTC_ADVERTISE_IP}
     volumes:
       - ../backend/data/:/application/data/


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

On windows the default becomes a string which is not compatible with the model
`time="2026-01-20T10:49:37+01:00" level=warning msg="The \"ICE_SERVERS\" variable is not set. Defaulting to a blank string."`

```
geti-tune-1  |   File "/application/backend/.venv/lib/python3.13/site-packages/pydantic_settings/main.py", line 438, in _settings_build_values
geti-tune-1  |     source_state = source()
geti-tune-1  |   File "/application/backend/.venv/lib/python3.13/site-packages/pydantic_settings/sources/base.py", line 512, in __call__
geti-tune-1  |     raise SettingsError(
geti-tune-1  |         f'error parsing value for field "{field_name}" from source "{self.__class__.__name__}"'
geti-tune-1  |     ) from e
geti-tune-1  | pydantic_settings.exceptions.SettingsError: error parsing value for field "ice_servers" from source "EnvSettingsSource"
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
