### PR TITLE
Add build step to install latest Docker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,6 +68,10 @@ jobs:
         with:
           type: "pre-build"
 
+      # Install the latest Docker, since the version available by default on the runners may be outdated
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 #v4.7.0
+
       - name: Set up Docker Compose
         uses: docker/setup-compose-action@364cc21a5de5b1ee4a7f5f9d3fa374ce0ccde746 #v1.2.0
 


### PR DESCRIPTION
### Summary

This PR adds an extra step to the `build` GHA workflow to install the latest Docker version, since the one shipped by default in the GH runners (28.0.4) is outdated and affected by several bugs that are fixed in more recent versions (see [Docker release notes](https://docs.docker.com/engine/release-notes/29/))

After this PR, you can expect that the Docker images sizes reported in the PR as comment will be smaller than before.

Resolves #5590

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
