### PR TITLE
Add size in bytes to dataset revision

### DIFF
--- a/application/backend/app/alembic/versions/2d2b0c9a5c2c_schema.py
+++ b/application/backend/app/alembic/versions/2d2b0c9a5c2c_schema.py
@@ -1,8 +1,8 @@
 """schema
 
-Revision ID: 9b945d895014
+Revision ID: 2d2b0c9a5c2c
 Revises:
-Create Date: 2026-02-08 11:51:05.866607
+Create Date: 2026-02-16 09:57:35.227516
 
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "9b945d895014"
+revision: str = "2d2b0c9a5c2c"
 down_revision: str | Sequence[str] | None = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
@@ -65,6 +65,7 @@ def upgrade() -> None:
         sa.Column("validation_count", sa.Integer(), nullable=False),
         sa.Column("testing_count", sa.Integer(), nullable=False),
         sa.Column("total_count", sa.Integer(), nullable=False),
+        sa.Column("size", sa.Integer(), nullable=False),
         sa.Column("id", sa.Text(), nullable=False),
         sa.Column("created_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
         sa.Column("updated_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),

--- a/application/backend/app/api/schemas/dataset_revision.py
+++ b/application/backend/app/api/schemas/dataset_revision.py
@@ -23,6 +23,7 @@ class DatasetRevisionView(BaseIDModel):
     name: str = Field(..., description="Name of the dataset revision")
     created_at: datetime = Field(..., description="Timestamp when the dataset revision was created")
     files_deleted: bool = Field(..., description="Indicates if the dataset revision files have been deleted")
+    size: int = Field(..., description="Size in bytes of all files from this dataset revision on disk")
     item_counts: ItemCount = Field(..., description="Number of items in the dataset")
 
     model_config = {
@@ -32,6 +33,7 @@ class DatasetRevisionView(BaseIDModel):
                 "name": "Dataset (1ed5487a)",
                 "created_at": "2023-10-01T12:00:00Z",
                 "files_deleted": False,
+                "size": 456123,
                 "item_counts": {"total": 100, "training": 70, "validation": 20, "testing": 10},
             }
         }

--- a/application/backend/app/db/schema.py
+++ b/application/backend/app/db/schema.py
@@ -100,6 +100,7 @@ class DatasetRevisionDB(BaseID):
     validation_count: Mapped[int] = mapped_column(Integer, default=0)
     testing_count: Mapped[int] = mapped_column(Integer, default=0)
     total_count: Mapped[int] = mapped_column(Integer, default=0)
+    size: Mapped[int] = mapped_column(Integer, default=0)
 
 
 class DatasetItemDB(Base):

--- a/application/backend/app/models/dataset_revision.py
+++ b/application/backend/app/models/dataset_revision.py
@@ -41,6 +41,7 @@ class DatasetRevision(BaseEntity):
         name: Name of the dataset revision.
         created_at: Timestamp indicating when the dataset revision was created.
         files_deleted: Flag indicating whether the files associated with this dataset revision have been deleted.
+        size: Size on disk in bytes
         item_counts: Number of items in the subsets Training, Validation and Testing and total count.
     """
 
@@ -48,6 +49,7 @@ class DatasetRevision(BaseEntity):
     name: str
     created_at: datetime
     files_deleted: bool
+    size: int
     item_counts: DatasetRevisionCounts
 
     @model_validator(mode="before")
@@ -59,6 +61,7 @@ class DatasetRevision(BaseEntity):
                 "name": data.name,
                 "created_at": data.created_at,
                 "files_deleted": data.files_deleted,
+                "size": data.size,
                 "item_counts": DatasetRevisionCounts.model_validate(data),
             }
         return data

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -11,6 +11,7 @@ import polars as pl
 from datumaro.experimental.export_import import export_dataset, import_dataset
 from loguru import logger
 from PIL import Image, UnidentifiedImageError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetRevisionDB
