### PR TITLE
Fix training on XPU after PT Lightning update

### DIFF
--- a/library/src/otx/backend/native/lightning/accelerators/xpu.py
+++ b/library/src/otx/backend/native/lightning/accelerators/xpu.py
@@ -5,11 +5,12 @@
 
 from __future__ import annotations
 
-from typing import Any, override
+from typing import Any
 
 import torch
 from lightning.pytorch.accelerators import AcceleratorRegistry
 from lightning.pytorch.accelerators.accelerator import Accelerator
+from typing_extensions import override
 
 from otx.utils.device import is_xpu_available
 

--- a/library/src/otx/backend/native/lightning/accelerators/xpu.py
+++ b/library/src/otx/backend/native/lightning/accelerators/xpu.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 import torch
 from lightning.pytorch.accelerators import AcceleratorRegistry
@@ -19,6 +19,7 @@ class XPUAccelerator(Accelerator):
 
     accelerator_name = "xpu"
 
+    @override
     def setup_device(self, device: torch.device) -> None:
         """Sets up the specified device."""
         if device.type != "xpu":
@@ -28,6 +29,7 @@ class XPUAccelerator(Accelerator):
         torch.xpu.set_device(device)
 
     @staticmethod
+    @override
     def parse_devices(devices: str | list | torch.device) -> list:
         """Parses devices for multi-GPU training."""
         if isinstance(devices, list):
@@ -35,24 +37,34 @@ class XPUAccelerator(Accelerator):
         return [devices]
 
     @staticmethod
+    @override
     def get_parallel_devices(devices: list) -> list[torch.device]:
-        """Generates a list of parrallel devices."""
+        """Generates a list of parallel devices."""
         return [torch.device("xpu", idx) for idx in devices]
 
     @staticmethod
+    @override
     def auto_device_count() -> int:
         """Returns number of XPU devices available."""
         return torch.xpu.device_count()
 
     @staticmethod
+    @override
     def is_available() -> bool:
         """Checks if XPU available."""
         return is_xpu_available()
+
+    @staticmethod
+    @override
+    def name() -> str:
+        """The name of the accelerator."""
+        return XPUAccelerator.accelerator_name
 
     def get_device_stats(self, device: str | torch.device) -> dict[str, Any]:
         """Returns XPU devices stats."""
         return {}
 
+    @override
     def teardown(self) -> None:
         """Clean up any state created by the accelerator."""
 

--- a/library/tests/unit/backend/native/lightning/accelerators/test_xpu.py
+++ b/library/tests/unit/backend/native/lightning/accelerators/test_xpu.py
@@ -3,8 +3,6 @@
 
 """Test for otx.algo.accelerators.xpu"""
 
-from unittest import mock
-
 import pytest
 import torch
 
@@ -14,15 +12,9 @@ from otx.utils.device import is_xpu_available
 
 class TestXPUAccelerator:
     @pytest.fixture
-    def accelerator(self):
-        patcher = mock.patch("otx.backend.native.lightning.accelerators.xpu.torch")
-        mock_torch = patcher.start()
-        try:
-            # XPUAccelerator is abstract in Lightning (requires 'name'), create a test subclass
-            xpu_for_test = type("XPUForTest", (XPUAccelerator,), {"name": "xpu"})
-            yield xpu_for_test(), mock_torch
-        finally:
-            patcher.stop()
+    def accelerator(self, mocker):
+        mock_torch = mocker.patch("otx.backend.native.lightning.accelerators.xpu.torch")
+        return XPUAccelerator(), mock_torch
 
     def test_setup_device(self, accelerator):
         accelerator, mock_torch = accelerator
@@ -58,6 +50,11 @@ class TestXPUAccelerator:
         available = accelerator.is_available()
         assert isinstance(available, bool)
         assert available == is_xpu_available()
+
+    def test_name(self, accelerator):
+        accelerator, _ = accelerator
+        name = accelerator.name()
+        assert name == "xpu"
 
     def test_get_device_stats(self, accelerator):
         accelerator, _ = accelerator


### PR DESCRIPTION
### Summary

After the recent update of `lightning` to 2.6, the `XPUAccelerator` broke due to a missing property `name`, that is now required by the lightning `Accelerator` interface ([source](https://github.com/Lightning-AI/pytorch-lightning/blob/8d86b2417d56703d5cc4f0da76acc71717d1dab7/src/lightning/fabric/accelerators/accelerator.py#L61)). This PR fixes the issue by adding the `name` property.

Fixes #5578 

### How to test

Train a model in Geti Tune with XPU device.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
