### PR TITLE
Serve files as FastAPI FileResponse

### DIFF
--- a/application/backend/app/api/io_utils.py
+++ b/application/backend/app/api/io_utils.py
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Generator
 from io import BytesIO
-from mimetypes import guess_file_type
 from pathlib import Path
 
 from PIL.Image import Image
-from starlette.responses import StreamingResponse
+from starlette.responses import FileResponse, StreamingResponse
 
 
 def file_iterator(filepath: Path, chunk_size: int = 1024 * 1024) -> Generator[bytes]:
@@ -75,9 +74,9 @@ def write_image_to_response(image: Image, filename: str, cache_control: str | No
     )
 
 
-def write_file_to_response(path: Path, filename: str, cache_control: str | None = None) -> StreamingResponse:
+def write_file_to_response(path: Path, filename: str, cache_control: str | None = None) -> FileResponse:
     """
-    Stream a file from file system to FastAPI StreamingResponse.
+    Return a file from file system as FastAPI FileResponse.
     Additionally, method sets file name and cache control headers if provided.
 
     Args:
@@ -86,9 +85,9 @@ def write_file_to_response(path: Path, filename: str, cache_control: str | None 
         cache_control: Cache control header, optional.
 
     Returns:
-        FastAPI StreamingResponse.
+        FastAPI FileResponse.
     """
-    media_type, _ = guess_file_type(path)
-    return write_bytes_to_response(
-        bytes=file_iterator(filepath=path), filename=filename, media_type=media_type, cache_control=cache_control
-    )
+    headers = {}
+    if cache_control:
+        headers["Cache-Control"] = cache_control
+    return FileResponse(path=path, filename=filename, headers=headers)

--- a/application/backend/app/api/routers/dataset_revisions.py
+++ b/application/backend/app/api/routers/dataset_revisions.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from fastapi.openapi.models import Example
-from starlette.responses import StreamingResponse
+from starlette.responses import FileResponse, StreamingResponse
 
 from app.api.dependencies import get_dataset_revision, get_dataset_revision_service, get_project
 from app.api.io_utils import write_file_to_response, write_image_to_response
@@ -185,7 +185,7 @@ def get_dataset_revision_item_binary(
     dataset_revision: Annotated[DatasetRevision, Depends(get_dataset_revision)],
     dataset_item_id: DatasetItemID,
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
-) -> StreamingResponse:
+) -> FileResponse:
     """Get the image data of an item in the dataset revision"""
     binary_path = dataset_revision_service.get_dataset_revision_item(
         project_id=project.id,

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
-from starlette.responses import Response
+from starlette.responses import FileResponse, StreamingResponse
 
 from app.api.dependencies import get_dataset_service, get_file_name_and_extension, get_media_service, get_project
 from app.api.io_utils import write_file_to_response, write_image_to_response
@@ -306,7 +306,7 @@ def get_media_binary(
     project: Annotated[Project, Depends(get_project)],
     media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> Response:
+) -> StreamingResponse | FileResponse:
     """Get media binary content"""
     if isinstance(media, NotAnnotatedFrame):
         frame_binary = media_service.get_frame_binary(project=project, video=media.video, frame_index=media.frame_index)
@@ -332,7 +332,7 @@ def get_media_thumbnail(
     project: Annotated[Project, Depends(get_project)],
     media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> Response:
+) -> StreamingResponse | FileResponse:
     """Get media thumbnail binary content"""
     if isinstance(media, NotAnnotatedFrame):
         frame_thumbnail = media_service.get_frame_thumbnail(

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -322,6 +322,7 @@ def get_media_binary(
 
 @router.get(
     "/{media_id}/thumbnail",
+    response_model=None,
     responses={
         status.HTTP_200_OK: {"description": "Media thumbnail found"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid media ID or project ID"},

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
-from starlette.responses import StreamingResponse
+from starlette.responses import Response
 
 from app.api.dependencies import get_dataset_service, get_file_name_and_extension, get_media_service, get_project
 from app.api.io_utils import write_file_to_response, write_image_to_response
@@ -306,7 +306,7 @@ def get_media_binary(
     project: Annotated[Project, Depends(get_project)],
     media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> StreamingResponse:
+) -> Response:
     """Get media binary content"""
     if isinstance(media, NotAnnotatedFrame):
         frame_binary = media_service.get_frame_binary(project=project, video=media.video, frame_index=media.frame_index)
@@ -332,7 +332,7 @@ def get_media_thumbnail(
     project: Annotated[Project, Depends(get_project)],
     media: Annotated[Media | NotAnnotatedFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> StreamingResponse:
+) -> Response:
     """Get media thumbnail binary content"""
     if isinstance(media, NotAnnotatedFrame):
         frame_thumbnail = media_service.get_frame_thumbnail(

--- a/application/backend/tests/unit/routers/test_media.py
+++ b/application/backend/tests/unit/routers/test_media.py
@@ -609,20 +609,14 @@ class TestMediaEndpoints:
         fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
 
     @pytest.mark.parametrize(
-        "media, suffix, mime_type",
+        "media, suffix",
         [
-            (MagicMock(spec=Image, id=uuid4(), format=ImageFormat.JPG, type=MediaType.IMAGE), ".jpg", "image/jpeg"),
-            (MagicMock(spec=Video, id=uuid4(), format=VideoFormat.MP4, type=MediaType.VIDEO), ".mp4", "video/mp4"),
-            (
-                MagicMock(spec=VideoFrame, id=uuid4(), format=ImageFormat.JPG, type=MediaType.VIDEO_FRAME),
-                ".jpg",
-                "image/jpeg",
-            ),
+            (MagicMock(spec=Image, id=uuid4(), format=ImageFormat.JPG, type=MediaType.IMAGE), ".jpg"),
+            (MagicMock(spec=Video, id=uuid4(), format=VideoFormat.MP4, type=MediaType.VIDEO), ".mp4"),
+            (MagicMock(spec=VideoFrame, id=uuid4(), format=ImageFormat.JPG, type=MediaType.VIDEO_FRAME), ".jpg"),
         ],
     )
-    def test_get_media_thumbnail_success(
-        self, fxt_get_project, fxt_media_service, fxt_client, media, suffix, mime_type
-    ):
+    def test_get_media_thumbnail_success(self, fxt_get_project, fxt_media_service, fxt_client, media, suffix):
         # Create a temporary JPEG file to act as the thumbnail
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
             thumbnail_path = Path(tmp_file.name)
@@ -636,7 +630,7 @@ class TestMediaEndpoints:
             response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/media/{str(media.id)}/thumbnail")
 
             assert response.status_code == status.HTTP_200_OK
-            assert response.headers["content-type"] == mime_type
+            assert response.headers["content-type"] == "image/jpeg"
             with open(thumbnail_path, "rb") as f:
                 assert response.content == f.read()
             fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)


### PR DESCRIPTION
To fix issues with video playback, FileResponse is used to serve static content to the client.
Additionally, byte range requests should be handled more efficiently in this case and we don't need to process data into intermediate buffer (even with chunks) in case of large files.