### PR TITLE
Improve 'evaluations' response

### DIFF
--- a/application/backend/app/api/schemas/evaluation.py
+++ b/application/backend/app/api/schemas/evaluation.py
@@ -1,11 +1,42 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import StrEnum
 from uuid import UUID
 
+from loguru import logger
 from pydantic import BaseModel, model_validator
 
 from app.models import EvaluationResult
+
+
+class EvaluationMetricName(StrEnum):
+    ACCURACY = "Accuracy"
+    PRECISION = "Precision"
+    RECALL = "Recall"
+    F_MEASURE = "F-measure"
+    MAP = "mAP"  # mAP@0.5:0.95
+    MAP_50 = "mAP@0.5"
+    MAP_75 = "mAP@0.75"
+    MAR_1 = "mAR@1"
+    MAR_10 = "mAR@10"
+    MAR_100 = "mAR@100"
+
+
+# Mapping from raw metric names (returned by OTX) to user-friendly metric names (returned by the API).
+# All keys in this mapping are lowercase; the mapping is applied in a case-insensitive manner.
+RAW_METRICS_TO_API_METRICS = {
+    "accuracy": EvaluationMetricName.ACCURACY,
+    "precision": EvaluationMetricName.PRECISION,
+    "recall": EvaluationMetricName.RECALL,
+    "f_measure": EvaluationMetricName.F_MEASURE,
+    "map": EvaluationMetricName.MAP,
+    "map_50": EvaluationMetricName.MAP_50,
+    "map_75": EvaluationMetricName.MAP_75,
+    "mar_1": EvaluationMetricName.MAR_1,
+    "mar_10": EvaluationMetricName.MAR_10,
+    "mar_100": EvaluationMetricName.MAR_100,
+}
 
 
 class MetricView(BaseModel):
@@ -13,18 +44,21 @@ class MetricView(BaseModel):
     Represents a single evaluation metric with its name and value.
 
     Attributes:
-        name: The metric name (e.g., "accuracy", "f1_score", "precision").
+        name: The metric name.
         value: The metric value as a floating-point number.
