### PR TITLE
Add endpoint to retrieve dataset statistics

### DIFF
--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -7,21 +7,22 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 
 from app.api.dependencies import get_dataset_service, get_project
+from app.api.schemas.dataset import DatasetStatisticsView
 from app.api.schemas.dataset_item import DatasetItemAssignSubset, DatasetItemsWithPagination, DatasetItemView
-from app.api.validators import DatasetItemID
+from app.api.validators import DatasetItemID, ProjectID
 from app.core.models import Pagination
 from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Project
 from app.services import DatasetService
 from app.services.dataset_service import DatasetItemFilters, SubsetAlreadyAssignedError
 
-router = APIRouter(prefix="/api/projects/{project_id}/dataset/items", tags=["Datasets"])
+router = APIRouter(prefix="/api/projects/{project_id}/dataset", tags=["Datasets"])
 
 DEFAULT_DATASET_ITEMS_NUMBER_RETURNED = 10
 MAX_DATASET_ITEMS_NUMBER_RETURNED = 100
 
 
 @router.get(
-    "",
+    "/items",
     responses={
         status.HTTP_200_OK: {"description": "List of available dataset items", "model": DatasetItemsWithPagination},
     },
@@ -74,7 +75,7 @@ def list_dataset_items(  # noqa: PLR0913
 
 
 @router.get(
-    "/{dataset_item_id}",
+    "/items/{dataset_item_id}",
     responses={
         status.HTTP_200_OK: {"description": "Dataset item found", "model": DatasetItemView},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid dataset item ID or project ID"},
@@ -91,8 +92,25 @@ def get_dataset_item(
     return DatasetItemView.model_validate(dataset_item, from_attributes=True)
 
 
+@router.get(
+    "/statistics",
+    responses={
+        status.HTTP_200_OK: {"description": "Dataset statistics retrieved", "model": DatasetStatisticsView},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID"},
+        status.HTTP_404_NOT_FOUND: {"description": "Project not found"},
+    },
+)
+def get_dataset_statistics(
+    project_id: ProjectID,
+    dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
+) -> DatasetStatisticsView:
+    """Get information about a specific dataset item"""
+    dataset_statistics = dataset_service.get_dataset_statistics(project_id=project_id)
+    return DatasetStatisticsView.model_validate(dataset_statistics, from_attributes=True)
+
+
 @router.patch(
-    "/{dataset_item_id}/subset",
+    "/items/{dataset_item_id}/subset",
     status_code=status.HTTP_200_OK,
     responses={
         status.HTTP_200_OK: {"description": "Dataset item subset is assigned"},

--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -104,9 +104,8 @@ def get_dataset_statistics(
     project_id: ProjectID,
     dataset_service: Annotated[DatasetService, Depends(get_dataset_service)],
 ) -> DatasetStatisticsView:
-    """Get information about a specific dataset item"""
+    """Get statistics about the number of media and annotations in a dataset"""
     dataset_statistics = dataset_service.get_dataset_statistics(project_id=project_id)
-    print(dataset_statistics)
     return DatasetStatisticsView.model_validate(dataset_statistics, from_attributes=True)
 
 

--- a/application/backend/app/api/routers/datasets.py
+++ b/application/backend/app/api/routers/datasets.py
@@ -106,6 +106,7 @@ def get_dataset_statistics(
 ) -> DatasetStatisticsView:
     """Get information about a specific dataset item"""
     dataset_statistics = dataset_service.get_dataset_statistics(project_id=project_id)
+    print(dataset_statistics)
     return DatasetStatisticsView.model_validate(dataset_statistics, from_attributes=True)
 
 

--- a/application/backend/app/api/schemas/dataset.py
+++ b/application/backend/app/api/schemas/dataset.py
@@ -77,31 +77,33 @@ class StagedDatasetView(BaseRequiredIDModel):
         return data
 
 
-class MediaCounts(BaseModel):
+class MediaCountsView(BaseModel):
     """Media counts"""
 
-    images: int
-    videos: int
-    video_frames: int
+    images: int = Field(0, description="Number of images in dataset")
+    videos: int = Field(0, description="Number of videos in dataset")
+    video_frames: int = Field(0, description="Number of video frames in dataset")
 
     model_config = {"json_schema_extra": {"example": {"images": 10, "videos": 3, "video_frames": 312}}}
 
 
-class InstancesPerLabel(BaseModel):
-    label_id: UUID
-    instances: int
+class InstancesPerLabelView(BaseModel):
+    label_id: UUID = Field(..., description="Unique identifier of label")
+    instances: int = Field(0, description="Number of video frames in dataset")
 
     model_config = {
         "json_schema_extra": {"example": {"label_id": "5fffd195-7766-4171-8efe-4064a6eb0e95", "instances": 24}}
     }
 
 
-class AnnotationCounts(BaseModel):
-    annotated_images: int
-    annotated_videos: int
-    annotated_video_frames: int
-    instances: int
-    instances_per_label: list[InstancesPerLabel]
+class AnnotationCountsView(BaseModel):
+    annotated_images: int = Field(0, description="Number of annotated images in dataset")
+    annotated_videos: int = Field(0, description="Number of annotated videos in dataset")
+    annotated_video_frames: int = Field(0, description="Number of annotated video frames in dataset")
+    instances: int = Field(0, description="Number of annotation shapes in dataset")
+    instances_per_label: list[InstancesPerLabelView] = Field(
+        [], description="List of number of annotation shapes per label"
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -124,8 +126,10 @@ class DatasetStatisticsView(BaseModel):
     Dataset statistics
     """
 
-    media_counts: MediaCounts
-    annotations_counts: AnnotationCounts
+    media_counts: MediaCountsView = Field(..., description="Number of media per media type in dataset")
+    annotations_counts: AnnotationCountsView = Field(
+        ..., description="Number of annotated media per media type en labels"
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/app/api/schemas/dataset.py
+++ b/application/backend/app/api/schemas/dataset.py
@@ -89,7 +89,7 @@ class MediaCountsView(BaseModel):
 
 class InstancesPerLabelView(BaseModel):
     label_id: UUID = Field(..., description="Unique identifier of label")
-    instances: int = Field(0, description="Number of video frames in dataset")
+    instances: int = Field(0, description="Number of annotation instances with this label in dataset")
 
     model_config = {
         "json_schema_extra": {"example": {"label_id": "5fffd195-7766-4171-8efe-4064a6eb0e95", "instances": 24}}
@@ -128,7 +128,7 @@ class DatasetStatisticsView(BaseModel):
 
     media_counts: MediaCountsView = Field(..., description="Number of media per media type in dataset")
     annotations_counts: AnnotationCountsView = Field(
-        ..., description="Number of annotated media per media type en labels"
+        ..., description="Number of annotated media per media type and labels"
     )
 
     model_config = {

--- a/application/backend/app/api/schemas/dataset.py
+++ b/application/backend/app/api/schemas/dataset.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from uuid import UUID
+
 from pydantic import BaseModel, Field, model_validator
 
 from app.core.models import BaseRequiredIDModel
@@ -73,3 +75,72 @@ class StagedDatasetView(BaseRequiredIDModel):
                 "metadata": data.metadata,
             }
         return data
+
+
+class MediaCounts(BaseModel):
+    """Media counts"""
+
+    images: int
+    videos: int
+    video_frames: int
+
+    model_config = {"json_schema_extra": {"example": {"images": 10, "videos": 3, "video_frames": 312}}}
+
+
+class InstancesPerLabel(BaseModel):
+    label_id: UUID
+    instances: int
+
+    model_config = {
+        "json_schema_extra": {"example": {"label_id": "5fffd195-7766-4171-8efe-4064a6eb0e95", "instances": 24}}
+    }
+
+
+class AnnotationCounts(BaseModel):
+    annotated_images: int
+    annotated_videos: int
+    annotated_video_frames: int
+    instances: int
+    instances_per_label: list[InstancesPerLabel]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "annotated_images": 8,
+                "annotated_videos": 2,
+                "annotated_video_frames": 29,
+                "instances": 56,
+                "instances_per_label": [
+                    {"label_id": "5fffd195-7766-4171-8efe-4064a6eb0e95", "instances": 24},
+                    {"label_id": "20f1defc-8d40-47ff-9f9d-8e82f0ef224d", "instances": 32},
+                ],
+            }
+        }
+    }
+
+
+class DatasetStatisticsView(BaseModel):
+    """
+    Dataset statistics
+    """
+
+    media_counts: MediaCounts
+    annotations_counts: AnnotationCounts
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "media_counts": {"images": 10, "videos": 3, "video_frames": 312},
+                "annotations_counts": {
+                    "annotated_images": 8,
+                    "annotated_videos": 2,
+                    "annotated_video_frames": 29,
+                    "instances": 56,
+                    "instances_per_label": [
+                        {"label_id": "5fffd195-7766-4171-8efe-4064a6eb0e95", "instances": 24},
+                        {"label_id": "20f1defc-8d40-47ff-9f9d-8e82f0ef224d", "instances": 32},
+                    ],
+                },
+            }
+        }
+    }

--- a/application/backend/app/models/dataset.py
+++ b/application/backend/app/models/dataset.py
@@ -2,10 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import StrEnum
+from uuid import UUID
+
+from pydantic import Field, model_validator
 
 from pydantic import BaseModel
 
 from app.core.models import BaseRequiredIDModel
+from app.models.base import BaseEntity
 
 
 class AnnotationType(StrEnum):
@@ -37,3 +41,73 @@ class StagedDataset(BaseRequiredIDModel):
     format: DatasetFormat
     size: int
     metadata: DatasetMetadata | None = None
+
+
+class MediaCounts(BaseEntity):
+    images: int = 0
+    videos: int = 0
+    video_frames: int = 0
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_media_counts(cls, data: object) -> object:
+        if isinstance(data, dict):
+            return {
+                "images": data.get("images", 0),
+                "videos": data.get("videos", 0),
+                "video_frames": data.get("video_frames", 0),
+            }
+        return data
+
+
+class InstancesPerLabel(BaseEntity):
+    label_id: UUID
+    instances: int = 0
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_instances_per_label(cls, data: object) -> object:
+        if isinstance(data, dict):
+            return {
+                "label_id": UUID(str(data.get("label_id"))),
+                "instances": data.get("instances", 0),
+            }
+        return data
+
+
+class AnnotationCounts(BaseEntity):
+    annotated_images: int = 0
+    annotated_videos: int = 0
+    annotated_video_frames: int = 0
+    instances: int = 0
+    instances_per_label: list[InstancesPerLabel] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_annotation_counts(cls, data: object) -> object:
+        if isinstance(data, dict):
+            return {
+                "annotated_images": data.get("annotated_images", 0),
+                "annotated_videos": data.get("annotated_videos", 0),
+                "annotated_video_frames": data.get("annotated_video_frames", 0),
+                "instances": data.get("instances", 0),
+                "instances_per_label": [
+                    InstancesPerLabel.model_validate(item) for item in data.get("instances_per_label", [])
+                ],
+            }
+        return data
+
+
+class DatasetStatistics(BaseEntity):
+    media_counts: MediaCounts = Field(default_factory=MediaCounts)
+    annotations_counts: AnnotationCounts = Field(default_factory=AnnotationCounts)
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_dataset_statistics(cls, data: object) -> object:
+        if isinstance(data, dict):
+            return {
+                "media_counts": MediaCounts.model_validate(data),
+                "annotations_counts": AnnotationCounts.model_validate(data),
+            }
+        return data

--- a/application/backend/app/models/dataset.py
+++ b/application/backend/app/models/dataset.py
@@ -4,9 +4,7 @@
 from enum import StrEnum
 from uuid import UUID
 
-from pydantic import Field, model_validator
-
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
 from app.core.models import BaseRequiredIDModel
 from app.models.base import BaseEntity

--- a/application/backend/app/models/dataset.py
+++ b/application/backend/app/models/dataset.py
@@ -48,17 +48,6 @@ class MediaCounts(BaseEntity):
     videos: int = 0
     video_frames: int = 0
 
-    @model_validator(mode="before")
-    @classmethod
-    def populate_media_counts(cls, data: object) -> object:
-        if isinstance(data, dict):
-            return {
-                "images": data.get("images", 0),
-                "videos": data.get("videos", 0),
-                "video_frames": data.get("video_frames", 0),
-            }
-        return data
-
 
 class InstancesPerLabel(BaseEntity):
     label_id: UUID

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -251,7 +251,7 @@ class DatasetItemRepository:
 
         # Annotation Counts (annotated videos)
         annotated_video_stmt = (
-            select(func.count(func.distinct(MediaDB.id)).label("count"))
+            select(func.count(func.distinct(MediaDB.video_id)).label("count"))
             .join(DatasetItemDB, DatasetItemDB.id == MediaDB.id)
             .where(
                 DatasetItemDB.project_id == self.project_id,

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -239,7 +239,11 @@ class DatasetItemRepository:
         annotated_images_frames_stmt = (
             select(MediaDB.type, func.count(DatasetItemDB.id).label("count"))
             .join(DatasetItemDB, DatasetItemDB.id == MediaDB.id)
-            .where(DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None))
+            .where(
+                DatasetItemDB.project_id == self.project_id,
+                DatasetItemDB.annotation_data.isnot(None),
+                DatasetItemDB.user_reviewed,
+            )
             .group_by(MediaDB.type)
         )
         result = self.db.execute(annotated_images_frames_stmt)
@@ -252,6 +256,7 @@ class DatasetItemRepository:
             .where(
                 DatasetItemDB.project_id == self.project_id,
                 DatasetItemDB.annotation_data.isnot(None),
+                DatasetItemDB.user_reviewed,
                 MediaDB.type == "video_frame",
             )
         )
@@ -260,7 +265,9 @@ class DatasetItemRepository:
 
         # Total instances:
         annotated_dataset_items_stmt = select(DatasetItemDB.annotation_data).where(
-            DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
+            DatasetItemDB.project_id == self.project_id,
+            DatasetItemDB.annotation_data.isnot(None),
+            DatasetItemDB.user_reviewed,
         )
         annotated_counts["instances"] = sum(
             len(item.annotation_data) for item in self.db.execute(annotated_dataset_items_stmt)

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from datetime import UTC, datetime
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple, cast
 
 from sqlalchemy import CursorResult, Select, delete, func, select, update
 from sqlalchemy.dialects.sqlite import insert
@@ -219,3 +219,48 @@ class DatasetItemRepository:
         )
         result = self.db.execute(stmt)
         return {row.subset: row.count for row in result}  # type: ignore[misc]
+
+    def get_statistics(self) -> dict[str, Any]:
+        # Media Counts (images, videos, video frames):
+        stmt = (
+            select(
+                MediaDB.type, func.count(MediaDB.id).label("count"), func.sum(MediaDB.frame_count).label("frame_count")
+            )
+            .where(MediaDB.project_id == self.project_id)
+            .group_by(MediaDB.type)
+        )
+        result = self.db.execute(stmt)
+        media_counts: dict[str, int] = {f"{row.type}s": cast(int, row.count) for row in result}
+        media_counts["video_frames"] = int(sum(row.frame_count for row in result))
+
+        # Annotation Counts (annotated images, videos, video frames):
+        stmt = (
+            select(MediaDB.type, func.count(DatasetItemDB.id).label("count"))
+            .join(DatasetItemDB, DatasetItemDB.id == MediaDB.id)
+            .where(DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None))
+            .group_by(MediaDB.type)
+        )
+        result = self.db.execute(stmt)
+        annotated_counts: dict[str, Any] = {f"annotated_{row.type}s": row.count for row in result}
+
+        # Instances per label:
+        stmt = (
+            select(DatasetItemLabelDB.label_id, func.count(DatasetItemLabelDB.dataset_item_id).label("instances"))
+            .join(DatasetItemDB, DatasetItemLabelDB.dataset_item_id == DatasetItemDB.id)
+            .where(DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None))
+            .group_by(DatasetItemLabelDB.label_id)
+        )
+        result = self.db.execute(stmt)
+        annotated_counts["instances_per_label"] = [
+            {"label_id": row.label_id, "instances": row.instances} for row in result
+        ]
+
+        # Total instances:
+        # We need to sum the number of instances in annotation_data for all annotated items.
+        stmt = select(DatasetItemDB.annotation_data).where(
+            DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
+        )
+        result = self.db.execute(stmt)
+        annotated_counts["instances"] = sum(len(item.annotation_data) for item in result)
+
+        return {"media_counts": media_counts, "annotated_counts": annotated_counts}

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -256,7 +256,6 @@ class DatasetItemRepository:
         ]
 
         # Total instances:
-        # We need to sum the number of instances in annotation_data for all annotated items.
         stmt = select(DatasetItemDB.annotation_data).where(
             DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
         )

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -223,39 +223,65 @@ class DatasetItemRepository:
 
     def get_statistics(self) -> dict[str, Any]:
         # Media Counts (images, videos, video frames):
-        stmt = (
+        media_counts_stmt = (
             select(
                 MediaDB.type, func.count(MediaDB.id).label("count"), func.sum(MediaDB.frame_count).label("frame_count")
             )
             .where(MediaDB.project_id == self.project_id)
             .group_by(MediaDB.type)
         )
-        result = self.db.execute(stmt)
+        result = self.db.execute(media_counts_stmt)
         rows = list(result)
         statistics: dict[str, Any] = {f"{row.type}s": cast(int, row.count) for row in rows}
         statistics["video_frames"] = int(sum(row.frame_count or 0 for row in rows))
 
-        # Annotation Counts (annotated images, videos, video frames):
-        stmt = (
+        # Annotation Counts (annotated images and video frames):
+        annotated_images_frames_stmt = (
             select(MediaDB.type, func.count(DatasetItemDB.id).label("count"))
             .join(DatasetItemDB, DatasetItemDB.id == MediaDB.id)
             .where(DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None))
             .group_by(MediaDB.type)
         )
-        result = self.db.execute(stmt)
+        result = self.db.execute(annotated_images_frames_stmt)
         annotated_counts: dict[str, Any] = {f"annotated_{row.type}s": row.count for row in result}
 
+        # Annotation Counts (annotated videos)
+        annotated_video_stmt = (
+            select(func.count(func.distinct(MediaDB.id)).label("count"))
+            .join(DatasetItemDB, DatasetItemDB.id == MediaDB.id)
+            .where(
+                DatasetItemDB.project_id == self.project_id,
+                DatasetItemDB.annotation_data.isnot(None),
+                MediaDB.type == "video_frame",
+            )
+        )
+        annotated_video_count = self.db.execute(annotated_video_stmt).scalar()
+        annotated_counts["annotated_videos"] = annotated_video_count or 0
+
         # Total instances:
-        stmt = select(DatasetItemDB.annotation_data).where(
+        annotated_dataset_items_stmt = select(DatasetItemDB.annotation_data).where(
             DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
         )
-        result = list(self.db.execute(stmt))
-        annotated_counts["instances"] = sum(len(item.annotation_data) for item in result)
+        annotated_counts["instances"] = sum(
+            len(item.annotation_data) for item in self.db.execute(annotated_dataset_items_stmt)
+        )
+
+        # instances_per_label
+        annotated_dataset_items_stmt = select(DatasetItemDB.annotation_data).where(
+            DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
+        )
+
         labels_counts = Counter(
-            label["id"] for item in result for annotation in item.annotation_data for label in annotation["labels"]
+            label["id"]
+            for item in self.db.execute(annotated_dataset_items_stmt)
+            for annotation in item.annotation_data
+            for label in annotation["labels"]
         )
         annotated_counts["instances_per_label"] = [
             {"label_id": label_id, "instances": count} for label_id, count in labels_counts.items()
+        ]
+        annotated_counts["instances_per_label"] = [
+            {"label_id": row.label_id, "instances": row.instances} for row in labels_counts
         ]
 
         statistics.update(annotated_counts)

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from collections import Counter
 from datetime import UTC, datetime
 from typing import Any, NamedTuple, cast
 
@@ -244,24 +245,18 @@ class DatasetItemRepository:
         result = self.db.execute(stmt)
         annotated_counts: dict[str, Any] = {f"annotated_{row.type}s": row.count for row in result}
 
-        # Instances per label:
-        stmt = (
-            select(DatasetItemLabelDB.label_id, func.count(DatasetItemLabelDB.dataset_item_id).label("instances"))
-            .join(DatasetItemDB, DatasetItemLabelDB.dataset_item_id == DatasetItemDB.id)
-            .where(DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None))
-            .group_by(DatasetItemLabelDB.label_id)
-        )
-        result = self.db.execute(stmt)
-        annotated_counts["instances_per_label"] = [
-            {"label_id": row.label_id, "instances": row.instances} for row in result
-        ]
-
         # Total instances:
         stmt = select(DatasetItemDB.annotation_data).where(
             DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
         )
-        result = self.db.execute(stmt)
+        result = list(self.db.execute(stmt))
         annotated_counts["instances"] = sum(len(item.annotation_data) for item in result)
+        labels_counts = Counter(
+            label["id"] for item in result for annotation in item.annotation_data for label in annotation["labels"]
+        )
+        annotated_counts["instances_per_label"] = [
+            {"label_id": label_id, "instances": count} for label_id, count in labels_counts.items()
+        ]
 
         statistics.update(annotated_counts)
 

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -230,8 +230,8 @@ class DatasetItemRepository:
             .group_by(MediaDB.type)
         )
         result = self.db.execute(stmt)
-        media_counts: dict[str, int] = {f"{row.type}s": cast(int, row.count) for row in result}
-        media_counts["video_frames"] = int(sum(row.frame_count for row in result))
+        statistics: dict[str, Any] = {f"{row.type}s": cast(int, row.count) for row in result}
+        statistics["video_frames"] = int(sum(row.frame_count for row in result))
 
         # Annotation Counts (annotated images, videos, video frames):
         stmt = (
@@ -263,4 +263,6 @@ class DatasetItemRepository:
         result = self.db.execute(stmt)
         annotated_counts["instances"] = sum(len(item.annotation_data) for item in result)
 
-        return {"media_counts": media_counts, "annotated_counts": annotated_counts}
+        statistics.update(annotated_counts)
+
+        return statistics

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -287,9 +287,6 @@ class DatasetItemRepository:
         annotated_counts["instances_per_label"] = [
             {"label_id": label_id, "instances": count} for label_id, count in labels_counts.items()
         ]
-        annotated_counts["instances_per_label"] = [
-            {"label_id": row.label_id, "instances": row.instances} for row in labels_counts
-        ]
 
         statistics.update(annotated_counts)
 

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -230,8 +230,9 @@ class DatasetItemRepository:
             .group_by(MediaDB.type)
         )
         result = self.db.execute(stmt)
-        statistics: dict[str, Any] = {f"{row.type}s": cast(int, row.count) for row in result}
-        statistics["video_frames"] = int(sum(row.frame_count for row in result))
+        rows = list(result)
+        statistics: dict[str, Any] = {f"{row.type}s": cast(int, row.count) for row in rows}
+        statistics["video_frames"] = int(sum(row.frame_count or 0 for row in rows))
 
         # Annotation Counts (annotated images, videos, video frames):
         stmt = (

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -4,6 +4,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 import datumaro.experimental as dm
@@ -130,6 +131,11 @@ class DatasetService(BaseSessionManagedService):
             label_ids=label_ids_str,
             subset=subset,
         )
+
+    def get_dataset_statistics(self, project_id: UUID) -> dict[str, Any]:
+        """Get dataset statistics"""
+        repo = DatasetItemRepository(project_id=str(project_id), db=self.db_session)
+        return repo.get_statistics()
 
     def list_dataset_items(
         self,

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -4,7 +4,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
 from uuid import UUID
 
 import datumaro.experimental as dm
@@ -26,6 +25,7 @@ from app.models import (
     Task,
     TaskType,
 )
+from app.models.dataset import DatasetStatistics
 from app.models.media import MediaAdapter
 from app.repositories import DatasetItemRepository
 from app.services.media_service import MediaService
@@ -132,10 +132,11 @@ class DatasetService(BaseSessionManagedService):
             subset=subset,
         )
 
-    def get_dataset_statistics(self, project_id: UUID) -> dict[str, Any]:
+    def get_dataset_statistics(self, project_id: UUID) -> DatasetStatistics:
         """Get dataset statistics"""
         repo = DatasetItemRepository(project_id=str(project_id), db=self.db_session)
-        return repo.get_statistics()
+        statistics_dict = repo.get_statistics()
+        return DatasetStatistics.model_validate(statistics_dict)
 
     def list_dataset_items(
         self,

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -484,125 +484,137 @@ def fxt_project_with_rich_dataset_items(fxt_project_with_pipeline, db_session) -
     label_1_id = str(project.task.labels[0].id)
     label_2_id = str(project.task.labels[1].id)
 
+    db_media_items = []
+    db_frame_items = []
     db_dataset_items = []
 
+    default_media_values = {
+        "size": 1024,
+        "width": 1024,
+        "height": 768,
+        "project_id": str(project.id),
+        "created_at": datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    }
+    default_item_values = {
+        "project_id": str(project.id),
+        "subset": "training",
+        "created_at": datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    }
+    annotation_data_1 = {
+        "labels": [{"id": label_1_id}],
+        "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10},
+    }
+    annotation_data_2 = {
+        "labels": [{"id": label_2_id}],
+        "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10},
+    }
+
     # Image (unannotated)
-    media_img = MediaDB(
+    unannotated_image = MediaDB(
+        id=str(uuid4()),
         type="image",
         name="img1",
         format="jpg",
-        size=1024,
-        width=1024,
-        height=768,
-        project_id=str(project.id),
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+        **default_media_values,
     )
-    db_session.add(media_img)
-    db_session.flush()
-    item_img = DatasetItemDB(
-        id=str(media_img.id),
-        project_id=str(project.id),
-        subset="unassigned",
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    item_unannotated_image = DatasetItemDB(
+        id=str(unannotated_image.id),
+        **default_item_values,
     )
-    db_session.add(item_img)
-    db_dataset_items.append(item_img)
-    db_session.flush()
+    db_media_items.append(unannotated_image)
+    db_dataset_items.append(item_unannotated_image)
 
-    # Video (unannotated)
-    media_vid = MediaDB(
-        type="video",
-        name="vid1",
-        format="mp4",
-        size=2048,
-        width=1920,
-        height=1080,
-        fps=30.0,
-        frame_count=2,
-        project_id=str(project.id),
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
-    )
-    db_session.add(media_vid)
-    db_session.flush()
-    item_vid = DatasetItemDB(
-        id=str(media_vid.id),
-        project_id=str(project.id),
-        subset="unassigned",
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
-    )
-    db_session.add(item_vid)
-    db_dataset_items.append(item_vid)
-    db_session.flush()
-
-    # Video frame (annotated with label_1)
-    media_vf = MediaDB(
-        type="video_frame",
-        name="vf1",
-        format="jpg",
-        size=512,
-        width=1920,
-        height=1080,
-        fps=30.0,
-        frame_count=None,
-        video_id=str(media_vid.id),
-        frame_index=0,
-        project_id=str(project.id),
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
-    )
-    db_session.add(media_vf)
-    db_session.flush()
-    item_vf = DatasetItemDB(
-        id=str(media_vf.id),
-        project_id=str(project.id),
-        subset="unassigned",
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
-        annotation_data=[
-            {"labels": [{"id": label_1_id}], "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10}}
-        ],
-        user_reviewed=True,
-    )
-    db_session.add(item_vf)
-    db_session.flush()
-    db_dataset_items.append(item_vf)
-    db_session.add(DatasetItemLabelDB(dataset_item_id=item_vf.id, label_id=label_1_id))
-    db_session.flush()
-
-    # Dataset item with multiple annotations (2 with label_1, 1 with label_2)
-    media_multi = MediaDB(
+    # Image (annotated with multiple annotations (2 with label_1, 1 with label_2)
+    annotated_image = MediaDB(
+        id=str(uuid4()),
         type="image",
         name="multi_ann",
         format="jpg",
-        size=1024,
-        width=1024,
-        height=768,
-        project_id=str(project.id),
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+        **default_media_values,
     )
-    db_session.add(media_multi)
-    db_session.flush()
-    item_multi = DatasetItemDB(
-        id=str(media_multi.id),
-        project_id=str(project.id),
-        subset="training",
-        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
-        annotation_data=[
-            {"labels": [{"id": label_1_id}], "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10}},
-            {
-                "labels": [{"id": label_1_id}],
-                "shape": {"type": "rectangle", "x": 20, "y": 20, "width": 10, "height": 10},
-            },
-            {
-                "labels": [{"id": label_2_id}],
-                "shape": {"type": "rectangle", "x": 40, "y": 40, "width": 10, "height": 10},
-            },
-        ],
+    item_annotated_image = DatasetItemDB(
+        id=str(annotated_image.id),
+        **default_item_values,
+        annotation_data=[annotation_data_1, annotation_data_1, annotation_data_2],
         user_reviewed=True,
     )
-    db_session.add(item_multi)
+    db_media_items.append(annotated_image)
+    db_dataset_items.append(item_annotated_image)
+
+    # Video (annotated frames)
+    annotated_video = MediaDB(
+        id=str(uuid4()),
+        type="video",
+        name="vid1",
+        format="mp4",
+        fps=30.0,
+        frame_count=20,
+        **default_media_values,
+    )
+    db_media_items.append(annotated_video)
+
+    # Video frame (annotated with label_1)
+    annotated_video_frame_1 = MediaDB(
+        id=str(uuid4()),
+        type="video_frame",
+        name="vf1",
+        format="jpg",
+        video_id=str(annotated_video.id),
+        frame_index=3,
+        **default_media_values,
+    )
+    item_annotated_video_frame_1 = DatasetItemDB(
+        id=str(annotated_video_frame_1.id),
+        **default_item_values,
+        annotation_data=[annotation_data_1],
+        user_reviewed=True,
+    )
+    db_frame_items.append(annotated_video_frame_1)
+    db_dataset_items.append(item_annotated_video_frame_1)
+
+    # Video frame (annotated with label_2)
+    annotated_video_frame_2 = MediaDB(
+        id=str(uuid4()),
+        type="video_frame",
+        name="vf2",
+        format="jpg",
+        video_id=str(annotated_video.id),
+        frame_index=8,
+        **default_media_values,
+    )
+    item_annotated_video_frame_2 = DatasetItemDB(
+        id=str(annotated_video_frame_2.id),
+        **default_item_values,
+        annotation_data=[annotation_data_2],
+        user_reviewed=True,
+    )
+    db_frame_items.append(annotated_video_frame_2)
+    db_dataset_items.append(item_annotated_video_frame_2)
+
+    # Video (no annotated frames)
+    unannotated_video = MediaDB(
+        id=str(uuid4()),
+        type="video",
+        name="vid2",
+        format="mp4",
+        fps=30.0,
+        frame_count=15,
+        **default_media_values,
+    )
+    db_media_items.append(unannotated_video)
+
+    [db_session.add(item) for item in db_media_items]
     db_session.flush()
-    db_dataset_items.append(item_multi)
-    db_session.add(DatasetItemLabelDB(dataset_item_id=item_multi.id, label_id=label_1_id))
-    db_session.add(DatasetItemLabelDB(dataset_item_id=item_multi.id, label_id=label_2_id))
+    db_session.commit()
+    [db_session.add(item) for item in db_frame_items]
+    db_session.flush()
+    [db_session.add(item) for item in db_dataset_items]
+    db_session.flush()
+
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_annotated_video_frame_1.id, label_id=label_1_id))
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_annotated_video_frame_2.id, label_id=label_2_id))
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_annotated_image.id, label_id=label_1_id))
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_annotated_image.id, label_id=label_2_id))
     db_session.flush()
 
     return project, db_dataset_items
@@ -1441,19 +1453,19 @@ class TestDatasetServiceIntegration:
 
         statistics = fxt_dataset_service.get_dataset_statistics(project_id=project.id)
 
-        # There are 2 images, 1 video, 1 video_frame
+        # Media counts
         assert statistics.media_counts.images == 2
-        assert statistics.media_counts.videos == 1
-        assert statistics.media_counts.video_frames == 2
+        assert statistics.media_counts.videos == 2
+        assert statistics.media_counts.video_frames == 35
 
-        # Only item_multi is in training subset and annotated, item_vf is annotated video_frame
-        assert statistics.annotations_counts.annotated_images == 1  # item_multi
+        # Annotation counts
+        assert statistics.annotations_counts.annotated_images == 1
         assert statistics.annotations_counts.annotated_videos == 1
-        assert statistics.annotations_counts.annotated_video_frames == 1  # item_vf
+        assert statistics.annotations_counts.annotated_video_frames == 2
 
-        # item_multi: 2 instances label_1, 1 instance label_2; item_vf: 1 instance label_1
-        assert statistics.annotations_counts.instances == 4
+        # Instances counts
+        assert statistics.annotations_counts.instances == 5
         assert len(statistics.annotations_counts.instances_per_label) == 2
         label_counts = {str(lbl.label_id): lbl.instances for lbl in statistics.annotations_counts.instances_per_label}
         assert label_counts[str(project.task.labels[0].id)] == 3
-        assert label_counts[str(project.task.labels[1].id)] == 1
+        assert label_counts[str(project.task.labels[1].id)] == 2

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -476,6 +476,138 @@ def fxt_project_with_subset_items(fxt_project_with_pipeline, db_session) -> tupl
     return project, db_dataset_items
 
 
+@pytest.fixture
+def fxt_project_with_rich_dataset_items(fxt_project_with_pipeline, db_session) -> tuple[Project, list[DatasetItemDB]]:
+    """Fixture with images, videos, annotated video frames, and a dataset item with multiple annotations."""
+    project, _ = fxt_project_with_pipeline
+
+    label_1_id = str(project.task.labels[0].id)
+    label_2_id = str(project.task.labels[1].id)
+
+    db_dataset_items = []
+
+    # Image (unannotated)
+    media_img = MediaDB(
+        type="image",
+        name="img1",
+        format="jpg",
+        size=1024,
+        width=1024,
+        height=768,
+        project_id=str(project.id),
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    )
+    db_session.add(media_img)
+    db_session.flush()
+    item_img = DatasetItemDB(
+        id=str(media_img.id),
+        project_id=str(project.id),
+        subset="unassigned",
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    )
+    db_session.add(item_img)
+    db_dataset_items.append(item_img)
+    db_session.flush()
+
+    # Video (unannotated)
+    media_vid = MediaDB(
+        type="video",
+        name="vid1",
+        format="mp4",
+        size=2048,
+        width=1920,
+        height=1080,
+        fps=30.0,
+        frame_count=2,
+        project_id=str(project.id),
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    )
+    db_session.add(media_vid)
+    db_session.flush()
+    item_vid = DatasetItemDB(
+        id=str(media_vid.id),
+        project_id=str(project.id),
+        subset="unassigned",
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    )
+    db_session.add(item_vid)
+    db_dataset_items.append(item_vid)
+    db_session.flush()
+
+    # Video frame (annotated with label_1)
+    media_vf = MediaDB(
+        type="video_frame",
+        name="vf1",
+        format="jpg",
+        size=512,
+        width=1920,
+        height=1080,
+        fps=30.0,
+        frame_count=None,
+        video_id=str(media_vid.id),
+        frame_index=0,
+        project_id=str(project.id),
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    )
+    db_session.add(media_vf)
+    db_session.flush()
+    item_vf = DatasetItemDB(
+        id=str(media_vf.id),
+        project_id=str(project.id),
+        subset="unassigned",
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+        annotation_data=[
+            {"labels": [{"id": label_1_id}], "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10}}
+        ],
+        user_reviewed=True,
+    )
+    db_session.add(item_vf)
+    db_session.flush()
+    db_dataset_items.append(item_vf)
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_vf.id, label_id=label_1_id))
+    db_session.flush()
+
+    # Dataset item with multiple annotations (2 with label_1, 1 with label_2)
+    media_multi = MediaDB(
+        type="image",
+        name="multi_ann",
+        format="jpg",
+        size=1024,
+        width=1024,
+        height=768,
+        project_id=str(project.id),
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+    )
+    db_session.add(media_multi)
+    db_session.flush()
+    item_multi = DatasetItemDB(
+        id=str(media_multi.id),
+        project_id=str(project.id),
+        subset="training",
+        created_at=datetime.fromisoformat("2025-02-01T00:00:00Z"),
+        annotation_data=[
+            {"labels": [{"id": label_1_id}], "shape": {"type": "rectangle", "x": 0, "y": 0, "width": 10, "height": 10}},
+            {
+                "labels": [{"id": label_1_id}],
+                "shape": {"type": "rectangle", "x": 20, "y": 20, "width": 10, "height": 10},
+            },
+            {
+                "labels": [{"id": label_2_id}],
+                "shape": {"type": "rectangle", "x": 40, "y": 40, "width": 10, "height": 10},
+            },
+        ],
+        user_reviewed=True,
+    )
+    db_session.add(item_multi)
+    db_session.flush()
+    db_dataset_items.append(item_multi)
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_multi.id, label_id=label_1_id))
+    db_session.add(DatasetItemLabelDB(dataset_item_id=item_multi.id, label_id=label_2_id))
+    db_session.flush()
+
+    return project, db_dataset_items
+
+
 class TestDatasetServiceIntegration:
     """Integration tests for DatasetService."""
 
@@ -1302,25 +1434,26 @@ class TestDatasetServiceIntegration:
     def test_get_dataset_statistics(
         self,
         fxt_dataset_service: DatasetService,
-        fxt_project_with_dataset_items: tuple[Project, list[DatasetItemDB]],
+        fxt_project_with_rich_dataset_items: tuple[Project, list[DatasetItemDB]],
     ):
-        """Test retrieving dataset statistics."""
-        project, _ = fxt_project_with_dataset_items
+        """Test retrieving dataset statistics with images, videos, video frames, and multiple annotation instances."""
+        project, _ = fxt_project_with_rich_dataset_items
 
         statistics = fxt_dataset_service.get_dataset_statistics(project_id=project.id)
 
-        # There are 3 images, 0 videos, 0 video_frames in fxt_project_with_dataset_items
-        assert statistics.media_counts.images == 3
-        assert statistics.media_counts.videos == 0
-        assert statistics.media_counts.video_frames == 0
+        # There are 2 images, 1 video, 1 video_frame
+        assert statistics.media_counts.images == 2
+        assert statistics.media_counts.videos == 1
+        assert statistics.media_counts.video_frames == 2
 
-        # Only item 2 is in training subset, item 1 has annotation, so annotated_images = 1
-        assert statistics.annotations_counts.annotated_images == 1
-        assert statistics.annotations_counts.annotated_videos == 0
-        assert statistics.annotations_counts.annotated_video_frames == 0
+        # Only item_multi is in training subset and annotated, item_vf is annotated video_frame
+        assert statistics.annotations_counts.annotated_images == 1  # item_multi
+        assert statistics.annotations_counts.annotated_videos == 1
+        assert statistics.annotations_counts.annotated_video_frames == 1  # item_vf
 
-        # Only one annotation instance (item 1)
-        assert statistics.annotations_counts.instances == 1
-        assert len(statistics.annotations_counts.instances_per_label) == 1
-        assert statistics.annotations_counts.instances_per_label[0].instances == 1
-        assert statistics.annotations_counts.instances_per_label[0].label_id == project.task.labels[0].id
+        # item_multi: 2 instances label_1, 1 instance label_2; item_vf: 1 instance label_1
+        assert statistics.annotations_counts.instances == 4
+        assert len(statistics.annotations_counts.instances_per_label) == 2
+        label_counts = {str(lbl.label_id): lbl.instances for lbl in statistics.annotations_counts.instances_per_label}
+        assert label_counts[str(project.task.labels[0].id)] == 3
+        assert label_counts[str(project.task.labels[1].id)] == 1

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -1298,3 +1298,29 @@ class TestDatasetServiceIntegration:
         assert len(testing_items) == 1
         for item in testing_items:
             assert item.subset == DatasetItemSubset.TESTING
+
+    def test_get_dataset_statistics(
+        self,
+        fxt_dataset_service: DatasetService,
+        fxt_project_with_dataset_items: tuple[Project, list[DatasetItemDB]],
+    ):
+        """Test retrieving dataset statistics."""
+        project, _ = fxt_project_with_dataset_items
+
+        statistics = fxt_dataset_service.get_dataset_statistics(project_id=project.id)
+
+        # There are 3 images, 0 videos, 0 video_frames in fxt_project_with_dataset_items
+        assert statistics.media_counts.images == 3
+        assert statistics.media_counts.videos == 0
+        assert statistics.media_counts.video_frames == 0
+
+        # Only item 2 is in training subset, item 1 has annotation, so annotated_images = 1
+        assert statistics.annotations_counts.annotated_images == 1
+        assert statistics.annotations_counts.annotated_videos == 0
+        assert statistics.annotations_counts.annotated_video_frames == 0
+
+        # Only one annotation instance (item 1)
+        assert statistics.annotations_counts.instances == 1
+        assert len(statistics.annotations_counts.instances_per_label) == 1
+        assert statistics.annotations_counts.instances_per_label[0].instances == 1
+        assert statistics.annotations_counts.instances_per_label[0].label_id == project.task.labels[0].id

--- a/application/backend/tests/unit/api/routers/test_datasets.py
+++ b/application/backend/tests/unit/api/routers/test_datasets.py
@@ -12,6 +12,7 @@ from app.api.dependencies import get_dataset_service
 from app.api.schemas.dataset_item import DatasetItemAssignSubset, DatasetItemSubset, DatasetItemView
 from app.main import app
 from app.models import DatasetItem, DatasetItemAnnotationStatus
+from app.models.dataset import DatasetStatistics
 from app.services import DatasetService, ResourceNotFoundError, ResourceType
 from app.services.dataset_service import DatasetItemFilters, SubsetAlreadyAssignedError
 
@@ -304,3 +305,42 @@ class TestDatasetItemEndpoints:
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_dataset_service.assign_dataset_item_subset.assert_not_called()
+
+    def test_get_dataset_statistics(self, fxt_get_project, fxt_dataset_service, fxt_client):
+        statistics_dict = {
+            "images": 5,
+            "videos": 2,
+            "video_frames": 10,
+            "annotated_images": 3,
+            "annotated_videos": 1,
+            "annotated_video_frames": 4,
+            "instances": 7,
+            "instances_per_label": [
+                {"label_id": "11111111-1111-1111-1111-111111111111", "instances": 5},
+                {"label_id": "22222222-2222-2222-2222-222222222222", "instances": 2},
+            ],
+        }
+        # Patch the service to return a DatasetStatistics model with the correct fields
+        fxt_dataset_service.get_dataset_statistics.return_value = DatasetStatistics.model_validate(statistics_dict)
+
+        response = fxt_client.get(f"/api/projects/{str(fxt_get_project.id)}/dataset/statistics")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "media_counts": {
+                "images": 5,
+                "videos": 2,
+                "video_frames": 10,
+            },
+            "annotations_counts": {
+                "annotated_images": 3,
+                "annotated_videos": 1,
+                "annotated_video_frames": 4,
+                "instances": 7,
+                "instances_per_label": [
+                    {"label_id": "11111111-1111-1111-1111-111111111111", "instances": 5},
+                    {"label_id": "22222222-2222-2222-2222-222222222222", "instances": 2},
+                ],
+            },
+        }
+        fxt_dataset_service.get_dataset_statistics.assert_called_once_with(project_id=fxt_get_project.id)


### PR DESCRIPTION
Add endpoint for retrieving dataset statistics.

The main logic is in `dataset_item_repo` where the statistics are obtained as a whole. The dataset service and router are responsible for transforming the dictionary of statistics to a `DatasetStatisticsView`.

Resolves #5560 

### How to test

Unit test added for router and integration test added for dataset service, which calls and checks the dataset item repository.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
