### PR TITLE
Upgrade GPU drivers

### DIFF
--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -158,14 +158,14 @@ USER root
 
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends wget=1.25.0-2 \
-    && wget -q https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb \
+    && wget -q https://developer.download.nvidia.com/compute/cuda/repos/debian13/x86_64/cuda-keyring_1.1-1_all.deb \
     && dpkg -i cuda-keyring_1.1-1_all.deb \
     && rm -rf cuda-keyring_1.1-1_all.deb \
     && apt-get remove -y wget
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      nvidia-open=580.105.08-1 \
+      nvidia-open=590.48.01-1 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
### Summary

This PR upgrades the `nvidia-open` driver to 590.48 in the `geti-tune-gpu` Docker image, fetching it from the `debian13` repository. This fixes a build problem that causes the CI to fail, because the previous driver was signed with SHA-1 which is no longer accepted by apt:
> Signing key on EB693B3035CD5710E231E123A4B469963BF863CC is not bound:            No binding signature at time 2026-01-29T20:38:07Z   because: Policy rejected non-revocation signature (PositiveCertification) requiring second pre-image resistance   because: SHA1 is not considered secure since 2026-02-01T00:00:00Z

### How to test

Build the `geti-tune-gpu` image.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
