### PR TITLE
Metrics parser fix

### DIFF
--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -25,48 +25,57 @@ from app.supported_models import SupportedModels
 from .base import BaseSessionManagedService, ResourceInUseError, ResourceNotFoundError, ResourceType
 from .parent_process_guard import parent_process_only
 
-# Mapping of CSV column keys to display names for series metrics.
-# Keys not included here will be ignored.
-KEY_MAPPING = {
-    "epoch": "Epoch",
-    "lr-SGD": "Learning rate (SGD)",
-    "lr-SGD-1": "Learning rate (SGD-1)",
-    "lr-SGD-1-momentum": "Learning rate momentum (SGD-1)",
-    "lr-SGD-momentum": "Learning rate momentum (SGD)",
-    "step": "Step",
-    "train/data_time": "Training data time",
-    "train/iter_time": "Training iteration time",
-    "train/loss": "Training loss",
-    "train/loss_bbox": "Training loss bbox",
-    "train/loss_centerness": "Training loss centerness",
-    "train/loss_cls": "Training loss cls",
-    "train/loss_mask": "Training loss mask",
-    "train/loss_obj": "Training loss obj",
-    "train/total_loss": "Training total loss",
-    "val/accuracy": "Validation accuracy",
-    "val/classes": "Validation classes",
-    "val/f1-score": "Validation F1 score",
-    "val/map": "Validation mAP",
-    "val/map_50": "Validation mAP@50",
-    "val/map_75": "Validation mAP@75",
-    "val/map_large": "Validation mAP large",
-    "val/map_medium": "Validation mAP medium",
-    "val/map_per_class": "Validation mAP per class",
-    "val/map_small": "Validation mAP small",
-    "val/mar_1": "Validation mAR@1",
-    "val/mar_10": "Validation mAR@10",
-    "val/mar_100": "Validation mAR@100",
-    "val/mar_100_per_class": "Validation mAR@100 per class",
-    "val/mar_large": "Validation mAR large",
-    "val/mar_medium": "Validation mAR medium",
-    "val/mar_small": "Validation mAR small",
-    "validation/data_time": "Validation data time",
-    "validation/iter_time": "Validation iteration time",
-}
 
