### PR TITLE
feat: Add 'Use current revision' for the modal training

### DIFF
--- a/application/ui/src/features/models/hooks/api/use-train-model-mutation.ts
+++ b/application/ui/src/features/models/hooks/api/use-train-model-mutation.ts
@@ -14,6 +14,7 @@ export const useTrainModelMutation = () => {
         {
             device,
             modelArchitectureId,
+            datasetRevisionId,
         }: {
             device: DeviceType;
             modelArchitectureId: string;
@@ -29,8 +30,7 @@ export const useTrainModelMutation = () => {
                     parameters: {
                         device,
                         model_architecture_id: modelArchitectureId,
-                        // TODO: uncomment once supported by backend
-                        // dataset_revision_id: datasetRevisionId,
+                        dataset_revision_id: datasetRevisionId,
                     },
                 },
             },

--- a/application/ui/src/features/models/train-model/select-dataset-revision.component.tsx
+++ b/application/ui/src/features/models/train-model/select-dataset-revision.component.tsx
@@ -6,15 +6,15 @@ import { Item, Picker } from '@geti/ui';
 import { useTrainModel } from './train-model-provider.component';
 
 export const SelectDatasetRevision = () => {
-    const { datasetRevisions, selectedDatasetRevision, onSelectDatasetRevision } = useTrainModel();
+    const { datasetRevisions, selectedDatasetRevisionId, onSelectDatasetRevisionId } = useTrainModel();
 
     return (
         <Picker
             flex={1}
             items={datasetRevisions}
             label={'Select dataset revision'}
-            selectedKey={selectedDatasetRevision}
-            onSelectionChange={(key) => onSelectDatasetRevision(String(key))}
+            selectedKey={selectedDatasetRevisionId}
+            onSelectionChange={(key) => onSelectDatasetRevisionId(String(key))}
         >
             {(item) => <Item key={item.id}>{item.name}</Item>}
         </Picker>

--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -14,7 +14,8 @@ type TrainModelDialogProps = {
 };
 
 export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
-    const { selectedTrainingDevice, selectedModelArchitectureId, selectedDatasetRevision } = useTrainModel();
+    const { selectedTrainingDevice, selectedModelArchitectureId, selectedDatasetRevisionId, datasetRevisions } =
+        useTrainModel();
     const trainModelMutation = useTrainModelMutation();
     const projectId = useProjectIdentifier();
 
@@ -23,10 +24,12 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
     const trainModel = () => {
         if (isStartButtonDisabled) return;
 
+        const datasetRevisionId = datasetRevisions.find((revision) => revision.id === selectedDatasetRevisionId)?.value;
+
         trainModelMutation.mutate(
             {
+                datasetRevisionId: datasetRevisionId === undefined ? null : datasetRevisionId,
                 device: selectedTrainingDevice,
-                datasetRevisionId: selectedDatasetRevision ?? null,
                 modelArchitectureId: selectedModelArchitectureId,
             },
             () => {

--- a/application/ui/src/features/models/train-model/train-model-provider.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-provider.component.tsx
@@ -16,6 +16,8 @@ import { useGetActiveModelArchitectureId } from '../hooks/api/use-get-active-mod
 import { useGetTaskModelArchitectures } from '../hooks/api/use-get-model-architectures.hook';
 import { useGetTrainingDevices } from '../hooks/api/use-get-training-devices';
 
+type DatasetRevisionWithValue = Pick<DatasetRevision, 'id' | 'name'> & { value: string | null };
+
 type TrainModelContextProps = {
     modelArchitectures: ModelArchitectureWithPerformanceCategory[];
 
@@ -28,9 +30,9 @@ type TrainModelContextProps = {
     selectedTrainingDevice: DeviceType | null;
     onSelectTrainingDevice: (deviceType: DeviceType | null) => void;
 
-    datasetRevisions: DatasetRevision[];
-    selectedDatasetRevision: string | null;
-    onSelectDatasetRevision: (datasetRevision: string | null) => void;
+    datasetRevisions: DatasetRevisionWithValue[];
+    selectedDatasetRevisionId: string | null;
+    onSelectDatasetRevisionId: (datasetRevision: string | null) => void;
 };
 
 const TrainModelContext = createContext<TrainModelContextProps | null>(null);
@@ -66,10 +68,20 @@ const getModelArchitectures = (
     });
 };
 
+const useDatasetRevisions = () => {
+    const { data: datasetRevisions } = useGetDatasetRevisions();
+    return {
+        datasetRevisions: [
+            { id: 'use-current-dataset-revision', name: 'Use current revision', value: null },
+            ...(datasetRevisions?.map(({ id, name }) => ({ id, name, value: String(id) })) ?? []),
+        ],
+    };
+};
+
 export const TrainModelProvider = ({ children, preSelectedDatasetRevisionId }: TrainModelProviderProps) => {
     const { data } = useGetTaskModelArchitectures();
     const { data: trainingDevices } = useGetTrainingDevices();
-    const { data: datasetRevisions } = useGetDatasetRevisions();
+    const { datasetRevisions } = useDatasetRevisions();
     const activeModelArchitectureId = useGetActiveModelArchitectureId();
 
     const modelArchitectures: ModelArchitectureWithPerformanceCategory[] = getModelArchitectures(
@@ -88,7 +100,7 @@ export const TrainModelProvider = ({ children, preSelectedDatasetRevisionId }: T
     const [selectedTrainingDevice, setSelectedTrainingDevice] = useState<DeviceType | null>(
         trainingDevices?.at(0)?.type ?? null
     );
-    const [selectedDatasetRevision, setSelectedDatasetRevision] = useState<string | null>(
+    const [selectedDatasetRevisionId, setSelectedDatasetRevisionId] = useState<string | null>(
         preSelectedDatasetRevisionId ?? datasetRevisions?.at(0)?.id ?? null
     );
 
@@ -106,9 +118,9 @@ export const TrainModelProvider = ({ children, preSelectedDatasetRevisionId }: T
                 selectedTrainingDevice,
                 onSelectTrainingDevice: setSelectedTrainingDevice,
 
-                datasetRevisions: datasetRevisions ?? [],
-                selectedDatasetRevision,
-                onSelectDatasetRevision: setSelectedDatasetRevision,
+                datasetRevisions,
+                selectedDatasetRevisionId,
+                onSelectDatasetRevisionId: setSelectedDatasetRevisionId,
             }}
         >
             {children}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

<img width="949" height="697" alt="image" src="https://github.com/user-attachments/assets/08ac227b-ef2d-4ab1-a756-d540d45bd875" />

Close #5406 
### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
