### PR TITLE
feat: Support media download and deletion

### DIFF
--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -176,7 +176,9 @@ def get_media_binary(
     """Get media binary content"""
     try:
         binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media_id)
-        return FileResponse(path=binary_path)
+        media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
+        filename = f"{media.name}.{media.format.value.lower()}"
+        return FileResponse(path=binary_path, headers={"Content-Disposition": f'attachment; filename="{filename}"'})
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -178,7 +178,7 @@ def get_media_binary(
         binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media_id)
         media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
         filename = f"{media.name}.{media.format.value.lower()}"
-        return FileResponse(path=binary_path, headers={"Content-Disposition": f'attachment; filename="{filename}"'})
+        return FileResponse(path=binary_path, filename=filename)
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/application/ui/src/components/add-media-button/add-media-button.component.tsx
+++ b/application/ui/src/components/add-media-button/add-media-button.component.tsx
@@ -10,6 +10,12 @@ interface AddMediaButtonProps {
     multiple?: boolean;
 }
 
+const VALID_VIDEO_EXT = ['mp4', 'avi', 'mkv', 'mov', 'webm', 'm4v'];
+const VALID_IMAGE_EXT = ['jpg', 'jpeg', 'png'];
+const VALID_EXT = [...VALID_VIDEO_EXT, ...VALID_IMAGE_EXT];
+
+const acceptedExtensions = VALID_EXT.map((ext) => `.${ext}`).join(',');
+
 export const AddMediaButton = ({ onFilesSelected, multiple = true }: AddMediaButtonProps) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -40,6 +46,7 @@ export const AddMediaButton = ({ onFilesSelected, multiple = true }: AddMediaBut
                 onChange={handleFileChange}
                 style={{ display: 'none' }}
                 aria-label={'Upload media files'}
+                accept={acceptedExtensions}
             />
             <Button variant={'secondary'} onPress={handleClick}>
                 Upload Files

--- a/application/ui/src/components/media-item/media-item.module.scss
+++ b/application/ui/src/components/media-item/media-item.module.scss
@@ -2,7 +2,7 @@
     opacity: 0;
     position: absolute;
     line-height: 0px;
-    padding: var(--spectrum-global-dimension-size-125);
+    padding: var(--spectrum-global-dimension-size-150);
     border-radius: var(--spectrum-global-dimension-size-50);
 
     &:empty {
@@ -20,6 +20,7 @@
     background: var(--spectrum-global-color-gray-50);
     top: var(--spectrum-global-dimension-size-50);
     right: var(--spectrum-global-dimension-size-50);
+    padding: var(--spectrum-global-dimension-size-50);
 }
 
 .bottomLeftElement {
@@ -35,6 +36,13 @@
 
 div[class*='mediaItem']:is([data-hovered], [data-selected]) {
     .floatingContainer {
+        opacity: 1;
+    }
+}
+
+// When media actions menu is open, we don't want to hide the button that opens it
+div[class*='mediaItem']:has(button[aria-label='Media actions'][aria-expanded='true']) {
+    .rightTopElement {
         opacity: 1;
     }
 }

--- a/application/ui/src/features/dataset/api/use-delete-media-item.ts
+++ b/application/ui/src/features/dataset/api/use-delete-media-item.ts
@@ -1,0 +1,79 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { toast } from '@geti/ui';
+import { useOverlayTriggerState } from '@react-stately/overlays';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { isFunction } from 'lodash-es';
+
+import { $api } from '../../../api/client';
+
+const useDeleteMediaItemMutation = (projectId: string) => {
+    return $api.useMutation('delete', `/api/projects/{project_id}/dataset/media/{media_id}`, {
+        meta: {
+            invalidateQueries: [
+                [
+                    'get',
+                    '/api/projects/{project_id}/dataset/media',
+                    {
+                        params: {
+                            path: {
+                                project_id: projectId,
+                            },
+                        },
+                    },
+                ],
+            ],
+        },
+        onError: (error, { params: { path } }) => {
+            const { media_id: itemId } = path;
+
+            toast({
+                id: String(itemId),
+                type: 'error',
+                message: `Failed to delete, ${error?.detail}`,
+            });
+        },
+    });
+};
+
+const isFulfilled = (response: PromiseSettledResult<{ itemId: string }>) => response.status === 'fulfilled';
+
+export const useDeleteMediaItem = () => {
+    const projectId = useProjectIdentifier();
+    const deleteMutation = useDeleteMediaItemMutation(projectId);
+
+    const alertDialogState = useOverlayTriggerState({});
+
+    const handleDeleteItems = async (ids: string[], onDeleted?: (ids: string[]) => void) => {
+        alertDialogState.close();
+
+        toast({ id: 'deleting-notification', type: 'info', message: `Deleting items...` });
+
+        const deleteItemPromises = ids.map(async (media_id) => {
+            await deleteMutation.mutateAsync({ params: { path: { project_id: projectId, media_id } } });
+
+            return { itemId: media_id };
+        });
+
+        const responses = await Promise.allSettled(deleteItemPromises);
+        const deletedIds = responses.filter(isFulfilled).map(({ value }) => value.itemId);
+
+        isFunction(onDeleted) && onDeleted(deletedIds);
+
+        toast({
+            id: 'deleting-notification',
+            type: 'success',
+            message: `${deletedIds.length} item(s) deleted successfully`,
+            duration: 3000,
+        });
+    };
+
+    return {
+        deleteMedia: handleDeleteItems,
+        isPending: deleteMutation.isPending,
+        isDeleteDialogOpen: alertDialogState.isOpen,
+        openDeleteDialog: alertDialogState.open,
+        closeDeleteDialog: alertDialogState.close,
+    };
+};

--- a/application/ui/src/features/dataset/gallery/delete-media-item/delete-media-item.component.tsx
+++ b/application/ui/src/features/dataset/gallery/delete-media-item/delete-media-item.component.tsx
@@ -1,13 +1,10 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActionButton, DialogContainer, toast } from '@geti/ui';
+import { ActionButton, DialogContainer } from '@geti/ui';
 import { Delete } from '@geti/ui/icons';
-import { useOverlayTriggerState } from '@react-stately/overlays';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { isFunction } from 'lodash-es';
 
-import { $api } from '../../../../api/client';
+import { useDeleteMediaItem } from '../../api/use-delete-media-item';
 import { AlertDialogContent } from './alert-dialog-content.component';
 
 import classes from './delete-media-item.module.scss';
@@ -17,61 +14,11 @@ type DeleteMediaItemProps = {
     onDeleted?: (deletedIds: string[]) => void;
 };
 
-const isFulfilled = (response: PromiseSettledResult<{ itemId: string }>) => response.status === 'fulfilled';
-
 export const DeleteMediaItem = ({ itemsIds = [], onDeleted }: DeleteMediaItemProps) => {
-    const project_id = useProjectIdentifier();
-    const alertDialogState = useOverlayTriggerState({});
+    const { deleteMedia, openDeleteDialog, closeDeleteDialog, isPending, isDeleteDialogOpen } = useDeleteMediaItem();
 
-    const removeMutation = $api.useMutation('delete', `/api/projects/{project_id}/dataset/media/{media_id}`, {
-        meta: {
-            invalidateQueries: [
-                [
-                    'get',
-                    '/api/projects/{project_id}/dataset/media',
-                    {
-                        params: {
-                            path: {
-                                project_id,
-                            },
-                        },
-                    },
-                ],
-            ],
-        },
-        onError: (error, { params: { path } }) => {
-            const { media_id: itemId } = path;
-
-            toast({
-                id: String(itemId),
-                type: 'error',
-                message: `Failed to delete, ${error?.detail}`,
-            });
-        },
-    });
-
-    const handleRemoveItems = async () => {
-        alertDialogState.close();
-
-        toast({ id: 'deleting-notification', type: 'info', message: `Deleting items...` });
-
-        const deleteItemPromises = itemsIds.map(async (media_id) => {
-            await removeMutation.mutateAsync({ params: { path: { project_id, media_id } } });
-
-            return { itemId: media_id };
-        });
-
-        const responses = await Promise.allSettled(deleteItemPromises);
-        const deletedIds = responses.filter(isFulfilled).map(({ value }) => value.itemId);
-
-        isFunction(onDeleted) && onDeleted(deletedIds);
-
-        toast({
-            id: 'deleting-notification',
-            type: 'success',
-            message: `${deletedIds.length} item(s) deleted successfully`,
-            duration: 3000,
-        });
+    const handleDelete = async () => {
+        await deleteMedia(itemsIds, onDeleted);
     };
 
     return (
@@ -79,17 +26,15 @@ export const DeleteMediaItem = ({ itemsIds = [], onDeleted }: DeleteMediaItemPro
             <ActionButton
                 isQuiet
                 aria-label='delete media item'
-                isDisabled={removeMutation.isPending}
+                isDisabled={isPending}
                 UNSAFE_className={classes.deleteButton}
-                onPress={alertDialogState.open}
+                onPress={openDeleteDialog}
             >
                 <Delete />
             </ActionButton>
 
-            <DialogContainer onDismiss={alertDialogState.close}>
-                {alertDialogState.isOpen && (
-                    <AlertDialogContent itemsIds={itemsIds} onPrimaryAction={handleRemoveItems} />
-                )}
+            <DialogContainer onDismiss={closeDeleteDialog}>
+                {isDeleteDialogOpen && <AlertDialogContent itemsIds={itemsIds} onPrimaryAction={handleDelete} />}
             </DialogContainer>
         </>
     );

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -9,11 +9,11 @@ import { MediaItem } from '../../../components/media-item/media-item.component';
 import { MediaThumbnail } from '../../../components/media-thumbnail/media-thumbnail.component';
 import { VirtualizerGridLayout } from '../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import type { Media } from '../../../constants/shared-types';
-import { getThumbnailUrl } from '../../../shared/media-url.utils';
+import { getMediaBinaryUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
 import { MediaPreview } from '../media-preview/media-preview.component';
 import { useSelectedData } from '../selected-data-provider.component';
-import { DeleteMediaItem } from './delete-media-item/delete-media-item.component';
 import { useSelectDatasetItem } from './hooks/use-select-dataset-item.hook';
+import { MediaItemActions } from './media-item-actions/media-item-actions.component';
 
 type GalleryProps = {
     items: Media[];
@@ -49,34 +49,45 @@ export const Gallery = ({ items, viewMode, hasNextPage, isFetchingNextPage, fetc
                 isLoadingMore={isFetchingNextPage}
                 onLoadMore={() => hasNextPage && fetchNextPage()}
                 onSelectionChange={setSelectedKeys}
-                contentItem={(item) => (
-                    <MediaItem
-                        contentElement={() => (
-                            <MediaThumbnail
-                                alt={item.name}
-                                url={getThumbnailUrl(projectId, String(item.id))}
-                                onDoubleClick={() => onSelectedMediaItemChange(item)}
-                            />
-                        )}
-                        topLeftElement={() => (
-                            <Flex
-                                width={'size-200'}
-                                height={'size-200'}
-                                alignItems={'center'}
-                                justifyContent={'center'}
-                            >
-                                <Checkbox
-                                    aria-label={`Select media item ${item.name}`}
-                                    onChange={() => toggleSelectedKeys([String(item.id)])}
-                                    isSelected={isSetSelectedKeys && selectedKeys.has(String(item.id))}
+                contentItem={(item) => {
+                    const mediaUrl = getThumbnailUrl(projectId, item.id);
+                    const fullMediaUrl = getMediaBinaryUrl(projectId, item.id);
+                    const mediaFileName = `${item.name}.${item.format};`;
+
+                    return (
+                        <MediaItem
+                            contentElement={() => (
+                                <MediaThumbnail
+                                    alt={item.name}
+                                    url={mediaUrl}
+                                    onDoubleClick={() => onSelectedMediaItemChange(item)}
                                 />
-                            </Flex>
-                        )}
-                        topRightElement={() => (
-                            <DeleteMediaItem itemsIds={[String(item.id)]} onDeleted={toggleSelectedKeys} />
-                        )}
-                    />
-                )}
+                            )}
+                            topLeftElement={() => (
+                                <Flex
+                                    width={'size-200'}
+                                    height={'size-200'}
+                                    alignItems={'center'}
+                                    justifyContent={'center'}
+                                >
+                                    <Checkbox
+                                        aria-label={`Select media item ${item.name}`}
+                                        onChange={() => toggleSelectedKeys([String(item.id)])}
+                                        isSelected={isSetSelectedKeys && selectedKeys.has(String(item.id))}
+                                    />
+                                </Flex>
+                            )}
+                            topRightElement={() => (
+                                <MediaItemActions
+                                    id={item.id}
+                                    onDeleted={toggleSelectedKeys}
+                                    mediaUrl={fullMediaUrl}
+                                    mediaFileName={mediaFileName}
+                                />
+                            )}
+                        />
+                    );
+                }}
             />
 
             <DialogContainer type={'fullscreenTakeover'} onDismiss={() => onSelectedMediaItemChange(null)}>

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -52,7 +52,7 @@ export const Gallery = ({ items, viewMode, hasNextPage, isFetchingNextPage, fetc
                 contentItem={(item) => {
                     const mediaUrl = getThumbnailUrl(projectId, item.id);
                     const fullMediaUrl = getMediaBinaryUrl(projectId, item.id);
-                    const mediaFileName = `${item.name}.${item.format};`;
+                    const mediaFileName = `${item.name}.${item.format}`;
 
                     return (
                         <MediaItem

--- a/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
+++ b/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
@@ -1,0 +1,64 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Key } from 'react';
+
+import { ActionButton, DialogContainer, Item, Menu, MenuTrigger } from '@geti/ui';
+import { MoreMenu } from '@geti/ui/icons';
+
+import { useDeleteMediaItem } from '../../api/use-delete-media-item';
+import { AlertDialogContent } from '../delete-media-item/alert-dialog-content.component';
+
+const MEDIA_ACTIONS = {
+    DOWNLOAD: 'download',
+    DELETE: 'delete',
+};
+
+type MediaItemActionsProps = {
+    id: string;
+    mediaUrl: string;
+    mediaFileName: string;
+    onDeleted: (deletedIds: string[]) => void;
+};
+
+export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName }: MediaItemActionsProps) => {
+    const { closeDeleteDialog, openDeleteDialog, isDeleteDialogOpen, deleteMedia, isPending } = useDeleteMediaItem();
+
+    const handleDownload = () => {
+        const link = document.createElement('a');
+        link.href = mediaUrl;
+        // Just in case, the "Content-Disposition" header takes precedence over this filename.
+        link.download = mediaFileName;
+        link.hidden = true;
+        link.click();
+    };
+
+    const handleAction = (key: Key) => {
+        if (key === MEDIA_ACTIONS.DOWNLOAD) {
+            handleDownload();
+        } else if (key === MEDIA_ACTIONS.DELETE) {
+            openDeleteDialog();
+        }
+    };
+
+    const handleDeleteMedia = async () => {
+        await deleteMedia([id], onDeleted);
+    };
+
+    return (
+        <>
+            <MenuTrigger>
+                <ActionButton isQuiet aria-label={'Media actions'} isDisabled={isPending}>
+                    <MoreMenu />
+                </ActionButton>
+                <Menu onAction={handleAction} aria-label={'Media actions menu'}>
+                    <Item key={MEDIA_ACTIONS.DOWNLOAD}>Download</Item>
+                    <Item key={MEDIA_ACTIONS.DELETE}>Delete</Item>
+                </Menu>
+            </MenuTrigger>
+            <DialogContainer onDismiss={closeDeleteDialog}>
+                {isDeleteDialogOpen && <AlertDialogContent itemsIds={[id]} onPrimaryAction={handleDeleteMedia} />}
+            </DialogContainer>
+        </>
+    );
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Introduced media item actions menu with deletion (logic reused) and download (I think "Annotate" might be a third good option to add, please let me know in the comment what's your thought)
2. Introduced media supported types while uploading.
3. Updated backend service so when UI requests to download the media, it's not opened in the browser but it's downloaded.

<img width="337" height="270" alt="image" src="https://github.com/user-attachments/assets/ae01f736-51f5-4cfb-a4fb-88cbd07fedc7" />

Close #5500 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
