### PR TITLE
Add model size calculation

### DIFF
--- a/application/backend/app/api/schemas/model.py
+++ b/application/backend/app/api/schemas/model.py
@@ -25,6 +25,7 @@ class ModelView(BaseIDModel):
     training_info: TrainingInfo = Field(..., description="Information about the training process")
     variants: list[ModelVariant] = Field(description="Variants of the model", default=[])
     files_deleted: bool = Field(description="Indicates if model files have been deleted", default=False)
+    size: int = Field(description="Total size of model and all its files in bytes")
 
     model_config = {
         "json_schema_extra": {
@@ -70,6 +71,7 @@ class ModelView(BaseIDModel):
                     },
                 ],
                 "files_deleted": False,
+                "size": 370368,
             }
         }
     }
@@ -122,6 +124,7 @@ class ExtendedModelView(ModelView):
                     },
                 ],
                 "files_deleted": False,
+                "size": 370368,
                 "evaluations": [
                     {
                         "dataset_revision_id": "3c6c6d38-1cd8-4458-b759-b9880c048b78",

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -3,6 +3,7 @@
 
 import shutil
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import cast
 from uuid import UUID
@@ -94,11 +95,17 @@ class ModelService(BaseSessionManagedService):
         Returns:
             int: Total size of the model and all its files in bytes.
         """
+
+        @lru_cache
+        def _cached_model_size_in_bytes(_model_path: Path) -> int:
+            return sum(f.stat().st_size for f in _model_path.glob("**/*") if f.is_file())
+
         model_revision = self.get_model(project_id=project_id, model_id=model_id)
         if model_revision.files_deleted:
             return 0
+
         model_path = self._projects_dir / str(project_id) / "models" / str(model_id)
-        return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
+        return _cached_model_size_in_bytes(_model_path=model_path)
 
     def rename_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
         """

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -84,6 +84,22 @@ class ModelService(BaseSessionManagedService):
 
         return model_variants
 
+    def get_model_size_in_bytes(self, project_id: UUID, model_id: UUID) -> int:
+        """
+        Get the total size of the model and all its files in bytes.
+
+        Args:
+            project_id (UUID): The unique identifier of the project whose models to get.
+            model_id (UUID): The unique identifier of the model to retrieve size for.
+        Returns:
+            int: Total size of the model and all its files in bytes.
+        """
+        model_revision = self.get_model(project_id=project_id, model_id=model_id)
+        if model_revision.files_deleted:
+            return 0
+        model_path = self._projects_dir / str(project_id) / "models" / str(model_id)
+        return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
+
     def rename_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
         """
         Rename a model revision.

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -118,6 +118,21 @@ class TestModelServiceIntegration:
             assert variant.get("precision") in ["fp16", "fp32"]
             assert variant.get("weights_size") == 0  # Files are empty, so size is 0
 
+    def test_get_model_size_in_bytes(
+        self, tmp_path: Path, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService
+    ):
+        """Test retrieving total model size in bytes."""
+        model_size_path = tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id)
+        model_size_path.mkdir(parents=True, exist_ok=True)
+        (model_size_path / "model.xml").write_bytes(b"x" * 100)
+        (model_size_path / "model.bin").write_bytes(b"x" * 200)
+        (model_size_path / "model.onnx").write_bytes(b"x" * 300)
+        (model_size_path / "model.ckpt").write_bytes(b"x" * 400)
+
+        total_size = fxt_model_service.get_model_size_in_bytes(fxt_project_id, fxt_model_id)
+
+        assert total_size == 100 + 200 + 300 + 400
+
     def test_update_model(self, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService):
         """Test updating name of a model by ID."""
         new_model_name = "This is a new model name"

--- a/application/backend/tests/unit/routers/test_models.py
+++ b/application/backend/tests/unit/routers/test_models.py
@@ -22,6 +22,7 @@ def fxt_model() -> ModelView:
         name="Object_Detection_YOLOX (id-short)",
         architecture="Object_Detection_YOLOX",
         training_info=TrainingInfo(status=TrainingStatus.NOT_STARTED, label_schema_revision={}, configuration={}),  # type: ignore
+        size=0,
     )  # type: ignore
 
 

--- a/application/ui/mocks/mock-model.ts
+++ b/application/ui/mocks/mock-model.ts
@@ -8,6 +8,7 @@ export const getMockedModel = (overrides: Partial<SchemaModelView> = {}): Schema
     name: 'Object_Detection_YOLOX_X (76e07d18)',
     architecture: 'Object_Detection_YOLOX_X',
     parent_revision: null,
+    size: 1048576,
     training_info: {
         status: 'successful',
         label_schema_revision: {

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
@@ -23,10 +23,6 @@ type ModelRowProps = {
     onModelAction?: (key: Key) => void;
 };
 
-const getTotalModelSize = (model: Model): number => {
-    return (model.variants ?? []).reduce((total, variant) => total + (variant.weights_size ?? 0), 0);
-};
-
 export const ModelRow = ({
     model,
     activeModelArchitectureId,
@@ -35,7 +31,7 @@ export const ModelRow = ({
     onModelAction,
 }: ModelRowProps) => {
     const trainingEndTime = model.training_info.end_time;
-    const totalSize = getTotalModelSize(model);
+    const totalSize = model.size;
 
     return (
         <Grid columns={GRID_COLUMNS} alignItems={'center'} width={'100%'} columnGap={'size-200'}>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds model size to the ModelView. All files and artifacts in the model folder are used in the calculation.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
