### PR TITLE
Fix media annotation status

### DIFF
--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -7,7 +7,6 @@ import { AriaComponentsListBox, GridLayout, ListBoxItem, Loading, View, Virtuali
 import { useLoadMore } from '@react-aria/utils';
 import { GridLayoutOptions } from 'react-aria-components';
 
-import { MediaStateMap } from '../../constants/shared-types';
 import { useGetTargetPosition } from './use-get-target-position.hook';
 
 import classes from './virtualizer-grid-layout.module.scss';
@@ -23,7 +22,6 @@ interface VirtualizerGridLayoutProps<T extends GridItem>
     extends Pick<AriaComponentsListBoxProps, 'selectedKeys' | 'onSelectionChange'> {
     items: T[];
     ariaLabel: string;
-    mediaState?: MediaStateMap;
     scrollToIndex?: number;
     selectionMode: 'single' | 'multiple' | 'none';
     layoutOptions: GridLayoutOptions;
@@ -38,7 +36,6 @@ const MIN_SPACE = 18; // default value for GridLayoutOptions.minSpace.height
 export const VirtualizerGridLayout = <T extends GridItem>({
     items,
     ariaLabel,
-    mediaState,
     selectedKeys,
     isLoadingMore,
     selectionMode,
@@ -77,7 +74,6 @@ export const VirtualizerGridLayout = <T extends GridItem>({
                 >
                     {items.map((item, index) => {
                         const itemId = getItemId(item);
-                        const itemState = mediaState?.get(String(itemId));
 
                         return (
                             <ListBoxItem
@@ -85,8 +81,6 @@ export const VirtualizerGridLayout = <T extends GridItem>({
                                 key={`${ariaLabel}-${itemId}-${index}`}
                                 textValue={String(itemId)}
                                 className={classes.mediaItem}
-                                data-accepted={itemState === 'accepted'}
-                                data-rejected={itemState === 'rejected'}
                             >
                                 {contentItem(item)}
                             </ListBoxItem>

--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.test.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.test.tsx
@@ -6,7 +6,6 @@ import { getMultipleMockedMediaImage } from 'mocks/mock-media';
 import { Size } from 'react-aria-components';
 import { render } from 'test-utils/render';
 
-import { MediaStateMap } from '../../constants/shared-types';
 import { VirtualizerGridLayout } from './virtualizer-grid-layout.component';
 
 // required configuration; otherwise, the list renders empty
@@ -26,7 +25,6 @@ describe('VirtualizerGridLayout', () => {
             <VirtualizerGridLayout
                 items={mockedItems}
                 ariaLabel={'test list'}
-                mediaState={new Map() as MediaStateMap}
                 selectionMode={'single'}
                 layoutOptions={mockedLayoutOptions}
                 isLoadingMore={false}
@@ -44,7 +42,6 @@ describe('VirtualizerGridLayout', () => {
             <VirtualizerGridLayout
                 items={[]}
                 ariaLabel={'empty list'}
-                mediaState={new Map() as MediaStateMap}
                 selectionMode={'single'}
                 layoutOptions={mockedLayoutOptions}
                 isLoadingMore={false}
@@ -61,7 +58,6 @@ describe('VirtualizerGridLayout', () => {
             <VirtualizerGridLayout
                 items={mockedItems}
                 ariaLabel={'loading list'}
-                mediaState={new Map() as MediaStateMap}
                 selectionMode={'single'}
                 layoutOptions={mockedLayoutOptions}
                 isLoadingMore={true}

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -38,7 +38,6 @@ export type MediaDTO = MediaImage | MediaVideo | MediaVideoFrameDTO;
 export type Media = MediaImage | MediaVideo | MediaVideoFrame;
 
 export type MediaItemState = 'accepted' | 'rejected';
-export type MediaStateMap = Map<string, MediaItemState>;
 
 export type DeviceType = components['schemas']['DeviceType'];
 export type TrainingDevice = {
@@ -71,3 +70,4 @@ export type SourceConfig =
 export type SourceConfigPayload = Exclude<SourceConfig, DisconnectedSourceConfig>;
 
 export type AnnotationDTO = components['schemas']['DatasetItemAnnotation-Input'];
+export type DatasetItemAnnotationStatus = components['schemas']['DatasetItemAnnotationStatus'];

--- a/application/ui/src/features/dataset/gallery/annotation-state-icon.module.scss
+++ b/application/ui/src/features/dataset/gallery/annotation-state-icon.module.scss
@@ -2,7 +2,7 @@
 .rejected,
 .toReview {
     border-radius: var(--spectrum-global-dimension-size-200);
-    padding: var(--spectrum-global-dimension-size-100) var(--spectrum-global-dimension-size-200);
+    padding: var(--spectrum-global-dimension-size-50) var(--spectrum-global-dimension-size-100);
 }
 
 .accepted {

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -11,9 +11,11 @@ import { MediaItem } from '../../../components/media-item/media-item.component';
 import { MediaThumbnail } from '../../../components/media-thumbnail/media-thumbnail.component';
 import { VirtualizerGridLayout } from '../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import type { Media } from '../../../constants/shared-types';
+import { useGetDatasetItemsById } from '../../../hooks/use-get-dataset-items-by-id.hook';
 import { getMediaBinaryUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
 import { MediaPreview } from '../media-preview/media-preview.component';
 import { useSelectedData } from '../selected-data-provider.component';
+import { AnnotationStatusIcon } from './annotation-state-icon.component';
 import { useSelectDatasetItem } from './hooks/use-select-dataset-item.hook';
 import { MediaItemActions } from './media-item-actions/media-item-actions.component';
 
@@ -43,7 +45,8 @@ export const Gallery = ({
 }: GalleryProps) => {
     const projectId = useProjectIdentifier();
     const { selectedMediaItem, onSelectedMediaItemChange } = useSelectDatasetItem();
-    const { selectedKeys, mediaState, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
+    const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
+    const { datasetItemsById } = useGetDatasetItemsById();
 
     const isSetSelectedKeys = selectedKeys instanceof Set;
 
@@ -62,7 +65,6 @@ export const Gallery = ({
                 items={items}
                 ariaLabel='data-collection-grid'
                 selectionMode='multiple'
-                mediaState={mediaState}
                 selectedKeys={selectedKeys}
                 layoutOptions={VIEW_MODE_SETTINGS[viewMode]}
                 isLoadingMore={isFetchingNextPage}
@@ -106,6 +108,12 @@ export const Gallery = ({
                                     onAnnotate={() => onSelectedMediaItemChange(item)}
                                 />
                             )}
+                            bottomRightElement={() => {
+                                const mediaItemId = String(item.id);
+                                const isUserReviewed = datasetItemsById.get(mediaItemId) ?? false;
+
+                                return <AnnotationStatusIcon state={isUserReviewed ? 'accepted' : undefined} />;
+                            }}
                         />
                     );
                 }}

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -28,7 +28,7 @@ import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-it
 import { ImportExport } from '../../import-export/import-export.component';
 import { useSelectedData } from '../../selected-data-provider.component';
 import { useSelectDatasetItem } from '../hooks/use-select-dataset-item.hook';
-import { toggleMultipleSelection, updateSelectedKeysTo } from './util';
+import { toggleMultipleSelection } from './util';
 
 type ToolbarProps = {
     items: Media[];
@@ -54,9 +54,14 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
     const queryClient = useQueryClient();
 
     const { onSelectedMediaItemChange } = useSelectDatasetItem();
-    const { selectedKeys, setSelectedKeys, setMediaState, toggleSelectedKeys } = useSelectedData();
+    const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
 
     const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media');
+    const acceptMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media/{media_id}/annotations');
+    const declineMutation = $api.useMutation(
+        'delete',
+        '/api/projects/{project_id}/dataset/media/{media_id}/annotations'
+    );
 
     const totalSelectedElements = selectedKeys instanceof Set ? selectedKeys.size : 0;
     const hasSelectedElements = totalSelectedElements > 0;
@@ -67,14 +72,55 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
         setSelectedKeys(toggleMultipleSelection(images));
     };
 
-    const handleAccept = () => {
-        setSelectedKeys(new Set());
-        setMediaState(updateSelectedKeysTo(selectedKeys, 'accepted'));
+    const syncReviewStatus = async (action: 'accept' | 'decline') => {
+        if (selectedKeys === 'all') {
+            return;
+        }
+
+        const selectedMediaIds = Array.from(selectedKeys).map(String);
+
+        const requests = selectedMediaIds.map((mediaId) => {
+            const payload = {
+                params: {
+                    path: {
+                        project_id: projectId,
+                        media_id: mediaId,
+                    },
+                },
+            };
+
+            return action === 'accept'
+                ? acceptMutation.mutateAsync({ ...payload, body: { annotations: [] } })
+                : declineMutation.mutateAsync(payload);
+        });
+
+        await Promise.allSettled(requests);
+
+        await Promise.all([
+            queryClient.invalidateQueries({
+                queryKey: getQueryKey([
+                    'get',
+                    '/api/projects/{project_id}/dataset/items',
+                    { params: { path: { project_id: projectId } } },
+                ]),
+            }),
+            queryClient.invalidateQueries({
+                queryKey: ['get', '/api/projects/{project_id}/dataset/items/{dataset_item_id}'],
+            }),
+            queryClient.invalidateQueries({
+                queryKey: ['get', '/api/projects/{project_id}/dataset/media/{media_id}/annotations'],
+            }),
+        ]);
     };
 
-    const handleReject = () => {
+    const handleAccept = async () => {
+        await syncReviewStatus('accept');
         setSelectedKeys(new Set());
-        setMediaState(updateSelectedKeysTo(selectedKeys, 'rejected'));
+    };
+
+    const handleReject = async () => {
+        await syncReviewStatus('decline');
+        setSelectedKeys(new Set());
     };
 
     const handleAddMediaItem = async (files: File[]) => {

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -57,11 +57,6 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
     const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
 
     const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media');
-    const acceptMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media/{media_id}/annotations');
-    const declineMutation = $api.useMutation(
-        'delete',
-        '/api/projects/{project_id}/dataset/media/{media_id}/annotations'
-    );
 
     const totalSelectedElements = selectedKeys instanceof Set ? selectedKeys.size : 0;
     const hasSelectedElements = totalSelectedElements > 0;
@@ -70,57 +65,6 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
     const handleToggleManyItemSelection = () => {
         const images = items.map((item) => String(item.id));
         setSelectedKeys(toggleMultipleSelection(images));
-    };
-
-    const syncReviewStatus = async (action: 'accept' | 'decline') => {
-        if (selectedKeys === 'all') {
-            return;
-        }
-
-        const selectedMediaIds = Array.from(selectedKeys).map(String);
-
-        const requests = selectedMediaIds.map((mediaId) => {
-            const payload = {
-                params: {
-                    path: {
-                        project_id: projectId,
-                        media_id: mediaId,
-                    },
-                },
-            };
-
-            return action === 'accept'
-                ? acceptMutation.mutateAsync({ ...payload, body: { annotations: [] } })
-                : declineMutation.mutateAsync(payload);
-        });
-
-        await Promise.allSettled(requests);
-
-        await Promise.all([
-            queryClient.invalidateQueries({
-                queryKey: getQueryKey([
-                    'get',
-                    '/api/projects/{project_id}/dataset/items',
-                    { params: { path: { project_id: projectId } } },
-                ]),
-            }),
-            queryClient.invalidateQueries({
-                queryKey: ['get', '/api/projects/{project_id}/dataset/items/{dataset_item_id}'],
-            }),
-            queryClient.invalidateQueries({
-                queryKey: ['get', '/api/projects/{project_id}/dataset/media/{media_id}/annotations'],
-            }),
-        ]);
-    };
-
-    const handleAccept = async () => {
-        await syncReviewStatus('accept');
-        setSelectedKeys(new Set());
-    };
-
-    const handleReject = async () => {
-        await syncReviewStatus('decline');
-        setSelectedKeys(new Set());
     };
 
     const handleAddMediaItem = async (files: File[]) => {
@@ -203,12 +147,17 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
                                 onDeleted={toggleSelectedKeys}
                             />
 
-                            <Button variant={'accent'} onPress={handleAccept}>
+                            {/* 
+                                TODO: In the future we will have a single endpoint to accept/decline
+                                    multiple media items at once instead of sending multiple requests in a loop.
+                                    Once we have that, we can reenable these buttons.
+                            */}
+                            {/* <Button variant={'accent'} onPress={handleAccept}>
                                 Accept
                             </Button>
                             <Button variant={'secondary'} onPress={handleReject}>
                                 Decline
-                            </Button>
+                            </Button> */}
                         </>
                     )}
                 </Flex>

--- a/application/ui/src/features/dataset/gallery/toolbar/util.test.ts
+++ b/application/ui/src/features/dataset/gallery/toolbar/util.test.ts
@@ -1,8 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { MediaStateMap } from '../../../../constants/shared-types';
-import { toggleMultipleSelection, updateSelectedKeysTo } from './util';
+import { toggleMultipleSelection } from './util';
 
 describe('toggleMultipleSelection', () => {
     const items = ['a', 'b', 'c'];
@@ -30,34 +29,5 @@ describe('toggleMultipleSelection', () => {
     it('should select all items if more than one but not all items are selected', () => {
         const result = toggleMultipleSelection(items)(new Set(['a', 'b']));
         expect(result).toEqual(new Set(items));
-    });
-});
-describe('updateSelectedKeysTo', () => {
-    it('returns a new map with updated annotationState for each selected key', () => {
-        const selectedKeys = new Set(['1', '2']);
-        const initialMap: MediaStateMap = new Map([
-            ['1', 'accepted'],
-            ['2', 'accepted'],
-        ]);
-
-        const result = updateSelectedKeysTo(selectedKeys, 'accepted')(initialMap);
-
-        expect(result.get('1')).toBe('accepted');
-        expect(result.get('2')).toBe('accepted');
-
-        expect(result).not.toBe(initialMap);
-    });
-
-    it('returns a new map with all entries if selectedKeys is "all"', () => {
-        const selectedKeys = 'all';
-        const initialMap: MediaStateMap = new Map([
-            ['1', 'accepted'],
-            ['2', 'accepted'],
-        ]);
-
-        const result = updateSelectedKeysTo(selectedKeys, 'rejected')(initialMap);
-
-        expect(result).not.toBe(initialMap);
-        expect(result).toEqual(initialMap);
     });
 });

--- a/application/ui/src/features/dataset/gallery/toolbar/util.ts
+++ b/application/ui/src/features/dataset/gallery/toolbar/util.ts
@@ -3,8 +3,6 @@
 
 import { Key, Selection } from '@geti/ui';
 
-import type { MediaItemState, MediaStateMap } from '../../../../constants/shared-types';
-
 export const toggleMultipleSelection =
     (items: Key[]) =>
     (selectedItems: Selection): Selection => {
@@ -20,17 +18,4 @@ export const toggleMultipleSelection =
         }
 
         return new Set();
-    };
-
-export const updateSelectedKeysTo =
-    (selectedKeys: Selection, mediaItemState: MediaItemState) => (map: MediaStateMap) => {
-        const newMap = new Map(map.entries());
-
-        if (selectedKeys === 'all') {
-            return newMap;
-        }
-
-        selectedKeys.forEach((mediaId) => newMap.set(String(mediaId), mediaItemState));
-
-        return newMap;
     };

--- a/application/ui/src/features/dataset/import-export/export-dataset/dataset-statistics.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-dataset/dataset-statistics.component.tsx
@@ -5,7 +5,7 @@ import { DatasetStatistics } from '../../../../components/dataset-statistics/dat
 import { useGetDatasetItems } from '../../../../hooks/use-get-dataset-items.hook';
 
 export const MainDatasetStatistics = () => {
-    const { data: annotatedItems } = useGetDatasetItems({ limit: 1, annotationStatus: 'reviewed' });
+    const { data: annotatedItems } = useGetDatasetItems({ annotationStatus: 'reviewed' });
     const { data: mediaItems } = useGetDatasetItems();
 
     const totalMediaItems = mediaItems?.pagination.total ?? 0;

--- a/application/ui/src/features/dataset/import-export/export-dataset/dataset-statistics.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-dataset/dataset-statistics.component.tsx
@@ -1,24 +1,12 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-
-import { $api } from '../../../../api/client';
 import { DatasetStatistics } from '../../../../components/dataset-statistics/dataset-statistics.component';
+import { useGetDatasetItems } from '../../../../hooks/use-get-dataset-items.hook';
 
 export const MainDatasetStatistics = () => {
-    const projectId = useProjectIdentifier();
-
-    const { data: annotatedItems } = $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
-        params: {
-            path: { project_id: projectId },
-            query: { limit: 1, annotation_status: 'reviewed' },
-        },
-    });
-
-    const { data: mediaItems } = $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
-        params: { path: { project_id: projectId } },
-    });
+    const { data: annotatedItems } = useGetDatasetItems({ limit: 1, annotationStatus: 'reviewed' });
+    const { data: mediaItems } = useGetDatasetItems();
 
     const totalMediaItems = mediaItems?.pagination.total ?? 0;
     const totalAnnotatedItems = annotatedItems?.pagination.total ?? 0;

--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.test.tsx
@@ -15,16 +15,15 @@ import { CanvasSettingsProvider } from '../primary-toolbar/settings/canvas-setti
 import { BottomToolbar } from './bottom-toolbar.component';
 
 type BottomToolbarProps = {
-    isUserReviewed: boolean;
     mediaItem: ReturnType<typeof getMockedMediaImage>;
 };
 
-const renderBottomToolbar = ({ isUserReviewed, mediaItem }: BottomToolbarProps) => {
+const renderBottomToolbar = ({ mediaItem }: BottomToolbarProps) => {
     return render(
         <ZoomProvider>
             <AnnotationVisibilityProvider>
                 <CanvasSettingsProvider>
-                    <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
+                    <BottomToolbar mediaItem={mediaItem} />
                 </CanvasSettingsProvider>
             </AnnotationVisibilityProvider>
         </ZoomProvider>
@@ -41,25 +40,41 @@ describe('BottomToolbar', () => {
     });
 
     it('displays the filename with correct format and dimensions', () => {
-        renderBottomToolbar({ isUserReviewed: false, mediaItem: mockMediaItem });
+        renderBottomToolbar({ mediaItem: mockMediaItem });
 
         expect(screen.getByText('test-image.jpg (1920 x 1080 px)')).toBeInTheDocument();
     });
 
-    it('displays "Accepted" tag when user has reviewed the media', () => {
-        renderBottomToolbar({ isUserReviewed: true, mediaItem: mockMediaItem });
+    it('displays "Accepted" tag when user has reviewed the media', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/items/{dataset_item_id}', () => {
+                return HttpResponse.json(getMockedDatasetItem({ id: 'media-123', user_reviewed: true }), {
+                    status: 200,
+                });
+            })
+        );
 
-        expect(screen.getByLabelText('Accepted')).toBeInTheDocument();
+        renderBottomToolbar({ mediaItem: mockMediaItem });
+
+        expect(await screen.findByLabelText('Accepted')).toBeInTheDocument();
     });
 
     it('displays "For Review" tag when user has not reviewed the media', () => {
-        renderBottomToolbar({ isUserReviewed: false, mediaItem: mockMediaItem });
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/items/{dataset_item_id}', () => {
+                return HttpResponse.json(getMockedDatasetItem({ id: 'media-123', user_reviewed: false }), {
+                    status: 200,
+                });
+            })
+        );
+
+        renderBottomToolbar({ mediaItem: mockMediaItem });
 
         expect(screen.getByLabelText('For Review')).toBeInTheDocument();
     });
 
     it('renders the subset picker with default placeholder', () => {
-        renderBottomToolbar({ isUserReviewed: false, mediaItem: mockMediaItem });
+        renderBottomToolbar({ mediaItem: mockMediaItem });
 
         expect(screen.getByLabelText('Select subset')).toBeInTheDocument();
     });
@@ -87,7 +102,7 @@ describe('BottomToolbar', () => {
             )
         );
 
-        renderBottomToolbar({ isUserReviewed: false, mediaItem: mockMediaItem });
+        renderBottomToolbar({ mediaItem: mockMediaItem });
 
         const pickerButton = screen.getByRole('button', { name: /select subset/i });
         fireEvent.click(pickerButton);

--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
@@ -19,8 +19,8 @@ import { Toolbar } from '../toolbar-container/toolbar-container.component';
 import classes from './bottom-toolbar.module.scss';
 
 type BottomToolbarProps = {
-    isUserReviewed: boolean;
     mediaItem: Media;
+    isUserReviewed?: boolean;
     hideHotkeys?: boolean;
 };
 
@@ -63,13 +63,14 @@ const useSubsets = (mediaItemId: string) => {
         });
     };
 
-    return { currentSubset: data?.subset ?? null, handleSubsetChange };
+    return { currentSubset: data?.subset ?? null, isUserReviewed: data?.user_reviewed ?? false, handleSubsetChange };
 };
 
-export const BottomToolbar = ({ isUserReviewed, mediaItem, hideHotkeys }: BottomToolbarProps) => {
+export const BottomToolbar = ({ mediaItem, isUserReviewed: isUserReviewedProp, hideHotkeys }: BottomToolbarProps) => {
     const fileName = `${mediaItem.name}.${mediaItem.format} (${mediaItem.width} x ${mediaItem.height} px)`;
 
-    const { currentSubset, handleSubsetChange } = useSubsets(mediaItem.id);
+    const { currentSubset, isUserReviewed: fetchedIsUserReviewed, handleSubsetChange } = useSubsets(mediaItem.id);
+    const isUserReviewed = isUserReviewedProp ?? fetchedIsUserReviewed;
 
     return (
         <Flex justifyContent={'end'}>

--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
@@ -20,7 +20,6 @@ import classes from './bottom-toolbar.module.scss';
 
 type BottomToolbarProps = {
     mediaItem: Media;
-    isUserReviewed?: boolean;
     hideHotkeys?: boolean;
 };
 
@@ -66,11 +65,10 @@ const useSubsets = (mediaItemId: string) => {
     return { currentSubset: data?.subset ?? null, isUserReviewed: data?.user_reviewed ?? false, handleSubsetChange };
 };
 
-export const BottomToolbar = ({ mediaItem, isUserReviewed: isUserReviewedProp, hideHotkeys }: BottomToolbarProps) => {
+export const BottomToolbar = ({ mediaItem, hideHotkeys }: BottomToolbarProps) => {
     const fileName = `${mediaItem.name}.${mediaItem.format} (${mediaItem.width} x ${mediaItem.height} px)`;
 
-    const { currentSubset, isUserReviewed: fetchedIsUserReviewed, handleSubsetChange } = useSubsets(mediaItem.id);
-    const isUserReviewed = isUserReviewedProp ?? fetchedIsUserReviewed;
+    const { currentSubset, isUserReviewed, handleSubsetChange } = useSubsets(mediaItem.id);
 
     return (
         <Flex justifyContent={'end'}>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -72,7 +72,7 @@ const Annotator = ({
         onSelectedMediaItem(item);
     };
 
-    const isUserReviewed = datasetItemsById.get(String(mediaItem.id)) ?? false;
+    const isUserReviewed = datasetItemsById.get(String(mediaItem.id));
 
     return (
         <VideoPlayerProvider
@@ -83,7 +83,6 @@ const Annotator = ({
                 <ReadOnlyAnnotator
                     image={image}
                     mediaItem={mediaItem}
-                    isUserReviewed={isUserReviewed}
                     onModeChange={changeAnnotatorMode}
                     onClose={onClose}
                     onAcceptPrediction={onSubmitAnnotations}

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -8,7 +8,6 @@ import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
 import type { Media } from '../../../constants/shared-types';
-import { useGetDatasetItemsById } from '../../../hooks/use-get-dataset-items-by-id.hook';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
@@ -65,14 +64,11 @@ const Annotator = ({
     onSelectedMediaItem,
 }: AnnotatorProps) => {
     const { mediaItem, setMediaItem, image } = useSelectedMediaItem();
-    const { datasetItemsById } = useGetDatasetItemsById();
 
     const selectMediaItem = (item: Media) => {
         setMediaItem(item);
         onSelectedMediaItem(item);
     };
-
-    const isUserReviewed = datasetItemsById.get(String(mediaItem.id));
 
     return (
         <VideoPlayerProvider
@@ -112,7 +108,7 @@ const Annotator = ({
                     )}
 
                     <View gridArea={'bottom'}>
-                        <BottomToolbar mediaItem={mediaItem} isUserReviewed={isUserReviewed} />
+                        <BottomToolbar mediaItem={mediaItem} />
                     </View>
 
                     <View gridArea={'canvas'} overflow={'hidden'}>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -8,13 +8,13 @@ import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
 import type { Media } from '../../../constants/shared-types';
+import { useGetDatasetItemsById } from '../../../hooks/use-get-dataset-items-by-id.hook';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
-import { useSelectedData } from '../selected-data-provider.component';
 import { AnnotatorProviders } from './annotator-providers.component';
 import { useAnnotationsQuery } from './api/use-annotations-query';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
@@ -48,7 +48,6 @@ const invalidateMediaItemAnnotations = (queryClient: QueryClient) => {
 };
 
 type AnnotatorProps = {
-    isUserReviewed: boolean;
     mode: AnnotatorMode;
     changeAnnotatorMode: (mode: AnnotatorMode) => void;
     onClose: () => void;
@@ -58,7 +57,6 @@ type AnnotatorProps = {
 };
 
 const Annotator = ({
-    isUserReviewed,
     mode,
     changeAnnotatorMode,
     onClose,
@@ -67,11 +65,14 @@ const Annotator = ({
     onSelectedMediaItem,
 }: AnnotatorProps) => {
     const { mediaItem, setMediaItem, image } = useSelectedMediaItem();
+    const { datasetItemsById } = useGetDatasetItemsById();
 
     const selectMediaItem = (item: Media) => {
         setMediaItem(item);
         onSelectedMediaItem(item);
     };
+
+    const isUserReviewed = datasetItemsById.get(String(mediaItem.id)) ?? false;
 
     return (
         <VideoPlayerProvider
@@ -112,7 +113,7 @@ const Annotator = ({
                     )}
 
                     <View gridArea={'bottom'}>
-                        <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} />
+                        <BottomToolbar mediaItem={mediaItem} isUserReviewed={isUserReviewed} />
                     </View>
 
                     <View gridArea={'canvas'} overflow={'hidden'}>
@@ -133,19 +134,10 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
 
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
     const queryClient = useQueryClient();
-    const { setMediaState } = useSelectedData();
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 
     const handleSubmitAnnotations = async () => {
-        setMediaState((prev) => {
-            const newState = new Map(prev);
-
-            newState.set(String(mediaItem.id), 'accepted');
-
-            return newState;
-        });
-
         const nextItem = getNextItem(items.length - 1, selectedIndex);
         onSelectedMediaItem(items[nextItem]);
 
@@ -175,7 +167,6 @@ const MediaPreviewContent = ({ items, mediaItem, onSelectedMediaItem, onClose }:
                     items={items}
                     onClose={onClose}
                     changeAnnotatorMode={setMode}
-                    isUserReviewed={isUserReviewed}
                     onSelectedMediaItem={onSelectedMediaItem}
                     onSubmitAnnotations={handleSubmitAnnotations}
                 />

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -17,7 +17,6 @@ import classes from './read-only-annotator.module.scss';
 type ReadOnlyAnnotatorProps = {
     mediaItem: Media;
     image: ImageData;
-    isUserReviewed: boolean;
     onClose: () => void;
     onModeChange?: (mode: 'annotation' | 'prediction') => void;
     onAcceptPrediction?: () => void;
@@ -37,7 +36,6 @@ type ReadOnlyAnnotatorProps = {
 export const ReadOnlyAnnotator = ({
     image,
     mediaItem,
-    isUserReviewed,
     onModeChange,
     onClose,
     onAcceptPrediction,
@@ -86,7 +84,7 @@ export const ReadOnlyAnnotator = ({
             </View>
 
             <View gridArea={'bottom'}>
-                <BottomToolbar mediaItem={mediaItem} isUserReviewed={isUserReviewed} hideHotkeys />
+                <BottomToolbar mediaItem={mediaItem} hideHotkeys />
             </View>
         </>
     );

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -86,7 +86,7 @@ export const ReadOnlyAnnotator = ({
             </View>
 
             <View gridArea={'bottom'}>
-                <BottomToolbar isUserReviewed={isUserReviewed} mediaItem={mediaItem} hideHotkeys />
+                <BottomToolbar mediaItem={mediaItem} isUserReviewed={isUserReviewed} hideHotkeys />
             </View>
         </>
     );

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -39,7 +39,7 @@ export const SidebarItems = ({
 }: SidebarItemsProps) => {
     const ref = useRef(null);
     const unwrapRef = useUnwrapDOMRef(ref);
-    const { datasetItemsById } = useGetDatasetItemsById();
+    const { datasetItemsById } = useGetDatasetItemsById({ limit: Math.max(items.length, 1) });
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -7,7 +7,7 @@ import { Size, useUnwrapDOMRef, View } from '@geti/ui';
 
 import { VirtualizerGridLayout } from '../../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import type { Media } from '../../../../constants/shared-types';
-import { useSelectedData } from '../../selected-data-provider.component';
+import { useGetDatasetItemsById } from '../../../../hooks/use-get-dataset-items-by-id.hook';
 import { SIDEBAR_MEDIA_SIZE } from '../constants';
 import { SidebarMediaItem } from './sidebar-media-item.component';
 import { useKeyboardNavigation } from './use-keyboard-navigation.hook';
@@ -39,7 +39,7 @@ export const SidebarItems = ({
 }: SidebarItemsProps) => {
     const ref = useRef(null);
     const unwrapRef = useUnwrapDOMRef(ref);
-    const { mediaState } = useSelectedData();
+    const { datasetItemsById } = useGetDatasetItemsById();
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 
@@ -56,13 +56,23 @@ export const SidebarItems = ({
                 items={items}
                 ariaLabel='sidebar-items'
                 selectionMode='single'
-                mediaState={mediaState}
                 selectedKeys={new Set([String(mediaItem.id)])}
                 layoutOptions={layoutOptions}
                 isLoadingMore={isFetchingNextPage}
                 scrollToIndex={selectedIndex}
                 onLoadMore={() => hasNextPage && fetchNextPage()}
-                contentItem={(item) => <SidebarMediaItem item={item} onSelectedMediaItem={onSelectedMediaItem} />}
+                contentItem={(item) => {
+                    const itemId = String(item.id);
+                    const isUserReviewed = datasetItemsById.get(itemId) ?? false;
+
+                    return (
+                        <SidebarMediaItem
+                            item={item}
+                            onSelectedMediaItem={onSelectedMediaItem}
+                            isUserReviewed={isUserReviewed}
+                        />
+                    );
+                }}
             />
         </View>
     );

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-media-item.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-media-item.component.tsx
@@ -7,13 +7,15 @@ import { MediaItem } from '../../../../components/media-item/media-item.componen
 import { MediaThumbnail } from '../../../../components/media-thumbnail/media-thumbnail.component';
 import type { Media } from '../../../../constants/shared-types';
 import { getThumbnailUrl } from '../../../../shared/media-url.utils';
+import { AnnotationStatusIcon } from '../../gallery/annotation-state-icon.component';
 
 type SidebarMediaItemProps = {
     item: Media;
+    isUserReviewed: boolean;
     onSelectedMediaItem: (item: Media) => void;
 };
 
-export const SidebarMediaItem = ({ item, onSelectedMediaItem }: SidebarMediaItemProps) => {
+export const SidebarMediaItem = ({ item, isUserReviewed, onSelectedMediaItem }: SidebarMediaItemProps) => {
     const projectId = useProjectIdentifier();
 
     return (
@@ -26,6 +28,9 @@ export const SidebarMediaItem = ({ item, onSelectedMediaItem }: SidebarMediaItem
                     onClick={() => onSelectedMediaItem(item)}
                 />
             )}
+            bottomRightElement={() => {
+                return <AnnotationStatusIcon state={isUserReviewed ? 'accepted' : undefined} />;
+            }}
         />
     );
 };

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/use-keyboard-navigation.hook.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/use-keyboard-navigation.hook.tsx
@@ -28,6 +28,7 @@ export const useKeyboardNavigation = ({
         if (key === 'ArrowDown') {
             return Math.min(items.length - 1, selectedIndex + 1);
         }
+
         return selectedIndex;
     };
 

--- a/application/ui/src/features/dataset/selected-data-provider.component.tsx
+++ b/application/ui/src/features/dataset/selected-data-provider.component.tsx
@@ -5,21 +5,15 @@ import { createContext, ReactNode, useContext, useState, type Dispatch, type Set
 
 import { Selection } from '@geti/ui';
 
-import { MediaStateMap } from '../../constants/shared-types';
-
 type SelectedDataState = null | {
     selectedKeys: Selection;
     setSelectedKeys: Dispatch<SetStateAction<Selection>>;
-
-    mediaState: MediaStateMap;
-    setMediaState: Dispatch<SetStateAction<MediaStateMap>>;
     toggleSelectedKeys: (key: string[]) => void;
 };
 
 const SelectedDataContext = createContext<SelectedDataState>(null);
 
 export const SelectedDataProvider = ({ children }: { children: ReactNode }) => {
-    const [mediaState, setMediaState] = useState<MediaStateMap>(new Map());
     const [selectedKeys, setSelectedKeys] = useState<Selection>(new Set());
 
     const toggleSelectedKeys = (keys: string[]) => {
@@ -39,9 +33,6 @@ export const SelectedDataProvider = ({ children }: { children: ReactNode }) => {
             value={{
                 selectedKeys,
                 setSelectedKeys,
-
-                mediaState,
-                setMediaState,
                 toggleSelectedKeys,
             }}
         >

--- a/application/ui/src/features/inference/header/active-model.component.tsx
+++ b/application/ui/src/features/inference/header/active-model.component.tsx
@@ -9,7 +9,7 @@ import { useGetActiveModel } from '../../models/hooks/api/use-get-active-model.h
 import { useGetModels } from '../../models/hooks/api/use-get-models.hook';
 
 export const ActiveModel = () => {
-    const { data: models = [] } = useGetModels();
+    const { data: models } = useGetModels();
     const activeModel = useGetActiveModel();
     const projectId = useProjectIdentifier();
     const updatePipeline = usePatchPipeline();

--- a/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
@@ -1,29 +1,12 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-
-import { $api } from '../../../api/client';
-
-const useGetDatasetItems = () => {
-    const projectId = useProjectIdentifier();
-    return $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
-        params: {
-            path: {
-                project_id: projectId,
-            },
-            query: {
-                limit: 5,
-                annotation_status: 'reviewed',
-            },
-        },
-    });
-};
+import { useGetDatasetItems } from '../../../hooks/use-get-dataset-items.hook';
 
 const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 
 export const useIsTrainingButtonDisabled = () => {
-    const { data: datasetItems } = useGetDatasetItems();
+    const { data: datasetItems } = useGetDatasetItems({ limit: 5, annotationStatus: 'reviewed' });
     const count = datasetItems?.pagination.total ?? 0;
 
     return count < MIN_NUMBER_OF_ANNOTATED_ITEMS;

--- a/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
@@ -6,7 +6,7 @@ import { useGetDatasetItems } from '../../../hooks/use-get-dataset-items.hook';
 const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 
 export const useIsTrainingButtonDisabled = () => {
-    const { data: datasetItems } = useGetDatasetItems({ limit: 5, annotationStatus: 'reviewed' });
+    const { data: datasetItems } = useGetDatasetItems({ annotationStatus: 'reviewed' });
     const count = datasetItems?.pagination.total ?? 0;
 
     return count < MIN_NUMBER_OF_ANNOTATED_ITEMS;

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -69,12 +69,7 @@ const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
                         mode={mode}
                         isReadOnly
                     >
-                        <ReadOnlyAnnotator
-                            image={image}
-                            mediaItem={mediaItem}
-                            isUserReviewed={isUserReviewed}
-                            onClose={onClose}
-                        />
+                        <ReadOnlyAnnotator image={image} mediaItem={mediaItem} onClose={onClose} />
                     </AnnotatorProviders>
                 </Grid>
             </Content>

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import { useGetDatasetItems } from './use-get-dataset-items.hook';
+
+export const useGetDatasetItemsById = (options?: Parameters<typeof useGetDatasetItems>[0]) => {
+    const { data } = useGetDatasetItems(options);
+
+    const datasetItemsById = useMemo(() => {
+        const datasetItems = data?.items ?? [];
+
+        return new Map(datasetItems.map(({ id, user_reviewed }) => [id, user_reviewed]));
+    }, [data?.items]);
+
+    return { datasetItemsById };
+};

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -7,37 +7,21 @@ import { useProjectIdentifier } from './use-project-identifier.hook';
 
 type UseGetDatasetItemsOptions = {
     limit?: number;
-    offset?: number;
     annotationStatus?: DatasetItemAnnotationStatus;
 };
 
 export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
     const project_id = useProjectIdentifier();
 
-    const query: {
-        limit?: number;
-        offset?: number;
-        annotation_status?: DatasetItemAnnotationStatus;
-    } = {};
-
-    if (options?.limit !== undefined) {
-        query.limit = options.limit;
-    }
-
-    if (options?.offset !== undefined) {
-        query.offset = options.offset;
-    }
-
-    if (options?.annotationStatus !== undefined) {
-        query.annotation_status = options.annotationStatus;
-    }
-
     return $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
         params: {
             path: {
                 project_id,
             },
-            query,
+            query: {
+                limit: options?.limit ?? 1,
+                annotation_status: options?.annotationStatus,
+            },
         },
     });
 };

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -37,7 +37,7 @@ export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
             path: {
                 project_id,
             },
-            ...query,
+            query,
         },
     });
 };

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -1,0 +1,43 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { $api } from '../api/client';
+import type { DatasetItemAnnotationStatus } from '../constants/shared-types';
+import { useProjectIdentifier } from './use-project-identifier.hook';
+
+type UseGetDatasetItemsOptions = {
+    limit?: number;
+    offset?: number;
+    annotationStatus?: DatasetItemAnnotationStatus;
+};
+
+export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
+    const project_id = useProjectIdentifier();
+
+    const query: {
+        limit?: number;
+        offset?: number;
+        annotation_status?: DatasetItemAnnotationStatus;
+    } = {};
+
+    if (options?.limit !== undefined) {
+        query.limit = options.limit;
+    }
+
+    if (options?.offset !== undefined) {
+        query.offset = options.offset;
+    }
+
+    if (options?.annotationStatus !== undefined) {
+        query.annotation_status = options.annotationStatus;
+    }
+
+    return $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
+        params: {
+            path: {
+                project_id,
+            },
+            ...query,
+        },
+    });
+};

--- a/application/ui/src/routes/project/create-project.tsx
+++ b/application/ui/src/routes/project/create-project.tsx
@@ -9,7 +9,7 @@ import { useProjects } from '../../hooks/api/project.hook';
 import backgroundStyles from '../../features/project/project-background.module.scss';
 
 export const CreateProject = () => {
-    const { data: projects = [] } = useProjects();
+    const { data: projects } = useProjects();
 
     return (
         <View UNSAFE_className={backgroundStyles.projectBackground} height='100%' width='100%'>

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -89,6 +89,11 @@ export const AnnotationActionsProvider = ({
                     { params: { path: { project_id: projectId, media_id: mediaItem.id } } },
                 ],
                 ['get', '/api/projects/{project_id}/dataset/items', { params: { path: { project_id: projectId } } }],
+                [
+                    'get',
+                    '/api/projects/{project_id}/dataset/items/{dataset_item_id}',
+                    { params: { path: { project_id: projectId, dataset_item_id: mediaItem.id } } },
+                ],
             ],
         },
     });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Closes https://github.com/open-edge-platform/training_extensions/issues/5556

* Got rid of `mediaState` and have only 1 source of truth (server response) because now, thanks to https://github.com/open-edge-platform/training_extensions/pull/5538 we have these values
* Cross reference `mediaItemId` with dataset item, to get the review status information
* Got rid of accept/reject from dataset gallery, we do not support bulk accept/reject yet (full discussion here: https://www.figma.com/design/75tPOrtAyA5zUAKaDF2GKl?node-id=3771-9094#1622340206)

<img width="1246" height="1191" alt="Screenshot 2026-02-26 at 15 24 04" src="https://github.com/user-attachments/assets/bfafa6bb-7e1c-4519-8da3-315ce649754c" />
<img width="1275" height="889" alt="Screenshot 2026-02-26 at 15 24 07" src="https://github.com/user-attachments/assets/9de45c02-dcc1-4cf8-ab99-aa0dec0b601c" />
<img width="1268" height="802" alt="Screenshot 2026-02-26 at 15 32 54" src="https://github.com/user-attachments/assets/d09de4b0-91f4-4609-bd86-c3e5efb023f5" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
