### PR TITLE
feat: Disable training model button

### DIFF
--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -8,6 +8,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { $api } from '../../../../api/client';
 import { AddMediaButton } from '../../../../components/add-media-button/add-media-button.component';
 import type { Media } from '../../../../constants/shared-types';
+import { getQueryKey } from '../../../../query-client/query-client';
 import { TrainModel } from '../../../models/train-model/train-model.component';
 import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-item.component';
 import { useSelectedData } from '../../selected-data-provider.component';
@@ -75,7 +76,17 @@ export const Toolbar = ({ items }: ToolbarProps) => {
         const failed = promises.filter((result) => result.status === 'rejected').length;
 
         await queryClient.invalidateQueries({
-            queryKey: ['get', '/api/projects/{project_id}/dataset/media'],
+            queryKey: getQueryKey([
+                'get',
+                '/api/projects/{project_id}/dataset/media',
+                {
+                    params: {
+                        path: {
+                            project_id: projectId,
+                        },
+                    },
+                },
+            ]),
         });
 
         if (failed === 0) {

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -5,10 +5,10 @@ import { Suspense, useState } from 'react';
 
 import { Content, Dialog, Flex, Grid, Loading, View } from '@geti/ui';
 import { clsx } from 'clsx';
+import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
 import { ZoomProvider } from '../../../components/zoom/zoom.provider';
 import type { Media } from '../../../constants/shared-types';
-import { useGetDatasetItems } from '../../../hooks/use-get-dataset-items.hook';
 import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-actions-provider.component';
 import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
 import { AnnotatorProvider } from '../../../shared/annotator/annotator-provider.component';
@@ -111,7 +111,7 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
 };
 
 export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPreviewProps) => {
-    const { items, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetDatasetItems();
+    const { items, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetDatasetMediaItems();
 
     return (
         <Dialog

--- a/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
@@ -24,7 +24,7 @@ const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 
 export const useIsTrainingButtonDisabled = () => {
     const { data: datasetItems } = useGetDatasetItems();
-    const count = datasetItems?.items.length ?? 0;
+    const count = datasetItems?.pagination.total ?? 0;
 
     return count < MIN_NUMBER_OF_ANNOTATED_ITEMS;
 };

--- a/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
@@ -1,0 +1,30 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { $api } from '../../../api/client';
+
+const useGetDatasetItems = () => {
+    const projectId = useProjectIdentifier();
+    return $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
+        params: {
+            path: {
+                project_id: projectId,
+            },
+            query: {
+                limit: 5,
+                annotation_status: 'reviewed',
+            },
+        },
+    });
+};
+
+const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
+
+export const useIsTrainingButtonDisabled = () => {
+    const { data: datasetItems } = useGetDatasetItems();
+    const count = datasetItems?.items.length ?? 0;
+
+    return count < MIN_NUMBER_OF_ANNOTATED_ITEMS;
+};

--- a/application/ui/src/features/models/train-model/train-model.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react';
 
 import { Button, DialogTrigger, Loading, View } from '@geti/ui';
 
+import { useIsTrainingButtonDisabled } from '../hooks/use-is-training-button-disabled';
 import { TrainModelDialog } from './train-model-dialog.component';
 import { TrainModelProvider } from './train-model-provider.component';
 
@@ -13,9 +14,11 @@ type TrainModelProps = {
 };
 
 export const TrainModel = ({ preSelectedDatasetRevisionId }: TrainModelProps) => {
+    const isTrainingDisabled = useIsTrainingButtonDisabled();
+
     return (
         <DialogTrigger>
-            <Button>Train model</Button>
+            <Button isDisabled={isTrainingDisabled}>Train model</Button>
             {(close) => (
                 <Suspense
                     fallback={

--- a/application/ui/src/features/models/train-model/train-model.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.tsx
@@ -11,6 +11,7 @@ import { TrainModelProvider } from './train-model-provider.component';
 type TrainModelProps = {
     preSelectedDatasetRevisionId?: string;
 };
+
 export const TrainModel = ({ preSelectedDatasetRevisionId }: TrainModelProps) => {
     return (
         <DialogTrigger>

--- a/application/ui/src/features/models/train-model/train-model.test.tsx
+++ b/application/ui/src/features/models/train-model/train-model.test.tsx
@@ -1,0 +1,86 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen, waitFor } from '@testing-library/react';
+import { HttpResponse } from 'msw';
+import { render } from 'test-utils/render';
+
+import { http } from '../../../api/utils';
+import { server } from '../../../msw-node-setup';
+import { TrainModel } from './train-model.component';
+
+describe('TrainModel', () => {
+    it('disables train model button when there are no enough annotated media items', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/items', () => {
+                return HttpResponse.json({
+                    items: [
+                        {
+                            id: '1',
+                            subset: 'unassigned',
+                        },
+                        {
+                            id: '2',
+                            subset: 'unassigned',
+                        },
+                        {
+                            id: '3',
+                            subset: 'unassigned',
+                        },
+                    ],
+                    pagination: {
+                        total: 3,
+                        count: 3,
+                        limit: 10,
+                        offset: 0,
+                    },
+                });
+            })
+        );
+
+        render(<TrainModel />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Train model' })).toBeDisabled();
+        });
+    });
+
+    it('enables train model button when there are enough annotated media items', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/items', () => {
+                return HttpResponse.json({
+                    items: [
+                        {
+                            id: '1',
+                            subset: 'unassigned',
+                        },
+                        {
+                            id: '2',
+                            subset: 'unassigned',
+                        },
+                        {
+                            id: '3',
+                            subset: 'unassigned',
+                        },
+                        {
+                            id: '4',
+                            subset: 'unassigned',
+                        },
+                    ],
+                    pagination: {
+                        total: 4,
+                        count: 4,
+                        limit: 10,
+                        offset: 0,
+                    },
+                });
+            })
+        );
+
+        render(<TrainModel />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Train model' })).toBeEnabled();
+        });
+    });
+});

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -8,11 +8,11 @@ import { DatasetSubset } from '../constants/shared-types';
 
 const DATASET_ITEMS_LIMIT = 20;
 
