### PR TITLE
fix: SAM tool, dataset revision created at, models page

### DIFF
--- a/application/ui/src/components/label-fields/label-color-picker.component.tsx
+++ b/application/ui/src/components/label-fields/label-color-picker.component.tsx
@@ -18,8 +18,8 @@ export const LabelColorPicker = ({ color, onChange }: LabelColorPickerProps) => 
             rounding={'none'}
         >
             <Flex direction='column' gap='size-300'>
-                <ColorEditor />
-                <ColorSwatchPicker width={'size-3600'}>
+                <ColorEditor hideAlphaChannel />
+                <ColorSwatchPicker width={'size-3000'}>
                     {DISTINCT_COLORS.map((presetColor) => (
                         <ColorSwatch color={presetColor} key={presetColor} />
                     ))}

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { PointerEvent, useRef, useState } from 'react';
+import { PointerEvent, useCallback, useRef, useState } from 'react';
 
 import { clampPointBetweenImage } from '@geti/smart-tools/utils';
 
@@ -16,6 +16,7 @@ import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { useAddAndSelectAnnotations } from '../use-add-and-select-annotations.hook';
 import { getRelativePoint, removeOffLimitPoints } from '../utils';
 import { SAMLoading } from './sam-loading.component';
+import { InteractiveAnnotationPoint } from './segment-anything.interface';
 import { useSegmentAnythingModel } from './use-segment-anything.hook';
 import { useSingleStackFn } from './use-single-stack-fn.hook';
 
@@ -50,6 +51,30 @@ const PreviewAnnotations = ({ previewAnnotations, image }: PreviewAnnotationsPro
     );
 };
 
