### PR TITLE
WebRTC broadcast frames to all connected streams

### DIFF
--- a/application/backend/app/lifecycle.py
+++ b/application/backend/app/lifecycle.py
@@ -121,7 +121,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         advertise_ip=settings.webrtc_advertise_ip,
     )
     sdp_handler = SDPHandler()
-    webrtc_manager = WebRTCManager(app_scheduler.rtc_stream_queue, webrtc_settings, sdp_handler)
+    webrtc_manager = WebRTCManager(app_scheduler.rtc_stream_broadcaster, webrtc_settings, sdp_handler)
     app.state.webrtc_manager = webrtc_manager
     logger.info("Application startup completed")
 

--- a/application/backend/app/scheduler.py
+++ b/application/backend/app/scheduler.py
@@ -3,16 +3,17 @@
 
 import multiprocessing as mp
 import os
-import queue
 import threading
 from multiprocessing.shared_memory import SharedMemory
 
+import numpy as np
 import psutil
 from loguru import logger
 
 from app.services.data_collect import DataCollector
 from app.services.event.event_bus import EventBus
 from app.services.metrics_service import SIZE
+from app.webrtc.broadcaster import FrameBroadcaster
 from app.workers import DispatchingWorker, InferenceWorker, InferenceWorkerConfig, StreamLoader
 
 
@@ -31,8 +32,8 @@ class Scheduler:
         self.frame_queue: mp.Queue = mp.Queue(maxsize=self.FRAME_QUEUE_SIZE)
         # Queue for the inference results (predictions)
         self.pred_queue: mp.Queue = mp.Queue(maxsize=self.PREDICTION_QUEUE_SIZE)
-        # Queue for pushing predictions to the visualization stream (WebRTC)
-        self.rtc_stream_broadcaster: queue.Queue = queue.Queue(maxsize=1)
+        # Broadcaster for pushing predictions to the visualization stream (WebRTC)
+        self.rtc_stream_broadcaster: FrameBroadcaster[np.ndarray] = FrameBroadcaster[np.ndarray]()
         # Event to sync all processes on application shutdown
         self.mp_stop_event = mp.Event()
 
@@ -70,7 +71,7 @@ class Scheduler:
         dispatching_thread = DispatchingWorker(
             event_bus=self._event_bus,
             pred_queue=self.pred_queue,
-            rtc_stream_queue=self.rtc_stream_broadcaster,
+            rtc_stream_broadcaster=self.rtc_stream_broadcaster,
             stop_event=self.mp_stop_event,
             data_collector=self._data_collector,
         )

--- a/application/backend/app/scheduler.py
+++ b/application/backend/app/scheduler.py
@@ -32,7 +32,7 @@ class Scheduler:
         # Queue for the inference results (predictions)
         self.pred_queue: mp.Queue = mp.Queue(maxsize=self.PREDICTION_QUEUE_SIZE)
         # Queue for pushing predictions to the visualization stream (WebRTC)
-        self.rtc_stream_queue: queue.Queue = queue.Queue(maxsize=1)
+        self.rtc_stream_broadcaster: queue.Queue = queue.Queue(maxsize=1)
         # Event to sync all processes on application shutdown
         self.mp_stop_event = mp.Event()
 
@@ -70,7 +70,7 @@ class Scheduler:
         dispatching_thread = DispatchingWorker(
             event_bus=self._event_bus,
             pred_queue=self.pred_queue,
-            rtc_stream_queue=self.rtc_stream_queue,
+            rtc_stream_queue=self.rtc_stream_broadcaster,
             stop_event=self.mp_stop_event,
             data_collector=self._data_collector,
         )

--- a/application/backend/app/webrtc/__init__.py
+++ b/application/backend/app/webrtc/__init__.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from .broadcaster import FrameBroadcaster
 from .manager import WebRTCManager, WebRTCSettings
 from .sdp_handler import SDPHandler
 
-__all__ = ["SDPHandler", "WebRTCManager", "WebRTCSettings"]
+__all__ = ["FrameBroadcaster", "SDPHandler", "WebRTCManager", "WebRTCSettings"]

--- a/application/backend/app/webrtc/broadcaster.py
+++ b/application/backend/app/webrtc/broadcaster.py
@@ -21,7 +21,7 @@ class FrameBroadcaster[T]:
     """
 
     def __init__(self) -> None:
-        self.queues: list[Queue[T]] = []
+        self.queues: dict[str, Queue[T]] = {}
         self._lock = Lock()
         self._latest_frame: T | None = None
 
@@ -30,7 +30,7 @@ class FrameBroadcaster[T]:
         """Get the most recently broadcasted frame."""
         return self._latest_frame
 
-    def register(self) -> Queue[T]:
+    def register(self, webrtc_id: str) -> Queue[T]:
         """Register a new consumer and return its personal queue.
 
         If a frame has already been broadcast, the latest frame is immediately
@@ -38,7 +38,7 @@ class FrameBroadcaster[T]:
         """
         with self._lock:
             queue: Queue[T] = Queue(maxsize=5)
-            self.queues.append(queue)
+            self.queues[webrtc_id] = queue
 
             # Send the latest frame to new consumer if available
             if self._latest_frame is not None:
@@ -50,13 +50,13 @@ class FrameBroadcaster[T]:
             logging.info("FrameBroadcaster registered a new consumer. Total consumers: %d", len(self.queues))
             return queue
 
-    def unregister(self, queue: Queue[T]) -> None:
+    def unregister(self, webrtc_id: str) -> None:
         """Unregister a consumer by its queue."""
         with self._lock:
             try:
-                self.queues.remove(queue)
+                del self.queues[webrtc_id]
                 logging.info("FrameBroadcaster unregistered a consumer. Total consumers:%d", len(self.queues))
-            except ValueError:
+            except KeyError:
                 # if a client unregisters twice.
                 pass
 
@@ -64,7 +64,7 @@ class FrameBroadcaster[T]:
         """Broadcast frame to all registered queues."""
         self._latest_frame = frame
         with self._lock:
-            for queue in self.queues:
+            for queue in self.queues.values():
                 try:
                     queue.put_nowait(frame)
                 except Full:
@@ -79,7 +79,7 @@ class FrameBroadcaster[T]:
         after a component swap (e.g., changing the source).
         """
         with self._lock:
-            for q in self.queues:
+            for q in self.queues.values():
                 while True:
                     try:
                         q.get_nowait()

