### PR TITLE
Fix user_reviewed status for newly uploaded media

### DIFF
--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -52,7 +52,7 @@ def add_media(
         dataset_service.create_dataset_item(
             project=project,
             media=media,
-            user_reviewed=True,
+            user_reviewed=False,
         )
         return MediaView.model_validate(media, from_attributes=True)
     except InvalidImageError:

--- a/application/backend/app/models/dataset_item.py
+++ b/application/backend/app/models/dataset_item.py
@@ -61,8 +61,10 @@ class DatasetItem(BaseEntity):
         id: Unique identifier for the dataset item, is equal to the corresponding media.
         project_id: Identifier of the project to which the dataset item belongs.
         annotation_data: List of annotations associated with the dataset item.
-        user_reviewed: Indicates whether the dataset item has been reviewed by a user,
-            namely if its annotation has been created/accepted by a human or if it is just a raw model prediction.
+        user_reviewed: Flag indicating whether the dataset item requires the user's attention before it can be used
+            for training. Typically, it is false for unannotated media (since they need to be annotated) and model
+            predictions (since they need to be reviewed). It is true for items with user-submitted annotations, or
+            model predictions that have been accepted (with or without modification) by a user.
         prediction_model_id: Identifier of the model that generated predictions for this dataset item, if applicable.
         subset: Subset to which the dataset item belongs (e.g., training, validation, testing).
         subset_assigned_at: Timestamp indicating when the dataset item was assigned to its subset.

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -45,9 +45,9 @@ class DatasetItemRepository:
         if annotation_status == DatasetItemAnnotationStatus.UNANNOTATED:
             stmt = stmt.where(DatasetItemDB.annotation_data.is_(None))
         elif annotation_status == DatasetItemAnnotationStatus.REVIEWED:
-            stmt = stmt.where(DatasetItemDB.annotation_data.is_not(None), DatasetItemDB.user_reviewed.is_(True))
+            stmt = stmt.where(DatasetItemDB.user_reviewed.is_(True))
         elif annotation_status == DatasetItemAnnotationStatus.TO_REVIEW:
-            stmt = stmt.where(DatasetItemDB.annotation_data.is_not(None), DatasetItemDB.user_reviewed.is_(False))
+            stmt = stmt.where(DatasetItemDB.user_reviewed.is_(False))
         return stmt
 
     @staticmethod

--- a/application/backend/app/repositories/media_repo.py
+++ b/application/backend/app/repositories/media_repo.py
@@ -38,9 +38,9 @@ class MediaRepository:
         if annotation_status == DatasetItemAnnotationStatus.UNANNOTATED:
             stmt = stmt.where(DatasetItemDB.annotation_data.is_(None))
         elif annotation_status == DatasetItemAnnotationStatus.REVIEWED:
-            stmt = stmt.where(DatasetItemDB.annotation_data.is_not(None), DatasetItemDB.user_reviewed.is_(True))
+            stmt = stmt.where(DatasetItemDB.user_reviewed.is_(True))
         elif annotation_status == DatasetItemAnnotationStatus.TO_REVIEW:
-            stmt = stmt.where(DatasetItemDB.annotation_data.is_not(None), DatasetItemDB.user_reviewed.is_(False))
+            stmt = stmt.where(DatasetItemDB.user_reviewed.is_(False))
         return stmt
 
     @staticmethod

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -875,7 +875,7 @@ class TestDatasetServiceIntegration:
             (None, 7),  # All items
             ("unannotated", 2),  # 2 unannotated items
             ("reviewed", 3),  # 3 reviewed items
-            ("to_review", 2),  # 2 to_review items
+            ("to_review", 4),  # 2 unannotated items + 2 with 'user_reviewed=False'
         ],
     )
     def test_count_dataset_items_with_annotation_status(
@@ -898,7 +898,7 @@ class TestDatasetServiceIntegration:
             (None, ["unannotated1", "unannotated2", "reviewed1", "reviewed2", "reviewed3", "to_review1", "to_review2"]),
             (DatasetItemAnnotationStatus.UNANNOTATED, ["unannotated1", "unannotated2"]),
             (DatasetItemAnnotationStatus.REVIEWED, ["reviewed1", "reviewed2", "reviewed3"]),
-            (DatasetItemAnnotationStatus.TO_REVIEW, ["to_review1", "to_review2"]),
+            (DatasetItemAnnotationStatus.TO_REVIEW, ["unannotated1", "unannotated2", "to_review1", "to_review2"]),
         ],
     )
     def test_list_dataset_items_with_annotation_status(
@@ -928,7 +928,7 @@ class TestDatasetServiceIntegration:
             (DatasetItemAnnotationStatus.UNANNOTATED, 1, 2, 0),  # Beyond available unannotated items
             (DatasetItemAnnotationStatus.REVIEWED, 2, 0, 2),  # First page of reviewed
             (DatasetItemAnnotationStatus.REVIEWED, 2, 2, 1),  # Second page of reviewed (only 1 left)
-            (DatasetItemAnnotationStatus.TO_REVIEW, 10, 0, 2),  # All to_review items
+            (DatasetItemAnnotationStatus.TO_REVIEW, 10, 0, 4),  # All items with user_reviewed=False
         ],
     )
     def test_list_dataset_items_with_annotation_status_pagination(
@@ -1005,7 +1005,7 @@ class TestDatasetServiceIntegration:
         for item in unannotated_items:
             assert item.annotation_data is None
 
-        # Reviewed items should have annotation_data and user_reviewed=True
+        # Reviewed items should have user_reviewed=True
         reviewed_items = fxt_dataset_service.list_dataset_items(
             project_id=project.id,
             filters=DatasetItemFilters(
@@ -1014,19 +1014,17 @@ class TestDatasetServiceIntegration:
         )
         assert len(reviewed_items) == 3
         for item in reviewed_items:
-            assert item.annotation_data is not None
             assert item.user_reviewed is True
 
-        # To review items should have annotation_data and user_reviewed=False
+        # To review items should have user_reviewed=False
         to_review_items = fxt_dataset_service.list_dataset_items(
             project_id=project.id,
             filters=DatasetItemFilters(
                 annotation_status=DatasetItemAnnotationStatus.TO_REVIEW,
             ),
         )
-        assert len(to_review_items) == 2
+        assert len(to_review_items) == 4
         for item in to_review_items:
-            assert item.annotation_data is not None
             assert item.user_reviewed is False
 
     def test_list_dataset_items_filter_by_single_label(

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -741,8 +741,8 @@ class TestMediaServiceIntegration:
         [
             (None, 7),  # All items
             ("unannotated", 2),  # 2 unannotated items
-            ("reviewed", 3),  # 3 reviewed items
-            ("to_review", 2),  # 2 to_review items
+            ("reviewed", 3),  # 3 items with user_reviewed=True
+            ("to_review", 4),  # 2 unannotated items + 2 items with user_reviewed=False
         ],
     )
     def test_count_media_with_annotation_status(
@@ -765,7 +765,7 @@ class TestMediaServiceIntegration:
             (None, ["unannotated1", "unannotated2", "reviewed1", "reviewed2", "reviewed3", "to_review1", "to_review2"]),
             (DatasetItemAnnotationStatus.UNANNOTATED, ["unannotated1", "unannotated2"]),
             (DatasetItemAnnotationStatus.REVIEWED, ["reviewed1", "reviewed2", "reviewed3"]),
-            (DatasetItemAnnotationStatus.TO_REVIEW, ["to_review1", "to_review2"]),
+            (DatasetItemAnnotationStatus.TO_REVIEW, ["unannotated1", "unannotated2", "to_review1", "to_review2"]),
         ],
     )
     def test_list_media_with_annotation_status(
@@ -797,7 +797,7 @@ class TestMediaServiceIntegration:
             (DatasetItemAnnotationStatus.UNANNOTATED, 1, 2, 0),  # Beyond available unannotated items
             (DatasetItemAnnotationStatus.REVIEWED, 2, 0, 2),  # First page of reviewed
             (DatasetItemAnnotationStatus.REVIEWED, 2, 2, 1),  # Second page of reviewed (only 1 left)
-            (DatasetItemAnnotationStatus.TO_REVIEW, 10, 0, 2),  # All to_review items
+            (DatasetItemAnnotationStatus.TO_REVIEW, 10, 0, 4),  # All items with user_reviewed=False
         ],
     )
     def test_list_media_with_annotation_status_pagination(
@@ -883,7 +883,7 @@ class TestMediaServiceIntegration:
                 annotation_status=DatasetItemAnnotationStatus.TO_REVIEW,
             ),
         )
-        assert len(to_review_media) == 2
+        assert len(to_review_media) == 4
 
     def test_list_media_filter_by_single_label(
         self,

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -100,7 +100,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.create_dataset_item.assert_called_once_with(
             project=fxt_get_project,
             media=fxt_media,
-            user_reviewed=True,
+            user_reviewed=False,
         )
 
     def test_list_media(self, fxt_get_project, fxt_media, fxt_media_service, fxt_client):


### PR DESCRIPTION
### Summary

Changes:
- Set `user_reviewed=False` when uploading an (unannotated) media
- Clarify the meaning of `user_reviewed` in the entity docstring
- Fix tests

### How to test

Call the media API with annotation filters

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
