### PR TITLE
fix: Show proper toast message on successful training start depending on url

### DIFF
--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -3,6 +3,7 @@
 
 import { Button, ButtonGroup, Content, Dialog, Divider, Flex, Heading, Link, Text, toast } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { useMatch } from 'react-router';
 
 import { paths } from '../../../constants/paths';
 import { useTrainModelMutation } from '../hooks/api/use-train-model-mutation';
@@ -18,6 +19,7 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
         useTrainModel();
     const trainModelMutation = useTrainModelMutation();
     const projectId = useProjectIdentifier();
+    const isModelsPage = useMatch(paths.project.models.pattern);
 
     const isStartButtonDisabled = selectedModelArchitectureId === null || selectedTrainingDevice === null;
 
@@ -36,7 +38,9 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
                 onClose();
 
                 toast({
-                    message: (
+                    message: isModelsPage ? (
+                        <Text>Model training started successfully.</Text>
+                    ) : (
                         <Flex alignItems={'center'} gap={'size-50'} wrap={'wrap'}>
                             <Text>
                                 Model training started successfully.{' '}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
