### PR TITLE
Fix annotation validation to properly handle the empty label case

### DIFF
--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -94,7 +94,7 @@ class DatasetService(BaseSessionManagedService):
         if annotations is not None:
             labels = self._label_service.list_all(project_id=project.id)
             DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
-            DatasetService._validate_annotations(annotations=annotations, project=project)
+            DatasetService._validate_annotations(annotations=annotations, task=project.task)
             DatasetService._validate_annotations_coordinates(annotations=annotations, media=media)
 
             dataset_item.annotation_data = [annotation.model_dump(mode="json") for annotation in annotations]
@@ -191,15 +191,20 @@ class DatasetService(BaseSessionManagedService):
                     raise AnnotationValidationError(f"Label {str(annotation_label.id)} is not found in the project.")
 
     @staticmethod
-    def _validate_annotations(annotations: list[DatasetItemAnnotation], project: Project) -> None:  # noqa: C901
-        match project.task.task_type:
+    def _validate_annotations(annotations: list[DatasetItemAnnotation], task: Task) -> None:  # noqa: C901, PLR0912
+        match task.task_type:
             case TaskType.CLASSIFICATION:
+                if len(annotations) == 0:
+                    if task.exclusive_labels:  # multiclass classification -> empty label not allowed
+                        raise AnnotationValidationError("Multiclass classification project requires one annotation.")
+                    # multilabel classification  -> empty label allowed
+                    return
                 if len(annotations) > 1:
                     raise AnnotationValidationError("Classification project doesn't allow more than one annotation.")
                 annotation = annotations[0]
                 if not isinstance(annotation.shape, FullImage):
                     raise AnnotationValidationError("Classification project supports only full_image shapes.")
-                if project.task.exclusive_labels and len(annotation.labels) > 1:
+                if task.exclusive_labels and len(annotation.labels) > 1:
                     raise AnnotationValidationError(
                         "Multiclass classification project doesn't allow more than one label per annotation."
                     )
