### PR TITLE
Fix model revision name to use arch name and not id

### DIFF
--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -17,6 +17,7 @@ from app.models import EvaluationResult, ModelRevision, TrainingStatus
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.models.training_configuration.configuration import TrainingConfiguration
 from app.repositories import EvaluationRepository, LabelRepository, ModelRevisionRepository
+from app.supported_models import SupportedModels
 
 from .base import BaseSessionManagedService, ResourceInUseError, ResourceNotFoundError, ResourceType
 from .parent_process_guard import parent_process_only
@@ -233,11 +234,13 @@ class ModelService(BaseSessionManagedService):
         project_id = str(metadata.project_id)
         label_repo = LabelRepository(project_id=project_id, db=self.db_session)
         labels_schema_rev = {"labels": [{"name": label.name, "id": label.id} for label in label_repo.list_all()]}
+        arch_name = SupportedModels.get_model_manifest_by_id(metadata.architecture_id).name
+
         model_revision_repo = ModelRevisionRepository(project_id=project_id, db=self.db_session)
         model_revision_repo.save(
             ModelRevisionDB(
                 id=str(metadata.model_id),
-                name=f"{metadata.architecture_id} ({str(metadata.model_id).split('-')[0]})",
+                name=f"{arch_name} ({str(metadata.model_id).split('-')[0]})",
                 project_id=str(metadata.project_id),
                 architecture=metadata.architecture_id,
                 parent_revision=str(metadata.parent_revision_id) if metadata.parent_revision_id else None,

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -317,7 +317,7 @@ class TestModelServiceIntegration:
         db_session.flush()
         model_id = uuid4()
         dataset_revision_id = UUID(dataset_revision_db.id)
-        architecture_id = "MODEL_ARCHITECTURE_ID"
+        architecture_id = "object-detection-atss-mobilenet-v2"
 
         fxt_model_service.create_revision(
             ModelRevisionMetadata(
@@ -337,6 +337,7 @@ class TestModelServiceIntegration:
         assert model_db.training_dataset_id == str(dataset_revision_id)
         assert model_db.architecture == architecture_id
         assert model_db.training_status == TrainingStatus.IN_PROGRESS
+        assert model_db.name == f"ATSS-MobileNet-V2 ({str(model_id).split('-')[0]})"
 
     def test_update_revision(
         self, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService, db_session: Session


### PR DESCRIPTION
This pull request updates the way model revision names are generated and stored, ensuring the names use the human-readable architecture name instead of the architecture ID. It also updates the integration test to reflect this change.

**Model revision naming improvements:**

* The model revision name is now set using the architecture's human-readable name, retrieved from `SupportedModels`, rather than the architecture ID.
* The `SupportedModels` module is imported in `model_service.py` to support this change.

**Test updates:**

* The integration test for creating a model revision now uses a real architecture ID and checks that the model revision name matches the expected human-readable format. [[1]](diffhunk://#diff-b94bbfa4c3b6d7ffac7f3fe323039b1a135e8a5894966e23b9b1d4e82fbebdbcL320-R320) [[2]](diffhunk://#diff-b94bbfa4c3b6d7ffac7f3fe323039b1a135e8a5894966e23b9b1d4e82fbebdbcR340)

Resolves #5473 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
