### PR TITLE
Progress reporting in the training job

### DIFF
--- a/application/backend/app/core/jobs/exec/thread_run.py
+++ b/application/backend/app/core/jobs/exec/thread_run.py
@@ -64,7 +64,7 @@ class ThreadRun(Runner[Job, ExecutionEvent]):
                 # Continue polling if no events available
                 continue
 
-    async def stop(self, graceful_timeout: float = 6.0, term_timeout: float = 3.0, kill_timeout: float = 1.0) -> None:  # noqa: ARG002
+    async def stop(self, graceful_timeout: float = 6.0, term_timeout: float = 3.0, kill_timeout: float = 1.0) -> None:
         """Stop the runner by setting the cancellation event."""
         self._cancel_event.set()
 

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -52,7 +52,7 @@ class FixedRatePolicyChecker(PolicyChecker):
         self.min_interval = 1.0 / policy.rate
         self.last_collect_time = 0.0
 
-    def should_collect(self, timestamp: float, confidence_scores: list[float]) -> bool:  # noqa: ARG002
+    def should_collect(self, timestamp: float, confidence_scores: list[float]) -> bool:
         time_since_last = timestamp - self.last_collect_time
         if time_since_last < self.min_interval:
             return False

--- a/application/backend/app/services/training/base.py
+++ b/application/backend/app/services/training/base.py
@@ -14,7 +14,7 @@ from app.core.run import ExecutionContext, Runnable
 T = TypeVar("T")
 
 
-def step(name: str) -> Callable[[Callable[..., T]], Callable[..., T]]:
+def step(name: str, complete: float | None = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     Decorator to mark a method as a training step.
 
@@ -30,18 +30,19 @@ def step(name: str) -> Callable[[Callable[..., T]], Callable[..., T]]:
 
     Args:
         name: Human-readable name for the step (used in logging and progress reporting).
+        complete: Optional float indicating the completion percentage after this step.
     """
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> T:
-            self.report_progress(f"Starting: {name}")
+            self.report_progress(f"Started: {name}")
             try:
                 result = func(self, *args, **kwargs)
             except Exception:
                 self.report_progress(f"Failed: {name}", exc=True)
                 raise
-            self.report_progress(f"Completed: {name}")
+            self.report_progress(f"Completed: {name}", percent=complete)
             return result
 
         return wrapper

--- a/application/backend/app/services/training/progress.py
+++ b/application/backend/app/services/training/progress.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from typing import Any
+
+from lightning import Callback, LightningModule
+from lightning import Trainer as LightningTrainer
+from lightning.pytorch.utilities.types import STEP_OUTPUT
+
+
+class TrainingProgressCallback(Callback):
+    def __init__(self, report_progress: Callable[[str, float], None], min_p: float = 0, max_p: float = 100.0):
+        self._report_progress = report_progress
+        self._min_p = min_p
+        self._max_p = max_p
+        self._total_steps: int | None = None
+        self._current_step: int = 0
+
+    def _update_total_steps(self, trainer: LightningTrainer) -> None:
+        if self._total_steps is not None:
+            return
+        max_epochs = trainer.max_epochs or 1
+        steps_per_epoch = int(trainer.num_training_batches)
+        self._total_steps = max(1, max_epochs * steps_per_epoch)
+
+    def _emit_progress(self) -> None:
+        if self._total_steps is None:
+            return
+        ratio = self._current_step / self._total_steps
+        progress = self._min_p + ratio * (self._max_p - self._min_p)
+        self._report_progress("", progress)
+
+    def on_train_batch_end(
+        self,
+        trainer: LightningTrainer,
+        pl_module: LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        self._update_total_steps(trainer)
+        self._current_step += 1
+        self._emit_progress()

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -96,7 +96,7 @@ line-ending = "lf"
 [tool.ruff.lint]
 select = ["ARG", "E", "F", "I", "N", "UP", "YTT", "ASYNC", "S", "COM", "C4", "FA", "PIE", "PYI", "Q", "RSE", "RET", "SIM",
     "TID", "PL", "RUF", "C90", "D103", "ANN001", "ANN201", "ANN205"]
-ignore = ["N801", "N805","N806","N807", "N818", "COM812", "RET503", "SIM108", "SIM105", "PLR2004",
+ignore = ["ARG002", "N801", "N805","N806","N807", "N818", "COM812", "RET503", "SIM108", "SIM105", "PLR2004",
     "RUF010", "RUF012", "CPY001", "PLE1205"]
 fixable = ["ALL"]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/application/backend/tests/unit/services/training/test_progress.py
+++ b/application/backend/tests/unit/services/training/test_progress.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+from lightning import Trainer as LightningTrainer
+
+from app.services.training.otx_trainer import TrainingProgressCallback
+
+
+class DummyTrainer:
+    def __init__(self, max_epochs: int | None, num_training_batches: int):
+        self.max_epochs = max_epochs
+        self.num_training_batches = num_training_batches
+
+
+def _make_trainer(max_epochs: int | None = 5, num_training_batches: int = 10) -> LightningTrainer:
+    return DummyTrainer(max_epochs=max_epochs, num_training_batches=num_training_batches)  # type: ignore[return-value]
+
+
+class TestTrainingProgressCallback:
+    def test_emit_progress_does_nothing_when_total_steps_none(self) -> None:
+        report_progress = Mock()
+        cb = TrainingProgressCallback(report_progress)
+
+        cb._emit_progress()
+
+        report_progress.assert_not_called()
+
+    def test_on_train_batch_end_emits_progress_in_range(self) -> None:
+        report_progress = Mock()
+        cb = TrainingProgressCallback(report_progress, min_p=10.0, max_p=80.0)
+
+        trainer = _make_trainer(max_epochs=2, num_training_batches=5)
+
+        for i in range(3):
+            cb.on_train_batch_end(
+                trainer=trainer,
+                pl_module=Mock(),
+                outputs=Mock(),
+                batch=Mock(),
+                batch_idx=i,
+            )
+
+        assert cb._current_step == 3
+        assert cb._total_steps == 10
+
+        calls = report_progress.call_args_list
+        assert len(calls) == 3
+
+        # progress = min_p + (step / total) * (max_p - min_p)
+        # steps: 1, 2, 3 (because we increment before emit)
+        expected = [
+            10.0 + (1 / 10) * 70.0,
+            10.0 + (2 / 10) * 70.0,
+            10.0 + (3 / 10) * 70.0,
+        ]
+        actual = [c.args[1] for c in calls]
+        assert actual == expected
+
+    def test_on_train_batch_end_respects_custom_progress_bounds(self) -> None:
+        report_progress = Mock()
+        cb = TrainingProgressCallback(report_progress, min_p=0.0, max_p=100.0)
+
+        trainer = _make_trainer(max_epochs=1, num_training_batches=4)
+
+        for i in range(4):
+            cb.on_train_batch_end(
+                trainer=trainer,
+                pl_module=Mock(),
+                outputs=Mock(),
+                batch=Mock(),
+                batch_idx=i,
+            )
+
+        expected = [25.0, 50.0, 75.0, 100.0]
+        actual = [c.args[1] for c in report_progress.call_args_list]
+        assert actual == expected


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Progress reporting follows the following convention:

- [0-10%] for dataset preparation
- [10-80%] for the training loop
- [80-95%] for the final evaluation on test set
- [95-100%] for the remaining steps

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
