### PR TITLE
feat: Video playback

### DIFF
--- a/application/ui/rsbuild.config.ts
+++ b/application/ui/rsbuild.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
                 "worker-src 'self' blob:; " +
                 "connect-src 'self' http://localhost:7860 data:; " +
                 "img-src 'self' http://localhost:7860 data: blob:; " +
+                "media-src 'self' http://localhost:7860 blob: data:; " +
                 "style-src 'self' 'unsafe-inline';",
         },
     },

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -1,23 +1,51 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MouseEvent } from 'react';
+import { MouseEvent, useEffect, useRef } from 'react';
 
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-
-import { API_BASE_URL } from '../../../api/client';
 import { ZoomTransform } from '../../../components/zoom/zoom-transform';
 import type { Media } from '../../../constants/shared-types';
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
+import { useAnnotator } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
+import { isVideo } from '../../dataset/utils';
 import { Annotations } from '../annotations/annotations.component';
 import { ToolManager } from '../tools/tool-manager.component';
+import { VideoFrame } from '../video-player/video-frame.component';
 
-import styles from './annotator-canvas.module.scss';
+import classes from './annotator-canvas.module.scss';
 
-const getImageUrl = (projectId: string, itemId: string) => {
-    return `${API_BASE_URL}/api/projects/${projectId}/dataset/media/${itemId}/binary`;
+type MediaImageProps = {
+    image: ImageData;
+    mediaItem: Media;
+};
+
+const useDrawImageOnCanvas = (image: ImageData) => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        const ctx = canvasRef?.current?.getContext('2d');
+
+        if (ctx == null) {
+            return;
+        }
+
+        ctx.putImageData(image, 0, 0);
+    }, [image]);
+
+    return canvasRef;
+};
+
+const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
+    const canvasRef = useDrawImageOnCanvas(image);
+
+    return (
+        <>
+            <canvas ref={canvasRef} width={image.width} height={image.height} className={classes.image} />
+            {isVideo(mediaItem) && <VideoFrame canvasRef={canvasRef} mediaItem={mediaItem} />}
+        </>
+    );
 };
 
 type AnnotatorCanvasProps = {
@@ -25,10 +53,10 @@ type AnnotatorCanvasProps = {
 };
 
 export const AnnotatorCanvas = ({ mediaItem }: AnnotatorCanvasProps) => {
-    const project_id = useProjectIdentifier();
     const { annotations } = useAnnotationActions();
     const { selectedAnnotations } = useSelectedAnnotations();
     const { isFocussed } = useAnnotationVisibility();
+    const { image } = useAnnotator();
 
     // Order annotations by selection. Selected annotation should always be on top.
     const orderedAnnotations = [
@@ -44,11 +72,7 @@ export const AnnotatorCanvas = ({ mediaItem }: AnnotatorCanvasProps) => {
                 style={{ position: 'relative', height: '100%', width: '100%' }}
                 onContextMenu={(event: MouseEvent): void => event.preventDefault()}
             >
-                <img
-                    src={getImageUrl(project_id, String(mediaItem.id))}
-                    alt='Collected data'
-                    className={styles.image}
-                />
+                <MediaImage image={image} mediaItem={mediaItem} />
 
                 <Annotations
                     width={size.width}

--- a/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
+++ b/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
@@ -5,20 +5,19 @@ import { useSuspenseQuery, UseSuspenseQueryResult } from '@tanstack/react-query'
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { API_BASE_URL } from '../../../api/client';
-import type { Media } from '../../../constants/shared-types';
 import { getImageData, loadImage } from '../tools/utils';
 
-export const useLoadImageQuery = (mediaItem: Media | undefined): UseSuspenseQueryResult<ImageData, unknown> => {
+export const useLoadImageQuery = (mediaItemId: string | undefined): UseSuspenseQueryResult<ImageData, unknown> => {
     const projectId = useProjectIdentifier();
 
     return useSuspenseQuery({
-        queryKey: ['mediaItem', mediaItem?.id, projectId],
+        queryKey: ['mediaItem', mediaItemId, projectId],
         queryFn: async () => {
-            if (mediaItem === undefined) {
+            if (mediaItemId === undefined) {
                 throw new Error("Can't fetch undefined media item");
             }
 
-            const imageUrl = `${API_BASE_URL}/api/projects/${projectId}/dataset/media/${mediaItem.id}/binary`;
+            const imageUrl = `${API_BASE_URL}/api/projects/${projectId}/dataset/media/${mediaItemId}/binary`;
             const image = await loadImage(imageUrl);
 
             return getImageData(image);

--- a/application/ui/src/features/annotator/video-player/video-frame.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-frame.component.tsx
@@ -1,22 +1,24 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { RefObject, useEffect, useRef } from 'react';
+import { RefObject, useEffect } from 'react';
 
 import { VisuallyHidden } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { type Media } from '../../../constants/shared-types';
 import { getMediaBinaryUrl } from '../../../shared/media-url.utils';
+import { useVideoPlayer } from './video-player-provider.component';
 
 type VideoFrameProps = {
     canvasRef: RefObject<HTMLCanvasElement | null>;
     mediaItem: Media;
 };
 
-const useRequestVideoFrameCallback = (canvasRef: RefObject<HTMLCanvasElement | null>) => {
-    const videoRef = useRef<HTMLVideoElement>(null);
-
+const useRequestVideoFrameCallback = (
+    videoRef: RefObject<HTMLVideoElement | null>,
+    canvasRef: RefObject<HTMLCanvasElement | null>
+) => {
     useEffect(() => {
         if (videoRef.current === null) {
             return;
@@ -26,7 +28,7 @@ const useRequestVideoFrameCallback = (canvasRef: RefObject<HTMLCanvasElement | n
 
         let callbackId: number | null = null;
 
-        const updateCanvas: VideoFrameRequestCallback = (now, metadata) => {
+        const updateCanvas: VideoFrameRequestCallback = () => {
             if (videoRef.current === null) {
                 return;
             }
@@ -36,8 +38,6 @@ const useRequestVideoFrameCallback = (canvasRef: RefObject<HTMLCanvasElement | n
             if (ctx == null) {
                 return;
             }
-
-            console.log({ now, metadata });
 
             ctx.drawImage(video, 0, 0);
 
@@ -51,22 +51,16 @@ const useRequestVideoFrameCallback = (canvasRef: RefObject<HTMLCanvasElement | n
                 video.cancelVideoFrameCallback(callbackId);
             }
         };
-    }, [canvasRef]);
-
-    useEffect(() => {
-        if (videoRef.current === null) {
-            return;
-        }
-
-        // videoRef.current.play();
-    }, []);
+    }, [videoRef, canvasRef]);
 
     return videoRef;
 };
 
 export const VideoFrame = ({ canvasRef, mediaItem }: VideoFrameProps) => {
     const projectId = useProjectIdentifier();
-    const videoRef = useRequestVideoFrameCallback(canvasRef);
+    const { videoRef } = useVideoPlayer();
+
+    useRequestVideoFrameCallback(videoRef, canvasRef);
 
     return (
         <VisuallyHidden>

--- a/application/ui/src/features/annotator/video-player/video-frame.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-frame.component.tsx
@@ -1,0 +1,83 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { RefObject, useEffect, useRef } from 'react';
+
+import { VisuallyHidden } from '@geti/ui';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { type Media } from '../../../constants/shared-types';
+import { getMediaBinaryUrl } from '../../../shared/media-url.utils';
+
+type VideoFrameProps = {
+    canvasRef: RefObject<HTMLCanvasElement | null>;
+    mediaItem: Media;
+};
+
+const useRequestVideoFrameCallback = (canvasRef: RefObject<HTMLCanvasElement | null>) => {
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    useEffect(() => {
+        if (videoRef.current === null) {
+            return;
+        }
+
+        const video = videoRef.current;
+
+        let callbackId: number | null = null;
+
+        const updateCanvas: VideoFrameRequestCallback = (now, metadata) => {
+            if (videoRef.current === null) {
+                return;
+            }
+
+            const ctx = canvasRef.current?.getContext('2d');
+
+            if (ctx == null) {
+                return;
+            }
+
+            console.log({ now, metadata });
+
+            ctx.drawImage(video, 0, 0);
+
+            callbackId = video.requestVideoFrameCallback(updateCanvas);
+        };
+
+        callbackId = video.requestVideoFrameCallback(updateCanvas);
+
+        return () => {
+            if (callbackId !== null) {
+                video.cancelVideoFrameCallback(callbackId);
+            }
+        };
+    }, [canvasRef]);
+
+    useEffect(() => {
+        if (videoRef.current === null) {
+            return;
+        }
+
+        // videoRef.current.play();
+    }, []);
+
+    return videoRef;
+};
+
+export const VideoFrame = ({ canvasRef, mediaItem }: VideoFrameProps) => {
+    const projectId = useProjectIdentifier();
+    const videoRef = useRequestVideoFrameCallback(canvasRef);
+
+    return (
+        <VisuallyHidden>
+            <video
+                ref={videoRef}
+                src={getMediaBinaryUrl(projectId, mediaItem.id)}
+                width={mediaItem.width}
+                height={mediaItem.height}
+                preload={'auto'}
+                muted
+            />
+        </VisuallyHidden>
+    );
+};

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -1,0 +1,29 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, ReactNode, RefObject, use, useRef } from 'react';
+
+type VideoPlayerContextProps = {
+    videoRef: RefObject<HTMLVideoElement | null>;
+};
+
+const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
+
+type VideoPlayerProviderProps = {
+    children: ReactNode;
+};
+
+export const VideoPlayerProvider = ({ children }: VideoPlayerProviderProps) => {
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    return <VideoPlayerContext value={{ videoRef }}>{children}</VideoPlayerContext>;
+};
+
+export const useVideoPlayer = () => {
+    const context = use(VideoPlayerContext);
+
+    if (context === null) {
+        throw new Error('useVideoPlayer must be used within a VideoPlayerProvider');
+    }
+    return context;
+};

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -37,10 +37,6 @@ export const useAnnotationsQuery = (datasetItemId: string) => {
                 }
             );
 
-            if (error !== undefined) {
-                return { annotations: [], user_reviewed: false };
-            }
-
             if (isUnannotatedError(error)) {
                 return { annotations: [], user_reviewed: false };
             }

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -37,6 +37,10 @@ export const useAnnotationsQuery = (datasetItemId: string) => {
                 }
             );
 
+            if (error !== undefined) {
+                return { annotations: [], user_reviewed: false };
+            }
+
             if (isUnannotatedError(error)) {
                 return { annotations: [], user_reviewed: false };
             }

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -10,6 +10,7 @@ import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook'
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
+import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { useSelectedData } from '../selected-data-provider.component';
 import { AnnotatorProviders } from './annotator-providers.component';
 import { useAnnotationsQuery } from './api/use-annotations-query';
@@ -96,7 +97,7 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                         onAcceptPrediction={handleSubmitAnnotations}
                     />
                 ) : (
-                    <>
+                    <VideoPlayerProvider>
                         <View gridArea={'header'}>
                             <SecondaryToolbar
                                 mode={mode}
@@ -122,7 +123,7 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                                 <AnnotatorCanvas mediaItem={mediaItem} />
                             </AnnotatorCanvasSettings>
                         </View>
-                    </>
+                    </VideoPlayerProvider>
                 )}
             </AnnotatorProviders>
         </ToolProvider>

--- a/application/ui/src/shared/annotator/annotator-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotator-provider.component.tsx
@@ -5,6 +5,7 @@ import { createContext, ReactNode, useContext, useState } from 'react';
 
 import type { Label, Media } from '../../constants/shared-types';
 import { useLoadImageQuery } from '../../features/annotator/hooks/use-load-image-query.hook';
+import { isVideo } from '../../features/dataset/utils';
 import { isClassificationTask } from '../../features/project/task-type-guards';
 import { useProject } from '../../hooks/api/project.hook';
 import type { RegionOfInterest } from '../types';
@@ -42,6 +43,15 @@ const useSelectedLabel = () => {
     };
 };
 
+const getMediaItem = (mediaItem: Media) => {
+    if (isVideo(mediaItem)) {
+        // For video, we want to get the first frame of the video, that's not supported right now
+        return undefined;
+    }
+
+    return mediaItem;
+};
+
 type AnnotatorProviderProps = {
     mediaItem: Media;
     children: ReactNode;
@@ -50,7 +60,9 @@ type AnnotatorProviderProps = {
 export const AnnotatorProvider = ({ mediaItem, children }: AnnotatorProviderProps) => {
     const { selectedLabel, selectedLabelId, setSelectedLabelId, labels } = useSelectedLabel();
 
-    const imageQuery = useLoadImageQuery(mediaItem);
+    const media = getMediaItem(mediaItem);
+
+    const imageQuery = useLoadImageQuery(media?.id);
 
     return (
         <AnnotatorProviderContext.Provider


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR implements video content playback.
How it should work when API is ready:
1. When video is opened in the annotator, its first frame is downloaded (we get that image with annotations or predictions).
2. When user plays video, the next frames from the video content are drawn on canvas.
3. When video is stopped, we fetch that frame that user has stopped on.

To mock that steps 1 and 2 I did some tricks locally to see if the video playback works (instead of fetching the first video frame I fetched random image from the dataset [visible in the background of the video]), mock throwing the error in the `useAnnotationsQuery` and added automatic video playing. Those tricks are not part of this PR, I have them locally to be able to develop further.

<img width="1918" height="928" alt="image" src="https://github.com/user-attachments/assets/bc6b7a81-d134-4934-9fb0-a14e7cc7b056" />
(GH/Intel blocks uploading the video even tho the extension is right 😢)

Close #5521 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
