### PR TITLE
Disallow label removal on readOnly mode

### DIFF
--- a/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.test.tsx
@@ -72,6 +72,18 @@ describe('AnnotationLabels', () => {
         expect(mockOnRemove).toHaveBeenCalledWith('label-1');
     });
 
+    it('does not render remove button when labels are non-removable', () => {
+        const label = getMockedLabel({ id: 'label-1', name: 'Person' });
+
+        render(
+            <svg>
+                <AnnotationLabels labels={[label]} onRemove={mockOnRemove} isRemovable={false} />
+            </svg>
+        );
+
+        expect(screen.queryByLabelText('Remove Person')).not.toBeInTheDocument();
+    });
+
     it('positions foreignObject just above annotation anchor for CSS scaling', () => {
         const label = getMockedLabel({ name: 'Person' });
 

--- a/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.tsx
@@ -21,6 +21,7 @@ interface AnnotationLabelsProps {
     labels: AnnotationLabel[];
     onRemove: (labelId: string) => void;
     useBottomCorners?: boolean;
+    isRemovable?: boolean;
 }
 
 const formatPredictionScore = (score: number) => {
@@ -31,7 +32,12 @@ const getLabelText = (label: AnnotationLabel) => {
     return `${label.name} ${isPrediction(label) ? formatPredictionScore(label.probability) : ''}`.trim();
 };
 
-export const AnnotationLabels = ({ labels, onRemove, useBottomCorners = false }: AnnotationLabelsProps) => {
+export const AnnotationLabels = ({
+    labels,
+    onRemove,
+    useBottomCorners = false,
+    isRemovable = true,
+}: AnnotationLabelsProps) => {
     const { scale } = useZoom();
 
     const onDeleteLabel = useCallback(
@@ -82,7 +88,7 @@ export const AnnotationLabels = ({ labels, onRemove, useBottomCorners = false }:
                             aria-label={`label ${label.name} background`}
                         >
                             <span aria-label={`label ${label.name}`}>{getLabelText(label)}</span>
-                            {!isPlaceholder && (
+                            {!isPlaceholder && isRemovable && (
                                 <button
                                     className={classes.removeButton}
                                     onPointerDown={onDeleteLabel(label.id)}

--- a/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.tsx
@@ -21,11 +21,15 @@ type AnnotationShapeProps = {
 export const AnnotationShapeWithLabels = ({ annotation }: AnnotationShapeProps) => {
     const { data: selectedProject } = useProject();
     const { isVisible } = useAnnotationVisibility();
-    const { updateAnnotations, deleteAnnotations } = useAnnotationActions();
+    const { updateAnnotations, deleteAnnotations, isReadOnlyMode } = useAnnotationActions();
 
     const { shape, labels } = annotation;
 
     const removeLabels = (labelId: Key | null) => {
+        if (isReadOnlyMode) {
+            return;
+        }
+
         const updatedLabels = annotation.labels.filter((label) => label.id !== labelId) as Label[];
         const hasNoLabels = updatedLabels.length === 0;
 
@@ -40,7 +44,7 @@ export const AnnotationShapeWithLabels = ({ annotation }: AnnotationShapeProps) 
         return (
             <g display={isVisible ? 'block' : 'none'}>
                 <AnnotationShape annotation={annotation} />
-                <AnnotationLabels labels={labels} onRemove={removeLabels} />
+                <AnnotationLabels labels={labels} onRemove={removeLabels} isRemovable={!isReadOnlyMode} />
             </g>
         );
     }
@@ -49,7 +53,7 @@ export const AnnotationShapeWithLabels = ({ annotation }: AnnotationShapeProps) 
         return (
             <g transform={`translate(${shape.x}, ${shape.y})`} display={isVisible ? 'block' : 'none'}>
                 <AnnotationShape annotation={{ ...annotation, shape: { ...shape, x: 0, y: 0 } }} />
-                <AnnotationLabels labels={labels} onRemove={removeLabels} />
+                <AnnotationLabels labels={labels} onRemove={removeLabels} isRemovable={!isReadOnlyMode} />
             </g>
         );
     }
@@ -62,7 +66,7 @@ export const AnnotationShapeWithLabels = ({ annotation }: AnnotationShapeProps) 
             <g transform={`translate(${-labelX}, ${-labelY})`}>
                 <AnnotationShape annotation={annotation} />
             </g>
-            <AnnotationLabels labels={labels} onRemove={removeLabels} useBottomCorners />
+            <AnnotationLabels labels={labels} onRemove={removeLabels} useBottomCorners isRemovable={!isReadOnlyMode} />
         </g>
     );
 };

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -19,6 +19,7 @@ type AnnotatorProvidersProps = {
     initialPredictionsDTO: AnnotationDTO[];
     isUserReviewed: boolean;
     mode: AnnotatorMode;
+    isReadOnly?: boolean;
     children: ReactNode;
 };
 
@@ -39,6 +40,7 @@ export const AnnotatorProviders = ({
     initialPredictionsDTO,
     isUserReviewed,
     mode,
+    isReadOnly = false,
     children,
 }: AnnotatorProvidersProps) => {
     return (
@@ -55,6 +57,7 @@ export const AnnotatorProviders = ({
                                     initialPredictionsDTO={initialPredictionsDTO}
                                     isUserReviewed={isUserReviewed}
                                     mode={mode}
+                                    isReadOnly={isReadOnly}
                                 >
                                     {children}
                                 </AnnotationActionsProvider>

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -64,6 +64,7 @@ const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
                         initialPredictionsDTO={[]}
                         isUserReviewed={isUserReviewed}
                         mode={mode}
+                        isReadOnly
                     >
                         <ReadOnlyAnnotator mediaItem={mediaItem} isUserReviewed={isUserReviewed} onClose={onClose} />
                     </AnnotatorProviders>

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -51,6 +51,7 @@ interface AnnotationsContextValue {
     submitAnnotations: () => Promise<void>;
     isUserReviewed: boolean;
     isSaving: boolean;
+    isReadOnlyMode: boolean;
 }
 
 const AnnotationsContext = createContext<AnnotationsContextValue | null>(null);
@@ -62,6 +63,7 @@ type AnnotationActionsProviderProps = {
     isUserReviewed?: boolean;
     mediaItem: Media;
     mode: AnnotatorMode;
+    isReadOnly?: boolean;
 };
 
 const filterOutAnnotationWithEmptyLabel = (annotations: Annotation[]): Annotation[] => {
@@ -75,6 +77,7 @@ export const AnnotationActionsProvider = ({
     isUserReviewed = false,
     mediaItem,
     mode,
+    isReadOnly = false,
 }: AnnotationActionsProviderProps) => {
     const projectId = useProjectIdentifier();
     const saveMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media/{media_id}/annotations', {
@@ -177,6 +180,7 @@ export const AnnotationActionsProvider = ({
     };
 
     const annotationsToRender = mode === 'annotation' ? annotations : predictions;
+    const isReadOnlyMode = isReadOnly || mode === 'prediction';
 
     return (
         <AnnotationsContext.Provider
@@ -194,6 +198,7 @@ export const AnnotationActionsProvider = ({
                 submitAnnotations,
 
                 isSaving: saveMutation.isPending,
+                isReadOnlyMode,
             }}
         >
             <UndoRedoProvider state={undoRedoActions}>{children}</UndoRedoProvider>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary


* User wont be able to delete a label on readonly mode now. Fixes https://github.com/open-edge-platform/training_extensions/issues/5636


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
