### PR TITLE
Add user_reviewed to DatasetItem response

### DIFF
--- a/application/backend/app/api/schemas/dataset_item.py
+++ b/application/backend/app/api/schemas/dataset_item.py
@@ -39,7 +39,7 @@ class DatasetItemView(BaseRequiredIDModel):
     """
 
     subset: DatasetItemSubset
-    user_reviewed: bool
+    user_reviewed: bool = False
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/api/schemas/dataset_item.py
+++ b/application/backend/app/api/schemas/dataset_item.py
@@ -39,12 +39,14 @@ class DatasetItemView(BaseRequiredIDModel):
     """
 
     subset: DatasetItemSubset
+    user_reviewed: bool
 
     model_config = {
         "json_schema_extra": {
             "example": {
                 "id": "7b073838-99d3-42ff-9018-4e901eb047fc",
-                "subset": "unassigned",
+                "user_reviewed": False,
+                "subset": "training",
             }
         }
     }

--- a/application/backend/tests/unit/routers/test_datasets.py
+++ b/application/backend/tests/unit/routers/test_datasets.py
@@ -47,6 +47,7 @@ def test_convert_dataset_item_to_view(fxt_dataset_item) -> None:
     assert view == DatasetItemView(
         id=fxt_dataset_item.id,
         subset=DatasetItemSubset.UNASSIGNED,
+        user_reviewed=False,
     )
 
 
@@ -235,6 +236,7 @@ class TestDatasetItemEndpoints:
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "id": str(fxt_dataset_item.id),
+            "user_reviewed": False,
             "subset": "unassigned",
         }
         fxt_dataset_service.get_dataset_item_by_id.assert_called_once_with(
@@ -432,6 +434,7 @@ class TestDatasetItemEndpoints:
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             "id": str(fxt_dataset_item.id),
+            "user_reviewed": False,
             "subset": "unassigned",
         }
         fxt_dataset_service.assign_dataset_item_subset.assert_called_once_with(

--- a/application/ui/mocks/mock-dataset-item.ts
+++ b/application/ui/mocks/mock-dataset-item.ts
@@ -1,0 +1,11 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { type DatasetItem } from '../src/constants/shared-types';
+
+export const getMockedDatasetItem = (overrides: Partial<DatasetItem>): DatasetItem => ({
+    id: '1',
+    subset: 'unassigned',
+    user_reviewed: false,
+    ...overrides,
+});

--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { getMockedDatasetItem } from 'mocks/mock-dataset-item';
 import { mockedMedia } from 'mocks/mock-media';
 import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
@@ -68,7 +69,9 @@ describe('BottomToolbar', () => {
 
         server.use(
             http.get('/api/projects/{project_id}/dataset/items/{dataset_item_id}', () => {
-                return HttpResponse.json({ id: 'media-123', subset: 'unassigned' }, { status: 200 });
+                return HttpResponse.json(getMockedDatasetItem({ id: 'media-123', subset: 'unassigned' }), {
+                    status: 200,
+                });
             }),
             http.patch(
                 '/api/projects/{project_id}/dataset/items/{dataset_item_id}/subset',
@@ -77,7 +80,9 @@ describe('BottomToolbar', () => {
 
                     patchSpy(params, body);
 
-                    return HttpResponse.json({ id: 'media-123', subset: 'validation' }, { status: 200 });
+                    return HttpResponse.json(getMockedDatasetItem({ id: 'media-123', subset: 'validation' }), {
+                        status: 200,
+                    });
                 }
             )
         );

--- a/application/ui/src/features/models/train-model/train-model.component.test.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { getMockedDatasetItem } from 'mocks/mock-dataset-item';
 import { getMockedPipeline } from 'mocks/mock-pipeline';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
@@ -40,14 +41,14 @@ describe('TrainModel', () => {
             http.get('/api/projects/{project_id}/dataset/items', () => {
                 return HttpResponse.json({
                     items: [
-                        {
+                        getMockedDatasetItem({
                             id: '1',
                             subset: 'unassigned',
-                        },
-                        {
+                        }),
+                        getMockedDatasetItem({
                             id: '2',
                             subset: 'unassigned',
-                        },
+                        }),
                     ],
                     pagination: {
                         total: 2,
@@ -73,22 +74,22 @@ describe('TrainModel', () => {
             http.get('/api/projects/{project_id}/dataset/items', () => {
                 return HttpResponse.json({
                     items: [
-                        {
+                        getMockedDatasetItem({
                             id: '1',
                             subset: 'unassigned',
-                        },
-                        {
+                        }),
+                        getMockedDatasetItem({
                             id: '2',
                             subset: 'unassigned',
-                        },
-                        {
+                        }),
+                        getMockedDatasetItem({
                             id: '3',
                             subset: 'unassigned',
-                        },
-                        {
+                        }),
+                        getMockedDatasetItem({
                             id: '4',
                             subset: 'unassigned',
-                        },
+                        }),
                     ],
                     pagination: {
                         total: 4,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Endpoints:

- GET /api/projects/{project_id}/dataset/items
- GET /api/projects/{project_id}/dataset/items/{dataset_item_id}
- PATCH /api/projects/{project_id}/dataset/items/{dataset_item_id}/subset

have been extended with `user_reviewed` field.

### How to test

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
