### PR TITLE
fix: Don't display tools in read only

### DIFF
--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -50,9 +50,10 @@ const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
 
 type AnnotatorCanvasProps = {
     mediaItem: Media;
+    isReadOnly?: boolean;
 };
 
-export const AnnotatorCanvas = ({ mediaItem }: AnnotatorCanvasProps) => {
+export const AnnotatorCanvas = ({ mediaItem, isReadOnly = false }: AnnotatorCanvasProps) => {
     const { annotations } = useAnnotationActions();
     const { selectedAnnotations } = useSelectedAnnotations();
     const { isFocussed } = useAnnotationVisibility();
@@ -80,7 +81,7 @@ export const AnnotatorCanvas = ({ mediaItem }: AnnotatorCanvasProps) => {
                     isFocussed={isFocussed}
                     annotations={orderedAnnotations}
                 />
-                <ToolManager />
+                {!isReadOnly && <ToolManager />}
             </div>
         </ZoomTransform>
     );

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -84,7 +84,7 @@ export const ReadOnlyAnnotator = ({
                 <AnnotatorCanvasSettings>
                     <Suspense fallback={<Loading size='L' mode='inline' style={{ height: '100%' }} />}>
                         <MediaItemImageLoader>
-                            <AnnotatorCanvas mediaItem={mediaItem} />
+                            <AnnotatorCanvas isReadOnly mediaItem={mediaItem} />
                         </MediaItemImageLoader>
                     </Suspense>
                 </AnnotatorCanvasSettings>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that the app was crashing whenever annotator was opened in the training datasets (in the models screen). This was because of the missing `ToolProvider` which is not needed in the read only view.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
