### PR TITLE
chore: Use fps as frame stride

### DIFF
--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -60,8 +60,7 @@ export const VideoPlayerProvider = ({ children, videoFrame, changeSelectedMediaI
             frame_count: videoFrame.frame_count,
             fps: videoFrame.fps,
             duration: videoFrame.duration,
-            // TODO: This should be returned by the backend, atm it's mocked to be 60 fps
-            frame_stride: 60,
+            frame_stride: videoFrame.fps,
         };
     }, [currentFrameIndex, videoFrame]);
 

--- a/application/ui/src/features/annotator/video-player/video-toolbar/frame-step/frame-step.module.scss
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/frame-step/frame-step.module.scss
@@ -1,5 +1,4 @@
 .frameStepBadge {
-    box-sizing: border-box !important;
     color: var(--spectrum-global-color-gray-50);
     font-size: var(--spectrum-global-dimension-size-100);
     background-color: var(--spectrum-global-color-gray-800);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Server won't return frame stride, we agreed to use `fps` on the UI side.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
