### PR TITLE
Fix error 500 when loading dataset revision items

### DIFF
--- a/application/backend/app/api/schemas/dataset_item.py
+++ b/application/backend/app/api/schemas/dataset_item.py
@@ -6,11 +6,11 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from app.core.models import BaseRequiredIDModel, BaseRequiredIDNameModel, Pagination
+from app.core.models import BaseRequiredIDModel, Pagination
 from app.models import DatasetItemAnnotation, DatasetItemSubset, MediaFormat
 
 
-class DatasetRevisionItemView(BaseRequiredIDNameModel):
+class DatasetRevisionItemView(BaseRequiredIDModel):
     """
     Dataset Revision item
     """
@@ -24,7 +24,6 @@ class DatasetRevisionItemView(BaseRequiredIDNameModel):
         "json_schema_extra": {
             "example": {
                 "id": "7b073838-99d3-42ff-9018-4e901eb047fc",
-                "name": "img-010203",
                 "format": "jpg",
                 "width": 1280,
                 "height": 720,

--- a/application/backend/app/models/dataset_item_revision.py
+++ b/application/backend/app/models/dataset_item_revision.py
@@ -13,7 +13,6 @@ class DatasetRevisionItem(BaseEntity):
 
     Attributes:
         id: Unique identifier for the dataset revision item.
-        name: Name of the dataset revision item.
         format: Format of the dataset revision item (e.g., JPG, PNG).
         width: Width of the dataset revision item in pixels.
         height: Height of the dataset revision item in pixels.
@@ -21,7 +20,6 @@ class DatasetRevisionItem(BaseEntity):
     """
 
     id: UUID
-    name: str
     format: MediaFormat
     width: int
     height: int

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -179,12 +179,11 @@ class DatasetRevisionService(BaseSessionManagedService):
             dataset_revision_items.append(
                 DatasetRevisionItem.model_validate(
                     {
-                        "id": item["id"],
-                        "name": Path(item["image"]).stem,
+                        "id": UUID(Path(item["image"]).stem),
                         "format": Path(item["image"]).suffix.lstrip("."),
                         "width": item["image_info"]["width"],
                         "height": item["image_info"]["height"],
-                        "subset": item["subset"],
+                        "subset": DatasetItemSubset[item["subset"]],
                     }
                 )
             )

--- a/application/backend/tests/unit/routers/test_dataset_revisions.py
+++ b/application/backend/tests/unit/routers/test_dataset_revisions.py
@@ -65,7 +65,6 @@ class TestDatasetRevisionItemEndpoints:
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
         mock_item_data = {
             "id": str(fxt_dataset_item.id),
-            "name": "test_dataset_item",
             "format": MediaFormat.JPG.value,
             "width": 1024,
             "height": 768,
@@ -85,7 +84,6 @@ class TestDatasetRevisionItemEndpoints:
         assert response_data["pagination"]["offset"] == 0
         assert len(response_data["items"]) == 1
         assert response_data["items"][0]["id"] == str(fxt_dataset_item.id)
-        assert response_data["items"][0]["name"] == "test_dataset_item"
 
         fxt_dataset_revision_service.get_dataset_revision.assert_called_once_with(
             project_id=fxt_get_project.id, revision_id=fxt_dataset_revision_id
@@ -104,7 +102,6 @@ class TestDatasetRevisionItemEndpoints:
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
         mock_item_data = {
             "id": str(fxt_dataset_item.id),
-            "name": "test_dataset_item",
             "format": MediaFormat.JPG.value,
             "width": 1024,
             "height": 768,
@@ -143,7 +140,6 @@ class TestDatasetRevisionItemEndpoints:
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
         mock_item_data = {
             "id": str(fxt_dataset_item.id),
-            "name": "test_dataset_item",
             "format": MediaFormat.JPG.value,
             "width": 1024,
             "height": 768,
@@ -200,7 +196,6 @@ class TestDatasetRevisionItemEndpoints:
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
         mock_item_data = {
             "id": str(fxt_dataset_item.id),
-            "name": "test_dataset_item",
             "format": MediaFormat.JPG.value,
             "width": 1024,
             "height": 768,
@@ -215,7 +210,6 @@ class TestDatasetRevisionItemEndpoints:
         assert response.status_code == status.HTTP_200_OK
         response_json = response.json()
         assert response_json["id"] == str(fxt_dataset_item.id)
-        assert response_json["name"] == "test_dataset_item"
         assert response_json["width"] == 1024
         assert response_json["height"] == 768
         assert response_json["subset"] == "training"


### PR DESCRIPTION
### Summary

Changes:
- Initialize dataset revision item `id` from the filename, since it matches the id by construction
- Remove unnecessary property `name` from the dataset revision items

This PR fixes a 500 Internal Server Error when loading the item:
```
  File "/home/leoll2/training_extensions/application/backend/app/api/routers/dataset_revisions.py", line 49, in list_dataset_revision_items
    dataset_revision_items, total_count = dataset_revision_service.list_dataset_revision_items(
                                          │                        └ <function DatasetRevisionService.list_dataset_revision_items at 0x781a77297060>
                                          └ <app.services.dataset_revision_service.DatasetRevisionService object at 0x781a4a0126c0>

  File "/home/leoll2/training_extensions/application/backend/app/services/dataset_revision_service.py", line 182, in list_dataset_revision_items
    "id": item["id"],
          └ {'image': 'data/projects/9d6af8e8-6017-4ebe-9126-33aae739c5fa/dataset/3f8665c1-de48-4fa6-9daf-245a2ff4f173.jpg', 'image_info'...

KeyError: 'id'
```

### How to test

Train a model, then view the training dataset.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
