### PR TITLE
Subset splitter should guarantee at least 1 item in each subset

### DIFF
--- a/application/backend/app/services/training/subset_assignment/distribution.py
+++ b/application/backend/app/services/training/subset_assignment/distribution.py
@@ -13,8 +13,9 @@ class SubsetDistribution:
         self._counts = counts.copy()
 
     @property
-    def total(self) -> int:
-        return sum(self._counts.values())
+    def total_assigned(self) -> int:
+        """Total count of assigned items across train, validation, and test subsets."""
+        return sum(count for subset, count in self._counts.items() if subset != DatasetItemSubset.UNASSIGNED)
 
     def get_count(self, subset: DatasetItemSubset) -> int:
         return self._counts.get(subset, 0)
@@ -30,7 +31,7 @@ class SubsetDistribution:
         if unassigned_count == 0:
             return target_ratios
 
-        target_counts = target_ratios.to_fold_sizes(self.total + unassigned_count)
+        target_counts = target_ratios.to_fold_sizes(self.total_assigned + unassigned_count)
 
         # Calculate how many more items are needed in each subset
         needed = {

--- a/application/backend/app/services/training/subset_assignment/models.py
+++ b/application/backend/app/services/training/subset_assignment/models.py
@@ -21,10 +21,47 @@ class SplitRatios:
             raise ValueError(f"Split ratios must sum to 1.0, got {total}")
 
     def to_fold_sizes(self, total_items: int) -> dict[DatasetItemSubset, int]:
-        """Convert split ratios to absolute fold sizes based on total items"""
-        train_size = int(total_items * self.train)
-        val_size = int(total_items * self.val)
-        test_size = total_items - (train_size + val_size)
+        """
+        Convert split ratios to absolute fold sizes based on total items
+
+        Each fold is guaranteed to receive at least 1 item. If the sum of rounded sizes exceeds total_items (due to
+        the minimum of 1 per fold), the excess is reduced from the fold with the largest ratio first. When ratios are
+        equal, reduction priority is: val > train > test.
+
+        Args:
+            total_items: Total number of items to distribute across folds
+
+        Returns:
+            Dictionary mapping each subset to its absolute size
+
+        Raises:
+            ValueError: If total_items < 3 (need at least 1 item per fold)
+        """
+        if total_items < 3:
+            raise ValueError(f"Need at least 3 items to create all subsets, got {total_items}")
+
+        # Ensure minimum of 1 per fold
+        train_size = max(1, round(total_items * self.train))
+        val_size = max(1, round(total_items * self.val))
+        test_size = max(1, round(total_items * self.test))
+
+        # Adjust to match exact total by reducing from the largest fold
+        diff = (train_size + val_size + test_size) - total_items
+        if diff > 0:
+            # Sort by ratio to reduce from the largest first, prioritizing val over the train if equal
+            folds = [(self.val, "val"), (self.train, "train"), (self.test, "test")]
+            folds.sort(reverse=True, key=lambda x: x[0])
+
+            sizes = {"train": train_size, "val": val_size, "test": test_size}
+
+            for _, fold_name in folds:
+                if sizes[fold_name] > 1 and diff > 0:
+                    reduction = min(sizes[fold_name] - 1, diff)
+                    sizes[fold_name] -= reduction
+                    diff -= reduction
+
+            train_size, val_size, test_size = sizes["train"], sizes["val"], sizes["test"]
+
         return {
             DatasetItemSubset.TRAINING: train_size,
             DatasetItemSubset.VALIDATION: val_size,

--- a/application/backend/app/services/training/subset_assignment/models.py
+++ b/application/backend/app/services/training/subset_assignment/models.py
@@ -24,9 +24,10 @@ class SplitRatios:
         """
         Convert split ratios to absolute fold sizes based on total items
 
-        Each fold is guaranteed to receive at least 1 item. If the sum of rounded sizes exceeds total_items (due to
-        the minimum of 1 per fold), the excess is reduced from the fold with the largest ratio first. When ratios are
-        equal, reduction priority is: val > train > test.
+        Each fold is guaranteed to receive at least 1 item. Fold sizes are calculated by rounding proportional
+        allocations. If the sum differs from total_items due to rounding, the difference is adjusted by adding/removing
+        items from folds in order of their ratio size (largest first).
+        When ratios are equal, priority is: val > train > test.
 
         Args:
             total_items: Total number of items to distribute across folds
@@ -47,18 +48,25 @@ class SplitRatios:
 
         # Adjust to match exact total by reducing from the largest fold
         diff = (train_size + val_size + test_size) - total_items
-        if diff > 0:
-            # Sort by ratio to reduce from the largest first, prioritizing val over the train if equal
+        if diff != 0:
+            # Sort by ratio to adjust the largest first, prioritizing val over the train if equal
             folds = [(self.val, "val"), (self.train, "train"), (self.test, "test")]
             folds.sort(reverse=True, key=lambda x: x[0])
 
             sizes = {"train": train_size, "val": val_size, "test": test_size}
 
             for _, fold_name in folds:
-                if sizes[fold_name] > 1 and diff > 0:
-                    reduction = min(sizes[fold_name] - 1, diff)
-                    sizes[fold_name] -= reduction
-                    diff -= reduction
+                if diff > 0:  # Over-allocated: reduce
+                    if sizes[fold_name] > 1:
+                        reduction = min(sizes[fold_name] - 1, diff)
+                        sizes[fold_name] -= reduction
+                        diff -= reduction
+                elif diff < 0:  # Under-allocated: increase
+                    addition = abs(diff)
+                    sizes[fold_name] += addition
+                    diff += addition
+                if diff == 0:
+                    break
 
             train_size, val_size, test_size = sizes["train"], sizes["val"], sizes["test"]
 

--- a/application/backend/tests/unit/services/training/subset_assignment/test_distribution.py
+++ b/application/backend/tests/unit/services/training/subset_assignment/test_distribution.py
@@ -14,7 +14,7 @@ class TestSubsetDistribution:
     def test_create_distribution_empty(self):
         """Test creation of empty distribution"""
         distribution = SubsetDistribution(counts={})
-        assert distribution.total == 0
+        assert distribution.total_assigned == 0
 
     def test_create_distribution_with_counts(self):
         """Test creation of distribution with initial counts"""
@@ -22,13 +22,15 @@ class TestSubsetDistribution:
             DatasetItemSubset.TRAINING: 70,
             DatasetItemSubset.VALIDATION: 20,
             DatasetItemSubset.TESTING: 10,
+            DatasetItemSubset.UNASSIGNED: 10,  # Should not be included in total
         }
         distribution = SubsetDistribution(counts=counts)
 
         assert distribution.get_count(DatasetItemSubset.TRAINING) == 70
         assert distribution.get_count(DatasetItemSubset.VALIDATION) == 20
         assert distribution.get_count(DatasetItemSubset.TESTING) == 10
-        assert distribution.total == 100
+        assert distribution.get_count(DatasetItemSubset.UNASSIGNED) == 10
+        assert distribution.total_assigned == 100
 
     def test_get_count_existing_subset(self):
         """Test getting count for an existing subset"""

--- a/application/backend/tests/unit/services/training/subset_assignment/test_split_ratios.py
+++ b/application/backend/tests/unit/services/training/subset_assignment/test_split_ratios.py
@@ -44,13 +44,14 @@ class TestSplitRatios:
             (100, 70, 20, 10, (0.7, 0.2, 0.1)),  # basic
             (97, 68, 19, 10, (0.7, 0.2, 0.1)),  # rounding case
             (300, 99, 99, 102, (0.33, 0.33, 0.34)),  # equal ratios with rounding
+            (10, 4, 3, 3, (0.34, 0.33, 0.33)),  # equal ratios with rounding
             (4, 2, 1, 1, (0.5, 0.5, 0)),  # reduction priority when val and train are equal
             (11, 7, 3, 1, (0.6, 0.3, 0.1)),  # reduction from the largest
             (3, 1, 1, 1, (0.8, 0.15, 0.05)),  # each fold gets at least 1 item, even if ratios are skewed
             (3, 1, 1, 1, (1.0, 0.0, 0.0)),  # all train, but still need to assign 1 to val and test
         ],
     )
-    def test_to_fold_sizes(self, target: int, train: int, val: int, test: int, ratios: tuple[int, ...]):
+    def test_to_fold_sizes(self, target: int, train: int, val: int, test: int, ratios: tuple[float, ...]):
         """Test conversion of split ratios to absolute fold sizes"""
         split = SplitRatios(*ratios)
         fold_sizes = split.to_fold_sizes(target)

--- a/application/backend/tests/unit/services/training/subset_assignment/test_split_ratios.py
+++ b/application/backend/tests/unit/services/training/subset_assignment/test_split_ratios.py
@@ -39,24 +39,32 @@ class TestSplitRatios:
         assert split.train + split.val + split.test == 1.01
 
     @pytest.mark.parametrize(
-        "target,train,val,test",
+        "target,train,val,test,ratios",
         [
-            (100, 70, 20, 10),  # basic
-            (10, 7, 2, 1),  # small numbers
-            (50, 35, 10, 5),  # half size
-            (97, 67, 19, 11),  # rounding case
-            (1, 0, 0, 1),  # single item
+            (100, 70, 20, 10, (0.7, 0.2, 0.1)),  # basic
+            (97, 68, 19, 10, (0.7, 0.2, 0.1)),  # rounding case
+            (300, 99, 99, 102, (0.33, 0.33, 0.34)),  # equal ratios with rounding
+            (4, 2, 1, 1, (0.5, 0.5, 0)),  # reduction priority when val and train are equal
+            (11, 7, 3, 1, (0.6, 0.3, 0.1)),  # reduction from the largest
+            (3, 1, 1, 1, (0.8, 0.15, 0.05)),  # each fold gets at least 1 item, even if ratios are skewed
+            (3, 1, 1, 1, (1.0, 0.0, 0.0)),  # all train, but still need to assign 1 to val and test
         ],
     )
-    def test_to_fold_sizes(self, target, train, val, test):
+    def test_to_fold_sizes(self, target: int, train: int, val: int, test: int, ratios: tuple[int, ...]):
         """Test conversion of split ratios to absolute fold sizes"""
-        split = SplitRatios(train=0.7, val=0.2, test=0.1)
+        split = SplitRatios(*ratios)
         fold_sizes = split.to_fold_sizes(target)
 
         assert fold_sizes[DatasetItemSubset.TRAINING] == train
         assert fold_sizes[DatasetItemSubset.VALIDATION] == val
         assert fold_sizes[DatasetItemSubset.TESTING] == test
         assert sum(fold_sizes.values()) == target
+
+    def test_to_fold_sizes_boundary_low(self):
+        """Test that to_fold_sizes raises error for less than 3 items"""
+        split = SplitRatios(train=0.7, val=0.2, test=0.1)
+        with pytest.raises(ValueError, match="Need at least 3 items to create all subsets"):
+            split.to_fold_sizes(2)
 
     def test_to_list(self):
         """Test conversion of split ratios to list"""
@@ -65,23 +73,3 @@ class TestSplitRatios:
 
         assert ratios_list == [0.7, 0.2, 0.1]
         assert len(ratios_list) == 3
-
-    def test_all_train(self):
-        """Test split with all items in training"""
-        split = SplitRatios(train=1.0, val=0.0, test=0.0)
-        fold_sizes = split.to_fold_sizes(100)
-
-        assert fold_sizes[DatasetItemSubset.TRAINING] == 100
-        assert fold_sizes[DatasetItemSubset.VALIDATION] == 0
-        assert fold_sizes[DatasetItemSubset.TESTING] == 0
-
-    def test_equal_split(self):
-        """Test equal split across all subsets"""
-        split = SplitRatios(train=0.33, val=0.33, test=0.34)
-        fold_sizes = split.to_fold_sizes(300)
-
-        assert fold_sizes[DatasetItemSubset.TRAINING] == 99
-        assert fold_sizes[DatasetItemSubset.VALIDATION] == 99
-        # Test gets the remainder to ensure total is preserved
-        assert fold_sizes[DatasetItemSubset.TESTING] == 102
-        assert sum(fold_sizes.values()) == 300


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Fix `SubsetDistribution.compute_adjusted_ratios` to consider only total assigned items
- [x] Update `SplitRatios.to_fold_sizes` to guarantee at least 1 in each fold

### How to test

1. Create a project
2. Upload and annotate 3 images
3. Train

Training job should succeed.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
