### PR TITLE
fix: Project navigation and color watches width

### DIFF
--- a/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
+++ b/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
@@ -129,7 +129,7 @@ export const ProjectListItem = ({ project, isInEditMode, onBlur, onRename, onDel
     };
 
     const handleNavigateToProject = () => {
-        navigate(paths.project.details({ projectId: project.id }));
+        navigate(paths.project.inference({ projectId: project.id }));
     };
 
     return (

--- a/application/ui/src/features/project/label-selection/create-label/create-label.component.tsx
+++ b/application/ui/src/features/project/label-selection/create-label/create-label.component.tsx
@@ -33,7 +33,7 @@ const ColorPicker = ({ onChange, value }: SpectrumColorPickerProps) => {
         <SpectrumColorPicker value={value} onChange={onChange} rounding={'none'}>
             <Flex direction='column' gap='size-300'>
                 <ColorEditor />
-                <ColorSwatchPicker>
+                <ColorSwatchPicker width={'size-3600'}>
                     {DISTINCT_COLORS.map((color) => {
                         return <ColorSwatch color={color} key={color} />;
                     })}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Previously when navigating from projects panel (inside the project), user was navigated to project details. When navigating from the main projects listing, we navigate to the inference page, so atm flow is consistent.
2. When we added more colors to the colors picker, dialog width was too large, fixed that.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
