### PR TITLE
refactor: Persist annotations between annotation vs prediction

### DIFF
--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -24,7 +24,7 @@ import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settin
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
-import { getAnnotations } from './utils';
+import { getInitialAnnotations, getInitialPredictions } from './utils';
 
 const isUnannotatedError = (error: unknown): boolean => {
     return (
@@ -62,7 +62,7 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
         }
     );
 
-    const isUserReviewedMedia = annotationsData?.user_reviewed ?? false;
+    const isUserReviewed = annotationsData?.user_reviewed ?? false;
     const annotationsDTO = annotationsData?.annotations ?? [];
 
     return (
@@ -79,8 +79,9 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                     <AnnotationActionsProvider
                         key={mediaItem.id}
                         mediaItem={mediaItem}
-                        initialAnnotationsDTO={annotationsDTO}
-                        isUserReviewed={isUserReviewedMedia}
+                        initialAnnotationsDTO={getInitialAnnotations(mode, isUserReviewed, annotationsDTO)}
+                        initialPredictionsDTO={getInitialPredictions(mode, isUserReviewed, annotationsDTO)}
+                        isUserReviewed={isUserReviewed}
                         mode={mode}
                     >
                         <ZoomProvider>
@@ -106,7 +107,7 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
 
                                                 <View gridArea={'bottom'}>
                                                     <BottomToolbar
-                                                        isUserReviewed={isUserReviewedMedia}
+                                                        isUserReviewed={isUserReviewed}
                                                         mediaItem={mediaItem}
                                                     />
                                                 </View>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -77,9 +77,11 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                     areas={['header header aside', 'toolbar canvas aside', 'toolbar bottom aside']}
                 >
                     <AnnotationActionsProvider
+                        key={mediaItem.id}
                         mediaItem={mediaItem}
-                        initialAnnotationsDTO={getAnnotations(mode, isUserReviewedMedia, annotationsDTO)}
+                        initialAnnotationsDTO={annotationsDTO}
                         isUserReviewed={isUserReviewedMedia}
+                        mode={mode}
                     >
                         <ZoomProvider>
                             <Suspense fallback={<CanvasAreaLoading />}>
@@ -120,18 +122,18 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                                 </SelectAnnotationProvider>
                             </Suspense>
                         </ZoomProvider>
-
-                        <View gridArea={'aside'}>
-                            <SidebarItems
-                                items={items}
-                                mediaItem={mediaItem}
-                                hasNextPage={hasNextPage}
-                                isFetchingNextPage={isFetchingNextPage}
-                                fetchNextPage={fetchNextPage}
-                                onSelectedMediaItem={onSelectedMediaItem}
-                            />
-                        </View>
                     </AnnotationActionsProvider>
+
+                    <View gridArea={'aside'}>
+                        <SidebarItems
+                            items={items}
+                            mediaItem={mediaItem}
+                            hasNextPage={hasNextPage}
+                            isFetchingNextPage={isFetchingNextPage}
+                            fetchNextPage={fetchNextPage}
+                            onSelectedMediaItem={onSelectedMediaItem}
+                        />
+                    </View>
                 </Grid>
             </Content>
         </Dialog>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -44,14 +44,18 @@ const CanvasAreaLoading = () => (
     </Flex>
 );
 
-export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPreviewProps) => {
-    const projectId = useProjectIdentifier();
+type MediaPreviewContentProps = {
+    items: Media[];
+    mediaItem: Media;
+    onClose: () => void;
+    onSelectedMediaItem: (item: Media) => void;
+};
 
+const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }: MediaPreviewContentProps) => {
+    const projectId = useProjectIdentifier();
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
 
-    const { items, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetDatasetItems();
-
-    const { data: annotationsData } = $api.useQuery(
+    const { data: annotationsData } = $api.useSuspenseQuery(
         'get',
         '/api/projects/{project_id}/dataset/items/{dataset_item_id}/annotations',
         {
@@ -66,6 +70,52 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
     const annotationsDTO = annotationsData?.annotations ?? [];
 
     return (
+        <AnnotationActionsProvider
+            key={mediaItem.id}
+            mediaItem={mediaItem}
+            initialAnnotationsDTO={getInitialAnnotations(mode, isUserReviewed, annotationsDTO)}
+            initialPredictionsDTO={getInitialPredictions(mode, isUserReviewed, annotationsDTO)}
+            isUserReviewed={isUserReviewed}
+            mode={mode}
+        >
+            <SelectAnnotationProvider>
+                <AnnotationVisibilityProvider>
+                    <AnnotatorProvider mediaItem={mediaItem}>
+                        <CanvasSettingsProvider>
+                            <View gridArea={'header'}>
+                                <SecondaryToolbar
+                                    items={items}
+                                    onClose={onClose}
+                                    mediaItem={mediaItem}
+                                    onSelectedMediaItem={onSelectedMediaItem}
+                                    mode={mode}
+                                    onModeChange={setMode}
+                                />
+                            </View>
+
+                            <View gridArea={'toolbar'}>{mode === 'annotation' && <PrimaryToolbar />}</View>
+
+                            <View gridArea={'bottom'}>
+                                <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
+                            </View>
+
+                            <View gridArea={'canvas'} overflow={'hidden'}>
+                                <AnnotatorCanvasSettings>
+                                    <AnnotatorCanvas mediaItem={mediaItem} />
+                                </AnnotatorCanvasSettings>
+                            </View>
+                        </CanvasSettingsProvider>
+                    </AnnotatorProvider>
+                </AnnotationVisibilityProvider>
+            </SelectAnnotationProvider>
+        </AnnotationActionsProvider>
+    );
+};
+
+export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPreviewProps) => {
+    const { items, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetDatasetItems();
+
+    return (
         <Dialog UNSAFE_style={{ backgroundColor: 'var(--spectrum-global-color-gray-50)' }}>
             <Content>
                 <Grid
@@ -76,54 +126,16 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                     columns={['size-800', '1fr', SIDEBAR_WIDTH]}
                     areas={['header header aside', 'toolbar canvas aside', 'toolbar bottom aside']}
                 >
-                    <AnnotationActionsProvider
-                        key={mediaItem.id}
-                        mediaItem={mediaItem}
-                        initialAnnotationsDTO={getInitialAnnotations(mode, isUserReviewed, annotationsDTO)}
-                        initialPredictionsDTO={getInitialPredictions(mode, isUserReviewed, annotationsDTO)}
-                        isUserReviewed={isUserReviewed}
-                        mode={mode}
-                    >
-                        <ZoomProvider>
-                            <Suspense fallback={<CanvasAreaLoading />}>
-                                <SelectAnnotationProvider>
-                                    <AnnotationVisibilityProvider>
-                                        <AnnotatorProvider mediaItem={mediaItem}>
-                                            <CanvasSettingsProvider>
-                                                <View gridArea={'header'}>
-                                                    <SecondaryToolbar
-                                                        items={items}
-                                                        onClose={close}
-                                                        mediaItem={mediaItem}
-                                                        onSelectedMediaItem={onSelectedMediaItem}
-                                                        mode={mode}
-                                                        onModeChange={setMode}
-                                                    />
-                                                </View>
-
-                                                <View gridArea={'toolbar'}>
-                                                    {mode === 'annotation' && <PrimaryToolbar />}
-                                                </View>
-
-                                                <View gridArea={'bottom'}>
-                                                    <BottomToolbar
-                                                        isUserReviewed={isUserReviewed}
-                                                        mediaItem={mediaItem}
-                                                    />
-                                                </View>
-
-                                                <View gridArea={'canvas'} overflow={'hidden'}>
-                                                    <AnnotatorCanvasSettings>
-                                                        <AnnotatorCanvas mediaItem={mediaItem} />
-                                                    </AnnotatorCanvasSettings>
-                                                </View>
-                                            </CanvasSettingsProvider>
-                                        </AnnotatorProvider>
-                                    </AnnotationVisibilityProvider>
-                                </SelectAnnotationProvider>
-                            </Suspense>
-                        </ZoomProvider>
-                    </AnnotationActionsProvider>
+                    <ZoomProvider>
+                        <Suspense fallback={<CanvasAreaLoading />}>
+                            <MediaPreviewContent
+                                items={items}
+                                mediaItem={mediaItem}
+                                onClose={close}
+                                onSelectedMediaItem={onSelectedMediaItem}
+                            />
+                        </Suspense>
+                    </ZoomProvider>
 
                     <View gridArea={'aside'}>
                         <SidebarItems

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -73,11 +73,7 @@ export const SecondaryToolbar = ({
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 
     const handleSubmit = async () => {
-        if (mode === 'annotation') {
-            await submitAnnotations();
-        } else {
-            await submitPredictions();
-        }
+        await submitAnnotations();
 
         setMediaState((prev) => {
             const newState = new Map(prev);

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -58,14 +58,8 @@ export const SecondaryToolbar = ({
     const { data: selectedProject } = useProject();
     const { selectedLabel, setSelectedLabelId } = useAnnotator();
 
-    const {
-        annotations,
-        isSaving,
-        addAnnotations,
-        updateAnnotations,
-        deleteAnnotations,
-        submitAnnotations,
-    } = useAnnotationActions();
+    const { annotations, isSaving, addAnnotations, updateAnnotations, deleteAnnotations, submitAnnotations } =
+        useAnnotationActions();
 
     const hasAnnotations = !isEmpty(annotations);
     const isMultiLabel = selectedProject.task.exclusive_labels === false;

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -65,7 +65,6 @@ export const SecondaryToolbar = ({
         updateAnnotations,
         deleteAnnotations,
         submitAnnotations,
-        submitPredictions,
     } = useAnnotationActions();
 
     const hasAnnotations = !isEmpty(annotations);

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { AnnotationDTO } from '../../../constants/shared-types';
-import { getAnnotations } from './utils';
+import { getInitialAnnotations, getInitialPredictions } from './utils';
 
-describe('getAnnotations', () => {
+describe('getInitialAnnotations', () => {
     const mockAnnotations: AnnotationDTO[] = [
         {
             shape: { type: 'rectangle', x: 0, y: 0, width: 100, height: 100 },
@@ -28,37 +28,72 @@ describe('getAnnotations', () => {
 
     describe('annotation mode', () => {
         it('returns annotations when mode is annotation and user has reviewed', () => {
-            const result = getAnnotations('annotation', true, mockAnnotations);
+            const result = getInitialAnnotations('annotation', true, mockAnnotations);
             expect(result).toEqual(mockAnnotations);
         });
 
         it('returns empty array when mode is annotation and user has not reviewed', () => {
-            const result = getAnnotations('annotation', false, mockAnnotations);
+            const result = getInitialAnnotations('annotation', false, mockAnnotations);
             expect(result).toEqual([]);
         });
     });
 
     describe('prediction mode', () => {
         it('returns empty array when mode is prediction and user has reviewed', () => {
-            const result = getAnnotations('prediction', true, mockAnnotations);
+            const result = getInitialAnnotations('prediction', true, mockAnnotations);
+            expect(result).toEqual([]);
+        });
+
+        it('returns empty array when mode is prediction and user has not reviewed', () => {
+            const result = getInitialAnnotations('prediction', false, mockAnnotations);
+            expect(result).toEqual([]);
+        });
+    });
+});
+
+describe('getInitialPredictions', () => {
+    const mockAnnotations: AnnotationDTO[] = [
+        {
+            shape: { type: 'rectangle', x: 0, y: 0, width: 100, height: 100 },
+            labels: [{ id: '1' }],
+        },
+        {
+            shape: {
+                type: 'polygon',
+                points: [
+                    { x: 0, y: 0 },
+                    { x: 100, y: 100 },
+                ],
+            },
+            labels: [{ id: '2' }],
+        },
+        {
+            shape: { type: 'full_image' },
+            labels: [{ id: '3' }],
+        },
+    ];
+
+    describe('annotation mode', () => {
+        it('returns empty array when mode is annotation and user has reviewed', () => {
+            const result = getInitialPredictions('annotation', true, mockAnnotations);
+            expect(result).toEqual([]);
+        });
+
+        it('returns empty array when mode is annotation and user has not reviewed', () => {
+            const result = getInitialPredictions('annotation', false, mockAnnotations);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('prediction mode', () => {
+        it('returns empty array when mode is prediction and user has reviewed', () => {
+            const result = getInitialPredictions('prediction', true, mockAnnotations);
             expect(result).toEqual([]);
         });
 
         it('returns annotations when mode is prediction and user has not reviewed', () => {
-            const result = getAnnotations('prediction', false, mockAnnotations);
+            const result = getInitialPredictions('prediction', false, mockAnnotations);
             expect(result).toEqual(mockAnnotations);
-        });
-    });
-
-    describe('edge cases', () => {
-        it('handles empty annotations array in annotation mode with review', () => {
-            const result = getAnnotations('annotation', true, []);
-            expect(result).toEqual([]);
-        });
-
-        it('handles empty annotations array in prediction mode without review', () => {
-            const result = getAnnotations('prediction', false, []);
-            expect(result).toEqual([]);
         });
     });
 });

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -4,17 +4,18 @@
 import type { AnnotationDTO } from '../../../constants/shared-types';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 
-export const getAnnotations = (
+export const getInitialAnnotations = (
     mode: AnnotatorMode,
     isUserReviewed: boolean,
-    annotations: AnnotationDTO[]
+    annotationsDTO: AnnotationDTO[]
 ): AnnotationDTO[] => {
-    if (mode === 'annotation') {
-        return isUserReviewed ? annotations : [];
-    }
-    if (mode === 'prediction') {
-        return isUserReviewed ? [] : annotations;
-    }
+    return mode === 'annotation' ? (isUserReviewed ? annotationsDTO : []) : [];
+};
 
-    return [];
+export const getInitialPredictions = (
+    mode: AnnotatorMode,
+    isUserReviewed: boolean,
+    annotationsDTO: AnnotationDTO[]
+): AnnotationDTO[] => {
+    return mode === 'prediction' ? (isUserReviewed ? [] : annotationsDTO) : [];
 };

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, ReactNode, useContext, useMemo } from 'react';
 
 import { useProject } from 'hooks/api/project.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
@@ -78,11 +78,9 @@ export const AnnotationActionsProvider = ({
 
     const { data: project } = useProject();
 
-    const getPredictions = () => {
+    const predictions = useMemo(() => {
         return mapServerAnnotationsToLocal(initialPredictionsDTO, project.task.labels ?? []);
-    };
-
-    const predictions = getPredictions();
+    }, [initialPredictionsDTO, project.task.labels]);
 
     const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>(() => {
         const projectLabels = project?.task?.labels ?? [];

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useEffect } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
 
 import { useProject } from 'hooks/api/project.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
@@ -84,18 +84,11 @@ export const AnnotationActionsProvider = ({
 
     const predictions = getPredictions();
 
-    const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>([]);
-
-    useEffect(() => {
-        if (mode === 'prediction' || isUserReviewed === false) return;
-
+    const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>(() => {
         const projectLabels = project?.task?.labels ?? [];
 
-        const localAnnotations = mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels);
-
-        undoRedoActions.reset(localAnnotations);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [initialAnnotationsDTO, project?.task?.labels]);
+        return mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels);
+    });
 
     const updateAnnotations = (updatedAnnotations: Annotation[]) => {
         const updatedMap = new Map(updatedAnnotations.map((annotation) => [annotation.id, annotation]));

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -11,6 +11,8 @@ import { $api } from '../../api/client';
 import type { AnnotationDTO, Label, Media } from '../../constants/shared-types';
 import { UndoRedoProvider } from '../../features/dataset/media-preview/primary-toolbar/undo-redo/undo-redo-provider.component';
 import useUndoRedoState from '../../features/dataset/media-preview/primary-toolbar/undo-redo/use-undo-redo-state';
+import { AnnotatorMode } from '../../features/dataset/media-preview/secondary-toolbar/annotator-modes/mode';
+import { getAnnotations } from '../../features/dataset/media-preview/utils';
 import type { Annotation, Shape } from '../types';
 
 const mapServerAnnotationsToLocal = (serverAnnotations: AnnotationDTO[], projectLabels: Label[]): Annotation[] => {
@@ -58,6 +60,7 @@ type AnnotationActionsProviderProps = {
     initialAnnotationsDTO?: AnnotationDTO[];
     isUserReviewed?: boolean;
     mediaItem: Media;
+    mode: AnnotatorMode;
 };
 
 export const AnnotationActionsProvider = ({
@@ -65,6 +68,7 @@ export const AnnotationActionsProvider = ({
     initialAnnotationsDTO = [],
     isUserReviewed = false,
     mediaItem,
+    mode,
 }: AnnotationActionsProviderProps) => {
     const projectId = useProjectIdentifier();
     const saveMutation = $api.useMutation(
@@ -74,10 +78,24 @@ export const AnnotationActionsProvider = ({
 
     const { data: project } = useProject();
 
+    const getPredictions = () => {
+        if (mode === 'annotation' || isUserReviewed) {
+            return [];
+        }
+
+        return mapServerAnnotationsToLocal(initialAnnotationsDTO, project.task.labels ?? []);
+    };
+
+    const predictions = getPredictions();
+
     const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>([]);
 
     useEffect(() => {
-        const projectLabels = project?.task?.labels || [];
+        if (mode === 'prediction' || isUserReviewed === false) {
+            return;
+        }
+
+        const projectLabels = project?.task?.labels ?? [];
 
         const localAnnotations = mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels);
 
@@ -118,9 +136,9 @@ export const AnnotationActionsProvider = ({
     };
 
     const submitAnnotations = async () => {
-        const serverFormattedAnnotations = mapLocalAnnotationsToServer(annotations);
+        const serverAnnotations = mapLocalAnnotationsToServer(mode === 'annotation' ? annotations : predictions);
 
-        await saveAnnotations(serverFormattedAnnotations);
+        await saveAnnotations(serverAnnotations);
     };
 
     const submitPredictions = async () => {
@@ -131,11 +149,13 @@ export const AnnotationActionsProvider = ({
         await saveAnnotations(serverFormattedAnnotationsWithoutConfidences);
     };
 
+    const annotationsToRender = mode === 'annotation' ? annotations : predictions;
+
     return (
         <AnnotationsContext.Provider
             value={{
                 isUserReviewed,
-                annotations,
+                annotations: annotationsToRender,
 
                 // Local
                 addAnnotations,

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -12,7 +12,6 @@ import type { AnnotationDTO, Label, Media } from '../../constants/shared-types';
 import { UndoRedoProvider } from '../../features/dataset/media-preview/primary-toolbar/undo-redo/undo-redo-provider.component';
 import useUndoRedoState from '../../features/dataset/media-preview/primary-toolbar/undo-redo/use-undo-redo-state';
 import { AnnotatorMode } from '../../features/dataset/media-preview/secondary-toolbar/annotator-modes/mode';
-import { getAnnotations } from '../../features/dataset/media-preview/utils';
 import type { Annotation, Shape } from '../types';
 
 const mapServerAnnotationsToLocal = (serverAnnotations: AnnotationDTO[], projectLabels: Label[]): Annotation[] => {
@@ -48,7 +47,6 @@ interface AnnotationsContextValue {
     deleteAnnotations: (annotationIds: string[]) => void;
     updateAnnotations: (updatedAnnotations: Annotation[]) => void;
     submitAnnotations: () => Promise<void>;
-    submitPredictions: () => Promise<void>;
     isUserReviewed: boolean;
     isSaving: boolean;
 }
@@ -57,7 +55,8 @@ const AnnotationsContext = createContext<AnnotationsContextValue | null>(null);
 
 type AnnotationActionsProviderProps = {
     children: ReactNode;
-    initialAnnotationsDTO?: AnnotationDTO[];
+    initialAnnotationsDTO: AnnotationDTO[];
+    initialPredictionsDTO: AnnotationDTO[];
     isUserReviewed?: boolean;
     mediaItem: Media;
     mode: AnnotatorMode;
@@ -65,7 +64,8 @@ type AnnotationActionsProviderProps = {
 
 export const AnnotationActionsProvider = ({
     children,
-    initialAnnotationsDTO = [],
+    initialAnnotationsDTO,
+    initialPredictionsDTO,
     isUserReviewed = false,
     mediaItem,
     mode,
@@ -79,11 +79,7 @@ export const AnnotationActionsProvider = ({
     const { data: project } = useProject();
 
     const getPredictions = () => {
-        if (mode === 'annotation' || isUserReviewed) {
-            return [];
-        }
-
-        return mapServerAnnotationsToLocal(initialAnnotationsDTO, project.task.labels ?? []);
+        return mapServerAnnotationsToLocal(initialPredictionsDTO, project.task.labels ?? []);
     };
 
     const predictions = getPredictions();
@@ -91,9 +87,7 @@ export const AnnotationActionsProvider = ({
     const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>([]);
 
     useEffect(() => {
-        if (mode === 'prediction' || isUserReviewed === false) {
-            return;
-        }
+        if (mode === 'prediction' || isUserReviewed === false) return;
 
         const projectLabels = project?.task?.labels ?? [];
 
@@ -135,18 +129,22 @@ export const AnnotationActionsProvider = ({
         });
     };
 
-    const submitAnnotations = async () => {
-        const serverAnnotations = mapLocalAnnotationsToServer(mode === 'annotation' ? annotations : predictions);
-
-        await saveAnnotations(serverAnnotations);
-    };
-
     const submitPredictions = async () => {
         const serverFormattedAnnotationsWithoutConfidences: AnnotationDTO[] = mapLocalAnnotationsToServer(
-            annotations
+            predictions
         ).map(({ confidences, ...restOfAnnotation }) => restOfAnnotation);
 
         await saveAnnotations(serverFormattedAnnotationsWithoutConfidences);
+    };
+
+    const submitAnnotations = async () => {
+        if (mode === 'prediction') {
+            await submitPredictions();
+        } else {
+            const serverAnnotations = mapLocalAnnotationsToServer(annotations);
+
+            await saveAnnotations(serverAnnotations);
+        }
     };
 
     const annotationsToRender = mode === 'annotation' ? annotations : predictions;
@@ -164,7 +162,6 @@ export const AnnotationActionsProvider = ({
 
                 // Remote
                 submitAnnotations,
-                submitPredictions,
 
                 isSaving: saveMutation.isPending,
             }}

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -45,6 +45,12 @@ test.beforeEach(async ({ network, page }) => {
             return HttpResponse.arrayBuffer(candyPngBuffer.buffer, {
                 headers: { 'Content-Type': 'image/png' },
             });
+        }),
+        http.get('/api/projects/{project_id}/dataset/items/{dataset_item_id}/annotations', async () => {
+            return HttpResponse.json({
+                annotations: [],
+                user_reviewed: false,
+            });
         })
     );
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The goal of this PR is to persist state when user switches from annotation to prediction (e.g. user created annotation, switched to prediction, saw predictions, switched back to annotation mode, annotation that was created in the 1. step is visible).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
