### PR TITLE
chore: Disable canvas and primary toolbar in prediction mode

### DIFF
--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -4,6 +4,7 @@
 import { Suspense, useState } from 'react';
 
 import { Content, Dialog, Flex, Grid, Loading, View } from '@geti/ui';
+import { clsx } from 'clsx';
 
 import { ZoomProvider } from '../../../components/zoom/zoom.provider';
 import type { Media } from '../../../constants/shared-types';
@@ -23,6 +24,8 @@ import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { getInitialAnnotations, getInitialPredictions } from './utils';
+
+import styles from './media-preview.module.scss';
 
 type MediaPreviewProps = {
     mediaItem: Media;
@@ -51,6 +54,8 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
     const annotationsDTO = annotationsData?.annotations ?? [];
 
+    const isReadOnlyCanvas = mode === 'prediction';
+
     return (
         <AnnotationActionsProvider
             key={mediaItem.id}
@@ -75,13 +80,24 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                                 />
                             </View>
 
-                            <View gridArea={'toolbar'}>{mode === 'annotation' && <PrimaryToolbar />}</View>
+                            <div
+                                style={{ gridArea: 'toolbar' }}
+                                aria-label={'primary toolbar'}
+                                aria-disabled={isReadOnlyCanvas}
+                                className={clsx({ [styles.primaryToolbarDisabled]: isReadOnlyCanvas })}
+                            >
+                                <PrimaryToolbar />
+                            </div>
 
                             <View gridArea={'bottom'}>
                                 <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
                             </View>
 
-                            <View gridArea={'canvas'} overflow={'hidden'}>
+                            <View
+                                gridArea={'canvas'}
+                                overflow={'hidden'}
+                                UNSAFE_className={clsx({ [styles.readOnlyCanvas]: isReadOnlyCanvas })}
+                            >
                                 <AnnotatorCanvasSettings>
                                     <AnnotatorCanvas mediaItem={mediaItem} />
                                 </AnnotatorCanvasSettings>

--- a/application/ui/src/features/dataset/media-preview/media-preview.module.scss
+++ b/application/ui/src/features/dataset/media-preview/media-preview.module.scss
@@ -1,0 +1,10 @@
+.readOnlyCanvas {
+    & * {
+        pointer-events: none !important;
+    }
+}
+
+.primaryToolbarDisabled {
+    opacity: 0.6;
+    pointer-events: none;
+}

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -229,7 +229,7 @@ test.describe('Annotator', () => {
             await expect(annotatorPage.getAnnotationMode('Prediction')).toHaveAttribute('aria-pressed', 'true');
             await expect(annotatorPage.getAnnotationMode('Annotation')).toHaveAttribute('aria-pressed', 'false');
 
-            await expect(annotatorPage.getPrimaryToolbar()).toBeHidden();
+            await expect(annotatorPage.getPrimaryToolbar()).toHaveAttribute('aria-disabled', 'true');
             await expect(page.getByLabel('Labels')).toHaveAttribute('aria-disabled', 'true');
 
             await expect(page.getByLabel(`label ${blueLabel.name} background`)).toHaveCount(predictions.length);

--- a/application/ui/tests/datasets/annotator-page.ts
+++ b/application/ui/tests/datasets/annotator-page.ts
@@ -112,6 +112,6 @@ export class AnnotatorPage {
     }
 
     getPrimaryToolbar() {
-        return this.page.getByTestId('primary-toolbar-id');
+        return this.page.getByLabel('primary toolbar');
     }
 }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Prediction mode is treated like read only mode. Only in annotation mode user is allowed to create and edit annotations.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
