### PR TITLE
Generate dataset item thumbnail on request

### DIFF
--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -245,7 +245,7 @@ def get_dataset_item_thumbnail(
         buffer.seek(0)
         return StreamingResponse(
             buffer,
-            media_type="image/png",
+            media_type="image/jpeg",
             headers={
                 "Content-Disposition": f"inline; filename={dataset_item_id}.jpeg",
                 "Cache-Control": "public, max-age=31536000",

--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -241,12 +241,15 @@ def get_dataset_item_thumbnail(
     try:
         thumbnail = dataset_service.generate_dataset_item_thumbnail(project=project, dataset_item_id=dataset_item_id)
         buffer = BytesIO()
-        thumbnail.save(buffer, format="PNG")
+        thumbnail.save(buffer, format="JPEG")
         buffer.seek(0)
         return StreamingResponse(
             buffer,
             media_type="image/png",
-            headers={"Content-Disposition": f"inline; filename={dataset_item_id}.png"},
+            headers={
+                "Content-Disposition": f"inline; filename={dataset_item_id}.jpeg",
+                "Cache-Control": "public, max-age=31536000",
+            },
         )
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
+from io import BytesIO
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, StreamingResponse
 
 from app.api.dependencies import get_dataset_service, get_file_name_and_extension, get_project
 from app.api.schemas.dataset_item import (
@@ -235,13 +236,18 @@ def get_dataset_item_thumbnail(
     project: Annotated[Project, Depends(get_project)],
     dataset_item_id: DatasetItemID,
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
-) -> FileResponse:
+) -> StreamingResponse:
     """Get dataset item thumbnail binary content"""
     try:
-        thumbnail_path = dataset_service.get_dataset_item_thumbnail_path_by_id(
-            project=project, dataset_item_id=dataset_item_id
+        thumbnail = dataset_service.generate_dataset_item_thumbnail(project=project, dataset_item_id=dataset_item_id)
+        buffer = BytesIO()
+        thumbnail.save(buffer, format="PNG")
+        buffer.seek(0)
+        return StreamingResponse(
+            buffer,
+            media_type="image/png",
+            headers={"Content-Disposition": f"inline; filename={dataset_item_id}.png"},
         )
-        return FileResponse(path=thumbnail_path)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -236,6 +236,17 @@ class DatasetService(BaseSessionManagedService):
         dataset_item = self.get_dataset_item_by_id(project_id=project.id, dataset_item_id=dataset_item_id)
         return self.projects_dir / f"{project.id}/dataset/{dataset_item.id}-thumb.jpg"
 
+    def generate_dataset_item_thumbnail(self, project: Project, dataset_item_id: UUID) -> Image.Image:
+        """Regenerate a dataset item thumbnail by its ID"""
+        dataset_item = self.get_dataset_item_by_id(project_id=project.id, dataset_item_id=dataset_item_id)
+        dataset_dir = self.projects_dir / f"{project.id}/dataset"
+        binary_path = dataset_dir / f"{dataset_item.id}.{dataset_item.format}"
+        try:
+            image = Image.open(binary_path)
+        except UnidentifiedImageError:
+            raise InvalidImageError("Failed to open image for thumbnail generation.")
+        return crop_to_thumbnail(image=image, target_width=64, target_height=64)
+
     def delete_dataset_item(self, project: Project, dataset_item_id: UUID) -> None:
         """Delete a dataset item by its ID"""
         dataset_item = self.get_dataset_item_by_id(project_id=project.id, dataset_item_id=dataset_item_id)

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -242,10 +242,12 @@ class DatasetService(BaseSessionManagedService):
         dataset_dir = self.projects_dir / f"{project.id}/dataset"
         binary_path = dataset_dir / f"{dataset_item.id}.{dataset_item.format}"
         try:
-            image = Image.open(binary_path)
+            with Image.open(binary_path) as image:
+                thumbnail = crop_to_thumbnail(image=image, target_width=64, target_height=64)
         except UnidentifiedImageError:
+            logger.error("Failed to open image {} for thumbnail generation", binary_path)
             raise InvalidImageError("Failed to open image for thumbnail generation.")
-        return crop_to_thumbnail(image=image, target_width=64, target_height=64)
+        return thumbnail
 
     def delete_dataset_item(self, project: Project, dataset_item_id: UUID) -> None:
         """Delete a dataset item by its ID"""

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -255,7 +255,7 @@ class TestDatasetItemEndpoints:
             (
                 "get",
                 f"/api/projects/{uuid4()}/dataset/items/invalid-id/thumbnail",
-                "get_dataset_item_thumbnail_path_by_id",
+                "generate_dataset_item_thumbnail",
             ),
             ("delete", f"/api/projects/{uuid4()}/dataset/items/invalid-id", "delete_dataset_item"),
             ("post", f"/api/projects/{uuid4()}/dataset/items/invalid-id/annotations", "set_dataset_item_annotations"),
@@ -342,36 +342,33 @@ class TestDatasetItemEndpoints:
 
     def test_get_dataset_item_thumbnail_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()
-        fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.side_effect = ResourceNotFoundError(
+        fxt_dataset_service.generate_dataset_item_thumbnail.side_effect = ResourceNotFoundError(
             ResourceType.DATASET_ITEM, str(dataset_item_id)
         )
 
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.assert_called_once_with(
+        fxt_dataset_service.generate_dataset_item_thumbnail.assert_called_once_with(
             project=fxt_get_project, dataset_item_id=dataset_item_id
         )
 
     def test_get_dataset_item_thumbnail_success(self, fxt_get_project, fxt_dataset_service, fxt_client):
+        from PIL import Image
+
         dataset_item_id = uuid4()
 
-        tmp_file_path = None
-        try:
-            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-                temp_file_path = tmp_file.name
-                fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.return_value = temp_file_path
-                response = fxt_client.get(
-                    f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail"
-                )
+        # Create a test PIL Image to return from the mock
+        test_image = Image.new("RGB", (64, 64), color="blue")
+        fxt_dataset_service.generate_dataset_item_thumbnail.return_value = test_image
 
-            assert response.status_code == status.HTTP_200_OK
-            fxt_dataset_service.get_dataset_item_thumbnail_path_by_id.assert_called_once_with(
-                project=fxt_get_project, dataset_item_id=dataset_item_id
-            )
-        finally:
-            if tmp_file_path and os.path.exists(tmp_file_path):
-                os.unlink(tmp_file_path)
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.headers["content-type"] == "image/png"
+        fxt_dataset_service.generate_dataset_item_thumbnail.assert_called_once_with(
+            project=fxt_get_project, dataset_item_id=dataset_item_id
+        )
 
     def test_delete_dataset_item_not_found(self, fxt_get_project, fxt_dataset_service, fxt_client):
         dataset_item_id = uuid4()

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -365,7 +365,7 @@ class TestDatasetItemEndpoints:
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/items/{str(dataset_item_id)}/thumbnail")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.headers["content-type"] == "image/png"
+        assert response.headers["content-type"] == "image/jpeg"
         fxt_dataset_service.generate_dataset_item_thumbnail.assert_called_once_with(
             project=fxt_get_project, dataset_item_id=dataset_item_id
         )


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Generates the thumbnail in memory on endpoint request, and streams it back. The UI will cache the thumbnails.

`GET /api/projects/47811205-13ad-4286-aef5-c35abc203154/dataset/items/9d31a9e3-5834-43f9-b079-a08987e339ad/thumbnail`

<img width="1286" height="756" alt="image" src="https://github.com/user-attachments/assets/61b34390-4021-405d-96b0-da1b3cf98f9c" />


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