--- a/application/backend/app/webrtc/broadcaster.py
+++ b/application/backend/app/webrtc/broadcaster.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from queue import Empty, Full, Queue
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+
+class FrameBroadcaster[T]:
+    """
+    A thread-safe class to broadcast frames to multiple consumers.
+
+    It manages a queue for each registered consumer. If a consumer's
+    queue is full the oldest frame is dropped to make space for the new one.
+
+    The live nature of WebRTC streams requires consumers to be registered and unregistered dynamically as they connect
+    and disconnect. If we were to share a single queue for all consumers, they would compete for frames, effectively
+    stealing them from each other. This broadcaster ensures every consumer gets its own queue.
+    """
+
+    def __init__(self) -> None:
+        self.queues: list[Queue[T]] = []
+        self._lock = Lock()
+        self._latest_frame: T | None = None
+
+    @property
+    def latest_frame(self) -> T | None:
+        """Get the most recently broadcasted frame."""
+        return self._latest_frame
+
+    def register(self) -> Queue[T]:
+        """Register a new consumer and return its personal queue.
+
+        If a frame has already been broadcast, the latest frame is immediately
+        added to the new consumer's queue so they don't miss the current state.
+        """
+        with self._lock:
+            queue: Queue[T] = Queue(maxsize=5)
+            self.queues.append(queue)
+
+            # Send the latest frame to new consumer if available
+            if self._latest_frame is not None:
+                try:
+                    queue.put_nowait(self._latest_frame)
+                except Full:
+                    logging.warning("Could not send latest frame to new consumer - queue full")
+
+            logging.info("FrameBroadcaster registered a new consumer. Total consumers: %d", len(self.queues))
+            return queue
+
+    def unregister(self, queue: Queue[T]) -> None:
+        """Unregister a consumer by its queue."""
+        with self._lock:
+            try:
+                self.queues.remove(queue)
+                logging.info("FrameBroadcaster unregistered a consumer. Total consumers:%d", len(self.queues))
+            except ValueError:
+                # if a client unregisters twice.
+                pass
+
+    def broadcast(self, frame: T) -> None:
+        """Broadcast frame to all registered queues."""
+        self._latest_frame = frame
+        with self._lock:
+            for queue in self.queues:
+                try:
+                    queue.put_nowait(frame)
+                except Full:
+                    self._handle_full_queue(queue, frame)
+                except Exception:
+                    logger.exception("Error broadcasting to queue")
+
+    def clear(self) -> None:
+        """
+        Drop all queued frames for all consumers.
+        Keeps consumer queues registered, but drains them so no stale frames are delivered
+        after a component swap (e.g., changing the source).
+        """
+        with self._lock:
+            for q in self.queues:
+                while True:
+                    try:
+                        q.get_nowait()
+                    except Empty:
+                        logger.debug("Drained queued frames for consumer queue %s", id(q))
+                        break
+            self._latest_frame = None
+
+    def _handle_full_queue(self, queue: Queue[T], frame: T) -> None:
+        """Handle a full queue by dropping the oldest frame and adding the new one."""
+        try:
+            queue.get_nowait()
+        except Empty:
+            pass
+
+        try:
+            queue.put_nowait(frame)
+        except Full:
+            logger.warning("Queue still full after clearing, skipping frame")
+        except Exception:
+            logger.exception("Error replacing frame in full queue")

--- a/application/backend/app/webrtc/broadcaster.py
+++ b/application/backend/app/webrtc/broadcaster.py
@@ -111,8 +111,9 @@ class FrameBroadcaster[T]:
         """
         Drop all queues and frames from memory
         """
-        self.queues.clear()
-        self._latest_frame = None
+        with self._lock:
+            self.queues.clear()
+            self._latest_frame = None
 
     def _handle_full_queue(self, queue: Queue[T], frame: T) -> None:
         """Handle a full queue by dropping the oldest frame and adding the new one."""

--- a/application/backend/app/webrtc/broadcaster.py
+++ b/application/backend/app/webrtc/broadcaster.py
@@ -1,11 +1,10 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 from queue import Empty, Full, Queue
 from threading import Lock
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 
 class FrameBroadcaster[T]:
@@ -45,9 +44,9 @@ class FrameBroadcaster[T]:
                 try:
                     queue.put_nowait(self._latest_frame)
                 except Full:
-                    logging.warning("Could not send latest frame to new consumer - queue full")
+                    logger.warning("Could not send latest frame to new consumer - queue full")
 
-            logging.info("FrameBroadcaster registered a new consumer. Total consumers: %d", len(self.queues))
+            logger.info("FrameBroadcaster registered a new consumer. Total consumers: %d", len(self.queues))
             return queue
 
     def unregister(self, webrtc_id: str) -> None:
@@ -55,7 +54,7 @@ class FrameBroadcaster[T]:
         with self._lock:
             try:
                 del self.queues[webrtc_id]
-                logging.info("FrameBroadcaster unregistered a consumer. Total consumers:%d", len(self.queues))
+                logger.info("FrameBroadcaster unregistered a consumer. Total consumers:%d", len(self.queues))
             except KeyError:
                 # if a client unregisters twice.
                 pass

--- a/application/backend/app/webrtc/broadcaster.py
+++ b/application/backend/app/webrtc/broadcaster.py
@@ -29,6 +29,16 @@ class FrameBroadcaster[T]:
         """Get the most recently broadcasted frame."""
         return self._latest_frame
 
+    def is_registered(self, webrtc_id: str) -> bool:
+        """Check if a consumer is registered."""
+        with self._lock:
+            return webrtc_id in self.queues
+
+    def consumer_count(self) -> int:
+        """Get the number of registered consumers."""
+        with self._lock:
+            return len(self.queues)
+
     def register(self, webrtc_id: str) -> Queue[T]:
         """Register a new consumer and return its personal queue.
 
@@ -36,6 +46,16 @@ class FrameBroadcaster[T]:
         added to the new consumer's queue so they don't miss the current state.
         """
         with self._lock:
+            # If this webrtc_id is already registered, return the existing queue
+            existing_queue = self.queues.get(webrtc_id)
+            if existing_queue is not None:
+                logger.warning(
+                    "FrameBroadcaster received duplicate registration for webrtc_id {}; "
+                    "returning existing consumer queue",
+                    webrtc_id,
+                )
+                return existing_queue
+
             queue: Queue[T] = Queue(maxsize=5)
             self.queues[webrtc_id] = queue
 
