### PR TITLE
Update Pyrefly config to only check source and test folders

### DIFF
--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -164,4 +164,5 @@ pythonpath = [
 
 [tool.pyrefly]
 python-version = "3.13.0"
+project-includes = ["app/**/*.py*", "pyinstaller/**/*.py*", "tests/**/*.py*"]
 ignore-missing-imports = ["*"]

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -422,4 +422,5 @@ python_files = "tests/**/*.py"
 
 [tool.pyrefly]
 python-version = "3.10.0"
+project-includes = ["src/otx/**/*.py*", "tests/**/*.py*"]
 ignore-missing-imports = ["*"]


### PR DESCRIPTION
### Summary

With the new `project-includes` settings, Pyrefly won't verify local scripts (debug, utilities, ...) that developers often save locally in the project without committing them.

### How to test

Use `uv run pyrefly dump-config` to verify the list of covered files.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