@@ -252,7 +257,7 @@ class DatasetService(BaseSessionManagedService):
         """
         labels = self._label_service.list_all(project_id=project.id)
         DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
-        DatasetService._validate_annotations(annotations=annotations, project=project)
+        DatasetService._validate_annotations(annotations=annotations, task=project.task)
 
         repo = DatasetItemRepository(project_id=str(project.id), db=self.db_session)
         self.get_dataset_item_by_id(project_id=project.id, dataset_item_id=dataset_item_id)

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -197,7 +197,7 @@ class DatasetService(BaseSessionManagedService):
                 if len(annotations) == 0:
                     if task.exclusive_labels:  # multiclass classification -> empty label not allowed
                         raise AnnotationValidationError("Multiclass classification project requires one annotation.")
-                    # multilabel classification  -> empty label allowed
+                    # multilabel classification -> empty label allowed
                     return
                 if len(annotations) > 1:
                     raise AnnotationValidationError("Classification project doesn't allow more than one annotation.")

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -166,9 +166,11 @@ class TestDatasetServiceUnit:
                 shape=FullImage(type="full_image"),
             )
         ]
+        # Should not raise any exception since multilabel classification allows multiple labels
         DatasetService._validate_annotations(annotations=annotations, task=fxt_multilabel_classification_project.task)
 
     def test_validate_annotations_multilabel_classification_empty(self, fxt_multilabel_classification_project) -> None:
+        # Should not raise any exception since multilabel classification allows the empty label
         DatasetService._validate_annotations(annotations=[], task=fxt_multilabel_classification_project.task)
 
     def test_validate_annotations_multilabel_classification_multi_annotations(
@@ -184,6 +186,8 @@ class TestDatasetServiceUnit:
                 shape=FullImage(type="full_image"),
             ),
         ]
+        # Should raise an exception since multilabel classification does not allow multiple annotations
+        # (only one 'full_image' shape, possibly with multiple labels, is allowed)
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(
                 annotations=annotations, task=fxt_multilabel_classification_project.task
@@ -205,6 +209,7 @@ class TestDatasetServiceUnit:
                 shape=shape,
             )
         ]
+        # Should raise an exception since classification only allows 'full_image' shape
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(
                 annotations=annotations, task=fxt_multilabel_classification_project.task
@@ -217,9 +222,11 @@ class TestDatasetServiceUnit:
                 shape=FullImage(type="full_image"),
             )
         ]
+        # Should not raise any exception since the annotation is valid for multiclass classification
         DatasetService._validate_annotations(annotations=annotations, task=fxt_multiclass_classification_project.task)
 
     def test_validate_annotations_multiclass_classification_empty(self, fxt_multiclass_classification_project) -> None:
+        # Should raise an exception since multiclass classification requires exactly one label (empty label not allowed)
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(annotations=[], task=fxt_multiclass_classification_project.task)
 
@@ -232,6 +239,7 @@ class TestDatasetServiceUnit:
                 shape=FullImage(type="full_image"),
             )
         ]
+        # Should raise an exception since multiclass classification does not allow multiple labels
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(
                 annotations=annotations, task=fxt_multiclass_classification_project.task
@@ -248,9 +256,11 @@ class TestDatasetServiceUnit:
                 shape=Rectangle(type="rectangle", x=10, y=10, width=10, height=10),
             ),
         ]
+        # Should not raise any exception since the annotations are valid for detection task
         DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
 
     def test_validate_annotations_detection_empty(self, fxt_detection_project) -> None:
+        # Should not raise any exception since detection task allows the empty label
         DatasetService._validate_annotations(annotations=[], task=fxt_detection_project.task)
 
     @pytest.mark.parametrize(
@@ -271,6 +281,7 @@ class TestDatasetServiceUnit:
                 shape=shape,
             ),
         ]
+        # Should raise an exception since detection task only allows 'rectangle' shape
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
 
@@ -285,6 +296,7 @@ class TestDatasetServiceUnit:
                 shape=Rectangle(type="rectangle", x=10, y=10, width=10, height=10),
             ),
         ]
+        # Should raise an exception since detection task does not allow multiple labels on the same shape
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
 
@@ -299,9 +311,11 @@ class TestDatasetServiceUnit:
                 shape=Polygon(type="polygon", points=[Point(x=10, y=10), Point(x=20, y=20)]),
             ),
         ]
+        # Should not raise any exception since the annotations are valid for segmentation task
         DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
 
     def test_validate_annotations_segmentation_empty(self, fxt_segmentation_project) -> None:
+        # Should not raise any exception since segmentation task allows the empty label
         DatasetService._validate_annotations(annotations=[], task=fxt_segmentation_project.task)
 
     @pytest.mark.parametrize(
@@ -322,6 +336,7 @@ class TestDatasetServiceUnit:
                 shape=shape,
             ),
         ]
+        # Should raise an exception since segmentation task only allows 'polygon' shape
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
 
@@ -336,6 +351,7 @@ class TestDatasetServiceUnit:
                 shape=Polygon(type="polygon", points=[Point(x=10, y=10), Point(x=20, y=20)]),
             ),
         ]
+        # Should raise an exception since segmentation task does not allow multiple labels on the same shape
         with pytest.raises(AnnotationValidationError):
             DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
 

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -166,7 +166,10 @@ class TestDatasetServiceUnit:
                 shape=FullImage(type="full_image"),
             )
         ]
-        DatasetService._validate_annotations(annotations=annotations, project=fxt_multilabel_classification_project)
+        DatasetService._validate_annotations(annotations=annotations, task=fxt_multilabel_classification_project.task)
+
+    def test_validate_annotations_multilabel_classification_empty(self, fxt_multilabel_classification_project) -> None:
+        DatasetService._validate_annotations(annotations=[], task=fxt_multilabel_classification_project.task)
 
     def test_validate_annotations_multilabel_classification_multi_annotations(
         self, fxt_multilabel_classification_project
@@ -182,7 +185,9 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_multilabel_classification_project)
+            DatasetService._validate_annotations(
+                annotations=annotations, task=fxt_multilabel_classification_project.task
+            )
 
     @pytest.mark.parametrize(
         "shape",
@@ -201,7 +206,22 @@ class TestDatasetServiceUnit:
             )
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_multilabel_classification_project)
+            DatasetService._validate_annotations(
+                annotations=annotations, task=fxt_multilabel_classification_project.task
+            )
+
+    def test_validate_annotations_multiclass_classification(self, fxt_multiclass_classification_project) -> None:
+        annotations = [
+            DatasetItemAnnotation(
+                labels=[LabelReference(id=uuid4())],
+                shape=FullImage(type="full_image"),
+            )
+        ]
+        DatasetService._validate_annotations(annotations=annotations, task=fxt_multiclass_classification_project.task)
+
+    def test_validate_annotations_multiclass_classification_empty(self, fxt_multiclass_classification_project) -> None:
+        with pytest.raises(AnnotationValidationError):
+            DatasetService._validate_annotations(annotations=[], task=fxt_multiclass_classification_project.task)
 
     def test_validate_annotations_multiclass_classification_multiple_labels(
         self, fxt_multiclass_classification_project
@@ -213,7 +233,9 @@ class TestDatasetServiceUnit:
             )
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_multiclass_classification_project)
+            DatasetService._validate_annotations(
+                annotations=annotations, task=fxt_multiclass_classification_project.task
+            )
 
     def test_validate_annotations_detection(self, fxt_detection_project) -> None:
         annotations = [
@@ -226,7 +248,10 @@ class TestDatasetServiceUnit:
                 shape=Rectangle(type="rectangle", x=10, y=10, width=10, height=10),
             ),
         ]
-        DatasetService._validate_annotations(annotations=annotations, project=fxt_detection_project)
+        DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
+
+    def test_validate_annotations_detection_empty(self, fxt_detection_project) -> None:
+        DatasetService._validate_annotations(annotations=[], task=fxt_detection_project.task)
 
     @pytest.mark.parametrize(
         "shape",
@@ -247,7 +272,7 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_detection_project)
+            DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
 
     def test_validate_annotations_detection_wrong_shape_multiple_labels(self, fxt_detection_project) -> None:
         annotations = [
@@ -261,7 +286,7 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_detection_project)
+            DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
 
     def test_validate_annotations_segmentation(self, fxt_segmentation_project) -> None:
         annotations = [
@@ -274,7 +299,10 @@ class TestDatasetServiceUnit:
                 shape=Polygon(type="polygon", points=[Point(x=10, y=10), Point(x=20, y=20)]),
             ),
         ]
-        DatasetService._validate_annotations(annotations=annotations, project=fxt_segmentation_project)
+        DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
+
+    def test_validate_annotations_segmentation_empty(self, fxt_segmentation_project) -> None:
+        DatasetService._validate_annotations(annotations=[], task=fxt_segmentation_project.task)
 
     @pytest.mark.parametrize(
         "shape",
@@ -295,7 +323,7 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_segmentation_project)
+            DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
 
     def test_validate_annotations_segmentation_wrong_shape_multiple_labels(self, fxt_segmentation_project) -> None:
         annotations = [
@@ -309,7 +337,7 @@ class TestDatasetServiceUnit:
             ),
         ]
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, project=fxt_segmentation_project)
+            DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
 
     def test_set_dataset_item_annotations(self, fxt_dataset_service, fxt_detection_project) -> None:
         dataset_service = fxt_dataset_service


### PR DESCRIPTION
### Summary

The following tasks should allow the empty label (represented as `annotations: []`):
- multilabel classification
- detection
- instance segmentation

Whereas the following don't:
- multiclass classification

### How to test

Create a project of each task, upload an image and submit an annotation with the empty label.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
