### PR TITLE
feat: Add `Annotate` to the media item actions

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -95,6 +95,7 @@ export const Gallery = ({ items, viewMode, hasNextPage, isFetchingNextPage, fetc
                                     onDeleted={toggleSelectedKeys}
                                     mediaUrl={fullMediaUrl}
                                     mediaFileName={mediaFileName}
+                                    onAnnotate={() => onSelectedMediaItemChange(item)}
                                 />
                             )}
                         />

--- a/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
+++ b/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
@@ -12,6 +12,7 @@ import { AlertDialogContent } from '../delete-media-item/alert-dialog-content.co
 const MEDIA_ACTIONS = {
     DOWNLOAD: 'download',
     DELETE: 'delete',
+    ANNOTATE: 'annotate',
 };
 
 type MediaItemActionsProps = {
@@ -19,9 +20,10 @@ type MediaItemActionsProps = {
     mediaUrl: string;
     mediaFileName: string;
     onDeleted: (deletedIds: string[]) => void;
+    onAnnotate: () => void;
 };
 
-export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName }: MediaItemActionsProps) => {
+export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName, onAnnotate }: MediaItemActionsProps) => {
     const { closeDeleteDialog, openDeleteDialog, isDeleteDialogOpen, deleteMedia, isPending } = useDeleteMediaItem();
 
     const handleDownload = () => {
@@ -38,6 +40,8 @@ export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName }: Med
             handleDownload();
         } else if (key === MEDIA_ACTIONS.DELETE) {
             openDeleteDialog();
+        } else if (key === MEDIA_ACTIONS.ANNOTATE) {
+            onAnnotate();
         }
     };
 
@@ -52,6 +56,7 @@ export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName }: Med
                     <MoreMenu />
                 </ActionButton>
                 <Menu onAction={handleAction} aria-label={'Media actions menu'}>
+                    <Item key={MEDIA_ACTIONS.ANNOTATE}>Annotate</Item>
                     <Item key={MEDIA_ACTIONS.DOWNLOAD}>Download</Item>
                     <Item key={MEDIA_ACTIONS.DELETE}>Delete</Item>
                 </Menu>

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -151,7 +151,7 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
                     <Checkbox
                         aria-label={'select all'}
                         onChange={handleToggleManyItemSelection}
-                        isSelected={totalSelectedElements === items.length}
+                        isSelected={hasSelectedElements && totalSelectedElements === items.length}
                     />
 
                     <Divider orientation={'vertical'} size={'S'} />

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -88,43 +88,45 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                 isUserReviewed={isUserReviewed}
                 mode={mode}
             >
-                {mode === 'prediction' ? (
-                    <ReadOnlyAnnotator
-                        mediaItem={mediaItem}
-                        isUserReviewed={isUserReviewed}
-                        onModeChange={setMode}
-                        onClose={onClose}
-                        onAcceptPrediction={handleSubmitAnnotations}
-                    />
-                ) : (
-                    <VideoPlayerProvider>
-                        <View gridArea={'header'}>
-                            <SecondaryToolbar
-                                mode={mode}
-                                items={items}
-                                onClose={onClose}
-                                mediaItem={mediaItem}
-                                onSelectedMediaItem={onSelectedMediaItem}
-                                onModeChange={setMode}
-                                onAcceptPrediction={handleSubmitAnnotations}
-                            />
-                        </View>
+                <VideoPlayerProvider>
+                    {mode === 'prediction' ? (
+                        <ReadOnlyAnnotator
+                            mediaItem={mediaItem}
+                            isUserReviewed={isUserReviewed}
+                            onModeChange={setMode}
+                            onClose={onClose}
+                            onAcceptPrediction={handleSubmitAnnotations}
+                        />
+                    ) : (
+                        <>
+                            <View gridArea={'header'}>
+                                <SecondaryToolbar
+                                    mode={mode}
+                                    items={items}
+                                    onClose={onClose}
+                                    mediaItem={mediaItem}
+                                    onSelectedMediaItem={onSelectedMediaItem}
+                                    onModeChange={setMode}
+                                    onAcceptPrediction={handleSubmitAnnotations}
+                                />
+                            </View>
 
-                        <View gridArea={'toolbar'} aria-label={'primary toolbar'}>
-                            <PrimaryToolbar />
-                        </View>
+                            <View gridArea={'toolbar'} aria-label={'primary toolbar'}>
+                                <PrimaryToolbar />
+                            </View>
 
-                        <View gridArea={'bottom'}>
-                            <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
-                        </View>
+                            <View gridArea={'bottom'}>
+                                <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
+                            </View>
 
-                        <View gridArea={'canvas'} overflow={'hidden'}>
-                            <AnnotatorCanvasSettings>
-                                <AnnotatorCanvas mediaItem={mediaItem} />
-                            </AnnotatorCanvasSettings>
-                        </View>
-                    </VideoPlayerProvider>
-                )}
+                            <View gridArea={'canvas'} overflow={'hidden'}>
+                                <AnnotatorCanvasSettings>
+                                    <AnnotatorCanvas mediaItem={mediaItem} />
+                                </AnnotatorCanvasSettings>
+                            </View>
+                        </>
+                    )}
+                </VideoPlayerProvider>
             </AnnotatorProviders>
         </ToolProvider>
     );


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Add annotate as an action the media item (double click might not be intuitive).
2. Fix checkbox selection so it's not selected when there are no media items.
3. Fix video player provider issue so it's present in the read only mode as well (context hook was not available and that caused app crashing).

<img width="525" height="319" alt="image" src="https://github.com/user-attachments/assets/160acae0-7755-476b-95ad-8e2670185ac7" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