+        primary: Indicates if this metric is the default choice for visualization purposes.
     """
 
-    name: str
+    name: EvaluationMetricName
     value: float
+    primary: bool = False
 
     model_config = {
         "json_schema_extra": {
             "example": {
-                "name": "accuracy",
+                "name": "Accuracy",
                 "value": 0.97,
+                "primary": True,
             }
         }
     }
@@ -54,21 +88,57 @@ class EvaluationView(BaseModel):
                 "subset": "testing",
                 "metrics": [
                     {
-                        "name": "accuracy",
+                        "name": "Accuracy",
                         "value": 0.97,
+                        "primary": True,
                     },
                     {
-                        "name": "precision",
+                        "name": "Precision",
                         "value": 0.98,
+                        "primary": False,
                     },
                     {
-                        "name": "recall",
+                        "name": "Recall",
                         "value": 0.94,
+                        "primary": False,
                     },
                 ],
             }
         }
     }
+
+    @classmethod
+    def __serialize_metrics(cls, metrics: dict[str, float]) -> list[MetricView]:
+        """
+        Convert raw metric names and values into a list of MetricView instances with user-friendly names.
+
+        This method maps raw metric names (e.g., "accuracy") to their corresponding
+        user-friendly names defined in the EvaluationMetricName enum (e.g., "Accuracy").
+        Only metrics that have an explicit mapping are included in the output and eventually returned by the API.
+
+        Args:
+            metrics: A dictionary of raw metric names and their float values.
+        Returns:
+            A list of MetricView instances with user-friendly metric names and their values.
+        """
+        raw_keys = {k.lower(): k for k in metrics}
+        if "map" in raw_keys:
+            primary_metric_name = EvaluationMetricName.MAP
+        elif "accuracy" in raw_keys:
+            primary_metric_name = EvaluationMetricName.ACCURACY
+        else:
+            logger.error("Failed to resolve the primary evaluation metric. Raw metric keys: {}", raw_keys)
+            raise ValueError("Unable to determine the primary evaluation metric.")
+
+        metric_views = []
+        for raw_name, value in metrics.items():
+            api_metric_name = RAW_METRICS_TO_API_METRICS.get(raw_name.lower(), None)
+            if api_metric_name is None:
+                logger.debug(f"Skipping metric '{raw_name}' as it does not have a mapping to a user-friendly name.")
+                continue
+            primary = api_metric_name == primary_metric_name
+            metric_views.append(MetricView(name=api_metric_name, value=value, primary=primary))
+        return metric_views
 
     @model_validator(mode="before")
     @classmethod
@@ -77,12 +147,12 @@ class EvaluationView(BaseModel):
             return {
                 "dataset_revision_id": data.dataset_revision_id,
                 "subset": data.subset.value,
-                "metrics": [MetricView(name=m[0], value=m[1]) for m in data.metrics.items()],
+                "metrics": cls.__serialize_metrics(data.metrics),
             }
         if isinstance(data, dict):
             return {
                 "dataset_revision_id": data["dataset_revision_id"],
                 "subset": data["subset"].value,
-                "metrics": [MetricView(name=m[0], value=m[1]) for m in data["metrics"].items()],
+                "metrics": cls.__serialize_metrics(data["metrics"]),
             }
         return data

--- a/application/backend/app/models/model_revision.py
+++ b/application/backend/app/models/model_revision.py
@@ -82,7 +82,7 @@ class ModelRevision(BaseEntity):
 
     @model_validator(mode="before")
     @classmethod
-    def populate_training_info(cls, data: object) -> object:
+    def populate_model_revision(cls, data: object) -> object:
         if isinstance(data, ModelRevisionDB):
             return {
                 "id": data.id,

--- a/application/backend/tests/unit/routers/test_models.py
+++ b/application/backend/tests/unit/routers/test_models.py
@@ -8,22 +8,47 @@ import pytest
 from fastapi import status
 
 from app.api.dependencies import get_model_service
-from app.api.schemas import ModelView
+from app.api.schemas.model import ModelVariant
 from app.main import app
-from app.models import TrainingInfo, TrainingStatus
+from app.models import DatasetItemSubset, EvaluationResult, ModelRevision, TrainingInfo, TrainingStatus
 from app.models.model_revision import ModelFormat
 from app.services import ModelService, ResourceInUseError, ResourceNotFoundError, ResourceType
 
 
 @pytest.fixture
-def fxt_model() -> ModelView:
-    return ModelView(
-        id=uuid4(),
+def fxt_model() -> ModelRevision:
+    model_revision_id = uuid4()
+    dataset_revision_id = uuid4()
+    return ModelRevision(
+        id=model_revision_id,
         name="YOLOX-X (abc123)",
         architecture="object-detection-yolox-x",
-        training_info=TrainingInfo(status=TrainingStatus.NOT_STARTED, label_schema_revision={}, configuration={}),  # type: ignore
-        size=0,
-    )  # type: ignore
+        parent_revision=uuid4(),
+        training_info=TrainingInfo(
+            status=TrainingStatus.NOT_STARTED,
+            label_schema_revision={"labels": [{"name": "dog", "id": "05db02c9-6a54-4089-bd8e-b85dfe3bec03"}]},
+            dataset_revision_id=dataset_revision_id,
+        ),
+        training_configuration={"learning_rate": 0.001, "batch_size": 16},
+        evaluations=[
+            EvaluationResult(
+                model_revision_id=model_revision_id,
+                dataset_revision_id=dataset_revision_id,
+                subset=DatasetItemSubset.TESTING,
+                metrics={"map": 0.85, "map_50": 0.90, "map_75": 0.80, "mar_1": 0.88, "mar_10": 0.90, "mar_100": 0.92},
+            )
+        ],
+        files_deleted=False,
+    )
+
+
+@pytest.fixture
+def fxt_model_variants() -> list[ModelVariant]:
+    return [
+        ModelVariant(format="openvino", precision="fp16", weights_size=100000),
+        ModelVariant(format="onnx", precision="fp16", weights_size=100100),
+        ModelVariant(format="pytorch", precision="fp32", weights_size=100200),
+    ]
 
 
 @pytest.fixture
@@ -34,10 +59,10 @@ def fxt_model_service() -> MagicMock:
 
 
 class TestModelEndpoints:
-    def test_list_model_success(self, fxt_model, fxt_get_project, fxt_model_service, fxt_client):
+    def test_list_model_success(self, fxt_model, fxt_model_variants, fxt_get_project, fxt_model_service, fxt_client):
         fxt_model_service.list_models.return_value = [fxt_model] * 2
-        fxt_model_service.get_model_size_in_bytes.side_effect = [1024] * 2
-        fxt_model_service.get_model_variants.side_effect = [[], []]
+        fxt_model_service.get_model_size_in_bytes.side_effect = [300200] * 2
+        fxt_model_service.get_model_variants.side_effect = [fxt_model_variants, fxt_model_variants]
 
         dataset_revision_id = uuid4()
         response = fxt_client.get(
@@ -77,10 +102,10 @@ class TestModelEndpoints:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         fxt_model_service.list_models.assert_not_called()
 
-    def test_get_model_success(self, fxt_model, fxt_get_project, fxt_model_service, fxt_client):
+    def test_get_model_success(self, fxt_model, fxt_model_variants, fxt_get_project, fxt_model_service, fxt_client):
         fxt_model_service.get_model.return_value = fxt_model
-        fxt_model_service.get_model_size_in_bytes.return_value = 1024
-        fxt_model_service.get_model_variants.return_value = []
+        fxt_model_service.get_model_size_in_bytes.return_value = 300100
+        fxt_model_service.get_model_variants.return_value = fxt_model_variants
 
         response = fxt_client.get(f"/api/projects/{fxt_get_project.id}/models/{fxt_model.id}")
 
@@ -92,6 +117,38 @@ class TestModelEndpoints:
         fxt_model_service.get_model_variants.assert_called_once_with(
             project_id=fxt_get_project.id, model_id=fxt_model.id
         )
+        response_data = response.json()
+        assert response_data["id"] == str(fxt_model.id)
+        assert response_data["name"] == fxt_model.name
+        assert response_data["architecture"] == fxt_model.architecture
+        assert response_data["parent_revision"] == str(fxt_model.parent_revision)
+        assert response_data["training_info"]["status"] == fxt_model.training_info.status.value
+        assert response_data["training_info"]["label_schema_revision"] == fxt_model.training_info.label_schema_revision
+        assert response_data["training_info"]["dataset_revision_id"] == str(fxt_model.training_info.dataset_revision_id)
+        assert response_data["training_configuration"] == fxt_model.training_configuration
+        assert response_data["evaluations"] == [
+            {
+                "dataset_revision_id": str(fxt_model.evaluations[0].dataset_revision_id),
+                "subset": fxt_model.evaluations[0].subset.value,
+                "metrics": [
+                    {"name": "mAP", "value": 0.85, "primary": True},
+                    {"name": "mAP@0.5", "value": 0.90, "primary": False},
+                    {"name": "mAP@0.75", "value": 0.80, "primary": False},
+                    {"name": "mAR@1", "value": 0.88, "primary": False},
+                    {"name": "mAR@10", "value": 0.90, "primary": False},
+                    {"name": "mAR@100", "value": 0.92, "primary": False},
+                ],
+            }
+        ]
+        assert response_data["variants"] == [
+            {
+                "format": variant.format,
+                "precision": variant.precision,
+                "weights_size": variant.weights_size,
+            }
+            for variant in fxt_model_variants
+        ]
+        assert response_data["size"] == 300100
 
     @pytest.mark.parametrize(
         "http_method, service_method",

--- a/application/ui/mocks/mock-model.ts
+++ b/application/ui/mocks/mock-model.ts
@@ -34,9 +34,9 @@ export const getMockedExtendedModel = (overrides: Partial<ExtendedModel> = {}): 
             dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
             subset: 'testing',
             metrics: [
-                { name: 'accuracy', value: 0.97 },
-                { name: 'precision', value: 0.98 },
-                { name: 'recall', value: 0.94 },
+                { name: 'Accuracy', value: 0.97, primary: true },
+                { name: 'Precision', value: 0.98, primary: false },
+                { name: 'Recall', value: 0.94, primary: false },
             ],
         },
     ],


### PR DESCRIPTION
### Summary

Set a user-friendly name for the metrics and indicate which metric is the primary one to display

### How to test

Train models and check the 'evaluations' response.

**MC cls**

<img width="402" height="159" alt="image" src="https://github.com/user-attachments/assets/a7efabea-bcb0-4d23-9ece-4d2da239bff6" />

**ML cls**

<img width="409" height="221" alt="image" src="https://github.com/user-attachments/assets/10ab7f01-ba3c-461e-a8a1-9f093ab463b4" />

**Detection**

<img width="400" height="462" alt="image" src="https://github.com/user-attachments/assets/3e18e059-b8c5-403e-83da-4ecdb01912c3" />

**Segmentation**

<img width="400" height="459" alt="image" src="https://github.com/user-attachments/assets/c90486ed-986f-44f7-990c-8bbab37f7d8e" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
