### PR TITLE
Fix paths that trigger the execution of backend and build GHA workflows

### DIFF
--- a/.github/workflows/backend-lint-and-test.yaml
+++ b/.github/workflows/backend-lint-and-test.yaml
@@ -40,6 +40,7 @@ jobs:
           files_yaml: |
             test:
               - application/backend/**
+              - library/**
               - .github/**
 
   python-checks:
@@ -109,11 +110,11 @@ jobs:
         working-directory: application/backend
         run: uv run pytest --ignore=tests/integration/stream/test_ip_camera_stream.py --ignore=tests/integration/services/dispatchers/test_mqtt.py tests/integration
 
-# Temporarily skipping BDD tests on CI due to instability and flakiness. Will be re-enabled once the underlying issues are resolved.
-#      - name: Run bdd tests
-#        if: matrix.os == 'ubuntu-latest'
-#        working-directory: application/backend
-#        run: uv run behave tests/bdd
+  # Temporarily skipping BDD tests on CI due to instability and flakiness. Will be re-enabled once the underlying issues are resolved.
+  #      - name: Run bdd tests
+  #        if: matrix.os == 'ubuntu-latest'
+  #        working-directory: application/backend
+  #        run: uv run behave tests/bdd
 
   required_check:
     name: Required Check backend-lint-and-test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,9 +40,8 @@ jobs:
         with:
           files_yaml: |
             test:
-              - application/backend/**
-              - application/docker/**
-              - application/ui/**
+              - application/**
+              - '!application/docs/**'
               - library/**
               - .github/**
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,10 @@ jobs:
         with:
           files_yaml: |
             test:
-              - application/**
+              - application/backend/**
+              - application/docker/**
+              - application/ui/**
+              - library/**
               - .github/**
 
   build:


### PR DESCRIPTION
### Summary

Backend and build GHA workflows should be also triggered when there are changes in the library, since they both depend on otx.

Fixes #5580 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