@@ -19,6 +20,7 @@ from app.models.dataset_item_revision import DatasetRevisionItem
 from app.models.dataset_revision import DatasetRevision, DatasetRevisionCounts
 from app.models.media import ImageFormat
 from app.repositories import DatasetRevisionRepository
+from app.repositories.base import PrimaryKeyIntegrityError, UniqueConstraintIntegrityError
 from app.utils.images import crop_to_thumbnail
 
 from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
@@ -55,7 +57,7 @@ class DatasetRevisionService(BaseSessionManagedService):
         dataset_name = f"Dataset ({short_id})"
 
         revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / dataset_revision_id
-        logger.info("Saving dataset revision '{}' to '{}'", dataset_revision_id, revision_path)
+        logger.info("Saving dataset revision '{}' to '{}'.", dataset_revision_id, revision_path)
         export_dataset(
             dataset=dataset,
             output_path=revision_path,
@@ -64,18 +66,25 @@ class DatasetRevisionService(BaseSessionManagedService):
         )
         size_in_bytes = sum(item.stat().st_size for item in revision_path.rglob("*") if item.is_file())
 
-        revision_db = revision_repo.save(
-            DatasetRevisionDB(
-                id=dataset_revision_id,
-                project_id=str(project_id),
-                name=dataset_name,
-                total_count=item_counts.total,
-                training_count=item_counts.training,
-                validation_count=item_counts.validation,
-                testing_count=item_counts.testing,
-                size=size_in_bytes,
+        try:
+            revision_db = revision_repo.save(
+                DatasetRevisionDB(
+                    id=dataset_revision_id,
+                    project_id=str(project_id),
+                    name=dataset_name,
+                    total_count=item_counts.total,
+                    training_count=item_counts.training,
+                    validation_count=item_counts.validation,
+                    testing_count=item_counts.testing,
+                    size=size_in_bytes,
+                )
             )
-        )
+        except (IntegrityError, PrimaryKeyIntegrityError, UniqueConstraintIntegrityError):
+            logger.error("Could not save dataset revision '{}' in the database.", dataset_revision_id)
+            if revision_path.exists():
+                shutil.rmtree(revision_path)
+                logger.info("Deleted dataset revision files at '{}'.", revision_path)
+            raise
 
         return UUID(revision_db.id)
 
@@ -166,6 +175,10 @@ class DatasetRevisionService(BaseSessionManagedService):
                 name=dataset_revision.name,
                 files_deleted=dataset_revision.files_deleted,
                 size=0 if dataset_revision.files_deleted else dataset_revision.size,
+                total_count=dataset_revision.item_counts.total,
+                training_count=dataset_revision.item_counts.training,
+                validation_count=dataset_revision.item_counts.validation,
+                testing_count=dataset_revision.item_counts.testing,
             )
         )
 

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -53,6 +53,17 @@ class DatasetRevisionService(BaseSessionManagedService):
         dataset_revision_id = str(uuid4())
         short_id = dataset_revision_id.split("-")[0]
         dataset_name = f"Dataset ({short_id})"
+
+        revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / dataset_revision_id
+        logger.info("Saving dataset revision '{}' to '{}'", dataset_revision_id, revision_path)
+        export_dataset(
+            dataset=dataset,
+            output_path=revision_path,
+            export_images=True,
+            as_zip=False,  # Export as uncompressed directory, see #5070 for details
+        )
+        size_in_bytes = sum(item.stat().st_size for item in revision_path.rglob("*") if item.is_file())
+
         revision_db = revision_repo.save(
             DatasetRevisionDB(
                 id=dataset_revision_id,
@@ -62,16 +73,10 @@ class DatasetRevisionService(BaseSessionManagedService):
                 training_count=item_counts.training,
                 validation_count=item_counts.validation,
                 testing_count=item_counts.testing,
+                size=size_in_bytes,
             )
         )
