### PR TITLE
Support content negotiation for model logs endpoint

### DIFF
--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -240,7 +240,7 @@ def get_training_logs(
     Supports content negotiation via Accept header (text/plain, application/x-ndjson).
     """
     try:
-        as_text: bool = accept and "text/plain" in accept.lower()  # pyrefly: ignore
+        as_text = accept is not None and "text/plain" in accept.lower()
 
         training_log = model_service.get_logs(project_id=project.id, model_id=model_id, as_text=as_text)
         if training_log is None:

--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -240,7 +240,7 @@ def get_training_logs(
     Supports content negotiation via Accept header (text/plain, application/x-ndjson).
     """
     try:
-        as_text = (accept and "text/plain" in accept.lower()) or False
+        as_text: bool = accept and "text/plain" in accept.lower()  # pyrefly: ignore
 
         training_log = model_service.get_logs(project_id=project.id, model_id=model_id, as_text=as_text)
         if training_log is None:

--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -4,11 +4,13 @@
 import io
 import os
 import zipfile
-from typing import Annotated
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
 from fastapi.openapi.models import Example
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import StreamingResponse
 from starlette.responses import FileResponse
 
 from app.api.dependencies import get_model_service, get_project
@@ -214,9 +216,9 @@ def get_training_metrics(
     response_model=None,
     responses={
         status.HTTP_200_OK: {
-            "description": "Model configuration successfully deleted",
+            "description": "Training logs for the model",
             "content": {
-                "application/json": {"description": "NDJSON format (newline-delimited JSON)"},
+                "application/x-ndjson": {"description": "NDJSON format (newline-delimited JSON)"},
                 "text/plain": {"description": "Plain text format (extracted from NDJSON)"},
             },
         },
@@ -232,25 +234,26 @@ def get_training_logs(
     model_id: ModelID,
     model_service: Annotated[ModelService, Depends(get_model_service)],
     accept: Annotated[str | None, Header(description="Accept header to specify the desired response format")] = None,
-) -> FileResponse | Response:
+) -> FileResponse | StreamingResponse:
     """
     Download the training log file for a given model.
-    Supports content negotiation via Accept header (text/plain, application/json).
+    Supports content negotiation via Accept header (text/plain, application/x-ndjson).
     """
     try:
         as_text = (accept and "text/plain" in accept.lower()) or False
 
-        log_content = model_service.get_logs(project_id=project.id, model_id=model_id, as_text=as_text)
-        if not log_content:
+        training_log = model_service.get_logs(project_id=project.id, model_id=model_id, as_text=as_text)
+        if training_log is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Log file not found")
 
         if as_text:
-            return Response(
-                content=log_content,
+            return StreamingResponse(
+                content=cast(Iterable, training_log),
                 media_type="text/plain",
                 headers={"Content-Disposition": f'attachment; filename="training-{model_id}.log"'},
             )
 
-        return FileResponse(log_content, media_type="application/json", filename=os.path.basename(log_content))
+        log_file = cast(Path, training_log)
+        return FileResponse(log_file, media_type="application/x-ndjson", filename=os.path.basename(log_file))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))

--- a/application/backend/app/api/routers/models.py
+++ b/application/backend/app/api/routers/models.py
@@ -6,9 +6,9 @@ import os
 import zipfile
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
 from fastapi.openapi.models import Example
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from starlette.responses import FileResponse
 
 from app.api.dependencies import get_model_service, get_project
@@ -211,9 +211,14 @@ def get_training_metrics(
 
 @router.get(
     "/{model_id}/logs",
+    response_model=None,
     responses={
         status.HTTP_200_OK: {
             "description": "Model configuration successfully deleted",
+            "content": {
+                "application/json": {"description": "NDJSON format (newline-delimited JSON)"},
+                "text/plain": {"description": "Plain text format (extracted from NDJSON)"},
+            },
         },
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid project or model ID"},
         status.HTTP_404_NOT_FOUND: {"description": "Project, model or log file not found"},
@@ -222,18 +227,30 @@ def get_training_metrics(
         },
     },
 )
-async def get_training_logs(
+def get_training_logs(
     project: Annotated[ProjectView, Depends(get_project)],
     model_id: ModelID,
     model_service: Annotated[ModelService, Depends(get_model_service)],
-) -> FileResponse:
+    accept: Annotated[str | None, Header(description="Accept header to specify the desired response format")] = None,
+) -> FileResponse | Response:
     """
     Download the training log file for a given model.
+    Supports content negotiation via Accept header (text/plain, application/json).
     """
     try:
-        log_file = model_service.get_logs(project_id=project.id, model_id=model_id)
-        if not log_file:
+        as_text = (accept and "text/plain" in accept.lower()) or False
+
+        log_content = model_service.get_logs(project_id=project.id, model_id=model_id, as_text=as_text)
+        if not log_content:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Log file not found")
-        return FileResponse(log_file, media_type="text/plain", filename=os.path.basename(log_file))
+
+        if as_text:
+            return Response(
+                content=log_content,
+                media_type="text/plain",
+                headers={"Content-Disposition": f'attachment; filename="training-{model_id}.log"'},
+            )
+
+        return FileResponse(log_content, media_type="application/json", filename=os.path.basename(log_content))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import shutil
 from dataclasses import dataclass
 from functools import lru_cache
@@ -512,16 +513,18 @@ class ModelService(BaseSessionManagedService):
         # If the number of unique steps equals the expected count, they are consecutive and hence step-based
         return len(unique_steps) == expected_count
 
-    def get_logs(self, project_id: UUID, model_id: UUID) -> Path | None:
+    def get_logs(self, project_id: UUID, model_id: UUID, as_text: bool = False) -> Path | str | None:
         """
         Get the training logs for a model revision.
 
         Args:
             project_id (UUID): The unique identifier of the project.
             model_id (UUID): The unique identifier of the model.
+            as_text (bool): If True, parse NDJSON and return plain text. If False, return file path.
 
         Returns:
-            Path | None: Path to the training log file.
+            Path | str | None: Path to the training log file (if as_text=False),
+                           plain text logs (if as_text=True), or None if logs don't exist.
 
         Raises:
             ResourceNotFoundError: If no model with the given model_id is found.
@@ -542,4 +545,17 @@ class ModelService(BaseSessionManagedService):
         if not log_file.exists():
             return None
 
-        return log_file
+        if not as_text:
+            return log_file
+
+        text_lines = []
+        with open(log_file, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                    text_lines.append(entry.get("text", ""))
+                except json.JSONDecodeError as e:
+                    logger.warning("Failed to parse log line: {}", e)
+                    continue
+
+        return "".join(text_lines)

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -3,6 +3,7 @@
 
 import json
 import shutil
+from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -513,7 +514,7 @@ class ModelService(BaseSessionManagedService):
         # If the number of unique steps equals the expected count, they are consecutive and hence step-based
         return len(unique_steps) == expected_count
 
-    def get_logs(self, project_id: UUID, model_id: UUID, as_text: bool = False) -> Path | str | None:
+    def get_logs(self, project_id: UUID, model_id: UUID, as_text: bool = False) -> Path | Iterator[str] | None:
         """
         Get the training logs for a model revision.
 
@@ -523,8 +524,8 @@ class ModelService(BaseSessionManagedService):
             as_text (bool): If True, parse NDJSON and return plain text. If False, return file path.
 
         Returns:
-            Path | str | None: Path to the training log file (if as_text=False),
-                           plain text logs (if as_text=True), or None if logs don't exist.
+            Path | Iterator[str] | None: Path to the training log file (if as_text=False),
+                iterator yielding plain text log lines (if as_text=True), or None if logs don't exist.
 
         Raises:
             ResourceNotFoundError: If no model with the given model_id is found.
@@ -548,14 +549,16 @@ class ModelService(BaseSessionManagedService):
         if not as_text:
             return log_file
 
-        text_lines = []
-        with open(log_file, encoding="utf-8") as f:
-            for line in f:
-                try:
-                    entry = json.loads(line)
-                    text_lines.append(entry.get("text", ""))
-                except json.JSONDecodeError as e:
-                    logger.warning("Failed to parse log line: {}", e)
-                    continue
+        def _iter_text_lines() -> Iterator[str]:
+            with open(log_file, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line)
+                        text = entry.get("text", "")
+                        if text:
+                            yield text
+                    except json.JSONDecodeError as e:
+                        logger.warning("Failed to parse log line: {}", e)
+                        continue
 
-        return "".join(text_lines)
+        return _iter_text_lines()

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -559,6 +559,6 @@ class ModelService(BaseSessionManagedService):
                             yield text
                     except json.JSONDecodeError as e:
                         logger.warning("Failed to parse log line: {}", e)
-                        continue
+                        yield "[MALFORMED LOG LINE]\n"
 
         return _iter_text_lines()

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -587,15 +588,15 @@ class TestModelServiceIntegration:
         # Assert
         assert result is not None
         if as_text:
-            assert isinstance(result, str)
-            assert result == "Training started\nEpoch 1/10\n"
+            assert isinstance(result, Iterator)
+            assert list(result) == ["Training started\n", "Epoch 1/10\n"]
         else:
             assert isinstance(result, Path)
             assert result.exists()
             assert result.read_text() == log_content
 
     @pytest.mark.parametrize("training_status", [TrainingStatus.NOT_STARTED, TrainingStatus.IN_PROGRESS])
-    def test_get_logs_in_status(
+    def test_get_logs_not_supported_status(
         self,
         training_status: TrainingStatus,
         fxt_project_id: UUID,

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -547,10 +547,19 @@ class TestModelServiceIntegration:
 
         assert "metrics.csv not found" in str(exc_info.value)
 
-    @pytest.mark.parametrize("training_status", [TrainingStatus.SUCCESSFUL, TrainingStatus.FAILED])
+    @pytest.mark.parametrize(
+        "training_status, as_text",
+        [
+            (TrainingStatus.SUCCESSFUL, True),
+            (TrainingStatus.SUCCESSFUL, False),
+            (TrainingStatus.FAILED, True),
+            (TrainingStatus.FAILED, False),
+        ],
+    )
     def test_get_logs_success(
         self,
         training_status: TrainingStatus,
+        as_text: bool,
         tmp_path: Path,
         fxt_model_id: UUID,
         fxt_project_id: UUID,
@@ -567,16 +576,23 @@ class TestModelServiceIntegration:
 
         log_file = tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id) / "training.log"
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        log_content = "Training started\nEpoch 1/10\nLoss: 0.5\n"
+        log_content = (
+            '{ "text": "Training started\\n", "payload": "abc" }\n{ "text": "Epoch 1/10\\n", "payload": "dfe"}\n'
+        )
         log_file.write_text(log_content)
 
         # Act
-        result = fxt_model_service.get_logs(project_id=fxt_project_id, model_id=fxt_model_id)
+        result = fxt_model_service.get_logs(project_id=fxt_project_id, model_id=fxt_model_id, as_text=as_text)
 
         # Assert
         assert result is not None
-        assert result.exists()
-        assert result.read_text() == log_content
+        if as_text:
+            assert isinstance(result, str)
+            assert result == "Training started\nEpoch 1/10\n"
+        else:
+            assert isinstance(result, Path)
+            assert result.exists()
+            assert result.read_text() == log_content
 
     @pytest.mark.parametrize("training_status", [TrainingStatus.NOT_STARTED, TrainingStatus.IN_PROGRESS])
     def test_get_logs_in_status(

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -578,7 +578,9 @@ class TestModelServiceIntegration:
         log_file = tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id) / "training.log"
         log_file.parent.mkdir(parents=True, exist_ok=True)
         log_content = (
-            '{ "text": "Training started\\n", "payload": "abc" }\n{ "text": "Epoch 1/10\\n", "payload": "dfe"}\n'
+            '{ "text": "Training started\\n", "payload": "abc" }\n'
+            '{ "text": "Epoch 1/10\\n", "payload": "dfe"}\n'
+            '{ "text": "Epoch 2/10\\n"\n'
         )
         log_file.write_text(log_content)
 
@@ -589,7 +591,7 @@ class TestModelServiceIntegration:
         assert result is not None
         if as_text:
             assert isinstance(result, Iterator)
-            assert list(result) == ["Training started\n", "Epoch 1/10\n"]
+            assert list(result) == ["Training started\n", "Epoch 1/10\n", "[MALFORMED LOG LINE]\n"]
         else:
             assert isinstance(result, Path)
             assert result.exists()

--- a/application/backend/tests/unit/routers/test_models.py
+++ b/application/backend/tests/unit/routers/test_models.py
@@ -358,19 +358,35 @@ class TestModelEndpoints:
             project_id=fxt_get_project.id, model_id=model_id
         )
 
-    def test_get_training_logs_success(self, fxt_get_project, fxt_model, fxt_model_service, fxt_client, tmp_path):
+    @pytest.mark.parametrize(
+        "accept_header, expected_content_type",
+        [
+            ("application/json", "application/json"),
+            ("text/plain", "text/plain; charset=utf-8"),
+            (None, "application/json"),  # Default to JSON if no Accept header is provided
+        ],
+    )
+    def test_get_training_logs_as_json_success(
+        self, accept_header, expected_content_type, fxt_get_project, fxt_model, fxt_model_service, fxt_client, tmp_path
+    ):
         log_file = tmp_path / "training.log"
         log_content = "Training started\nEpoch 1/10\nLoss: 0.5\n"
         log_file.write_text(log_content, newline="\n")
 
-        fxt_model_service.get_logs.return_value = log_file
+        if accept_header == "text/plain":
+            fxt_model_service.get_logs.return_value = log_content
+        else:
+            fxt_model_service.get_logs.return_value = log_file
 
-        response = fxt_client.get(f"/api/projects/{fxt_get_project.id}/models/{fxt_model.id}/logs")
+        headers = {"Accept": accept_header} if accept_header is not None else {}
+        response = fxt_client.get(f"/api/projects/{fxt_get_project.id}/models/{fxt_model.id}/logs", headers=headers)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.headers["content-type"] == "text/plain; charset=utf-8"
+        assert response.headers["content-type"] == expected_content_type
         assert response.text == log_content
-        fxt_model_service.get_logs.assert_called_once_with(project_id=fxt_get_project.id, model_id=fxt_model.id)
+        fxt_model_service.get_logs.assert_called_once_with(
+            project_id=fxt_get_project.id, model_id=fxt_model.id, as_text="text/plain" in expected_content_type
+        )
 
     def test_get_training_logs_not_found(self, fxt_get_project, fxt_model_service, fxt_client):
         model_id = uuid4()
@@ -379,7 +395,9 @@ class TestModelEndpoints:
         response = fxt_client.get(f"/api/projects/{fxt_get_project.id}/models/{model_id}/logs")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_model_service.get_logs.assert_called_once_with(project_id=fxt_get_project.id, model_id=model_id)
+        fxt_model_service.get_logs.assert_called_once_with(
+            project_id=fxt_get_project.id, model_id=model_id, as_text=False
+        )
 
     def test_get_training_logs_invalid_id(self, fxt_get_project, fxt_model_service, fxt_client):
         response = fxt_client.get(f"/api/projects/{fxt_get_project.id}/models/invalid-id/logs")
@@ -395,7 +413,9 @@ class TestModelEndpoints:
         response = fxt_client.get(f"/api/projects/{fxt_get_project.id}/models/{fxt_model.id}/logs")
 
         assert response.status_code == status.HTTP_409_CONFLICT
-        fxt_model_service.get_logs.assert_called_once_with(project_id=fxt_get_project.id, model_id=fxt_model.id)
+        fxt_model_service.get_logs.assert_called_once_with(
+            project_id=fxt_get_project.id, model_id=fxt_model.id, as_text=False
+        )
 
     def test_get_training_logs_file_not_exists(self, fxt_get_project, fxt_model, fxt_model_service, fxt_client):
         fxt_model_service.get_logs.return_value = None
@@ -404,4 +424,6 @@ class TestModelEndpoints:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json() == {"detail": "Log file not found"}
-        fxt_model_service.get_logs.assert_called_once_with(project_id=fxt_get_project.id, model_id=fxt_model.id)
+        fxt_model_service.get_logs.assert_called_once_with(
+            project_id=fxt_get_project.id, model_id=fxt_model.id, as_text=False
+        )

--- a/application/backend/tests/unit/routers/test_models.py
+++ b/application/backend/tests/unit/routers/test_models.py
@@ -361,12 +361,13 @@ class TestModelEndpoints:
     @pytest.mark.parametrize(
         "accept_header, expected_content_type",
         [
-            ("application/json", "application/json"),
+            ("application/json", "application/x-ndjson"),
+            ("application/x-ndjson", "application/x-ndjson"),
             ("text/plain", "text/plain; charset=utf-8"),
-            (None, "application/json"),  # Default to JSON if no Accept header is provided
+            (None, "application/x-ndjson"),  # Default to JSON if no Accept header is provided
         ],
     )
-    def test_get_training_logs_as_json_success(
+    def test_get_training_logs_success(
         self, accept_header, expected_content_type, fxt_get_project, fxt_model, fxt_model_service, fxt_client, tmp_path
     ):
         log_file = tmp_path / "training.log"

--- a/application/docs/api.md
+++ b/application/docs/api.md
@@ -104,12 +104,14 @@
 
 ### Models
 
-| Method   | Path                                          | Payload | Return         | Description                            |
-| -------- | --------------------------------------------- | ------- | -------------- | -------------------------------------- |
-| `GET`    | `/api/projects/<id>/models`                   | -       | list of models | List all the models in a project       |
-| `GET`    | `/api/projects/<id>/models/<model_id>`        | -       | model info     | Get info about a specific model        |
-| `GET`    | `/api/projects/<id>/models/<model_id>/labels` | -       | labels         | Get the labels used to train the model |
-| `DELETE` | `/api/projects/<id>/models/<model_id>`        | -       | -              | Delete a model (option 'weights_only') |
+| Method   | Path                                                    | Payload | Return           | Description                                                             |
+| -------- | ------------------------------------------------------- | ------- | ---------------- | ----------------------------------------------------------------------- |
+| `GET`    | `/api/projects/<id>/models`                             | -       | list of models   | List all the models in a project                                        |
+| `GET`    | `/api/projects/<id>/models/<model_id>`                  | -       | model info       | Get info about a specific model                                         |
+| `GET`    | `/api/projects/<id>/models/<model_id>/labels`           | -       | labels           | Get the labels used to train the model                                  |
+| `DELETE` | `/api/projects/<id>/models/<model_id>`                  | -       | -                | Delete a model (option 'weights_only')                                  |
+| `GET`    | `/api/projects/<id>/models/<model_id>/training_metrics` | -       | training metrics | Get training metrics                                                    |
+| `GET`    | `/api/projects/<id>/models/<model_id>/logs`             | -       | training log     | Get training logs (supports Accept: text/plain or application/x-ndjson) |
 
 ### Dataset revisions (training datasets, etc...)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->
Enhanced the `GET /api/projects/{project_id}/models/{model_id}/logs` endpoint to support content negotiation via the `Accept` header:
- `Accept: text/plain` - Returns plain text format (parsed from `NDJSON`)
- `Accept: application/json` or `Accept: application/x-ndjson` - Returns `NDJSON` format (default)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

- **text:** `curl -H "Accept: text/plain" http://localhost:7860/api/projects/2d3280e3-2cb2-4b13-8f4a-dcaaed969678/models/61e82b16-b782-4e5d-8fda-e17d2e06352f/logs -o training.txt`
- **json:** `curl http://localhost:7860/api/projects/2d3280e3-2cb2-4b13-8f4a-dcaaed969678/models/61e82b16-b782-4e5d-8fda-e17d2e06352f/logs -o training.log`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