@@ -46,23 +66,23 @@ class FrameBroadcaster[T]:
                 except Full:
                     logger.warning("Could not send latest frame to new consumer - queue full")
 
-            logger.info("FrameBroadcaster registered a new consumer. Total consumers: %d", len(self.queues))
+            logger.info("FrameBroadcaster registered a new consumer. Total consumers: {}", len(self.queues))
             return queue
 
     def unregister(self, webrtc_id: str) -> None:
-        """Unregister a consumer by its queue."""
+        """Unregister a consumer by its WebRTC ID."""
         with self._lock:
             try:
                 del self.queues[webrtc_id]
-                logger.info("FrameBroadcaster unregistered a consumer. Total consumers:%d", len(self.queues))
+                logger.info("FrameBroadcaster unregistered a consumer. Total consumers: {}", len(self.queues))
             except KeyError:
                 # if a client unregisters twice.
                 pass
 
     def broadcast(self, frame: T) -> None:
         """Broadcast frame to all registered queues."""
-        self._latest_frame = frame
         with self._lock:
+            self._latest_frame = frame
             for queue in self.queues.values():
                 try:
                     queue.put_nowait(frame)
@@ -83,9 +103,16 @@ class FrameBroadcaster[T]:
                     try:
                         q.get_nowait()
                     except Empty:
-                        logger.debug("Drained queued frames for consumer queue %s", id(q))
+                        logger.debug("Drained queued frames for consumer queue {}", id(q))
                         break
             self._latest_frame = None
+
+    def cleanup(self) -> None:
+        """
+        Drop all queues and frames from memory
+        """
+        self.queues.clear()
+        self._latest_frame = None
 
     def _handle_full_queue(self, queue: Queue[T], frame: T) -> None:
         """Handle a full queue by dropping the oldest frame and adding the new one."""

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import queue
 from dataclasses import dataclass
 from typing import Any
 
@@ -11,6 +10,7 @@ from loguru import logger
 
 from app.models.webrtc import Answer, InputData, Offer
 
+from .broadcaster import FrameBroadcaster
 from .sdp_handler import SDPHandler
 from .stream import InferenceVideoStreamTrack
 
@@ -24,10 +24,10 @@ class WebRTCSettings:
 class WebRTCManager:
     """Manager for handling WebRTC connections."""
 
-    def __init__(self, stream_queue: queue.Queue, settings: WebRTCSettings, sdp_handler: SDPHandler) -> None:
+    def __init__(self, frame_broadcaster: FrameBroadcaster, settings: WebRTCSettings, sdp_handler: SDPHandler) -> None:
         self._pcs: dict[str, RTCPeerConnection] = {}
         self._input_data: dict[str, Any] = {}
-        self._stream_queue = stream_queue
+        self._frame_broadcaster = frame_broadcaster
         self._settings = settings
         self._sdp_handler = sdp_handler
 
@@ -37,13 +37,15 @@ class WebRTCManager:
         self._pcs[offer.webrtc_id] = pc
 
         # Add video track
-        track = InferenceVideoStreamTrack(self._stream_queue)
+        stream_queue = self._frame_broadcaster.register()
+        track = InferenceVideoStreamTrack(stream_queue=stream_queue)
         pc.addTrack(track)
 
         @pc.on("connectionstatechange")
         async def connection_state_change() -> None:
             if pc.connectionState in ["failed", "closed"]:
                 await self.cleanup_connection(offer.webrtc_id)
+                self._frame_broadcaster.unregister(stream_queue)
 
         # Set remote description from client's offer
         await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -34,33 +34,34 @@ class WebRTCManager:
 
     async def handle_offer(self, offer: Offer) -> Answer:
         """Create an SDP offer for a new WebRTC connection."""
+        pc = RTCPeerConnection(configuration=self._settings.config)
+
         async with self._lock:
-            pc = RTCPeerConnection(configuration=self._settings.config)
             self._pcs[offer.webrtc_id] = pc
 
-            # Add video track
-            stream_queue = self._frame_broadcaster.register(webrtc_id=offer.webrtc_id)
-            track = InferenceVideoStreamTrack(stream_queue=stream_queue)
-            pc.addTrack(track)
+        # Add video track
+        stream_queue = self._frame_broadcaster.register(webrtc_id=offer.webrtc_id)
+        track = InferenceVideoStreamTrack(stream_queue=stream_queue)
+        pc.addTrack(track)
 
-            @pc.on("connectionstatechange")
-            async def connection_state_change() -> None:
-                if pc.connectionState in ["failed", "closed"]:
-                    await self.cleanup_connection(offer.webrtc_id)
+        @pc.on("connectionstatechange")
+        async def connection_state_change() -> None:
+            if pc.connectionState in ["failed", "closed"]:
+                await self.cleanup_connection(offer.webrtc_id)
 
-            # Set remote description from client's offer
-            await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))
+        # Set remote description from client's offer
+        await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))
 
-            # Create answer
-            answer = await pc.createAnswer()
-            await pc.setLocalDescription(answer)
+        # Create answer
+        answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
 
-            # Mangle SDP if public IP is configured
-            sdp = pc.localDescription.sdp
-            if self._settings.advertise_ip:
-                sdp = await self._sdp_handler.mangle_sdp(sdp, self._settings.advertise_ip)
+        # Mangle SDP if public IP is configured
+        sdp = pc.localDescription.sdp
+        if self._settings.advertise_ip:
+            sdp = await self._sdp_handler.mangle_sdp(sdp, self._settings.advertise_ip)
 
-            return Answer(sdp=sdp, type=pc.localDescription.type)
+        return Answer(sdp=sdp, type=pc.localDescription.type)
 
     def set_input(self, data: InputData) -> None:
         """Set input data for specific WebRTC connection"""

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -79,8 +79,9 @@ class WebRTCManager:
 
     async def cleanup(self) -> None:
         """Clean up all connections"""
-        for pc in list(self._pcs.values()):
+        for webrtc_id, pc in self._pcs.items():
             await pc.close()
+            self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
         self._pcs.clear()
         self._input_data.clear()
-        self._frame_broadcaster.queues.clear()
+        self._frame_broadcaster.cleanup()

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -79,7 +79,7 @@ class WebRTCManager:
 
     async def cleanup(self) -> None:
         """Clean up all connections"""
-        for webrtc_id, pc in self._pcs.items():
+        for webrtc_id, pc in list(self._pcs.items()):
             await pc.close()
             self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
         self._pcs.clear()

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -83,7 +83,7 @@ class WebRTCManager:
     async def cleanup(self) -> None:
         """Clean up all connections"""
         async with self._lock:
-            for webrtc_id, pc in list(self._pcs.items()):
+            for webrtc_id, pc in self._pcs.items():
                 await pc.close()
                 self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
             self._pcs.clear()

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -37,7 +37,7 @@ class WebRTCManager:
         self._pcs[offer.webrtc_id] = pc
 
         # Add video track
-        stream_queue = self._frame_broadcaster.register()
+        stream_queue = self._frame_broadcaster.register(webrtc_id=offer.webrtc_id)
         track = InferenceVideoStreamTrack(stream_queue=stream_queue)
         pc.addTrack(track)
 
@@ -45,7 +45,6 @@ class WebRTCManager:
         async def connection_state_change() -> None:
             if pc.connectionState in ["failed", "closed"]:
                 await self.cleanup_connection(offer.webrtc_id)
-                self._frame_broadcaster.unregister(stream_queue)
 
         # Set remote description from client's offer
         await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))
@@ -76,6 +75,7 @@ class WebRTCManager:
             await pc.close()
             logger.debug("Connection {} successfully closed.", webrtc_id)
             self._input_data.pop(webrtc_id, None)
+        self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
 
     async def cleanup(self) -> None:
         """Clean up all connections"""
@@ -83,3 +83,4 @@ class WebRTCManager:
             await pc.close()
         self._pcs.clear()
         self._input_data.clear()
+        self._frame_broadcaster.queues.clear()

--- a/application/backend/app/webrtc/manager.py
+++ b/application/backend/app/webrtc/manager.py
@@ -30,35 +30,37 @@ class WebRTCManager:
         self._frame_broadcaster = frame_broadcaster
         self._settings = settings
         self._sdp_handler = sdp_handler
+        self._lock = asyncio.Lock()
 
     async def handle_offer(self, offer: Offer) -> Answer:
         """Create an SDP offer for a new WebRTC connection."""
-        pc = RTCPeerConnection(configuration=self._settings.config)
-        self._pcs[offer.webrtc_id] = pc
+        async with self._lock:
+            pc = RTCPeerConnection(configuration=self._settings.config)
+            self._pcs[offer.webrtc_id] = pc
 
-        # Add video track
-        stream_queue = self._frame_broadcaster.register(webrtc_id=offer.webrtc_id)
-        track = InferenceVideoStreamTrack(stream_queue=stream_queue)
-        pc.addTrack(track)
+            # Add video track
+            stream_queue = self._frame_broadcaster.register(webrtc_id=offer.webrtc_id)
+            track = InferenceVideoStreamTrack(stream_queue=stream_queue)
+            pc.addTrack(track)
 
-        @pc.on("connectionstatechange")
-        async def connection_state_change() -> None:
-            if pc.connectionState in ["failed", "closed"]:
-                await self.cleanup_connection(offer.webrtc_id)
+            @pc.on("connectionstatechange")
+            async def connection_state_change() -> None:
+                if pc.connectionState in ["failed", "closed"]:
+                    await self.cleanup_connection(offer.webrtc_id)
 
-        # Set remote description from client's offer
-        await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))
+            # Set remote description from client's offer
+            await pc.setRemoteDescription(RTCSessionDescription(sdp=offer.sdp, type=offer.type))
 
-        # Create answer
-        answer = await pc.createAnswer()
-        await pc.setLocalDescription(answer)
+            # Create answer
+            answer = await pc.createAnswer()
+            await pc.setLocalDescription(answer)
 
-        # Mangle SDP if public IP is configured
-        sdp = pc.localDescription.sdp
-        if self._settings.advertise_ip:
-            sdp = await self._sdp_handler.mangle_sdp(sdp, self._settings.advertise_ip)
+            # Mangle SDP if public IP is configured
+            sdp = pc.localDescription.sdp
+            if self._settings.advertise_ip:
+                sdp = await self._sdp_handler.mangle_sdp(sdp, self._settings.advertise_ip)
 
-        return Answer(sdp=sdp, type=pc.localDescription.type)
+            return Answer(sdp=sdp, type=pc.localDescription.type)
 
     def set_input(self, data: InputData) -> None:
         """Set input data for specific WebRTC connection"""
@@ -69,19 +71,21 @@ class WebRTCManager:
 
     async def cleanup_connection(self, webrtc_id: str) -> None:
         """Clean up a specific WebRTC connection by its ID."""
-        if webrtc_id in self._pcs:
-            logger.debug("Cleaning up connection: {}", webrtc_id)
-            pc = self._pcs.pop(webrtc_id)
-            await pc.close()
-            logger.debug("Connection {} successfully closed.", webrtc_id)
-            self._input_data.pop(webrtc_id, None)
-        self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
+        async with self._lock:
+            if webrtc_id in self._pcs:
+                logger.debug("Cleaning up connection: {}", webrtc_id)
+                pc = self._pcs.pop(webrtc_id)
+                await pc.close()
+                logger.debug("Connection {} successfully closed.", webrtc_id)
+                self._input_data.pop(webrtc_id, None)
+            self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
 
     async def cleanup(self) -> None:
         """Clean up all connections"""
-        for webrtc_id, pc in list(self._pcs.items()):
-            await pc.close()
-            self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
-        self._pcs.clear()
-        self._input_data.clear()
-        self._frame_broadcaster.cleanup()
+        async with self._lock:
+            for webrtc_id, pc in list(self._pcs.items()):
+                await pc.close()
+                self._frame_broadcaster.unregister(webrtc_id=webrtc_id)
+            self._pcs.clear()
+            self._input_data.clear()
+            self._frame_broadcaster.cleanup()

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -5,6 +5,7 @@ import multiprocessing as mp
 import queue
 from multiprocessing.synchronize import Event as EventClass
 
+import numpy as np
 from loguru import logger
 
 from app.db import get_db_session
@@ -13,7 +14,7 @@ from app.services import DispatchService, SinkService
 from app.services.data_collect import DataCollector
 from app.services.dispatchers import Dispatcher
 from app.services.event.event_bus import EventBus, EventType
-from app.stream.stream_data import InferenceData, StreamData
+from app.stream.stream_data import StreamData
 from app.webrtc import FrameBroadcaster
 from app.workers.base import BaseThreadWorker
 
@@ -30,7 +31,7 @@ class DispatchingWorker(BaseThreadWorker):
         self,
         event_bus: EventBus,
         pred_queue: mp.Queue,