-# Columns that should be excluded from metrics parsing
-# (used as axis values or are not actual metrics)
-BLACKLISTED_KEYS = {"epoch", "step"}
+@dataclass
+class MetricDisplayInfo:
+    display_name: str
+    frequency: str = "step"  # "step" or "epoch"
+
+    @property
+    def x_axis_label(self) -> str:
+        return self.frequency.capitalize()
+
+
+KEY_MAPPING = {
+    "epoch": MetricDisplayInfo(display_name="Epoch", frequency="epoch"),
+    "step": MetricDisplayInfo(display_name="Step", frequency="step"),
+    # Epoch based learning rate metrics
+    "lr": MetricDisplayInfo(display_name="Learning rate", frequency="epoch"),
+    "lr-SGD": MetricDisplayInfo(display_name="Learning rate (SGD)", frequency="epoch"),
+    "lr-SGD-1": MetricDisplayInfo(display_name="Learning rate (SGD-1)", frequency="epoch"),
+    "lr-SGD-1-momentum": MetricDisplayInfo(display_name="Learning rate momentum (SGD-1)", frequency="epoch"),
+    "lr-SGD-momentum": MetricDisplayInfo(display_name="Learning rate momentum (SGD)", frequency="epoch"),
+    # Step based training metric
+    "train/data_time": MetricDisplayInfo(display_name="Training data time", frequency="step"),
+    "train/iter_time": MetricDisplayInfo(display_name="Training iteration time", frequency="step"),
+    "train/loss": MetricDisplayInfo(display_name="Training loss", frequency="step"),
+    "train/loss_bbox": MetricDisplayInfo(display_name="Training loss bbox", frequency="step"),
+    "train/loss_centerness": MetricDisplayInfo(display_name="Training loss centerness", frequency="step"),
+    "train/loss_cls": MetricDisplayInfo(display_name="Training loss cls", frequency="step"),
+    "train/loss_mask": MetricDisplayInfo(display_name="Training loss mask", frequency="step"),
+    "train/loss_obj": MetricDisplayInfo(display_name="Training loss obj", frequency="step"),
+    "train/total_loss": MetricDisplayInfo(display_name="Training total loss", frequency="step"),
+    # Epoch based validation metrics
+    "val/accuracy": MetricDisplayInfo(display_name="Validation accuracy", frequency="epoch"),
+    "val/classes": MetricDisplayInfo(display_name="Validation classes", frequency="epoch"),
+    "val/f1-score": MetricDisplayInfo(display_name="Validation F1 score", frequency="epoch"),
+    "val/map": MetricDisplayInfo(display_name="Validation mAP", frequency="epoch"),
+    "val/map_50": MetricDisplayInfo(display_name="Validation mAP@50", frequency="epoch"),
+    "val/map_75": MetricDisplayInfo(display_name="Validation mAP@75", frequency="epoch"),
+    "val/map_large": MetricDisplayInfo(display_name="Validation mAP large", frequency="epoch"),
+    "val/map_medium": MetricDisplayInfo(display_name="Validation mAP medium", frequency="epoch"),
+    "val/map_per_class": MetricDisplayInfo(display_name="Validation mAP per class", frequency="epoch"),
+    "val/map_small": MetricDisplayInfo(display_name="Validation mAP small", frequency="epoch"),
+    "val/mar_1": MetricDisplayInfo(display_name="Validation mAR@1", frequency="epoch"),
+    "val/mar_10": MetricDisplayInfo(display_name="Validation mAR@10", frequency="epoch"),
+    "val/mar_100": MetricDisplayInfo(display_name="Validation mAR@100", frequency="epoch"),
+    "val/mar_100_per_class": MetricDisplayInfo(display_name="Validation mAR@100 per class", frequency="epoch"),
+    "val/mar_large": MetricDisplayInfo(display_name="Validation mAR large", frequency="epoch"),
+    "val/mar_medium": MetricDisplayInfo(display_name="Validation mAR medium", frequency="epoch"),
+    "val/mar_small": MetricDisplayInfo(display_name="Validation mAR small", frequency="epoch"),
+    "validation/data_time": MetricDisplayInfo(display_name="Validation data time", frequency="epoch"),
+    "validation/iter_time": MetricDisplayInfo(display_name="Validation iteration time", frequency="epoch"),
+}
 
 
 @dataclass(frozen=True)
