### PR TITLE
Fix server errors in dataset revision endpoints

### DIFF
--- a/application/backend/app/api/routers/dataset_revisions.py
+++ b/application/backend/app/api/routers/dataset_revisions.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
+from io import BytesIO
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, StreamingResponse
 
 from app.api.dependencies import get_dataset_revision, get_dataset_revision_service, get_project
 from app.api.schemas.dataset_item import (
@@ -135,13 +135,15 @@ def get_dataset_revision_item(
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
 ) -> DatasetRevisionItemView:
     """Get information about a specific item in the dataset revision"""
-    dataset_revision_item = dataset_revision_service.get_dataset_revision_item(
-        project_id=project.id,
-        dataset_revision=dataset_revision,
-        item_id=str(dataset_item_id),
-    )
-
-    return DatasetRevisionItemView.model_validate(dataset_revision_item, from_attributes=True)
+    try:
+        dataset_revision_item = dataset_revision_service.get_dataset_revision_item(
+            project_id=project.id,
+            dataset_revision=dataset_revision,
+            item_id=str(dataset_item_id),
+        )
+        return DatasetRevisionItemView.model_validate(dataset_revision_item, from_attributes=True)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
 @router.get(
@@ -149,7 +151,7 @@ def get_dataset_revision_item(
     responses={
         status.HTTP_200_OK: {"description": "Dataset item binary found"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid dataset item ID or revision ID"},
-        status.HTTP_404_NOT_FOUND: {"description": "Dataset item, binary, revision, or project not found"},
+        status.HTTP_404_NOT_FOUND: {"description": "Dataset revision, item or project not found"},
     },
 )
 def get_dataset_revision_item_binary(
@@ -159,12 +161,15 @@ def get_dataset_revision_item_binary(
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
 ) -> FileResponse:
     """Get the image data of an item in the dataset revision"""
-    binary_path = dataset_revision_service.get_dataset_revision_item_binary_path(
-        project_id=project.id,
-        dataset_revision=dataset_revision,
-        item_id=str(dataset_item_id),
-    )
-    return FileResponse(binary_path, media_type="application/octet-stream")
+    try:
+        binary_path = dataset_revision_service.get_dataset_revision_item(
+            project_id=project.id,
+            dataset_revision=dataset_revision,
+            item_id=str(dataset_item_id),
+        ).image_path
+        return FileResponse(binary_path)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
 @router.get(
@@ -172,7 +177,7 @@ def get_dataset_revision_item_binary(
     responses={
         status.HTTP_200_OK: {"description": "Dataset item thumbnail found"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid dataset item ID or revision ID"},
-        status.HTTP_404_NOT_FOUND: {"description": "Dataset item, thumbnail, revision, or project not found"},
+        status.HTTP_404_NOT_FOUND: {"description": "Dataset revision, item or project not found"},
     },
 )
 def get_dataset_revision_item_thumbnail(
@@ -180,15 +185,27 @@ def get_dataset_revision_item_thumbnail(
     dataset_revision: Annotated[DatasetRevision, Depends(get_dataset_revision)],
     dataset_item_id: DatasetItemID,
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
-) -> FileResponse:
+) -> StreamingResponse:
     """Get the thumbnail of an item in the dataset revision"""
-    # TODO: correctly compute thumbnail image and return it.
-    binary_path = dataset_revision_service.get_dataset_revision_item_binary_path(
-        project_id=project.id,
-        dataset_revision=dataset_revision,
-        item_id=str(dataset_item_id),
-    )
-    return FileResponse(binary_path, media_type="image/jpeg")
+    try:
+        thumbnail = dataset_revision_service.get_dataset_revision_item_thumbnail(
+            project_id=project.id,
+            dataset_revision=dataset_revision,
+            item_id=str(dataset_item_id),
+        )
+        buffer = BytesIO()
+        thumbnail.save(buffer, format="JPEG")
+        buffer.seek(0)
+        return StreamingResponse(
+            buffer,
+            media_type="image/jpeg",
+            headers={
+                "Content-Disposition": f"inline; filename={dataset_item_id}.jpeg",
+                "Cache-Control": "public, max-age=31536000",
+            },
+        )
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
 @router.delete(
@@ -206,4 +223,7 @@ def delete_dataset_revision_files(
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
 ) -> None:
     """Delete the files associated with a dataset revision"""
-    dataset_revision_service.delete_dataset_revision_files(project_id=project.id, revision_id=dataset_revision_id)
+    try:
+        dataset_revision_service.delete_dataset_revision_files(project_id=project.id, revision_id=dataset_revision_id)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/application/backend/app/models/dataset_item_revision.py
+++ b/application/backend/app/models/dataset_item_revision.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from uuid import UUID
 
 from app.models import DatasetItemSubset, MediaFormat
@@ -14,6 +15,7 @@ class DatasetRevisionItem(BaseEntity):
     Attributes:
         id: Unique identifier for the dataset revision item.
         format: Format of the dataset revision item (e.g., JPG, PNG).
+        image_path: Path to the image file of the item, relative to the data folder.
         width: Width of the dataset revision item in pixels.
         height: Height of the dataset revision item in pixels.
         subset: Subset to which the dataset revision item belongs (e.g., training, validation, testing).
@@ -21,6 +23,7 @@ class DatasetRevisionItem(BaseEntity):
 
     id: UUID
     format: MediaFormat
+    image_path: Path
     width: int
     height: int
     subset: DatasetItemSubset

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -4,12 +4,14 @@
 import shutil
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 from uuid import UUID, uuid4
 
 import datumaro.experimental as dm
 import polars as pl
 from datumaro.experimental.export_import import export_dataset
 from loguru import logger
+from PIL import Image, UnidentifiedImageError
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetRevisionDB
@@ -17,8 +19,10 @@ from app.models import DatasetItemSubset
 from app.models.dataset_item_revision import DatasetRevisionItem
 from app.models.dataset_revision import DatasetRevision
 from app.repositories import DatasetRevisionRepository
+from app.utils.images import crop_to_thumbnail
 
 from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
+from .media_service import InvalidImageError
 
 
 class DatasetRevisionService(BaseSessionManagedService):
@@ -187,6 +191,72 @@ class DatasetRevisionService(BaseSessionManagedService):
         counts["total"] = total
         return counts
 
+    def _parse_revision_item_from_df_row_dict(
+        self, project_id: UUID, dataset_revision_id: UUID, df_revision_item: dict[str, Any]
+    ) -> DatasetRevisionItem:
+        """
+        Utility method to convert a dataset revision item from a dict representation
+        (a row of the Polars dataframe, serialized with to_dicts()) to a DatasetRevisionItem.
+
+        The dict is expected to have the following structure:
+        {
+            "id": "9bedc1ec-edf1-4eec-8549-82239c585c48",
+            "image": "relative/path/to/image.jpg",
+            "image_info": {
+                "width": 1024,
+                "height": 768
+            },
+            "subset": "TRAINING",
+            ... other fields ...
+        }
+
+        Args:
+            project_id: The UUID of the project.
+            dataset_revision_id: The UUID of the dataset revision.
+            df_revision_item: The dataset revision item as a dict.
+
+        Returns:
+            DatasetRevisionItem
+        """
+        dataset_revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / str(dataset_revision_id)
+        try:
+            # The path stored in the 'image' column is relative to the dataset revision base folder
+            image_rel_path = Path(df_revision_item["image"])
+
+            if "data/projects" in str(image_rel_path):
+                # TODO due to a bug in Datumaro, the above assumption doesn't always hold true, and the image path
+                #  may be relative to the app data folder instead. This workaround can be removed after the bug is fixed
+                #  in Datumaro: https://github.com/open-edge-platform/datumaro/issues/2019
+                image_path = image_rel_path
+            else:
+                image_path = dataset_revision_path / image_rel_path
+
+            if "id" not in df_revision_item:
+                # Fallback: if the 'id' field is missing, try to extract it from the image filename
+                # TODO remove this fallback logic after ensuring the 'id' is always saved in the parquet file
+                #  https://github.com/open-edge-platform/training_extensions/issues/5350
+                logger.warning(
+                    "Dataset revision item is missing 'id' field, attempting to extract from image filename: {}",
+                    image_rel_path,
+                )
+                df_revision_item["id"] = image_rel_path.stem  # Filename without extension
+
+            return DatasetRevisionItem(
+                id=UUID(df_revision_item["id"]),
+                format=image_rel_path.suffix.lstrip("."),
+                image_path=image_path,
+                width=df_revision_item["image_info"]["width"],
+                height=df_revision_item["image_info"]["height"],
+                subset=DatasetItemSubset(df_revision_item["subset"].lower()),
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to parse dataset revision item from dataframe row dict: {}. Error: {}",
+                df_revision_item,
+                e,
+            )
+            raise
+
     def list_dataset_revision_items(
         self,
         project_id: UUID,
@@ -210,25 +280,19 @@ class DatasetRevisionService(BaseSessionManagedService):
         """
         parquet_path = self._get_revision_parquet_path(project_id, dataset_revision.id)
 
-        df = pl.read_parquet(parquet_path)
+        df = pl.scan_parquet(parquet_path)
 
         if subset is not None:
             df = df.filter(pl.col("subset") == subset.name)
 
-        total_count = len(df)
-        df = df.slice(offset, limit)
+        total_count = df.select(pl.len()).collect().item()
+        df = df.slice(offset, limit).collect()
 
         dataset_revision_items = []
         for item in df.to_dicts():
             dataset_revision_items.append(
-                DatasetRevisionItem.model_validate(
-                    {
-                        "id": UUID(Path(item["image"]).stem),
-                        "format": Path(item["image"]).suffix.lstrip("."),
-                        "width": item["image_info"]["width"],
-                        "height": item["image_info"]["height"],
-                        "subset": DatasetItemSubset[item["subset"]],
-                    }
+                self._parse_revision_item_from_df_row_dict(
+                    project_id=project_id, dataset_revision_id=dataset_revision.id, df_revision_item=item
                 )
             )
         return dataset_revision_items, total_count
@@ -238,7 +302,7 @@ class DatasetRevisionService(BaseSessionManagedService):
         project_id: UUID,
         dataset_revision: DatasetRevision,
         item_id: str,
-    ) -> dict:
+    ) -> DatasetRevisionItem:
         """
         Get a specific item from a dataset revision by ID.
 
@@ -248,34 +312,38 @@ class DatasetRevisionService(BaseSessionManagedService):
             item_id: The ID of the item within the dataset.
 
         Returns:
-            Dictionary containing the item data.
+            DatasetRevisionItem: The requested dataset revision item.
 
         Raises:
             ResourceNotFoundError: If the item is not found.
         """
         parquet_path = self._get_revision_parquet_path(project_id, dataset_revision.id)
 
-        df = pl.read_parquet(parquet_path)
+        df = pl.scan_parquet(parquet_path)
 
         if "id" in df.columns:
-            filtered = df.filter(pl.col("id") == item_id)
-        else:
-            # Fallback: try to use image column
-            filtered = df.filter(pl.col("image").str.contains(item_id))
-
-        if len(filtered) == 0:
+            df = df.filter(pl.col("id") == item_id).collect()
+        else:  # Fallback: locate the item through the 'image' column, if it contains the item ID
+            logger.warning("Dataset revision parquet does not contain 'id' column, falling back to search via 'image'")
+            df = df.filter(pl.col("image").str.contains(item_id)).collect()
+        if len(df) == 0:
             raise ResourceNotFoundError(ResourceType.DATASET_ITEM, item_id)
 
-        return filtered.to_dicts()[0]
+        item = df.to_dicts()[0]
+        item["id"] = item_id  # Ensure the ID is set correctly
 
-    def get_dataset_revision_item_binary_path(
+        return self._parse_revision_item_from_df_row_dict(
+            project_id=project_id, dataset_revision_id=dataset_revision.id, df_revision_item=item
+        )
+
+    def get_dataset_revision_item_thumbnail(
         self,
         project_id: UUID,
         dataset_revision: DatasetRevision,
         item_id: str,
-    ) -> Path:
+    ) -> Image.Image:
         """
-        Get the path to the binary file for a dataset revision item.
+        Generate and return a thumbnail for a specific dataset revision item.
 
         Args:
             project_id: The UUID of the project.
@@ -283,21 +351,20 @@ class DatasetRevisionService(BaseSessionManagedService):
             item_id: The ID of the item within the dataset.
 
         Returns:
-            Path to the image file.
+            Image.Image: The generated thumbnail image.
         """
-        item = self.get_dataset_revision_item(project_id, dataset_revision, item_id)
-        revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / str(dataset_revision.id)
-
-        if isinstance(item.get("image"), str):
-            image_path = revision_path / "images" / Path(item["image"]).name
-        else:
-            # Fallback: try to find by item_id
-            images_dir = revision_path / "images"
-            for file in images_dir.glob(f"*{item_id}*"):
-                return file
-            raise ResourceNotFoundError(ResourceType.DATASET_ITEM, item_id)
-
-        return image_path
+        binary_path = self.get_dataset_revision_item(
+            project_id=project_id,
+            dataset_revision=dataset_revision,
+            item_id=item_id,
+        ).image_path
+        try:
+            with Image.open(binary_path) as image:
+                thumbnail = crop_to_thumbnail(image=image, target_width=64, target_height=64)
+        except UnidentifiedImageError:
+            logger.error("Failed to open image {} for thumbnail generation", binary_path)
+            raise InvalidImageError("Failed to open image for thumbnail generation.")
+        return thumbnail
 
     @staticmethod
     def _to_dataset_revision(dataset_db: DatasetRevisionDB) -> DatasetRevision:

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from pathlib import Path
 from uuid import UUID, uuid4
 
+import polars as pl
 import pytest
+from PIL import Image
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, DatasetRevisionDB, MediaDB, PipelineDB
@@ -248,6 +250,57 @@ def fxt_project_with_subset_items_on_disk(
     return project, media_and_dataset_items
 
 
+@pytest.fixture
+def fxt_dataset_revision_with_parquet(
+    fxt_projects_dir: Path,
+    fxt_project_with_pipeline: tuple[Project, Pipeline],
+    db_session: Session,
+) -> tuple[Project, UUID]:
+    """Fixture that creates a dataset revision with a Parquet file and image."""
+    project, _ = fxt_project_with_pipeline
+    revision_id = uuid4()
+
+    # Create revision in database
+    db_revision = DatasetRevisionDB(
+        id=str(revision_id),
+        project_id=str(project.id),
+        name=f"Dataset ({str(revision_id).split('-')[0]})",
+        files_deleted=False,
+    )
+    db_session.add(db_revision)
+    db_session.flush()
+
+    # Create revision directory structure
+    revision_path = fxt_projects_dir / str(project.id) / "dataset_revisions" / str(revision_id)
+    images_path = revision_path / "images"
+    images_path.mkdir(parents=True, exist_ok=True)
+
+    # Create a real image file
+    item_id = uuid4()
+    image_filename = "img_000001.jpg"
+    image_path = images_path / image_filename
+
+    # Create a simple test image (64x64 red square)
+    test_image = Image.new("RGB", (1024, 768), color="red")
+    test_image.save(image_path, "JPEG")
+
+    # Create Polars dataframe with expected schema
+    df = pl.DataFrame(
+        {
+            "id": [str(item_id)],
+            "image": [f"images/{image_filename}"],
+            "image_info": [{"width": 1024, "height": 768}],
+            "subset": ["TRAINING"],
+        }
+    )
+
+    # Save as Parquet
+    parquet_path = revision_path / "data.parquet"
+    df.write_parquet(parquet_path)
+
+    return project, revision_id
+
+
 class TestDatasetRevisionServiceIntegration:
     """Integration tests for DatasetRevisionService."""
 
@@ -488,3 +541,106 @@ class TestDatasetRevisionServiceIntegration:
         # Verify it's marked as deleted
         revision = fxt_dataset_revision_service.get_dataset_revision(project_id=project.id, revision_id=revision_id)
         assert revision.files_deleted is True
+
+    def test_get_dataset_revision_item(
+        self,
+        fxt_dataset_revision_service: DatasetRevisionService,
+        fxt_dataset_revision_with_parquet: tuple[Project, UUID],
+    ) -> None:
+        """Test getting a specific dataset revision item."""
+        project, revision_id = fxt_dataset_revision_with_parquet
+
+        # Get the revision
+        revision = fxt_dataset_revision_service.get_dataset_revision(project_id=project.id, revision_id=revision_id)
+
+        # Read the parquet to get the item_id
+        revision_path = (
+            fxt_dataset_revision_service.projects_dir / str(project.id) / "dataset_revisions" / str(revision_id)
+        )
+        df = pl.read_parquet(revision_path / "data.parquet")
+        item_id = df["id"][0]
+
+        # Get the item
+        item = fxt_dataset_revision_service.get_dataset_revision_item(
+            project_id=project.id,
+            dataset_revision=revision,
+            item_id=item_id,
+        )
+
+        assert item.id == UUID(item_id)
+        assert item.format == "jpg"
+        assert item.width == 1024
+        assert item.height == 768
+        assert item.subset == DatasetItemSubset.TRAINING
+        assert item.image_path.exists()
+
+    def test_get_dataset_revision_item_not_found(
+        self,
+        fxt_dataset_revision_service: DatasetRevisionService,
+        fxt_dataset_revision_with_parquet: tuple[Project, UUID],
+    ) -> None:
+        """Test getting a non-existent dataset revision item raises error."""
+        project, revision_id = fxt_dataset_revision_with_parquet
+
+        revision = fxt_dataset_revision_service.get_dataset_revision(project_id=project.id, revision_id=revision_id)
+
+        non_existent_id = str(uuid4())
+
+        with pytest.raises(ResourceNotFoundError) as excinfo:
+            fxt_dataset_revision_service.get_dataset_revision_item(
+                project_id=project.id,
+                dataset_revision=revision,
+                item_id=non_existent_id,
+            )
+
+        assert excinfo.value.resource_type == ResourceType.DATASET_ITEM
+        assert excinfo.value.resource_id == non_existent_id
+
+    def test_get_dataset_revision_item_thumbnail(
+        self,
+        fxt_dataset_revision_service: DatasetRevisionService,
+        fxt_dataset_revision_with_parquet: tuple[Project, UUID],
+    ) -> None:
+        """Test generating a thumbnail for a dataset revision item."""
+        project, revision_id = fxt_dataset_revision_with_parquet
+
+        revision = fxt_dataset_revision_service.get_dataset_revision(project_id=project.id, revision_id=revision_id)
+
+        # Read the parquet to get the item_id
+        revision_path = (
+            fxt_dataset_revision_service.projects_dir / str(project.id) / "dataset_revisions" / str(revision_id)
+        )
+        df = pl.read_parquet(revision_path / "data.parquet")
+        item_id = df["id"][0]
+
+        # Get the thumbnail
+        thumbnail = fxt_dataset_revision_service.get_dataset_revision_item_thumbnail(
+            project_id=project.id,
+            dataset_revision=revision,
+            item_id=item_id,
+        )
+
+        assert isinstance(thumbnail, Image.Image)
+        assert thumbnail.width == thumbnail.height == 64
+
+    def test_get_dataset_revision_item_thumbnail_not_found(
+        self,
+        fxt_dataset_revision_service: DatasetRevisionService,
+        fxt_dataset_revision_with_parquet: tuple[Project, UUID],
+    ) -> None:
+        """Test getting thumbnail for non-existent item raises error."""
+        project, revision_id = fxt_dataset_revision_with_parquet
+
+        revision = fxt_dataset_revision_service.get_dataset_revision(project_id=project.id, revision_id=revision_id)
+
+        non_existent_id = str(uuid4())
+
+        with pytest.raises(ResourceNotFoundError) as excinfo:
+            fxt_dataset_revision_service.get_dataset_revision_item_thumbnail(
+                project_id=project.id,
+                dataset_revision=revision,
+                item_id=non_existent_id,
+            )
+
+        assert excinfo.value.resource_type == ResourceType.DATASET_ITEM
+        assert excinfo.value.resource_id == non_existent_id

--- a/application/backend/tests/unit/routers/test_dataset_revisions.py
+++ b/application/backend/tests/unit/routers/test_dataset_revisions.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
 import os
 import tempfile
 from unittest.mock import MagicMock
@@ -8,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import status
+from PIL import Image
 
 from app.api.dependencies import get_dataset_revision, get_dataset_revision_service
 from app.api.schemas.dataset_item import DatasetItemSubset
@@ -337,12 +337,11 @@ class TestDatasetRevisionItemEndpoints:
             ResourceType.DATASET_ITEM, str(dataset_item_id)
         )
 
-        with pytest.raises(ResourceNotFoundError):
-            response = fxt_client.get(
-                f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}"
-            )
+        response = fxt_client.get(
+            f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}"
+        )
 
-            assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_get_dataset_revision_item_invalid_ids(self, fxt_get_project, fxt_dataset_revision_service, fxt_client):
         response = fxt_client.get(
@@ -364,7 +363,7 @@ class TestDatasetRevisionItemEndpoints:
             tmp_file_path = tmp_file.name
 
         try:
-            fxt_dataset_revision_service.get_dataset_revision_item_binary_path.return_value = tmp_file_path
+            fxt_dataset_revision_service.get_dataset_revision_item.return_value = MagicMock(image_path=tmp_file_path)
 
             response = fxt_client.get(
                 f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/binary"
@@ -374,7 +373,7 @@ class TestDatasetRevisionItemEndpoints:
             fxt_dataset_revision_service.get_dataset_revision.assert_called_once_with(
                 project_id=fxt_get_project.id, revision_id=fxt_dataset_revision_id
             )
-            fxt_dataset_revision_service.get_dataset_revision_item_binary_path.assert_called_once_with(
+            fxt_dataset_revision_service.get_dataset_revision_item.assert_called_once_with(
                 project_id=fxt_get_project.id,
                 dataset_revision=fxt_dataset_revision_service.get_dataset_revision(),
                 item_id=str(dataset_item_id),
@@ -396,23 +395,22 @@ class TestDatasetRevisionItemEndpoints:
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_dataset_revision_service.get_dataset_revision_item_binary_path.assert_not_called()
+        fxt_dataset_revision_service.get_dataset_revision_item.assert_not_called()
 
     def test_get_dataset_revision_item_binary_not_found(
         self, fxt_get_project, fxt_dataset_revision_id, fxt_dataset_revision_service, fxt_client
     ):
         dataset_item_id = uuid4()
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
-        fxt_dataset_revision_service.get_dataset_revision_item_binary_path.side_effect = ResourceNotFoundError(
+        fxt_dataset_revision_service.get_dataset_revision_item.side_effect = ResourceNotFoundError(
             ResourceType.DATASET_ITEM, str(dataset_item_id)
         )
 
-        with pytest.raises(ResourceNotFoundError):
-            response = fxt_client.get(
-                f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/binary"
-            )
+        response = fxt_client.get(
+            f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/binary"
+        )
 
-            assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_get_dataset_revision_item_binary_invalid_ids(
         self, fxt_get_project, fxt_dataset_revision_service, fxt_client
@@ -430,47 +428,38 @@ class TestDatasetRevisionItemEndpoints:
         dataset_item_id = uuid4()
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
 
-        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-            tmp_file.write(b"test thumbnail data")
-            tmp_file.flush()
-            tmp_file_path = tmp_file.name
+        # Create a dummy PIL image to return as the thumbnail
+        dummy_image = Image.new("RGB", (64, 64), color="red")
+        fxt_dataset_revision_service.get_dataset_revision_item_thumbnail.return_value = dummy_image
 
-        try:
-            # Thumbnail endpoint now uses the same method as binary (returns full image)
-            fxt_dataset_revision_service.get_dataset_revision_item_binary_path.return_value = tmp_file_path
+        response = fxt_client.get(
+            f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/thumbnail"
+        )
 
-            response = fxt_client.get(
-                f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/thumbnail"
-            )
-
-            assert response.status_code == status.HTTP_200_OK
-            fxt_dataset_revision_service.get_dataset_revision.assert_called_once_with(
-                project_id=fxt_get_project.id, revision_id=fxt_dataset_revision_id
-            )
-            fxt_dataset_revision_service.get_dataset_revision_item_binary_path.assert_called_once_with(
-                project_id=fxt_get_project.id,
-                dataset_revision=fxt_dataset_revision_service.get_dataset_revision(),
-                item_id=str(dataset_item_id),
-            )
-        finally:
-            if os.path.exists(tmp_file_path):
-                os.unlink(tmp_file_path)
+        assert response.status_code == status.HTTP_200_OK
+        fxt_dataset_revision_service.get_dataset_revision.assert_called_once_with(
+            project_id=fxt_get_project.id, revision_id=fxt_dataset_revision_id
+        )
+        fxt_dataset_revision_service.get_dataset_revision_item_thumbnail.assert_called_once_with(
+            project_id=fxt_get_project.id,
+            dataset_revision=fxt_dataset_revision_service.get_dataset_revision(),
+            item_id=str(dataset_item_id),
+        )
 
     def test_get_dataset_revision_item_thumbnail_not_found(
         self, fxt_get_project, fxt_dataset_revision_id, fxt_dataset_revision_service, fxt_client
     ):
         dataset_item_id = uuid4()
         fxt_dataset_revision_service.get_dataset_revision.return_value = MagicMock(id=fxt_dataset_revision_id)
-        fxt_dataset_revision_service.get_dataset_revision_item_binary_path.side_effect = ResourceNotFoundError(
+        fxt_dataset_revision_service.get_dataset_revision_item_thumbnail.side_effect = ResourceNotFoundError(
             ResourceType.DATASET_ITEM, str(dataset_item_id)
         )
 
-        with pytest.raises(ResourceNotFoundError):
-            response = fxt_client.get(
-                f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/thumbnail"
-            )
+        response = fxt_client.get(
+            f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}/items/{str(dataset_item_id)}/thumbnail"
+        )
 
-            assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_get_dataset_revision_item_thumbnail_invalid_ids(
         self, fxt_get_project, fxt_dataset_revision_service, fxt_client
@@ -501,12 +490,11 @@ class TestDatasetRevisionItemEndpoints:
             ResourceType.DATASET_REVISION, str(fxt_dataset_revision_id)
         )
 
-        with pytest.raises(ResourceNotFoundError):
-            response = fxt_client.delete(
-                f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}"
-            )
+        response = fxt_client.delete(
+            f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/{str(fxt_dataset_revision_id)}"
+        )
 
-            assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_delete_dataset_revision_files_invalid_id(self, fxt_get_project, fxt_dataset_revision_service, fxt_client):
         response = fxt_client.delete(f"/api/projects/{str(fxt_get_project.id)}/dataset_revisions/invalid-id")


### PR DESCRIPTION
### Summary

This PR fixes several bugs in the dataset revision endpoints that would trigger '500 Internal Server Errors'.

_Note:_ the internal structure of dataset revision is going to change after #5350 and https://github.com/open-edge-platform/datumaro/issues/2019; this PR anticipates those changes providing forward-compatibility.

Fixes #5348 
Resolves #5258 

### How to test

Call the dataset revision endpoints, also with invalid parameters, and verify that the API behaves correctly.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