+const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Promise<Shape[]>) => {
+    const abortController = useRef(new AbortController());
+
+    const cancellableCallback = useCallback(
+        async (...args: Parameters<typeof fn>) => {
+            abortController.current = new AbortController();
+
+            const result = await fn(...args);
+
+            if (abortController.current.signal.aborted) {
+                throw new Error('Aborted');
+            }
+
+            return result;
+        },
+        [fn]
+    );
+
+    return {
+        call: cancellableCallback,
+        cancel: () => abortController.current.abort(),
+    };
+};
+
 export const SegmentAnythingTool = () => {
     const [previewShapes, setPreviewShapes] = useState<Shape[]>([]);
     const [acceptedShapes, setAcceptedShapes] = useState<Shape[] | null>(null);
@@ -60,6 +85,7 @@ export const SegmentAnythingTool = () => {
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
     const { isLoading, decodingQueryFn } = useSegmentAnythingModel();
     const throttledDecodingQueryFn = useSingleStackFn(decodingQueryFn);
+    const cancellableThrottledDecodingQueryFn = useWithCancel(throttledDecodingQueryFn);
 
     const canvasRef = useRef<SVGRectElement>(null);
 
@@ -78,7 +104,8 @@ export const SegmentAnythingTool = () => {
             getRelativePoint(canvasRef.current, { x: event.clientX, y: event.clientY }, zoom.scale)
         );
 
-        throttledDecodingQueryFn([{ ...point, positive: true }])
+        cancellableThrottledDecodingQueryFn
+            .call([{ ...point, positive: true }])
             .then((shapes) => {
                 setPreviewShapes(shapes.map((shape) => removeOffLimitPoints(shape, roi)));
             })
@@ -116,6 +143,11 @@ export const SegmentAnythingTool = () => {
         handleAddAnnotations(previewShapes, selectedLabel);
     };
 
+    const handlePointerLeave = () => {
+        cancellableThrottledDecodingQueryFn.cancel();
+        setPreviewShapes([]);
+    };
+
     const previewAnnotations = (acceptedShapes ?? previewShapes).map((shape, idx): Annotation => {
         return {
             shape,
@@ -136,7 +168,7 @@ export const SegmentAnythingTool = () => {
             aria-label='SAM tool canvas'
             onPointerMove={handleMouseMove}
             onPointerDown={handlePointerDown}
-            onPointerLeave={() => setPreviewShapes([])}
+            onPointerLeave={handlePointerLeave}
             style={{ cursor: `url(${selectionCursor}) ${CURSOR_OFFSET}, auto` }}
         >
             <PreviewAnnotations previewAnnotations={previewAnnotations} image={image} />

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -19,6 +19,7 @@ import { SAMLoading } from './sam-loading.component';
 import { InteractiveAnnotationPoint } from './segment-anything.interface';
 import { useSegmentAnythingModel } from './use-segment-anything.hook';
 import { useSingleStackFn } from './use-single-stack-fn.hook';
+import { useWithCancel } from './use-with-cancel';
 
 import classes from './segment-anything.module.scss';
 
@@ -49,44 +50,6 @@ const PreviewAnnotations = ({ previewAnnotations, image }: PreviewAnnotationsPro
             ))}
         </MaskAnnotations>
     );
-};
-
-const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Promise<Shape[]>) => {
-    const abortController = useRef<AbortController | null>(null);
-
-    const cancellableCallback = useCallback(
-        async (...args: Parameters<typeof fn>) => {
-            // Cancel any ongoing request
-            abortController.current?.abort();
-
-            abortController.current = new AbortController();
-
-            const result = await fn(...args);
-
-            if (abortController.current.signal.aborted) {
-                throw new DOMException('Request aborted', 'AbortError');
-            }
-
-            return result;
-        },
-        [fn]
-    );
-
-    const cancel = useCallback(() => {
-        abortController.current?.abort();
-        abortController.current = null;
-    }, [abortController]);
-
-    useEffect(() => {
-        return () => {
-            cancel();
-        };
-    }, [cancel]);
-
-    return {
-        call: cancellableCallback,
-        cancel,
-    };
 };
 
 export const SegmentAnythingTool = () => {

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { PointerEvent, useCallback, useRef, useState } from 'react';
+import { PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { clampPointBetweenImage } from '@geti/smart-tools/utils';
 
@@ -52,16 +52,19 @@ const PreviewAnnotations = ({ previewAnnotations, image }: PreviewAnnotationsPro
 };
 
 const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Promise<Shape[]>) => {
-    const abortController = useRef(new AbortController());
+    const abortController = useRef<AbortController | null>(null);
 
     const cancellableCallback = useCallback(
         async (...args: Parameters<typeof fn>) => {
+            // Cancel any ongoing request
+            abortController.current?.abort();
+
             abortController.current = new AbortController();
 
             const result = await fn(...args);
 
             if (abortController.current.signal.aborted) {
-                throw new Error('Aborted');
+                throw new DOMException('Request aborted', 'AbortError');
             }
 
             return result;
@@ -69,9 +72,20 @@ const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Promise<Sha
         [fn]
     );
 
+    const cancel = useCallback(() => {
+        abortController.current?.abort();
+        abortController.current = null;
+    }, [abortController]);
+
+    useEffect(() => {
+        return () => {
+            cancel();
+        };
+    }, [cancel]);
+
     return {
         call: cancellableCallback,
-        cancel: () => abortController.current.abort(),
+        cancel,
     };
 };
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { PointerEvent, useRef, useState } from 'react';
 
 import { clampPointBetweenImage } from '@geti/smart-tools/utils';
 
@@ -16,7 +16,6 @@ import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { useAddAndSelectAnnotations } from '../use-add-and-select-annotations.hook';
 import { getRelativePoint, removeOffLimitPoints } from '../utils';
 import { SAMLoading } from './sam-loading.component';
-import { InteractiveAnnotationPoint } from './segment-anything.interface';
 import { useSegmentAnythingModel } from './use-segment-anything.hook';
 import { useSingleStackFn } from './use-single-stack-fn.hook';
 import { useWithCancel } from './use-with-cancel';

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.ts
@@ -1,0 +1,45 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useRef } from 'react';
+
+import type { Shape } from '../../../../shared/types';
+import { InteractiveAnnotationPoint } from './segment-anything.interface';
+
+export const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Promise<Shape[]>) => {
+    const abortController = useRef<AbortController | null>(null);
+
+    const cancellableCallback = useCallback(
+        async (...args: Parameters<typeof fn>) => {
+            // Cancel any ongoing request
+            abortController.current?.abort();
+
+            abortController.current = new AbortController();
+
+            const result = await fn(...args);
+
+            if (abortController.current.signal.aborted) {
+                throw new DOMException('Request aborted', 'AbortError');
+            }
+
+            return result;
+        },
+        [fn]
+    );
+
+    const cancel = useCallback(() => {
+        abortController.current?.abort();
+        abortController.current = null;
+    }, [abortController]);
+
+    useEffect(() => {
+        return () => {
+            cancel();
+        };
+    }, [cancel]);
+
+    return {
+        call: cancellableCallback,
+        cancel,
+    };
+};

--- a/application/ui/src/features/models/model-listing/hooks/use-grouped-models.hook.test.ts
+++ b/application/ui/src/features/models/model-listing/hooks/use-grouped-models.hook.test.ts
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { getMockedDatasetRevision } from 'mocks/mock-dataset-revision';
 import { getMockedModel } from 'mocks/mock-model';
 import { renderHook } from 'test-utils/render';
 
@@ -86,7 +87,10 @@ describe('useGroupedModels', () => {
                     sortBy: 'name',
                     pinActive: false,
                     searchBy: '',
-                    datasetRevisions: [],
+                    datasetRevisions: [
+                        getMockedDatasetRevision({ id: 'dataset-1' }),
+                        getMockedDatasetRevision({ id: 'dataset-2' }),
+                    ],
                     showFailedModels: true,
                 })
             );

