### PR TITLE
Fix image-classification-efficientnet-b0 pretrained weights download

### DIFF
--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
@@ -3,7 +3,7 @@ name: EfficientNet-B0
 
 pretrained_weights:
   url: https://github.com/osmr/imgclsmob/releases/download/v0.0.364/efficientnet_b0-0752-0e386130.pth.zip
-  sha_sum: bb693fa44ebec3faa35219513eb876cf0e1a1bf9c18dc60949089b9b30e03580
+  sha_sum: 79f2b405a15399a0772337bd7f58052cb88299a65ed838a43c1ea8d3e0253f70
 
 description: "EfficientNet-B0 is the baseline model of the EfficientNet family, designed using neural architecture search to optimize accuracy and efficiency. It uses a compound scaling method to balance network depth, width, and resolution, achieving strong performance with relatively low computational cost and around 5.3M parameters."
 stats:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Updates the SHA sum for the pretrained model weights for `image-classification-efficientnet-b0`

File was downloaded from https://github.com/osmr/imgclsmob/releases/tag/v0.0.364 and manually checked/computed the SHA.

Fixes: #5427 

### How to test

`BaseWeightsService(Path("./data")).get_local_weights_path(task=TaskType.CLASSIFICATION, model_manifest_id="image-classification-efficientnet-b0", allow_download=True)`


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
