### PR TITLE
feat: Display performance metrics

### DIFF
--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.test.tsx
@@ -40,7 +40,7 @@ describe('ModelRow', () => {
     const modelArchitecture = getMockedModelArchitecture({ performanceCategory: 'Speed' });
 
     describe('basic rendering', () => {
-        it('should render all model information correctly when grouped by architecture', () => {
+        it('renders all model information correctly when grouped by architecture', () => {
             render(
                 <ModelRow
                     model={defaultModel}
@@ -67,7 +67,7 @@ describe('ModelRow', () => {
             expect(screen.queryByText(modelArchitecture.performanceCategory ?? '')).not.toBeInTheDocument();
         });
 
-        it('should render all model information correctly when grouped by dataset', () => {
+        it('renders all model information correctly when grouped by dataset', () => {
             render(
                 <ModelRow
                     model={defaultModel}
@@ -86,7 +86,7 @@ describe('ModelRow', () => {
             expect(screen.queryByTestId('labels-count')).not.toBeInTheDocument();
         });
 
-        it('should render "Unnamed Model" when model name is null or undefined', () => {
+        it('renders "Unnamed Model" when model name is null or undefined', () => {
             const modelWithoutName = getMockedModel({ name: undefined });
 
             render(
@@ -101,7 +101,7 @@ describe('ModelRow', () => {
             expect(screen.getByTestId('model-name')).toHaveTextContent('Unnamed Model');
         });
 
-        it('should render "-" when model size is 0 or negative', () => {
+        it('renders "-" when model size is 0 or negative', () => {
             const modelWithZeroSize = getMockedModel({ size: 0 });
 
             render(
@@ -113,7 +113,7 @@ describe('ModelRow', () => {
                 />
             );
 
-            expect(screen.getByText('-')).toBeInTheDocument();
+            expect(screen.getByTestId('model size')).toHaveTextContent('-');
         });
 
         it('renders "Failed" badge when training status is failed', () => {
@@ -137,7 +137,7 @@ describe('ModelRow', () => {
     });
 
     describe('active model tag', () => {
-        it('should show active tag only when model id matches activeModelId', () => {
+        it('shows active tag only when model id matches activeModelId', () => {
             const { rerender } = render(
                 <ModelRow
                     model={defaultModel}
@@ -173,7 +173,7 @@ describe('ModelRow', () => {
     });
 
     describe('parent revision model', () => {
-        it('should render parent revision model when provided and call onExpandModel when clicked', async () => {
+        it('renders parent revision model when provided and call onExpandModel when clicked', async () => {
             const onExpandModel = vi.fn();
             const parentModel = getMockedModel({
                 id: 'parent-123',
@@ -199,7 +199,7 @@ describe('ModelRow', () => {
             expect(onExpandModel).toHaveBeenCalledWith('parent-123');
         });
 
-        it('should not render parent revision model when not provided', () => {
+        it('does not render parent revision model when not provided', () => {
             render(
                 <ModelRow
                     model={defaultModel}

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
@@ -18,6 +18,7 @@ import { ActiveModelTag } from '../active-model-tag.component';
 import { ParentRevisionModel } from '../parent-revision-model.component';
 import { ArchitectureColumn } from './architecture-column.component';
 import { DatasetColumn } from './dataset-revision-column.component';
+import { getTestingMetric } from './utils';
 
 import styles from './model-row.module.scss';
 
@@ -51,6 +52,8 @@ export const ModelRow = ({
         'labels' in labelSchemaRevision && Array.isArray(labelSchemaRevision.labels)
             ? labelSchemaRevision.labels.length
             : undefined;
+
+    const metricValue = getTestingMetric(model)?.value;
 
     return (
         <Grid columns={GRID_COLUMNS} alignItems={'center'} width={'100%'} columnGap={'size-200'}>
@@ -90,7 +93,7 @@ export const ModelRow = ({
 
             <Text UNSAFE_className={styles.smallText}>{totalSize > 0 ? formatModelSize(totalSize) : '-'}</Text>
 
-            <AccuracyIndicator accuracy={72} />
+            {metricValue === undefined ? <Text>-</Text> : <AccuracyIndicator accuracy={metricValue} />}
         </Grid>
     );
 };

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
@@ -91,7 +91,9 @@ export const ModelRow = ({
                 <ArchitectureColumn architecture={modelArchitecture} />
             )}
 
-            <Text UNSAFE_className={styles.smallText}>{totalSize > 0 ? formatModelSize(totalSize) : '-'}</Text>
+            <Text UNSAFE_className={styles.smallText} data-testid={'model size'}>
+                {totalSize > 0 ? formatModelSize(totalSize) : '-'}
+            </Text>
 
             {metricValue === undefined ? <Text>-</Text> : <AccuracyIndicator accuracy={metricValue} />}
         </Grid>

--- a/application/ui/src/features/models/model-listing/components/model-row/utils.test.ts
+++ b/application/ui/src/features/models/model-listing/components/model-row/utils.test.ts
@@ -1,0 +1,119 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { getMockedModel } from 'mocks/mock-model';
+import { describe, expect, it } from 'vitest';
+
+import { getTestingMetric } from './utils';
+
+describe('getTestingMetric', () => {
+    it('returns undefined when model has no evaluations', () => {
+        const model = getMockedModel({ evaluations: [] });
+
+        const result = getTestingMetric(model);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when model has no testing subset evaluation', () => {
+        const model = getMockedModel({
+            evaluations: [
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'training',
+                    metrics: [{ name: 'Accuracy', value: 0.97, primary: true }],
+                },
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'validation',
+                    metrics: [{ name: 'Accuracy', value: 0.95, primary: true }],
+                },
+            ],
+        });
+
+        const result = getTestingMetric(model);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when testing subset has no primary metric', () => {
+        const model = getMockedModel({
+            evaluations: [
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'testing',
+                    metrics: [
+                        { name: 'Precision', value: 0.98, primary: false },
+                        { name: 'Recall', value: 0.94, primary: false },
+                    ],
+                },
+            ],
+        });
+
+        const result = getTestingMetric(model);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('returns testing metric when model has testing subset with primary metric', () => {
+        const model = getMockedModel({
+            evaluations: [
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'testing',
+                    metrics: [
+                        { name: 'Accuracy', value: 0.97, primary: true },
+                        { name: 'Precision', value: 0.98, primary: false },
+                        { name: 'Recall', value: 0.94, primary: false },
+                    ],
+                },
+            ],
+        });
+
+        const result = getTestingMetric(model);
+
+        expect(result).toEqual({ name: 'Accuracy', value: 97 });
+    });
+
+    it('rounds metric value to nearest integer', () => {
+        const model = getMockedModel({
+            evaluations: [
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'testing',
+                    metrics: [{ name: 'Accuracy', value: 0.8547, primary: true }],
+                },
+            ],
+        });
+
+        const result = getTestingMetric(model);
+
+        expect(result).toEqual({ name: 'Accuracy', value: 85 });
+    });
+
+    it('uses testing subset when multiple subsets exist', () => {
+        const model = getMockedModel({
+            evaluations: [
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'training',
+                    metrics: [{ name: 'Accuracy', value: 0.99, primary: true }],
+                },
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'testing',
+                    metrics: [{ name: 'Accuracy', value: 0.87, primary: true }],
+                },
+                {
+                    dataset_revision_id: '3c6c6d38-1cd8-4458-b759-b9880c048b78',
+                    subset: 'validation',
+                    metrics: [{ name: 'Accuracy', value: 0.95, primary: true }],
+                },
+            ],
+        });
+
+        const result = getTestingMetric(model);
+
+        expect(result).toEqual({ name: 'Accuracy', value: 87 });
+    });
+});

--- a/application/ui/src/features/models/model-listing/components/model-row/utils.ts
+++ b/application/ui/src/features/models/model-listing/components/model-row/utils.ts
@@ -1,0 +1,30 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { type Model } from '../../../../../constants/shared-types';
+
+export const getTestingMetric = (model: Model): { name: string; value: number } | undefined => {
+    const evaluation = model.evaluations.find(({ subset }) => subset === 'testing');
+    const primaryMetric = evaluation?.metrics.find(({ primary }) => primary);
+
+    if (primaryMetric !== undefined) {
+        return { name: primaryMetric.name, value: Math.round(primaryMetric.value * 100) };
+    }
+};
+
+export const getFirstAvailableTestingMetric = (models: Model[] | undefined): { name: string; value: number } | null => {
+    // Should never happen, but just in case
+    if (models === undefined) {
+        return null;
+    }
+
+    for (const model of models) {
+        const modelPerformanceEntity = getTestingMetric(model);
+
+        if (modelPerformanceEntity !== undefined) {
+            return modelPerformanceEntity;
+        }
+    }
+
+    return null;
+};

--- a/application/ui/src/features/models/model-listing/components/model-row/utils.ts
+++ b/application/ui/src/features/models/model-listing/components/model-row/utils.ts
@@ -10,6 +10,8 @@ export const getTestingMetric = (model: Model): { name: string; value: number } 
     if (primaryMetric !== undefined) {
         return { name: primaryMetric.name, value: Math.round(primaryMetric.value * 100) };
     }
+
+    return undefined;
 };
 
 export const getFirstAvailableTestingMetric = (

--- a/application/ui/src/features/models/model-listing/components/model-row/utils.ts
+++ b/application/ui/src/features/models/model-listing/components/model-row/utils.ts
@@ -12,19 +12,21 @@ export const getTestingMetric = (model: Model): { name: string; value: number } 
     }
 };
 
-export const getFirstAvailableTestingMetric = (models: Model[] | undefined): { name: string; value: number } | null => {
+export const getFirstAvailableTestingMetric = (
+    models: Model[] | undefined
+): { name: string; value: number } | undefined => {
     // Should never happen, but just in case
     if (models === undefined) {
-        return null;
+        return undefined;
     }
 
     for (const model of models) {
-        const modelPerformanceEntity = getTestingMetric(model);
+        const testingMetric = getTestingMetric(model);
 
-        if (modelPerformanceEntity !== undefined) {
-            return modelPerformanceEntity;
+        if (testingMetric !== undefined) {
+            return testingMetric;
         }
     }
 
-    return null;
+    return undefined;
 };

--- a/application/ui/src/features/models/model-listing/components/models-table-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/models-table-header.component.tsx
@@ -1,11 +1,14 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useMemo } from 'react';
+
 import { dimensionValue, Flex, Grid, Text } from '@geti/ui';
 import { SortDown } from '@geti/ui/icons';
 
 import { GRID_COLUMNS } from '../constants';
 import { useModelListing } from '../provider/model-listing-provider';
+import { getFirstAvailableTestingMetric } from './model-row/utils';
 
 const ColumnHeader = ({ label, isSorted }: { label: string; isSorted?: boolean }) => (
     <Flex alignItems='center' gap='size-50'>
@@ -18,7 +21,13 @@ const ColumnHeader = ({ label, isSorted }: { label: string; isSorted?: boolean }
 // We are just rendering the result of the sort, not doing the sort itself on the table.
 // The actual sorting comes from the models screen Header.
 export const ModelsTableHeader = () => {
-    const { groupBy, sortBy } = useModelListing();
+    const { groupBy, sortBy, groupedModels } = useModelListing();
+
+    const performanceColumnName = useMemo(() => {
+        const models = groupedModels.flatMap((group) => group.models);
+
+        return getFirstAvailableTestingMetric(models)?.name ?? 'Score';
+    }, [groupedModels]);
 
     return (
         <Grid
@@ -39,7 +48,7 @@ export const ModelsTableHeader = () => {
                 isSorted={sortBy === 'architecture'}
             />
             <ColumnHeader label='Total size' isSorted={sortBy === 'size'} />
-            <ColumnHeader label='Score' isSorted={sortBy === 'score'} />
+            <ColumnHeader label={performanceColumnName} isSorted={sortBy === 'score'} />
             <div />
         </Grid>
     );

--- a/application/ui/src/features/models/model-listing/utils/sorting.ts
+++ b/application/ui/src/features/models/model-listing/utils/sorting.ts
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { orderBy } from 'lodash-es';
 
 import type { Model } from '../../../../constants/shared-types';
+import { getTestingMetric } from '../components/model-row/utils';
 import type { SortBy } from '../types';
 
 export const sortModels = (models: Model[], sortBy: SortBy): Model[] => {
@@ -24,11 +25,9 @@ export const sortModels = (models: Model[], sortBy: SortBy): Model[] => {
                 'desc'
             );
         case 'size':
-        // TODO: uncomment once backend returns size
-        // return orderBy(models, (model) => model.size ?? 0, 'asc');
+            return orderBy(models, (model) => model.size ?? 0, 'asc');
         case 'score':
-        // TODO: uncomment once backend returns score
-        // return orderBy(models, (model) => model.score ?? 0, 'desc');
+            return orderBy(models, (model) => getTestingMetric(model)?.value ?? 0, 'asc');
         default:
             return models;
     }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR handles the name and value of the metric that we want to show in the models page.
Algorithm is simple:
1. Get testing set.
2. Find metric that has `primary: true`.
3. Use that metric's name and value. Name is the column name, value is column value.

Moreover I fixed sorting by model size and score.

<img width="1839" height="1287" alt="image" src="https://github.com/user-attachments/assets/6591fd3f-d11a-4570-9e0b-03ffa2aa9fb2" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
