### PR TITLE
Delete project files when project is deleted

### DIFF
--- a/application/backend/app/services/project_service.py
+++ b/application/backend/app/services/project_service.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import shutil
 from pathlib import Path
 from uuid import UUID
 
+from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.db.schema import ProjectDB
@@ -101,8 +103,15 @@ class ProjectService(BaseSessionManagedService):
         if is_running:
             raise ResourceInUseError(ResourceType.PROJECT, str(project_id), MSG_ERR_DELETE_ACTIVE_PROJECT)
         project_repo = ProjectRepository(self.db_session)
-        if not project_repo.delete(str(project_id)):
+
+        project_deleted = project_repo.delete(str(project_id))
+        if not project_deleted:
             raise ResourceNotFoundError(ResourceType.PROJECT, str(project_id))
+
+        project_path = self._projects_dir / str(project_id)
+        if project_path.exists():
+            shutil.rmtree(project_path)
+            logger.info("Deleted project files at '{}'", project_path)
 
     def get_project_thumbnail_path(self, project_id: UUID) -> Path | None:
         """Get the path to the project's thumbnail image, as determined by the earliest media"""

--- a/application/backend/tests/integration/services/test_project_service.py
+++ b/application/backend/tests/integration/services/test_project_service.py
@@ -3,15 +3,19 @@
 from pathlib import Path
 from uuid import UUID, uuid4
 
+import numpy as np
 import pytest
+from PIL import Image
 from sqlalchemy.orm import Session
 
 from app.db.schema import LabelDB, MediaDB, PipelineDB, ProjectDB
 from app.models import Label, Task, TaskType
+from app.models.media import ImageFormat
 from app.services import LabelService, PipelineService, ResourceWithIdAlreadyExistsError, SystemService
 from app.services.base import ResourceInUseError, ResourceNotFoundError, ResourceType
 from app.services.event.event_bus import EventBus
 from app.services.label_service import DuplicateLabelsError
+from app.services.media_service import MediaService
 from app.services.project_service import ProjectService
 
 
@@ -39,6 +43,15 @@ def fxt_pipeline_service(
 def fxt_label_service(db_session: Session) -> LabelService:
     """Fixture to create a LabelService instance."""
     return LabelService(db_session=db_session)
+
+
+@pytest.fixture
+def fxt_media_service(
+    fxt_projects_dir: Path,
+    db_session: Session,
+) -> MediaService:
+    """Fixture to create a MediaService instance."""
+    return MediaService(data_dir=fxt_projects_dir.parent, db_session=db_session)
 
 
 @pytest.fixture
@@ -220,12 +233,32 @@ class TestProjectServiceIntegration:
         assert excinfo.value.resource_id == str(non_existent_id)
 
     def test_delete_project(
-        self, fxt_project_service: ProjectService, fxt_db_projects: list[ProjectDB], db_session: Session
+        self,
+        fxt_project_service: ProjectService,
+        fxt_media_service: MediaService,
+        fxt_db_projects: list[ProjectDB],
+        db_session: Session,
     ):
         """Test deleting a project."""
         db_project = fxt_db_projects[0]
         db_session.add(db_project)
         db_session.flush()
+        project = fxt_project_service.get_project_by_id(UUID(db_project.id))
+
+        # Create a dummy image
+        dummy_image = Image.fromarray(np.zeros((10, 10, 3), dtype=np.uint8))
+        # Create media using the service
+        media = fxt_media_service.create_image(
+            project=project,
+            name="test_image.jpg",
+            format=ImageFormat.JPG,
+            data=dummy_image,
+            source_id=None,
+        )
+        project_folder = fxt_project_service._projects_dir / db_project.id
+        media_file = project_folder / f"dataset/{media.id}.jpg"
+        assert project_folder.exists()
+        assert media_file.exists()
 
         fxt_project_service.delete_project_by_id(UUID(db_project.id))
         db_session.expire_all()  # Clear the session cache
@@ -233,6 +266,8 @@ class TestProjectServiceIntegration:
         assert db_session.get(ProjectDB, db_project.id) is None
         # Ensure the associated pipeline is deleted
         assert db_session.get(PipelineDB, db_project.id) is None
+        # Ensure the project directory has been removed
+        assert not project_folder.exists()
 
     def test_delete_active_project(
         self,


### PR DESCRIPTION
This pull request enhances the project deletion process by ensuring that all associated project files are removed from disk when a project is deleted. It also adds a comprehensive integration test to verify this behavior. The most important changes are grouped below:

**Project Deletion Logic:**

* Updated the `delete_project_by_id` method in `project_service.py` to remove the project's directory from disk using `shutil.rmtree` after deleting the project record, and added logging to confirm file removal.
* Imported `shutil` and `logger` in `project_service.py` to support directory removal and logging.

**Testing Enhancements:**

* Added a fixture for `MediaService` to facilitate media creation in integration tests.
* Expanded the `test_delete_project` integration test to create a dummy image file within the project directory, verify its existence, and assert that the directory and file are deleted after the project is removed.
* Added necessary imports (`numpy`, `PIL.Image`, `ImageFormat`, and `MediaService`) to support the new test logic.

Resolves: #5543 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