@@ -415,11 +424,9 @@ class ModelService(BaseSessionManagedService):
         """
         Parse a metrics CSV file and return the formatted metrics.
 
-        For each metric column (excluding 'epoch', 'step', and blacklisted keys):
+        For each metric column (excluding 'epoch' and 'step'):
         1. Filter out rows with null values in the metric column
-        2. Determine if the metric is epoch-based or step-based by checking if 'step'
-           contains consecutive integers from 1 to N
-        3. Build a TrainingMetrics object for that metric
+        2. Build a TrainingMetrics object for that metric
 
         Args:
             metrics_file (Path): Path to the metrics.csv file.
@@ -432,11 +439,24 @@ class ModelService(BaseSessionManagedService):
         # Read the CSV file with polars
         df = pl.read_csv(metrics_file)
 
-        # Get all metric columns (exclude 'epoch', 'step', and blacklisted keys)
-        metric_columns = [col for col in df.columns if col not in BLACKLISTED_KEYS and col in KEY_MAPPING]
+        # Due to a quirk in SimpleLearningRateMonitor/LearningRateMonitor, the LR metric does not log the epoch value.
+        # Fill in missing epoch values.
+        for i in range(df.shape[0]):
+            if df[i, "epoch"] is None:
+                df[i, "epoch"] = df[i + 1, "epoch"]
 
-        for col in metric_columns:
-            mapped_name = KEY_MAPPING.get(col)
+        for col in df.columns:
+            if col in ["epoch", "step"]:
+                continue
+
+            mapped_metric = KEY_MAPPING.get(col)
+            if mapped_metric is None:
+                logger.debug("Metric '{}' is not in KEY_MAPPING, skipping", col)
+                continue
+
+            display_name = mapped_metric.display_name
+            frequency = mapped_metric.frequency
+            x_axis_label = mapped_metric.x_axis_label
 
             # Filter to include only 'epoch', 'step', and the current metric column
             # Then filter out rows where the metric column has null values
@@ -446,32 +466,22 @@ class ModelService(BaseSessionManagedService):
                 logger.debug("Metric '{}' has no non-null values, skipping", col)
                 continue
 
-            # Determine if the metric is step-based or epoch-based
-            # Step-based: 'step' column contains consecutive integers from 1 to N
-            # Epoch-based: 'epoch' column contains consecutive integers from 1 to N
-            is_step_based = ModelService._is_step_based(metric_df)
-
-            # Choose the appropriate x-axis column
-            x_axis_col = "step" if is_step_based else "epoch"
-            x_axis_label = "Step" if is_step_based else "Epoch"
-
-            # Build the points list
             points = [
-                {"x": float(row[x_axis_col]), "y": float(row[col]), "type": "point"}
+                {"x": float(row[frequency]), "y": float(row[col]), "type": "point"}
                 for row in metric_df.iter_rows(named=True)
             ]
 
             metric = {
-                "header": mapped_name,
+                "header": display_name,
                 "type": "line",
-                "key": mapped_name,
+                "key": display_name,
                 "value": {
                     "x_axis_label": x_axis_label,
-                    "y_axis_label": mapped_name,
+                    "y_axis_label": display_name,
                     "line_data": [
                         {
-                            "header": mapped_name,
-                            "key": mapped_name,
+                            "header": display_name,
+                            "key": display_name,
                             "points": points,
                         }
                     ],
@@ -480,39 +490,6 @@ class ModelService(BaseSessionManagedService):
             metrics.append(metric)
 
         return metrics
-
-    @staticmethod
-    def _is_step_based(metric_df: pl.DataFrame) -> bool:
-        """
-        Determine if a metric is step-based by checking if the 'step' column
-        contains all consecutive integers from 1 to N without skipping any value.
-
-        Args:
-            metric_df (pl.DataFrame): DataFrame to check for step-based or epoch-based metric.
-                It is expected to have 'step' and 'epoch' columns, and at least one metric column (with no null values)
-
-        Returns:
-            bool: True if the metric is step-based, False if epoch-based.
-        """
-        # Get the step values and filter out nulls
-        step_values = metric_df.select("step")
-        epoch_values = metric_df.select("epoch")
-
-        if step_values.is_empty() or epoch_values.is_empty():
-            raise ValueError("Malformed metrics data: 'step' or 'epoch' column is missing or empty")
-
-        # Get unique step values and sort them
-        unique_steps = step_values["step"].unique()
-
-        # Get the minimum and maximum step values
-        min_step = int(unique_steps.min())  # pyrefly: ignore[no-matching-overload]
-        max_step = int(unique_steps.max())  # pyrefly: ignore[no-matching-overload]
-
-        # Expected count for consecutive integers from min to max
-        expected_count = max_step - min_step + 1
-
-        # If the number of unique steps equals the expected count, they are consecutive and hence step-based
-        return len(unique_steps) == expected_count
 
     def get_logs(self, project_id: UUID, model_id: UUID, as_text: bool = False) -> Path | Iterator[str] | None:
         """

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -441,9 +441,12 @@ class ModelService(BaseSessionManagedService):
 
         # Due to a quirk in SimpleLearningRateMonitor/LearningRateMonitor, the LR metric does not log the epoch value.
         # Fill in missing epoch values.
