### PR TITLE
feat: Add annotate button to open preview

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -1,8 +1,6 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
-
 import { DialogContainer, Size } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
@@ -35,8 +33,14 @@ const layoutOptions = {
 export const Gallery = ({ items, hasNextPage, isFetchingNextPage, fetchNextPage }: GalleryProps) => {
     const project_id = useProjectIdentifier();
 
-    const [selectedMediaItem, setSelectedMediaItem] = useState<null | Media>(null);
-    const { selectedKeys, mediaState, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
+    const {
+        selectedKeys,
+        mediaState,
+        setSelectedKeys,
+        toggleSelectedKeys,
+        selectedMediaItem,
+        onSelectedMediaItemChange,
+    } = useSelectedData();
 
     const isSetSelectedKeys = selectedKeys instanceof Set;
 
@@ -59,7 +63,7 @@ export const Gallery = ({ items, hasNextPage, isFetchingNextPage, fetchNextPage 
                             <MediaThumbnail
                                 alt={item.name}
                                 url={getThumbnailUrl(project_id, String(item.id))}
-                                onDoubleClick={() => setSelectedMediaItem(item)}
+                                onDoubleClick={() => onSelectedMediaItemChange(item)}
                             />
                         )}
                         topLeftElement={() => (
@@ -77,12 +81,12 @@ export const Gallery = ({ items, hasNextPage, isFetchingNextPage, fetchNextPage 
                 )}
             />
 
-            <DialogContainer onDismiss={() => setSelectedMediaItem(null)}>
+            <DialogContainer onDismiss={() => onSelectedMediaItemChange(null)}>
                 {selectedMediaItem !== null && (
                     <MediaPreview
                         mediaItem={selectedMediaItem}
-                        close={() => setSelectedMediaItem(null)}
-                        onSelectedMediaItem={setSelectedMediaItem}
+                        close={() => onSelectedMediaItemChange(null)}
+                        onSelectedMediaItem={onSelectedMediaItemChange}
                     />
                 )}
             </DialogContainer>

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -18,6 +18,24 @@ type ToolbarProps = {
     items: Media[];
 };
 
+type AnnotateButtonProps = {
+    item: Media | undefined;
+};
+
+const AnnotateButton = ({ item }: AnnotateButtonProps) => {
+    const { onSelectedMediaItemChange } = useSelectedData();
+
+    if (item === undefined) {
+        return null;
+    }
+
+    return (
+        <Button variant={'primary'} onPress={() => onSelectedMediaItemChange(item)}>
+            Annotate
+        </Button>
+    );
+};
+
 export const Toolbar = ({ items }: ToolbarProps) => {
     const projectId = useProjectIdentifier();
     const queryClient = useQueryClient();
@@ -84,6 +102,7 @@ export const Toolbar = ({ items }: ToolbarProps) => {
                 <ButtonGroup>
                     <AddMediaButton onFilesSelected={handleAddMediaItem} />
                     <TrainModel />
+                    <AnnotateButton item={items.at(0)} />
                 </ButtonGroup>
             </Flex>
 

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -25,12 +25,12 @@ type AnnotateButtonProps = {
 const AnnotateButton = ({ item }: AnnotateButtonProps) => {
     const { onSelectedMediaItemChange } = useSelectedData();
 
-    if (item === undefined) {
-        return null;
-    }
-
     return (
-        <Button variant={'primary'} onPress={() => onSelectedMediaItemChange(item)}>
+        <Button
+            variant={'primary'}
+            onPress={() => item !== undefined && onSelectedMediaItemChange(item)}
+            isDisabled={item === undefined}
+        >
             Annotate
         </Button>
     );

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -19,18 +19,13 @@ type ToolbarProps = {
 };
 
 type AnnotateButtonProps = {
-    item: Media | undefined;
+    isDisabled?: boolean;
+    onClick?: () => void;
 };
 
-const AnnotateButton = ({ item }: AnnotateButtonProps) => {
-    const { onSelectedMediaItemChange } = useSelectedData();
-
+const AnnotateButton = ({ isDisabled, onClick }: AnnotateButtonProps) => {
     return (
-        <Button
-            variant={'primary'}
-            onPress={() => item !== undefined && onSelectedMediaItemChange(item)}
-            isDisabled={item === undefined}
-        >
+        <Button variant={'primary'} onPress={onClick} isDisabled={isDisabled}>
             Annotate
         </Button>
     );
@@ -39,7 +34,8 @@ const AnnotateButton = ({ item }: AnnotateButtonProps) => {
 export const Toolbar = ({ items }: ToolbarProps) => {
     const projectId = useProjectIdentifier();
     const queryClient = useQueryClient();
-    const { selectedKeys, setSelectedKeys, setMediaState, toggleSelectedKeys } = useSelectedData();
+    const { selectedKeys, setSelectedKeys, setMediaState, toggleSelectedKeys, onSelectedMediaItemChange } =
+        useSelectedData();
 
     const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media');
 
@@ -102,7 +98,10 @@ export const Toolbar = ({ items }: ToolbarProps) => {
                 <ButtonGroup>
                     <AddMediaButton onFilesSelected={handleAddMediaItem} />
                     <TrainModel />
-                    <AnnotateButton item={items.at(0)} />
+                    <AnnotateButton
+                        isDisabled={items.at(0) === undefined}
+                        onClick={items.at(0) === undefined ? undefined : () => onSelectedMediaItemChange(items[0])}
+                    />
                 </ButtonGroup>
             </Flex>
 

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -46,7 +46,7 @@ export const SidebarItems = ({
         ref: unwrapRef,
         items,
         selectedIndex,
-        onSelectedMediaItemChange: onSelectedMediaItem,
+        onSelectedMediaItem,
     });
 
     return (

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -46,7 +46,7 @@ export const SidebarItems = ({
         ref: unwrapRef,
         items,
         selectedIndex,
-        onSelectedMediaItem,
+        onSelectedMediaItemChange: onSelectedMediaItem,
     });
 
     return (

--- a/application/ui/src/features/dataset/selected-data-provider.component.tsx
+++ b/application/ui/src/features/dataset/selected-data-provider.component.tsx
@@ -5,7 +5,7 @@ import { createContext, ReactNode, useContext, useState, type Dispatch, type Set
 
 import { Selection } from '@geti/ui';
 
-import { MediaStateMap } from '../../constants/shared-types';
+import { MediaStateMap, type Media } from '../../constants/shared-types';
 
 type SelectedDataState = null | {
     selectedKeys: Selection;
@@ -14,6 +14,9 @@ type SelectedDataState = null | {
     mediaState: MediaStateMap;
     setMediaState: Dispatch<SetStateAction<MediaStateMap>>;
     toggleSelectedKeys: (key: string[]) => void;
+
+    selectedMediaItem: Media | null;
+    onSelectedMediaItemChange: (item: Media | null) => void;
 };
 
 const SelectedDataContext = createContext<SelectedDataState>(null);
@@ -21,6 +24,7 @@ const SelectedDataContext = createContext<SelectedDataState>(null);
 export const SelectedDataProvider = ({ children }: { children: ReactNode }) => {
     const [mediaState, setMediaState] = useState<MediaStateMap>(new Map());
     const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
+    const [selectedMediaItem, setSelectedMediaItem] = useState<null | Media>(null);
 
     const toggleSelectedKeys = (keys: string[]) => {
         setSelectedKeys((prevSelectedKeys) => {
@@ -36,7 +40,15 @@ export const SelectedDataProvider = ({ children }: { children: ReactNode }) => {
 
     return (
         <SelectedDataContext.Provider
-            value={{ selectedKeys, setSelectedKeys, mediaState, setMediaState, toggleSelectedKeys }}
+            value={{
+                selectedKeys,
+                setSelectedKeys,
+                mediaState,
+                setMediaState,
+                toggleSelectedKeys,
+                selectedMediaItem,
+                onSelectedMediaItemChange: setSelectedMediaItem,
+            }}
         >
             {children}
         </SelectedDataContext.Provider>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR adds annotate button that when clicked opens preview (as double clicked media item). I think double click is not obvious so that change should improve UX a bit.

<img width="1269" height="932" alt="image" src="https://github.com/user-attachments/assets/1556a08e-ceaf-40b7-91f1-d9751f394f2c" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
