### PR TITLE
fix: Update video time based on the initial frame

### DIFF
--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -1,7 +1,18 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, Dispatch, ReactNode, RefObject, SetStateAction, use, useMemo, useRef, useState } from 'react';
+import {
+    createContext,
+    Dispatch,
+    ReactNode,
+    RefObject,
+    SetStateAction,
+    use,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 
 import { VisuallyHidden } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
@@ -29,6 +40,25 @@ type VideoPlayerContextProps = {
     changeStep: Dispatch<SetStateAction<number>>;
 };
 
+const useSynchronizeVideoTimeWithInitialFrame = (
+    videoRef: RefObject<HTMLVideoElement | null>,
+    videoFrame: MediaVideoFrame | undefined
+) => {
+    /*
+     * This part is responsible for updating video time on the initial load when the frame number is not 0.
+     * In that case we need to move the video to the correct frame number.
+     * */
+    useLayoutEffect(() => {
+        if (videoFrame?.frame_number == undefined || videoRef.current === null) {
+            return;
+        }
+
+        if (videoFrame.frame_number > 0 && videoRef.current.currentTime === 0) {
+            videoRef.current.currentTime = (videoFrame.frame_number + 1) / videoFrame.fps;
+        }
+    }, [videoFrame?.frame_number, videoFrame?.fps, videoRef]);
+};
+
 const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
 
 type VideoPlayerProviderProps = {
@@ -43,6 +73,8 @@ export const VideoPlayerProvider = ({ children, videoFrame, changeSelectedMediaI
     const [isMuted, setIsMuted] = useState<boolean>(false);
     const [playbackRate, setPlaybackRate] = useState<number>(1);
     const [currentFrameIndex, setCurrentFrameIndex] = useState<number>(videoFrame?.frame_number ?? 0);
+
+    useSynchronizeVideoTimeWithInitialFrame(videoRef, videoFrame);
 
     const playingVideoFrame: MediaVideoFrame | undefined = useMemo(() => {
         if (videoFrame === undefined) {

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -53,6 +53,10 @@ const useSynchronizeVideoTimeWithInitialFrame = (
             return;
         }
 
+        if (videoFrame.frame_number === 0) {
+            return;
+        }
+
         const videoElement = videoRef.current;
         const seekToInitialFrame = () => {
             if (videoFrame.frame_number > 0 && videoElement.currentTime === 0) {

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -49,13 +49,33 @@ const useSynchronizeVideoTimeWithInitialFrame = (
      * In that case we need to move the video to the correct frame number.
      * */
     useLayoutEffect(() => {
-        if (videoFrame?.frame_number == undefined || videoRef.current === null) {
+        if (videoFrame?.frame_number == undefined || videoFrame?.fps === undefined || videoRef.current === null) {
             return;
         }
 
-        if (videoFrame.frame_number > 0 && videoRef.current.currentTime === 0) {
-            videoRef.current.currentTime = (videoFrame.frame_number + 1) / videoFrame.fps;
+        const videoElement = videoRef.current;
+        const seekToInitialFrame = () => {
+            if (videoFrame.frame_number > 0 && videoElement.currentTime === 0) {
+                videoElement.currentTime = (videoFrame.frame_number + 1) / videoFrame.fps;
+            }
+        };
+
+        // If metadata is already loaded (readyState >= HAVE_METADATA == 1), seek immediately.
+        if (videoElement.readyState >= 1) {
+            seekToInitialFrame();
+            return;
         }
+
+        // Otherwise wait for metadata to load before seeking.
+        const handleLoadedMetadata = () => {
+            seekToInitialFrame();
+        };
+
+        videoElement.addEventListener('loadedmetadata', handleLoadedMetadata, { once: true });
+
+        return () => {
+            videoElement.removeEventListener('loadedmetadata', handleLoadedMetadata);
+        };
     }, [videoFrame?.frame_number, videoFrame?.fps, videoRef]);
 };
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

When we navigate to frame 120 and we refresh the page, the video should be displayed at frame 120 and when played, should start from that frame.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