-        revision_path = self.projects_dir / str(project_id) / "dataset_revisions" / revision_db.id
-        logger.info("Saving dataset revision '{}' to '{}'", revision_db.id, revision_path)
-        export_dataset(
-            dataset=dataset,
-            output_path=revision_path,
-            export_images=True,
-            as_zip=False,  # Export as uncompressed directory, see #5070 for details
-        )
+
         return UUID(revision_db.id)
 
     def load_revision(self, project_id: UUID, dataset_revision_id: UUID) -> dm.Dataset:
@@ -160,6 +165,7 @@ class DatasetRevisionService(BaseSessionManagedService):
                 project_id=str(project_id),
                 name=dataset_revision.name,
                 files_deleted=dataset_revision.files_deleted,
+                size=0 if dataset_revision.files_deleted else dataset_revision.size,
             )
         )
 

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -323,7 +323,14 @@ class TestDatasetRevisionServiceIntegration:
         )
 
         # Verify that a revision entry was created
-        assert db_session.get(DatasetRevisionDB, str(revision_id)) is not None
+        dataset_revision = db_session.get(DatasetRevisionDB, str(revision_id))
+        assert dataset_revision is not None
+        assert not dataset_revision.files_deleted
+        assert 5000 < dataset_revision.size < 7000
+        assert dataset_revision.total_count == 8
+        assert dataset_revision.training_count == 3
+        assert dataset_revision.validation_count == 2
+        assert dataset_revision.testing_count == 1
         assert (fxt_projects_dir / str(project.id) / "dataset_revisions" / str(revision_id) / "data.parquet").exists()
 
     def test_save_revision_zero_count(

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -519,8 +519,8 @@ class TestMediaServiceIntegration:
         with tempfile.TemporaryDirectory(delete=True) as tmp_dir:
             tmp_file = Path(tmp_dir) / "video.avi"
 
-            fxt_video_data(Path(tmp_file.name))
-            with open(tmp_file.name, mode="rb") as data:
+            fxt_video_data(Path(tmp_file))
+            with open(tmp_file, mode="rb") as data:
                 created_media = fxt_media_service.create_video(
                     project=project,
                     name="test",

--- a/application/backend/tests/unit/routers/test_dataset_revisions.py
+++ b/application/backend/tests/unit/routers/test_dataset_revisions.py
@@ -45,6 +45,7 @@ def fxt_dataset_revision(fxt_get_project):
         name="Dataset (mock)",
         created_at=datetime(2026, 1, 1),
         files_deleted=False,
+        size=456123,
         item_counts=ItemCount(total=10, training=7, validation=2, testing=1),
     )
 
@@ -57,6 +58,7 @@ def fxt_get_dataset_revision(fxt_dataset_revision):
         name=fxt_dataset_revision.name,
         created_at=datetime(2026, 1, 1),
         files_deleted=fxt_dataset_revision.files_deleted,
+        size=456123,
         item_counts=DatasetRevisionCounts(
             total=10,
             training=7,
@@ -126,6 +128,7 @@ class TestDatasetRevisionItemEndpoints:
             name="New name",
             created_at=datetime(2026, 1, 1),
             files_deleted=False,
+            size=456123,
             item_counts=DatasetRevisionCounts(
                 total=10,
                 training=7,

--- a/application/ui/mocks/mock-dataset-revision.ts
+++ b/application/ui/mocks/mock-dataset-revision.ts
@@ -14,5 +14,6 @@ export const getMockedDatasetRevision = (overrides: Partial<DatasetRevision> = {
         total: 100,
     },
     files_deleted: false,
+    size: 1048576,
     ...overrides,
 });

--- a/application/ui/src/features/models/model-listing/utils/grouping.test.ts
+++ b/application/ui/src/features/models/model-listing/utils/grouping.test.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { getMockedDatasetRevision } from 'mocks/mock-dataset-revision';
 import { getMockedModel } from 'mocks/mock-model';
 
 import type { DatasetRevision } from '../../../../constants/shared-types';
@@ -61,8 +62,8 @@ describe('groupModelsByDataset', () => {
             }),
         ];
 
-        const datasetRevisions: DatasetRevision[] = [
-            {
+        const datasetRevisions = [
+            getMockedDatasetRevision({
                 id: 'dataset-1',
                 created_at: '2025-01-01T00:00:00.000000+00:00',
                 name: 'My Custom Dataset',
@@ -73,7 +74,7 @@ describe('groupModelsByDataset', () => {
                     validation: 20,
                     testing: 10,
                 },
-            },
+            }),
         ];
 
         const groupedModels = groupModelsByDataset(models, { datasetRevisions });


### PR DESCRIPTION
This pull request adds support for tracking the on-disk size (in bytes) of dataset revisions throughout the backend. It updates the database schema, API models, service logic, and tests to ensure the `size` attribute is consistently handled and validated.

**Database and Schema Updates**
- Added a new `size` column to the `dataset_revision` table via Alembic migration and updated the corresponding SQLAlchemy model (`DatasetRevisionDB`). [[1]](diffhunk://#diff-8ff64e54bcb92d8512fd8bbb66f1b4af192feed19ec3673901e1e827f259b82cR68) [[2]](diffhunk://#diff-8a5fe51e36428f9d874a68decf7a22fc42235143b5fc708756be7fadd4ebb528R103)

**API and Model Changes**
- Added a `size` field to the API schema (`DatasetRevisionView`), the domain model (`DatasetRevision`), and related example data and validation logic. [[1]](diffhunk://#diff-b2ae5112111f8cadf27f05350e7ac5e6a59d325f19bc53a2cb872ef51cd6b44dR26) [[2]](diffhunk://#diff-b2ae5112111f8cadf27f05350e7ac5e6a59d325f19bc53a2cb872ef51cd6b44dR36) [[3]](diffhunk://#diff-9e159e0c61cf600e499e28580f0f95dc272e194f19d229e10b8834bcc46a6781R44-R52) [[4]](diffhunk://#diff-9e159e0c61cf600e499e28580f0f95dc272e194f19d229e10b8834bcc46a6781R64)

**Service Logic Enhancements**
- Modified the dataset revision service to calculate and store the total disk size of each dataset revision when saving or updating revisions. The size is set to zero if files are deleted. [[1]](diffhunk://#diff-5b55fc3d2095e10e887af994e3e3b3473db52bd4d96b7543a1ed9882c1b80de5R56-R66) [[2]](diffhunk://#diff-5b55fc3d2095e10e887af994e3e3b3473db52bd4d96b7543a1ed9882c1b80de5R76-R79) [[3]](diffhunk://#diff-5b55fc3d2095e10e887af994e3e3b3473db52bd4d96b7543a1ed9882c1b80de5R168)

**Testing Updates**
- Updated integration and unit tests to verify the correct handling of the `size` attribute in dataset revisions, including assertions on its value and presence in fixtures. [[1]](diffhunk://#diff-17859d947cf4a4178c0b812e9543641723ee7985811ead6c8b966533b7811b21L326-R333) [[2]](diffhunk://#diff-f2f136025be5c7c41c2dea86f1b358eb5ec529194964841d6879be13424044c5R48) [[3]](diffhunk://#diff-f2f136025be5c7c41c2dea86f1b358eb5ec529194964841d6879be13424044c5R61) [[4]](diffhunk://#diff-f2f136025be5c7c41c2dea86f1b358eb5ec529194964841d6879be13424044c5R131)

**Migration File Maintenance**
- Renamed and updated the Alembic migration script to reflect the new schema revision. [[1]](diffhunk://#diff-8ff64e54bcb92d8512fd8bbb66f1b4af192feed19ec3673901e1e827f259b82cL3-R5) [[2]](diffhunk://#diff-8ff64e54bcb92d8512fd8bbb66f1b4af192feed19ec3673901e1e827f259b82cL15-R15)

Resolves #5458 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