--- a/application/ui/src/features/models/model-listing/utils/grouping.test.ts
+++ b/application/ui/src/features/models/model-listing/utils/grouping.test.ts
@@ -43,7 +43,12 @@ describe('groupModelsByDataset', () => {
             }),
         ];
 
-        const groupedModels = groupModelsByDataset(models);
+        const groupedModels = groupModelsByDataset(models, {
+            datasetRevisions: [
+                getMockedDatasetRevision({ id: 'dataset-1' }),
+                getMockedDatasetRevision({ id: 'dataset-2' }),
+            ],
+        });
 
         expect(groupedModels).toHaveLength(2);
         expect(groupedModels[0].models).toHaveLength(2);

--- a/application/ui/src/features/models/model-listing/utils/grouping.ts
+++ b/application/ui/src/features/models/model-listing/utils/grouping.ts
@@ -39,20 +39,22 @@ export const groupModelsByDataset = (models: Model[], options?: GroupModelsByDat
         const labelCount = Array.isArray(labels) ? labels.length : 0;
         const datasetRevision = datasetRevisionsMap.get(datasetId);
 
-        if (!groups[datasetId] && datasetRevision !== undefined) {
+        if (!groups[datasetId]) {
             groups[datasetId] = {
                 group: {
                     id: datasetId,
-                    name: datasetRevision.name,
-                    createdAt: formatDatasetStartTime(datasetRevision.created_at),
+                    name: datasetRevision?.name ?? `Dataset #${datasetId.slice(0, 8)}`,
+                    createdAt: formatDatasetStartTime(
+                        datasetRevision ? datasetRevision.created_at : model.training_info.start_time
+                    ),
                     labelCount,
-                    imageCount: datasetRevision.item_counts.total,
+                    imageCount: datasetRevision?.item_counts?.total ?? 0,
                     trainingSubsets: {
-                        training: datasetRevision.item_counts.training,
-                        validation: datasetRevision.item_counts.validation,
-                        testing: datasetRevision.item_counts.testing,
+                        training: datasetRevision?.item_counts?.training ?? 0,
+                        validation: datasetRevision?.item_counts?.validation ?? 0,
+                        testing: datasetRevision?.item_counts?.testing ?? 0,
                     },
-                    filesDeleted: datasetRevision.files_deleted,
+                    filesDeleted: datasetRevision?.files_deleted ?? false,
                 },
                 models: [],
             };

--- a/application/ui/src/features/models/model-listing/utils/grouping.ts
+++ b/application/ui/src/features/models/model-listing/utils/grouping.ts
@@ -39,26 +39,28 @@ export const groupModelsByDataset = (models: Model[], options?: GroupModelsByDat
         const labelCount = Array.isArray(labels) ? labels.length : 0;
         const datasetRevision = datasetRevisionsMap.get(datasetId);
 
-        if (!groups[datasetId]) {
+        if (!groups[datasetId] && datasetRevision !== undefined) {
             groups[datasetId] = {
                 group: {
                     id: datasetId,
-                    name: datasetRevision?.name ?? `Dataset #${datasetId.slice(0, 8)}`,
-                    createdAt: formatDatasetStartTime(model.training_info.start_time),
+                    name: datasetRevision.name,
+                    createdAt: formatDatasetStartTime(datasetRevision.created_at),
                     labelCount,
-                    imageCount: datasetRevision?.item_counts?.total ?? 0,
+                    imageCount: datasetRevision.item_counts.total,
                     trainingSubsets: {
-                        training: datasetRevision?.item_counts?.training ?? 0,
-                        validation: datasetRevision?.item_counts?.validation ?? 0,
-                        testing: datasetRevision?.item_counts?.testing ?? 0,
+                        training: datasetRevision.item_counts.training,
+                        validation: datasetRevision.item_counts.validation,
+                        testing: datasetRevision.item_counts.testing,
                     },
-                    filesDeleted: datasetRevision?.files_deleted ?? false,
+                    filesDeleted: datasetRevision.files_deleted,
                 },
                 models: [],
             };
         }
 
-        groups[datasetId].models.push(model);
+        if (groups[datasetId] !== undefined) {
+            groups[datasetId].models.push(model);
+        }
     });
 
     return Object.values(groups);

--- a/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
@@ -24,7 +24,7 @@ export const AllModelArchitectures = ({
     onSelectedModelArchitectureIdChange,
     selectedModelArchitectureId,
 }: AllModelArchitecturesProps) => {
-    const [sortBy, setSortBy] = useState<SortingOptions>(SortingOptions.NAME_DESC);
+    const [sortBy, setSortBy] = useState<SortingOptions>(SortingOptions.NAME_ASC);
     const sortedModelArchitectures = SORTING_HANDLERS[sortBy](modelArchitectures);
 
     return (

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -32,7 +32,7 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
     const [name, setName] = useState<string>(`Project #${numberOfProjects + 1}`);
     const selectedTaskOption = TASK_OPTIONS.find((task) => task.value === selectedTask);
 
-    const [classificationTaskType, setClassificationTaskType] = useState<ClassificationTaskType>('multi-label');
+    const [classificationTaskType, setClassificationTaskType] = useState<ClassificationTaskType>('single-label');
 
     const navigate = useNavigate();
     const createProjectMutation = useCreateProject();

--- a/application/ui/tests/models/model-details.spec.ts
+++ b/application/ui/tests/models/model-details.spec.ts
@@ -105,6 +105,10 @@ test.describe('Model Details', () => {
                 id: 'model-1',
                 name: 'YOLOX Model v1',
                 variants: [],
+                training_info: {
+                    ...getMockedModel().training_info,
+                    dataset_revision_id: mockedDatasetRevision.id,
+                },
             });
 
             network.use(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR fixes:
1. Training dialog, option "Show more" - The default "Sort models by" is Z-A. Should be A-Z. -> just changed the default value.
2. Dataset revisions - Should display the actual creation date instead of "-". -> we didn't use dataset revision creation date, updated it.
3. Project creation, label color picker - the right column (transparency?) doesn't work. I suggest to remove it. -> added `hideAlphaChannel`
4. Segmentation smart tool - when I move the cursor outside of the image, no area should be selected. -> the issue was that we updated state in `onPointerLeave` properly but there was pending decoding function that updated the state again (e.g. we updated state to be empty array, decoding update the state to have the shape again). We missed the proper function cancellation, I updated it.
5. Project creation - for classification, single-label should be the default. -> just changed the default value.

from https://github.com/open-edge-platform/training_extensions/issues/5532.

5 fixes, 5 commits, one commit per fix.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