-        for i in range(df.shape[0]):
-            if df[i, "epoch"] is None:
-                df[i, "epoch"] = df[i + 1, "epoch"]
+        df = df.with_columns(
+            pl.when(pl.col("epoch").is_null() & pl.col("epoch").shift(-1).is_not_null())
+            .then(pl.col("epoch").shift(-1))
+            .otherwise(pl.col("epoch"))
+            .alias("epoch")
+        )
 
         for col in df.columns:
             if col in ["epoch", "step"]:

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -498,16 +498,16 @@ class TestModelServiceIntegration:
             assert metric["key"] in ["Training total loss", "Validation F1 score"]
             assert metric.get("value")
             # Check that x_axis_label is set correctly (should be "Step" since steps are consecutive)
-            assert metric["value"]["x_axis_label"] == "Step"
+            assert metric["value"]["x_axis_label"] in ["Step", "Epoch"]
 
-    def test_get_training_metrics_epoch_based(
+    def test_get_training_metrics_epoch_step_based(
         self,
         tmp_path: Path,
         fxt_project_id: UUID,
         fxt_model_id: UUID,
         fxt_model_service: ModelService,
     ):
-        """Test retrieving training metrics when steps are not consecutive (epoch-based)."""
+        """Test retrieving training metrics when steps are not consecutive."""
         # Create a model directory with a metrics.csv file in the correct path
         metrics_dir = (
             tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id) / "metrics" / "version_0"
@@ -528,8 +528,14 @@ class TestModelServiceIntegration:
         for metric in metrics:
             assert metric["header"] in ["Training total loss", "Validation F1 score"]
             assert metric["type"] == "line"
-            # Check that x_axis_label is "Epoch" since steps are NOT consecutive
-            assert metric["value"]["x_axis_label"] == "Epoch"
+            # This test requires the metrics to be correctly identified
+            # Even though the steps are not consecutive,
+            # the x_axis_label should still be "Step" for train/total_loss and "Epoch" for val/f1-score.
+            # This can happen when the user sets log_n_steps = 4 (>1)
+            if metric["header"] == "Training total loss":
+                assert metric["value"]["x_axis_label"] == "Step"
+            elif metric["header"] == "Validation F1 score":
+                assert metric["value"]["x_axis_label"] == "Epoch"
 
     def test_get_training_metrics_file_not_found(
         self,

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -516,9 +516,9 @@ class TestModelServiceIntegration:
 
         # Steps are not consecutive (1, 5, 9) so metric should be epoch-based
         csv_content = """epoch,step,train/total_loss,val/f1-score
-        1,1,0.1,0.95
-        2,5,0.2,0.89
-        3,9,0.3,0.92
+        ,1,0.1,0.95
+        1,5,0.2,0.89
+        2,9,0.3,0.92
         """.replace(" ", "")  # Remove leading tabs for correct CSV formatting
         (metrics_dir / "metrics.csv").write_text(csv_content)
 

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -497,7 +497,7 @@ class TestModelServiceIntegration:
             assert metric["type"] == "line"
             assert metric["key"] in ["Training total loss", "Validation F1 score"]
             assert metric.get("value")
-            # Check that x_axis_label is set correctly (should be "Step" since steps are consecutive)
+            # Check that x_axis_label is set correctly
             assert metric["value"]["x_axis_label"] in ["Step", "Epoch"]
 
     def test_get_training_metrics_epoch_step_based(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Fixes the metrics parser by hard coding the frequency of the metrics.

The epoch column is also sanitized by replacing `null` values with correct integers.
Learning rate rows are epoch based, yet the logger does not log the epochs.

Relying on the epoch/step column and if they are consecutive is not reliable, the user can chose to log at every 5 steps for example.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
