### PR TITLE
feat: Delete annotation using backspace

### DIFF
--- a/application/ui/src/features/annotator/annotations/selectable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/selectable-annotation.component.tsx
@@ -63,7 +63,7 @@ export const SelectableAnnotation = ({ children }: { children: ReactNode }) => {
         deleteAnnotations(annotationsToDelete);
     };
 
-    useHotkeys([HOTKEYS.deleteAnnotation, HOTKEYS.deleteAnnotationWithBackspace], () => {
+    useHotkeys([HOTKEYS.deleteAnnotation, HOTKEYS.deleteAnnotationAlternative], () => {
         // Focus the parent SVG container to keep focus within the annotation area
         const parentSvg = elementRef.current?.closest('svg');
         if (parentSvg) {

--- a/application/ui/src/features/annotator/annotations/selectable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/selectable-annotation.component.tsx
@@ -63,7 +63,7 @@ export const SelectableAnnotation = ({ children }: { children: ReactNode }) => {
         deleteAnnotations(annotationsToDelete);
     };
 
-    useHotkeys(HOTKEYS.deleteAnnotation, () => {
+    useHotkeys([HOTKEYS.deleteAnnotation, HOTKEYS.deleteAnnotationWithBackspace], () => {
         // Focus the parent SVG container to keep focus within the annotation area
         const parentSvg = elementRef.current?.closest('svg');
         if (parentSvg) {

--- a/application/ui/src/shared/hotkeys-definition.ts
+++ b/application/ui/src/shared/hotkeys-definition.ts
@@ -14,7 +14,7 @@ export const HOTKEYS = {
     redo: `${CTRL_OR_COMMAND_KEY}+y`,
     toggleAnnotationsVisibility: 'a',
     deleteAnnotation: 'delete',
-    deleteAnnotationWithBackspace: 'backspace',
+    deleteAnnotationAlternative: 'backspace',
     fitToScreen: 'r',
     selectionTool: 'v',
     boundingBoxTool: 'b',

--- a/application/ui/src/shared/hotkeys-definition.ts
+++ b/application/ui/src/shared/hotkeys-definition.ts
@@ -14,6 +14,7 @@ export const HOTKEYS = {
     redo: `${CTRL_OR_COMMAND_KEY}+y`,
     toggleAnnotationsVisibility: 'a',
     deleteAnnotation: 'delete',
+    deleteAnnotationWithBackspace: 'backspace',
     fitToScreen: 'r',
     selectionTool: 'v',
     boundingBoxTool: 'b',


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Using macbook without external keyboard I noticed that it was impossible to delete the annotation so this PR adds `backspace` as alternative to delete the annotation.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
