### PR TITLE
Subset splits

### DIFF
--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -10,7 +10,7 @@ type MediaThumbnailProps = {
 
 export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt }: MediaThumbnailProps) => {
     return (
-        <div onDoubleClick={onDoubleClick} onClick={onClick}>
+        <div onDoubleClick={onDoubleClick} onClick={onClick} style={{ textAlign: 'center' }}>
             <img
                 src={url}
                 alt={alt}

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -12,9 +12,9 @@ import styles from './model-training-datasets.module.scss';
 
 type SubsetBoxProps = {
     title: string;
-    subsetSplit: number;
     subset: DatasetSubset;
     datasetRevisionId: string;
+    totalItems: number;
 };
 
 const BoxActions = () => {
@@ -36,13 +36,15 @@ const BoxActions = () => {
     );
 };
 
-const SubsetBox = ({ title, subsetSplit, subset, datasetRevisionId }: SubsetBoxProps) => {
+const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxProps) => {
     const { items, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, totalCount } = useGetDatasetRevisionItems(
         {
             datasetRevisionId,
             subset,
         }
     );
+
+    const subsetPercentage = totalItems > 0 ? Math.round((totalCount / totalItems) * 100) : 0;
 
     return (
         <Flex
@@ -56,7 +58,7 @@ const SubsetBox = ({ title, subsetSplit, subset, datasetRevisionId }: SubsetBoxP
             <Flex UNSAFE_className={styles.boxHeading} justifyContent={'space-between'} alignItems={'center'}>
                 <Flex gap={'size-100'} alignItems={'center'}>
                     <Heading level={5}>
-                        {title} {subsetSplit}%
+                        {title} {subsetPercentage}%
                     </Heading>
                     <Text>({totalCount})</Text>
                 </Flex>
@@ -78,20 +80,45 @@ const SubsetBox = ({ title, subsetSplit, subset, datasetRevisionId }: SubsetBoxP
 };
 
 export const ModelTrainingDatasets = ({ datasetRevisionId }: { datasetRevisionId: string | undefined | null }) => {
+    const { totalCount: trainingCount } = useGetDatasetRevisionItems({
+        datasetRevisionId: datasetRevisionId ?? '',
+        subset: 'training',
+    });
+    const { totalCount: validationCount } = useGetDatasetRevisionItems({
+        datasetRevisionId: datasetRevisionId ?? '',
+        subset: 'validation',
+    });
+    const { totalCount: testingCount } = useGetDatasetRevisionItems({
+        datasetRevisionId: datasetRevisionId ?? '',
+        subset: 'testing',
+    });
+
+    const totalItems = trainingCount + validationCount + testingCount;
+
     if (!datasetRevisionId) {
         return <Text>No dataset revision found for this model</Text>;
     }
 
     return (
         <Flex gap={'size-300'} width={'100%'}>
-            <SubsetBox title={'Training'} subsetSplit={70} subset={'training'} datasetRevisionId={datasetRevisionId} />
+            <SubsetBox
+                title={'Training'}
+                subset={'training'}
+                datasetRevisionId={datasetRevisionId}
+                totalItems={totalItems}
+            />
             <SubsetBox
                 title={'Validation'}
-                subsetSplit={20}
                 subset={'validation'}
                 datasetRevisionId={datasetRevisionId}
+                totalItems={totalItems}
             />
-            <SubsetBox title={'Testing'} subsetSplit={10} subset={'testing'} datasetRevisionId={datasetRevisionId} />
+            <SubsetBox
+                title={'Testing'}
+                subset={'testing'}
+                datasetRevisionId={datasetRevisionId}
+                totalItems={totalItems}
+            />
         </Flex>
     );
 };

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -3,6 +3,7 @@
 
 import { ActionButton, Content, Flex, Heading, Text } from '@geti/ui';
 import { Filter, GridSmall, Search, SortUpDown } from '@geti/ui/icons';
+import { useNumberFormatter } from 'react-aria';
 
 import type { DatasetSubset } from '../../../../constants/shared-types';
 import { useGetDatasetRevisionItems } from '../../../../hooks/use-get-dataset-revision-items.hook';
@@ -44,7 +45,8 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
         }
     );
 
-    const subsetPercentage = totalItems > 0 ? Math.round((totalCount / totalItems) * 100) : 0;
+    const formatter = useNumberFormatter({ style: 'percent', maximumFractionDigits: 0 });
+    const subsetPercentage = totalItems > 0 ? totalCount / totalItems : 0;
 
     return (
         <Flex
@@ -58,7 +60,7 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
             <Flex UNSAFE_className={styles.boxHeading} justifyContent={'space-between'} alignItems={'center'}>
                 <Flex gap={'size-100'} alignItems={'center'}>
                     <Heading level={5}>
-                        {title} {subsetPercentage}%
+                        {title} {formatter.format(subsetPercentage)}
                     </Heading>
                     <Text>({totalCount})</Text>
                 </Flex>

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -53,10 +53,10 @@ export const SubsetGallery = ({
     }
 
     return (
-        <View height={'100%'} width={'100%'} position={'relative'} minHeight={'size-5000'}>
+        <View height={'size-5000'} width={'100%'}>
             <VirtualizerGridLayout
                 items={items}
-                ariaLabel='subset-media-grid'
+                ariaLabel={'subset media grid'}
                 selectionMode='none'
                 layoutOptions={layoutOptions}
                 isLoadingMore={isFetchingNextPage}
@@ -65,7 +65,7 @@ export const SubsetGallery = ({
                     <MediaItem
                         contentElement={() => (
                             <MediaThumbnail
-                                alt={item.id}
+                                alt={item.subset + ' item'}
                                 url={getDatasetRevisionThumbnailUrl(projectId, datasetRevisionId, item.id)}
                                 // TODO: leverage onDoubleClick to open a dialog
                             />

--- a/application/ui/src/features/models/model-listing/model-variants/accuracy-indicator.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/accuracy-indicator.component.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Flex } from '@geti/ui';
-import { Cell, Label, Pie, PieChart } from 'recharts';
+import { Pie, PieChart, Sector } from 'recharts';
 
 interface AccuracyIndicatorProps {
     accuracy: number;
@@ -29,27 +29,33 @@ export const AccuracyIndicator = ({ accuracy }: AccuracyIndicatorProps) => {
 
     return (
         <Flex direction={'column'}>
-            <PieChart width={60} height={50}>
+            <PieChart width={70} height={50}>
                 <Pie
                     data={graphData}
                     cx={30}
-                    cy={32}
+                    cy={26}
                     startAngle={180}
                     endAngle={0}
                     innerRadius={20}
                     outerRadius={26}
                     dataKey='value'
                     stroke='none'
+                    shape={(props) => {
+                        const fill = props.index === 0 ? getColor(accuracy) : 'var(--spectrum-global-color-gray-400)';
+
+                        return <Sector {...props} fill={fill} />;
+                    }}
+                />
+                <text
+                    x={'50%'}
+                    y={'50%'}
+                    textAnchor={'middle'}
+                    dominantBaseline={'middle'}
+                    fill={'var(--spectrum-global-color-gray-900)'}
+                    fontSize={'var(--spectrum-global-dimension-size-125)'}
                 >
-                    <Cell fill={getColor(accuracy)} />
-                    <Cell fill='var(--spectrum-global-color-gray-400)' />
-                    <Label
-                        value={`${accuracy}%`}
-                        position='center'
-                        fill='var(--spectrum-global-color-gray-900)'
-                        fontSize={10}
-                    />
-                </Pie>
+                    {`${accuracy}%`}
+                </text>
             </PieChart>
         </Flex>
     );


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Fix accuracy indicator styles after recharts update
* Update training dataset subset split (fixes & add count) - ATM we get all 500's which is a backend bug, they are working on it

<img width="1174" height="712" alt="Screenshot 2026-01-28 at 13 54 57" src="https://github.com/user-attachments/assets/38df2399-882c-43af-ad0d-f39413a1516b" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
