### PR TITLE
feat: Implement video timeline navigation

### DIFF
--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -26,9 +26,18 @@ export type PrepareImportDatasetJob = Job & {
 
 export type MediaImage = components['schemas']['ImageView'];
 export type MediaVideo = components['schemas']['VideoView'];
-export type MediaVideoFrame = components['schemas']['VideoFrameView'];
+export type MediaVideoFrame2 = components['schemas']['VideoFrameView'];
+export type MediaVideoFrame = MediaVideo & {
+    fps: number;
+    frame_number: number;
+    frame_count: number;
+    frame_stride: number;
+    duration: number;
+    type: 'video_frame';
+};
 
 export type Media = MediaImage | MediaVideo | MediaVideoFrame;
+
 export type MediaItemState = 'accepted' | 'rejected';
 export type MediaStateMap = Map<string, MediaItemState>;
 

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -26,15 +26,14 @@ export type PrepareImportDatasetJob = Job & {
 
 export type MediaImage = components['schemas']['ImageView'];
 export type MediaVideo = components['schemas']['VideoView'];
-export type MediaVideoFrame2 = components['schemas']['VideoFrameView'];
-export type MediaVideoFrame = MediaVideo & {
-    fps: number;
+export type MediaVideoFrameDTO = components['schemas']['VideoFrameView'];
+export type MediaVideoFrame = Omit<MediaVideo, 'type'> & {
     frame_number: number;
-    frame_count: number;
     frame_stride: number;
-    duration: number;
     type: 'video_frame';
 };
+
+export type MediaDTO = MediaImage | MediaVideo | MediaVideoFrameDTO;
 
 export type Media = MediaImage | MediaVideo | MediaVideoFrame;
 

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -8,7 +8,7 @@ import type { Media } from '../../../constants/shared-types';
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
-import { isVideo } from '../../../shared/media-item-utils';
+import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { useMediaItemImage } from '../selected-media-item-provider.component';
 import { ToolManager } from '../tools/tool-manager.component';
@@ -43,7 +43,9 @@ const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
     return (
         <>
             <canvas ref={canvasRef} width={image.width} height={image.height} className={classes.image} />
-            {isVideo(mediaItem) && <VideoFrame canvasRef={canvasRef} mediaItem={mediaItem} />}
+            {(isVideo(mediaItem) || isVideoFrame(mediaItem)) && (
+                <VideoFrame canvasRef={canvasRef} mediaItem={mediaItem} />
+            )}
         </>
     );
 };

--- a/application/ui/src/features/annotator/video-player/use-video-controls.ts
+++ b/application/ui/src/features/annotator/video-player/use-video-controls.ts
@@ -19,15 +19,15 @@ export type VideoControls = {
 
 export const useVideoControls = (
     videoRef: RefObject<HTMLVideoElement | null>,
-    mediaItem: MediaVideoFrame | undefined,
+    videoFrame: MediaVideoFrame | undefined,
     selectVideoFrame: (media: MediaVideoFrame) => void,
     changeCurrentFrameIndex: (index: number) => void
 ): VideoControls => {
     const [isPlaying, setIsPlaying] = useState<boolean>(false);
 
-    const totalFrames = mediaItem?.frame_count ?? 1;
-    const step = mediaItem?.frame_stride;
-    const currentFrameNumber = mediaItem.frame_number;
+    const totalFrames = videoFrame?.frame_count ?? 1;
+    const step = videoFrame?.frame_stride ?? 1;
+    const currentFrameNumber = videoFrame?.frame_number ?? 0;
 
     const round = (x: number) => Math.round(x / step) * step;
     const previousVideoFrameNumber = round(currentFrameNumber - step);
@@ -37,14 +37,13 @@ export const useVideoControls = (
     const canSelectNextFrame = nextVideoFrameNumber < totalFrames;
 
     const selectFrame = (frameNumber: number) => {
-        if (videoRef.current === null) {
+        if (videoRef.current === null || videoFrame === undefined) {
             return;
         }
-        // TODO: Update selected video frame in selected media item provider
-        selectVideoFrame({ ...mediaItem, frame_number: frameNumber });
+        selectVideoFrame({ ...videoFrame, frame_number: frameNumber });
         changeCurrentFrameIndex(frameNumber);
 
-        videoRef.current.currentTime = (frameNumber + 1) / mediaItem.fps;
+        videoRef.current.currentTime = (frameNumber + 1) / videoFrame.fps;
     };
 
     const play = async () => {
@@ -63,14 +62,14 @@ export const useVideoControls = (
     };
 
     const pause = () => {
-        if (videoRef.current === null) {
+        if (videoRef.current === null || videoFrame === undefined) {
             return;
         }
 
         setIsPlaying(false);
         videoRef.current.pause();
 
-        const maxNearestFrame = Math.floor((mediaItem.frame_count - 1) / step) * step;
+        const maxNearestFrame = Math.floor((videoFrame.frame_count - 1) / step) * step;
         const nearestFrame = Math.min(maxNearestFrame, Math.round(currentFrameNumber / step) * step);
 
         goto(nearestFrame);
@@ -101,7 +100,7 @@ export const useVideoControls = (
     };
 
     const goto = (frameNumber: number) => {
-        if (videoRef.current === null) {
+        if (videoRef.current === null || videoFrame === undefined) {
             return;
         }
 
@@ -114,7 +113,7 @@ export const useVideoControls = (
             setIsPlaying(false);
         }
 
-        videoRef.current.currentTime = (frameNumber + 1) / mediaItem.fps;
+        videoRef.current.currentTime = (frameNumber + 1) / videoFrame.fps;
         const nearest = Math.min(Math.round(frameNumber / step) * step, totalFrames - 1);
 
         selectFrame(nearest);

--- a/application/ui/src/features/annotator/video-player/use-video-controls.ts
+++ b/application/ui/src/features/annotator/video-player/use-video-controls.ts
@@ -3,7 +3,7 @@
 
 import { RefObject, useState } from 'react';
 
-import type { MediaVideo } from '../../../constants/shared-types';
+import type { MediaVideoFrame } from '../../../constants/shared-types';
 
 export type VideoControls = {
     canSelectPreviousFrame: boolean;
@@ -19,9 +19,33 @@ export type VideoControls = {
 
 export const useVideoControls = (
     videoRef: RefObject<HTMLVideoElement | null>,
-    mediaItem: MediaVideo | undefined
+    mediaItem: MediaVideoFrame | undefined,
+    selectVideoFrame: (media: MediaVideoFrame) => void,
+    changeCurrentFrameIndex: (index: number) => void
 ): VideoControls => {
     const [isPlaying, setIsPlaying] = useState<boolean>(false);
+
+    const totalFrames = mediaItem?.frame_count ?? 1;
+    const step = mediaItem?.frame_stride;
+    const currentFrameNumber = mediaItem.frame_number;
+
+    const round = (x: number) => Math.round(x / step) * step;
+    const previousVideoFrameNumber = round(currentFrameNumber - step);
+    const canSelectPreviousFrame = previousVideoFrameNumber >= 0;
+
+    const nextVideoFrameNumber = round(currentFrameNumber + step);
+    const canSelectNextFrame = nextVideoFrameNumber < totalFrames;
+
+    const selectFrame = (frameNumber: number) => {
+        if (videoRef.current === null) {
+            return;
+        }
+        // TODO: Update selected video frame in selected media item provider
+        selectVideoFrame({ ...mediaItem, frame_number: frameNumber });
+        changeCurrentFrameIndex(frameNumber);
+
+        videoRef.current.currentTime = (frameNumber + 1) / mediaItem.fps;
+    };
 
     const play = async () => {
         if (videoRef.current === null) {
@@ -42,25 +66,26 @@ export const useVideoControls = (
         if (videoRef.current === null) {
             return;
         }
+
         setIsPlaying(false);
         videoRef.current.pause();
+
+        const maxNearestFrame = Math.floor((mediaItem.frame_count - 1) / step) * step;
+        const nearestFrame = Math.min(maxNearestFrame, Math.round(currentFrameNumber / step) * step);
+
+        goto(nearestFrame);
     };
-
-    const frames = mediaItem?.frame_count ?? 1;
-    const fps = mediaItem?.fps || 1;
-    const step = 1 / fps;
-    const currentTime = videoRef.current?.currentTime ?? 0;
-
-    // TODO: These will change once API for video frames is supported
-    const canSelectPreviousFrame = currentTime - step >= 0;
-    const canSelectNextFrame = currentTime + step <= frames / fps;
 
     const nextFrame = () => {
         if (!canSelectNextFrame || videoRef.current === null) {
             return;
         }
 
-        videoRef.current.currentTime = videoRef.current.currentTime + step;
+        if (!isPlaying) {
+            selectFrame(nextVideoFrameNumber);
+        } else {
+            videoRef.current.currentTime += 1;
+        }
     };
 
     const previousFrame = () => {
@@ -68,11 +93,31 @@ export const useVideoControls = (
             return;
         }
 
-        videoRef.current.currentTime = videoRef.current.currentTime - step;
+        if (!isPlaying) {
+            selectFrame(previousVideoFrameNumber);
+        } else {
+            videoRef.current.currentTime -= 1;
+        }
     };
 
-    const goto = (_frameNumber: number) => {
-        //
+    const goto = (frameNumber: number) => {
+        if (videoRef.current === null) {
+            return;
+        }
+
+        if (frameNumber >= totalFrames || frameNumber < 0) {
+            return;
+        }
+
+        if (isPlaying) {
+            videoRef.current.pause();
+            setIsPlaying(false);
+        }
+
+        videoRef.current.currentTime = (frameNumber + 1) / mediaItem.fps;
+        const nearest = Math.min(Math.round(frameNumber / step) * step, totalFrames - 1);
+
+        selectFrame(nearest);
     };
 
     return {

--- a/application/ui/src/features/annotator/video-player/use-video-controls.ts
+++ b/application/ui/src/features/annotator/video-player/use-video-controls.ts
@@ -83,6 +83,7 @@ export const useVideoControls = (
         if (!isPlaying) {
             selectFrame(nextVideoFrameNumber);
         } else {
+            changeCurrentFrameIndex(nextVideoFrameNumber);
             videoRef.current.currentTime += 1;
         }
     };
@@ -95,6 +96,7 @@ export const useVideoControls = (
         if (!isPlaying) {
             selectFrame(previousVideoFrameNumber);
         } else {
+            changeCurrentFrameIndex(previousVideoFrameNumber);
             videoRef.current.currentTime -= 1;
         }
     };

--- a/application/ui/src/features/annotator/video-player/video-frame.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-frame.component.tsx
@@ -19,7 +19,7 @@ const useRequestVideoFrameCallback = (
     videoRef: RefObject<HTMLVideoElement | null>,
     canvasRef: RefObject<HTMLCanvasElement | null>
 ) => {
-    const { videoControls } = useVideoPlayer();
+    const { videoControls, changeCurrentFrameIndex, videoFrame } = useVideoPlayer();
     const { isPlaying } = videoControls;
 
     useEffect(() => {
@@ -35,7 +35,7 @@ const useRequestVideoFrameCallback = (
 
         let callbackId: number | null = null;
 
-        const updateCanvas: VideoFrameRequestCallback = () => {
+        const updateCanvas: VideoFrameRequestCallback = (_now, metadata) => {
             if (videoRef.current === null) {
                 return;
             }
@@ -49,6 +49,9 @@ const useRequestVideoFrameCallback = (
             ctx.drawImage(video, 0, 0);
 
             callbackId = video.requestVideoFrameCallback(updateCanvas);
+
+            const nextFrameIndex = Math.ceil(metadata.mediaTime * videoFrame.fps);
+            changeCurrentFrameIndex(nextFrameIndex);
         };
 
         callbackId = video.requestVideoFrameCallback(updateCanvas);
@@ -58,16 +61,24 @@ const useRequestVideoFrameCallback = (
                 video.cancelVideoFrameCallback(callbackId);
             }
         };
-    }, [videoRef, canvasRef, isPlaying]);
+    }, [videoRef, canvasRef, isPlaying, videoFrame.fps, changeCurrentFrameIndex]);
 
     return videoRef;
 };
 
 export const VideoFrame = ({ canvasRef, mediaItem }: VideoFrameProps) => {
     const projectId = useProjectIdentifier();
-    const { videoRef } = useVideoPlayer();
+    const { videoRef, videoControls } = useVideoPlayer();
 
     useRequestVideoFrameCallback(videoRef, canvasRef);
+
+    const handleEnded = () => {
+        if (videoRef.current === null) {
+            return;
+        }
+        videoControls.pause();
+        videoRef.current.currentTime = 0;
+    };
 
     return (
         <VisuallyHidden>
@@ -77,6 +88,7 @@ export const VideoFrame = ({ canvasRef, mediaItem }: VideoFrameProps) => {
                 width={mediaItem.width}
                 height={mediaItem.height}
                 preload={'auto'}
+                onEnded={handleEnded}
                 muted
             />
         </VisuallyHidden>

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -26,7 +26,8 @@ const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
 
 type VideoPlayerProviderProps = {
     children: ReactNode;
-    mediaItem: MediaVideo | undefined;
+    // TODO: Narrow the type to be MediaVideoFrame | undefined
+    mediaItem: MediaVideo | MediaVideoFrame | undefined;
     changeSelectedMediaItem: (media: MediaVideoFrame) => void;
 };
 

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -4,7 +4,6 @@
 import { createContext, ReactNode, RefObject, use, useMemo, useRef, useState } from 'react';
 
 import type { MediaVideo, MediaVideoFrame } from '../../../constants/shared-types';
-import { useSelectedMediaItem } from '../selected-media-item-provider.component';
 import { useVideoControls, VideoControls } from './use-video-controls';
 
 type VideoPlayerContextProps = {
@@ -28,15 +27,15 @@ const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
 type VideoPlayerProviderProps = {
     children: ReactNode;
     mediaItem: MediaVideo | undefined;
+    changeSelectedMediaItem: (media: MediaVideoFrame) => void;
 };
 
-export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProviderProps) => {
+export const VideoPlayerProvider = ({ children, mediaItem, changeSelectedMediaItem }: VideoPlayerProviderProps) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const [isMuted, setIsMuted] = useState<boolean>(false);
     const [playbackRate, setPlaybackRate] = useState<number>(1);
     // TODO: Update default to be media item frame index
     const [currentFrameIndex, setCurrentFrameIndex] = useState<number>(0);
-    const { setMediaItem } = useSelectedMediaItem();
 
     const playingVideoFrame: MediaVideoFrame | undefined = useMemo(() => {
         if (mediaItem === undefined) {
@@ -57,7 +56,7 @@ export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProvider
         };
     }, [currentFrameIndex, mediaItem]);
 
-    const videoControls = useVideoControls(videoRef, playingVideoFrame, setMediaItem, setCurrentFrameIndex);
+    const videoControls = useVideoControls(videoRef, playingVideoFrame, changeSelectedMediaItem, setCurrentFrameIndex);
 
     const toggleMute = () => {
         setIsMuted((prevIsMuted) => {

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -3,8 +3,7 @@
 
 import { createContext, ReactNode, RefObject, use, useMemo, useRef, useState } from 'react';
 
-import type { MediaVideoFrame, Media } from '../../../constants/shared-types';
-import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
+import type { MediaVideo, MediaVideoFrame } from '../../../constants/shared-types';
 import { useSelectedMediaItem } from '../selected-media-item-provider.component';
 import { useVideoControls, VideoControls } from './use-video-controls';
 
@@ -39,16 +38,20 @@ export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProvider
     const [currentFrameIndex, setCurrentFrameIndex] = useState<number>(0);
     const { setMediaItem } = useSelectedMediaItem();
 
-    const playingVideoFrame: MediaVideoFrame = useMemo(() => {
+    const playingVideoFrame: MediaVideoFrame | undefined = useMemo(() => {
+        if (mediaItem === undefined) {
+            return undefined;
+        }
+
         return {
             ...mediaItem,
             frame_number: currentFrameIndex,
 
             // TODO: This logic should be moved to selected media item provider
             type: 'video_frame',
-            frame_count: Number(mediaItem.frame_count),
-            fps: Number(mediaItem.fps),
-            duration: Number(mediaItem.duration),
+            frame_count: mediaItem.frame_count,
+            fps: mediaItem.fps,
+            duration: mediaItem.duration,
             // TODO: This should be returned by the backend, atm it's mocked to be 60 fps
             frame_stride: 60,
         };
@@ -85,7 +88,7 @@ export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProvider
     };
 
     const value =
-        mediaItem !== undefined
+        playingVideoFrame !== undefined
             ? {
                   videoFrame: playingVideoFrame,
                   videoRef,

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -1,9 +1,11 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, RefObject, use, useRef, useState } from 'react';
+import { createContext, ReactNode, RefObject, use, useMemo, useRef, useState } from 'react';
 
-import type { MediaVideo } from '../../../constants/shared-types';
+import type { MediaVideoFrame, Media } from '../../../constants/shared-types';
+import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
+import { useSelectedMediaItem } from '../selected-media-item-provider.component';
 import { useVideoControls, VideoControls } from './use-video-controls';
 
 type VideoPlayerContextProps = {
@@ -12,12 +14,14 @@ type VideoPlayerContextProps = {
     isMuted: boolean;
     toggleMute: () => void;
 
-    videoFrame: MediaVideo;
+    videoFrame: MediaVideoFrame;
 
     playbackRate: number;
     changePlaybackRate: (rate: number) => void;
 
     videoControls: VideoControls;
+
+    changeCurrentFrameIndex: (index: number) => void;
 };
 
 const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
@@ -31,8 +35,26 @@ export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProvider
     const videoRef = useRef<HTMLVideoElement>(null);
     const [isMuted, setIsMuted] = useState<boolean>(false);
     const [playbackRate, setPlaybackRate] = useState<number>(1);
+    // TODO: Update default to be media item frame index
+    const [currentFrameIndex, setCurrentFrameIndex] = useState<number>(0);
+    const { setMediaItem } = useSelectedMediaItem();
 
-    const videoControls = useVideoControls(videoRef, mediaItem);
+    const playingVideoFrame: MediaVideoFrame = useMemo(() => {
+        return {
+            ...mediaItem,
+            frame_number: currentFrameIndex,
+
+            // TODO: This logic should be moved to selected media item provider
+            type: 'video_frame',
+            frame_count: Number(mediaItem.frame_count),
+            fps: Number(mediaItem.fps),
+            duration: Number(mediaItem.duration),
+            // TODO: This should be returned by the backend, atm it's mocked to be 60 fps
+            frame_stride: 60,
+        };
+    }, [currentFrameIndex, mediaItem]);
+
+    const videoControls = useVideoControls(videoRef, playingVideoFrame, setMediaItem, setCurrentFrameIndex);
 
     const toggleMute = () => {
         setIsMuted((prevIsMuted) => {
@@ -65,7 +87,7 @@ export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProvider
     const value =
         mediaItem !== undefined
             ? {
-                  videoFrame: mediaItem,
+                  videoFrame: playingVideoFrame,
                   videoRef,
                   videoControls,
 
@@ -74,6 +96,8 @@ export const VideoPlayerProvider = ({ children, mediaItem }: VideoPlayerProvider
 
                   playbackRate,
                   changePlaybackRate,
+
+                  changeCurrentFrameIndex: setCurrentFrameIndex,
               }
             : null;
 

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segments.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segments.component.tsx
@@ -23,6 +23,7 @@ type VideoFrameSegmentsProps = {
     ref: MutableRefObject<HTMLDivElement | null>;
     items: Item[];
     frameNumber: number;
+    selectFrame: (frameNumber: number) => void;
 };
 
 export const VideoFrameSegments = ({
@@ -35,11 +36,8 @@ export const VideoFrameSegments = ({
     ref,
     items,
     frameNumber,
+    selectFrame,
 }: VideoFrameSegmentsProps) => {
-    const selectFrame = (_frameNumber: number) => {
-        // TODO: implement this properly
-    };
-
     return (
         <div
             ref={ref}

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/thumbnail-preview.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/thumbnail-preview.component.tsx
@@ -4,28 +4,28 @@
 import { Image, View } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
-import type { MediaVideo } from '../../../../../../../constants/shared-types';
+import type { MediaVideoFrame } from '../../../../../../../constants/shared-types';
 import { getThumbnailUrl } from '../../../../../../../shared/media-url.utils';
 import { formatDurationText } from '../../../time-utils';
 import { FrameNumberIndicator } from './frame-number-indicator.component';
 
 interface ThumbnailPreviewProps {
-    videoFrame: number;
-    mediaItem: MediaVideo;
+    frameNumber: number;
+    videoFrame: MediaVideoFrame;
     width: number;
     height: number;
     x: number;
 }
 
-export const ThumbnailPreview = ({ mediaItem, videoFrame: frameNumber, width, height, x }: ThumbnailPreviewProps) => {
+export const ThumbnailPreview = ({ videoFrame, frameNumber, width, height, x }: ThumbnailPreviewProps) => {
     // TODO: Use it when video frame navigation is ready and API supports it.
     // const constructVideoFrame = useConstructVideoFrame(mediaItem);
     // const videoFrame = constructVideoFrame(frameNumber) as VideoFrame;
     const projectIdentifier = useProjectIdentifier();
 
-    const fps = mediaItem.fps;
+    const fps = videoFrame.fps;
     // TODO: Replace it with the video frame thumbnail when the endpoint will be ready.
-    const src = getThumbnailUrl(projectIdentifier, mediaItem.id);
+    const src = getThumbnailUrl(projectIdentifier, videoFrame.id);
 
     const durationText = formatDurationText(frameNumber / fps);
 

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/video-player-slider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/video-player-slider.component.tsx
@@ -7,14 +7,14 @@ import { useDebouncedCallback } from 'hooks/use-debounced-callback/use-debounced
 import { defer } from 'lodash-es';
 import { useHover } from 'react-aria';
 
-import { MediaVideo } from '../../../../../../../constants/shared-types';
+import type { MediaVideoFrame } from '../../../../../../../constants/shared-types';
 import { ThumbnailPreview } from './thumbnail-preview.component';
 import { VideoSlider } from './video-slider.component';
 
 import classes from './video-slider.module.scss';
 
 type VideoPlayerSliderProps = {
-    mediaItem: MediaVideo;
+    videoFrame: MediaVideoFrame;
     step: number;
     frameNumber: number;
     sizePerSquare: number;
@@ -93,7 +93,7 @@ const blurActiveInput = (isFocused: boolean): void => {
 
 export const VideoPlayerSlider = ({
     ref,
-    mediaItem,
+    videoFrame,
     step,
     frameNumber,
     sizePerSquare,
@@ -114,7 +114,7 @@ export const VideoPlayerSlider = ({
         thumbnailPosition,
     } = useShowThumbnail();
 
-    const framesCount = mediaItem.frame_count;
+    const framesCount = videoFrame.frame_count;
     const minValue = 0;
     const maxValue = framesCount - 1;
     const lastFrame = framesCount - step;
@@ -172,8 +172,8 @@ export const VideoPlayerSlider = ({
                     x={thumbnailPosition}
                     width={100}
                     height={100}
-                    videoFrame={thumbnailVideoFrame}
-                    mediaItem={mediaItem}
+                    frameNumber={thumbnailVideoFrame}
+                    videoFrame={videoFrame}
                 />
             )}
         </div>

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/video-player-slider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/video-player-slider.component.tsx
@@ -20,6 +20,7 @@ type VideoPlayerSliderProps = {
     sizePerSquare: number;
     frameOffset?: number;
     ref?: RefObject<HTMLDivElement | null>;
+    selectFrame: (frameNumber: number) => void;
 };
 
 const THUMBNAIL_DELAY = 1000;
@@ -96,9 +97,12 @@ export const VideoPlayerSlider = ({
     step,
     frameNumber,
     sizePerSquare,
+    selectFrame,
     frameOffset = 0,
 }: VideoPlayerSliderProps) => {
     const [sliderValue, setSliderValue] = useState<number>(frameNumber);
+
+    useEffect(() => setSliderValue(frameNumber), [frameNumber]);
 
     const {
         hoverProps,
@@ -152,9 +156,8 @@ export const VideoPlayerSlider = ({
                     setSliderValue(newFrameNumber);
                     onShowThumbnail(true);
                 }}
-                onChangeEnd={(_newFrameNumber) => {
-                    // TODO: Implement frame selection behavior on slider change end once selectFrame is available.
-                    // selectFrame(newFrameNumber);
+                onChangeEnd={(newFrameNumber) => {
+                    selectFrame(newFrameNumber);
                     blurActiveInput(true);
                 }}
                 step={step}

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-timeline.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-timeline.component.tsx
@@ -50,7 +50,7 @@ export const VideoTimeline = ({ labels }: VideoTimelineProps) => {
                 <div style={{ width: sizePerSquare * totalSegments }} className={classes.timelineSliderWrapper}>
                     <VideoPlayerSlider
                         ref={outerRef}
-                        mediaItem={videoFrame}
+                        videoFrame={videoFrame}
                         step={step}
                         frameNumber={frameNumber}
                         sizePerSquare={sizePerSquare}

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-timeline.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-timeline.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useSizeHook } from 'hooks/use-size.hook';
 import useVirtual from 'react-cool-virtual';
@@ -24,21 +24,25 @@ export const VideoTimeline = ({ labels }: VideoTimelineProps) => {
     const size = useSizeHook(containerRef);
     const { videoFrame, videoControls } = useVideoPlayer();
     const { isPlaying } = videoControls;
-    const frameNumber = 0;
 
-    const step = 60;
+    const frameNumber = videoFrame.frame_number;
+    const step = videoFrame.frame_stride;
     const totalFrames = videoFrame.frame_count;
 
     const totalSegments = Math.ceil(totalFrames / step);
     const sizePerSquare = size === undefined ? 0 : Math.max(MIN_SIZE_OF_SEGMENT, size.width / totalSegments);
     const frameOffset = Math.round(sizePerSquare / 2);
 
-    const { outerRef, innerRef, items } = useVirtual<HTMLDivElement, HTMLDivElement>({
+    const { outerRef, innerRef, items, scrollToItem } = useVirtual<HTMLDivElement, HTMLDivElement>({
         horizontal: true,
         itemCount: totalSegments,
         itemSize: sizePerSquare,
         overscanCount: 5,
     });
+
+    useEffect(() => {
+        scrollToItem({ index: Math.round(frameNumber / step), align: 'center', smooth: true });
+    }, [scrollToItem, frameNumber, step]);
 
     return (
         <div ref={containerRef}>
@@ -51,6 +55,7 @@ export const VideoTimeline = ({ labels }: VideoTimelineProps) => {
                         frameNumber={frameNumber}
                         sizePerSquare={sizePerSquare}
                         frameOffset={frameOffset}
+                        selectFrame={videoControls.goto}
                     />
                 </div>
                 <VideoFrameSegments
@@ -63,6 +68,7 @@ export const VideoTimeline = ({ labels }: VideoTimelineProps) => {
                     totalSegments={totalSegments}
                     minSizeOfSegment={MIN_SIZE_OF_SEGMENT}
                     isPlaying={isPlaying}
+                    selectFrame={videoControls.goto}
                 />
             </div>
         </div>

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-duration.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-duration.component.tsx
@@ -5,10 +5,9 @@ import { useVideoPlayer } from '../video-player-provider.component';
 import { formatDurationText } from './time-utils';
 
 export const VideoDuration = () => {
-    const { videoRef } = useVideoPlayer();
-    // TODO: use video player state
-    const currentTime = videoRef.current?.currentTime ?? 0;
-    const endTime = videoRef.current?.duration ?? 0;
+    const { videoFrame } = useVideoPlayer();
+    const currentTime = videoFrame.frame_number / videoFrame.fps;
+    const endTime = videoFrame.duration;
 
     const currentFormattedTime = formatDurationText(currentTime);
     const endFormattedTime = formatDurationText(endTime);

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.component.tsx
@@ -33,7 +33,9 @@ export const VideoToolbar = () => {
                         </Flex>
 
                         <Flex alignItems={'center'} gap={'size-100'}>
-                            <Text>Current frame: 0 / Total frames: {videoFrame.frame_count}</Text>
+                            <Text>
+                                Current frame: {videoFrame.frame_number} / Total frames: {videoFrame.frame_count}
+                            </Text>
                             <ActionButton
                                 isQuiet
                                 onPress={() => setIsExpanded((prev) => !prev)}

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -6,22 +6,35 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isObject } from 'lodash-es';
 
 import { fetchClient } from '../../../../api/client';
-import { AnnotationDTO } from '../../../../constants/shared-types';
+import type { AnnotationDTO, Media } from '../../../../constants/shared-types';
 import { getQueryKey } from '../../../../query-client/query-client';
 import { EMPTY_LABEL_ID } from '../../../../shared/annotator/labels';
+import { isVideo } from '../../../../shared/media-item-utils';
 
 const isUnannotatedError = (error: unknown): boolean => {
     return isObject(error) && 'detail' in error && /Media has not been annotated yet/i.test(String(error.detail));
 };
 
-export const useAnnotationsQuery = (mediaId: string) => {
+export const useAnnotationsQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
+
+    // TODO: Remove this part when we have new Media types and logic inside selected media item provider
+    const queryParams = isVideo(media)
+        ? {
+              frame_index: 0,
+          }
+        : {};
 
     return useQuery({
         queryKey: getQueryKey([
             'get',
             `/api/projects/{project_id}/dataset/media/{media_id}/annotations`,
-            { params: { path: { project_id: projectId, media_id: mediaId } } },
+            {
+                params: {
+                    path: { project_id: projectId, media_id: media.id },
+                    query: queryParams,
+                },
+            },
         ]),
         queryFn: async () => {
             const { data, error, response } = await fetchClient.GET(
@@ -30,8 +43,9 @@ export const useAnnotationsQuery = (mediaId: string) => {
                     params: {
                         path: {
                             project_id: projectId,
-                            media_id: mediaId,
+                            media_id: media.id,
                         },
+                        query: queryParams,
                     },
                 }
             );

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -9,7 +9,7 @@ import { fetchClient } from '../../../../api/client';
 import type { AnnotationDTO, Media } from '../../../../constants/shared-types';
 import { getQueryKey } from '../../../../query-client/query-client';
 import { EMPTY_LABEL_ID } from '../../../../shared/annotator/labels';
-import { isVideo } from '../../../../shared/media-item-utils';
+import { isVideo, isVideoFrame } from '../../../../shared/media-item-utils';
 
 const isUnannotatedError = (error: unknown): boolean => {
     return isObject(error) && 'detail' in error && /Media has not been annotated yet/i.test(String(error.detail));
@@ -19,11 +19,12 @@ export const useAnnotationsQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
 
     // TODO: Remove this part when we have new Media types and logic inside selected media item provider
-    const queryParams = isVideo(media)
-        ? {
-              frame_index: 0,
-          }
-        : {};
+    const queryParams =
+        isVideo(media) || isVideoFrame(media)
+            ? {
+                  frame_index: 0,
+              }
+            : undefined;
 
     return useQuery({
         queryKey: getQueryKey([

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -50,7 +50,7 @@ const invalidateMediaItemAnnotations = (queryClient: QueryClient) => {
 const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }: MediaPreviewContentProps) => {
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
 
-    const { data: annotationsData } = useAnnotationsQuery(mediaItem.id);
+    const { data: annotationsData } = useAnnotationsQuery(mediaItem);
 
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
     const queryClient = useQueryClient();

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -47,6 +47,83 @@ const invalidateMediaItemAnnotations = (queryClient: QueryClient) => {
     });
 };
 
+type AnnotatorProps = {
+    isUserReviewed: boolean;
+    mode: AnnotatorMode;
+    changeAnnotatorMode: (mode: AnnotatorMode) => void;
+    onClose: () => void;
+    onSubmitAnnotations: () => void;
+    items: Media[];
+    onSelectedMediaItem: (item: Media) => void;
+};
+
+const Annotator = ({
+    isUserReviewed,
+    mode,
+    changeAnnotatorMode,
+    onClose,
+    onSubmitAnnotations,
+    items,
+    onSelectedMediaItem,
+}: AnnotatorProps) => {
+    const { mediaItem, setMediaItem } = useSelectedMediaItem();
+
+    return (
+        <VideoPlayerProvider
+            mediaItem={isVideo(mediaItem) ? mediaItem : undefined}
+            changeSelectedMediaItem={setMediaItem}
+        >
+            {mode === 'prediction' ? (
+                <ReadOnlyAnnotator
+                    mediaItem={mediaItem}
+                    isUserReviewed={isUserReviewed}
+                    onModeChange={changeAnnotatorMode}
+                    onClose={onClose}
+                    onAcceptPrediction={onSubmitAnnotations}
+                />
+            ) : (
+                <>
+                    <View gridArea={'header'}>
+                        <SecondaryToolbar
+                            mode={mode}
+                            items={items}
+                            onClose={onClose}
+                            mediaItem={mediaItem}
+                            onSelectedMediaItem={onSelectedMediaItem}
+                            onModeChange={changeAnnotatorMode}
+                            onAcceptPrediction={onSubmitAnnotations}
+                        />
+                    </View>
+
+                    <View gridArea={'toolbar'} aria-label={'primary toolbar'}>
+                        <PrimaryToolbar />
+                    </View>
+
+                    {isVideo(mediaItem) && (
+                        <View gridArea={'video-toolbar'}>
+                            <VideoToolbar />
+                        </View>
+                    )}
+
+                    <View gridArea={'bottom'}>
+                        <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
+                    </View>
+
+                    <View gridArea={'canvas'} overflow={'hidden'}>
+                        <AnnotatorCanvasSettings>
+                            <Suspense fallback={<Loading size='L' mode='inline' style={{ height: '100%' }} />}>
+                                <MediaItemImageLoader>
+                                    <AnnotatorCanvas mediaItem={mediaItem} />
+                                </MediaItemImageLoader>
+                            </Suspense>
+                        </AnnotatorCanvasSettings>
+                    </View>
+                </>
+            )}
+        </VideoPlayerProvider>
+    );
+};
+
 const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }: MediaPreviewContentProps) => {
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
 
@@ -55,7 +132,6 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
     const queryClient = useQueryClient();
     const { setMediaState } = useSelectedData();
-    const { setMediaItem } = useSelectedMediaItem();
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 
@@ -92,58 +168,15 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                 isUserReviewed={isUserReviewed}
                 mode={mode}
             >
-                <VideoPlayerProvider
-                    mediaItem={isVideo(mediaItem) ? mediaItem : undefined}
-                    changeSelectedMediaItem={setMediaItem}
-                >
-                    {mode === 'prediction' ? (
-                        <ReadOnlyAnnotator
-                            mediaItem={mediaItem}
-                            isUserReviewed={isUserReviewed}
-                            onModeChange={setMode}
-                            onClose={onClose}
-                            onAcceptPrediction={handleSubmitAnnotations}
-                        />
-                    ) : (
-                        <>
-                            <View gridArea={'header'}>
-                                <SecondaryToolbar
-                                    mode={mode}
-                                    items={items}
-                                    onClose={onClose}
-                                    mediaItem={mediaItem}
-                                    onSelectedMediaItem={onSelectedMediaItem}
-                                    onModeChange={setMode}
-                                    onAcceptPrediction={handleSubmitAnnotations}
-                                />
-                            </View>
-
-                            <View gridArea={'toolbar'} aria-label={'primary toolbar'}>
-                                <PrimaryToolbar />
-                            </View>
-
-                            {isVideo(mediaItem) && (
-                                <View gridArea={'video-toolbar'}>
-                                    <VideoToolbar />
-                                </View>
-                            )}
-
-                            <View gridArea={'bottom'}>
-                                <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
-                            </View>
-
-                            <View gridArea={'canvas'} overflow={'hidden'}>
-                                <AnnotatorCanvasSettings>
-                                    <Suspense fallback={<Loading size='L' mode='inline' style={{ height: '100%' }} />}>
-                                        <MediaItemImageLoader>
-                                            <AnnotatorCanvas mediaItem={mediaItem} />
-                                        </MediaItemImageLoader>
-                                    </Suspense>
-                                </AnnotatorCanvasSettings>
-                            </View>
-                        </>
-                    )}
-                </VideoPlayerProvider>
+                <Annotator
+                    mode={mode}
+                    items={items}
+                    onClose={onClose}
+                    changeAnnotatorMode={setMode}
+                    isUserReviewed={isUserReviewed}
+                    onSelectedMediaItem={onSelectedMediaItem}
+                    onSubmitAnnotations={handleSubmitAnnotations}
+                />
             </AnnotatorProviders>
         </ToolProvider>
     );

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -11,7 +11,7 @@ import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { isVideo } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { MediaItemImageLoader } from '../../annotator/selected-media-item-provider.component';
+import { MediaItemImageLoader, useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { useSelectedData } from '../selected-data-provider.component';
@@ -55,6 +55,7 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
     const queryClient = useQueryClient();
     const { setMediaState } = useSelectedData();
+    const { setMediaItem } = useSelectedMediaItem();
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 
@@ -91,7 +92,10 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                 isUserReviewed={isUserReviewed}
                 mode={mode}
             >
-                <VideoPlayerProvider mediaItem={isVideo(mediaItem) ? mediaItem : undefined}>
+                <VideoPlayerProvider
+                    mediaItem={isVideo(mediaItem) ? mediaItem : undefined}
+                    changeSelectedMediaItem={setMediaItem}
+                >
                     {mode === 'prediction' ? (
                         <ReadOnlyAnnotator
                             mediaItem={mediaItem}

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -9,7 +9,7 @@ import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook'
 
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
-import { isVideo } from '../../../shared/media-item-utils';
+import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
 import { MediaItemImageLoader, useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
@@ -70,7 +70,7 @@ const Annotator = ({
 
     return (
         <VideoPlayerProvider
-            mediaItem={isVideo(mediaItem) ? mediaItem : undefined}
+            mediaItem={isVideo(mediaItem) || isVideoFrame(mediaItem) ? mediaItem : undefined}
             changeSelectedMediaItem={setMediaItem}
         >
             {mode === 'prediction' ? (
@@ -99,7 +99,7 @@ const Annotator = ({
                         <PrimaryToolbar />
                     </View>
 
-                    {isVideo(mediaItem) && (
+                    {(isVideo(mediaItem) || isVideoFrame(mediaItem)) && (
                         <View gridArea={'video-toolbar'}>
                             <VideoToolbar />
                         </View>

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -39,11 +39,11 @@ type SubsetMediaDialogProps = {
 };
 
 const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
-    const { data: annotationsData } = useAnnotationsQuery(item.id);
+    const mediaItem = datasetRevisionItemToMedia(item);
+    const { data: annotationsData } = useAnnotationsQuery(mediaItem);
 
     const annotationsDTO = annotationsData?.annotations ?? [];
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
-    const mediaItem = datasetRevisionItemToMedia(item);
     const mode = 'annotation';
 
     return (

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -1,16 +1,37 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useMemo } from 'react';
+
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../api/client';
-import { DatasetSubset } from '../constants/shared-types';
+import { DatasetSubset, Media, MediaDTO } from '../constants/shared-types';
 
 const DATASET_ITEMS_LIMIT = 20;
 
 interface UseGetDatasetMediaItemsOptions {
     subset?: DatasetSubset;
 }
+
+const getMediaEntities = (items: MediaDTO[]): Media[] => {
+    return items.map((item) => {
+        // We will never get the video frame using '/api/projects/{project_id}/dataset/media', it's added only because
+        // of documentation reasons. We use MediaVideoFrame as a local type to work with the played frame in the video.
+        if (item.type === 'video_frame') {
+            return {
+                duration: 0,
+                frame_count: 0,
+                fps: 0,
+                frame_number: 0,
+                frame_stride: 0,
+                ...item,
+            };
+        }
+
+        return item;
+    });
+};
 
 export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions) => {
     const project_id = useProjectIdentifier();
@@ -47,7 +68,10 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
         }
     );
 
-    const items = data?.pages.flatMap((page) => page.items) ?? [];
+    const items = useMemo(() => {
+        const mediaItems = data?.pages.flatMap((page) => page.items) ?? [];
+        return getMediaEntities(mediaItems);
+    }, [data?.pages]);
     const totalCount = data?.pages[0]?.pagination?.total ?? 0;
 
     return { items, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, totalCount };

--- a/application/ui/src/query-client/query-client.interface.ts
+++ b/application/ui/src/query-client/query-client.interface.ts
@@ -51,16 +51,25 @@ type PathParamsFor<Paths extends paths, P extends keyof Paths, Method extends Ht
  * block as either required (`query:`) or optional (`query?:`), so both forms
  * are handled here.
  *
+ * When the spec writes `query?: never` (explicitly no query params), TypeScript
+ * infers `QP` as `never | undefined` = `undefined` in the optional branch.
+ * `Exclude<QP, undefined>` strips that back to `never` so those endpoints are
+ * treated as having no query params at all.
+ *
  * @example
- * // Optional query block (query?:) → resolves to the inner type:
+ * // Optional query block (query?:) → resolves to the inner object type (undefined stripped):
  * type QP = QueryParamsFor<paths, '/api/projects/{project_id}/dataset/media/{media_id}/annotations', 'get'>
- * // => { frame_index?: number | null } | undefined
+ * // => { frame_index?: number | null }
  *
  * // Required query block (query:) → resolves to the inner type directly:
  * type QP = QueryParamsFor<paths, '/api/model_architectures', 'get'>
  * // => { task: TaskType }
  *
- * // No query params at all → resolves to never:
+ * // Explicitly no query params (query?: never) → resolves to never:
+ * type QP = QueryParamsFor<paths, '/api/sinks', 'get'>
+ * // => never
+ *
+ * // No query field at all → resolves to never:
  * type QP = QueryParamsFor<paths, '/api/staged_datasets', 'get'>
  * // => never
  */
@@ -68,7 +77,7 @@ type QueryParamsFor<Paths extends paths, P extends keyof Paths, Method extends H
     OperationFor<Paths, P, Method> extends { parameters: { query: infer QP } }
         ? QP
         : OperationFor<Paths, P, Method> extends { parameters: { query?: infer QP } }
-          ? QP
+          ? Exclude<QP, undefined>
           : never;
 
 /** Returns all HTTP methods that are actually defined (not `never`) for a given path. */

--- a/application/ui/src/query-client/query-client.interface.ts
+++ b/application/ui/src/query-client/query-client.interface.ts
@@ -5,28 +5,163 @@ import type { HttpMethod } from 'openapi-typescript-helpers';
 
 import { type paths } from '../api/openapi-spec';
 
+/**
+ * Resolves the full operation object for a given path + HTTP method combination
+ * from the OpenAPI spec's `paths` map.
+ *
+ * The OpenAPI spec defines every endpoint as a path entry, each containing one or
+ * more HTTP method handlers. For example, `/api/staged_datasets` has both `get`
+ * and `post`. `OperationFor` narrows down to the specific method object so that
+ * the other helpers can inspect its `parameters`, `requestBody`, and `responses`.
+ *
+ * @example
+ * // Resolves to the full `get_media_annotations_api_...` operation object:
+ * type Op = OperationFor<paths, '/api/projects/{project_id}/dataset/media/{media_id}/annotations', 'get'>
+ * // => { parameters: { query?: { frame_index?: number | null }; path: { project_id: unknown; media_id: unknown } }; }
+ */
 type OperationFor<Paths extends paths, P extends keyof Paths, Method extends HttpMethod> = Method extends keyof Paths[P]
     ? Paths[P][Method]
     : never;
 
+/**
+ * Extracts the `path` parameters object from an operation, or `never` if the
+ * operation has no path parameters.
+ *
+ * Path parameters are the dynamic segments embedded in the URL, denoted by
+ * curly braces in the OpenAPI spec (e.g. `{project_id}`, `{media_id}`).
+ *
+ * @example
+ * // Has path params → resolves to the path params object:
+ * type PP = PathParamsFor<paths, '/api/projects/{project_id}/dataset/media/{media_id}/annotations', 'get'>
+ * // => { project_id: string; media_id: string }
+ *
+ * // Has no path params → resolves to never:
+ * type PP = PathParamsFor<paths, '/api/staged_datasets', 'get'>
+ * // => never
+ */
 type PathParamsFor<Paths extends paths, P extends keyof Paths, Method extends HttpMethod> =
     OperationFor<Paths, P, Method> extends { parameters: { path: infer PP } } ? PP : never;
 
+/**
+ * Extracts the `query` parameters object from an operation, or `never` if the
+ * operation accepts no query parameters.
+ *
+ * Query parameters are the key-value pairs appended after `?` in a URL
+ * (e.g. `?frame_index=0`). The spec marks the entire `query`
+ * block as either required (`query:`) or optional (`query?:`), so both forms
+ * are handled here.
+ *
+ * @example
+ * // Optional query block (query?:) → resolves to the inner type:
+ * type QP = QueryParamsFor<paths, '/api/projects/{project_id}/dataset/media/{media_id}/annotations', 'get'>
+ * // => { frame_index?: number | null } | undefined
+ *
+ * // Required query block (query:) → resolves to the inner type directly:
+ * type QP = QueryParamsFor<paths, '/api/model_architectures', 'get'>
+ * // => { task: TaskType }
+ *
+ * // No query params at all → resolves to never:
+ * type QP = QueryParamsFor<paths, '/api/staged_datasets', 'get'>
+ * // => never
+ */
+type QueryParamsFor<Paths extends paths, P extends keyof Paths, Method extends HttpMethod> =
+    OperationFor<Paths, P, Method> extends { parameters: { query: infer QP } }
+        ? QP
+        : OperationFor<Paths, P, Method> extends { parameters: { query?: infer QP } }
+          ? QP
+          : never;
+
+/** Returns all HTTP methods that are actually defined (not `never`) for a given path. */
 type MethodsForPath<Paths extends paths, P extends keyof Paths> = Extract<keyof Paths[P], HttpMethod>;
 
+/**
+ * Builds the third element of a `QueryKey` tuple — the `{ params: ... }` object —
+ * based on which combination of path and query parameters an operation has.
+ *
+ * The four possible outcomes:
+ *
+ * 1. **Neither path nor query** → `never`
+ *    The `QueryKey` for this operation will be a 2-tuple `[method, path]` with no
+ *    params object at all.
+ *    @example
+ *    // GET /api/staged_datasets — no parameters whatsoever
+ *    type K = ['get', '/api/staged_datasets']
+ *
+ * 2. **Path only** → `{ params: { path: PP } }`
+ *    @example
+ *    // GET /api/projects/{project_id} — only a project_id in the URL
+ *    type K = ['get', '/api/projects/{project_id}', { params: { path: { project_id: unknown } } }]
+ *
+ * 3. **Query only** → `{ params: { query?: QP } }`
+ *    @example
+ *    // GET /api/model_architectures?task=detection — only a query string, no path segments
+ *    type K = ['get', '/api/model_architectures', { params: { query?: { task: TaskType } } }]
+ *
+ * 4. **Both path and query** → `{ params: { path: PP; query?: QP } }`
+ *    @example
+ *    // GET /api/projects/{project_id}/dataset/media/{media_id}/annotations?frame_index=0
+ *    type K = [
+ *      'get',
+ *      '/api/projects/{project_id}/dataset/media/{media_id}/annotations',
+ *      { params: { path: { project_id: unknown; media_id: unknown }; query?: { frame_index?: number | null } } }
+ *    ]
+ *
+ * `query` is always marked optional (`query?`) because the spec itself defines the
+ * query block as optional (`query?:`) on most operations, meaning callers are never
+ * forced to pass it when all query fields are themselves optional.
+ */
+type ParamsObject<PP, QP> = [PP] extends [never]
+    ? [QP] extends [never]
+        ? never
+        : { params: { query?: QP } }
+    : [QP] extends [never]
+      ? { params: { path: PP } }
+      : { params: { path: PP; query?: QP } };
+
+/**
+ * A fully type-safe query key for any endpoint defined in the OpenAPI spec.
+ *
+ * A `QueryKey` is a tuple whose shape depends on the parameters of the endpoint:
+ *
+ * - `[method, path]` — for endpoints with no parameters
+ * - `[method, path, { params: { path } }]` — for endpoints with only path params
+ * - `[method, path, { params: { query? } }]` — for endpoints with only query params
+ * - `[method, path, { params: { path, query? } }]` — for endpoints with both
+ *
+ * TypeScript will enforce the exact shape required by each endpoint, so passing
+ * the wrong path params, omitting a required query field, or using the wrong method
+ * will all be caught at compile time.
+ *
+ * Use `getQueryKey()` to construct a validated key at the call site.
+ *
+ * @example
+ * // ✅ No params needed — 2-tuple is enough
+ * getQueryKey(['get', '/api/staged_datasets'])
+ *
+ * // ✅ Path params only
+ * getQueryKey(['get', '/api/projects/{project_id}', { params: { path: { project_id: '123' } } }])
+ *
+ * // ✅ Query params only
+ * getQueryKey(['get', '/api/model_architectures', { params: { query: { task: 'detection' } } }])
+ *
+ * // ✅ Both path and optional query
+ * getQueryKey([
+ *   'get',
+ *   '/api/projects/{project_id}/dataset/media/{media_id}/annotations',
+ *   { params: { path: { project_id: '123', media_id: '456' }, query: { frame_index: 0 } } }
+ * ])
+ *
+ * // ❌ Wrong path param key — TypeScript error
+ * getQueryKey(['get', '/api/projects/{project_id}', { params: { path: { id: '123' } } }])
+ */
 export type QueryKey<Paths extends paths> = {
     [P in keyof Paths]: {
-        [M in MethodsForPath<Paths, P>]: PathParamsFor<Paths, P, M> extends never
+        [M in MethodsForPath<Paths, P>]: ParamsObject<
+            PathParamsFor<Paths, P, M>,
+            QueryParamsFor<Paths, P, M>
+        > extends never
             ? [M, P]
-            : [
-                  M,
-                  P,
-                  {
-                      params: {
-                          path: PathParamsFor<Paths, P, M>;
-                      };
-                  },
-              ];
+            : [M, P, ParamsObject<PathParamsFor<Paths, P, M>, QueryParamsFor<Paths, P, M>>];
     }[MethodsForPath<Paths, P>];
 }[keyof Paths];
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR includes:
1. Adds logic to video controllers to be able to navigate the video.
2. Improves `query-client.interface.ts` so whenever API exposes `query` parameter, that `query` can be used as part of the strongly typed `queryKey`.
3. https://github.com/open-edge-platform/training_extensions/pull/5575 introduced discriminated types, also for `MediaVideoFrameDTO` but that type won't be used (endpoint does not return frames, only video. We can retrieve only thumbnail and binary of the frame). Because of that we create our local `MediaVideoFrame` type that we use across the components.

https://github.com/user-attachments/assets/cc98c303-62cf-407e-af9a-f3f4e50b06a2

Closes #5598 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
