### PR TITLE
refactor: Use css zoom instead of transform

### DIFF
--- a/application/ui/src/components/zoom/zoom-transform.tsx
+++ b/application/ui/src/components/zoom/zoom-transform.tsx
@@ -111,7 +111,7 @@ export const ZoomTransform = ({ children, target, zoomInMultiplier = 10, zoomOut
             onPointerUp={onPointerUp}
             onMouseLeave={onMouseLeave}
         >
-            <div data-testid='zoom-transform' className={classes.wrapperInternal}>
+            <div data-testid='zoom-transform' data-zoom-value={zoom.scale} className={classes.wrapperInternal}>
                 {children}
             </div>
         </div>

--- a/application/ui/src/components/zoom/zoom-transform.tsx
+++ b/application/ui/src/components/zoom/zoom-transform.tsx
@@ -111,15 +111,7 @@ export const ZoomTransform = ({ children, target, zoomInMultiplier = 10, zoomOut
             onPointerUp={onPointerUp}
             onMouseLeave={onMouseLeave}
         >
-            <div
-                data-testid='zoom-transform'
-                className={classes.wrapperInternal}
-                style={{
-                    transformOrigin: '0 0',
-                    transition: zoom.hasAnimation ? 'transform 0.2s ease' : 'none',
-                    transform: `translate(${zoom.translate.x}px, ${zoom.translate.y}px) scale(${zoom.scale})`,
-                }}
-            >
+            <div data-testid='zoom-transform' className={classes.wrapperInternal}>
                 {children}
             </div>
         </div>

--- a/application/ui/src/components/zoom/zoom.module.scss
+++ b/application/ui/src/components/zoom/zoom.module.scss
@@ -6,6 +6,9 @@
     width: 100%;
     height: 100%;
     user-select: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .wrapperInternal {
@@ -13,4 +16,5 @@
     flex-wrap: wrap;
     width: fit-content;
     height: fit-content;
+    zoom: var(--zoom-scale);
 }

--- a/application/ui/src/components/zoom/zoom.test.tsx
+++ b/application/ui/src/components/zoom/zoom.test.tsx
@@ -16,7 +16,7 @@ describe('Zoom', () => {
     it('Scales and translates content so that it fits the screen', () => {
         const screenSize = { width: 500, height: 500 };
         const contentSize = { width: 500, height: 500 };
-        const expectedZoom = { translate: { x: 25, y: 25 }, scale: 0.9 };
+        const expectedZoom = 0.9;
 
         vi.mocked(useContainerSize).mockImplementation(() => screenSize);
 
@@ -28,8 +28,6 @@ describe('Zoom', () => {
 
         const transform = screen.getByTestId('zoom-transform');
 
-        expect(transform).toHaveStyle({
-            transform: `translate(${expectedZoom.translate.x}px, ${expectedZoom.translate.y}px) scale(${expectedZoom.scale})`,
-        });
+        expect(transform).toHaveAttribute('data-zoom-value', expectedZoom.toString());
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Today I realised that css has `zoom` built-in feature, tested it locally and that's working like a charm.

https://caniuse.com/?search=zoom

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
