### PR TITLE
chore: update stale annotations

### DIFF
--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -73,7 +73,18 @@ export const AnnotationActionsProvider = ({
     const projectId = useProjectIdentifier();
     const saveMutation = $api.useMutation(
         'post',
-        '/api/projects/{project_id}/dataset/items/{dataset_item_id}/annotations'
+        '/api/projects/{project_id}/dataset/items/{dataset_item_id}/annotations',
+        {
+            meta: {
+                invalidateQueries: [
+                    [
+                        'get',
+                        '/api/projects/{project_id}/dataset/items/{dataset_item_id}/annotations',
+                        { params: { path: { project_id: projectId, dataset_item_id: mediaItem.id } } },
+                    ],
+                ],
+            },
+        }
     );
 
     const { data: project } = useProject();


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Update the media item annotation cache so that when a user returns to the item after submitting, the latest annotations are visible.

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
