### PR TITLE
Delete & rename dataset revision

### DIFF
--- a/application/ui/mocks/mock-dataset-revision.ts
+++ b/application/ui/mocks/mock-dataset-revision.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { DatasetRevision } from '../src/constants/shared-types';
+
+export const getMockedDatasetRevision = (overrides: Partial<DatasetRevision> = {}): DatasetRevision => ({
+    id: 'dataset-1',
+    project_id: 'project-1',
+    name: 'Dataset Revision 1',
+    item_counts: {
+        training: 70,
+        validation: 20,
+        testing: 10,
+        total: 100,
+    },
+    files_deleted: false,
+    ...overrides,
+});

--- a/application/ui/src/features/models/hooks/api/use-train-model-mutation.ts
+++ b/application/ui/src/features/models/hooks/api/use-train-model-mutation.ts
@@ -17,7 +17,7 @@ export const useTrainModelMutation = () => {
         }: {
             device: DeviceType;
             modelArchitectureId: string;
-            datasetRevisionId: string;
+            datasetRevisionId: string | null;
         },
         onSuccess?: () => void
     ) => {

--- a/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test-utils/render';
+
+import type { DatasetGroup } from '../../types';
+import { DatasetActions } from './dataset-actions.component';
+
+const mockDataset: DatasetGroup = {
+    id: 'dataset-123',
+    name: 'Test Dataset',
+    createdAt: '10 Jan 2025',
+    labelCount: 5,
+    imageCount: 100,
+    trainingSubsets: {
+        training: 70,
+        validation: 20,
+        testing: 10,
+    },
+};
+
+describe('DatasetActions', () => {
+    it('should render menu with all items', async () => {
+        render(<DatasetActions dataset={mockDataset} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Dataset actions' });
+        expect(menuButton).toBeInTheDocument();
+
+        await userEvent.click(menuButton);
+
+        expect(screen.getByRole('menuitem', { name: 'Rename' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+    });
+
+    it('should open rename dialog when rename action is clicked', async () => {
+        render(<DatasetActions dataset={mockDataset} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Dataset actions' });
+        await userEvent.click(menuButton);
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+
+        expect(screen.getByRole('dialog', { name: 'Rename dataset revision' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /Dataset revision name/ })).toHaveValue('Test Dataset');
+    });
+
+    it('should open delete dialog when delete action is clicked', async () => {
+        render(<DatasetActions dataset={mockDataset} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Dataset actions' });
+        await userEvent.click(menuButton);
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+        expect(screen.getByRole('alertdialog', { name: 'Delete dataset revision' })).toBeInTheDocument();
+        expect(screen.getByText(/Are you sure you want to delete dataset revision/)).toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.tsx
@@ -1,0 +1,100 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+
+import { ActionButton, AlertDialog, DialogContainer, Item, Key, Menu, MenuTrigger } from '@geti/ui';
+import { MoreMenu } from '@geti/ui/icons';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { useDeleteDatasetRevision } from '../../hooks/use-delete-dataset-revision.hook';
+import { useRenameDatasetRevision } from '../../hooks/use-rename-dataset-revision.hook';
+import type { DatasetGroup } from '../../types';
+import { RenameDatasetRevisionDialog } from '../group-headers/rename-dataset-revision-dialog.component';
+
+type DatasetActionsProps = {
+    dataset: DatasetGroup;
+};
+
+export const DatasetActions = ({ dataset }: DatasetActionsProps) => {
+    const projectId = useProjectIdentifier();
+    const renameDatasetRevisionMutation = useRenameDatasetRevision();
+    const deleteDatasetRevisionMutation = useDeleteDatasetRevision();
+
+    const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+    const handleDatasetMenuAction = (key: Key) => {
+        switch (key) {
+            case 'rename':
+                setIsRenameDialogOpen(true);
+                break;
+            case 'delete':
+                setIsDeleteDialogOpen(true);
+                break;
+            default:
+                break;
+        }
+    };
+
+    const handleRename = (newName: string) => {
+        renameDatasetRevisionMutation.mutate(
+            {
+                params: { path: { project_id: projectId, dataset_revision_id: dataset.id } },
+                body: { name: newName },
+            },
+            {
+                onSuccess: () => {
+                    setIsRenameDialogOpen(false);
+                },
+            }
+        );
+    };
+
+    const handleDelete = () => {
+        deleteDatasetRevisionMutation.mutate({
+            params: { path: { project_id: projectId, dataset_revision_id: dataset.id } },
+        });
+    };
+
+    return (
+        <>
+            <MenuTrigger>
+                <ActionButton isQuiet aria-label={'Dataset actions'}>
+                    <MoreMenu />
+                </ActionButton>
+                <Menu onAction={handleDatasetMenuAction} aria-label={'Dataset actions menu'}>
+                    <Item key={'rename'}>Rename</Item>
+                    <Item key={'delete'}>Delete</Item>
+                </Menu>
+            </MenuTrigger>
+
+            <DialogContainer onDismiss={() => setIsRenameDialogOpen(false)}>
+                {isRenameDialogOpen && (
+                    <RenameDatasetRevisionDialog
+                        currentName={dataset.name}
+                        onRename={handleRename}
+                        isPending={renameDatasetRevisionMutation.isPending}
+                        onClose={() => setIsRenameDialogOpen(false)}
+                    />
+                )}
+            </DialogContainer>
+
+            <DialogContainer onDismiss={() => setIsDeleteDialogOpen(false)}>
+                {isDeleteDialogOpen && (
+                    <AlertDialog
+                        title='Delete dataset revision'
+                        variant='destructive'
+                        primaryActionLabel='Delete'
+                        onPrimaryAction={handleDelete}
+                        cancelLabel='Cancel'
+                    >
+                        {`Are you sure you want to delete dataset revision "${dataset.name}"? ` +
+                            `You will still be able to see the model statistics but you won't ` +
+                            `be able to access the training dataset files.`}
+                    </AlertDialog>
+                )}
+            </DialogContainer>
+        </>
+    );
+};

--- a/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
@@ -51,7 +51,7 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
             />
 
             <Flex>
-                <TrainModel />
+                <TrainModel preSelectedDatasetRevisionId={dataset.id} />
             </Flex>
         </Grid>
     );

--- a/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
@@ -87,7 +87,7 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
                 </Heading>
 
                 <MenuTrigger>
-                    <ActionButton isQuiet aria-label={'Model actions'}>
+                    <ActionButton isQuiet aria-label={'Dataset actions'}>
                         <MoreMenu />
                     </ActionButton>
                     <Menu onAction={handleDatasetMenuAction} aria-label={'Dataset actions menu'}>

--- a/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
@@ -1,12 +1,31 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { dimensionValue, Flex, Grid, Heading, Text } from '@geti/ui';
-import { Image, Tag } from '@geti/ui/icons';
+import { useState } from 'react';
+
+import {
+    ActionButton,
+    AlertDialog,
+    DialogContainer,
+    dimensionValue,
+    Flex,
+    Grid,
+    Heading,
+    Item,
+    Key,
+    Menu,
+    MenuTrigger,
+    Text,
+} from '@geti/ui';
+import { Image, MoreMenu, Tag } from '@geti/ui/icons';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { TrainModel } from '../../../train-model/train-model.component';
+import { useDeleteDatasetRevision } from '../../hooks/use-delete-dataset-revision.hook';
+import { useRenameDatasetRevision } from '../../hooks/use-rename-dataset-revision.hook';
 import type { DatasetGroup } from '../../types';
 import { ThreeSectionRange } from '../three-section-range/three-section-range.component';
+import { RenameDatasetRevisionDialog } from './rename-dataset-revision-dialog.component';
 
 import classes from './group-headers.module.scss';
 
@@ -15,6 +34,46 @@ type DatasetGroupHeaderProps = {
 };
 
 export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
+    const projectId = useProjectIdentifier();
+    const renameDatasetRevisionMutation = useRenameDatasetRevision();
+    const deleteDatasetRevisionMutation = useDeleteDatasetRevision();
+
+    const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+    const handleDatasetMenuAction = (key: Key) => {
+        switch (key) {
+            case 'rename':
+                setIsRenameDialogOpen(true);
+                break;
+            case 'delete':
+                setIsDeleteDialogOpen(true);
+                break;
+            default:
+                break;
+        }
+    };
+
+    const handleRename = (newName: string) => {
+        renameDatasetRevisionMutation.mutate(
+            {
+                params: { path: { project_id: projectId, dataset_revision_id: dataset.id } },
+                body: { name: newName },
+            },
+            {
+                onSuccess: () => {
+                    setIsRenameDialogOpen(false);
+                },
+            }
+        );
+    };
+
+    const handleDelete = () => {
+        deleteDatasetRevisionMutation.mutate({
+            params: { path: { project_id: projectId, dataset_revision_id: dataset.id } },
+        });
+    };
+
     return (
         <Grid
             columns={['auto', '1fr', 'auto', '1fr', 'auto']}
@@ -26,6 +85,16 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
                 <Heading level={2} UNSAFE_style={{ fontSize: dimensionValue('size-300') }}>
                     {dataset.name}
                 </Heading>
+
+                <MenuTrigger>
+                    <ActionButton isQuiet aria-label={'Model actions'}>
+                        <MoreMenu />
+                    </ActionButton>
+                    <Menu onAction={handleDatasetMenuAction} aria-label={'Dataset actions menu'}>
+                        <Item key={'rename'}>Rename</Item>
+                        <Item key={'delete'}>Delete</Item>
+                    </Menu>
+                </MenuTrigger>
             </Flex>
             <Text
                 UNSAFE_style={{
@@ -53,6 +122,31 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
             <Flex>
                 <TrainModel preSelectedDatasetRevisionId={dataset.id} />
             </Flex>
+
+            <DialogContainer onDismiss={() => setIsRenameDialogOpen(false)}>
+                {isRenameDialogOpen && (
+                    <RenameDatasetRevisionDialog
+                        currentName={dataset.name}
+                        onRename={handleRename}
+                        isPending={renameDatasetRevisionMutation.isPending}
+                        onClose={() => setIsRenameDialogOpen(false)}
+                    />
+                )}
+            </DialogContainer>
+
+            <DialogContainer onDismiss={() => setIsDeleteDialogOpen(false)}>
+                {isDeleteDialogOpen && (
+                    <AlertDialog
+                        title='Delete'
+                        variant='destructive'
+                        primaryActionLabel='Delete'
+                        onPrimaryAction={handleDelete}
+                        cancelLabel='Cancel'
+                    >
+                        {`Are you sure you want to delete dataset revision "${dataset.name}"?`}
+                    </AlertDialog>
+                )}
+            </DialogContainer>
         </Grid>
     );
 };

--- a/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
@@ -1,31 +1,13 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
-
-import {
-    ActionButton,
-    AlertDialog,
-    DialogContainer,
-    dimensionValue,
-    Flex,
-    Grid,
-    Heading,
-    Item,
-    Key,
-    Menu,
-    MenuTrigger,
-    Text,
-} from '@geti/ui';
-import { Image, MoreMenu, Tag } from '@geti/ui/icons';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { dimensionValue, Flex, Grid, Heading, Text } from '@geti/ui';
+import { Image, Tag } from '@geti/ui/icons';
 
 import { TrainModel } from '../../../train-model/train-model.component';
-import { useDeleteDatasetRevision } from '../../hooks/use-delete-dataset-revision.hook';
-import { useRenameDatasetRevision } from '../../hooks/use-rename-dataset-revision.hook';
 import type { DatasetGroup } from '../../types';
+import { DatasetActions } from '../dataset-actions/dataset-actions.component';
 import { ThreeSectionRange } from '../three-section-range/three-section-range.component';
-import { RenameDatasetRevisionDialog } from './rename-dataset-revision-dialog.component';
 
 import classes from './group-headers.module.scss';
 
@@ -34,46 +16,6 @@ type DatasetGroupHeaderProps = {
 };
 
 export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
-    const projectId = useProjectIdentifier();
-    const renameDatasetRevisionMutation = useRenameDatasetRevision();
-    const deleteDatasetRevisionMutation = useDeleteDatasetRevision();
-
-    const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
-    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
-    const handleDatasetMenuAction = (key: Key) => {
-        switch (key) {
-            case 'rename':
-                setIsRenameDialogOpen(true);
-                break;
-            case 'delete':
-                setIsDeleteDialogOpen(true);
-                break;
-            default:
-                break;
-        }
-    };
-
-    const handleRename = (newName: string) => {
-        renameDatasetRevisionMutation.mutate(
-            {
-                params: { path: { project_id: projectId, dataset_revision_id: dataset.id } },
-                body: { name: newName },
-            },
-            {
-                onSuccess: () => {
-                    setIsRenameDialogOpen(false);
-                },
-            }
-        );
-    };
-
-    const handleDelete = () => {
-        deleteDatasetRevisionMutation.mutate({
-            params: { path: { project_id: projectId, dataset_revision_id: dataset.id } },
-        });
-    };
-
     return (
         <Grid
             columns={['auto', '1fr', 'auto', '1fr', 'auto']}
@@ -86,15 +28,7 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
                     {dataset.name}
                 </Heading>
 
-                <MenuTrigger>
-                    <ActionButton isQuiet aria-label={'Dataset actions'}>
-                        <MoreMenu />
-                    </ActionButton>
-                    <Menu onAction={handleDatasetMenuAction} aria-label={'Dataset actions menu'}>
-                        <Item key={'rename'}>Rename</Item>
-                        <Item key={'delete'}>Delete</Item>
-                    </Menu>
-                </MenuTrigger>
+                <DatasetActions dataset={dataset} />
             </Flex>
             <Text
                 UNSAFE_style={{
@@ -122,31 +56,6 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
             <Flex>
                 <TrainModel preSelectedDatasetRevisionId={dataset.id} />
             </Flex>
-
-            <DialogContainer onDismiss={() => setIsRenameDialogOpen(false)}>
-                {isRenameDialogOpen && (
-                    <RenameDatasetRevisionDialog
-                        currentName={dataset.name}
-                        onRename={handleRename}
-                        isPending={renameDatasetRevisionMutation.isPending}
-                        onClose={() => setIsRenameDialogOpen(false)}
-                    />
-                )}
-            </DialogContainer>
-
-            <DialogContainer onDismiss={() => setIsDeleteDialogOpen(false)}>
-                {isDeleteDialogOpen && (
-                    <AlertDialog
-                        title='Delete'
-                        variant='destructive'
-                        primaryActionLabel='Delete'
-                        onPrimaryAction={handleDelete}
-                        cancelLabel='Cancel'
-                    >
-                        {`Are you sure you want to delete dataset revision "${dataset.name}"?`}
-                    </AlertDialog>
-                )}
-            </DialogContainer>
         </Grid>
     );
 };

--- a/application/ui/src/features/models/model-listing/components/group-headers/rename-dataset-revision-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/rename-dataset-revision-dialog.component.tsx
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+
+import { Button, ButtonGroup, Content, Dialog, Divider, Form, Heading, TextField } from '@geti/ui';
+
+interface RenameDatasetRevisionDialogProps {
+    currentName: string;
+    onRename: (newName: string) => void;
+    onClose: () => void;
+    isPending?: boolean;
+}
+
+export const RenameDatasetRevisionDialog = ({
+    currentName,
+    onRename,
+    onClose,
+    isPending,
+}: RenameDatasetRevisionDialogProps) => {
+    const [newName, setNewName] = useState(currentName);
+
+    const hasSameName = newName.trim() === currentName;
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        onRename(newName.trim());
+    };
+
+    return (
+        <Dialog>
+            <Heading>Rename dataset revision</Heading>
+
+            <Divider />
+
+            <Content>
+                <Form onSubmit={handleSubmit} validationBehavior={'native'}>
+                    <TextField
+                        label={'Dataset revision name'}
+                        value={newName}
+                        onChange={setNewName}
+                        width={'100%'}
+                        isRequired
+                    />
+                    <ButtonGroup align={'end'} marginTop={'size-300'}>
+                        <Button variant={'secondary'} onPress={onClose}>
+                            Cancel
+                        </Button>
+                        <Button variant={'accent'} type={'submit'} isPending={isPending} isDisabled={hasSameName}>
+                            Rename
+                        </Button>
+                    </ButtonGroup>
+                </Form>
+            </Content>
+        </Dialog>
+    );
+};

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -1,0 +1,64 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getMockedModel } from 'mocks/mock-model';
+import { render } from 'test-utils/render';
+
+import { ModelActions } from './model-actions.component';
+
+const mockModel = getMockedModel({
+    id: 'model-123',
+    name: 'Test Model',
+    architecture: 'YOLOX',
+    size: 1024,
+    training_info: {
+        status: 'successful',
+        label_schema_revision: {
+            labels: [],
+        },
+        start_time: '2025-01-10T10:00:00.000000+00:00',
+        end_time: '2025-01-10T12:30:00.000000+00:00',
+        dataset_revision_id: 'dataset-123',
+    },
+});
+
+describe('ModelActions', () => {
+    it('should render menu with all items', async () => {
+        render(<ModelActions model={mockModel} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Model actions' });
+        expect(menuButton).toBeInTheDocument();
+
+        await userEvent.click(menuButton);
+
+        expect(screen.getByRole('menuitem', { name: 'Set as active' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Rename' })).toBeInTheDocument();
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+    });
+
+    it('should open rename dialog when rename action is clicked', async () => {
+        render(<ModelActions model={mockModel} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Model actions' });
+        await userEvent.click(menuButton);
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+
+        expect(screen.getByRole('dialog', { name: 'Rename model' })).toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: /Model name/ })).toHaveValue('Test Model');
+    });
+
+    it('should open delete dialog when delete action is clicked', async () => {
+        render(<ModelActions model={mockModel} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Model actions' });
+        await userEvent.click(menuButton);
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+        expect(screen.getByRole('alertdialog', { name: 'Delete model' })).toBeInTheDocument();
+        expect(screen.getByText(/Are you sure you want to delete/)).toBeInTheDocument();
+    });
+});

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
@@ -1,0 +1,105 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+
+import { ActionButton, AlertDialog, DialogContainer, Item, Key, Menu, MenuTrigger } from '@geti/ui';
+import { MoreMenu } from '@geti/ui/icons';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import type { Model } from '../../../../../constants/shared-types';
+import { usePatchPipeline } from '../../../../../hooks/api/pipeline.hook';
+import { useDeleteModel } from '../../../hooks/api/use-delete-model.hook';
+import { useRenameModel } from '../../../hooks/api/use-rename-model.hook';
+import { RenameModelDialog } from '../model-row/rename-model-dialog.component';
+
+const MODEL_ACTIONS = {
+    ACTIVE: 'active',
+    RENAME: 'rename',
+    DELETE: 'delete',
+    EXPORT: 'export',
+};
+
+type ModelActionsProps = {
+    model: Model;
+};
+
+export const ModelActions = ({ model }: ModelActionsProps) => {
+    const projectId = useProjectIdentifier();
+    const deleteModelMutation = useDeleteModel();
+    const renameModelMutation = useRenameModel();
+    const patchPipelineMutation = usePatchPipeline();
+
+    const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+    const handleAction = (key: Key) => {
+        if (key === MODEL_ACTIONS.ACTIVE) {
+            patchPipelineMutation.mutate({
+                params: { path: { project_id: projectId } },
+                body: { model_id: model.id },
+            });
+        } else if (key === MODEL_ACTIONS.DELETE) {
+            setIsDeleteDialogOpen(true);
+        } else if (key === MODEL_ACTIONS.RENAME) {
+            setIsRenameDialogOpen(true);
+        }
+    };
+
+    const handleRename = (newName: string) => {
+        renameModelMutation.mutate(
+            {
+                params: { path: { project_id: projectId, model_id: model.id } },
+                body: { name: newName },
+            },
+            {
+                onSuccess: () => {
+                    setIsRenameDialogOpen(false);
+                },
+            }
+        );
+    };
+
+    const handleDelete = () => {
+        deleteModelMutation.mutate({ params: { path: { project_id: projectId, model_id: model.id } } });
+    };
+
+    return (
+        <>
+            <MenuTrigger>
+                <ActionButton isQuiet aria-label={'Model actions'}>
+                    <MoreMenu />
+                </ActionButton>
+                <Menu onAction={handleAction} aria-label={'Model actions menu'}>
+                    <Item key={'active'}>Set as active</Item>
+                    <Item key={'rename'}>Rename</Item>
+                    <Item key={'delete'}>Delete</Item>
+                </Menu>
+            </MenuTrigger>
+
+            <DialogContainer onDismiss={() => setIsRenameDialogOpen(false)}>
+                {isRenameDialogOpen && (
+                    <RenameModelDialog
+                        currentName={model.name ?? ''}
+                        onRename={handleRename}
+                        isPending={renameModelMutation.isPending}
+                        onClose={() => setIsRenameDialogOpen(false)}
+                    />
+                )}
+            </DialogContainer>
+            <DialogContainer onDismiss={() => setIsDeleteDialogOpen(false)}>
+                {isDeleteDialogOpen && (
+                    <AlertDialog
+                        title='Delete model'
+                        variant='destructive'
+                        primaryActionLabel='Delete'
+                        onPrimaryAction={handleDelete}
+                        cancelLabel='Cancel'
+                    >
+                        {`Are you sure you want to delete model "${model.name ?? 'Unnamed Model'}"?`}
+                    </AlertDialog>
+                )}
+            </DialogContainer>
+        </>
+    );
+};

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.test.tsx
@@ -6,11 +6,10 @@ import userEvent from '@testing-library/user-event';
 import { render } from 'test-utils/render';
 
 import { getMockedModel } from '../../../../../../mocks/mock-model';
-import type { Model } from '../../../../../constants/shared-types';
 import { ModelRow } from './model-row.component';
 
 describe('ModelRow', () => {
-    const defaultModel: Model = getMockedModel({
+    const defaultModel = getMockedModel({
         id: 'model-123',
         name: 'Test Model',
         architecture: 'YOLOX',
@@ -68,7 +67,7 @@ describe('ModelRow', () => {
     describe('parent revision model', () => {
         it('should render parent revision model when provided and call onExpandModel when clicked', async () => {
             const onExpandModel = vi.fn();
-            const parentModel: Model = getMockedModel({
+            const parentModel = getMockedModel({
                 id: 'parent-123',
                 name: 'Parent Model',
             });
@@ -87,40 +86,6 @@ describe('ModelRow', () => {
             render(<ModelRow model={defaultModel} />);
 
             expect(screen.queryByText('Fine-tuned from')).not.toBeInTheDocument();
-        });
-    });
-
-    describe('model actions menu', () => {
-        it('should render menu with all items and handle clicks correctly', async () => {
-            const onModelAction = vi.fn();
-
-            render(<ModelRow model={defaultModel} onModelAction={onModelAction} />);
-
-            const menuButton = screen.getByRole('button', { name: 'Model actions' });
-            expect(menuButton).toBeInTheDocument();
-
-            await userEvent.click(menuButton);
-            expect(screen.getByRole('menuitem', { name: 'Set as active' })).toBeInTheDocument();
-            expect(screen.getByRole('menuitem', { name: 'Rename' })).toBeInTheDocument();
-            expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
-
-            await userEvent.click(screen.getByRole('menuitem', { name: 'Set as active' }));
-            expect(onModelAction).toHaveBeenCalledWith('active');
-            await userEvent.click(menuButton);
-            await userEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
-            expect(onModelAction).toHaveBeenCalledWith('rename');
-
-            await userEvent.click(menuButton);
-            await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
-            expect(onModelAction).toHaveBeenCalledWith('delete');
-
-            expect(onModelAction).toHaveBeenCalledTimes(3);
-        });
-
-        it('should not render actions menu when onModelAction is not provided', () => {
-            render(<ModelRow model={defaultModel} />);
-
-            expect(screen.queryByRole('button', { name: 'Model actions' })).not.toBeInTheDocument();
         });
     });
 });

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
@@ -1,8 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActionButton, Flex, Grid, Item, Key, Menu, MenuTrigger, Tag, Text } from '@geti/ui';
-import { MoreMenu } from '@geti/ui/icons';
+import { Flex, Grid, Tag, Text } from '@geti/ui';
 
 import { ReactComponent as ThumbsUp } from '../../../../../assets/icons/thumbs-up.svg';
 import type { Model } from '../../../../../constants/shared-types';
@@ -20,16 +19,9 @@ type ModelRowProps = {
     activeModelArchitectureId?: string;
     parentRevisionModel?: Model;
     onExpandModel?: (modelId: string) => void;
-    onModelAction?: (key: Key) => void;
 };
 
-export const ModelRow = ({
-    model,
-    activeModelArchitectureId,
-    parentRevisionModel,
-    onExpandModel,
-    onModelAction,
-}: ModelRowProps) => {
+export const ModelRow = ({ model, activeModelArchitectureId, parentRevisionModel, onExpandModel }: ModelRowProps) => {
     const trainingEndTime = model.training_info.end_time;
     const totalSize = model.size;
 
@@ -66,19 +58,6 @@ export const ModelRow = ({
             <Text UNSAFE_className={styles.smallText}>{totalSize > 0 ? formatModelSize(totalSize) : '-'}</Text>
 
             <AccuracyIndicator accuracy={72} />
-
-            {onModelAction ? (
-                <MenuTrigger>
-                    <ActionButton isQuiet aria-label={'Model actions'}>
-                        <MoreMenu />
-                    </ActionButton>
-                    <Menu onAction={onModelAction} aria-label={'Model actions menu'}>
-                        <Item key={'active'}>Set as active</Item>
-                        <Item key={'rename'}>Rename</Item>
-                        <Item key={'delete'}>Delete</Item>
-                    </Menu>
-                </MenuTrigger>
-            ) : null}
         </Grid>
     );
 };

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.container.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.container.tsx
@@ -1,72 +1,19 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
-
-import { AlertDialog, DialogContainer, Key } from '@geti/ui';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-
 import type { Model } from '../../../../../constants/shared-types';
-import { usePatchPipeline } from '../../../../../hooks/api/pipeline.hook';
-import { useDeleteModel } from '../../../hooks/api/use-delete-model.hook';
 import { useGetModel } from '../../../hooks/api/use-get-model.hook';
-import { useRenameModel } from '../../../hooks/api/use-rename-model.hook';
 import { useModelListing } from '../../provider/model-listing-provider';
+import { ModelActions } from '../model-actions/model-actions.component';
 import { ModelRow } from './model-row.component';
-import { RenameModelDialog } from './rename-model-dialog.component';
-
-const MODEL_ACTIONS = {
-    ACTIVE: 'active',
-    RENAME: 'rename',
-    DELETE: 'delete',
-    EXPORT: 'export',
-};
 
 type ModelRowContainerProps = {
     model: Model;
 };
 
 export const ModelRowContainer = ({ model }: ModelRowContainerProps) => {
-    const projectId = useProjectIdentifier();
     const { activeModelArchitectureId, onExpandModel } = useModelListing();
     const { data: parentRevisionModel } = useGetModel(model.parent_revision);
-    const deleteModelMutation = useDeleteModel();
-    const renameModelMutation = useRenameModel();
-    const patchPipelineMutation = usePatchPipeline();
-
-    const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
-    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
-    const handleAction = (key: Key) => {
-        if (key === MODEL_ACTIONS.ACTIVE) {
-            patchPipelineMutation.mutate({
-                params: { path: { project_id: projectId } },
-                body: { model_id: model.id },
-            });
-        } else if (key === MODEL_ACTIONS.DELETE) {
-            setIsDeleteDialogOpen(true);
-        } else if (key === MODEL_ACTIONS.RENAME) {
-            setIsRenameDialogOpen(true);
-        }
-    };
-
-    const handleRename = (newName: string) => {
-        renameModelMutation.mutate(
-            {
-                params: { path: { project_id: projectId, model_id: model.id } },
-                body: { name: newName },
-            },
-            {
-                onSuccess: () => {
-                    setIsRenameDialogOpen(false);
-                },
-            }
-        );
-    };
-
-    const handleDelete = () => {
-        deleteModelMutation.mutate({ params: { path: { project_id: projectId, model_id: model.id } } });
-    };
 
     return (
         <>
@@ -75,31 +22,8 @@ export const ModelRowContainer = ({ model }: ModelRowContainerProps) => {
                 activeModelArchitectureId={activeModelArchitectureId}
                 parentRevisionModel={parentRevisionModel}
                 onExpandModel={onExpandModel}
-                onModelAction={handleAction}
             />
-            <DialogContainer onDismiss={() => setIsRenameDialogOpen(false)}>
-                {isRenameDialogOpen && (
-                    <RenameModelDialog
-                        currentName={model.name ?? ''}
-                        onRename={handleRename}
-                        isPending={renameModelMutation.isPending}
-                        onClose={() => setIsRenameDialogOpen(false)}
-                    />
-                )}
-            </DialogContainer>
-            <DialogContainer onDismiss={() => setIsDeleteDialogOpen(false)}>
-                {isDeleteDialogOpen && (
-                    <AlertDialog
-                        title='Delete'
-                        variant='destructive'
-                        primaryActionLabel='Delete'
-                        onPrimaryAction={handleDelete}
-                        cancelLabel='Cancel'
-                    >
-                        {`Are you sure you want to delete model "${model.name ?? 'Unnamed Model'}"?`}
-                    </AlertDialog>
-                )}
-            </DialogContainer>
+            <ModelActions model={model} />
         </>
     );
 };

--- a/application/ui/src/features/models/model-listing/components/model-row/rename-model-dialog.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/rename-model-dialog.component.test.tsx
@@ -18,7 +18,7 @@ describe('RenameModelDialog', () => {
         it('should render dialog with heading and current name in input', () => {
             render(<RenameModelDialog {...defaultProps} />);
 
-            expect(screen.getByRole('heading', { name: 'Rename Model' })).toBeInTheDocument();
+            expect(screen.getByRole('heading', { name: 'Rename model' })).toBeInTheDocument();
             expect(screen.getByRole('textbox')).toHaveValue('Current Model Name');
             expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
             expect(screen.getByRole('button', { name: 'Rename' })).toBeInTheDocument();

--- a/application/ui/src/features/models/model-listing/components/model-row/rename-model-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/rename-model-dialog.component.tsx
@@ -25,7 +25,7 @@ export const RenameModelDialog = ({ currentName, onRename, onClose, isPending }:
 
     return (
         <Dialog>
-            <Heading>Rename Model</Heading>
+            <Heading>Rename model</Heading>
 
             <Divider />
 

--- a/application/ui/src/features/models/model-listing/hooks/use-delete-dataset-revision.hook.ts
+++ b/application/ui/src/features/models/model-listing/hooks/use-delete-dataset-revision.hook.ts
@@ -1,0 +1,12 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { $api } from '../../../../api/client';
+
+export const useDeleteDatasetRevision = () => {
+    return $api.useMutation('delete', '/api/projects/{project_id}/dataset_revisions/{dataset_revision_id}', {
+        meta: {
+            invalidateQueries: [['get', '/api/projects/{project_id}/dataset_revisions']],
+        },
+    });
+};

--- a/application/ui/src/features/models/model-listing/hooks/use-rename-dataset-revision.hook.ts
+++ b/application/ui/src/features/models/model-listing/hooks/use-rename-dataset-revision.hook.ts
@@ -1,0 +1,12 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { $api } from '../../../../api/client';
+
+export const useRenameDatasetRevision = () => {
+    return $api.useMutation('patch', '/api/projects/{project_id}/dataset_revisions/{dataset_revision_id}', {
+        meta: {
+            invalidateQueries: [['get', '/api/projects/{project_id}/dataset_revisions']],
+        },
+    });
+};

--- a/application/ui/src/features/models/model-listing/utils/grouping.ts
+++ b/application/ui/src/features/models/model-listing/utils/grouping.ts
@@ -33,7 +33,8 @@ export const groupModelsByDataset = (models: Model[], options?: GroupModelsByDat
     );
 
     models.forEach((model) => {
-        const datasetId = model.training_info.dataset_revision_id!;
+        // NOTE: We only need this ?? check if we develop with seeded models. This id should always exist.
+        const datasetId = model.training_info.dataset_revision_id ?? '';
         const labels = model.training_info.label_schema_revision?.labels;
         const labelCount = Array.isArray(labels) ? labels.length : 0;
         const datasetRevision = datasetRevisionsMap.get(datasetId);

--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -18,8 +18,7 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
     const trainModelMutation = useTrainModelMutation();
     const projectId = useProjectIdentifier();
 
-    const isStartButtonDisabled =
-        selectedModelArchitectureId === null || selectedTrainingDevice === null || selectedDatasetRevision === null;
+    const isStartButtonDisabled = selectedModelArchitectureId === null || selectedTrainingDevice === null;
 
     const trainModel = () => {
         if (isStartButtonDisabled) return;
@@ -27,7 +26,7 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
         trainModelMutation.mutate(
             {
                 device: selectedTrainingDevice,
-                datasetRevisionId: selectedDatasetRevision,
+                datasetRevisionId: selectedDatasetRevision ?? null,
                 modelArchitectureId: selectedModelArchitectureId,
             },
             () => {

--- a/application/ui/src/features/models/train-model/train-model-provider.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-provider.component.tsx
@@ -37,6 +37,7 @@ const TrainModelContext = createContext<TrainModelContextProps | null>(null);
 
 type TrainModelProviderProps = {
     children: ReactNode;
+    preSelectedDatasetRevisionId?: string;
 };
 
 const getModelArchitectures = (
@@ -65,7 +66,7 @@ const getModelArchitectures = (
     });
 };
 
-export const TrainModelProvider = ({ children }: TrainModelProviderProps) => {
+export const TrainModelProvider = ({ children, preSelectedDatasetRevisionId }: TrainModelProviderProps) => {
     const { data } = useGetTaskModelArchitectures();
     const { data: trainingDevices } = useGetTrainingDevices();
     const { data: datasetRevisions } = useGetDatasetRevisions();
@@ -88,7 +89,7 @@ export const TrainModelProvider = ({ children }: TrainModelProviderProps) => {
         trainingDevices?.at(0)?.type ?? null
     );
     const [selectedDatasetRevision, setSelectedDatasetRevision] = useState<string | null>(
-        datasetRevisions?.at(0)?.id ?? null
+        preSelectedDatasetRevisionId ?? datasetRevisions?.at(0)?.id ?? null
     );
 
     return (

--- a/application/ui/src/features/models/train-model/train-model.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.tsx
@@ -8,7 +8,10 @@ import { Button, DialogTrigger, Loading, View } from '@geti/ui';
 import { TrainModelDialog } from './train-model-dialog.component';
 import { TrainModelProvider } from './train-model-provider.component';
 
-export const TrainModel = () => {
+type TrainModelProps = {
+    preSelectedDatasetRevisionId?: string;
+};
+export const TrainModel = ({ preSelectedDatasetRevisionId }: TrainModelProps) => {
     return (
         <DialogTrigger>
             <Button>Train model</Button>
@@ -20,7 +23,7 @@ export const TrainModel = () => {
                         </View>
                     }
                 >
-                    <TrainModelProvider>
+                    <TrainModelProvider preSelectedDatasetRevisionId={preSelectedDatasetRevisionId}>
                         <TrainModelDialog onClose={close} />
                     </TrainModelProvider>
                 </Suspense>

--- a/application/ui/tests/models/models-page.ts
+++ b/application/ui/tests/models/models-page.ts
@@ -92,4 +92,23 @@ export class ModelsPage {
 
         return names;
     }
+
+    async openDatasetMenu() {
+        await this.page.getByLabel('Dataset actions').first().click();
+    }
+
+    async clickRenameDatasetAction() {
+        await this.page.getByRole('menuitem', { name: 'Rename' }).click();
+    }
+
+    async renameDatasetRevision(newName: string) {
+        const textbox = this.page.getByRole('textbox', { name: 'Dataset revision name' });
+
+        await textbox.fill(newName);
+        await textbox.press('Enter');
+    }
+
+    getDatasetHeaderByName(name: string) {
+        return this.page.getByRole('heading').filter({ hasText: name });
+    }
 }

--- a/application/ui/tests/models/models.spec.ts
+++ b/application/ui/tests/models/models.spec.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { getMockedDatasetRevision } from 'mocks/mock-dataset-revision';
 import { getMockedExtendedModel, getMockedModel } from 'mocks/mock-model';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
@@ -55,6 +56,12 @@ test.describe('Models', () => {
             }),
             http.get('/api/projects/{project_id}/models', () => {
                 return HttpResponse.json(mockedModels);
+            }),
+            http.get('/api/projects/{project_id}/dataset_revisions', () => {
+                return HttpResponse.json([
+                    getMockedDatasetRevision({ id: 'dataset-1', name: 'Dataset Revision 1' }),
+                    getMockedDatasetRevision({ id: 'dataset-2', name: 'Dataset Revision 2' }),
+                ]);
             }),
             http.get('/api/projects/{project_id}/models/{model_id}', ({ params }) => {
                 const foundModel = mockedModels.find((model) => model.id === params.model_id);
@@ -248,5 +255,29 @@ test.describe('Models', () => {
         await modelsPage.clickSetActiveAction();
 
         expect(activatedModelId).toBe('model-1');
+    });
+
+    test('can rename a dataset revision', async ({ modelsPage, network }) => {
+        network.use(
+            http.patch('/api/projects/{project_id}/dataset_revisions/{dataset_revision_id}', async ({ request }) => {
+                const body = (await request.json()) as { name: string };
+
+                return HttpResponse.json(getMockedDatasetRevision({ id: 'dataset-1', name: body.name }));
+            }),
+            http.get('/api/projects/{project_id}/dataset_revisions', () => {
+                return HttpResponse.json([
+                    getMockedDatasetRevision({ id: 'dataset-1', name: 'Renamed Dataset' }),
+                    getMockedDatasetRevision({ id: 'dataset-2', name: 'Dataset Revision 2' }),
+                ]);
+            })
+        );
+
+        await modelsPage.goto();
+
+        await modelsPage.openDatasetMenu();
+        await modelsPage.clickRenameDatasetAction();
+        await modelsPage.renameDatasetRevision('Renamed Dataset');
+
+        await expect(modelsPage.getDatasetHeaderByName('Renamed Dataset')).toBeVisible();
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Also add a new prop for TrainModelProvider to display the preSelectedDatasetRevisionId for when the user starts model training from the models screen
* Moved model/dataset actions to their own files & add tests
* ON THE NEXT PR i will address the dataset revision deletion, some things wont be visible, need to add more logic & tests.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
