### PR TITLE
feat: Connect UI to the API video frame thumbnails and binaries

### DIFF
--- a/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
+++ b/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
@@ -22,7 +22,7 @@ export const ProjectListItem = ({ project }: ProjectListItemProps) => {
     const { data: projects } = useProjects();
 
     const handleNavigateToProject = () => {
-        navigate(paths.project.dataset({ projectId: project.id }));
+        navigate(paths.project.dataset.index({ projectId: project.id }));
     };
 
     const handleDeleted = () => {

--- a/application/ui/src/constants/paths.ts
+++ b/application/ui/src/constants/paths.ts
@@ -21,8 +21,10 @@ export const paths = {
         inference,
         dataset: {
             index: dataset,
-            datasetItem,
-            videoFrame,
+            item: {
+                index: datasetItem,
+                frame: videoFrame,
+            },
         },
         models,
     },

--- a/application/ui/src/constants/paths.ts
+++ b/application/ui/src/constants/paths.ts
@@ -9,6 +9,7 @@ const project = projects.path('/:projectId');
 const inference = projects.path('/:projectId/inference');
 const dataset = projects.path('/:projectId/dataset');
 const datasetItem = dataset.path('/:datasetItemId');
+const videoFrame = datasetItem.path('/:frameNumber');
 const models = projects.path('/:projectId/models');
 
 export const paths = {
@@ -18,8 +19,11 @@ export const paths = {
         new: projects.path('/new'),
         details: project,
         inference,
-        dataset,
-        datasetItem,
+        dataset: {
+            index: dataset,
+            datasetItem,
+            videoFrame,
+        },
         models,
     },
 };

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -11,7 +11,6 @@ import { useSelectedAnnotations } from '../../../shared/annotator/select-annotat
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
-import { useMediaItemImage } from '../selected-media-item-provider.component';
 import { ToolManager } from '../tools/tool-manager.component';
 import { VideoFrame } from '../video-player/video-frame.component';
 
@@ -51,14 +50,14 @@ const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
 
 type AnnotatorCanvasProps = {
     mediaItem: Media;
+    image: ImageData;
     isReadOnly?: boolean;
 };
 
-export const AnnotatorCanvas = ({ mediaItem, isReadOnly = false }: AnnotatorCanvasProps) => {
+export const AnnotatorCanvas = ({ mediaItem, image, isReadOnly = false }: AnnotatorCanvasProps) => {
     const { annotations } = useAnnotationActions();
     const { selectedAnnotations } = useSelectedAnnotations();
     const { isFocussed } = useAnnotationVisibility();
-    const { image } = useMediaItemImage();
     const isSceneBusy = useIsAnnotatorSceneBusy();
 
     const areToolsDisabled = isSceneBusy || isReadOnly;

--- a/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
+++ b/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
@@ -1,27 +1,33 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useSuspenseQuery, UseSuspenseQueryResult } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
-import { API_BASE_URL } from '../../../api/client';
+import { Media } from '../../../constants/shared-types';
+import { isVideoFrame } from '../../../shared/media-item-utils';
+import { getMediaBinaryUrl, getVideoFrameBinaryUrl } from '../../../shared/media-url.utils';
 import { getImageData, loadImage } from '../tools/utils';
 
-export const useLoadImageQuery = (mediaItemId: string | undefined): UseSuspenseQueryResult<ImageData, unknown> => {
+export const useLoadImageQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
 
-    return useSuspenseQuery({
-        queryKey: ['mediaItem', mediaItemId, projectId],
-        queryFn: async () => {
-            if (mediaItemId === undefined) {
-                throw new Error("Can't fetch undefined media item");
-            }
+    const queryKey = isVideoFrame(media)
+        ? ['mediaItem', projectId, media.id, media.frame_number]
+        : ['mediaItem', projectId, media.id];
 
-            const imageUrl = `${API_BASE_URL}/api/projects/${projectId}/dataset/media/${mediaItemId}/binary`;
-            const image = await loadImage(imageUrl);
+    return useQuery({
+        queryKey,
+        queryFn: async () => {
+            const url = isVideoFrame(media)
+                ? getVideoFrameBinaryUrl(projectId, media.id, media.frame_number)
+                : getMediaBinaryUrl(projectId, media.id);
+
+            const image = await loadImage(url);
 
             return getImageData(image);
         },
+        placeholderData: keepPreviousData,
         // The image of a media item never changes so we don't want to refetch stale data
         staleTime: Infinity,
         retry: 0,

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -16,6 +16,7 @@ type SelectedMediaItemContextProps = {
     mediaItem: Media;
     roi: RegionOfInterest;
     setMediaItem: (item: Media) => void;
+    image: ImageData;
 };
 
 const SelectedMediaItemContext = createContext<SelectedMediaItemContextProps | null>(null);
@@ -64,9 +65,13 @@ export const SelectedMediaItemProvider = ({
 }: SelectedMediaItemProviderProps) => {
     const [mediaItem, setMediaItem] = useMediaItem(initialMediaItem);
 
+    const { data: image = getImageData(new Image()) } = useLoadImageQuery(mediaItem);
+
     const roi: RegionOfInterest = { x: 0, y: 0, width: mediaItem.width, height: mediaItem.height };
 
-    return <SelectedMediaItemContext value={{ mediaItem, roi, setMediaItem }}>{children}</SelectedMediaItemContext>;
+    return (
+        <SelectedMediaItemContext value={{ mediaItem, roi, setMediaItem, image }}>{children}</SelectedMediaItemContext>
+    );
 };
 
 export const useSelectedMediaItem = (): SelectedMediaItemContextProps => {
@@ -74,46 +79,6 @@ export const useSelectedMediaItem = (): SelectedMediaItemContextProps => {
 
     if (context === null) {
         throw new Error('useSelectedMediaItem was used outside of SelectedMediaItemProvider');
-    }
-
-    return context;
-};
-
-type MediaItemImageContextType = {
-    image: ImageData;
-};
-
-const MediaItemImageContext = createContext<MediaItemImageContextType | null>(null);
-
-/*
-TODO: Use this when API supports video frames
-const getMediaItem = (mediaItem: Media) => {
-    if (isVideo(mediaItem)) {
-        // For video, we want to get the first frame of the video, that's not supported right now
-        return undefined;
-    }
-
-    return mediaItem;
-};*/
-
-/**
- * Loads the image for the currently selected media item via a suspense query.
- * Must be placed INSIDE a <Suspense> boundary so that only the canvas area
- * suspends — not the toolbars or annotation state above it.
- */
-export const MediaItemImageLoader = ({ children }: { children: ReactNode }) => {
-    const { mediaItem } = useSelectedMediaItem();
-
-    const { data: image = getImageData(new Image()) } = useLoadImageQuery(mediaItem);
-
-    return <MediaItemImageContext value={{ image }}>{children}</MediaItemImageContext>;
-};
-
-export const useMediaItemImage = (): MediaItemImageContextType => {
-    const context = useContext(MediaItemImageContext);
-
-    if (context === null) {
-        throw new Error('useMediaItemImage was used outside of MediaItemImageLoader');
     }
 
     return context;

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -17,6 +17,7 @@ type SelectedMediaItemContextProps = {
     roi: RegionOfInterest;
     setMediaItem: (item: Media) => void;
     image: ImageData;
+    isImageReady: boolean;
 };
 
 const SelectedMediaItemContext = createContext<SelectedMediaItemContextProps | null>(null);
@@ -65,12 +66,15 @@ export const SelectedMediaItemProvider = ({
 }: SelectedMediaItemProviderProps) => {
     const [mediaItem, setMediaItem] = useMediaItem(initialMediaItem);
 
-    const { data: image = getImageData(new Image()) } = useLoadImageQuery(mediaItem);
+    const { data: image = getImageData(new Image()), isSuccess, isPlaceholderData } = useLoadImageQuery(mediaItem);
+    const isImageReady = isSuccess && !isPlaceholderData;
 
     const roi: RegionOfInterest = { x: 0, y: 0, width: mediaItem.width, height: mediaItem.height };
 
     return (
-        <SelectedMediaItemContext value={{ mediaItem, roi, setMediaItem, image }}>{children}</SelectedMediaItemContext>
+        <SelectedMediaItemContext value={{ mediaItem, roi, setMediaItem, image, isImageReady }}>
+            {children}
+        </SelectedMediaItemContext>
     );
 };
 

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useRef, useState } from 'react';
+import { createContext, ReactNode, useCallback, useContext, useRef, useState } from 'react';
 
 import { isEqual } from 'lodash-es';
 import { useParams } from 'react-router';
@@ -30,10 +30,16 @@ type SelectedMediaItemProviderProps = {
 const useVideoFrameNumberQueryParam = () => {
     const { frameNumber } = useParams<{ frameNumber?: string }>();
 
-    return frameNumber ? parseInt(frameNumber) : 0;
+    if (frameNumber === undefined) {
+        return 0;
+    }
+
+    const frameNumberInt = parseInt(frameNumber, 10);
+
+    return Number.isNaN(frameNumberInt) ? 0 : frameNumberInt;
 };
 
-const getMediaItem = (mediaItem: Media, frameNumber: number): Media => {
+const convertMediaItem = (mediaItem: Media, frameNumber: number): Media => {
     if (isVideo(mediaItem)) {
         return {
             ...mediaItem,
@@ -49,15 +55,25 @@ const getMediaItem = (mediaItem: Media, frameNumber: number): Media => {
 const useMediaItem = (initialMediaItem: Media) => {
     const frameNumber = useVideoFrameNumberQueryParam();
 
-    const [mediaItem, setMediaItem] = useState<Media>(() => getMediaItem(initialMediaItem, frameNumber));
+    const [mediaItem, setMediaItem] = useState<Media>(() => convertMediaItem(initialMediaItem, frameNumber));
     const prevInitialMediaItem = useRef(initialMediaItem);
 
     if (!isEqual(initialMediaItem, prevInitialMediaItem.current)) {
         prevInitialMediaItem.current = initialMediaItem;
-        setMediaItem(getMediaItem(initialMediaItem, frameNumber));
+        setMediaItem(convertMediaItem(initialMediaItem, frameNumber));
     }
 
-    return [mediaItem, setMediaItem] as const;
+    const changeMediaItem = useCallback((newMedia: Media) => {
+        setMediaItem((prevMediaItem) => {
+            if (isEqual(prevMediaItem, newMedia)) {
+                return prevMediaItem;
+            }
+
+            return convertMediaItem(newMedia, 0);
+        });
+    }, []);
+
+    return [mediaItem, changeMediaItem] as const;
 };
 
 export const SelectedMediaItemProvider = ({

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -10,6 +10,7 @@ import type { Media } from '../../constants/shared-types';
 import { isVideo } from '../../shared/media-item-utils';
 import type { RegionOfInterest } from '../../shared/types';
 import { useLoadImageQuery } from './hooks/use-load-image-query.hook';
+import { getImageData } from './tools/utils';
 
 type SelectedMediaItemContextProps = {
     mediaItem: Media;
@@ -103,8 +104,7 @@ const getMediaItem = (mediaItem: Media) => {
 export const MediaItemImageLoader = ({ children }: { children: ReactNode }) => {
     const { mediaItem } = useSelectedMediaItem();
 
-    // TODO: Use getMediaItem when API supports video frames
-    const { data: image } = useLoadImageQuery(mediaItem.id);
+    const { data: image = getImageData(new Image()) } = useLoadImageQuery(mediaItem);
 
     return <MediaItemImageContext value={{ image }}>{children}</MediaItemImageContext>;
 };

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -1,9 +1,13 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
+import { createContext, ReactNode, useContext, useRef, useState } from 'react';
+
+import { isEqual } from 'lodash-es';
+import { useParams } from 'react-router';
 
 import type { Media } from '../../constants/shared-types';
+import { isVideo } from '../../shared/media-item-utils';
 import type { RegionOfInterest } from '../../shared/types';
 import { useLoadImageQuery } from './hooks/use-load-image-query.hook';
 
@@ -20,16 +24,44 @@ type SelectedMediaItemProviderProps = {
     children: ReactNode;
 };
 
+const useVideoFrameNumberQueryParam = () => {
+    const { frameNumber } = useParams<{ frameNumber?: string }>();
+
+    return frameNumber ? parseInt(frameNumber) : 0;
+};
+
+const getMediaItem = (mediaItem: Media, frameNumber: number): Media => {
+    if (isVideo(mediaItem)) {
+        return {
+            ...mediaItem,
+            type: 'video_frame',
+            frame_stride: mediaItem.fps,
+            frame_number: frameNumber,
+        };
+    }
+
+    return mediaItem;
+};
+
+const useMediaItem = (initialMediaItem: Media) => {
+    const frameNumber = useVideoFrameNumberQueryParam();
+
+    const [mediaItem, setMediaItem] = useState<Media>(() => getMediaItem(initialMediaItem, frameNumber));
+    const prevInitialMediaItem = useRef(initialMediaItem);
+
+    if (!isEqual(initialMediaItem, prevInitialMediaItem.current)) {
+        prevInitialMediaItem.current = initialMediaItem;
+        setMediaItem(getMediaItem(initialMediaItem, frameNumber));
+    }
+
+    return [mediaItem, setMediaItem] as const;
+};
+
 export const SelectedMediaItemProvider = ({
     mediaItem: initialMediaItem,
     children,
 }: SelectedMediaItemProviderProps) => {
-    const [mediaItem, setMediaItem] = useState<Media>(initialMediaItem);
-
-    /* TODO: Check if we need this */
-    useEffect(() => {
-        setMediaItem(initialMediaItem);
-    }, [initialMediaItem]);
+    const [mediaItem, setMediaItem] = useMediaItem(initialMediaItem);
 
     const roi: RegionOfInterest = { x: 0, y: 0, width: mediaItem.width, height: mediaItem.height };
 

--- a/application/ui/src/features/annotator/tools/bounding-box-tool/bounding-box-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/bounding-box-tool/bounding-box-tool.component.tsx
@@ -5,15 +5,14 @@ import { useZoom } from '../../../../components/zoom/zoom.provider';
 import type { Label } from '../../../../constants/shared-types';
 import type { Rect } from '../../../../shared/types';
 import { useAnnotatorLabels } from '../../annotator-labels-provider.component';
-import { useMediaItemImage, useSelectedMediaItem } from '../../selected-media-item-provider.component';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { DrawingBox } from '../drawing-box-tool/drawing-box.component';
 import { useAddAndSelectAnnotations } from '../use-add-and-select-annotations.hook';
 
 export const BoundingBoxTool = () => {
     const { scale: zoom } = useZoom();
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
-    const { roi } = useSelectedMediaItem();
-    const { image } = useMediaItemImage();
+    const { roi, image } = useSelectedMediaItem();
     const { selectedLabel } = useAnnotatorLabels();
 
     const handleComplete = (shapes: Rect[], labels: Label[]): string[] => {

--- a/application/ui/src/features/annotator/tools/magnetic-lasso/magnetic-lasso.component.tsx
+++ b/application/ui/src/features/annotator/tools/magnetic-lasso/magnetic-lasso.component.tsx
@@ -12,7 +12,7 @@ import { useZoom } from '../../../../components/zoom/zoom.provider';
 import { Point } from '../../../../shared/types';
 import { isNonEmptyArray } from '../../../../shared/util';
 import { useAnnotatorLabels } from '../../annotator-labels-provider.component';
-import { useMediaItemImage } from '../../selected-media-item-provider.component';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { usePolygonConfig } from '../hooks/use-polygon-config.hook';
 import { PolygonDraw } from '../polygon-tool/polygon-draw.component';
 import {
@@ -34,7 +34,7 @@ export const MagneticLasso = () => {
     const { scale: zoom } = useZoom();
     const [mode, setMode] = useState<PolygonMode>(PolygonMode.MagneticLasso);
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
-    const { image } = useMediaItemImage();
+    const { image } = useSelectedMediaItem();
     const { selectedLabel } = useAnnotatorLabels();
     const [isPendingPolygonOptimization, startTransition] = useTransition();
 

--- a/application/ui/src/features/annotator/tools/polygon-tool/polygon-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/polygon-tool/polygon-tool.component.tsx
@@ -9,7 +9,7 @@ import { isEmpty } from 'lodash-es';
 import { useZoom } from '../../../../components/zoom/zoom.provider';
 import { Point } from '../../../../shared/types';
 import { useAnnotatorLabels } from '../../annotator-labels-provider.component';
-import { useMediaItemImage } from '../../selected-media-item-provider.component';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { usePolygonConfig } from '../hooks/use-polygon-config.hook';
 import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { useAddAndSelectAnnotations } from '../use-add-and-select-annotations.hook';
@@ -31,7 +31,7 @@ import classes from './polygon-tool.module.scss';
 export const PolygonTool = () => {
     const { scale: zoom } = useZoom();
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
-    const { image } = useMediaItemImage();
+    const { image } = useSelectedMediaItem();
     const { selectedLabel } = useAnnotatorLabels();
 
     const ref = useRef<SVGRectElement>({} as SVGRectElement);

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -12,7 +12,7 @@ import type { Annotation, RegionOfInterest, Shape } from '../../../../shared/typ
 import { AnnotationShape } from '../../annotations/annotation-shape/annotation-shape.component';
 import { MaskAnnotations } from '../../annotations/mask-annotations.component';
 import { useAnnotatorLabels } from '../../annotator-labels-provider.component';
-import { useMediaItemImage, useSelectedMediaItem } from '../../selected-media-item-provider.component';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { useAddAndSelectAnnotations } from '../use-add-and-select-annotations.hook';
 import { getRelativePoint, removeOffLimitPoints } from '../utils';
@@ -58,8 +58,7 @@ export const SegmentAnythingTool = () => {
     const ref = useRef<SVGSVGElement>(null);
 
     const zoom = useZoom();
-    const { roi } = useSelectedMediaItem();
-    const { image } = useMediaItemImage();
+    const { roi, image } = useSelectedMediaItem();
     const { selectedLabel } = useAnnotatorLabels();
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
     const { isLoading, decodingQueryFn } = useSegmentAnythingModel();

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -10,7 +10,7 @@ import { useProject } from 'hooks/api/project.hook';
 
 import type { Media } from '../../../../constants/shared-types';
 import { isDetectionTask } from '../../../project/task-type-guards';
-import { useMediaItemImage, useSelectedMediaItem } from '../../selected-media-item-provider.component';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { convertToolShapeToGetiShape } from '../utils';
 import { InteractiveAnnotationPoint } from './segment-anything.interface';
 
@@ -121,8 +121,7 @@ export const useSegmentAnythingModel = () => {
     const decoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER');
     const isLoadingWorkers = encoderModel === undefined || decoderModel === undefined;
 
-    const { mediaItem } = useSelectedMediaItem();
-    const { image } = useMediaItemImage();
+    const { mediaItem, image } = useSelectedMediaItem();
     const encodingQuery = useEncodingQuery(encoderModel, mediaItem, image);
     const decodingQueryFn = useDecodingFn(decoderModel, encodingQuery.data);
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -9,6 +9,7 @@ import { Remote, wrap } from 'comlink';
 import { useProject } from 'hooks/api/project.hook';
 
 import type { Media } from '../../../../constants/shared-types';
+import { isVideoFrame } from '../../../../shared/media-item-utils';
 import { isDetectionTask } from '../../../project/task-type-guards';
 import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { convertToolShapeToGetiShape } from '../utils';
@@ -55,23 +56,26 @@ const useSegmentAnythingWorker = (algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'S
     return modelRef.current;
 };
 
-const useEncodingQuery = (model: Remote<SegmentAnythingModel> | undefined, mediaItem: Media, image: ImageData) => {
+const useEncodingQuery = (
+    model: Remote<SegmentAnythingModel> | undefined,
+    mediaItem: Media,
+    image: ImageData,
+    isImageReady: boolean
+) => {
     return useQuery({
-        queryKey: ['segment-anything-model', 'encoding', mediaItem?.id],
+        queryKey: isVideoFrame(mediaItem)
+            ? ['segment-anything-model', 'encoding', mediaItem.id, mediaItem.frame_number]
+            : ['segment-anything-model', 'encoding', mediaItem.id],
         queryFn: async () => {
             if (model === undefined) {
                 throw new Error('Model not yet initialized');
-            }
-
-            if (image === undefined) {
-                throw new Error('Image not available');
             }
 
             return await model.processEncoder(image);
         },
         staleTime: Infinity,
         gcTime: 3600 * 15,
-        enabled: model !== undefined && mediaItem !== undefined,
+        enabled: model !== undefined && isImageReady,
     });
 };
 
@@ -121,8 +125,8 @@ export const useSegmentAnythingModel = () => {
     const decoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER');
     const isLoadingWorkers = encoderModel === undefined || decoderModel === undefined;
 
-    const { mediaItem, image } = useSelectedMediaItem();
-    const encodingQuery = useEncodingQuery(encoderModel, mediaItem, image);
+    const { mediaItem, image, isImageReady } = useSelectedMediaItem();
+    const encodingQuery = useEncodingQuery(encoderModel, mediaItem, image, isImageReady);
     const decodingQueryFn = useDecodingFn(decoderModel, encodingQuery.data);
 
     const isLoading = isLoadingWorkers || encodingQuery.isLoading;

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -1,17 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    createContext,
-    Dispatch,
-    ReactNode,
-    RefObject,
-    SetStateAction,
-    use,
-    useMemo,
-    useRef,
-    useState,
-} from 'react';
+import { createContext, Dispatch, ReactNode, RefObject, SetStateAction, use, useMemo, useRef, useState } from 'react';
 
 import { VisuallyHidden } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -1,12 +1,22 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, Dispatch, ReactNode, RefObject, SetStateAction, use, useMemo, useRef, useState } from 'react';
+import {
+    createContext,
+    Dispatch,
+    ReactNode,
+    RefObject,
+    SetStateAction,
+    use,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 
 import { VisuallyHidden } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
-import type { MediaVideo, MediaVideoFrame } from '../../../constants/shared-types';
+import type { MediaVideoFrame } from '../../../constants/shared-types';
 import { getMediaBinaryUrl } from '../../../shared/media-url.utils';
 import { useVideoControls, VideoControls } from './use-video-controls';
 
@@ -33,8 +43,7 @@ const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
 
 type VideoPlayerProviderProps = {
     children: ReactNode;
-    // TODO: Narrow the type to be MediaVideoFrame | undefined
-    videoFrame: MediaVideo | MediaVideoFrame | undefined;
+    videoFrame: MediaVideoFrame | undefined;
     changeSelectedMediaItem: (media: MediaVideoFrame) => void;
 };
 
@@ -43,8 +52,7 @@ export const VideoPlayerProvider = ({ children, videoFrame, changeSelectedMediaI
     const videoRef = useRef<HTMLVideoElement>(null);
     const [isMuted, setIsMuted] = useState<boolean>(false);
     const [playbackRate, setPlaybackRate] = useState<number>(1);
-    // TODO: Update default to be media item frame index
-    const [currentFrameIndex, setCurrentFrameIndex] = useState<number>(0);
+    const [currentFrameIndex, setCurrentFrameIndex] = useState<number>(videoFrame?.frame_number ?? 0);
 
     const playingVideoFrame: MediaVideoFrame | undefined = useMemo(() => {
         if (videoFrame === undefined) {
@@ -54,13 +62,6 @@ export const VideoPlayerProvider = ({ children, videoFrame, changeSelectedMediaI
         return {
             ...videoFrame,
             frame_number: currentFrameIndex,
-
-            // TODO: This logic should be moved to selected media item provider
-            type: 'video_frame',
-            frame_count: videoFrame.frame_count,
-            fps: videoFrame.fps,
-            duration: videoFrame.duration,
-            frame_stride: videoFrame.fps,
         };
     }, [currentFrameIndex, videoFrame]);
 

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/thumbnail-preview.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/thumbnail-preview.component.tsx
@@ -5,7 +5,7 @@ import { Image, View } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { MediaVideoFrame } from '../../../../../../../constants/shared-types';
-import { getThumbnailUrl } from '../../../../../../../shared/media-url.utils';
+import { getVideoFrameThumbnailUrl } from '../../../../../../../shared/media-url.utils';
 import { formatDurationText } from '../../../time-utils';
 import { FrameNumberIndicator } from './frame-number-indicator.component';
 
@@ -24,8 +24,7 @@ export const ThumbnailPreview = ({ videoFrame, frameNumber, width, height, x }: 
     const projectIdentifier = useProjectIdentifier();
 
     const fps = videoFrame.fps;
-    // TODO: Replace it with the video frame thumbnail when the endpoint will be ready.
-    const src = getThumbnailUrl(projectIdentifier, videoFrame.id);
+    const src = getVideoFrameThumbnailUrl(projectIdentifier, videoFrame.id, frameNumber);
 
     const durationText = formatDurationText(frameNumber / fps);
 

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -22,13 +22,13 @@ export const useSelectDatasetItem = () => {
         }
 
         if (isVideo(item)) {
-            navigate(paths.project.dataset.videoFrame({ projectId, datasetItemId: item.id, frameNumber: '0' }));
+            navigate(paths.project.dataset.item.frame({ projectId, datasetItemId: item.id, frameNumber: '0' }));
             return;
         }
 
         if (isVideoFrame(item)) {
             navigate(
-                paths.project.dataset.videoFrame({
+                paths.project.dataset.item.frame({
                     projectId,
                     datasetItemId: item.id,
                     frameNumber: item.frame_number.toString(),
@@ -37,7 +37,7 @@ export const useSelectDatasetItem = () => {
             return;
         }
 
-        navigate(paths.project.dataset.datasetItem({ projectId, datasetItemId: item.id }));
+        navigate(paths.project.dataset.item.index({ projectId, datasetItemId: item.id }));
     };
 
     return {

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -1,13 +1,13 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { isObject } from 'lodash-es';
 import { useNavigate, useParams } from 'react-router';
 
 import { paths } from '../../../../constants/paths';
 import { Media } from '../../../../constants/shared-types';
 import { useGetDatasetMediaItems } from '../../../../hooks/use-get-dataset-media-items.hook';
 import { useProjectIdentifier } from '../../../../hooks/use-project-identifier.hook';
+import { isVideo, isVideoFrame } from '../../../../shared/media-item-utils';
 
 export const useSelectDatasetItem = () => {
     const navigate = useNavigate();
@@ -16,11 +16,28 @@ export const useSelectDatasetItem = () => {
     const { datasetItemId: selectedDatasetItemId } = useParams<{ datasetItemId: string }>();
 
     const onSelectedMediaItemChange = (item: Media | null) => {
-        const route = isObject(item)
-            ? paths.project.datasetItem({ projectId, datasetItemId: item.id })
-            : paths.project.dataset({ projectId });
+        if (item === null) {
+            navigate(paths.project.dataset.index({ projectId }));
+            return;
+        }
 
-        navigate(route);
+        if (isVideo(item)) {
+            navigate(paths.project.dataset.videoFrame({ projectId, datasetItemId: item.id, frameNumber: '0' }));
+            return;
+        }
+
+        if (isVideoFrame(item)) {
+            navigate(
+                paths.project.dataset.videoFrame({
+                    projectId,
+                    datasetItemId: item.id,
+                    frameNumber: item.frame_number.toString(),
+                })
+            );
+            return;
+        }
+
+        navigate(paths.project.dataset.datasetItem({ projectId, datasetItemId: item.id }));
     };
 
     return {

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -68,10 +68,15 @@ const Annotator = ({
 }: AnnotatorProps) => {
     const { mediaItem, setMediaItem } = useSelectedMediaItem();
 
+    const selectMediaItem = (item: Media) => {
+        setMediaItem(item);
+        onSelectedMediaItem(item);
+    };
+
     return (
         <VideoPlayerProvider
-            videoFrame={isVideo(mediaItem) || isVideoFrame(mediaItem) ? mediaItem : undefined}
-            changeSelectedMediaItem={setMediaItem}
+            videoFrame={isVideoFrame(mediaItem) ? mediaItem : undefined}
+            changeSelectedMediaItem={selectMediaItem}
         >
             {mode === 'prediction' ? (
                 <ReadOnlyAnnotator

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Suspense, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
-import { Content, Dialog, Grid, Loading, View } from '@geti/ui';
+import { Content, Dialog, Grid, View } from '@geti/ui';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
@@ -11,7 +11,7 @@ import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { MediaItemImageLoader, useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
+import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { useSelectedData } from '../selected-data-provider.component';
@@ -66,7 +66,7 @@ const Annotator = ({
     items,
     onSelectedMediaItem,
 }: AnnotatorProps) => {
-    const { mediaItem, setMediaItem } = useSelectedMediaItem();
+    const { mediaItem, setMediaItem, image } = useSelectedMediaItem();
 
     const selectMediaItem = (item: Media) => {
         setMediaItem(item);
@@ -80,6 +80,7 @@ const Annotator = ({
         >
             {mode === 'prediction' ? (
                 <ReadOnlyAnnotator
+                    image={image}
                     mediaItem={mediaItem}
                     isUserReviewed={isUserReviewed}
                     onModeChange={changeAnnotatorMode}
@@ -116,11 +117,7 @@ const Annotator = ({
 
                     <View gridArea={'canvas'} overflow={'hidden'}>
                         <AnnotatorCanvasSettings>
-                            <Suspense fallback={<Loading size='L' mode='inline' style={{ height: '100%' }} />}>
-                                <MediaItemImageLoader>
-                                    <AnnotatorCanvas mediaItem={mediaItem} />
-                                </MediaItemImageLoader>
-                            </Suspense>
+                            <AnnotatorCanvas mediaItem={mediaItem} image={image} />
                         </AnnotatorCanvasSettings>
                     </View>
                 </>

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -8,7 +8,6 @@ import { Checkmark, CloseSemiBold } from '@geti/ui/icons';
 
 import type { Media } from '../../../constants/shared-types';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { MediaItemImageLoader } from '../../annotator/selected-media-item-provider.component';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';
 import { AnnotatorModes } from './secondary-toolbar/annotator-modes/annotator-modes-toggle.component';
@@ -19,6 +18,7 @@ import classes from './read-only-annotator.module.scss';
 
 type ReadOnlyAnnotatorProps = {
     mediaItem: Media;
+    image: ImageData;
     isUserReviewed: boolean;
     onClose: () => void;
     onModeChange?: (mode: 'annotation' | 'prediction') => void;
@@ -37,6 +37,7 @@ type ReadOnlyAnnotatorProps = {
  * It uses the same gridArea structure as the normal annotator but with fewer elements.
  */
 export const ReadOnlyAnnotator = ({
+    image,
     mediaItem,
     isUserReviewed,
     onModeChange,
@@ -82,11 +83,7 @@ export const ReadOnlyAnnotator = ({
 
             <View gridArea={'canvas'} overflow={'hidden'} UNSAFE_className={classes.readOnlyCanvas}>
                 <AnnotatorCanvasSettings>
-                    <Suspense fallback={<Loading size='L' mode='inline' style={{ height: '100%' }} />}>
-                        <MediaItemImageLoader>
-                            <AnnotatorCanvas isReadOnly mediaItem={mediaItem} />
-                        </MediaItemImageLoader>
-                    </Suspense>
+                    <AnnotatorCanvas isReadOnly mediaItem={mediaItem} image={image} />
                 </AnnotatorCanvasSettings>
             </View>
 

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -1,9 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Suspense } from 'react';
-
-import { ActionButton, Button, Flex, Loading, Text, View } from '@geti/ui';
+import { ActionButton, Button, Flex, Text, View } from '@geti/ui';
 import { Checkmark, CloseSemiBold } from '@geti/ui/icons';
 
 import type { Media } from '../../../constants/shared-types';

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -15,6 +15,8 @@ import { useAnnotationsQuery } from '../../../../features/dataset/media-preview/
 import { ReadOnlyAnnotator } from '../../../../features/dataset/media-preview/read-only-annotator.component';
 import { getInitialAnnotations } from '../../../../features/dataset/media-preview/utils';
 import { getDatasetRevisionThumbnailUrl } from '../../../../shared/media-url.utils';
+import { useLoadImageQuery } from '../../../annotator/hooks/use-load-image-query.hook';
+import { getImageData } from '../../../annotator/tools/utils';
 import { datasetRevisionItemToMedia } from './utils';
 
 const layoutOptions = {
@@ -41,6 +43,7 @@ type SubsetMediaDialogProps = {
 const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
     const mediaItem = datasetRevisionItemToMedia(item);
     const { data: annotationsData } = useAnnotationsQuery(mediaItem);
+    const { data: image = getImageData(new Image()) } = useLoadImageQuery(mediaItem);
 
     const annotationsDTO = annotationsData?.annotations ?? [];
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
@@ -65,7 +68,12 @@ const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
                         isUserReviewed={isUserReviewed}
                         mode={mode}
                     >
-                        <ReadOnlyAnnotator mediaItem={mediaItem} isUserReviewed={isUserReviewed} onClose={onClose} />
+                        <ReadOnlyAnnotator
+                            image={image}
+                            mediaItem={mediaItem}
+                            isUserReviewed={isUserReviewed}
+                            onClose={onClose}
+                        />
                     </AnnotatorProviders>
                 </Grid>
             </Content>

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -69,7 +69,7 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
             },
             {
                 onSuccess: () => {
-                    navigate(paths.project.dataset({ projectId }));
+                    navigate(paths.project.dataset.index({ projectId }));
                 },
             }
         );

--- a/application/ui/src/features/project/list/project-card.component.tsx
+++ b/application/ui/src/features/project/list/project-card.component.tsx
@@ -52,7 +52,7 @@ export const ProjectCard = ({ item }: ProjectCardProps) => {
 
     return (
         <div style={{ position: 'relative' }}>
-            <NavLink to={paths.project.dataset({ projectId: item.id })}>
+            <NavLink to={paths.project.dataset.index({ projectId: item.id })}>
                 <Flex UNSAFE_className={clsx({ [classes.card]: true, [classes.activeCard]: isActive })}>
                     <Flex>
                         <img src={getProjectThumbnailUrl(item.id)} alt={item.name} />

--- a/application/ui/src/layout.tsx
+++ b/application/ui/src/layout.tsx
@@ -43,7 +43,7 @@ const Header = () => {
                     <Item
                         textValue='Data collection page to visualise your media items'
                         key={'dataset'}
-                        href={paths.project.dataset({ projectId })}
+                        href={paths.project.dataset.index({ projectId })}
                     >
                         <Flex alignItems='center' gap='size-100'>
                             <BuildIcon style={iconStyles} />

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 
 import { paths } from './constants/paths';
 import { SelectedDataProvider } from './features/dataset/selected-data-provider.component';
@@ -30,7 +30,7 @@ const Redirect = () => {
         const projectId = projects[0].id;
 
         if (projectId) {
-            path = paths.project.dataset({ projectId });
+            path = paths.project.dataset.index({ projectId });
         } else {
             path = paths.project.new({});
         }
@@ -40,7 +40,7 @@ const Redirect = () => {
         const projectWithActivePipeline = projects.find((project) => Boolean(project.active_pipeline));
 
         if (projectWithActivePipeline) {
-            path = paths.project.dataset({ projectId: projectWithActivePipeline.id });
+            path = paths.project.dataset.index({ projectId: projectWithActivePipeline.id });
         } else {
             path = paths.project.index({});
         }
@@ -81,20 +81,26 @@ export const router = createBrowserRouter([
                         element: <Inference />,
                     },
                     {
-                        path: paths.project.dataset.pattern,
+                        path: paths.project.dataset.index.pattern,
                         element: (
                             <SelectedDataProvider>
-                                <Dataset />
+                                <Outlet />
                             </SelectedDataProvider>
                         ),
-                    },
-                    {
-                        path: paths.project.datasetItem.pattern,
-                        element: (
-                            <SelectedDataProvider>
-                                <Dataset />
-                            </SelectedDataProvider>
-                        ),
+                        children: [
+                            {
+                                index: true,
+                                element: <Dataset />,
+                            },
+                            {
+                                path: paths.project.dataset.datasetItem.pattern,
+                                element: <Dataset />,
+                            },
+                            {
+                                path: paths.project.dataset.videoFrame.pattern,
+                                element: <Dataset />,
+                            },
+                        ],
                     },
                     {
                         path: paths.project.models.pattern,

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -93,11 +93,11 @@ export const router = createBrowserRouter([
                                 element: <Dataset />,
                             },
                             {
-                                path: paths.project.dataset.datasetItem.pattern,
+                                path: paths.project.dataset.item.index.pattern,
                                 element: <Dataset />,
                             },
                             {
-                                path: paths.project.dataset.videoFrame.pattern,
+                                path: paths.project.dataset.item.frame.pattern,
                                 element: <Dataset />,
                             },
                         ],

--- a/application/ui/src/shared/media-url.utils.ts
+++ b/application/ui/src/shared/media-url.utils.ts
@@ -3,32 +3,33 @@
 
 import { API_BASE_URL } from '../api/client';
 
-export const getProjectThumbnailUrl = (projectId: string) => `${API_BASE_URL}/api/projects/${projectId}/thumbnail`;
+export const getProjectThumbnailUrl = (projectId: string) =>
+    new URL(`api/projects/${projectId}/thumbnail`, API_BASE_URL).toString();
 
 const getMediaBaseUrl = (projectId: string, itemId: string) =>
-    `${API_BASE_URL}/api/projects/${projectId}/dataset/media/${itemId}`;
+    new URL(`api/projects/${projectId}/dataset/media/${itemId}`, API_BASE_URL).toString();
 
 const getDatasetRevisionItemBaseUrl = (projectId: string, datasetRevisionId: string, itemId: string) =>
-    `${API_BASE_URL}/api/projects/${projectId}/dataset_revisions/${datasetRevisionId}/items/${itemId}`;
+    new URL(`api/projects/${projectId}/dataset_revisions/${datasetRevisionId}/items/${itemId}`, API_BASE_URL);
 
 export const getThumbnailUrl = (projectId: string, itemId: string) => {
-    return `${getMediaBaseUrl(projectId, itemId)}/thumbnail`;
+    return new URL('thumbnail', `${getMediaBaseUrl(projectId, itemId)}/`).toString();
 };
 
 export const getMediaBinaryUrl = (projectId: string, itemId: string) => {
-    return `${getMediaBaseUrl(projectId, itemId)}/binary`;
+    return new URL('binary', `${getMediaBaseUrl(projectId, itemId)}/`).toString();
 };
 
 export const getDatasetRevisionThumbnailUrl = (projectId: string, datasetRevisionId: string, itemId: string) => {
-    return `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/thumbnail`;
+    return new URL('thumbnail', `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/`).toString();
 };
 
 export const getDatasetRevisionMediaBinaryUrl = (projectId: string, datasetRevisionId: string, itemId: string) => {
-    return `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/binary`;
+    return new URL('binary', `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/`).toString();
 };
 
 export const getVideoFrameBinaryUrl = (projectId: string, itemId: string, frameNumber: number) => {
-    const url = new URL(`${getMediaBaseUrl(projectId, itemId)}/binary`);
+    const url = new URL(getMediaBinaryUrl(projectId, itemId));
 
     url.searchParams.set('frame_index', frameNumber.toString());
 
@@ -36,7 +37,7 @@ export const getVideoFrameBinaryUrl = (projectId: string, itemId: string, frameN
 };
 
 export const getVideoFrameThumbnailUrl = (projectId: string, itemId: string, frameNumber: number) => {
-    const url = new URL(`${getMediaBaseUrl(projectId, itemId)}/thumbnail`);
+    const url = new URL('thumbnail', `${getMediaBaseUrl(projectId, itemId)}/`);
 
     url.searchParams.set('frame_index', frameNumber.toString());
 

--- a/application/ui/src/shared/media-url.utils.ts
+++ b/application/ui/src/shared/media-url.utils.ts
@@ -28,9 +28,17 @@ export const getDatasetRevisionMediaBinaryUrl = (projectId: string, datasetRevis
 };
 
 export const getVideoFrameBinaryUrl = (projectId: string, itemId: string, frameNumber: number) => {
-    return `${getMediaBaseUrl(projectId, itemId)}/${frameNumber}/binary`;
+    const url = new URL(`${getMediaBaseUrl(projectId, itemId)}/binary`);
+
+    url.searchParams.set('frame_index', frameNumber.toString());
+
+    return url.toString();
 };
 
 export const getVideoFrameThumbnailUrl = (projectId: string, itemId: string, frameNumber: number) => {
-    return `${getMediaBaseUrl(projectId, itemId)}/${frameNumber}/thumbnail`;
+    const url = new URL(`${getMediaBaseUrl(projectId, itemId)}/thumbnail`);
+
+    url.searchParams.set('frame_index', frameNumber.toString());
+
+    return url.toString();
 };

--- a/application/ui/tests/datasets/datasets.spec.ts
+++ b/application/ui/tests/datasets/datasets.spec.ts
@@ -89,9 +89,7 @@ test.describe('Dataset', () => {
         await expect(annotatorPage.getAnnotationsList()).not.toBeInViewport();
 
         await page.getByRole('img', { name: firstElement.name, exact: true }).dblclick();
-        await expect(annotatorPage.getAnnotationsList()).not.toBeInViewport();
 
-        await page.reload();
         await expect(annotatorPage.getAnnotationsList()).toBeInViewport();
 
         expect(page.url()).toContain(`/dataset/${firstElement.id}`);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR integrates selected media item with the video frames from the server.
What's new:
1. Replaced the suspense query with query for loading image. That change allows us to move image to the selected media item provider. Moreover that also improved the UX, when we change the video frame/img we still show the img on the canvas instead of showing loading.
2. Added video frame to the URL. When we open video it will navigate to `.../dataset/{videoId}/{videoFrame}`.
3. Because of #1 the new issue was introduced, i.e. sam encoding query was triggered with the new media but with the old image. I explained more in the commit message.
4. If u test and notice any issue with video navigation, that issue should be fixed in https://github.com/open-edge-platform/training_extensions/pull/5640.

Closes #5605 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