-        rtc_stream_broadcaster: FrameBroadcaster[InferenceData],
+        rtc_stream_broadcaster: FrameBroadcaster[np.ndarray],
         stop_event: EventClass,
         data_collector: DataCollector,
     ) -> None:
@@ -96,10 +97,7 @@ class DispatchingWorker(BaseThreadWorker):
                 )
 
             # Dispatch to WebRTC stream
-            try:
-                self._rtc_stream_broadcaster.broadcast(image_with_visualization)
-            except queue.Full:
-                logger.debug("Visualization queue is full; skipping")
+            self._rtc_stream_broadcaster.broadcast(image_with_visualization)
 
             # Collect the image to project dataset if needed
             self._data_collector.collect(

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -13,7 +13,8 @@ from app.services import DispatchService, SinkService
 from app.services.data_collect import DataCollector
 from app.services.dispatchers import Dispatcher
 from app.services.event.event_bus import EventBus, EventType
-from app.stream.stream_data import StreamData
+from app.stream.stream_data import InferenceData, StreamData
+from app.webrtc import FrameBroadcaster
 from app.workers.base import BaseThreadWorker
 
 
@@ -29,14 +30,14 @@ class DispatchingWorker(BaseThreadWorker):
         self,
         event_bus: EventBus,
         pred_queue: mp.Queue,
-        rtc_stream_queue: queue.Queue,
+        rtc_stream_broadcaster: FrameBroadcaster[InferenceData],
         stop_event: EventClass,
         data_collector: DataCollector,
     ) -> None:
         super().__init__(stop_event=stop_event)
         self._event_bus = event_bus
         self._pred_queue = pred_queue
-        self._rtc_stream_queue = rtc_stream_queue
+        self._rtc_stream_broadcaster = rtc_stream_broadcaster
 
         self._data_collector = data_collector
 
@@ -96,7 +97,7 @@ class DispatchingWorker(BaseThreadWorker):
 
             # Dispatch to WebRTC stream
             try:
-                self._rtc_stream_queue.put(image_with_visualization, block=False)
+                self._rtc_stream_broadcaster.broadcast(image_with_visualization)
             except queue.Full:
                 logger.debug("Visualization queue is full; skipping")
 

--- a/application/backend/tests/integration/webrtc/test_manager.py
+++ b/application/backend/tests/integration/webrtc/test_manager.py
@@ -1,14 +1,15 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import queue
 import socket
 
+import numpy as np
 import pytest
 from aiortc import RTCConfiguration
 
 from app.models.webrtc import InputData, Offer
 from app.webrtc import SDPHandler
