### PR TITLE
Fix division by zero for rate limit bug

### DIFF
--- a/application/backend/app/models/data_collection_policy.py
+++ b/application/backend/app/models/data_collection_policy.py
@@ -12,7 +12,7 @@ class DataCollectionPolicyBase(BaseModel):
 
 class FixedRateDataCollectionPolicy(DataCollectionPolicyBase):
     type: Literal["fixed_rate"] = "fixed_rate"
-    rate: float
+    rate: float = Field(gt=0)
 
 
 class ConfidenceThresholdDataCollectionPolicy(DataCollectionPolicyBase):

--- a/application/backend/app/models/sink.py
+++ b/application/backend/app/models/sink.py
@@ -29,7 +29,7 @@ class SinkType(StrEnum):
 
 
 class BaseSinkConfig(BaseRequiredIDNameModel, BaseEntity):
-    rate_limit: float | None = None  # Rate limit in Hz, None means no limit
+    rate_limit: float | None = Field(default=None, gt=0)  # Rate limit in Hz, None means no limit
     output_formats: list[OutputFormat]
 
 

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -49,6 +49,8 @@ class FixedRatePolicyChecker(PolicyChecker):
     """
 
     def __init__(self, policy: FixedRateDataCollectionPolicy):
+        if not policy.rate:
+            raise ValueError("Collection rate cannot be set to 0 or None.")
         self.min_interval = 1.0 / policy.rate
         self.last_collect_time = 0.0
 

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -49,8 +49,8 @@ class FixedRatePolicyChecker(PolicyChecker):
     """
 
     def __init__(self, policy: FixedRateDataCollectionPolicy):
-        if not policy.rate:
-            raise ValueError("Collection rate cannot be set to 0 or None.")
+        if policy.rate is None or policy.rate <= 0:
+            raise ValueError(f"Collection rate must be a positive float, got {policy.rate} instead.")
         self.min_interval = 1.0 / policy.rate
         self.last_collect_time = 0.0
 

--- a/application/backend/app/services/dispatchers/base.py
+++ b/application/backend/app/services/dispatchers/base.py
@@ -41,9 +41,11 @@ class BaseDispatcher(metaclass=ABCMeta):
         Args:
             output_config: Configuration for the output destination
         """
+        if output_config.rate_limit is not None and not output_config.rate_limit:
+            raise ValueError("Rate limit cannot be 0. If no rate limit applies, do not set a limit instead.")
         self.output_formats = output_config.output_formats
         self.rate_limit = output_config.rate_limit
-        self.min_interval = 1.0 / self.rate_limit if self.rate_limit is not None else 0.0
+        self.min_interval = 1.0 / self.rate_limit if self.rate_limit else 0.0
         self.last_dispatch_time = 0.0
 
     @abstractmethod

--- a/application/backend/app/services/dispatchers/base.py
+++ b/application/backend/app/services/dispatchers/base.py
@@ -41,7 +41,7 @@ class BaseDispatcher(metaclass=ABCMeta):
         Args:
             output_config: Configuration for the output destination
         """
-        if output_config.rate_limit is not None and not output_config.rate_limit:
+        if output_config.rate_limit == 0:
             raise ValueError("Rate limit cannot be 0. If no rate limit applies, do not set a limit instead.")
         self.output_formats = output_config.output_formats
         self.rate_limit = output_config.rate_limit

--- a/application/backend/app/services/dispatchers/base.py
+++ b/application/backend/app/services/dispatchers/base.py
@@ -41,11 +41,13 @@ class BaseDispatcher(metaclass=ABCMeta):
         Args:
             output_config: Configuration for the output destination
         """
-        if output_config.rate_limit == 0:
-            raise ValueError("Rate limit cannot be 0. If no rate limit applies, do not set a limit instead.")
+        if output_config.rate_limit is not None and output_config.rate_limit <= 0:
+            raise ValueError(
+                f"Rate limit must be a positive float or unset (None), got {output_config.rate_limit} instead."
+            )
         self.output_formats = output_config.output_formats
         self.rate_limit = output_config.rate_limit
-        self.min_interval = 1.0 / self.rate_limit if self.rate_limit else 0.0
+        self.min_interval = 1.0 / self.rate_limit if self.rate_limit is not None else 0.0
         self.last_dispatch_time = 0.0
 
     @abstractmethod

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID, uuid4
 

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from uuid import UUID, uuid4
 

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, MagicMock, patch
 from uuid import uuid4
 
 import numpy as np
+import pydantic_core
 import pytest
 import time_machine
 
@@ -28,6 +29,20 @@ from app.services.data_collect.data_collector import (
 
 class TestFixedRatePolicyCheckerUnit:
     """Unit tests for FixedRatePolicyChecker."""
+
+    def test_zero_rate_raises_error_in_policy(self):
+        # Arrange, Act and Assert
+        with pytest.raises(pydantic_core.ValidationError):
+            FixedRateDataCollectionPolicy(rate=0)  # type: ignore[bad_argument_type]
+
+    def test_zero_rate_raises_error_in_checker(self):
+        # Arrange
+        policy = FixedRateDataCollectionPolicy(rate=0.1)
+        policy.rate = 0
+
+        # Act and Assert
+        with pytest.raises(ValueError):
+            FixedRatePolicyChecker(policy)
 
     def test_should_collect_true(self):
         # Arrange

--- a/application/backend/tests/unit/services/dispatchers/test_base_dispatcher.py
+++ b/application/backend/tests/unit/services/dispatchers/test_base_dispatcher.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from uuid import uuid4
+
+import pydantic_core
+import pytest
+
+from app.models.sink import BaseSinkConfig
+
+
+def test_zero_rate_limit_raises_in_sink() -> None:
+    with pytest.raises(pydantic_core.ValidationError):
+        BaseSinkConfig(id=uuid4(), name="name", rate_limit=0, output_formats=[])  # type: ignore[bad_argument_type]

--- a/application/backend/tests/unit/services/dispatchers/test_webhook.py
+++ b/application/backend/tests/unit/services/dispatchers/test_webhook.py
@@ -53,6 +53,12 @@ def fxt_sample_predictions():
 class TestWebhookDispatcher:
     """Unit tests for the WebhookDispatcher class."""
 
+    def test_init_zero_rate_limit_raises(self, fxt_webhook_config):
+        """Test that the BaseDispatcher raises ValueError when rate_limit is zero"""
+        fxt_webhook_config.rate_limit = 0
+        with pytest.raises(ValueError):
+            WebhookDispatcher(fxt_webhook_config)
+
     def test_init_sets_attributes(self, fxt_webhook_config):
         """Test that the WebhookDispatcher initializes with correct attributes."""
         dispatcher = WebhookDispatcher(fxt_webhook_config)


### PR DESCRIPTION
This pull request introduces stricter validation for the `rate_limit` configuration in sink-related models and services. The main goal is to prevent invalid values (specifically zero) for `rate_limit`, ensuring that rate limiting logic behaves as expected and avoids runtime errors.

Validation improvements:

* Updated the `rate_limit` field in `BaseSinkConfig` to enforce that only positive values are allowed using Pydantic's `Field(gt=0)`.
* Added a runtime check in the `BaseDispatcher` initializer to raise a `ValueError` if `rate_limit` is set to zero, with guidance to leave it unset if no limit is needed.

Rate limiting logic adjustment:

* Modified the calculation of `min_interval` in `BaseDispatcher` to ensure it only computes a value when `rate_limit` is set and non-zero, preventing division by zero and aligning with the new validation.

Resolves #5393

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
