### PR TITLE
Update test render with new query client

### DIFF
--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
@@ -9,7 +9,6 @@ import { getMockedProject } from '../../../mocks/mock-project';
 import { SchemaProjectView } from '../../api/openapi-spec';
 import { http } from '../../api/utils';
 import { server } from '../../msw-node-setup';
-import { queryClient } from '../../query-client/query-client';
 import { ExportDatasetConfig } from './export-dataset-config.component';
 
 describe('ExportDatasetConfig', () => {
@@ -20,10 +19,6 @@ describe('ExportDatasetConfig', () => {
         toggle: vi.fn(),
         setOpen: vi.fn(),
     };
-
-    beforeEach(() => {
-        queryClient.clear();
-    });
 
     const renderApp = (project: SchemaProjectView) => {
         server.use(

--- a/application/ui/src/features/inference/header/inference-devices.test.tsx
+++ b/application/ui/src/features/inference/header/inference-devices.test.tsx
@@ -9,7 +9,6 @@ import { render } from 'test-utils/render';
 
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
-import { queryClient } from '../../../query-client/query-client';
 import { InferenceDevices } from './inference-devices.component';
 
 const mockPipeline = getMockedPipeline({
@@ -41,7 +40,6 @@ describe('InferenceDevices', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
-        queryClient.removeQueries();
     });
 
     it('displays current device selection', async () => {

--- a/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/dataset-actions/dataset-actions.component.test.tsx
@@ -69,7 +69,7 @@ describe('DatasetActions', () => {
     it('should open rename dialog when rename action is clicked', async () => {
         renderApp();
 
-        const menuButton = screen.getByRole('button', { name: 'Dataset actions' });
+        const menuButton = await screen.findByRole('button', { name: 'Dataset actions' });
         await userEvent.click(menuButton);
 
         await userEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
@@ -81,7 +81,7 @@ describe('DatasetActions', () => {
     it('should open delete dialog when delete action is clicked', async () => {
         renderApp();
 
-        const menuButton = screen.getByRole('button', { name: 'Dataset actions' });
+        const menuButton = await screen.findByRole('button', { name: 'Dataset actions' });
         await userEvent.click(menuButton);
 
         await userEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
@@ -93,7 +93,7 @@ describe('DatasetActions', () => {
     it('should open export dialog when export action is clicked', async () => {
         renderApp();
 
-        const menuButton = screen.getByRole('button', { name: 'Dataset actions' });
+        const menuButton = await screen.findByRole('button', { name: 'Dataset actions' });
         await userEvent.click(menuButton);
 
         await userEvent.click(screen.getByRole('menuitem', { name: 'Export' }));

--- a/application/ui/src/hooks/api/jobs.hook.test.ts
+++ b/application/ui/src/hooks/api/jobs.hook.test.ts
@@ -8,7 +8,6 @@ import { renderHook } from 'test-utils/render';
 import { getMockedJob } from '../../../mocks/mock-job';
 import { http } from '../../api/utils';
 import { server } from '../../msw-node-setup';
-import { queryClient } from '../../query-client/query-client';
 import {
     getLastEventSource,
     MockEventSourceConstructor,
@@ -35,7 +34,6 @@ const createMockJobForProject = (overrides: Partial<ReturnType<typeof getMockedJ
 describe('useStreamJobStatus', () => {
     beforeEach(() => {
         resetMockEventSource();
-        queryClient.clear();
     });
 
     it('updates the React Query cache when an SSE message arrives', async () => {
@@ -85,7 +83,6 @@ describe('useStreamJobStatus', () => {
 describe('useGetCurrentTrainingJob', () => {
     beforeEach(() => {
         resetMockEventSource();
-        queryClient.clear();
     });
 
     it('returns undefined when there are no active training jobs', async () => {

--- a/application/ui/src/query-client/query-client.ts
+++ b/application/ui/src/query-client/query-client.ts
@@ -38,39 +38,45 @@ const getErrorMessage = (error: unknown): string => {
     return 'An unexpected error occurred. Please try again.';
 };
 
-export const queryClient = new QueryClient({
-    defaultOptions: {
-        queries: {
-            retry: false,
+export const createQueryClient = () => {
+    const client = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+            mutations: {
+                retry: false,
+            },
         },
-        mutations: {
-            retry: false,
-        },
-    },
-    mutationCache: new MutationCache({
-        onSuccess: (_data, _variables, _context, mutation) => {
-            const meta = mutation.meta;
-            const invalidateQueries = meta?.invalidateQueries;
+        mutationCache: new MutationCache({
+            onSuccess: (_data, _variables, _context, mutation) => {
+                const meta = mutation.meta;
+                const invalidateQueries = meta?.invalidateQueries;
 
-            if (invalidateQueries) {
-                queryClient.invalidateQueries({
-                    predicate: (query) => {
-                        return invalidateQueries.some((queryKey) => {
-                            return matchQuery({ queryKey }, query);
-                        });
-                    },
+                if (invalidateQueries) {
+                    client.invalidateQueries({
+                        predicate: (query) => {
+                            return invalidateQueries.some((queryKey) => {
+                                return matchQuery({ queryKey }, query);
+                            });
+                        },
+                    });
+                }
+            },
+            onError: (error) => {
+                toast({
+                    type: 'error',
+                    message: getErrorMessage(error),
+                    duration: TOAST_DURATION,
                 });
-            }
-        },
-        onError: (error) => {
-            toast({
-                type: 'error',
-                message: getErrorMessage(error),
-                duration: TOAST_DURATION,
-            });
-        },
-    }),
-});
+            },
+        }),
+    });
+
+    return client;
+};
+
+export const queryClient = createQueryClient();
 
 /**
  * Returns the provided query key.

--- a/application/ui/src/test-utils/render.tsx
+++ b/application/ui/src/test-utils/render.tsx
@@ -5,7 +5,7 @@ import { Suspense, type ReactNode } from 'react';
 
 import { IntelBrandedLoading, Toast } from '@geti/ui';
 import { ThemeProvider } from '@geti/ui/theme';
-import { QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
     render as rtlRender,
     renderHook as rtlRenderHook,
@@ -14,14 +14,15 @@ import {
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 import { paths } from '../constants/paths';
-import { queryClient } from '../query-client/query-client';
+import { createQueryClient } from '../query-client/query-client';
 
 export interface RenderOptions extends RTLRenderOptions {
     route?: string;
     path?: string;
+    queryClient?: QueryClient;
 }
 
-export const TestProviders = ({ children }: { children: ReactNode }) => {
+export const TestProviders = ({ children, queryClient }: { children: ReactNode; queryClient: QueryClient }) => {
     return (
         <QueryClientProvider client={queryClient}>
             <ThemeProvider>
@@ -32,7 +33,7 @@ export const TestProviders = ({ children }: { children: ReactNode }) => {
     );
 };
 
-const createTestRouter = (children: ReactNode, options: RenderOptions) => {
+const createTestRouter = (children: ReactNode, options: RenderOptions, queryClient: QueryClient) => {
     const route = options.route ?? paths.project.details({ projectId: '123' });
     const path = options.path ?? paths.project.details.pattern;
 
@@ -40,7 +41,7 @@ const createTestRouter = (children: ReactNode, options: RenderOptions) => {
         [
             {
                 path,
-                element: <TestProviders>{children}</TestProviders>,
+                element: <TestProviders queryClient={queryClient}>{children}</TestProviders>,
             },
         ],
         {
@@ -51,14 +52,17 @@ const createTestRouter = (children: ReactNode, options: RenderOptions) => {
 };
 
 export const render = (ui: ReactNode, options: RenderOptions = {}) => {
-    const router = createTestRouter(ui, options);
+    const testQueryClient = options.queryClient ?? createQueryClient();
+    const router = createTestRouter(ui, options, testQueryClient);
 
     return rtlRender(<RouterProvider router={router} />);
 };
 
 export const renderHook = <TProps, TResult>(callback: (props: TProps) => TResult, options: RenderOptions = {}) => {
+    const testQueryClient = options.queryClient ?? createQueryClient();
+
     const Wrapper = ({ children }: { children: ReactNode }) => {
-        const router = createTestRouter(children, options);
+        const router = createTestRouter(children, options, testQueryClient);
 
         return <RouterProvider router={router} />;
     };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Following up on https://github.com/open-edge-platform/training_extensions/pull/5620 . Instead of clearing or removing queries after each test (where we need to update api responses) we now either pass a new QC to the test renderer or it creates a new one on each test.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
