### PR TITLE
Handle dataset revision deletion

### DIFF
--- a/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
@@ -19,6 +19,7 @@ const mockDataset: DatasetGroup = {
         validation: 20,
         testing: 10,
     },
+    filesDeleted: false,
 };
 
 describe('DatasetActions', () => {

--- a/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
@@ -16,13 +16,10 @@ type DatasetGroupHeaderProps = {
 };
 
 export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
+    const gridColumns = dataset.filesDeleted ? ['auto', '1fr', 'auto', 'auto'] : ['auto', '1fr', 'auto', '1fr', 'auto'];
+
     return (
-        <Grid
-            columns={['auto', '1fr', 'auto', '1fr', 'auto']}
-            alignItems={'center'}
-            marginBottom={'size-225'}
-            gap={'size-200'}
-        >
+        <Grid columns={gridColumns} alignItems={'center'} marginBottom={'size-225'} gap={'size-200'}>
             <Flex alignItems={'center'} gap={'size-50'}>
                 <Heading level={2} UNSAFE_style={{ fontSize: dimensionValue('size-300') }}>
                     {dataset.name}

--- a/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/dataset-group-header.component.tsx
@@ -47,11 +47,14 @@ export const DatasetGroupHeader = ({ dataset }: DatasetGroupHeaderProps) => {
                 </Flex>
             </Flex>
 
-            <ThreeSectionRange
-                trainingValue={dataset.trainingSubsets.training}
-                validationValue={dataset.trainingSubsets.validation}
-                testingValue={dataset.trainingSubsets.testing}
-            />
+            {!dataset.filesDeleted && (
+                <ThreeSectionRange
+                    id={`dataset-range-${dataset.id}`}
+                    trainingValue={dataset.trainingSubsets.training}
+                    validationValue={dataset.trainingSubsets.validation}
+                    testingValue={dataset.trainingSubsets.testing}
+                />
+            )}
 
             <Flex>
                 <TrainModel preSelectedDatasetRevisionId={dataset.id} />

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
@@ -71,9 +71,9 @@ export const ModelActions = ({ model }: ModelActionsProps) => {
                     <MoreMenu />
                 </ActionButton>
                 <Menu onAction={handleAction} aria-label={'Model actions menu'}>
-                    <Item key={'active'}>Set as active</Item>
-                    <Item key={'rename'}>Rename</Item>
-                    <Item key={'delete'}>Delete</Item>
+                    <Item key={MODEL_ACTIONS.ACTIVE}>Set as active</Item>
+                    <Item key={MODEL_ACTIONS.RENAME}>Rename</Item>
+                    <Item key={MODEL_ACTIONS.DELETE}>Delete</Item>
                 </Menu>
             </MenuTrigger>
 

--- a/application/ui/src/features/models/model-listing/components/three-section-range/three-section-range.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/three-section-range/three-section-range.component.tsx
@@ -6,12 +6,13 @@ import { Flex, Grid, Text, View } from '@geti/ui';
 import classes from './three-section-range.module.scss';
 
 type ThreeSectionRangeProps = {
+    id?: string;
     trainingValue: number;
     validationValue: number;
     testingValue: number;
 };
 
-export const ThreeSectionRange = ({ trainingValue, validationValue, testingValue }: ThreeSectionRangeProps) => {
+export const ThreeSectionRange = ({ id, trainingValue, validationValue, testingValue }: ThreeSectionRangeProps) => {
     const gridColumns = [
         trainingValue > 0 ? `${trainingValue}fr` : '1fr',
         validationValue > 0 ? `${validationValue}fr` : '1fr',
@@ -19,7 +20,7 @@ export const ThreeSectionRange = ({ trainingValue, validationValue, testingValue
     ];
 
     return (
-        <Flex alignItems={'center'} width={'100%'}>
+        <Flex alignItems={'center'} width={'100%'} data-testid={id}>
             <Text UNSAFE_className={classes.label}>TRAINING SUBSETS</Text>
 
             <Grid

--- a/application/ui/src/features/models/model-listing/model-details/model-details-tabs.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-details/model-details-tabs.component.tsx
@@ -3,6 +3,7 @@
 
 import { Flex, Item, Loading, TabList, TabPanels, Tabs, Text } from '@geti/ui';
 
+import { useGetDatasetRevisions } from '../../../../hooks/use-get-dataset-revisions.hook';
 import { useGetModel } from '../../hooks/api/use-get-model.hook';
 import { ModelMetrics } from '../model-metrics/model-metrics.component';
 import { ModelTrainingDatasets } from '../model-training-datasets/model-training-datasets.component';
@@ -15,6 +16,7 @@ interface ModelDetailsTabsProps {
 
 export const ModelDetailsTabs = ({ modelId }: ModelDetailsTabsProps) => {
     const { isPending, isError, data: model } = useGetModel(modelId);
+    const { data: datasetRevisions = [] } = useGetDatasetRevisions();
 
     if (isPending) {
         return (
@@ -31,6 +33,11 @@ export const ModelDetailsTabs = ({ modelId }: ModelDetailsTabsProps) => {
             </Flex>
         );
     }
+
+    const currentDatasetRevisionId = model.training_info.dataset_revision_id;
+    const currentDatasetRevision = datasetRevisions.find(
+        (datasetRevision) => datasetRevision.id === currentDatasetRevisionId
+    );
 
     return (
         <Tabs
@@ -67,7 +74,7 @@ export const ModelDetailsTabs = ({ modelId }: ModelDetailsTabsProps) => {
                     <ModelTrainingParameters />
                 </Item>
                 <Item key='datasets'>
-                    <ModelTrainingDatasets datasetRevisionId={model.training_info.dataset_revision_id} />
+                    <ModelTrainingDatasets datasetRevision={currentDatasetRevision} />
                 </Item>
             </TabPanels>
         </Tabs>

--- a/application/ui/src/features/models/model-listing/model-details/model-details-tabs.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-details/model-details-tabs.component.tsx
@@ -35,6 +35,9 @@ export const ModelDetailsTabs = ({ modelId }: ModelDetailsTabsProps) => {
     }
 
     const currentDatasetRevisionId = model.training_info.dataset_revision_id;
+
+    // Note: currentDatasetRevision might be 'undefined' if the dataset revision was deleted after the model
+    // was trained.
     const currentDatasetRevision = datasetRevisions.find(
         (datasetRevision) => datasetRevision.id === currentDatasetRevisionId
     );

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -82,7 +82,7 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
 };
 
 const ModelTrainingContent = ({ datasetRevision }: { datasetRevision: DatasetRevision }) => {
-    const totalItems = datasetRevision.item_counts.total ?? 0;
+    const totalItems = datasetRevision.item_counts?.total ?? 0;
     const datasetRevisionId = String(datasetRevision.id);
 
     return (

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -5,11 +5,11 @@ import { ActionButton, Content, Flex, Heading, Text } from '@geti/ui';
 import { Filter, GridSmall, Search, SortUpDown } from '@geti/ui/icons';
 import { useNumberFormatter } from 'react-aria';
 
-import type { DatasetSubset } from '../../../../constants/shared-types';
+import type { DatasetRevision, DatasetSubset } from '../../../../constants/shared-types';
 import { useGetDatasetRevisionItems } from '../../../../hooks/use-get-dataset-revision-items.hook';
 import { SubsetGallery } from './subset-gallery.component';
 
-import styles from './model-training-datasets.module.scss';
+import classes from './model-training-datasets.module.scss';
 
 type SubsetBoxProps = {
     title: string;
@@ -57,7 +57,7 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
             minHeight={'size-5000'}
             justifyContent={'center'}
         >
-            <Flex UNSAFE_className={styles.boxHeading} justifyContent={'space-between'} alignItems={'center'}>
+            <Flex UNSAFE_className={classes.boxHeading} justifyContent={'space-between'} alignItems={'center'}>
                 <Flex gap={'size-100'} alignItems={'center'}>
                     <Heading level={5}>
                         {title} {formatter.format(subsetPercentage)}
@@ -67,7 +67,7 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
                 <BoxActions />
             </Flex>
 
-            <Content UNSAFE_className={styles.boxContent}>
+            <Content UNSAFE_className={classes.boxContent}>
                 <SubsetGallery
                     items={items}
                     datasetRevisionId={datasetRevisionId}
@@ -81,25 +81,9 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
     );
 };
 
-export const ModelTrainingDatasets = ({ datasetRevisionId }: { datasetRevisionId: string | undefined | null }) => {
-    const { totalCount: trainingCount } = useGetDatasetRevisionItems({
-        datasetRevisionId: datasetRevisionId ?? '',
-        subset: 'training',
-    });
-    const { totalCount: validationCount } = useGetDatasetRevisionItems({
-        datasetRevisionId: datasetRevisionId ?? '',
-        subset: 'validation',
-    });
-    const { totalCount: testingCount } = useGetDatasetRevisionItems({
-        datasetRevisionId: datasetRevisionId ?? '',
-        subset: 'testing',
-    });
-
-    const totalItems = trainingCount + validationCount + testingCount;
-
-    if (!datasetRevisionId) {
-        return <Text>No dataset revision found for this model</Text>;
-    }
+const ModelTrainingContent = ({ datasetRevision }: { datasetRevision: DatasetRevision }) => {
+    const totalItems = datasetRevision.item_counts.total ?? 0;
+    const datasetRevisionId = String(datasetRevision.id);
 
     return (
         <Flex gap={'size-300'} width={'100%'}>
@@ -123,4 +107,24 @@ export const ModelTrainingDatasets = ({ datasetRevisionId }: { datasetRevisionId
             />
         </Flex>
     );
+};
+
+export const ModelTrainingDatasets = ({ datasetRevision }: { datasetRevision?: DatasetRevision }) => {
+    if (!datasetRevision || !datasetRevision.id) {
+        return (
+            <Flex justifyContent={'center'} alignItems={'center'} height={'size-3000'}>
+                <Text>No dataset revision found for this model</Text>
+            </Flex>
+        );
+    }
+
+    if (datasetRevision.files_deleted) {
+        return (
+            <Flex justifyContent={'center'} alignItems={'center'} height={'size-3000'}>
+                <Text>The files for this dataset revision have been deleted.</Text>
+            </Flex>
+        );
+    }
+
+    return <ModelTrainingContent datasetRevision={datasetRevision} />;
 };

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.module.scss
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.module.scss
@@ -13,3 +13,8 @@
     justify-content: center;
     display: flex;
 }
+
+.emptyContainer {
+    color: var(--spectrum-global-color-gray-700);
+    font-size: var(--spectrum-global-dimension-font-size-200);
+}

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.module.scss
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.module.scss
@@ -13,8 +13,3 @@
     justify-content: center;
     display: flex;
 }
-
-.emptyContainer {
-    color: var(--spectrum-global-color-gray-700);
-    font-size: var(--spectrum-global-dimension-font-size-200);
-}

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-tabs.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-tabs.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Item, TabList, TabPanels, Tabs } from '@geti/ui';
+import { Flex, Item, TabList, TabPanels, Tabs, Text } from '@geti/ui';
 
 import { ReactComponent as ONNX } from '../../../../assets/icons/onnx-logo.svg';
 import { ReactComponent as OpenVINO } from '../../../../assets/icons/openvino-logo.svg';
@@ -16,6 +16,14 @@ type ModelVariantsTabsProps = {
 };
 
 export const ModelVariantsTabs = ({ model }: ModelVariantsTabsProps) => {
+    if (!model.variants || model.variants.length === 0) {
+        return (
+            <Flex justifyContent={'center'} alignItems={'center'} height={'size-3000'}>
+                <Text>There are no model variants available.</Text>
+            </Flex>
+        );
+    }
+
     return (
         <Tabs aria-label='Model variants' UNSAFE_className={classes.tabs}>
             <TabList>

--- a/application/ui/src/features/models/model-listing/types.ts
+++ b/application/ui/src/features/models/model-listing/types.ts
@@ -18,6 +18,7 @@ export type DatasetGroup = {
         validation: number;
         testing: number;
     };
+    filesDeleted: boolean;
 };
 
 export type ArchitectureGroup = {

--- a/application/ui/src/features/models/model-listing/utils/grouping.ts
+++ b/application/ui/src/features/models/model-listing/utils/grouping.ts
@@ -52,6 +52,7 @@ export const groupModelsByDataset = (models: Model[], options?: GroupModelsByDat
                         validation: datasetRevision?.item_counts?.validation ?? 0,
                         testing: datasetRevision?.item_counts?.testing ?? 0,
                     },
+                    filesDeleted: datasetRevision?.files_deleted ?? false,
                 },
                 models: [],
             };

--- a/application/ui/tests/models/models-page.ts
+++ b/application/ui/tests/models/models-page.ts
@@ -101,6 +101,10 @@ export class ModelsPage {
         await this.page.getByRole('menuitem', { name: 'Rename' }).click();
     }
 
+    async clickDeleteDatasetAction() {
+        await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+    }
+
     async renameDatasetRevision(newName: string) {
         const textbox = this.page.getByRole('textbox', { name: 'Dataset revision name' });
 
@@ -110,5 +114,13 @@ export class ModelsPage {
 
     getDatasetHeaderByName(name: string) {
         return this.page.getByRole('heading').filter({ hasText: name });
+    }
+
+    getThreeSectionRange(datasetId: string) {
+        return this.page.getByTestId(`dataset-range-${datasetId}`);
+    }
+
+    async clickTrainingDatasetsTab() {
+        await this.page.getByRole('tab', { name: 'Training datasets' }).click();
     }
 }

--- a/application/ui/tests/models/models.spec.ts
+++ b/application/ui/tests/models/models.spec.ts
@@ -280,4 +280,38 @@ test.describe('Models', () => {
 
         await expect(modelsPage.getDatasetHeaderByName('Renamed Dataset')).toBeVisible();
     });
+
+    test('handles dataset revision deletion correctly', async ({ modelsPage, network, page }) => {
+        await modelsPage.goto();
+
+        await expect(modelsPage.getThreeSectionRange('dataset-1')).toBeVisible();
+        await expect(modelsPage.getThreeSectionRange('dataset-2')).toBeVisible();
+
+        network.use(
+            http.delete('/api/projects/{project_id}/dataset_revisions/{dataset_revision_id}', () => {
+                return HttpResponse.json(null, { status: 204 });
+            }),
+            http.get('/api/projects/{project_id}/dataset_revisions', () => {
+                return HttpResponse.json([
+                    getMockedDatasetRevision({ id: 'dataset-1', name: 'Dataset Revision 1', files_deleted: true }),
+                    getMockedDatasetRevision({ id: 'dataset-2', name: 'Dataset Revision 2' }),
+                ]);
+            })
+        );
+
+        await modelsPage.openDatasetMenu();
+        await modelsPage.clickDeleteDatasetAction();
+        await modelsPage.confirmDelete();
+
+        await expect(modelsPage.getThreeSectionRange('dataset-1')).toBeHidden();
+        await expect(modelsPage.getThreeSectionRange('dataset-2')).toBeVisible();
+
+        await modelsPage.expandModel('YOLOX Model v1');
+        await modelsPage.clickTrainingDatasetsTab();
+
+        await expect(page.getByText('The files for this dataset revision have been deleted.')).toBeVisible();
+        await expect(page.getByRole('heading', { name: /Training/ })).toBeHidden();
+        await expect(page.getByRole('heading', { name: /Validation/ })).toBeHidden();
+        await expect(page.getByRole('heading', { name: /Testing/ })).toBeHidden();
+    });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Address comments from previous PRs
* Hide certain UIs once the dataset revision is deleted
* Add/update tests
* Reduce number of api calls on subsets

<img width="1427" height="660" alt="Screenshot 2026-02-02 at 15 15 05" src="https://github.com/user-attachments/assets/94495682-c62c-4c3f-b895-290dcc117d75" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
