### PR TITLE
Store id explicitly in dataset revision items

### DIFF
--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -18,6 +18,7 @@ from app.db.schema import DatasetRevisionDB
 from app.models import DatasetItemSubset
 from app.models.dataset_item_revision import DatasetRevisionItem
 from app.models.dataset_revision import DatasetRevision, DatasetRevisionCounts
+from app.models.media import ImageFormat
 from app.repositories import DatasetRevisionRepository
 from app.utils.images import crop_to_thumbnail
 
@@ -274,30 +275,13 @@ class DatasetRevisionService(BaseSessionManagedService):
         """
         dataset_revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / str(dataset_revision_id)
         try:
-            # The path stored in the 'image' column is relative to the dataset revision base folder
-            image_rel_path = Path(df_revision_item["image"])
-
-            if "data/projects" in str(image_rel_path):
-                # TODO due to a bug in Datumaro, the above assumption doesn't always hold true, and the image path
-                #  may be relative to the app data folder instead. This workaround can be removed after the bug is fixed
-                #  in Datumaro: https://github.com/open-edge-platform/datumaro/issues/2019
-                image_path = image_rel_path
-            else:
-                image_path = dataset_revision_path / image_rel_path
-
-            if "id" not in df_revision_item:
-                # Fallback: if the 'id' field is missing, try to extract it from the image filename
-                # TODO remove this fallback logic after ensuring the 'id' is always saved in the parquet file
-                #  https://github.com/open-edge-platform/training_extensions/issues/5350
-                logger.warning(
-                    "Dataset revision item is missing 'id' field, attempting to extract from image filename: {}",
-                    image_rel_path,
-                )
-                df_revision_item["id"] = image_rel_path.stem  # Filename without extension
+            # The value stored in the 'image' column is expected to be the name of the image file,
+            # relative to the dataset revision's images/ directory.
+            image_path = dataset_revision_path / "images" / Path(df_revision_item["image"])
 
             return DatasetRevisionItem(
                 id=UUID(df_revision_item["id"]),
-                format=image_rel_path.suffix.lstrip("."),
+                format=ImageFormat(image_path.suffix.lstrip(".").lower()),
                 image_path=image_path,
                 width=df_revision_item["image_info"]["width"],
                 height=df_revision_item["image_info"]["height"],

--- a/application/backend/app/services/datumaro_converter.py
+++ b/application/backend/app/services/datumaro_converter.py
@@ -17,6 +17,7 @@ from datumaro.experimental.fields import (
     label_field,
     numeric_field,
     polygon_field,
+    string_field,
     subset_field,
 )
 from loguru import logger
@@ -32,12 +33,14 @@ class ClassificationSample(Sample):
     Sample for multiclass classification datasets.
 
     Attributes:
+        id: Unique identifier of the sample
         image: Path to the image
         image_info: Image information (width, height)
         label: Class label index (0-based)
         confidence: Confidence score for the label. Only for model predictions.
     """
 
+    id: str = string_field()
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     label: int = label_field(dtype=pl.UInt8(), is_list=False)
@@ -50,12 +53,14 @@ class MultilabelClassificationSample(Sample):
     Sample for multilabel classification datasets.
 
     Attributes:
+        id: Unique identifier of the sample
         image: Path to the image
         image_info: Image information (width, height)
         label: Array of class label indices (0-based)
         confidence: Array of confidence scores for each label. Only for model predictions.
     """
 
+    id: str = string_field()
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     label: NDArrayInt = label_field(dtype=pl.UInt8(), multi_label=True)
@@ -68,6 +73,7 @@ class DetectionSample(Sample):
     Sample for object detection datasets.
 
     Attributes:
+        id: Unique identifier of the sample
         image: Path to the image
         image_info: Image information (width, height)
         bboxes: Array of bounding boxes in x1y1x2y2 format
@@ -75,6 +81,7 @@ class DetectionSample(Sample):
         confidence: Array of confidence scores for each bounding box. Only for model predictions.
     """
 