-interface UseGetDatasetItemsOptions {
+interface UseGetDatasetMediaItemsOptions {
     subset?: DatasetSubset;
 }
 
-export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
+export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions) => {
     const project_id = useProjectIdentifier();
     const subset = options?.subset;
 

--- a/application/ui/src/query-client/query-client.ts
+++ b/application/ui/src/query-client/query-client.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { toast } from '@geti/ui';
-import { MutationCache, QueryClient } from '@tanstack/react-query';
+import { matchQuery, MutationCache, QueryClient } from '@tanstack/react-query';
 
 import { paths } from '../api/openapi-spec';
 import { Meta, QueryKey } from './query-client.interface';
@@ -48,8 +48,12 @@ export const queryClient = new QueryClient({
             const invalidateQueries = meta?.invalidateQueries;
 
             if (invalidateQueries) {
-                invalidateQueries.forEach((queryKey) => {
-                    queryClient.invalidateQueries({ queryKey });
+                queryClient.invalidateQueries({
+                    predicate: (query) => {
+                        return invalidateQueries.some((queryKey) => {
+                            return matchQuery({ queryKey }, query);
+                        });
+                    },
                 });
             }
         },

--- a/application/ui/src/routes/dataset/dataset.component.tsx
+++ b/application/ui/src/routes/dataset/dataset.component.tsx
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dimensionValue, Flex } from '@geti/ui';
+import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
 import { Gallery } from '../../features/dataset/gallery/gallery.component';
 import { Toolbar } from '../../features/dataset/gallery/toolbar/toolbar.component';
-import { useGetDatasetItems } from '../../hooks/use-get-dataset-items.hook';
 
 export const Dataset = () => {
-    const { items, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetDatasetItems();
+    const { items, hasNextPage, isFetchingNextPage, fetchNextPage } = useGetDatasetMediaItems();
 
     return (
         <Flex

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -82,6 +82,11 @@ export const AnnotationActionsProvider = ({
                         '/api/projects/{project_id}/dataset/items/{dataset_item_id}/annotations',
                         { params: { path: { project_id: projectId, dataset_item_id: mediaItem.id } } },
                     ],
+                    [
+                        'get',
+                        '/api/projects/{project_id}/dataset/items',
+                        { params: { path: { project_id: projectId } } },
+                    ],
                 ],
             },
         }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR disables train model button when there are no enough annotated media items.
Moreover this PR fixes cache invalidation logic.

Close #5405 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