+from app.webrtc.broadcaster import FrameBroadcaster
 from app.webrtc.manager import WebRTCManager, WebRTCSettings
 
 VALID_SDP = (
@@ -30,7 +31,7 @@ VALID_SDP = (
 
 @pytest.fixture
 def fxt_stream_queue():
-    return queue.Queue()
+    return FrameBroadcaster[np.ndarray]()
 
 
 @pytest.fixture
@@ -73,6 +74,7 @@ class TestWebRTCManager:
         assert get_local_ip() in answer.sdp
         assert answer.type == "answer"
         assert "test_id" in fxt_manager._pcs
+        assert "test_id" in fxt_manager._frame_broadcaster.queues
 
     @pytest.mark.asyncio
     async def test_handle_offer_with_host_resolution(self, fxt_stream_queue, fxt_sdp_handler, fxt_offer):
@@ -82,12 +84,16 @@ class TestWebRTCManager:
         assert "127.0.0.1" in answer.sdp
         assert answer.type == "answer"
         assert "test_id" in manager._pcs
+        assert "test_id" in manager._frame_broadcaster.queues
 
     @pytest.mark.asyncio
     async def test_cleanup_connection_removes_pc(self, fxt_manager, fxt_offer):
         await fxt_manager.handle_offer(fxt_offer)
+        assert "test_id" in fxt_manager._pcs
+        assert "test_id" in fxt_manager._frame_broadcaster.queues
         await fxt_manager.cleanup_connection("test_id")
         assert "test_id" not in fxt_manager._pcs
+        assert "test_id" not in fxt_manager._frame_broadcaster.queues
 
     def test_set_input_stores_data(self, fxt_manager):
         data = InputData(webrtc_id="test_id", conf_threshold=0.5)
@@ -101,3 +107,4 @@ class TestWebRTCManager:
         await fxt_manager.cleanup()
         assert not fxt_manager._pcs
         assert not fxt_manager._input_data
+        assert not fxt_manager._frame_broadcaster.queues

--- a/application/backend/tests/integration/webrtc/test_manager.py
+++ b/application/backend/tests/integration/webrtc/test_manager.py
@@ -30,7 +30,7 @@ VALID_SDP = (
 
 
 @pytest.fixture
-def fxt_stream_queue():
+def fxt_frame_broadcaster():
     return FrameBroadcaster[np.ndarray]()
 
 

--- a/application/backend/tests/integration/webrtc/test_manager.py
+++ b/application/backend/tests/integration/webrtc/test_manager.py
@@ -45,8 +45,8 @@ def fxt_sdp_handler():
 
 
 @pytest.fixture
-def fxt_manager(fxt_stream_queue, fxt_settings, fxt_sdp_handler):
-    return WebRTCManager(fxt_stream_queue, fxt_settings, fxt_sdp_handler)
+def fxt_manager(fxt_frame_broadcaster, fxt_settings, fxt_sdp_handler):
+    return WebRTCManager(fxt_frame_broadcaster, fxt_settings, fxt_sdp_handler)
 
 
 @pytest.fixture
@@ -74,26 +74,26 @@ class TestWebRTCManager:
         assert get_local_ip() in answer.sdp
         assert answer.type == "answer"
         assert "test_id" in fxt_manager._pcs
-        assert "test_id" in fxt_manager._frame_broadcaster.queues
+        assert fxt_manager._frame_broadcaster.is_registered("test_id")
 
     @pytest.mark.asyncio
-    async def test_handle_offer_with_host_resolution(self, fxt_stream_queue, fxt_sdp_handler, fxt_offer):
+    async def test_handle_offer_with_host_resolution(self, fxt_frame_broadcaster, fxt_sdp_handler, fxt_offer):
         settings = WebRTCSettings(config=RTCConfiguration(iceServers=[]), advertise_ip="localhost")
-        manager = WebRTCManager(fxt_stream_queue, settings, fxt_sdp_handler)
+        manager = WebRTCManager(fxt_frame_broadcaster, settings, fxt_sdp_handler)
         answer = await manager.handle_offer(fxt_offer)
         assert "127.0.0.1" in answer.sdp
         assert answer.type == "answer"
         assert "test_id" in manager._pcs
-        assert "test_id" in manager._frame_broadcaster.queues
+        assert manager._frame_broadcaster.is_registered("test_id")
 
     @pytest.mark.asyncio
     async def test_cleanup_connection_removes_pc(self, fxt_manager, fxt_offer):
         await fxt_manager.handle_offer(fxt_offer)
         assert "test_id" in fxt_manager._pcs
-        assert "test_id" in fxt_manager._frame_broadcaster.queues
+        assert fxt_manager._frame_broadcaster.is_registered("test_id")
         await fxt_manager.cleanup_connection("test_id")
         assert "test_id" not in fxt_manager._pcs
-        assert "test_id" not in fxt_manager._frame_broadcaster.queues
+        assert not fxt_manager._frame_broadcaster.is_registered("test_id")
 
     def test_set_input_stores_data(self, fxt_manager):
         data = InputData(webrtc_id="test_id", conf_threshold=0.5)
@@ -107,4 +107,4 @@ class TestWebRTCManager:
         await fxt_manager.cleanup()
         assert not fxt_manager._pcs
         assert not fxt_manager._input_data
-        assert not fxt_manager._frame_broadcaster.queues
+        assert fxt_manager._frame_broadcaster.consumer_count() == 0

--- a/application/backend/tests/unit/webrtc/test_broadcaster.py
+++ b/application/backend/tests/unit/webrtc/test_broadcaster.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 
 from app.webrtc.broadcaster import FrameBroadcaster
 
@@ -11,7 +10,7 @@ class TestFrameBroadcaster:
         """Test that registering a consumer creates a queue."""
         broadcaster = FrameBroadcaster[str]()
         queue = broadcaster.register("consumer1")
-        
+
         assert queue is not None
         assert broadcaster.is_registered("consumer1")
         assert broadcaster.consumer_count() == 1
@@ -19,13 +18,13 @@ class TestFrameBroadcaster:
     def test_register_seeds_latest_frame(self):
         """Test that newly registered consumers receive the latest frame."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         # Broadcast a frame before registration
         broadcaster.broadcast("frame1")
-        
+
         # Register a new consumer
         queue = broadcaster.register("consumer1")
-        
+
         # The queue should contain the latest frame
         assert not queue.empty()
         frame = queue.get_nowait()
@@ -34,10 +33,10 @@ class TestFrameBroadcaster:
     def test_register_duplicate_returns_existing_queue(self):
         """Test that registering the same consumer twice returns the existing queue."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         queue1 = broadcaster.register("consumer1")
         queue2 = broadcaster.register("consumer1")
-        
+
         # Should return the same queue
         assert queue1 is queue2
         assert broadcaster.consumer_count() == 1
@@ -46,29 +45,29 @@ class TestFrameBroadcaster:
         """Test that unregistering removes a consumer."""
         broadcaster = FrameBroadcaster[str]()
         broadcaster.register("consumer1")
-        
+
         assert broadcaster.is_registered("consumer1")
-        
+
         broadcaster.unregister("consumer1")
-        
+
         assert not broadcaster.is_registered("consumer1")
         assert broadcaster.consumer_count() == 0
 
     def test_unregister_nonexistent_consumer_doesnt_raise(self):
         """Test that unregistering a non-existent consumer doesn't raise an error."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         # Should not raise an exception
         broadcaster.unregister("nonexistent")
 
     def test_broadcast_sends_to_all_consumers(self):
         """Test that broadcasting sends frames to all registered consumers."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         queue1 = broadcaster.register("consumer1")
         queue2 = broadcaster.register("consumer2")
         queue3 = broadcaster.register("consumer3")
-        
+
         # Clear initial frames from registration
         while not queue1.empty():
             queue1.get_nowait()
@@ -76,9 +75,9 @@ class TestFrameBroadcaster:
             queue2.get_nowait()
         while not queue3.empty():
             queue3.get_nowait()
-        
+
         broadcaster.broadcast("test_frame")
-        
+
         # All queues should have the frame
         assert queue1.get_nowait() == "test_frame"
         assert queue2.get_nowait() == "test_frame"
@@ -87,12 +86,12 @@ class TestFrameBroadcaster:
     def test_broadcast_updates_latest_frame(self):
         """Test that broadcasting updates the latest frame."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         assert broadcaster.latest_frame is None
-        
+
         broadcaster.broadcast("frame1")
         assert broadcaster.latest_frame == "frame1"
-        
+
         broadcaster.broadcast("frame2")
         assert broadcaster.latest_frame == "frame2"
 
@@ -100,27 +99,27 @@ class TestFrameBroadcaster:
         """Test that broadcasting drops the oldest frame when a queue is full."""
         broadcaster = FrameBroadcaster[int]()
         queue = broadcaster.register("consumer1")
-        
+
         # Clear initial state
         while not queue.empty():
             queue.get_nowait()
-        
+
         # Fill the queue to capacity (maxsize=5)
         for i in range(5):
             broadcaster.broadcast(i)
-        
+
         # Queue should be full
         assert queue.qsize() == 5
-        
+
         # Broadcast another frame - should drop oldest
         broadcaster.broadcast(99)
-        
+
         # Queue should still have 5 items
         assert queue.qsize() == 5
-        
+
         # First frame should be 1 (0 was dropped)
         assert queue.get_nowait() == 1
-        
+
         # Verify remaining frames
         assert queue.get_nowait() == 2
         assert queue.get_nowait() == 3
@@ -130,41 +129,41 @@ class TestFrameBroadcaster:
     def test_clear_drains_all_queues(self):
         """Test that clear drains all consumer queues."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         queue1 = broadcaster.register("consumer1")
         queue2 = broadcaster.register("consumer2")
-        
+
         # Broadcast some frames
         broadcaster.broadcast("frame1")
         broadcaster.broadcast("frame2")
         broadcaster.broadcast("frame3")
-        
+
         # Queues should have frames
         assert not queue1.empty()
         assert not queue2.empty()
-        
+
         # Clear all queues
         broadcaster.clear()
-        
+
         # Queues should be empty
         assert queue1.empty()
         assert queue2.empty()
-        
+
         # Latest frame should be reset
         assert broadcaster.latest_frame is None
 
     def test_clear_keeps_consumers_registered(self):
         """Test that clear drains queues but keeps consumers registered."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         broadcaster.register("consumer1")
         broadcaster.register("consumer2")
         broadcaster.broadcast("frame1")
-        
+
         assert broadcaster.consumer_count() == 2
-        
+
         broadcaster.clear()
-        
+
         # Consumers should still be registered
         assert broadcaster.consumer_count() == 2
         assert broadcaster.is_registered("consumer1")
@@ -173,35 +172,35 @@ class TestFrameBroadcaster:
     def test_consumer_count(self):
         """Test consumer_count returns correct number."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         assert broadcaster.consumer_count() == 0
-        
+
         broadcaster.register("consumer1")
         assert broadcaster.consumer_count() == 1
-        
+
         broadcaster.register("consumer2")
         assert broadcaster.consumer_count() == 2
-        
+
         broadcaster.unregister("consumer1")
         assert broadcaster.consumer_count() == 1
-        
+
         broadcaster.unregister("consumer2")
         assert broadcaster.consumer_count() == 0
 
     def test_is_registered(self):
         """Test is_registered correctly identifies registered consumers."""
         broadcaster = FrameBroadcaster[str]()
-        
+
         assert not broadcaster.is_registered("consumer1")
-        
+
         broadcaster.register("consumer1")
         assert broadcaster.is_registered("consumer1")
         assert not broadcaster.is_registered("consumer2")
-        
+
         broadcaster.register("consumer2")
         assert broadcaster.is_registered("consumer1")
         assert broadcaster.is_registered("consumer2")
-        
+
         broadcaster.unregister("consumer1")
         assert not broadcaster.is_registered("consumer1")
         assert broadcaster.is_registered("consumer2")

--- a/application/backend/tests/unit/webrtc/test_broadcaster.py
+++ b/application/backend/tests/unit/webrtc/test_broadcaster.py
@@ -1,0 +1,207 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from app.webrtc.broadcaster import FrameBroadcaster
+
+
+class TestFrameBroadcaster:
+    def test_register_creates_queue(self):
+        """Test that registering a consumer creates a queue."""
+        broadcaster = FrameBroadcaster[str]()
+        queue = broadcaster.register("consumer1")
+        
+        assert queue is not None
+        assert broadcaster.is_registered("consumer1")
+        assert broadcaster.consumer_count() == 1
+
+    def test_register_seeds_latest_frame(self):
+        """Test that newly registered consumers receive the latest frame."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        # Broadcast a frame before registration
+        broadcaster.broadcast("frame1")
+        
+        # Register a new consumer
+        queue = broadcaster.register("consumer1")
+        
+        # The queue should contain the latest frame
+        assert not queue.empty()
+        frame = queue.get_nowait()
+        assert frame == "frame1"
+
+    def test_register_duplicate_returns_existing_queue(self):
+        """Test that registering the same consumer twice returns the existing queue."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        queue1 = broadcaster.register("consumer1")
+        queue2 = broadcaster.register("consumer1")
+        
+        # Should return the same queue
+        assert queue1 is queue2
+        assert broadcaster.consumer_count() == 1
+
+    def test_unregister_removes_consumer(self):
+        """Test that unregistering removes a consumer."""
+        broadcaster = FrameBroadcaster[str]()
+        broadcaster.register("consumer1")
+        
+        assert broadcaster.is_registered("consumer1")
+        
+        broadcaster.unregister("consumer1")
+        
+        assert not broadcaster.is_registered("consumer1")
+        assert broadcaster.consumer_count() == 0
+
+    def test_unregister_nonexistent_consumer_doesnt_raise(self):
+        """Test that unregistering a non-existent consumer doesn't raise an error."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        # Should not raise an exception
+        broadcaster.unregister("nonexistent")
+
+    def test_broadcast_sends_to_all_consumers(self):
+        """Test that broadcasting sends frames to all registered consumers."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        queue1 = broadcaster.register("consumer1")
+        queue2 = broadcaster.register("consumer2")
+        queue3 = broadcaster.register("consumer3")
+        
+        # Clear initial frames from registration
+        while not queue1.empty():
+            queue1.get_nowait()
+        while not queue2.empty():
+            queue2.get_nowait()
+        while not queue3.empty():
+            queue3.get_nowait()
+        
+        broadcaster.broadcast("test_frame")
+        
+        # All queues should have the frame
+        assert queue1.get_nowait() == "test_frame"
+        assert queue2.get_nowait() == "test_frame"
+        assert queue3.get_nowait() == "test_frame"
+
+    def test_broadcast_updates_latest_frame(self):
+        """Test that broadcasting updates the latest frame."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        assert broadcaster.latest_frame is None
+        
+        broadcaster.broadcast("frame1")
+        assert broadcaster.latest_frame == "frame1"
+        
+        broadcaster.broadcast("frame2")
+        assert broadcaster.latest_frame == "frame2"
+
+    def test_broadcast_drops_oldest_when_queue_full(self):
+        """Test that broadcasting drops the oldest frame when a queue is full."""
+        broadcaster = FrameBroadcaster[int]()
+        queue = broadcaster.register("consumer1")
+        
+        # Clear initial state
+        while not queue.empty():
+            queue.get_nowait()
+        
+        # Fill the queue to capacity (maxsize=5)
+        for i in range(5):
+            broadcaster.broadcast(i)
+        
+        # Queue should be full
+        assert queue.qsize() == 5
+        
+        # Broadcast another frame - should drop oldest
+        broadcaster.broadcast(99)
+        
+        # Queue should still have 5 items
+        assert queue.qsize() == 5
+        
+        # First frame should be 1 (0 was dropped)
+        assert queue.get_nowait() == 1
+        
+        # Verify remaining frames
+        assert queue.get_nowait() == 2
+        assert queue.get_nowait() == 3
+        assert queue.get_nowait() == 4
+        assert queue.get_nowait() == 99
+
+    def test_clear_drains_all_queues(self):
+        """Test that clear drains all consumer queues."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        queue1 = broadcaster.register("consumer1")
+        queue2 = broadcaster.register("consumer2")
+        
+        # Broadcast some frames
+        broadcaster.broadcast("frame1")
+        broadcaster.broadcast("frame2")
+        broadcaster.broadcast("frame3")
+        
+        # Queues should have frames
+        assert not queue1.empty()
+        assert not queue2.empty()
+        
+        # Clear all queues
+        broadcaster.clear()
+        
+        # Queues should be empty
+        assert queue1.empty()
+        assert queue2.empty()
+        
+        # Latest frame should be reset
+        assert broadcaster.latest_frame is None
+
+    def test_clear_keeps_consumers_registered(self):
+        """Test that clear drains queues but keeps consumers registered."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        broadcaster.register("consumer1")
+        broadcaster.register("consumer2")
+        broadcaster.broadcast("frame1")
+        
+        assert broadcaster.consumer_count() == 2
+        
+        broadcaster.clear()
+        
+        # Consumers should still be registered
+        assert broadcaster.consumer_count() == 2
+        assert broadcaster.is_registered("consumer1")
+        assert broadcaster.is_registered("consumer2")
+
+    def test_consumer_count(self):
+        """Test consumer_count returns correct number."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        assert broadcaster.consumer_count() == 0
+        
+        broadcaster.register("consumer1")
+        assert broadcaster.consumer_count() == 1
+        
+        broadcaster.register("consumer2")
+        assert broadcaster.consumer_count() == 2
+        
+        broadcaster.unregister("consumer1")
+        assert broadcaster.consumer_count() == 1
+        
+        broadcaster.unregister("consumer2")
+        assert broadcaster.consumer_count() == 0
+
+    def test_is_registered(self):
+        """Test is_registered correctly identifies registered consumers."""
+        broadcaster = FrameBroadcaster[str]()
+        
+        assert not broadcaster.is_registered("consumer1")
+        
+        broadcaster.register("consumer1")
+        assert broadcaster.is_registered("consumer1")
+        assert not broadcaster.is_registered("consumer2")
+        
+        broadcaster.register("consumer2")
+        assert broadcaster.is_registered("consumer1")
+        assert broadcaster.is_registered("consumer2")
+        
+        broadcaster.unregister("consumer1")
+        assert not broadcaster.is_registered("consumer1")
+        assert broadcaster.is_registered("consumer2")


### PR DESCRIPTION
This pull request refactors the WebRTC streaming pipeline to enable broadcasting inference visualization frames to multiple WebRTC consumers, rather than using a single queue. The main change is the introduction of the new `FrameBroadcaster` class, which manages per-consumer queues and ensures each WebRTC client receives the latest frames independently. This improves scalability and reliability for live video streaming. The changes also update worker and manager classes to use this broadcaster, and adapt tests accordingly.

### WebRTC Streaming Pipeline Refactor

**New broadcasting mechanism:**

* Introduced `FrameBroadcaster` class in `application/backend/app/webrtc/broadcaster.py` for thread-safe broadcasting of frames to multiple consumers, replacing the previous single queue approach. Each consumer gets its own queue, and the broadcaster handles registration, unregistration, broadcasting, and queue management.

**Integration with application and worker logic:**

* Updated `Scheduler` and `DispatchingWorker` to use `FrameBroadcaster` instead of a queue for WebRTC streaming, ensuring that inference visualization frames are broadcast to all registered consumers. [[1]](diffhunk://#diff-05b21237ea7c8e927b86a1e0cb531c09d2b2fc2ed4d8aa57d926b4e20af1ed7dL34-R36) [[2]](diffhunk://#diff-05b21237ea7c8e927b86a1e0cb531c09d2b2fc2ed4d8aa57d926b4e20af1ed7dL73-R74) [[3]](diffhunk://#diff-489084482a62e50b3b568ef62f91e07f7a567a322f235a107c03bc701714e789L32-R41) [[4]](diffhunk://#diff-489084482a62e50b3b568ef62f91e07f7a567a322f235a107c03bc701714e789L98-R100)
* Changed application lifecycle and WebRTC manager initialization to use the broadcaster, and updated connection handling to register/unregister consumers and clean up queues. [[1]](diffhunk://#diff-a9eec037d866e2e965cc47d99bebf8a2ca549f5ea95eda781097228b834f85d6L124-R124) [[2]](diffhunk://#diff-29e4562203b1cfce7cf44632be1ed746eb7eee8e617f0320196b55014f0f60cdL27-R30) [[3]](diffhunk://#diff-29e4562203b1cfce7cf44632be1ed746eb7eee8e617f0320196b55014f0f60cdL40-R41) [[4]](diffhunk://#diff-29e4562203b1cfce7cf44632be1ed746eb7eee8e617f0320196b55014f0f60cdR78-R86)

**Testing updates:**

* Refactored integration tests for the WebRTC manager to use `FrameBroadcaster` and verify correct registration and cleanup of consumer queues. [[1]](diffhunk://#diff-6450311de3c8a448dcd9bec1f27050e7cabe6753587c9ad5f7115eff56dc9a4fL33-R34) [[2]](diffhunk://#diff-6450311de3c8a448dcd9bec1f27050e7cabe6753587c9ad5f7115eff56dc9a4fR77) [[3]](diffhunk://#diff-6450311de3c8a448dcd9bec1f27050e7cabe6753587c9ad5f7115eff56dc9a4fR87-R96) [[4]](diffhunk://#diff-6450311de3c8a448dcd9bec1f27050e7cabe6753587c9ad5f7115eff56dc9a4fR110)

**Imports and module exports:**

* Updated imports and `__all__` definitions across modules to include `FrameBroadcaster` and remove unused queue imports. [[1]](diffhunk://#diff-05b21237ea7c8e927b86a1e0cb531c09d2b2fc2ed4d8aa57d926b4e20af1ed7dL6-R16) [[2]](diffhunk://#diff-46501ba80eaf9642e0538e5c7d94270058969b1c6a3e9d6b39cbc6dea96a12c0R4-R8) [[3]](diffhunk://#diff-29e4562203b1cfce7cf44632be1ed746eb7eee8e617f0320196b55014f0f60cdL5) [[4]](diffhunk://#diff-29e4562203b1cfce7cf44632be1ed746eb7eee8e617f0320196b55014f0f60cdR13) [[5]](diffhunk://#diff-489084482a62e50b3b568ef62f91e07f7a567a322f235a107c03bc701714e789R8) [[6]](diffhunk://#diff-489084482a62e50b3b568ef62f91e07f7a567a322f235a107c03bc701714e789R18) [[7]](diffhunk://#diff-6450311de3c8a448dcd9bec1f27050e7cabe6753587c9ad5f7115eff56dc9a4fL4-R12)

---

This refactor enables robust multi-client WebRTC streaming, improves code clarity, and ensures reliable frame delivery for live inference visualization.

Resolves #5148 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