+    id: str = string_field()
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     bboxes: NDArrayInt = bbox_field(dtype=pl.Int32())
@@ -88,6 +95,7 @@ class InstanceSegmentationSample(Sample):
     Sample for instance segmentation datasets.
 
     Attributes:
+        id: Unique identifier of the sample
         image: Path to the image
         image_info: Image information (width, height)
         polygons: Array of polygons, each represented as a list of points in xy format
@@ -95,6 +103,7 @@ class InstanceSegmentationSample(Sample):
         confidence: Array of confidence scores for each polygon. Only for model predictions.
     """
 
+    id: str = string_field()
     image: str = image_path_field()
     image_info: ImageInfo = image_info_field()
     polygons: NDArrayFloat32 = polygon_field(dtype=pl.Float32())  # Ragged array (num_polygons, num_vertices, 2)
@@ -223,6 +232,7 @@ def convert_classification_dataset(
         try:
             annotation = dataset_item.annotation_data[0]  # classification -> only one shape (annotation)
             return ClassificationSample(
+                id=str(dataset_item.id),
                 image=image_path,
                 image_info=ImageInfo(width=media.width, height=media.height),
                 label=project_labels_ids.index(annotation.labels[0].id),  # multiclass -> only one label
@@ -271,6 +281,7 @@ def convert_multilabel_classification_dataset(
             logger.error("Unable to find one of dataset item {} labels in project", dataset_item.id)
             return None
         return MultilabelClassificationSample(
+            id=str(dataset_item.id),
             image=image_path,
             image_info=ImageInfo(width=media.width, height=media.height),
             label=np.array(labels_indexes),
@@ -342,6 +353,7 @@ def convert_detection_dataset(
             else []
         )
         return DetectionSample(
+            id=str(dataset_item.id),
             image=image_path,
             image_info=ImageInfo(width=media.width, height=media.height),
             bboxes=np.array(coords),
@@ -421,6 +433,7 @@ def convert_instance_segmentation_dataset(
         polygons_np = np.empty(len(polygons), dtype=object)
         polygons_np[:] = [np.asarray(p, dtype=np.float32) for p in polygons]
         return InstanceSegmentationSample(
+            id=str(dataset_item.id),
             image=image_path,
             image_info=ImageInfo(width=media.width, height=media.height),
             polygons=polygons_np,

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -289,7 +289,7 @@ def fxt_dataset_revision_with_parquet(
     df = pl.DataFrame(
         {
             "id": [str(item_id)],
-            "image": [f"images/{image_filename}"],
+            "image": [str(image_filename)],
             "image_info": [{"width": 1024, "height": 768}],
             "subset": ["TRAINING"],
         }

--- a/application/backend/tests/unit/services/evaluation/conftest.py
+++ b/application/backend/tests/unit/services/evaluation/conftest.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from uuid import uuid4
+
 import numpy as np
 import pytest
 from datumaro.experimental import Dataset
@@ -22,19 +24,44 @@ def fxt_multiclass_classification_dataset_gt() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         ClassificationSample(
-            image="/dummy/path/A.jpg", image_info=img_info, label=0, confidence=None, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/A.jpg",
+            image_info=img_info,
+            label=0,
+            confidence=None,
+            subset=Subset.VALIDATION,
         ),
         ClassificationSample(
-            image="/dummy/path/B.jpg", image_info=img_info, label=1, confidence=None, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/B.jpg",
+            image_info=img_info,
+            label=1,
+            confidence=None,
+            subset=Subset.VALIDATION,
         ),
         ClassificationSample(
-            image="/dummy/path/C.jpg", image_info=img_info, label=2, confidence=None, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/C.jpg",
+            image_info=img_info,
+            label=2,
+            confidence=None,
+            subset=Subset.VALIDATION,
         ),
         ClassificationSample(
-            image="/dummy/path/D.jpg", image_info=img_info, label=1, confidence=None, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/D.jpg",
+            image_info=img_info,
+            label=1,
+            confidence=None,
+            subset=Subset.VALIDATION,
         ),
         ClassificationSample(
-            image="/dummy/path/E.jpg", image_info=img_info, label=2, confidence=None, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/E.jpg",
+            image_info=img_info,
+            label=2,
+            confidence=None,
+            subset=Subset.VALIDATION,
         ),
     )
     for sample in samples:
@@ -49,19 +76,44 @@ def fxt_multiclass_classification_dataset_pred() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         ClassificationSample(
-            image="/dummy/path/A.jpg", image_info=img_info, label=0, confidence=0.9, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/A.jpg",
+            image_info=img_info,
+            label=0,
+            confidence=0.9,
+            subset=Subset.VALIDATION,
         ),  # correct
         ClassificationSample(
-            image="/dummy/path/B.jpg", image_info=img_info, label=2, confidence=0.6, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/B.jpg",
+            image_info=img_info,
+            label=2,
+            confidence=0.6,
+            subset=Subset.VALIDATION,
         ),  # wrong
         ClassificationSample(
-            image="/dummy/path/C.jpg", image_info=img_info, label=1, confidence=0.5, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/C.jpg",
+            image_info=img_info,
+            label=1,
+            confidence=0.5,
+            subset=Subset.VALIDATION,
         ),  # wrong
         ClassificationSample(
-            image="/dummy/path/D.jpg", image_info=img_info, label=1, confidence=0.8, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/D.jpg",
+            image_info=img_info,
+            label=1,
+            confidence=0.8,
+            subset=Subset.VALIDATION,
         ),  # correct
         ClassificationSample(
-            image="/dummy/path/E.jpg", image_info=img_info, label=2, confidence=0.9, subset=Subset.VALIDATION
+            id=str(uuid4()),
+            image="/dummy/path/E.jpg",
+            image_info=img_info,
+            label=2,
+            confidence=0.9,
+            subset=Subset.VALIDATION,
         ),  # correct
     )
     for sample in samples:
@@ -78,6 +130,7 @@ def fxt_multilabel_classification_dataset_gt() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         MultilabelClassificationSample(
+            id=str(uuid4()),
             image="/dummy/path/A.jpg",
             image_info=img_info,
             label=np.array([0, 1]),
@@ -85,6 +138,7 @@ def fxt_multilabel_classification_dataset_gt() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         MultilabelClassificationSample(
+            id=str(uuid4()),
             image="/dummy/path/B.jpg",
             image_info=img_info,
             label=np.array([1]),
@@ -92,6 +146,7 @@ def fxt_multilabel_classification_dataset_gt() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         MultilabelClassificationSample(
+            id=str(uuid4()),
             image="/dummy/path/C.jpg",
             image_info=img_info,
             label=np.array([2, 0]),
@@ -113,6 +168,7 @@ def fxt_multilabel_classification_dataset_pred() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         MultilabelClassificationSample(
+            id=str(uuid4()),
             image="/dummy/path/A.jpg",
             image_info=img_info,
             label=np.array([0]),
@@ -120,6 +176,7 @@ def fxt_multilabel_classification_dataset_pred() -> Dataset:
             subset=Subset.VALIDATION,
         ),  # missing one label
         MultilabelClassificationSample(
+            id=str(uuid4()),
             image="/dummy/path/B.jpg",
             image_info=img_info,
             label=np.array([1, 2]),
@@ -127,6 +184,7 @@ def fxt_multilabel_classification_dataset_pred() -> Dataset:
             subset=Subset.VALIDATION,
         ),  # one extra label
         MultilabelClassificationSample(
+            id=str(uuid4()),
             image="/dummy/path/C.jpg",
             image_info=img_info,
             label=np.array([2, 0]),
@@ -146,6 +204,7 @@ def fxt_detection_dataset_gt() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         DetectionSample(
+            id=str(uuid4()),
             image="/dummy/path/A.jpg",
             image_info=img_info,
             bboxes=np.array([[10, 15, 30, 35]]),
@@ -154,6 +213,7 @@ def fxt_detection_dataset_gt() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         DetectionSample(
+            id=str(uuid4()),
             image="/dummy/path/B.jpg",
             image_info=img_info,
             bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]]),
@@ -162,6 +222,7 @@ def fxt_detection_dataset_gt() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         DetectionSample(
+            id=str(uuid4()),
             image="/dummy/path/C.jpg",
             image_info=img_info,
             bboxes=np.array([[0, 0, 15, 15]]),
@@ -182,6 +243,7 @@ def fxt_detection_dataset_pred() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         DetectionSample(
+            id=str(uuid4()),
             image="/dummy/path/A.jpg",
             image_info=img_info,
             bboxes=np.array([[10, 20, 30, 40]]),  # partial overlap (IoU = 0.6)
@@ -190,6 +252,7 @@ def fxt_detection_dataset_pred() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         DetectionSample(
+            id=str(uuid4()),
             image="/dummy/path/B.jpg",
             image_info=img_info,
             bboxes=np.array([[5, 5, 20, 20], [25, 30, 50, 60]]),  # correct
@@ -198,6 +261,7 @@ def fxt_detection_dataset_pred() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         DetectionSample(
+            id=str(uuid4()),
             image="/dummy/path/C.jpg",
             image_info=img_info,
             bboxes=np.array([[0, 0, 15, 15]]),  # correct
@@ -218,6 +282,7 @@ def fxt_instance_segmentation_dataset_gt() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         InstanceSegmentationSample(
+            id=str(uuid4()),
             image="/dummy/path/A.jpg",
             image_info=img_info,
             polygons=np.array([[[10, 20], [30, 40], [40, 70], [10, 60]], [[10, 20], [30, 40], [50, 40]]], dtype=object),
@@ -226,6 +291,7 @@ def fxt_instance_segmentation_dataset_gt() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         InstanceSegmentationSample(
+            id=str(uuid4()),
             image="/dummy/path/B.jpg",
             image_info=img_info,
             polygons=np.array([[[50, 50], [90, 50], [50, 80]]]),
@@ -234,6 +300,7 @@ def fxt_instance_segmentation_dataset_gt() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         InstanceSegmentationSample(
+            id=str(uuid4()),
             image="/dummy/path/C.jpg",
             image_info=img_info,
             polygons=np.array([[[15, 15], [25, 15], [25, 25], [15, 25]]]),
@@ -254,6 +321,7 @@ def fxt_instance_segmentation_dataset_pred() -> Dataset:
     img_info = ImageInfo(width=100, height=100)
     samples = (
         InstanceSegmentationSample(
+            id=str(uuid4()),
             image="/dummy/path/A.jpg",
             image_info=img_info,
             polygons=np.array(
@@ -264,6 +332,7 @@ def fxt_instance_segmentation_dataset_pred() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         InstanceSegmentationSample(
+            id=str(uuid4()),
             image="/dummy/path/B.jpg",
             image_info=img_info,
             polygons=np.array([[[50, 50], [82, 50], [50, 74]]]),  # partial overlap (64% IoU)
@@ -272,6 +341,7 @@ def fxt_instance_segmentation_dataset_pred() -> Dataset:
             subset=Subset.VALIDATION,
         ),
         InstanceSegmentationSample(
+            id=str(uuid4()),
             image="/dummy/path/C.jpg",
             image_info=img_info,
             polygons=np.array([[[15, 15], [25, 15], [25, 25], [15, 25]]]),  # correct

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -263,11 +263,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "6.2.4"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/ede8680603f6016887c062a2cf4fc8fdba905866a3ab8831aa8aa651320c/cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607", size = 31731, upload-time = "2025-12-15T18:24:53.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/af/df70e9b65bc77a1cbe0768c0aa4617147f30f8306ded98c1744bcdc0ae1e/cachetools-7.0.0.tar.gz", hash = "sha256:a9abf18ff3b86c7d05b27ead412e235e16ae045925e531fae38d5fada5ed5b08", size = 35796, upload-time = "2026-02-01T18:59:47.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/fc/1d7b80d0eb7b714984ce40efc78859c022cd930e402f599d8ca9e39c78a4/cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51", size = 11551, upload-time = "2025-12-15T18:24:52.332Z" },
+    { url = "https://files.pythonhosted.org/packages/28/df/2dd32cce20cbcf6f2ec456b58d44368161ad28320729f64e5e1d5d7bd0ae/cachetools-7.0.0-py3-none-any.whl", hash = "sha256:d52fef60e6e964a1969cfb61ccf6242a801b432790fe520d78720d757c81cbd2", size = 13487, upload-time = "2026-02-01T18:59:45.981Z" },
 ]
 
 [[package]]
@@ -484,7 +484,7 @@ wheels = [
 [[package]]
 name = "datumaro"
 version = "2.0.0"
-source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#6fa021810193c16fa3efbed985a93ae7d0885191" }
+source = { git = "https://github.com/open-edge-platform/datumaro.git?rev=develop#a1a364d6408f1cc384edb16e172ce10dc6f6bee5" }
 dependencies = [
     { name = "attrs" },
     { name = "cachetools" },
@@ -3212,32 +3212,11 @@ wheels = [
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.17"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython' or (extra == 'extra-3-otx-cpu' and extra == 'extra-3-otx-cuda') or (extra == 'extra-3-otx-cpu' and extra == 'extra-3-otx-xpu') or (extra == 'extra-3-otx-cuda' and extra == 'extra-3-otx-xpu') or (extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda') or (extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-xpu') or (extra == 'extra-9-geti-tune-cuda' and extra == 'extra-9-geti-tune-xpu')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/fe/b6045c782f1fd1ae317d2a6ca1884857ce5c20f59befe6ab25a8603c43a7/ruamel_yaml-0.18.17-py3-none-any.whl", hash = "sha256:9c8ba9eb3e793efdf924b60d521820869d5bf0cb9c6f1b82d82de8295e290b9d", size = 121594, upload-time = "2025-12-17T20:02:07.657Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/5e/2f970ce4c573dc30c2f95825f2691c96d55560268ddc67603dc6ea2dd08e/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dcec721fddbb62e60c2801ba08c87010bd6b700054a09998c4d09c08147b8fb", size = 147450, upload-time = "2025-11-16T16:13:33.542Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/03/a1baa5b94f71383913f21b96172fb3a2eb5576a4637729adbf7cd9f797f8/ruamel_yaml_clib-0.2.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:65f48245279f9bb301d1276f9679b82e4c080a1ae25e679f682ac62446fac471", size = 133139, upload-time = "2025-11-16T16:13:34.587Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/19/40d676802390f85784235a05788fd28940923382e3f8b943d25febbb98b7/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46895c17ead5e22bea5e576f1db7e41cb273e8d062c04a6a49013d9f60996c25", size = 731474, upload-time = "2025-11-16T20:22:49.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/bb/6ef5abfa43b48dd55c30d53e997f8f978722f02add61efba31380d73e42e/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3eb199178b08956e5be6288ee0b05b2fb0b5c1f309725ad25d9c6ea7e27f962a", size = 748047, upload-time = "2025-11-16T16:13:35.633Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/5d/e4f84c9c448613e12bd62e90b23aa127ea4c46b697f3d760acc32cb94f25/ruamel_yaml_clib-0.2.15-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d1032919280ebc04a80e4fb1e93f7a738129857eaec9448310e638c8bccefcf", size = 782129, upload-time = "2025-11-16T16:13:36.781Z" },
-    { url = "https://files.pythonhosted.org/packages/de/4b/e98086e88f76c00c88a6bcf15eae27a1454f661a9eb72b111e6bbb69024d/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab0df0648d86a7ecbd9c632e8f8d6b21bb21b5fc9d9e095c796cacf32a728d2d", size = 736848, upload-time = "2025-11-16T16:13:37.952Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/5c/5964fcd1fd9acc53b7a3a5d9a05ea4f95ead9495d980003a557deb9769c7/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:331fb180858dd8534f0e61aa243b944f25e73a4dae9962bd44c46d1761126bbf", size = 741630, upload-time = "2025-11-16T20:22:51.718Z" },
-    { url = "https://files.pythonhosted.org/packages/07/1e/99660f5a30fceb58494598e7d15df883a07292346ef5696f0c0ae5dee8c6/ruamel_yaml_clib-0.2.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd4c928ddf6bce586285daa6d90680b9c291cfd045fc40aad34e445d57b1bf51", size = 766619, upload-time = "2025-11-16T16:13:39.178Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2f/fa0344a9327b58b54970e56a27b32416ffbcfe4dcc0700605516708579b2/ruamel_yaml_clib-0.2.15-cp313-cp313-win32.whl", hash = "sha256:bf0846d629e160223805db9fe8cc7aec16aaa11a07310c50c8c7164efa440aec", size = 100171, upload-time = "2025-11-16T16:13:40.456Z" },
-    { url = "https://files.pythonhosted.org/packages/06/c4/c124fbcef0684fcf3c9b72374c2a8c35c94464d8694c50f37eef27f5a145/ruamel_yaml_clib-0.2.15-cp313-cp313-win_amd64.whl", hash = "sha256:45702dfbea1420ba3450bb3dd9a80b33f0badd57539c6aac09f42584303e0db6", size = 118845, upload-time = "2025-11-16T16:13:41.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]
@@ -3647,6 +3626,7 @@ dependencies = [
     { name = "typing-extensions", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-otx-cpu' and extra == 'extra-9-geti-tune-cpu') or (sys_platform == 'linux' and extra != 'extra-3-otx-xpu' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda') or (sys_platform == 'linux' and extra != 'extra-3-otx-xpu' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-xpu') or (sys_platform == 'win32' and extra != 'extra-3-otx-xpu' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda') or (sys_platform == 'win32' and extra != 'extra-3-otx-xpu' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-xpu') or (extra == 'extra-3-otx-cpu' and extra == 'extra-3-otx-cuda') or (extra == 'extra-3-otx-cpu' and extra == 'extra-3-otx-xpu') or (extra == 'extra-3-otx-cuda' and extra == 'extra-3-otx-xpu') or (extra == 'extra-3-otx-cuda' and extra == 'extra-9-geti-tune-cuda' and extra == 'extra-9-geti-tune-xpu') or (extra == 'extra-3-otx-cuda' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda') or (extra == 'extra-3-otx-cuda' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-xpu') or (extra != 'extra-3-otx-cpu' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda') or (extra != 'extra-3-otx-cpu' and extra == 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-xpu') or (extra != 'extra-9-geti-tune-cpu' and extra == 'extra-9-geti-tune-cuda' and extra == 'extra-9-geti-tune-xpu')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/1b/af5fccb50c341bd69dc016769503cb0857c1423fbe9343410dfeb65240f2/torch-2.10.0-1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:7350f6652dfd761f11f9ecb590bfe95b573e2961f7a242eccb3c8e78348d26fe", size = 79498248, upload-time = "2026-02-06T17:37:31.982Z" },
     { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
     { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
     { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },


### PR DESCRIPTION
### Summary

Changes:
- Upgrade `datumaro` to latest version
- Add `id` field to dataset Sample classes
  - As a result, the dataset revision dataframe is extended with an `id` column
  - Previously, the id would be inferred from the image file name, which is hacky and can't work with the latest Datumaro format
- Update `DatasetRevisionService` to correctly process the `id` column in the dataframe

Resolves #5350 

### How to test

Train a model, view the training dataset and manually inspect the dataframe.

<img width="2437" height="254" alt="image" src="https://github.com/user-attachments/assets/8abec695-f1ca-4196-a661-9cb4b36c286d" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
