### PR TITLE
Specify 'dynamic_shapes' for conversion of detection models to ONNX via Dynamo

### DIFF
--- a/library/src/otx/backend/native/models/detection/atss.py
+++ b/library/src/otx/backend/native/models/detection/atss.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, Literal
 
+from torch.export import Dim
+
 from otx.backend.native.exporter.base import OTXModelExporter
 from otx.backend.native.exporter.native import OTXNativeModelExporter
 from otx.backend.native.models.base import DataInputParams, DefaultOptimizerCallable, DefaultSchedulerCallable
@@ -191,11 +193,7 @@ class ATSS(OTXDetectionModel):
             onnx_export_configuration={
                 "input_names": ["image"],
                 "output_names": ["boxes", "labels"],
-                "dynamic_axes": {
-                    "image": {0: "batch"},
-                    "boxes": {0: "batch", 1: "num_dets"},
-                    "labels": {0: "batch", 1: "num_dets"},
-                },
+                "dynamic_shapes": {"inputs": {0: Dim("batch")}},
                 "autograd_inlining": False,
             },
             output_names=["bboxes", "labels", "feature_vector", "saliency_map"] if self.explain_mode else None,

--- a/library/src/otx/backend/native/models/detection/rtdetr.py
+++ b/library/src/otx/backend/native/models/detection/rtdetr.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import torch
 from torch import Tensor, nn
+from torch.export import Dim
 from torchvision.ops import box_convert
 from torchvision.tv_tensors import BoundingBoxFormat
 
@@ -304,12 +305,7 @@ class RTDETR(OTXDetectionModel):
             onnx_export_configuration={
                 "input_names": ["images"],
                 "output_names": ["bboxes", "labels", "scores"],
-                "dynamic_axes": {
-                    "images": {0: "batch"},
-                    "boxes": {0: "batch", 1: "num_dets"},
-                    "labels": {0: "batch", 1: "num_dets"},
-                    "scores": {0: "batch", 1: "num_dets"},
-                },
+                "dynamic_shapes": {"inputs": {0: Dim("batch")}},
                 "autograd_inlining": False,
                 "opset_version": 18,
             },

--- a/library/src/otx/backend/native/models/detection/ssd.py
+++ b/library/src/otx/backend/native/models/detection/ssd.py
@@ -15,6 +15,7 @@ import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import numpy as np
+from torch.export import Dim
 
 from otx.backend.native.exporter.base import OTXModelExporter
 from otx.backend.native.exporter.native import OTXNativeModelExporter
@@ -355,11 +356,7 @@ class SSD(OTXDetectionModel):
             onnx_export_configuration={
                 "input_names": ["image"],
                 "output_names": ["boxes", "labels"],
-                "dynamic_axes": {
-                    "image": {0: "batch"},
-                    "boxes": {0: "batch", 1: "num_dets"},
-                    "labels": {0: "batch", 1: "num_dets"},
-                },
+                "dynamic_shapes": {"inputs": {0: Dim("batch")}},
                 "autograd_inlining": False,
             },
             output_names=["bboxes", "labels", "feature_vector", "saliency_map"] if self.explain_mode else None,

--- a/library/src/otx/backend/native/models/detection/yolox.py
+++ b/library/src/otx/backend/native/models/detection/yolox.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
+from torch.export import Dim
+
 from otx.backend.native.exporter.base import OTXModelExporter
 from otx.backend.native.exporter.native import OTXNativeModelExporter
 from otx.backend.native.models.base import DataInputParams, DefaultOptimizerCallable, DefaultSchedulerCallable
@@ -156,11 +158,7 @@ class YOLOX(OTXDetectionModel):
                 "output_names": ["boxes", "labels"],
                 "export_params": True,
                 "opset_version": 18,
-                "dynamic_axes": {
-                    "image": {0: "batch"},
-                    "boxes": {0: "batch", 1: "num_dets"},
-                    "labels": {0: "batch", 1: "num_dets"},
-                },
+                "dynamic_shapes": {"inputs": {0: Dim("batch")}},
                 "keep_initializers_as_inputs": False,
                 "verbose": False,
                 "autograd_inlining": False,


### PR DESCRIPTION
### Summary

This PR fixes an issue that occurs when converting some detection models to ONNX.

```
/home/leoll2/training_extensions/library/src/otx/backend/native/exporter/native.py:129: UserWarning: # 'dynamic_axes' is not recommended when dynamo=True, and may lead to 'torch._dynamo.exc.UserError: Constraints violated.' Supply the 'dynamic_shapes' argument instead if export is unsuccessful.
  torch.onnx.export(model, dummy_tensor, save_path, **self.onnx_export_configuration)
2026-01-26 12:50:57.802 | ERROR    | app.services.training.base:report_progress:74 - Failed: Export Model
Traceback (most recent call last):

  File "/home/leoll2/training_extensions/application/backend/.venv/lib/python3.13/site-packages/torch/onnx/_internal/exporter/_compat.py", line 104, in export_compat
    _dynamic_shapes.from_dynamic_axes_to_dynamic_shapes(
    │               └ <function from_dynamic_axes_to_dynamic_shapes at 0x7ea057fc6c00>
...
ValueError: treespec.unflatten(leaves): `leaves` has length 2 but the spec refers to a pytree that holds 1 items (TreeSpec(list, None, [*])).
...
RuntimeError: # Failed to convert 'dynamic_axes' to 'dynamic_shapes'. Please provide 'dynamic_shapes' directly. Refer to the documentation for 'torch.export.export' for more information on dynamic shapes.
```
The issue affects all detection models that are exported via Dynamo: RT-DETR-50, SSD, YOLO-X and MobileNet-ATSS.

Reference: https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/api_reference.html#module-torch.export

### How to test

Train and export all detection models.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
