### PR TITLE
Address frames using indexes instead of timestamps

### DIFF
--- a/application/backend/app/alembic/versions/2d2b0c9a5c2c_schema.py
+++ b/application/backend/app/alembic/versions/2d2b0c9a5c2c_schema.py
@@ -147,7 +147,7 @@ def upgrade() -> None:
         "video_frames",
         sa.Column("id", sa.Text(), nullable=False),
         sa.Column("video_id", sa.Text(), nullable=False),
-        sa.Column("timestamp", sa.Float(), nullable=False),
+        sa.Column("frame_index", sa.Integer(), nullable=False),
         sa.Column("created_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
         sa.Column("updated_at", sa.DateTime(), server_default=sa.text("(CURRENT_TIMESTAMP)"), nullable=False),
         sa.ForeignKeyConstraint(["id"], ["media.id"], ondelete="CASCADE"),
@@ -155,7 +155,7 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index("idx_video_frames_video_id", "video_frames", ["video_id"], unique=False)
-    op.create_index("idx_video_frames_video_id_timestamp", "video_frames", ["video_id", "timestamp"], unique=False)
+    op.create_index("idx_video_frames_video_id_frame_index", "video_frames", ["video_id", "frame_index"], unique=False)
     op.create_table(
         "dataset_items",
         sa.Column("id", sa.Text(), nullable=False),
@@ -237,7 +237,7 @@ def downgrade() -> None:
     op.drop_table("evaluations")
     op.drop_index("idx_dataset_items_user_reviewed", table_name="dataset_items")
     op.drop_table("dataset_items")
-    op.drop_index("idx_video_frames_video_id_timestamp", table_name="video_frames")
+    op.drop_index("idx_video_frames_video_id_frame_index", table_name="video_frames")
     op.drop_index("idx_video_frames_video_id", table_name="video_frames")
     op.drop_table("video_frames")
     op.drop_index("idx_model_revisions_project_status", table_name="model_revisions")

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -314,9 +314,9 @@ def set_media_annotations(
             # Video frames can be identified by video ID and frame index
             if frame_index is None:
                 raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame timestamp is not provided."
+                    status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided."
                 )
-            if frame_index > media.frame_count:  # pyrefly: ignore[unsupported-operation]
+            if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
@@ -375,9 +375,9 @@ def get_media_annotations(
         # Video frames can be identified by video ID and frame index
         if frame_index is None:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame timestamp is not provided."
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided."
             )
-        if frame_index > media.frame_count:  # pyrefly: ignore[unsupported-operation]
+        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
@@ -385,7 +385,7 @@ def get_media_annotations(
         video_frame = media_service.get_frame_by_video_id_and_index(video_id=media_id, frame_index=frame_index)
         if video_frame is None:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given timestamp."
+                status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given index."
             )
         dataset_item_id = video_frame.id
 
@@ -423,9 +423,9 @@ def delete_media_annotation(
         # Video frames can be identified by video ID and frame index
         if frame_index is None:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame timestamp is not provided."
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided."
             )
-        if frame_index > media.frame_count:  # pyrefly: ignore[unsupported-operation]
+        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
@@ -433,7 +433,7 @@ def delete_media_annotation(
         video_frame = media_service.get_frame_by_video_id_and_index(video_id=media_id, frame_index=frame_index)
         if video_frame is None:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given timestamp."
+                status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given index."
             )
         dataset_item_id = video_frame.id
 

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -374,9 +374,7 @@ def get_media_annotations(
     if media.type == MediaType.VIDEO:
         # Video frames can be identified by video ID and frame index
         if frame_index is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided."
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
         if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -422,9 +420,7 @@ def delete_media_annotation(
     if media.type == MediaType.VIDEO:
         # Video frames can be identified by video ID and frame index
         if frame_index is None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided."
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
         if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -303,7 +303,7 @@ def set_media_annotations(
     media_annotations: Annotated[SetMediaAnnotations, Body(openapi_examples=SET_MEDIA_ANNOTATIONS_BODY_EXAMPLES)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
-    timestamp: Annotated[float | None, Query(description="Video frame timestamp in seconds", ge=0)] = None,
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> MediaAnnotations:
     """Set media annotations"""
     # Dataset item has the same ID as media
@@ -311,20 +311,20 @@ def set_media_annotations(
     try:
         media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
         if media.type == MediaType.VIDEO:
-            # Video frames can be identified by video ID and frame timestamp
-            if timestamp is None:
+            # Video frames can be identified by video ID and frame index
+            if frame_index is None:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame timestamp is not provided."
                 )
-            if timestamp > media.duration:  # pyrefly: ignore[unsupported-operation]
+            if frame_index > media.frame_count:  # pyrefly: ignore[unsupported-operation]
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Video frame timestamp {timestamp} exceeds video duration {media.duration}.",
+                    detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
                 )
-            video_frame = media_service.get_frame_by_video_id_and_timestamp(video_id=media_id, timestamp=timestamp)
+            video_frame = media_service.get_frame_by_video_id_and_index(video_id=media_id, frame_index=frame_index)
             if video_frame is None:
                 video_frame_media, video_frame = media_service.extract_video_frame(
-                    project=project, video_id=media_id, timestamp=timestamp
+                    project=project, video_id=media_id, frame_index=frame_index
                 )
                 dataset_service.create_dataset_item(
                     project=project,
@@ -365,24 +365,24 @@ def get_media_annotations(
     media_id: MediaID,
     media_service: Annotated[MediaService, Depends(get_media_service)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
-    timestamp: Annotated[float | None, Query(description="Video frame timestamp in seconds", ge=0)] = None,
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> MediaAnnotations:
     """Get the media annotations"""
     # Dataset item has the same ID as media
     dataset_item_id = media_id
     media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
     if media.type == MediaType.VIDEO:
-        # Video frames can be identified by video ID and frame timestamp
-        if timestamp is None:
+        # Video frames can be identified by video ID and frame index
+        if frame_index is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame timestamp is not provided."
             )
-        if timestamp > media.duration:  # pyrefly: ignore[unsupported-operation]
+        if frame_index > media.frame_count:  # pyrefly: ignore[unsupported-operation]
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Video frame timestamp {timestamp} exceeds video duration {media.duration}.",
+                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
             )
-        video_frame = media_service.get_frame_by_video_id_and_timestamp(video_id=media_id, timestamp=timestamp)
+        video_frame = media_service.get_frame_by_video_id_and_index(video_id=media_id, frame_index=frame_index)
         if video_frame is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given timestamp."
@@ -413,24 +413,24 @@ def delete_media_annotation(
     media_id: MediaID,
     media_service: Annotated[MediaService, Depends(get_media_service)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
-    timestamp: Annotated[float | None, Query(description="Video frame timestamp in seconds", ge=0)] = None,
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> None:
     """Delete media annotations"""
     # Dataset item has the same ID as media
     dataset_item_id = media_id
     media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
     if media.type == MediaType.VIDEO:
-        # Video frames can be identified by video ID and frame timestamp
-        if timestamp is None:
+        # Video frames can be identified by video ID and frame index
+        if frame_index is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame timestamp is not provided."
             )
-        if timestamp > media.duration:  # pyrefly: ignore[unsupported-operation]
+        if frame_index > media.frame_count:  # pyrefly: ignore[unsupported-operation]
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Video frame timestamp {timestamp} exceeds video duration {media.duration}.",
+                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
             )
-        video_frame = media_service.get_frame_by_video_id_and_timestamp(video_id=media_id, timestamp=timestamp)
+        video_frame = media_service.get_frame_by_video_id_and_index(video_id=media_id, frame_index=frame_index)
         if video_frame is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given timestamp."

--- a/application/backend/app/db/schema.py
+++ b/application/backend/app/db/schema.py
@@ -138,12 +138,12 @@ class VideoFrameDB(Base):
     __tablename__ = "video_frames"
     __table_args__ = (
         Index("idx_video_frames_video_id", "video_id"),
-        Index("idx_video_frames_video_id_timestamp", "video_id", "timestamp"),
+        Index("idx_video_frames_video_id_frame_index", "video_id", "frame_index"),
     )
 
     id: Mapped[str] = mapped_column(Text, ForeignKey("media.id", ondelete="CASCADE"), primary_key=True, nullable=False)
     video_id: Mapped[str] = mapped_column(Text, ForeignKey("media.id", ondelete="CASCADE"), nullable=False)
-    timestamp: Mapped[float] = mapped_column(Float, nullable=False)
+    frame_index: Mapped[int] = mapped_column(Integer, nullable=False)
 
 
 class LabelDB(BaseID):

--- a/application/backend/app/models/media.py
+++ b/application/backend/app/models/media.py
@@ -77,4 +77,4 @@ class Media(BaseEntity):
 class VideoFrame(BaseEntity):
     id: UUID
     video_id: UUID
-    timestamp: float
+    frame_index: int

--- a/application/backend/app/repositories/video_frame_repo.py
+++ b/application/backend/app/repositories/video_frame_repo.py
@@ -20,7 +20,7 @@ class VideoFrameRepository:
         self.db.flush()
         return video_frame_db
 
-    def get_by_video_id_and_timestamp(self, video_id: str, frame_index: int) -> VideoFrameDB | None:
+    def get_by_video_id_and_index(self, video_id: str, frame_index: int) -> VideoFrameDB | None:
         stmt = select(VideoFrameDB).where(VideoFrameDB.video_id == video_id, VideoFrameDB.frame_index == frame_index)
         return self.db.scalar(stmt)
 

--- a/application/backend/app/repositories/video_frame_repo.py
+++ b/application/backend/app/repositories/video_frame_repo.py
@@ -28,6 +28,6 @@ class VideoFrameRepository:
         stmt = select(VideoFrameDB).where(
             VideoFrameDB.video_id == video_id,
             VideoFrameDB.frame_index >= frame_index_from,
-            VideoFrameDB.frame_index < frame_index_to,
+            VideoFrameDB.frame_index <= frame_index_to,
         )
         return list(self.db.scalars(stmt).all())

--- a/application/backend/app/repositories/video_frame_repo.py
+++ b/application/backend/app/repositories/video_frame_repo.py
@@ -14,30 +14,20 @@ class VideoFrameRepository:
     def __init__(self, db: Session):
         self.db = db
 
-    @staticmethod
-    def _normalize_timestamp(timestamp: float) -> float:
-        """Normalize timestamps to a fixed precision to avoid float equality issues."""
-        # Using millisecond precision
-        return round(timestamp, 3)
-
     def save(self, video_frame_db: VideoFrameDB) -> VideoFrameDB:
-        video_frame_db.timestamp = self._normalize_timestamp(video_frame_db.timestamp)
         video_frame_db.updated_at = datetime.now(UTC)
         self.db.add(video_frame_db)
         self.db.flush()
         return video_frame_db
 
-    def get_by_video_id_and_timestamp(self, video_id: str, timestamp: float) -> VideoFrameDB | None:
-        normalized_timestamp = self._normalize_timestamp(timestamp)
-        stmt = select(VideoFrameDB).where(
-            VideoFrameDB.video_id == video_id, VideoFrameDB.timestamp == normalized_timestamp
-        )
+    def get_by_video_id_and_timestamp(self, video_id: str, frame_index: int) -> VideoFrameDB | None:
+        stmt = select(VideoFrameDB).where(VideoFrameDB.video_id == video_id, VideoFrameDB.frame_index == frame_index)
         return self.db.scalar(stmt)
 
-    def get_by_video_id(self, video_id: str, timestamp_from: float = 0, timestamp_to: int = 10) -> list[VideoFrameDB]:
+    def get_by_video_id(self, video_id: str, frame_index_from: int = 0, frame_index_to: int = 10) -> list[VideoFrameDB]:
         stmt = select(VideoFrameDB).where(
             VideoFrameDB.video_id == video_id,
-            VideoFrameDB.timestamp >= self._normalize_timestamp(timestamp_from),
-            VideoFrameDB.timestamp < self._normalize_timestamp(timestamp_to),
+            VideoFrameDB.frame_index >= frame_index_from,
+            VideoFrameDB.frame_index < frame_index_to,
         )
         return list(self.db.scalars(stmt).all())

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -249,7 +249,7 @@ class MediaService(BaseSessionManagedService):
         if media.type == MediaType.VIDEO:
             return MediaService.generate_video_thumbnail(
                 binary_path=binary_path,
-                time=(media.frame_count / media.fps) // 2,  # pyrefly: ignore
+                frame_index=media.frame_count // 2,  # pyrefly: ignore
             )
         raise RuntimeError(f"Unknown media type: {media.type}")
 
@@ -269,14 +269,14 @@ class MediaService(BaseSessionManagedService):
         return thumbnail
 
     @staticmethod
-    def generate_video_thumbnail(binary_path: Path, time: float) -> Image.Image:
+    def generate_video_thumbnail(binary_path: Path, frame_index: int) -> Image.Image:
         """Regenerate a video thumbnail by its path"""
         fd, temp_path = tempfile.mkstemp(suffix=".jpg")
         os.close(fd)
 
         frame_file_path = Path(temp_path)
         try:
-            extract_video_frame(video_path=binary_path, video_frame_path=frame_file_path, time=time)
+            extract_video_frame(video_path=binary_path, video_frame_path=frame_file_path, frame_index=frame_index)
             return MediaService.generate_image_thumbnail(frame_file_path)
         finally:
             try:
@@ -301,10 +301,10 @@ class MediaService(BaseSessionManagedService):
 
         repo.delete(obj_id=str(media.id))
 
-    def get_frame_by_video_id_and_timestamp(self, video_id: UUID, timestamp: float) -> VideoFrame | None:
-        return self.video_frame_service.get_frame_by_video_id_and_timestamp(video_id=video_id, timestamp=timestamp)
+    def get_frame_by_video_id_and_index(self, video_id: UUID, frame_index: int) -> VideoFrame | None:
+        return self.video_frame_service.get_frame_by_video_id_and_index(video_id=video_id, frame_index=frame_index)
 
-    def extract_video_frame(self, project: Project, video_id: UUID, timestamp: float) -> tuple[Media, VideoFrame]:
+    def extract_video_frame(self, project: Project, video_id: UUID, frame_index: int) -> tuple[Media, VideoFrame]:
         """Extract video frame by video ID and timestamp"""
         video = self.get_media_by_id(project_id=project.id, media_id=video_id)
         if video.type != MediaType.VIDEO:
@@ -318,7 +318,7 @@ class MediaService(BaseSessionManagedService):
         video_frame_path = dataset_dir / f"{media_id}.{format}"
 
         video_frame_numpy = extract_video_frame(
-            video_path=video_path, video_frame_path=video_frame_path, time=timestamp
+            video_path=video_path, video_frame_path=video_frame_path, frame_index=frame_index
         )
         image = self._read_image_from_ndarray(video_frame_numpy)
 
@@ -326,7 +326,7 @@ class MediaService(BaseSessionManagedService):
             id=str(media_id),
             project_id=str(project.id),
             type=MediaType.VIDEO_FRAME,
-            name=f"{video.name}_frame_{timestamp:.3f}",
+            name=f"{video.name}_frame_{frame_index}",
             format=str(format),
             width=image.width,
             height=image.height,
@@ -339,7 +339,7 @@ class MediaService(BaseSessionManagedService):
         video_frame_media = Media.model_validate(db_video_frame)
 
         video_frame = self.video_frame_service.create_video_frame(
-            video_frame_media=video_frame_media, video=video, timestamp=timestamp
+            video_frame_media=video_frame_media, video=video, frame_index=frame_index
         )
 
         return video_frame_media, video_frame

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -305,7 +305,7 @@ class MediaService(BaseSessionManagedService):
         return self.video_frame_service.get_frame_by_video_id_and_index(video_id=video_id, frame_index=frame_index)
 
     def extract_video_frame(self, project: Project, video_id: UUID, frame_index: int) -> tuple[Media, VideoFrame]:
-        """Extract video frame by video ID and timestamp"""
+        """Extract video frame by video ID and index"""
         video = self.get_media_by_id(project_id=project.id, media_id=video_id)
         if video.type != MediaType.VIDEO:
             raise RuntimeError(f"Media {video_id} is not a video")

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -48,7 +48,7 @@ def get_video_metadata(video_path: Path) -> VideoMetadata:
 def extract_video_frame(
     video_path: Path,
     video_frame_path: Path,
-    time: float,
+    frame_index: int,
 ) -> np.ndarray:
     """
     Extracts a video frame and saves it to a local FS to specified file.
@@ -56,21 +56,22 @@ def extract_video_frame(
     Args:
         video_path: Video binary file path
         video_frame_path: Path of the file to write generated video frame to
-        time: Frame time in seconds
+        frame_index: Frame index
     """
     cap = cv2.VideoCapture(str(video_path))
     if not cap.isOpened():
         raise RuntimeError(f"Cannot open video: {video_path}")
 
     try:
-        cap.set(cv2.CAP_PROP_POS_MSEC, time * 1000.0)
+        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+        # Read the frame at the requested position
         read_success, frame = cap.read()
         if not read_success:
-            raise RuntimeError(f"Cannot read frame at {time} second(s) from video: {video_path}")
+            raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
         cv2.imwrite(str(video_frame_path), frame)
         return frame
     except Exception as e:
-        logger.error(f"Failed extracting video frame {time} from video {video_path}", exc_info=e)
+        logger.error(f"Failed extracting video frame {frame_index} from video {video_path}", exc_info=e)
         raise RuntimeError("Error occurred while extracting video frame")
     finally:
         cap.release()

--- a/application/backend/app/services/video_frame_service.py
+++ b/application/backend/app/services/video_frame_service.py
@@ -13,51 +13,51 @@ class VideoFrameService(BaseSessionManagedService):
         self,
         video_frame_media: Media,
         video: Media,
-        timestamp: float,
+        frame_index: int,
     ) -> VideoFrame:
         """Creates a new video frame"""
 
         db_video_frame = VideoFrameDB(
             id=str(video_frame_media.id),
             video_id=str(video.id),
-            timestamp=timestamp,
+            frame_index=frame_index,
         )
 
         repo = VideoFrameRepository(db=self.db_session)
         db_video_frame = repo.save(db_video_frame)
         return VideoFrame.model_validate(db_video_frame)
 
-    def get_frame_by_video_id_and_timestamp(self, video_id: UUID, timestamp: float) -> VideoFrame | None:
+    def get_frame_by_video_id_and_index(self, video_id: UUID, frame_index: int) -> VideoFrame | None:
         """
-        Returns annotated video frame by video ID and frame timestamp.
+        Returns annotated video frame by video ID and frame index.
 
         Args:
             video_id: Video identifier
-            timestamp: Frame timestamp in seconds
+            frame_index: Frame index
 
         Returns:
             Video frame data if such frame has been annotated, None otherwise.
         """
         repo = VideoFrameRepository(db=self.db_session)
-        db_video_frame = repo.get_by_video_id_and_timestamp(video_id=str(video_id), timestamp=timestamp)
+        db_video_frame = repo.get_by_video_id_and_timestamp(video_id=str(video_id), frame_index=frame_index)
         return VideoFrame.model_validate(db_video_frame) if db_video_frame else None
 
     def get_frames_by_video_id(
-        self, video_id: UUID, timestamp_from: float = 0, timestamp_to: int = 10
+        self, video_id: UUID, frame_index_from: int = 0, frame_index_to: int = 10
     ) -> list[VideoFrame]:
         """
         Returns all annotated video frame falling into the specified timestamp range.
 
         Args:
             video_id: Video identifier
-            timestamp_from: Frame timestamp range start in seconds, default is 0
-            timestamp_to: Frame timestamp range end in seconds, default is 10
+            frame_index_from: Frame index range start, default is 0
+            frame_index_to: Frame index range end, default is 10
 
         Returns:
             Annotated video frames list.
         """
         repo = VideoFrameRepository(db=self.db_session)
         db_video_frames = repo.get_by_video_id(
-            video_id=str(video_id), timestamp_from=timestamp_from, timestamp_to=timestamp_to
+            video_id=str(video_id), frame_index_from=frame_index_from, frame_index_to=frame_index_to
         )
         return [VideoFrame.model_validate(frame) for frame in db_video_frames]

--- a/application/backend/app/services/video_frame_service.py
+++ b/application/backend/app/services/video_frame_service.py
@@ -39,14 +39,14 @@ class VideoFrameService(BaseSessionManagedService):
             Video frame data if such frame has been annotated, None otherwise.
         """
         repo = VideoFrameRepository(db=self.db_session)
-        db_video_frame = repo.get_by_video_id_and_timestamp(video_id=str(video_id), frame_index=frame_index)
+        db_video_frame = repo.get_by_video_id_and_index(video_id=str(video_id), frame_index=frame_index)
         return VideoFrame.model_validate(db_video_frame) if db_video_frame else None
 
     def get_frames_by_video_id(
         self, video_id: UUID, frame_index_from: int = 0, frame_index_to: int = 10
     ) -> list[VideoFrame]:
         """
-        Returns all annotated video frame falling into the specified timestamp range.
+        Returns all annotated video frame falling into the specified index range.
 
         Args:
             video_id: Video identifier

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -1345,7 +1345,7 @@ class TestMediaServiceIntegration:
         fxt_video_data(video_path)
 
         video_frame_media, video_frame = fxt_media_service.extract_video_frame(
-            project=project, video_id=UUID(media.id), timestamp=2
+            project=project, video_id=UUID(media.id), frame_index=50
         )
 
         video_frame_binary_path = dataset_dir / f"{video_frame_media.id}.jpg"
@@ -1357,7 +1357,7 @@ class TestMediaServiceIntegration:
             db_video_frame_media.id == str(video_frame_media.id)
             and db_video_frame_media.project_id == str(project.id)
             and db_video_frame_media.type == "video_frame"
-            and db_video_frame_media.name == "test4_frame_2.000"
+            and db_video_frame_media.name == "test4_frame_50"
             and db_video_frame_media.format == "jpg"
             and db_video_frame_media.width == 640
             and db_video_frame_media.height == 480
@@ -1368,5 +1368,5 @@ class TestMediaServiceIntegration:
         assert (
             db_video_frame.id == str(video_frame.id)
             and db_video_frame.video_id == media.id
-            and db_video_frame.timestamp == 2
+            and db_video_frame.frame_index == 50
         )

--- a/application/backend/tests/integration/services/test_video_frame_service.py
+++ b/application/backend/tests/integration/services/test_video_frame_service.py
@@ -50,10 +50,10 @@ def fxt_video_media(fxt_project_id: UUID, db_session) -> MediaDB:
 @pytest.fixture
 def fxt_video_frame(
     fxt_project_id: UUID, fxt_video_media: MediaDB, db_session
-) -> Callable[[float], tuple[MediaDB, VideoFrameDB]]:
-    def _create_video_frame(timestamp: float) -> tuple[MediaDB, VideoFrameDB]:
+) -> Callable[[int], tuple[MediaDB, VideoFrameDB]]:
+    def _create_video_frame(frame_index: int) -> tuple[MediaDB, VideoFrameDB]:
         db_media = MediaDB(
-            type="video_frame", name=f"test4_frame_{timestamp:.3f}", format="jpg", size=1024, width=1024, height=768
+            type="video_frame", name=f"test4_frame_{frame_index}", format="jpg", size=1024, width=1024, height=768
         )
         db_media.project_id = str(fxt_project_id)
         db_media.created_at = datetime.fromisoformat("2025-02-01T00:00:00Z")
@@ -61,7 +61,7 @@ def fxt_video_frame(
         db_session.add(db_media)
         db_session.flush()
 
-        db_video_frame = VideoFrameDB(id=db_media.id, video_id=fxt_video_media.id, timestamp=timestamp)
+        db_video_frame = VideoFrameDB(id=db_media.id, video_id=fxt_video_media.id, frame_index=frame_index)
         db_session.add(db_video_frame)
         db_session.flush()
 
@@ -97,7 +97,7 @@ class TestVideoFrameServiceIntegration:
         created_video_frame = fxt_video_frame_service.create_video_frame(
             video_frame_media=video_frame_media,
             video=video_media,
-            timestamp=10.0,
+            frame_index=250,
         )
 
         video_frame = db_session.get(VideoFrameDB, str(created_video_frame.id))
@@ -105,34 +105,34 @@ class TestVideoFrameServiceIntegration:
         assert (
             video_frame.id == str(created_video_frame.id)
             and video_frame.video_id == str(created_video_frame.video_id)
-            and video_frame.timestamp == 10.0
+            and video_frame.frame_index == 250
         )
 
-    def test_get_frame_by_video_id_and_timestamp(
+    def test_get_frame_by_video_id_and_index(
         self,
         fxt_video_frame_service: VideoFrameService,
         fxt_video_media: MediaDB,
-        fxt_video_frame: Callable[[float], tuple[MediaDB, VideoFrameDB]],
+        fxt_video_frame: Callable[[int], tuple[MediaDB, VideoFrameDB]],
     ) -> None:
-        """Test getting a video frame by video ID and timestamp."""
-        fxt_video_frame(10.0)
+        """Test getting a video frame by video ID and index."""
+        fxt_video_frame(250)
 
-        video_frame = fxt_video_frame_service.get_frame_by_video_id_and_timestamp(
-            video_id=UUID(fxt_video_media.id), timestamp=10.0
+        video_frame = fxt_video_frame_service.get_frame_by_video_id_and_index(
+            video_id=UUID(fxt_video_media.id), frame_index=250
         )
         assert video_frame is not None
 
-    def test_get_non_existing_frame_by_video_id_and_timestamp(
+    def test_get_non_existing_frame_by_video_id_and_index(
         self,
         fxt_video_frame_service: VideoFrameService,
         fxt_video_media: MediaDB,
-        fxt_video_frame: Callable[[float], tuple[MediaDB, VideoFrameDB]],
+        fxt_video_frame: Callable[[int], tuple[MediaDB, VideoFrameDB]],
     ) -> None:
-        """Test getting a non extracted video frame by video ID and timestamp."""
-        fxt_video_frame(10.0)
+        """Test getting a non extracted video frame by video ID and index."""
+        fxt_video_frame(250)
 
-        video_frame = fxt_video_frame_service.get_frame_by_video_id_and_timestamp(
-            video_id=UUID(fxt_video_media.id), timestamp=20.0
+        video_frame = fxt_video_frame_service.get_frame_by_video_id_and_index(
+            video_id=UUID(fxt_video_media.id), frame_index=500
         )
         assert video_frame is None
 

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -526,7 +526,7 @@ class TestMediaEndpoints:
             user_reviewed=True,
         )
 
-    def test_set_video_annotations_missing_timestamp(
+    def test_set_video_annotations_missing_frame_index(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
@@ -567,14 +567,14 @@ class TestMediaEndpoints:
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
         video_frame = MagicMock(
             spec=VideoFrame,
             id=video_frame_id,
         )
-        fxt_media_service.get_frame_by_video_id_and_timestamp.return_value = video_frame
+        fxt_media_service.get_frame_by_video_id_and_index.return_value = video_frame
         dataset_item = MagicMock(
             spec=DatasetItem,
             annotation_data=annotations,
@@ -584,7 +584,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.set_dataset_item_annotations.return_value = dataset_item
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?timestamp=10",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
@@ -601,7 +601,7 @@ class TestMediaEndpoints:
             "user_reviewed": True,
         }
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
-        fxt_media_service.get_frame_by_video_id_and_timestamp.assert_called_once_with(video_id=media_id, timestamp=10)
+        fxt_media_service.get_frame_by_video_id_and_index.assert_called_once_with(video_id=media_id, frame_index=10)
         fxt_dataset_service.set_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
             dataset_item_id=video_frame_id,
@@ -624,10 +624,10 @@ class TestMediaEndpoints:
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
-        fxt_media_service.get_frame_by_video_id_and_timestamp.return_value = None
+        fxt_media_service.get_frame_by_video_id_and_index.return_value = None
         video_frame_media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO_FRAME,
@@ -646,7 +646,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.set_dataset_item_annotations.return_value = dataset_item
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?timestamp=10",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
@@ -663,9 +663,9 @@ class TestMediaEndpoints:
             "user_reviewed": True,
         }
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
-        fxt_media_service.get_frame_by_video_id_and_timestamp.assert_called_once_with(video_id=media_id, timestamp=10)
+        fxt_media_service.get_frame_by_video_id_and_index.assert_called_once_with(video_id=media_id, frame_index=10)
         fxt_media_service.extract_video_frame.assert_called_once_with(
-            project=fxt_get_project, video_id=media_id, timestamp=10
+            project=fxt_get_project, video_id=media_id, frame_index=10
         )
         fxt_dataset_service.create_dataset_item.assert_called_once_with(
             project=fxt_get_project,
@@ -789,14 +789,14 @@ class TestMediaEndpoints:
             dataset_item_id=media_id,
         )
 
-    def test_get_video_annotations_missing_timestamp(
+    def test_get_video_annotations_missing_frame_index(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         media_id = uuid4()
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
 
@@ -814,14 +814,14 @@ class TestMediaEndpoints:
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
         video_frame = MagicMock(
             spec=VideoFrame,
             id=video_frame_id,
         )
-        fxt_media_service.get_frame_by_video_id_and_timestamp.return_value = video_frame
+        fxt_media_service.get_frame_by_video_id_and_index.return_value = video_frame
         dataset_item = MagicMock(
             spec=DatasetItem,
             annotation_data=[
@@ -836,7 +836,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.get_dataset_item_by_id.return_value = dataset_item
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?timestamp=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -852,7 +852,7 @@ class TestMediaEndpoints:
             "user_reviewed": True,
         }
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
-        fxt_media_service.get_frame_by_video_id_and_timestamp.assert_called_once_with(video_id=media_id, timestamp=10)
+        fxt_media_service.get_frame_by_video_id_and_index.assert_called_once_with(video_id=media_id, frame_index=10)
         fxt_dataset_service.get_dataset_item_by_id.assert_called_once_with(
             project_id=fxt_get_project.id,
             dataset_item_id=video_frame_id,
@@ -866,10 +866,10 @@ class TestMediaEndpoints:
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
-        fxt_media_service.get_frame_by_video_id_and_timestamp.return_value = None
+        fxt_media_service.get_frame_by_video_id_and_index.return_value = None
         dataset_item = MagicMock(
             spec=DatasetItem,
             annotation_data=[
@@ -884,12 +884,12 @@ class TestMediaEndpoints:
         fxt_dataset_service.get_dataset_item_by_id.return_value = dataset_item
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?timestamp=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
-        fxt_media_service.get_frame_by_video_id_and_timestamp.assert_called_once_with(video_id=media_id, timestamp=10)
+        fxt_media_service.get_frame_by_video_id_and_index.assert_called_once_with(video_id=media_id, frame_index=10)
         fxt_dataset_service.get_dataset_item_by_id.assert_not_called()
 
     @pytest.mark.parametrize("media_type", [MediaType.IMAGE, MediaType.VIDEO_FRAME])
@@ -957,7 +957,7 @@ class TestMediaEndpoints:
             dataset_item_id=media_id,
         )
 
-    def test_delete_video_annotations_missing_timestamp(
+    def test_delete_video_annotations_missing_frame_index(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         media_id = uuid4()
@@ -981,17 +981,17 @@ class TestMediaEndpoints:
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
         video_frame = MagicMock(
             spec=VideoFrame,
             id=video_frame_id,
         )
-        fxt_media_service.get_frame_by_video_id_and_timestamp.return_value = video_frame
+        fxt_media_service.get_frame_by_video_id_and_index.return_value = video_frame
 
         response = fxt_client.delete(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?timestamp=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -1008,13 +1008,13 @@ class TestMediaEndpoints:
         media = MagicMock(
             spec=Media,
             type=MediaType.VIDEO,
-            duration=20,
+            frame_count=20,
         )
         fxt_media_service.get_media_by_id.return_value = media
-        fxt_media_service.get_frame_by_video_id_and_timestamp.return_value = None
+        fxt_media_service.get_frame_by_video_id_and_index.return_value = None
 
         response = fxt_client.delete(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?timestamp=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
To provide compatibility with Geti Classic components, frames are addressed using indexes and not timestamps.
In later phase the implementation will be adjusted to support both ways.