### PR TITLE
Set multiprocessing method in OTXDataModule

### DIFF
--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import multiprocessing
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -31,6 +32,9 @@ if TYPE_CHECKING:
     from otx.data.dataset.base import OTXDataset
 
 logger = logging.getLogger(__name__)
+
+
+_MP_CONTEXT = multiprocessing.get_context("spawn")
 
 
 class OTXDataModule(LightningDataModule):
@@ -460,6 +464,7 @@ class OTXDataModule(LightningDataModule):
             "persistent_workers": config.num_workers > 0,
             "sampler": sampler,
             "shuffle": sampler is None,
+            "multiprocessing_context": _MP_CONTEXT if config.num_workers > 0 else None,
         }
 
         tile_config = self.tile_config
@@ -487,6 +492,7 @@ class OTXDataModule(LightningDataModule):
             pin_memory=True,
             collate_fn=dataset.collate_fn,
             persistent_workers=config.num_workers > 0,
+            multiprocessing_context=_MP_CONTEXT if config.num_workers > 0 else None,
         )
 
     def test_dataloader(self) -> DataLoader:
@@ -502,6 +508,7 @@ class OTXDataModule(LightningDataModule):
             pin_memory=True,
             collate_fn=dataset.collate_fn,
             persistent_workers=config.num_workers > 0,
+            multiprocessing_context=_MP_CONTEXT if config.num_workers > 0 else None,
         )
 
     def predict_dataloader(self) -> DataLoader:
@@ -517,6 +524,7 @@ class OTXDataModule(LightningDataModule):
             pin_memory=True,
             collate_fn=dataset.collate_fn,
             persistent_workers=config.num_workers > 0,
+            multiprocessing_context=_MP_CONTEXT if config.num_workers > 0 else None,
         )
 
     def setup(self, stage: str) -> None:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
The OTXDataModule was still defaulting to fork multiprocessing method on linux causing a hanging training. This PR updates the module to set the multiprocessing context to spawn manually
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
