### PR TITLE
Media Endpoints - Get frame binary, thumbnail. Get list of annotated frames

### DIFF
--- a/application/backend/app/api/io_utils.py
+++ b/application/backend/app/api/io_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Generator
 from io import BytesIO
+from mimetypes import guess_file_type
 from pathlib import Path
 
 from PIL.Image import Image
@@ -87,4 +88,7 @@ def write_file_to_response(path: Path, filename: str, cache_control: str | None 
     Returns:
         FastAPI StreamingResponse.
     """
-    return write_bytes_to_response(bytes=file_iterator(filepath=path), filename=filename, cache_control=cache_control)
+    media_type, _ = guess_file_type(path)
+    return write_bytes_to_response(
+        bytes=file_iterator(filepath=path), filename=filename, media_type=media_type, cache_control=cache_control
+    )

--- a/application/backend/app/api/io_utils.py
+++ b/application/backend/app/api/io_utils.py
@@ -1,7 +1,11 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Generator
+from io import BytesIO
 from pathlib import Path
+
+from PIL.Image import Image
+from starlette.responses import StreamingResponse
 
 
 def file_iterator(filepath: Path, chunk_size: int = 1024 * 1024) -> Generator[bytes]:
@@ -25,3 +29,62 @@ def file_iterator(filepath: Path, chunk_size: int = 1024 * 1024) -> Generator[by
             if not chunk:
                 break
             yield chunk
+
+
+def write_bytes_to_response(
+    bytes: BytesIO | Generator[bytes], filename: str, media_type: str | None = None, cache_control: str | None = None
+) -> StreamingResponse:
+    """
+    Stream a binary content to FastAPI StreamingResponse.
+    Additionally, method sets file name, MIME type and cache control headers if provided,
+
+    Args:
+        bytes: Binary content.
+        filename: File name.
+        media_type: Content MIME type, optional.
+        cache_control: Cache control header, optional.
+
+    Returns:
+        FastAPI StreamingResponse.
+    """
+    headers = {"Content-Disposition": f"inline; filename={filename}"}
+    if cache_control:
+        headers["Cache-Control"] = cache_control
+    return StreamingResponse(bytes, media_type=media_type, headers=headers)
+
+
+def write_image_to_response(image: Image, filename: str, cache_control: str | None = None) -> StreamingResponse:
+    """
+    Stream a Pillow image as JPEG to FastAPI StreamingResponse.
+    Additionally, method sets file name and cache control headers if provided.
+
+    Args:
+        image: Pillow image.
+        filename: File name.
+        cache_control: Cache control header, optional.
+
+    Returns:
+        FastAPI StreamingResponse.
+    """
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    buffer.seek(0)
+    return write_bytes_to_response(
+        bytes=buffer, filename=filename, media_type="image/jpeg", cache_control=cache_control
+    )
+
+
+def write_file_to_response(path: Path, filename: str, cache_control: str | None = None) -> StreamingResponse:
+    """
+    Stream a file from file system to FastAPI StreamingResponse.
+    Additionally, method sets file name and cache control headers if provided.
+
+    Args:
+        path: Path to the file.
+        filename: File name.
+        cache_control: Cache control header, optional.
+
+    Returns:
+        FastAPI StreamingResponse.
+    """
+    return write_bytes_to_response(bytes=file_iterator(filepath=path), filename=filename, cache_control=cache_control)

--- a/application/backend/app/api/routers/dataset_revisions.py
+++ b/application/backend/app/api/routers/dataset_revisions.py
@@ -1,13 +1,13 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from io import BytesIO
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from fastapi.openapi.models import Example
-from starlette.responses import FileResponse, StreamingResponse
+from starlette.responses import StreamingResponse
 
 from app.api.dependencies import get_dataset_revision, get_dataset_revision_service, get_project
+from app.api.io_utils import write_file_to_response, write_image_to_response
 from app.api.schemas.dataset_item import DatasetRevisionItemsWithPagination, DatasetRevisionItemView
 from app.api.schemas.dataset_revision import DatasetRevisionView
 from app.api.validators import DatasetItemID, DatasetRevisionID
@@ -185,14 +185,14 @@ def get_dataset_revision_item_binary(
     dataset_revision: Annotated[DatasetRevision, Depends(get_dataset_revision)],
     dataset_item_id: DatasetItemID,
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
-) -> FileResponse:
+) -> StreamingResponse:
     """Get the image data of an item in the dataset revision"""
     binary_path = dataset_revision_service.get_dataset_revision_item(
         project_id=project.id,
         dataset_revision=dataset_revision,
         item_id=str(dataset_item_id),
     ).image_path
-    return FileResponse(binary_path)
+    return write_file_to_response(path=binary_path, filename=f"{dataset_item_id}.jpeg")
 
 
 @router.get(
@@ -215,16 +215,8 @@ def get_dataset_revision_item_thumbnail(
         dataset_revision=dataset_revision,
         item_id=str(dataset_item_id),
     )
-    buffer = BytesIO()
-    thumbnail.save(buffer, format="JPEG")
-    buffer.seek(0)
-    return StreamingResponse(
-        buffer,
-        media_type="image/jpeg",
-        headers={
-            "Content-Disposition": f"inline; filename={dataset_item_id}.jpeg",
-            "Cache-Control": "public, max-age=31536000",
-        },
+    return write_image_to_response(
+        image=thumbnail, filename=f"{dataset_item_id}_thumb.jpeg", cache_control="public, max-age=31536000"
     )
 
 

--- a/application/backend/app/api/routers/dataset_revisions.py
+++ b/application/backend/app/api/routers/dataset_revisions.py
@@ -216,7 +216,7 @@ def get_dataset_revision_item_thumbnail(
         item_id=str(dataset_item_id),
     )
     return write_image_to_response(
-        image=thumbnail, filename=f"{dataset_item_id}_thumb.jpeg", cache_control="public, max-age=31536000"
+        image=thumbnail, filename=f"{dataset_item_id}-thumb.jpeg", cache_control="public, max-age=31536000"
     )
 
 

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -8,10 +8,12 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
+from PIL.Image import Image
 from starlette.responses import FileResponse, StreamingResponse
 
 from app.api.dependencies import get_dataset_service, get_file_name_and_extension, get_media_service, get_project
 from app.api.schemas.media import (
+    AnnotatedVideoFrame,
     MediaAnnotations,
     MediaView,
     MediaViewAdapter,
@@ -30,6 +32,9 @@ router = APIRouter(prefix="/api/projects/{project_id}/dataset/media", tags=["Med
 
 DEFAULT_MEDIA_NUMBER_RETURNED = 10
 MAX_MEDIA_NUMBER_RETURNED = 100
+
+DEFAULT_FRAME_INDEX_FROM = 0
+DEFAULT_FRAME_INDEX_TO = 50
 
 SET_MEDIA_ANNOTATIONS_BODY_EXAMPLES = {
     "single_label": Example(
@@ -104,6 +109,16 @@ def _parse_media_format(extension: str) -> ImageFormat | VideoFormat:
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Unsupported media extension: {extension}",
             )
+
+
+def _write_image_to_response(image: Image, filename: str, cache_control: str | None = None) -> StreamingResponse:
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    buffer.seek(0)
+    headers = {"Content-Disposition": f"inline; filename={filename}"}
+    if cache_control:
+        headers["Cache-Control"] = cache_control
+    return StreamingResponse(buffer, media_type="image/jpeg", headers=headers)
 
 
 @router.post(
@@ -229,7 +244,46 @@ def get_media(
 
 
 @router.get(
+    "/{media_id}/frames",
+    responses={
+        status.HTTP_200_OK: {"description": "List of annotated video frames", "model": list[AnnotatedVideoFrame]},
+        status.HTTP_404_NOT_FOUND: {"description": "Project or video not found"},
+    },
+)
+def list_video_frames(
+    project: Annotated[Project, Depends(get_project)],
+    media_id: MediaID,
+    media_service: Annotated[MediaService, Depends(get_media_service)],
+    frame_index_from: Annotated[int, Query(ge=0)] = DEFAULT_FRAME_INDEX_FROM,
+    frame_index_to: Annotated[int, Query(ge=0)] = DEFAULT_FRAME_INDEX_TO,
+) -> list[AnnotatedVideoFrame]:
+    """Lists annotated video frames with frame index range"""
+    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
+    if media.type != MediaType.VIDEO:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Requested media is not video.")
+    annotated_video_frames = media_service.list_annotated_video_frames_by_video_id(
+        project=project,
+        video_id=media_id,
+        frame_index_from=frame_index_from,
+        frame_index_to=frame_index_to,
+    )
+    return [
+        AnnotatedVideoFrame(
+            media_id=video_frame.id,
+            frame_index=video_frame.frame_index,
+            dataset=MediaAnnotations(
+                annotations=dataset_item.annotation_data,  # type: ignore[arg-type]
+                prediction_model_id=dataset_item.prediction_model_id,
+                user_reviewed=dataset_item.user_reviewed,
+            ),
+        )
+        for (dataset_item, video_frame) in annotated_video_frames
+    ]
+
+
+@router.get(
     "/{media_id}/binary",
+    response_model=None,
     responses={
         status.HTTP_200_OK: {"description": "Media binary found"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid media ID or project ID"},
@@ -240,10 +294,27 @@ def get_media_binary(
     project: Annotated[Project, Depends(get_project)],
     media_id: MediaID,
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> FileResponse:
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
+) -> FileResponse | StreamingResponse:
     """Get media binary content"""
-    binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media_id)
     media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
+    print(media)
+    if media.type == MediaType.VIDEO and frame_index is not None:
+        # Video frames can be identified by video ID and frame index
+        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
+            )
+        video_frame = media_service.get_video_frame_by_video_id_and_index(
+            project=project, video_id=media_id, frame_index=frame_index
+        )
+        if video_frame is None:
+            frame_binary = media_service.get_frame_binary(project=project, video=media, frame_index=frame_index)
+            return _write_image_to_response(image=frame_binary, filename=f"{media.name}_frame_{frame_index}.jpeg")
+        media = video_frame
+
+    binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media.id)
     filename = f"{media.name}.{media.format.value.lower()}"
     return FileResponse(path=binary_path, filename=filename)
 
@@ -260,19 +331,28 @@ def get_media_thumbnail(
     project: Annotated[Project, Depends(get_project)],
     media_id: MediaID,
     media_service: Annotated[MediaService, Depends(get_media_service)],
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> StreamingResponse:
     """Get media thumbnail binary content"""
-    thumbnail = media_service.generate_media_thumbnail(project=project, media_id=media_id)
-    buffer = BytesIO()
-    thumbnail.save(buffer, format="JPEG")
-    buffer.seek(0)
-    return StreamingResponse(
-        buffer,
-        media_type="image/jpeg",
-        headers={
-            "Content-Disposition": f"inline; filename={media_id}.jpeg",
-            "Cache-Control": "public, max-age=31536000",
-        },
+    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
+    if media.type == MediaType.VIDEO and frame_index is not None:
+        # Video frames can be identified by video ID and frame index
+        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
+            )
+        video_frame = media_service.get_video_frame_by_video_id_and_index(
+            project=project, video_id=media_id, frame_index=frame_index
+        )
+        if video_frame is None:
+            frame_binary = media_service.get_frame_thumbnail(project=project, video=media, frame_index=frame_index)
+            return _write_image_to_response(image=frame_binary, filename=f"{media.name}_frame_{frame_index}_thumb.jpeg")
+        media = video_frame
+
+    thumbnail = media_service.generate_media_thumbnail(project=project, media=media)
+    return _write_image_to_response(
+        image=thumbnail, filename=f"{media_id}_thumb.jpeg", cache_control="public, max-age=31536000"
     )
 
 
@@ -331,9 +411,7 @@ def set_media_annotations(
                 project=project, video_id=media_id, frame_index=frame_index
             )
             if video_frame is None:
-                video_frame = media_service.extract_video_frame(
-                    project=project, video_id=media_id, frame_index=frame_index
-                )
+                video_frame = media_service.extract_video_frame(project=project, video=media, frame_index=frame_index)
                 dataset_service.create_dataset_item(
                     project=project,
                     media=video_frame,

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-
+import os.path
 from datetime import datetime
 from typing import Annotated
 from uuid import UUID
@@ -348,6 +348,8 @@ def get_media_thumbnail(
         )
 
     thumbnail_path = media_service.get_media_thumbnail_path(project=project, media=media)
+    if not os.path.exists(thumbnail_path):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media thumbnail file is not found.")
     return write_file_to_response(
         path=thumbnail_path, filename=f"{media.id}-thumb.jpeg", cache_control="public, max-age=31536000"
     )

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -260,20 +260,10 @@ def get_media_thumbnail(
     project: Annotated[Project, Depends(get_project)],
     media_id: MediaID,
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> StreamingResponse:
+) -> FileResponse:
     """Get media thumbnail binary content"""
-    thumbnail = media_service.generate_media_thumbnail(project=project, media_id=media_id)
-    buffer = BytesIO()
-    thumbnail.save(buffer, format="JPEG")
-    buffer.seek(0)
-    return StreamingResponse(
-        buffer,
-        media_type="image/jpeg",
-        headers={
-            "Content-Disposition": f"inline; filename={media_id}.jpeg",
-            "Cache-Control": "public, max-age=31536000",
-        },
-    )
+    thumbnail_path = media_service.get_media_thumbnail_path_by_id(project=project, media_id=media_id)
+    return FileResponse(path=thumbnail_path)
 
 
 @router.delete(

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -349,7 +349,7 @@ def get_media_thumbnail(
 
     thumbnail_path = media_service.get_media_thumbnail_path(project=project, media=media)
     return write_file_to_response(
-        path=thumbnail_path, filename=f"{media.id}_thumb.jpeg", cache_control="public, max-age=31536000"
+        path=thumbnail_path, filename=f"{media.id}-thumb.jpeg", cache_control="public, max-age=31536000"
     )
 
 

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
-from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
 from app.api.dependencies import get_dataset_service, get_file_name_and_extension, get_media_service, get_project
@@ -18,6 +17,7 @@ from app.api.schemas.media import (
     MediaView,
     MediaViewAdapter,
     MediaWithPagination,
+    NotAnnotatedFrame,
     SetMediaAnnotations,
 )
 from app.api.validators import MediaID
@@ -109,11 +109,6 @@ def _parse_media_format(extension: str) -> ImageFormat | VideoFormat:
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Unsupported media extension: {extension}",
             )
-
-
-class NotAnnotatedFrame(BaseModel):
-    video: Video
-    frame_index: int
 
 
 def _get_request_media(

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -347,7 +347,7 @@ def get_media_thumbnail(
             image=frame_thumbnail, filename=f"{media.video.name}_frame_{media.frame_index}.jpeg"
         )
 
-    thumbnail_path = media_service.get_media_thumbnail_path_by_id(project=project, media_id=media.id)
+    thumbnail_path = media_service.get_media_thumbnail_path(project=project, media=media)
     return write_file_to_response(
         path=thumbnail_path, filename=f"{media.id}_thumb.jpeg", cache_control="public, max-age=31536000"
     )

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from io import BytesIO
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
-from PIL.Image import Image
-from starlette.responses import FileResponse, StreamingResponse
+from pydantic import BaseModel
+from starlette.responses import StreamingResponse
 
 from app.api.dependencies import get_dataset_service, get_file_name_and_extension, get_media_service, get_project
+from app.api.io_utils import write_file_to_response, write_image_to_response
 from app.api.schemas.media import (
     AnnotatedVideoFrame,
     MediaAnnotations,
@@ -22,8 +22,8 @@ from app.api.schemas.media import (
 )
 from app.api.validators import MediaID
 from app.core.models import Pagination
-from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Project
-from app.models.media import ImageFormat, MediaType, VideoFormat
+from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Media, Project
+from app.models.media import ImageFormat, MediaType, Video, VideoFormat
 from app.services import DatasetService, MediaService
 from app.services.dataset_service import AnnotationValidationError
 from app.services.media_service import InvalidImageError, MediaFilters
@@ -111,14 +111,31 @@ def _parse_media_format(extension: str) -> ImageFormat | VideoFormat:
             )
 
 
-def _write_image_to_response(image: Image, filename: str, cache_control: str | None = None) -> StreamingResponse:
-    buffer = BytesIO()
-    image.save(buffer, format="JPEG")
-    buffer.seek(0)
-    headers = {"Content-Disposition": f"inline; filename={filename}"}
-    if cache_control:
-        headers["Cache-Control"] = cache_control
-    return StreamingResponse(buffer, media_type="image/jpeg", headers=headers)
+class NotAnnotatedFrame(BaseModel):
+    video: Video
+    frame_index: int
+
+
+def _get_request_media(
+    project: Annotated[Project, Depends(get_project)],
+    media_id: MediaID,
+    media_service: Annotated[MediaService, Depends(get_media_service)],
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
+) -> Media | NotAnnotatedFrame:
+    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
+    if media.type != MediaType.VIDEO or frame_index is None:
+        return media
+
+    # Video frames can be identified by video ID and frame index
+    if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
+        )
+    video_frame = media_service.get_video_frame_by_video_id_and_index(
+        project=project, video_id=media_id, frame_index=frame_index
+    )
+    return video_frame if video_frame is not None else NotAnnotatedFrame(video=media, frame_index=frame_index)
 
 
 @router.post(
@@ -271,7 +288,7 @@ def list_video_frames(
         AnnotatedVideoFrame(
             media_id=video_frame.id,
             frame_index=video_frame.frame_index,
-            dataset=MediaAnnotations(
+            annotation_data=MediaAnnotations(
                 annotations=dataset_item.annotation_data,  # type: ignore[arg-type]
                 prediction_model_id=dataset_item.prediction_model_id,
                 user_reviewed=dataset_item.user_reviewed,
@@ -292,31 +309,20 @@ def list_video_frames(
 )
 def get_media_binary(
     project: Annotated[Project, Depends(get_project)],
-    media_id: MediaID,
+    media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
-) -> FileResponse | StreamingResponse:
+) -> StreamingResponse:
     """Get media binary content"""
-    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
-    print(media)
-    if media.type == MediaType.VIDEO and frame_index is not None:
-        # Video frames can be identified by video ID and frame index
-        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
-            )
-        video_frame = media_service.get_video_frame_by_video_id_and_index(
-            project=project, video_id=media_id, frame_index=frame_index
+    if isinstance(media, NotAnnotatedFrame):
+        frame_binary = media_service.get_frame_binary(project=project, video=media.video, frame_index=media.frame_index)
+        return write_image_to_response(
+            image=frame_binary, filename=f"{media.video.name}_frame_{media.frame_index}.jpeg"
         )
-        if video_frame is None:
-            frame_binary = media_service.get_frame_binary(project=project, video=media, frame_index=frame_index)
-            return _write_image_to_response(image=frame_binary, filename=f"{media.name}_frame_{frame_index}.jpeg")
-        media = video_frame
 
     binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media.id)
     filename = f"{media.name}.{media.format.value.lower()}"
-    return FileResponse(path=binary_path, filename=filename)
+
+    return write_file_to_response(path=binary_path, filename=filename)
 
 
 @router.get(
@@ -329,30 +335,21 @@ def get_media_binary(
 )
 def get_media_thumbnail(
     project: Annotated[Project, Depends(get_project)],
-    media_id: MediaID,
+    media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> StreamingResponse:
     """Get media thumbnail binary content"""
-    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
-    if media.type == MediaType.VIDEO and frame_index is not None:
-        # Video frames can be identified by video ID and frame index
-        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
-            )
-        video_frame = media_service.get_video_frame_by_video_id_and_index(
-            project=project, video_id=media_id, frame_index=frame_index
+    if isinstance(media, NotAnnotatedFrame):
+        frame_thumbnail = media_service.get_frame_thumbnail(
+            project=project, video=media.video, frame_index=media.frame_index
         )
-        if video_frame is None:
-            frame_binary = media_service.get_frame_thumbnail(project=project, video=media, frame_index=frame_index)
-            return _write_image_to_response(image=frame_binary, filename=f"{media.name}_frame_{frame_index}_thumb.jpeg")
-        media = video_frame
+        return write_image_to_response(
+            image=frame_thumbnail, filename=f"{media.video.name}_frame_{media.frame_index}.jpeg"
+        )
 
     thumbnail = media_service.generate_media_thumbnail(project=project, media=media)
-    return _write_image_to_response(
-        image=thumbnail, filename=f"{media_id}_thumb.jpeg", cache_control="public, max-age=31536000"
+    return write_image_to_response(
+        image=thumbnail, filename=f"{media.id}_thumb.jpeg", cache_control="public, max-age=31536000"
     )
 
 
@@ -385,40 +382,28 @@ def delete_media(
 )
 def set_media_annotations(
     project: Annotated[Project, Depends(get_project)],
-    media_id: MediaID,
+    media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_annotations: Annotated[SetMediaAnnotations, Body(openapi_examples=SET_MEDIA_ANNOTATIONS_BODY_EXAMPLES)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
     frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> MediaAnnotations:
     """Set media annotations"""
+    if isinstance(media, Video) and not frame_index:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
+    if isinstance(media, NotAnnotatedFrame):
+        video_frame = media_service.extract_video_frame(
+            project=project, video=media.video, frame_index=media.frame_index
+        )
+        dataset_service.create_dataset_item(
+            project=project,
+            media=video_frame,
+            user_reviewed=True,
+        )
+        media = video_frame
     # Dataset item has the same ID as media
-    dataset_item_id = media_id
+    dataset_item_id = media.id
     try:
-        media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
-        if media.type == MediaType.VIDEO:
-            # Video frames can be identified by video ID and frame index
-            if frame_index is None:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided."
-                )
-            if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
-                )
-            video_frame = media_service.get_video_frame_by_video_id_and_index(
-                project=project, video_id=media_id, frame_index=frame_index
-            )
-            if video_frame is None:
-                video_frame = media_service.extract_video_frame(project=project, video=media, frame_index=frame_index)
-                dataset_service.create_dataset_item(
-                    project=project,
-                    media=video_frame,
-                    user_reviewed=True,
-                )
-            dataset_item_id = video_frame.id
-
         dataset_item = dataset_service.set_dataset_item_annotations(
             project=project,
             dataset_item_id=dataset_item_id,
@@ -448,33 +433,17 @@ def set_media_annotations(
 )
 def get_media_annotations(
     project: Annotated[Project, Depends(get_project)],
-    media_id: MediaID,
-    media_service: Annotated[MediaService, Depends(get_media_service)],
+    media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
     frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> MediaAnnotations:
     """Get the media annotations"""
+    if isinstance(media, Video) and not frame_index:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
+    if isinstance(media, NotAnnotatedFrame):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given index.")
     # Dataset item has the same ID as media
-    dataset_item_id = media_id
-    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
-    if media.type == MediaType.VIDEO:
-        # Video frames can be identified by video ID and frame index
-        if frame_index is None:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
-        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
-            )
-        video_frame = media_service.get_video_frame_by_video_id_and_index(
-            project=project, video_id=media_id, frame_index=frame_index
-        )
-        if video_frame is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given index."
-            )
-        dataset_item_id = video_frame.id
-
+    dataset_item_id = media.id
     dataset_item = dataset_service.get_dataset_item_by_id(project_id=project.id, dataset_item_id=dataset_item_id)
     if dataset_item.annotation_data is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media has not been annotated yet.")
@@ -496,31 +465,15 @@ def get_media_annotations(
 )
 def delete_media_annotation(
     project: Annotated[Project, Depends(get_project)],
-    media_id: MediaID,
-    media_service: Annotated[MediaService, Depends(get_media_service)],
+    media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
     frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> None:
     """Delete media annotations"""
+    if isinstance(media, Video) and not frame_index:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
+    if isinstance(media, NotAnnotatedFrame):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given index.")
     # Dataset item has the same ID as media
-    dataset_item_id = media_id
-    media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
-    if media.type == MediaType.VIDEO:
-        # Video frames can be identified by video ID and frame index
-        if frame_index is None:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Video frame index is not provided.")
-        if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
-            )
-        video_frame = media_service.get_video_frame_by_video_id_and_index(
-            project=project, video_id=media_id, frame_index=frame_index
-        )
-        if video_frame is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Video frame not found for the given index."
-            )
-        dataset_item_id = video_frame.id
-
+    dataset_item_id = media.id
     dataset_service.delete_dataset_item_annotations(project=project, dataset_item_id=dataset_item_id)

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -274,7 +274,7 @@ def list_video_frames(
     frame_index_from: Annotated[int, Query(ge=0)] = DEFAULT_FRAME_INDEX_FROM,
     frame_index_to: Annotated[int, Query(ge=0)] = DEFAULT_FRAME_INDEX_TO,
 ) -> list[AnnotatedVideoFrame]:
-    """Lists annotated video frames with frame index range"""
+    """List annotated video frames with frame index range"""
     media = media_service.get_media_by_id(project_id=project.id, media_id=media_id)
     if media.type != MediaType.VIDEO:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Requested media is not video.")

--- a/application/backend/app/api/schemas/media.py
+++ b/application/backend/app/api/schemas/media.py
@@ -164,4 +164,4 @@ class MediaAnnotations(BaseModel):
 class AnnotatedVideoFrame(BaseModel):
     media_id: UUID
     frame_index: int
-    dataset: MediaAnnotations
+    annotation_data: MediaAnnotations

--- a/application/backend/app/api/schemas/media.py
+++ b/application/backend/app/api/schemas/media.py
@@ -159,3 +159,9 @@ class MediaAnnotations(BaseModel):
             }
         }
     }
+
+
+class AnnotatedVideoFrame(BaseModel):
+    media_id: UUID
+    frame_index: int
+    dataset: MediaAnnotations

--- a/application/backend/app/api/schemas/media.py
+++ b/application/backend/app/api/schemas/media.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, TypeAdapter
 
 from app.core.models import BaseRequiredIDNameModel, Pagination
-from app.models import DatasetItemAnnotation, MediaFormat, MediaType
+from app.models import DatasetItemAnnotation, MediaFormat, MediaType, Video
 
 
 class ImageView(BaseRequiredIDNameModel):
@@ -165,3 +165,8 @@ class AnnotatedVideoFrame(BaseModel):
     media_id: UUID
     frame_index: int
     annotation_data: MediaAnnotations
+
+
+class NotAnnotatedFrame(BaseModel):
+    video: Video
+    frame_index: int

--- a/application/backend/app/repositories/media_repo.py
+++ b/application/backend/app/repositories/media_repo.py
@@ -121,12 +121,23 @@ class MediaRepository:
         stmt = self._base_select().where(MediaDB.video_id == video_id, MediaDB.frame_index == frame_index)
         return self.db.scalar(stmt)
 
-    def get_video_frames_by_video_id(
-        self, video_id: str, frame_index_from: int = 0, frame_index_to: int = 10
-    ) -> list[MediaDB]:
-        stmt = self._base_select().where(
-            MediaDB.video_id == video_id,
-            MediaDB.frame_index >= frame_index_from,
-            MediaDB.frame_index <= frame_index_to,
+    def list_annotated_video_frames_by_video_id(
+        self,
+        video_id: str,
+        frame_index_from: int = 0,
+        frame_index_to: int = 10,
+    ) -> list[tuple[DatasetItemDB, MediaDB]]:
+        stmt = (
+            select(DatasetItemDB, MediaDB)
+            .where(DatasetItemDB.project_id == self.project_id)
+            .join(MediaDB)
+            .order_by(MediaDB.frame_index.asc())
+            .where(
+                MediaDB.id == DatasetItemDB.id,
+                MediaDB.project_id == DatasetItemDB.project_id,
+                MediaDB.video_id == video_id,
+                MediaDB.frame_index >= frame_index_from,
+                MediaDB.frame_index <= frame_index_to,
+            )
         )
-        return list(self.db.scalars(stmt).all())
+        return [(dataset_item, media) for (dataset_item, media) in self.db.execute(stmt).all()]

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -100,22 +100,26 @@ class MediaService(BaseSessionManagedService):
         binary_path = dataset_dir / f"{media_id}.{format}"
         image.save(binary_path)
 
-        MediaService._generate_and_save_thumbnail(image, dataset_dir / f"{media_id}-thumb.jpg")
+        try:
+            MediaService._generate_and_save_thumbnail(image, dataset_dir / f"{media_id}-thumb.jpg")
 
-        media = MediaDB(
-            id=str(media_id),
-            project_id=str(project.id),
-            type=MediaType.IMAGE,
-            name=name,
-            format=str(format),
-            width=image.width,
-            height=image.height,
-            size=os.path.getsize(binary_path),
-            source_id=str(source_id) if source_id is not None else None,
-        )
+            media = MediaDB(
+                id=str(media_id),
+                project_id=str(project.id),
+                type=MediaType.IMAGE,
+                name=name,
+                format=str(format),
+                width=image.width,
+                height=image.height,
+                size=os.path.getsize(binary_path),
+                source_id=str(source_id) if source_id is not None else None,
+            )
 
-        repo = MediaRepository(project_id=str(project.id), db=self.db_session)
-        db_media = repo.save(media)
+            repo = MediaRepository(project_id=str(project.id), db=self.db_session)
+            db_media = repo.save(media)
+        except Exception as e:
+            binary_path.unlink(missing_ok=True)
+            raise e
         return MediaAdapter.validate_python(db_media)
 
     def create_video(
@@ -154,6 +158,11 @@ class MediaService(BaseSessionManagedService):
                 size=os.path.getsize(binary_path),
                 source_id=str(source_id) if source_id is not None else None,
             )
+
+            video_frame = MediaService._get_frame_binary_from_video_file(
+                video_path=binary_path, frame_index=video_metadata.frame_count // 2
+            )
+            MediaService._generate_and_save_thumbnail(image=video_frame, path=dataset_dir / f"{media_id}-thumb.jpg")
 
             repo = MediaRepository(project_id=str(project.id), db=self.db_session)
             db_media = repo.save(media)
@@ -282,22 +291,28 @@ class MediaService(BaseSessionManagedService):
         video_frame = self.get_frame_binary(project=project, video=video, frame_index=frame_index)
         video_frame.save(video_frame_path)
 
-        db_video_frame = MediaDB(
-            id=str(media_id),
-            project_id=str(project.id),
-            type=MediaType.VIDEO_FRAME,
-            name=f"{video.name}_frame_{frame_index}",
-            format=str(format),
-            width=video_frame.width,
-            height=video_frame.height,
-            video_id=str(video.id),
-            frame_index=frame_index,
-            size=os.path.getsize(video_frame_path),
-            source_id=None,
-        )
+        try:
+            MediaService._generate_and_save_thumbnail(image=video_frame, path=dataset_dir / f"{media_id}-thumb.jpg")
 
-        repo = MediaRepository(project_id=str(project.id), db=self.db_session)
-        db_video_frame = repo.save(db_video_frame)
+            db_video_frame = MediaDB(
+                id=str(media_id),
+                project_id=str(project.id),
+                type=MediaType.VIDEO_FRAME,
+                name=f"{video.name}_frame_{frame_index}",
+                format=str(format),
+                width=video_frame.width,
+                height=video_frame.height,
+                video_id=str(video.id),
+                frame_index=frame_index,
+                size=os.path.getsize(video_frame_path),
+                source_id=None,
+            )
+
+            repo = MediaRepository(project_id=str(project.id), db=self.db_session)
+            db_video_frame = repo.save(db_video_frame)
+        except Exception as e:
+            video_frame_path.unlink(missing_ok=True)
+            raise e
         return VideoFrame.model_validate(db_video_frame, from_attributes=True)
 
     def get_video_frame_by_video_id_and_index(self, project: Project, video_id: UUID, frame_index: int) -> Media | None:

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -221,20 +221,19 @@ class MediaService(BaseSessionManagedService):
         dataset_dir = self.projects_dir / f"{project_id}/dataset"
         return dataset_dir / f"{media.id}.{media.format}"
 
-    def get_media_binary_path_by_id(self, project_id: UUID, media_id: UUID) -> Path | str:
+    def get_media_binary_path_by_id(self, project_id: UUID, media_id: UUID) -> Path:
         """Get a media binary content by its ID"""
         media = self.get_media_by_id(project_id=project_id, media_id=media_id)
         return self.get_media_binary_path(project_id=project_id, media=media)
 
-    def get_media_thumbnail_path_by_id(self, project: Project, media_id: UUID) -> Path | str:
+    def get_media_thumbnail_path_by_id(self, project: Project, media_id: UUID) -> Path:
         """Get a media thumbnail binary content by its ID"""
         media = self.get_media_by_id(project_id=project.id, media_id=media_id)
         return self.projects_dir / f"{project.id}/dataset/{media.id}-thumb.jpg"
 
     def generate_media_thumbnail(self, project: Project, media: Media) -> Image.Image:
         """Regenerate a media thumbnail by its ID"""
-        dataset_dir = self.projects_dir / f"{project.id}/dataset"
-        binary_path = dataset_dir / f"{media.id}.{media.format}"
+        binary_path = self.get_media_binary_path(project_id=project.id, media=media)
 
         if media.type == MediaType.VIDEO:
             video_frame = MediaService._get_frame_binary_from_video_file(
@@ -263,13 +262,14 @@ class MediaService(BaseSessionManagedService):
         media = self.get_media_by_id(project_id=project.id, media_id=media_id)
         repo = MediaRepository(project_id=str(project.id), db=self.db_session)
 
-        dataset_dir = self.projects_dir / f"{project.id}/dataset"
+        binary_path = self.get_media_binary_path(project_id=project.id, media=media)
         try:
-            os.remove(dataset_dir / f"{media.id}.{media.format}")
+            os.remove(binary_path)
         except FileNotFoundError:
             logger.warning("Media {} binary was not found during deletion", media_id)
+        thumbnail_path = self.get_media_thumbnail_path_by_id(project=project, media_id=media.id)
         try:
-            os.remove(dataset_dir / f"{media_id}-thumb.jpg")
+            os.remove(thumbnail_path)
         except FileNotFoundError:
             logger.warning("Media {} thumbnail was not found during deletion", media_id)
 

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -226,26 +226,9 @@ class MediaService(BaseSessionManagedService):
         media = self.get_media_by_id(project_id=project_id, media_id=media_id)
         return self.get_media_binary_path(project_id=project_id, media=media)
 
-    def get_media_thumbnail_path_by_id(self, project: Project, media_id: UUID) -> Path:
-        """Get a media thumbnail binary content by its ID"""
-        media = self.get_media_by_id(project_id=project.id, media_id=media_id)
+    def get_media_thumbnail_path(self, project: Project, media: MediaDB | Media) -> Path:
+        """Get a media thumbnail binary content"""
         return self.projects_dir / f"{project.id}/dataset/{media.id}-thumb.jpg"
-
-    def generate_media_thumbnail(self, project: Project, media: Media) -> Image.Image:
-        """Regenerate a media thumbnail by its ID"""
-        binary_path = self.get_media_binary_path(project_id=project.id, media=media)
-
-        if media.type == MediaType.VIDEO:
-            video_frame = MediaService._get_frame_binary_from_video_file(
-                video_path=binary_path, frame_index=media.frame_count // 2
-            )
-            return MediaService._crop_image_to_thumbnail(video_frame)
-        try:
-            with Image.open(binary_path) as image:
-                return MediaService._crop_image_to_thumbnail(image)
-        except UnidentifiedImageError:
-            logger.error("Failed to open image {} for thumbnail generation", binary_path)
-            raise InvalidImageError("Failed to open image for thumbnail generation.")
 
     @staticmethod
     def _crop_image_to_thumbnail(image: Image.Image) -> Image.Image:
@@ -267,7 +250,7 @@ class MediaService(BaseSessionManagedService):
             os.remove(binary_path)
         except FileNotFoundError:
             logger.warning("Media {} binary was not found during deletion", media_id)
-        thumbnail_path = self.get_media_thumbnail_path_by_id(project=project, media_id=media.id)
+        thumbnail_path = self.get_media_thumbnail_path(project=project, media=media)
         try:
             os.remove(thumbnail_path)
         except FileNotFoundError:

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -3,7 +3,6 @@
 
 import os
 import os.path
-import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from io import BytesIO
@@ -17,7 +16,7 @@ from PIL import Image, UnidentifiedImageError
 from sqlalchemy.orm import Session
 
 from app.db.schema import MediaDB
-from app.models import DatasetItemAnnotationStatus, Media, MediaType, Project
+from app.models import DatasetItem, DatasetItemAnnotationStatus, Media, MediaType, Project, Video, VideoFrame
 from app.models.media import ImageFormat, MediaAdapter, VideoFormat
 from app.repositories import MediaRepository
 from app.services.video import extract_video_frame, get_video_metadata
@@ -232,51 +231,32 @@ class MediaService(BaseSessionManagedService):
         media = self.get_media_by_id(project_id=project.id, media_id=media_id)
         return self.projects_dir / f"{project.id}/dataset/{media.id}-thumb.jpg"
 
-    def generate_media_thumbnail(self, project: Project, media_id: UUID) -> Image.Image:
+    def generate_media_thumbnail(self, project: Project, media: Media) -> Image.Image:
         """Regenerate a media thumbnail by its ID"""
-        media = self.get_media_by_id(project_id=project.id, media_id=media_id)
         dataset_dir = self.projects_dir / f"{project.id}/dataset"
         binary_path = dataset_dir / f"{media.id}.{media.format}"
 
-        if media.type == MediaType.IMAGE:
-            return MediaService.generate_image_thumbnail(binary_path)
         if media.type == MediaType.VIDEO:
-            return MediaService.generate_video_thumbnail(
-                binary_path=binary_path,
-                frame_index=media.frame_count // 2,  # pyrefly: ignore
+            video_frame = MediaService._get_frame_binary_from_video_file(
+                video_path=binary_path, frame_index=media.frame_count // 2
             )
-        raise RuntimeError(f"Unknown media type: {media.type}")
-
-    @staticmethod
-    def generate_image_thumbnail(binary_path: Path) -> Image.Image:
-        """Regenerate an image thumbnail by its path"""
+            return MediaService._crop_image_to_thumbnail(video_frame)
         try:
             with Image.open(binary_path) as image:
-                thumbnail = crop_to_thumbnail(
-                    image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
-                )
-                if thumbnail.mode not in ("RGB", "L", "CMYK"):
-                    thumbnail = thumbnail.convert("RGB")
+                return MediaService._crop_image_to_thumbnail(image)
         except UnidentifiedImageError:
             logger.error("Failed to open image {} for thumbnail generation", binary_path)
             raise InvalidImageError("Failed to open image for thumbnail generation.")
-        return thumbnail
 
     @staticmethod
-    def generate_video_thumbnail(binary_path: Path, frame_index: int) -> Image.Image:
-        """Regenerate a video thumbnail by its path"""
-        fd, temp_path = tempfile.mkstemp(suffix=".jpg")
-        os.close(fd)
-
-        frame_file_path = Path(temp_path)
-        try:
-            extract_video_frame(video_path=binary_path, video_frame_path=frame_file_path, frame_index=frame_index)
-            return MediaService.generate_image_thumbnail(frame_file_path)
-        finally:
-            try:
-                os.remove(temp_path)
-            except FileNotFoundError:
-                pass
+    def _crop_image_to_thumbnail(image: Image.Image) -> Image.Image:
+        """Regenerate an image thumbnail by its path"""
+        thumbnail = crop_to_thumbnail(
+            image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
+        )
+        if thumbnail.mode not in ("RGB", "L", "CMYK"):
+            thumbnail = thumbnail.convert("RGB")
+        return thumbnail
 
     def delete_media(self, project: Project, media_id: UUID) -> None:
         """Delete a media by its ID"""
@@ -295,23 +275,29 @@ class MediaService(BaseSessionManagedService):
 
         repo.delete(obj_id=str(media.id))
 
-    def extract_video_frame(self, project: Project, video_id: UUID, frame_index: int) -> Media:
-        """Extract video frame by video ID and index"""
-        video = self.get_media_by_id(project_id=project.id, media_id=video_id)
-        if video.type != MediaType.VIDEO:
-            raise RuntimeError(f"Media {video_id} is not a video")
+    def get_frame_binary(self, project: Project, video: Video, frame_index: int) -> Image.Image:
+        video_path = self.get_media_binary_path(project_id=project.id, media=video)
+        return self._get_frame_binary_from_video_file(video_path=video_path, frame_index=frame_index)
 
+    def get_frame_thumbnail(self, project: Project, video: Video, frame_index: int) -> Image.Image:
+        video_frame = self.get_frame_binary(project=project, video=video, frame_index=frame_index)
+        return MediaService._crop_image_to_thumbnail(video_frame)
+
+    @staticmethod
+    def _get_frame_binary_from_video_file(video_path: Path, frame_index: int) -> Image.Image:
+        video_frame_numpy = extract_video_frame(video_path=video_path, frame_index=frame_index)
+        return MediaService._read_image_from_ndarray(video_frame_numpy)
+
+    def extract_video_frame(self, project: Project, video: Video, frame_index: int) -> VideoFrame:
+        """Extract video frame by video ID and frame_index"""
         media_id = uuid4()
         format = ImageFormat.JPG
 
         dataset_dir = self.projects_dir / f"{project.id}/dataset"
-        video_path = self.get_media_binary_path(project_id=project.id, media=video)
         video_frame_path = dataset_dir / f"{media_id}.{format}"
 
-        video_frame_numpy = extract_video_frame(
-            video_path=video_path, video_frame_path=video_frame_path, frame_index=frame_index
-        )
-        image = self._read_image_from_ndarray(video_frame_numpy)
+        video_frame = self.get_frame_binary(project=project, video=video, frame_index=frame_index)
+        video_frame.save(video_frame_path)
 
         db_video_frame = MediaDB(
             id=str(media_id),
@@ -319,8 +305,8 @@ class MediaService(BaseSessionManagedService):
             type=MediaType.VIDEO_FRAME,
             name=f"{video.name}_frame_{frame_index}",
             format=str(format),
-            width=image.width,
-            height=image.height,
+            width=video_frame.width,
+            height=video_frame.height,
             video_id=str(video.id),
             frame_index=frame_index,
             size=os.path.getsize(video_frame_path),
@@ -329,7 +315,7 @@ class MediaService(BaseSessionManagedService):
 
         repo = MediaRepository(project_id=str(project.id), db=self.db_session)
         db_video_frame = repo.save(db_video_frame)
-        return MediaAdapter.validate_python(db_video_frame)
+        return VideoFrame.model_validate(db_video_frame, from_attributes=True)
 
     def get_video_frame_by_video_id_and_index(self, project: Project, video_id: UUID, frame_index: int) -> Media | None:
         """
@@ -347,9 +333,9 @@ class MediaService(BaseSessionManagedService):
         db_media = repo.get_video_frame_by_video_id_and_index(video_id=str(video_id), frame_index=frame_index)
         return MediaAdapter.validate_python(db_media) if db_media else None
 
-    def get_video_frames_by_video_id(
+    def list_annotated_video_frames_by_video_id(
         self, project: Project, video_id: UUID, frame_index_from: int = 0, frame_index_to: int = 10
-    ) -> list[Media]:
+    ) -> list[tuple[DatasetItem, VideoFrame]]:
         """
         Returns all annotated video frames falling into the specified frame index range.
 
@@ -360,10 +346,13 @@ class MediaService(BaseSessionManagedService):
             frame_index_to: Frame index range end, default is 10
 
         Returns:
-            Annotated video frames list.
+            Annotated video frames list with corresponding dataset items.
         """
         repo = MediaRepository(project_id=str(project.id), db=self.db_session)
-        db_media_list = repo.get_video_frames_by_video_id(
+        db_media_list = repo.list_annotated_video_frames_by_video_id(
             video_id=str(video_id), frame_index_from=frame_index_from, frame_index_to=frame_index_to
         )
-        return [MediaAdapter.validate_python(db_media) for db_media in db_media_list]
+        return [
+            (DatasetItem.model_validate(db_dataset_item), VideoFrame.model_validate(db_media, from_attributes=True))
+            for (db_dataset_item, db_media) in db_media_list
+        ]

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -55,6 +55,9 @@ def extract_video_frame(
     Args:
         video_path: Video binary file path
         frame_index: Frame index
+
+    Returns:
+        Extracted video frame as numpy array (RGB format)
     """
     cap = cv2.VideoCapture(str(video_path))
     if not cap.isOpened():
@@ -64,9 +67,9 @@ def extract_video_frame(
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
         # Read the frame at the requested position
         read_success, frame = cap.read()
-        cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         if not read_success:
             raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
+        cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         return frame
     except Exception as e:
         logger.error(f"Failed extracting video frame {frame_index} from video {video_path}", exc_info=e)

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -69,8 +69,7 @@ def extract_video_frame(
         read_success, frame = cap.read()
         if not read_success:
             raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
-        cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-        return frame
+        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
     except Exception as e:
         logger.error(f"Failed extracting video frame {frame_index} from video {video_path}", exc_info=e)
         raise RuntimeError("Error occurred while extracting video frame")

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -47,15 +47,13 @@ def get_video_metadata(video_path: Path) -> VideoMetadata:
 
 def extract_video_frame(
     video_path: Path,
-    video_frame_path: Path,
     frame_index: int,
 ) -> np.ndarray:
     """
-    Extracts a video frame and saves it to a local FS to specified file.
+    Extracts a video frame.
 
     Args:
         video_path: Video binary file path
-        video_frame_path: Path of the file to write generated video frame to
         frame_index: Frame index
     """
     cap = cv2.VideoCapture(str(video_path))
@@ -68,7 +66,6 @@ def extract_video_frame(
         read_success, frame = cap.read()
         if not read_success:
             raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
-        cv2.imwrite(str(video_frame_path), frame)
         return frame
     except Exception as e:
         logger.error(f"Failed extracting video frame {frame_index} from video {video_path}", exc_info=e)

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -64,6 +64,7 @@ def extract_video_frame(
         cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
         # Read the frame at the requested position
         read_success, frame = cap.read()
+        cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         if not read_success:
             raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
         return frame

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -608,7 +608,7 @@ class TestMediaServiceIntegration:
         assert os.path.exists(binary_file_path)
         assert created_media.size == os.path.getsize(binary_file_path)
 
-        # Do not generate thumbnail on video upload
+        # Generate thumbnail on video upload
         thumbnail_file_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}-thumb.jpg"
         assert os.path.exists(thumbnail_file_path)
 

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -610,7 +610,7 @@ class TestMediaServiceIntegration:
 
         # Do not generate thumbnail on video upload
         thumbnail_file_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}-thumb.jpg"
-        assert not os.path.exists(thumbnail_file_path)
+        assert os.path.exists(thumbnail_file_path)
 
     def test_create_media_invalid_image(
         self,
@@ -1308,6 +1308,9 @@ class TestMediaServiceIntegration:
 
         video_frame_binary_path = dataset_dir / f"{video_frame.id}.jpg"
         assert os.path.exists(video_frame_binary_path)
+
+        video_frame_thumbnail_path = dataset_dir / f"{video_frame.id}-thumb.jpg"
+        assert os.path.exists(video_frame_thumbnail_path)
 
         db_video_frame = db_session.get(MediaDB, str(video_frame.id))
         assert db_video_frame is not None

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -16,7 +16,7 @@ from PIL import Image as PILImage
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, DatasetItemLabelDB, MediaDB, PipelineDB
-from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Image, Pipeline, Project, Video, VideoFrame
+from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Pipeline, Project, Video
 from app.models.media import ImageFormat, MediaType, VideoFormat
 from app.services import LabelService, PipelineService, ProjectService, SystemService
 from app.services.base import ResourceNotFoundError, ResourceType
@@ -810,7 +810,7 @@ class TestMediaServiceIntegration:
         assert excinfo.value.resource_type == ResourceType.MEDIA
         assert excinfo.value.resource_id == str(non_existent_id)
 
-    def test_get_media_thumbnail_path_by_id(
+    def test_get_media_thumbnail_path(
         self,
         tmp_path: Path,
         fxt_media_service: MediaService,
@@ -819,100 +819,9 @@ class TestMediaServiceIntegration:
         """Test retrieving a media thumbnail path by ID."""
         project, db_media_list = fxt_project_with_media
 
-        media_binary_path = fxt_media_service.get_media_thumbnail_path_by_id(
-            project=project, media_id=UUID(db_media_list[0].id)
-        )
+        media_binary_path = fxt_media_service.get_media_thumbnail_path(project=project, media=db_media_list[0])
 
         assert media_binary_path == tmp_path / f"projects/{str(project.id)}/dataset/{db_media_list[0].id}-thumb.jpg"
-
-    def test_get_media_thumbnail_path_by_id_not_found(
-        self,
-        fxt_media_service: MediaService,
-        fxt_project_with_media: tuple[Project, list[MediaDB]],
-    ):
-        """Test retrieving a non-existent media thumbnail path raises error."""
-        project, db_media_list = fxt_project_with_media
-        non_existent_id = uuid4()
-
-        with pytest.raises(ResourceNotFoundError) as excinfo:
-            fxt_media_service.get_media_thumbnail_path_by_id(project=project, media_id=non_existent_id)
-
-        assert excinfo.value.resource_type == ResourceType.MEDIA
-        assert excinfo.value.resource_id == str(non_existent_id)
-
-    def test_generate_image_thumbnail(
-        self,
-        tmp_path: Path,
-        fxt_projects_dir: Path,
-        fxt_media_service: MediaService,
-        fxt_project_with_media: tuple[Project, list[MediaDB]],
-    ):
-        """Test generating an image thumbnail returns a PIL Image."""
-        project, db_media_list = fxt_project_with_media
-        media = Image.model_validate(db_media_list[0], from_attributes=True)
-
-        # Create the dataset directory and a test image file
-        dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
-        dataset_dir.mkdir(parents=True, exist_ok=True)
-        image_path = dataset_dir / f"{media.id}.{media.format}"
-        test_image = PILImage.new("RGB", (1024, 768), color="red")
-        test_image.save(image_path)
-
-        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media=media)
-
-        assert isinstance(thumbnail, PILImage.Image)
-        assert thumbnail.width == 256
-        assert thumbnail.height == 256
-
-    def test_generate_video_frame_thumbnail(
-        self,
-        tmp_path: Path,
-        fxt_projects_dir: Path,
-        fxt_media_service: MediaService,
-        fxt_project_with_media: tuple[Project, list[MediaDB]],
-    ):
-        """Test generating an image thumbnail returns a PIL Image."""
-        project, db_media_list = fxt_project_with_media
-        media = VideoFrame.model_validate(db_media_list[4], from_attributes=True)
-
-        # Create the dataset directory and a test image file
-        dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
-        dataset_dir.mkdir(parents=True, exist_ok=True)
-        image_path = dataset_dir / f"{media.id}.{media.format}"
-        test_image = PILImage.new("RGB", (1024, 768), color="red")
-        test_image.save(image_path)
-
-        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media=media)
-
-        assert isinstance(thumbnail, PILImage.Image)
-        assert thumbnail.width == 256
-        assert thumbnail.height == 256
-
-    def test_generate_video_thumbnail(
-        self,
-        tmp_path: Path,
-        fxt_video_data: Callable[[Path], None],
-        fxt_projects_dir: Path,
-        fxt_media_service: MediaService,
-        fxt_project_with_media: tuple[Project, list[MediaDB]],
-    ):
-        """Test generating a video thumbnail returns a PIL Image."""
-        project, db_media_list = fxt_project_with_media
-        media = Video.model_validate(db_media_list[3], from_attributes=True)
-
-        # Create the dataset directory and a test video file
-        dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
-        dataset_dir.mkdir(parents=True, exist_ok=True)
-        video_path = dataset_dir / f"{media.id}.{media.format}"
-
-        # Generate video
-        fxt_video_data(video_path)
-
-        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media=media)
-
-        assert isinstance(thumbnail, PILImage.Image)
-        assert thumbnail.width == 256
-        assert thumbnail.height == 256
 
     def test_delete_media(
         self,

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -12,11 +12,11 @@ from uuid import UUID, uuid4
 import cv2
 import numpy as np
 import pytest
-from PIL import Image
+from PIL import Image as PILImage
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, DatasetItemLabelDB, MediaDB, PipelineDB
-from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Pipeline, Project
+from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Image, Pipeline, Project, Video, VideoFrame
 from app.models.media import ImageFormat, MediaType, VideoFormat
 from app.services import LabelService, PipelineService, ProjectService, SystemService
 from app.services.base import ResourceNotFoundError, ResourceType
@@ -165,8 +165,10 @@ def fxt_project_with_media(fxt_project_with_pipeline, db_session) -> tuple[Proje
 
 
 @pytest.fixture
-def fxt_video_frame(fxt_project_with_media: tuple[Project, list[MediaDB]], db_session) -> Callable[[int], MediaDB]:
-    def _create_video_frame(frame_index: int) -> MediaDB:
+def fxt_video_frame(
+    fxt_project_with_media: tuple[Project, list[MediaDB]], db_session
+) -> Callable[[int], tuple[DatasetItemDB, MediaDB]]:
+    def _create_video_frame(frame_index: int) -> tuple[DatasetItemDB, MediaDB]:
         project, db_media_list = fxt_project_with_media
         media = db_media_list[3]
 
@@ -186,7 +188,12 @@ def fxt_video_frame(fxt_project_with_media: tuple[Project, list[MediaDB]], db_se
         db_session.add(db_media)
         db_session.flush()
 
-        return db_media
+        db_dataset_item = DatasetItemDB(id=db_media.id, project_id=str(project.id), subset="unassigned")
+
+        db_session.add(db_dataset_item)
+        db_session.flush()
+
+        return db_dataset_item, db_media
 
     return _create_video_frame
 
@@ -516,7 +523,7 @@ class TestMediaServiceIntegration:
         use_pipeline_source: bool,
     ) -> None:
         """Test creating a media."""
-        image = Image.new("RGB", (1024, 768))
+        image = PILImage.new("RGB", (1024, 768))
 
         project, pipeline = fxt_project_with_pipeline
 
@@ -842,18 +849,42 @@ class TestMediaServiceIntegration:
     ):
         """Test generating an image thumbnail returns a PIL Image."""
         project, db_media_list = fxt_project_with_media
-        media = db_media_list[0]
+        media = Image.model_validate(db_media_list[0], from_attributes=True)
 
         # Create the dataset directory and a test image file
         dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
         dataset_dir.mkdir(parents=True, exist_ok=True)
         image_path = dataset_dir / f"{media.id}.{media.format}"
-        test_image = Image.new("RGB", (1024, 768), color="red")
+        test_image = PILImage.new("RGB", (1024, 768), color="red")
         test_image.save(image_path)
 
-        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media_id=UUID(media.id))
+        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media=media)
 
-        assert isinstance(thumbnail, Image.Image)
+        assert isinstance(thumbnail, PILImage.Image)
+        assert thumbnail.width == 256
+        assert thumbnail.height == 256
+
+    def test_generate_video_frame_thumbnail(
+        self,
+        tmp_path: Path,
+        fxt_projects_dir: Path,
+        fxt_media_service: MediaService,
+        fxt_project_with_media: tuple[Project, list[MediaDB]],
+    ):
+        """Test generating an image thumbnail returns a PIL Image."""
+        project, db_media_list = fxt_project_with_media
+        media = VideoFrame.model_validate(db_media_list[4], from_attributes=True)
+
+        # Create the dataset directory and a test image file
+        dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
+        dataset_dir.mkdir(parents=True, exist_ok=True)
+        image_path = dataset_dir / f"{media.id}.{media.format}"
+        test_image = PILImage.new("RGB", (1024, 768), color="red")
+        test_image.save(image_path)
+
+        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media=media)
+
+        assert isinstance(thumbnail, PILImage.Image)
         assert thumbnail.width == 256
         assert thumbnail.height == 256
 
@@ -867,7 +898,7 @@ class TestMediaServiceIntegration:
     ):
         """Test generating a video thumbnail returns a PIL Image."""
         project, db_media_list = fxt_project_with_media
-        media = db_media_list[3]
+        media = Video.model_validate(db_media_list[3], from_attributes=True)
 
         # Create the dataset directory and a test video file
         dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
@@ -877,26 +908,11 @@ class TestMediaServiceIntegration:
         # Generate video
         fxt_video_data(video_path)
 
-        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media_id=UUID(media.id))
+        thumbnail = fxt_media_service.generate_media_thumbnail(project=project, media=media)
 
-        assert isinstance(thumbnail, Image.Image)
+        assert isinstance(thumbnail, PILImage.Image)
         assert thumbnail.width == 256
         assert thumbnail.height == 256
-
-    def test_generate_media_thumbnail_not_found(
-        self,
-        fxt_media_service: MediaService,
-        fxt_project_with_media: tuple[Project, list[MediaDB]],
-    ):
-        """Test generating a thumbnail for a non-existent dataset item raises error."""
-        project, db_media_list = fxt_project_with_media
-        non_existent_id = uuid4()
-
-        with pytest.raises(ResourceNotFoundError) as excinfo:
-            fxt_media_service.generate_media_thumbnail(project=project, media_id=non_existent_id)
-
-        assert excinfo.value.resource_type == ResourceType.MEDIA
-        assert excinfo.value.resource_id == str(non_existent_id)
 
     def test_delete_media(
         self,
@@ -1369,7 +1385,7 @@ class TestMediaServiceIntegration:
     ):
         """Test extracting a videoframe."""
         project, db_media_list = fxt_project_with_media
-        media = db_media_list[3]
+        media = Video.model_validate(db_media_list[3], from_attributes=True)
 
         # Create the dataset directory and a test video file
         dataset_dir = tmp_path / fxt_projects_dir / str(project.id) / "dataset"
@@ -1379,7 +1395,7 @@ class TestMediaServiceIntegration:
         # Generate video
         fxt_video_data(video_path)
 
-        video_frame = fxt_media_service.extract_video_frame(project=project, video_id=UUID(media.id), frame_index=50)
+        video_frame = fxt_media_service.extract_video_frame(project=project, video=media, frame_index=50)
 
         video_frame_binary_path = dataset_dir / f"{video_frame.id}.jpg"
         assert os.path.exists(video_frame_binary_path)
@@ -1394,14 +1410,14 @@ class TestMediaServiceIntegration:
             and db_video_frame.format == "jpg"
             and db_video_frame.width == 640
             and db_video_frame.height == 480
-            and db_video_frame.video_id == media.id
+            and db_video_frame.video_id == str(media.id)
             and db_video_frame.frame_index == 50
         )
 
     def test_get_video_frame_by_video_id_and_index(
         self,
         fxt_media_service: MediaService,
-        fxt_video_frame: Callable[[int], MediaDB],
+        fxt_video_frame: Callable[[float], tuple[DatasetItemDB, MediaDB]],
         fxt_project_with_media: tuple[Project, list[MediaDB]],
     ) -> None:
         """Test getting a video frame by video ID and index."""
@@ -1417,7 +1433,7 @@ class TestMediaServiceIntegration:
     def test_get_non_existing_video_frame_by_video_id_and_index(
         self,
         fxt_media_service: MediaService,
-        fxt_video_frame: Callable[[int], MediaDB],
+        fxt_video_frame: Callable[[float], tuple[DatasetItemDB, MediaDB]],
         fxt_project_with_media: tuple[Project, list[MediaDB]],
     ) -> None:
         """Test getting a non extracted video frame by video ID and index."""
@@ -1433,7 +1449,7 @@ class TestMediaServiceIntegration:
     def test_get_video_frames_by_video_id(
         self,
         fxt_media_service: MediaService,
-        fxt_video_frame: Callable[[float], MediaDB],
+        fxt_video_frame: Callable[[float], tuple[DatasetItemDB, MediaDB]],
         fxt_project_with_media: tuple[Project, list[MediaDB]],
     ) -> None:
         """Test getting a list of video frames by video ID."""
@@ -1442,7 +1458,29 @@ class TestMediaServiceIntegration:
         fxt_video_frame(1.0)
         fxt_video_frame(2.0)
 
-        video_frames = fxt_media_service.get_video_frames_by_video_id(project=project, video_id=UUID(media.id))
-        print(video_frames)
+        video_frames = fxt_media_service.list_annotated_video_frames_by_video_id(
+            project=project, video_id=UUID(media.id)
+        )
         assert video_frames is not None
         assert len(video_frames) == 2
+
+    @pytest.mark.parametrize("index_from, index_to", [(0, 35), (35, 55)])
+    def test_get_video_frames_by_video_id_range(
+        self,
+        index_from: int,
+        index_to: int,
+        fxt_media_service: MediaService,
+        fxt_video_frame: Callable[[float], tuple[DatasetItemDB, MediaDB]],
+        fxt_project_with_media: tuple[Project, list[MediaDB]],
+    ) -> None:
+        """Test getting a list of video frames by video ID."""
+        project, db_media_list = fxt_project_with_media
+        media = db_media_list[3]
+        fxt_video_frame(30.0)
+        fxt_video_frame(40.0)
+
+        video_frames = fxt_media_service.list_annotated_video_frames_by_video_id(
+            project=project, video_id=UUID(media.id), frame_index_from=index_from, frame_index_to=index_to
+        )
+        assert video_frames is not None
+        assert len(video_frames) == 1

--- a/application/backend/tests/unit/routers/test_dataset_revisions.py
+++ b/application/backend/tests/unit/routers/test_dataset_revisions.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -376,7 +377,7 @@ class TestDatasetRevisionItemEndpoints:
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             tmp_file.write(b"test image data")
             tmp_file.flush()
-            tmp_file_path = tmp_file.name
+            tmp_file_path = Path(tmp_file.name)
 
         try:
             fxt_dataset_revision_service.get_dataset_revision_item.return_value = MagicMock(image_path=tmp_file_path)

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import os
+from pathlib import Path
 import tempfile
 from datetime import datetime
 from io import BytesIO
@@ -8,6 +9,7 @@ from unittest.mock import ANY, MagicMock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
+from PIL import Image as PILImage
 import pytest
 from fastapi import status
 
@@ -518,29 +520,42 @@ class TestMediaEndpoints:
 
     def test_get_media_thumbnail_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()
-        fxt_media_service.generate_media_thumbnail.side_effect = ResourceNotFoundError(
+        fxt_media_service.get_media_thumbnail_path_by_id.side_effect = ResourceNotFoundError(
             ResourceType.MEDIA, str(media_id)
         )
 
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/thumbnail")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media_id=media_id)
+        fxt_media_service.get_media_thumbnail_path_by_id.assert_called_once_with(
+            project=fxt_get_project, media_id=media_id
+        )
 
     def test_get_media_thumbnail_success(self, fxt_get_project, fxt_media_service, fxt_client):
-        from PIL import Image
-
+        project_id = uuid4()
         media_id = uuid4()
 
-        # Create a test PIL Image to return from the mock
-        test_image = Image.new("RGB", (64, 64), color="blue")
-        fxt_media_service.generate_media_thumbnail.return_value = test_image
+        # Create a temporary JPEG file to act as the thumbnail
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+            thumbnail_path = Path(tmp_file.name)
+            img = PILImage.new("RGB", (64, 64), color="red")
+            img.save(tmp_file, format="JPEG")
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/thumbnail")
+        try:
+            fxt_media_service.get_media_thumbnail_path_by_id.return_value = thumbnail_path
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.headers["content-type"] == "image/jpeg"
-        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media_id=media_id)
+            response = fxt_client.get(f"/api/projects/{project_id}/dataset/media/{str(media_id)}/thumbnail")
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.headers["content-type"] == "image/jpeg"
+            with open(thumbnail_path, "rb") as f:
+                assert response.content == f.read()
+            fxt_media_service.get_media_thumbnail_path_by_id.assert_called_once_with(
+                project=fxt_get_project, media_id=media_id
+            )
+        finally:
+            if thumbnail_path.exists():
+                os.unlink(thumbnail_path)
 
     def test_delete_media_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from datetime import datetime
 from io import BytesIO
+from pathlib import Path
 from unittest.mock import ANY, MagicMock, PropertyMock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
@@ -505,27 +506,25 @@ class TestMediaEndpoints:
     def test_get_media_binary_success(
         self, fxt_get_project, fxt_media_service, fxt_client, spec, media_type, format, suffix
     ):
-        media_id = uuid4()
-
-        media = MagicMock(spec=spec, id=media_id, format=format, type=media_type)
+        media = MagicMock(spec=spec, id=uuid4(), format=format, type=media_type)
         type(media).name = PropertyMock(return_value="test")
         fxt_media_service.get_media_by_id.return_value = media
 
         tmp_file_path = None
         try:
             with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
-                temp_file_path = tmp_file.name
+                temp_file_path = Path(tmp_file.name)
                 fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
-                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/binary")
+                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/binary")
 
         finally:
             if tmp_file_path and os.path.exists(tmp_file_path):
                 os.unlink(tmp_file_path)
         assert response.status_code == status.HTTP_200_OK
 
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_media_service.get_media_binary_path_by_id.assert_called_once_with(
-            project_id=fxt_get_project.id, media_id=media_id
+            project_id=fxt_get_project.id, media_id=media.id
         )
 
     def test_get_video_frame_binary_on_the_fly_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
@@ -542,7 +541,7 @@ class TestMediaEndpoints:
         tmp_file_path = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
-                temp_file_path = tmp_file.name
+                temp_file_path = Path(tmp_file.name)
                 fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
                 response = fxt_client.get(
                     f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/binary?frame_index=10"
@@ -621,9 +620,7 @@ class TestMediaEndpoints:
     ):
         from PIL import Image
 
-        media_id = uuid4()
-
-        media = MagicMock(spec=spec, id=media_id, format=format, type=media_type)
+        media = MagicMock(spec=spec, id=uuid4(), format=format, type=media_type)
         type(media).name = PropertyMock(return_value="test")
         fxt_media_service.get_media_by_id.return_value = media
 
@@ -631,7 +628,7 @@ class TestMediaEndpoints:
         test_image = Image.new("RGB", (64, 64), color="blue")
         fxt_media_service.generate_media_thumbnail.return_value = test_image
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/thumbnail")
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/thumbnail")
 
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["content-type"] == "image/jpeg"
@@ -720,20 +717,22 @@ class TestMediaEndpoints:
 
     def test_delete_media_success(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()
-
         response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         fxt_media_service.delete_media.assert_called_once_with(project=fxt_get_project, media_id=media_id)
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_set_media_annotations_success(
         self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=label_id)],
@@ -750,7 +749,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.set_dataset_item_annotations.return_value = dataset_item
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
@@ -766,10 +765,10 @@ class TestMediaEndpoints:
             "prediction_model_id": None,
             "user_reviewed": True,
         }
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.set_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
             annotations=annotations,
             user_reviewed=True,
         )
@@ -778,56 +777,50 @@ class TestMediaEndpoints:
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=label_id)],
                 shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
             )
         ]
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.set_dataset_item_annotations.assert_not_called()
 
     def test_set_video_annotations_index_exceeds(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=label_id)],
                 shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
             )
         ]
-        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=10)
+        media = MagicMock(spec=Video, id=uuid4(), type=MediaType.VIDEO, frame_count=10)
         fxt_media_service.get_media_by_id.return_value = media
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=100",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=100",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.set_dataset_item_annotations.assert_not_called()
 
     def test_set_video_annotations_existing_frame(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         video_frame_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
@@ -835,11 +828,7 @@ class TestMediaEndpoints:
                 shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
             )
         ]
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
         video_frame = MagicMock(
             spec=VideoFrame,
@@ -855,7 +844,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.set_dataset_item_annotations.return_value = dataset_item
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=10",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
@@ -871,9 +860,9 @@ class TestMediaEndpoints:
             "prediction_model_id": None,
             "user_reviewed": True,
         }
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-            project=fxt_get_project, video_id=media_id, frame_index=10
+            project=fxt_get_project, video_id=media.id, frame_index=10
         )
         fxt_dataset_service.set_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
@@ -886,7 +875,6 @@ class TestMediaEndpoints:
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         video_frame_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
@@ -894,11 +882,7 @@ class TestMediaEndpoints:
                 shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
             )
         ]
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
         video_frame = MagicMock(
@@ -916,7 +900,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.set_dataset_item_annotations.return_value = dataset_item
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=10",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
@@ -932,9 +916,9 @@ class TestMediaEndpoints:
             "prediction_model_id": None,
             "user_reviewed": True,
         }
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-            project=fxt_get_project, video_id=media_id, frame_index=10
+            project=fxt_get_project, video_id=media.id, frame_index=10
         )
         fxt_media_service.extract_video_frame.assert_called_once_with(
             project=fxt_get_project, video=media, frame_index=10
@@ -952,13 +936,16 @@ class TestMediaEndpoints:
         )
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_set_media_annotations_label_not_found(
         self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=label_id)],
@@ -969,26 +956,29 @@ class TestMediaEndpoints:
         fxt_dataset_service.set_dataset_item_annotations.side_effect = AnnotationValidationError(str(label_id))
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         fxt_dataset_service.set_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
             annotations=annotations,
             user_reviewed=True,
         )
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_set_media_annotations_not_found(
         self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=label_id)],
@@ -997,28 +987,31 @@ class TestMediaEndpoints:
         ]
         fxt_media_service.get_media_by_id.return_value = media
         fxt_dataset_service.set_dataset_item_annotations.side_effect = ResourceNotFoundError(
-            ResourceType.DATASET_ITEM, str(media_id)
+            ResourceType.DATASET_ITEM, str(media.id)
         )
 
         response = fxt_client.post(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations",
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         fxt_dataset_service.set_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
             annotations=annotations,
             user_reviewed=True,
         )
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_get_media_annotations(self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client):
         label_id = uuid4()
-        media_id = uuid4()
         fxt_media_service.get_media_by_id.return_value = media
         dataset_item = MagicMock(
             spec=DatasetItem,
@@ -1033,7 +1026,7 @@ class TestMediaEndpoints:
         )
         fxt_dataset_service.get_dataset_item_by_id.return_value = dataset_item
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -1047,24 +1040,19 @@ class TestMediaEndpoints:
             "prediction_model_id": None,
             "user_reviewed": True,
         }
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.get_dataset_item_by_id.assert_called_once_with(
             project_id=fxt_get_project.id,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
         )
 
     def test_get_video_annotations_missing_frame_index(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         fxt_dataset_service.get_dataset_item_by_id.assert_not_called()
@@ -1072,16 +1060,11 @@ class TestMediaEndpoints:
     def test_get_video_annotations_index_exceeds(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=10,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=10, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=100"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=100"
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1091,13 +1074,8 @@ class TestMediaEndpoints:
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
         video_frame_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
         video_frame = MagicMock(
             spec=VideoFrame,
@@ -1118,7 +1096,7 @@ class TestMediaEndpoints:
         fxt_dataset_service.get_dataset_item_by_id.return_value = dataset_item
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -1133,9 +1111,9 @@ class TestMediaEndpoints:
             "prediction_model_id": None,
             "user_reviewed": True,
         }
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-            project=fxt_get_project, video_id=media_id, frame_index=10
+            project=fxt_get_project, video_id=media.id, frame_index=10
         )
         fxt_dataset_service.get_dataset_item_by_id.assert_called_once_with(
             project_id=fxt_get_project.id,
@@ -1146,12 +1124,7 @@ class TestMediaEndpoints:
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
         label_id = uuid4()
-        media_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
         dataset_item = MagicMock(
@@ -1168,118 +1141,113 @@ class TestMediaEndpoints:
         fxt_dataset_service.get_dataset_item_by_id.return_value = dataset_item
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-            project=fxt_get_project, video_id=media_id, frame_index=10
+            project=fxt_get_project, video_id=media.id, frame_index=10
         )
         fxt_dataset_service.get_dataset_item_by_id.assert_not_called()
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_get_media_annotations_not_found(
         self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
         fxt_media_service.get_media_by_id.return_value = media
         fxt_dataset_service.get_dataset_item_by_id.side_effect = ResourceNotFoundError(
-            ResourceType.DATASET_ITEM, str(media_id)
+            ResourceType.DATASET_ITEM, str(media.id)
         )
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.get_dataset_item_by_id.assert_called_once_with(
             project_id=fxt_get_project.id,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
         )
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_get_media_annotations_not_annotated(
         self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
         fxt_media_service.get_media_by_id.return_value = media
         dataset_item = MagicMock(spec=DatasetItem, annotation_data=None, user_reviewed=False, prediction_model_id=None)
         fxt_dataset_service.get_dataset_item_by_id.return_value = dataset_item
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.get_dataset_item_by_id.assert_called_once_with(
             project_id=fxt_get_project.id,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
         )
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_delete_media_annotations(self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client):
-        media_id = uuid4()
         fxt_media_service.get_media_by_id.return_value = media
 
-        response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
         )
 
     def test_delete_video_annotations_missing_frame_index(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
 
-        response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_not_called()
 
     def test_delete_video_annotations_index_exceeds(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=10,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=10, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
 
         response = fxt_client.delete(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=100"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=100"
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_not_called()
 
     def test_delete_video_annotations_existing_frame(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
         video_frame_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
         video_frame = MagicMock(
             spec=VideoFrame,
@@ -1288,11 +1256,11 @@ class TestMediaEndpoints:
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
 
         response = fxt_client.delete(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
             dataset_item_id=video_frame_id,
@@ -1301,62 +1269,62 @@ class TestMediaEndpoints:
     def test_delete_video_annotations_frame_not_found(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
-        media = MagicMock(
-            spec=Video,
-            type=MediaType.VIDEO,
-            frame_count=20,
-        )
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=20, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = media
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
 
         response = fxt_client.delete(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=10"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations?frame_index=10"
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_not_called()
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_delete_media_annotations_not_found(
         self, media, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
-        media_id = uuid4()
         fxt_media_service.get_media_by_id.return_value = media
         fxt_dataset_service.delete_dataset_item_annotations.side_effect = ResourceNotFoundError(
-            ResourceType.DATASET_ITEM, str(media_id)
+            ResourceType.DATASET_ITEM, str(media.id)
         )
 
-        response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+        response = fxt_client.delete(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/annotations")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
-            dataset_item_id=media_id,
+            dataset_item_id=media.id,
         )
 
     @pytest.mark.parametrize(
-        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+        "media",
+        [
+            MagicMock(spec=Image, type=MediaType.IMAGE, id=uuid4()),
+            MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=uuid4()),
+        ],
     )
     def test_list_video_frames_wrong_type(self, media, fxt_get_project, fxt_media_service, fxt_client):
-        media_id = uuid4()
         fxt_media_service.get_media_by_id.return_value = media
 
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/frames")
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/frames")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
         fxt_media_service.list_annotated_video_frames_by_video_id.assert_not_called()
 
     def test_list_video_frames(self, fxt_get_project, fxt_media_service, fxt_client):
-        media_id = uuid4()
         video_frame_id = uuid4()
         label_id = uuid4()
-        video = MagicMock(spec=Video, type=MediaType.VIDEO, id=media_id)
+        video = MagicMock(spec=Video, type=MediaType.VIDEO, id=uuid4())
         fxt_media_service.get_media_by_id.return_value = video
 
         dataset_item = MagicMock(
@@ -1375,7 +1343,7 @@ class TestMediaEndpoints:
         fxt_media_service.list_annotated_video_frames_by_video_id.return_value = [(dataset_item, video_frame)]
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/frames?frame_index_from=1&frame_index_to=9"
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(video.id)}/frames?frame_index_from=1&frame_index_to=9"
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -1383,7 +1351,7 @@ class TestMediaEndpoints:
             {
                 "media_id": str(video_frame_id),
                 "frame_index": 5,
-                "dataset": {
+                "annotation_data": {
                     "annotations": [
                         {
                             "confidences": None,
@@ -1396,10 +1364,10 @@ class TestMediaEndpoints:
                 },
             }
         ]
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video.id)
         fxt_media_service.list_annotated_video_frames_by_video_id.assert_called_once_with(
             project=fxt_get_project,
-            video_id=media_id,
+            video_id=video.id,
             frame_index_from=1,
             frame_index_to=9,
         )

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from datetime import datetime
 from io import BytesIO
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, MagicMock, PropertyMock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
@@ -487,50 +487,145 @@ class TestMediaEndpoints:
 
     def test_get_media_binary_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()
-        fxt_media_service.get_media_binary_path_by_id.side_effect = ResourceNotFoundError(
-            ResourceType.DATASET_ITEM, str(media_id)
-        )
+        fxt_media_service.get_media_by_id.side_effect = ResourceNotFoundError(ResourceType.MEDIA, str(media_id))
 
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/binary")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+
+    @pytest.mark.parametrize(
+        "spec, media_type, format, suffix",
+        [
+            (Image, MediaType.IMAGE, ImageFormat.JPG, ".jpg"),
+            (Video, MediaType.VIDEO, VideoFormat.MP4, ".mp4"),
+            (VideoFrame, MediaType.VIDEO_FRAME, ImageFormat.JPG, ".jpg"),
+        ],
+    )
+    def test_get_media_binary_success(
+        self, fxt_get_project, fxt_media_service, fxt_client, spec, media_type, format, suffix
+    ):
+        media_id = uuid4()
+
+        media = MagicMock(spec=spec, id=media_id, format=format, type=media_type)
+        type(media).name = PropertyMock(return_value="test")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        tmp_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
+                temp_file_path = tmp_file.name
+                fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
+                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/binary")
+
+        finally:
+            if tmp_file_path and os.path.exists(tmp_file_path):
+                os.unlink(tmp_file_path)
+        assert response.status_code == status.HTTP_200_OK
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
         fxt_media_service.get_media_binary_path_by_id.assert_called_once_with(
             project_id=fxt_get_project.id, media_id=media_id
         )
 
-    def test_get_media_binary_success(self, fxt_get_project, fxt_media_service, fxt_client):
-        media_id = uuid4()
+    def test_get_video_frame_binary_on_the_fly_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
+        video_id = uuid4()
+        video_frame_id = uuid4()
+
+        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
+        fxt_media_service.get_media_by_id.return_value = media
+
+        video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG)
+        type(video_frame).name = PropertyMock(return_value="test_10")
+        fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
 
         tmp_file_path = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
                 temp_file_path = tmp_file.name
                 fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
-                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/binary")
+                response = fxt_client.get(
+                    f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/binary?frame_index=10"
+                )
 
-            assert response.status_code == status.HTTP_200_OK
-            fxt_media_service.get_media_binary_path_by_id.assert_called_once_with(
-                project_id=fxt_get_project.id, media_id=media_id
-            )
         finally:
             if tmp_file_path and os.path.exists(tmp_file_path):
                 os.unlink(tmp_file_path)
+        assert response.status_code == status.HTTP_200_OK
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
+            project=fxt_get_project, video_id=video_id, frame_index=10
+        )
+        fxt_media_service.get_media_binary_path_by_id.assert_called_once_with(
+            project_id=fxt_get_project.id, media_id=video_frame_id
+        )
+
+    def test_get_video_frame_binary_on_the_fly_not_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
+        from PIL import Image
+
+        video_id = uuid4()
+
+        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
+        type(media).name = PropertyMock(return_value="test")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
+        test_image = Image.new("RGB", (64, 64), color="blue")
+        fxt_media_service.get_frame_binary.return_value = test_image
+
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/binary?frame_index=10")
+        assert response.status_code == status.HTTP_200_OK
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
+            project=fxt_get_project, video_id=video_id, frame_index=10
+        )
+        fxt_media_service.get_frame_binary.assert_called_once_with(project=fxt_get_project, video=media, frame_index=10)
+        fxt_media_service.get_media_binary_path_by_id.assert_not_called()
+
+    def test_get_video_frame_binary_on_the_fly_index_exceeds(self, fxt_get_project, fxt_media_service, fxt_client):
+        video_id = uuid4()
+
+        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=10)
+        type(media).name = PropertyMock(return_value="test")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/binary?frame_index=100")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_video_frame_by_video_id_and_index.assert_not_called()
+        fxt_media_service.get_frame_binary.assert_not_called()
+        fxt_media_service.get_media_binary_path_by_id.assert_not_called()
 
     def test_get_media_thumbnail_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()
-        fxt_media_service.generate_media_thumbnail.side_effect = ResourceNotFoundError(
-            ResourceType.MEDIA, str(media_id)
-        )
+        fxt_media_service.get_media_by_id.side_effect = ResourceNotFoundError(ResourceType.MEDIA, str(media_id))
 
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/thumbnail")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media_id=media_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
 
-    def test_get_media_thumbnail_success(self, fxt_get_project, fxt_media_service, fxt_client):
+    @pytest.mark.parametrize(
+        "spec, media_type, format, suffix",
+        [
+            (Image, MediaType.IMAGE, ImageFormat.JPG, ".jpg"),
+            (Video, MediaType.VIDEO, VideoFormat.MP4, ".mp4"),
+            (VideoFrame, MediaType.VIDEO_FRAME, ImageFormat.JPG, ".jpg"),
+        ],
+    )
+    def test_get_media_thumbnail_success(
+        self, fxt_get_project, fxt_media_service, fxt_client, spec, media_type, format, suffix
+    ):
         from PIL import Image
 
         media_id = uuid4()
+
+        media = MagicMock(spec=spec, id=media_id, format=format, type=media_type)
+        type(media).name = PropertyMock(return_value="test")
+        fxt_media_service.get_media_by_id.return_value = media
 
         # Create a test PIL Image to return from the mock
         test_image = Image.new("RGB", (64, 64), color="blue")
@@ -540,7 +635,79 @@ class TestMediaEndpoints:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.headers["content-type"] == "image/jpeg"
-        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media_id=media_id)
+        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media=media)
+
+    def test_get_video_frame_thumbnail_on_the_fly_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
+        from PIL import Image
+
+        video_id = uuid4()
+        video_frame_id = uuid4()
+
+        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
+        fxt_media_service.get_media_by_id.return_value = media
+
+        video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG)
+        type(video_frame).name = PropertyMock(return_value="test_10")
+        fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
+
+        # Create a test PIL Image to return from the mock
+        test_image = Image.new("RGB", (64, 64), color="blue")
+        fxt_media_service.generate_media_thumbnail.return_value = test_image
+
+        response = fxt_client.get(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
+            project=fxt_get_project, video_id=video_id, frame_index=10
+        )
+        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media=video_frame)
+
+    def test_get_video_frame_thumbnail_on_the_fly_not_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
+        from PIL import Image
+
+        video_id = uuid4()
+
+        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
+        type(media).name = PropertyMock(return_value="test")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
+        test_image = Image.new("RGB", (64, 64), color="blue")
+        fxt_media_service.get_frame_thumbnail.return_value = test_image
+
+        response = fxt_client.get(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
+            project=fxt_get_project, video_id=video_id, frame_index=10
+        )
+        fxt_media_service.get_frame_thumbnail.assert_called_once_with(
+            project=fxt_get_project, video=media, frame_index=10
+        )
+        fxt_media_service.generate_media_thumbnail.assert_not_called()
+
+    def test_get_video_frame_thumbnail_on_the_fly_index_exceeds(self, fxt_get_project, fxt_media_service, fxt_client):
+        video_id = uuid4()
+
+        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=10)
+        type(media).name = PropertyMock(return_value="test")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.get(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=100"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_video_frame_by_video_id_and_index.assert_not_called()
+        fxt_media_service.get_frame_thumbnail.assert_not_called()
+        fxt_media_service.generate_media_thumbnail.assert_not_called()
 
     def test_delete_media_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()
@@ -626,6 +793,29 @@ class TestMediaEndpoints:
 
         response = fxt_client.post(
             f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations",
+            json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_dataset_service.set_dataset_item_annotations.assert_not_called()
+
+    def test_set_video_annotations_index_exceeds(
+        self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
+    ):
+        label_id = uuid4()
+        media_id = uuid4()
+        annotations = [
+            DatasetItemAnnotation(
+                labels=[LabelReference(id=label_id)],
+                shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
+            )
+        ]
+        media = MagicMock(spec=Video, type=MediaType.VIDEO, frame_count=10)
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.post(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=100",
             json=SetMediaAnnotations(annotations=annotations).model_dump(mode="json"),
         )
 
@@ -747,7 +937,7 @@ class TestMediaEndpoints:
             project=fxt_get_project, video_id=media_id, frame_index=10
         )
         fxt_media_service.extract_video_frame.assert_called_once_with(
-            project=fxt_get_project, video_id=media_id, frame_index=10
+            project=fxt_get_project, video=media, frame_index=10
         )
         fxt_dataset_service.create_dataset_item.assert_called_once_with(
             project=fxt_get_project,
@@ -875,6 +1065,24 @@ class TestMediaEndpoints:
         fxt_media_service.get_media_by_id.return_value = media
 
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        fxt_dataset_service.get_dataset_item_by_id.assert_not_called()
+
+    def test_get_video_annotations_index_exceeds(
+        self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
+    ):
+        media_id = uuid4()
+        media = MagicMock(
+            spec=Video,
+            type=MediaType.VIDEO,
+            frame_count=10,
+        )
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.get(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=100"
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         fxt_dataset_service.get_dataset_item_by_id.assert_not_called()
@@ -1043,6 +1251,25 @@ class TestMediaEndpoints:
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
         fxt_dataset_service.delete_dataset_item_annotations.assert_not_called()
 
+    def test_delete_video_annotations_index_exceeds(
+        self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
+    ):
+        media_id = uuid4()
+        media = MagicMock(
+            spec=Video,
+            type=MediaType.VIDEO,
+            frame_count=10,
+        )
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.delete(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/annotations?frame_index=100"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_dataset_service.delete_dataset_item_annotations.assert_not_called()
+
     def test_delete_video_annotations_existing_frame(
         self, fxt_get_project, fxt_media_service, fxt_dataset_service, fxt_client
     ):
@@ -1110,4 +1337,69 @@ class TestMediaEndpoints:
         fxt_dataset_service.delete_dataset_item_annotations.assert_called_once_with(
             project=fxt_get_project,
             dataset_item_id=media_id,
+        )
+
+    @pytest.mark.parametrize(
+        "media", [MagicMock(spec=Image, type=MediaType.IMAGE), MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME)]
+    )
+    def test_list_video_frames_wrong_type(self, media, fxt_get_project, fxt_media_service, fxt_client):
+        media_id = uuid4()
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/frames")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.list_annotated_video_frames_by_video_id.assert_not_called()
+
+    def test_list_video_frames(self, fxt_get_project, fxt_media_service, fxt_client):
+        media_id = uuid4()
+        video_frame_id = uuid4()
+        label_id = uuid4()
+        video = MagicMock(spec=Video, type=MediaType.VIDEO, id=media_id)
+        fxt_media_service.get_media_by_id.return_value = video
+
+        dataset_item = MagicMock(
+            spec=DatasetItem,
+            user_reviewed=True,
+            prediction_model_id=None,
+            annotation_data=[
+                DatasetItemAnnotation(
+                    labels=[LabelReference(id=label_id)],
+                    shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
+                )
+            ],
+        )
+        video_frame = MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, id=video_frame_id, frame_index=5)
+
+        fxt_media_service.list_annotated_video_frames_by_video_id.return_value = [(dataset_item, video_frame)]
+
+        response = fxt_client.get(
+            f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/frames?frame_index_from=1&frame_index_to=9"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == [
+            {
+                "media_id": str(video_frame_id),
+                "frame_index": 5,
+                "dataset": {
+                    "annotations": [
+                        {
+                            "confidences": None,
+                            "labels": [{"id": str(label_id)}],
+                            "shape": {"height": 10, "type": "rectangle", "width": 10, "x": 0, "y": 0},
+                        }
+                    ],
+                    "prediction_model_id": None,
+                    "user_reviewed": True,
+                },
+            }
+        ]
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
+        fxt_media_service.list_annotated_video_frames_by_video_id.assert_called_once_with(
+            project=fxt_get_project,
+            video_id=media_id,
+            frame_index_from=1,
+            frame_index_to=9,
         )

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -510,7 +510,7 @@ class TestMediaEndpoints:
         type(media).name = PropertyMock(return_value="test")
         fxt_media_service.get_media_by_id.return_value = media
 
-        tmp_file_path = None
+        temp_file_path = None
         try:
             with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
                 temp_file_path = Path(tmp_file.name)
@@ -518,8 +518,8 @@ class TestMediaEndpoints:
                 response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/binary")
 
         finally:
-            if tmp_file_path and os.path.exists(tmp_file_path):
-                os.unlink(tmp_file_path)
+            if temp_file_path and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
         assert response.status_code == status.HTTP_200_OK
 
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
@@ -538,7 +538,7 @@ class TestMediaEndpoints:
         type(video_frame).name = PropertyMock(return_value="test_10")
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
 
-        tmp_file_path = None
+        temp_file_path = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
                 temp_file_path = Path(tmp_file.name)
@@ -548,8 +548,8 @@ class TestMediaEndpoints:
                 )
 
         finally:
-            if tmp_file_path and os.path.exists(tmp_file_path):
-                os.unlink(tmp_file_path)
+            if temp_file_path and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
         assert response.status_code == status.HTTP_200_OK
 
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import os
-from pathlib import Path
 import tempfile
 from datetime import datetime
 from io import BytesIO
@@ -10,9 +9,9 @@ from unittest.mock import ANY, MagicMock, PropertyMock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
-from PIL import Image as PILImage
 import pytest
 from fastapi import status
+from PIL import Image as PILImage
 
 from app.api.dependencies import get_dataset_service, get_media_service
 from app.api.schemas.media import ImageView, MediaViewAdapter, SetMediaAnnotations, VideoFrameView, VideoView
@@ -388,7 +387,7 @@ class TestMediaEndpoints:
                 "get",
                 f"/api/projects/{uuid4()}/dataset/media/invalid-id/thumbnail",
                 "fxt_media_service",
-                "generate_media_thumbnail",
+                "get_media_thumbnail_path",
             ),
             ("delete", f"/api/projects/{uuid4()}/dataset/media/invalid-id", "fxt_media_service", "delete_media"),
             (
@@ -602,27 +601,28 @@ class TestMediaEndpoints:
 
     def test_get_media_thumbnail_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()
-        fxt_media_service.get_media_thumbnail_path_by_id.side_effect = ResourceNotFoundError(
-            ResourceType.MEDIA, str(media_id)
-        )
+        fxt_media_service.get_media_by_id.side_effect = ResourceNotFoundError(ResourceType.MEDIA, str(media_id))
 
         response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/thumbnail")
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_thumbnail_path_by_id.assert_called_once_with(
-            project=fxt_get_project, media_id=media_id
-        )
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
 
     @pytest.mark.parametrize(
-        "spec, media_type, format, suffix",
+        "media, suffix, mime_type",
         [
-            (Image, MediaType.IMAGE, ImageFormat.JPG, ".jpg"),
-            (Video, MediaType.VIDEO, VideoFormat.MP4, ".mp4"),
-            (VideoFrame, MediaType.VIDEO_FRAME, ImageFormat.JPG, ".jpg"),
+            (MagicMock(spec=Image, id=uuid4(), format=ImageFormat.JPG, type=MediaType.IMAGE), ".jpg", "image/jpeg"),
+            (MagicMock(spec=Video, id=uuid4(), format=VideoFormat.MP4, type=MediaType.VIDEO), ".mp4", "video/mp4"),
+            (
+                MagicMock(spec=VideoFrame, id=uuid4(), format=ImageFormat.JPG, type=MediaType.VIDEO_FRAME),
+                ".jpg",
+                "image/jpeg",
+            ),
         ],
     )
-    def test_get_media_thumbnail_success(self, fxt_get_project, fxt_media_service, fxt_client, spec, media_type, format, suffix):
-        media = MagicMock(spec=spec, id=uuid4(), format=format, type=media_type)
+    def test_get_media_thumbnail_success(
+        self, fxt_get_project, fxt_media_service, fxt_client, media, suffix, mime_type
+    ):
         # Create a temporary JPEG file to act as the thumbnail
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
             thumbnail_path = Path(tmp_file.name)
@@ -630,52 +630,58 @@ class TestMediaEndpoints:
             img.save(tmp_file, format="JPEG")
 
         try:
-            fxt_media_service.get_media_thumbnail_path_by_id.return_value = thumbnail_path
+            fxt_media_service.get_media_by_id.return_value = media
+            fxt_media_service.get_media_thumbnail_path.return_value = thumbnail_path
 
             response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/media/{str(media.id)}/thumbnail")
 
             assert response.status_code == status.HTTP_200_OK
-            assert response.headers["content-type"] == "image/jpeg"
+            assert response.headers["content-type"] == mime_type
             with open(thumbnail_path, "rb") as f:
                 assert response.content == f.read()
-            fxt_media_service.get_media_thumbnail_path_by_id.assert_called_once_with(
-                project=fxt_get_project, media_id=media.id
-            )
+            fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
+            fxt_media_service.get_media_thumbnail_path.assert_called_once_with(project=fxt_get_project, media=media)
         finally:
             if thumbnail_path.exists():
                 os.unlink(thumbnail_path)
 
     def test_get_video_frame_thumbnail_on_the_fly_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
-        from PIL import Image
+        # Create a temporary JPEG file to act as the thumbnail
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+            thumbnail_path = Path(tmp_file.name)
+            img = PILImage.new("RGB", (64, 64), color="red")
+            img.save(tmp_file, format="JPEG")
 
-        video_id = uuid4()
-        video_frame_id = uuid4()
+        try:
+            video_id = uuid4()
+            video_frame_id = uuid4()
 
-        media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
-        fxt_media_service.get_media_by_id.return_value = media
+            media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
+            fxt_media_service.get_media_by_id.return_value = media
 
-        video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG)
-        type(video_frame).name = PropertyMock(return_value="test_10")
-        fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
+            fxt_media_service.get_media_thumbnail_path.return_value = thumbnail_path
 
-        # Create a test PIL Image to return from the mock
-        test_image = Image.new("RGB", (64, 64), color="blue")
-        fxt_media_service.generate_media_thumbnail.return_value = test_image
+            video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG)
+            type(video_frame).name = PropertyMock(return_value="test_10")
+            fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
 
-        response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
-        )
-        assert response.status_code == status.HTTP_200_OK
+            response = fxt_client.get(
+                f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
+            )
+            assert response.status_code == status.HTTP_200_OK
 
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
-        fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-            project=fxt_get_project, video_id=video_id, frame_index=10
-        )
-        fxt_media_service.generate_media_thumbnail.assert_called_once_with(project=fxt_get_project, media=video_frame)
+            fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+            fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
+                project=fxt_get_project, video_id=video_id, frame_index=10
+            )
+            fxt_media_service.get_media_thumbnail_path.assert_called_once_with(
+                project=fxt_get_project, media=video_frame
+            )
+        finally:
+            if thumbnail_path.exists():
+                os.unlink(thumbnail_path)
 
     def test_get_video_frame_thumbnail_on_the_fly_not_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
-        from PIL import Image
-
         video_id = uuid4()
 
         media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
@@ -683,7 +689,7 @@ class TestMediaEndpoints:
         fxt_media_service.get_media_by_id.return_value = media
 
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
-        test_image = Image.new("RGB", (64, 64), color="blue")
+        test_image = PILImage.new("RGB", (64, 64), color="blue")
         fxt_media_service.get_frame_thumbnail.return_value = test_image
 
         response = fxt_client.get(
@@ -698,7 +704,6 @@ class TestMediaEndpoints:
         fxt_media_service.get_frame_thumbnail.assert_called_once_with(
             project=fxt_get_project, video=media, frame_index=10
         )
-        fxt_media_service.generate_media_thumbnail.assert_not_called()
 
     def test_get_video_frame_thumbnail_on_the_fly_index_exceeds(self, fxt_get_project, fxt_media_service, fxt_client):
         video_id = uuid4()
@@ -715,8 +720,6 @@ class TestMediaEndpoints:
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_not_called()
         fxt_media_service.get_frame_thumbnail.assert_not_called()
-        fxt_media_service.generate_media_thumbnail.assert_not_called()
-
 
     def test_delete_media_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
         media_id = uuid4()


### PR DESCRIPTION
Resolves #5282

Following endpoints were modified

```
GET /api/projects/{project_id}/dataset/media/{media_id}/binary
```
This endpoint now can return annotated frames pre-extracted image content, as well it can extract image frames on the fly in case if it's not annotated yet.
It can work with both frame ID and combination of video ID + frame index.

```
GET /api/projects/{project_id}/dataset/media/{media_id}/thumbnail
```
This endpoint now can return annotated frames pre-extracted image thumbnail, as well it can extract image frames and crop them on the fly in case if it's not annotated yet.
It can work with both frame ID and combination of video ID + frame index.

New endpoint has been added:
```
GET /api/projects/{project_id}/dataset/media/{media_id}/frames
```
It returns the list of annotated video frames.