### PR TITLE
Publish inference result in order

### DIFF
--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -103,9 +103,6 @@ class InferenceWorker(BaseProcessWorker):
 
         # To ensure broadcasting frames in order
         self._prediction_buffer = PredictionBuffer()
-        self._frame_index = 0
-        self._next_to_broadcast = 0
-        self._result_buffer = {}
 
     def setup(self) -> None:
         super().setup()

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -3,7 +3,7 @@
 
 import multiprocessing as mp
 import queue
-from collections.abc import Generator
+import threading
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event as EventClass
 from multiprocessing.synchronize import Lock
@@ -34,16 +34,16 @@ class InferenceWorkerConfig:
     logger_: LoguruLogger
 
 
-class PredictionBuffer:
+class PredictionReorderBuffer:
     """Buffers predictions to ensure async generated predictions are fed to the prediction queue in order"""
 
     def __init__(self, max_size: int = 10):
         self._buffer: dict[float, StreamData] = {}
         self._expected_timestamps: list[float] = []
         self._max_size = max_size
-        self._lock = mp.Lock()
+        self._lock = threading.Lock()
 
-    def append_expected_timestamp(self, timestamp: float) -> None:
+    def register_expected_timestamp(self, timestamp: float) -> None:
         with self._lock:
             self._expected_timestamps.append(timestamp)
             if len(self._expected_timestamps) > self._max_size:
@@ -51,7 +51,7 @@ class PredictionBuffer:
                 if oldest_timestamp in self._buffer:
                     del self._buffer[oldest_timestamp]
 
-    def add_to_buffer(self, timestamp: float, stream_data: StreamData) -> None:
+    def add_prediction_for_timestamp(self, timestamp: float, stream_data: StreamData) -> None:
         with self._lock:
             if timestamp in self._expected_timestamps:
                 self._buffer[timestamp] = stream_data
@@ -63,15 +63,14 @@ class PredictionBuffer:
                     timestamp,
                 )
 
-    def get_ready_predictions(self) -> Generator[StreamData]:
+    def get_ready_predictions(self) -> list[StreamData]:
+        result = []
         with self._lock:
-            if not self._expected_timestamps:
-                return
-            while self._expected_timestamps[0] in self._buffer:
-                timestamp = self._expected_timestamps.pop(0)
-                yield self._buffer.pop(timestamp)
-                if not self._expected_timestamps:
-                    return
+            while self._expected_timestamps and self._expected_timestamps[0] in self._buffer:
+                timestamp = self._expected_timestamps[0]
+                stream_data = self._buffer.pop(timestamp)
+                result.append(stream_data)
+        return result
 
     def clear(self) -> None:
         with self._lock:
@@ -102,7 +101,7 @@ class InferenceWorker(BaseProcessWorker):
         self._last_model_obj_id = 0  # track the id of the Model object to install the callback only once
 
         # To ensure broadcasting frames in order
-        self._prediction_buffer = PredictionBuffer()
+        self._prediction_buffer = PredictionReorderBuffer()
 
     def setup(self) -> None:
         super().setup()
@@ -127,7 +126,7 @@ class InferenceWorker(BaseProcessWorker):
 
         # Predictions are generated async, first add to buffer,
         # then check if next expected predictions are ready to be queued
-        self._prediction_buffer.add_to_buffer(timestamp=start_time, stream_data=stream_data)
+        self._prediction_buffer.add_prediction_for_timestamp(timestamp=start_time, stream_data=stream_data)
         for stream_data in self._prediction_buffer.get_ready_predictions():
             while not self.should_stop():
                 try:
@@ -161,8 +160,9 @@ class InferenceWorker(BaseProcessWorker):
             self._model_reload_event.clear()
             loaded_model = self._model_service.get_loaded_inference_model(force_reload=True)  # type: ignore
 
-        # Clear prediction buffer
-        self._prediction_buffer.clear()
+        if loaded_model is not None:
+            # Clear prediction buffer
+            self._prediction_buffer.clear()
 
         return loaded_model
 
@@ -184,7 +184,7 @@ class InferenceWorker(BaseProcessWorker):
                         continue
 
                     inference_start_time = self._metrics_service.record_inference_start()  # type: ignore
-                    self._prediction_buffer.append_expected_timestamp(inference_start_time)
+                    self._prediction_buffer.register_expected_timestamp(inference_start_time)
                     model.infer_async(
                         cv2.cvtColor(item.frame_data, cv2.COLOR_BGR2RGB),  # models expect RGB input
                         user_data={

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -3,6 +3,7 @@
 
 import multiprocessing as mp
 import queue
+from collections.abc import Generator
 from dataclasses import dataclass
 from multiprocessing.synchronize import Event as EventClass
 from multiprocessing.synchronize import Lock
@@ -33,6 +34,51 @@ class InferenceWorkerConfig:
     logger_: LoguruLogger
 
 
+class PredictionBuffer:
+    """Buffers predictions to ensure async generated predictions are fed to the prediction queue in order"""
+
+    def __init__(self, max_size: int = 10):
+        self._buffer: dict[float, StreamData] = {}
+        self._expected_timestamps: list[float] = []
+        self._max_size = max_size
+        self._lock = mp.Lock()
+
+    def append_expected_timestamp(self, timestamp: float) -> None:
+        with self._lock:
+            self._expected_timestamps.append(timestamp)
+            if len(self._expected_timestamps) > self._max_size:
+                oldest_timestamp = self._expected_timestamps.pop(0)
+                if oldest_timestamp in self._buffer:
+                    del self._buffer[oldest_timestamp]
+
+    def add_to_buffer(self, timestamp: float, stream_data: StreamData) -> None:
+        with self._lock:
+            if timestamp in self._expected_timestamps:
+                self._buffer[timestamp] = stream_data
+            else:
+                logger.warning(
+                    "Received prediction for buffering with unexpected timestamp: "
+                    "expected timestamps: {}, received timestamp {}",
+                    self._expected_timestamps,
+                    timestamp,
+                )
+
+    def get_ready_predictions(self) -> Generator[StreamData]:
+        with self._lock:
+            if not self._expected_timestamps:
+                return
+            while self._expected_timestamps[0] in self._buffer:
+                timestamp = self._expected_timestamps.pop(0)
+                yield self._buffer.pop(timestamp)
+                if not self._expected_timestamps:
+                    return
+
+    def clear(self) -> None:
+        with self._lock:
+            self._expected_timestamps = []
+            self._buffer = {}
+
+
 class InferenceWorker(BaseProcessWorker):
     """A process that pulls frames from the frame queue, runs inference, and pushes results to the prediction queue."""
 
@@ -56,6 +102,7 @@ class InferenceWorker(BaseProcessWorker):
         self._last_model_obj_id = 0  # track the id of the Model object to install the callback only once
 
         # To ensure broadcasting frames in order
+        self._prediction_buffer = PredictionBuffer()
         self._frame_index = 0
         self._next_to_broadcast = 0
         self._result_buffer = {}
@@ -66,31 +113,31 @@ class InferenceWorker(BaseProcessWorker):
         self._model_service = ActiveModelService(get_settings().data_dir)
 
     def _on_inference_completed(self, inf_result: Result, userdata: dict[str, Any]) -> None:
-        frame_index = userdata["frame_index"]
-        self._result_buffer[frame_index] = (inf_result, userdata)
-        while self._next_to_broadcast in self._result_buffer:
-            result, ud = self._result_buffer.pop(self._next_to_broadcast)
-            start_time = float(ud["inference_start_time"])
-            model_id = ud["model_id"]
-            self._metrics_service.record_inference_end(model_id=model_id, start_time=start_time)  # type: ignore
+        start_time = float(userdata["inference_start_time"])
+        model_id = userdata["model_id"]
+        self._metrics_service.record_inference_end(model_id=model_id, start_time=start_time)  # type: ignore
 
-            stream_data: StreamData = ud["stream_data"]
-            frame_with_predictions = Visualizer.overlay_predictions(
-                original_image=stream_data.frame_data, predictions=result
-            )
-            inference_data = InferenceData(
-                prediction=result,
-                visualized_prediction=frame_with_predictions,
-                model_id=model_id,
-            )
-            stream_data.inference_data = inference_data
+        stream_data: StreamData = userdata["stream_data"]
+        frame_with_predictions = Visualizer.overlay_predictions(
+            original_image=stream_data.frame_data, predictions=inf_result
+        )
+        inference_data = InferenceData(
+            prediction=inf_result,
+            visualized_prediction=frame_with_predictions,
+            model_id=model_id,
+        )
+        stream_data.inference_data = inference_data
+
+        # Predictions are generated async, first add to buffer,
+        # then check if next expected predictions are ready to be queued
+        self._prediction_buffer.add_to_buffer(timestamp=start_time, stream_data=stream_data)
+        for stream_data in self._prediction_buffer.get_ready_predictions():
             while not self.should_stop():
                 try:
                     self._pred_queue.put(stream_data, timeout=1)
                     break
                 except queue.Full:
                     logger.debug("Prediction queue is full, retrying...")
-            self._next_to_broadcast += 1
 
     def _install_callback_if_needed(self, model: Model) -> None:
         """Install inference completion callback once per model object instance."""
@@ -116,6 +163,10 @@ class InferenceWorker(BaseProcessWorker):
         while self._model_reload_event.is_set():
             self._model_reload_event.clear()
             loaded_model = self._model_service.get_loaded_inference_model(force_reload=True)  # type: ignore
+
+        # Clear prediction buffer
+        self._prediction_buffer.clear()
+
         return loaded_model
 
     def run_loop(self) -> None:
@@ -136,16 +187,15 @@ class InferenceWorker(BaseProcessWorker):
                         continue
 
                     inference_start_time = self._metrics_service.record_inference_start()  # type: ignore
+                    self._prediction_buffer.append_expected_timestamp(inference_start_time)
                     model.infer_async(
                         cv2.cvtColor(item.frame_data, cv2.COLOR_BGR2RGB),  # models expect RGB input
                         user_data={
                             "stream_data": item,
                             "model_id": self._loaded_model.id,
                             "inference_start_time": inference_start_time,
-                            "frame_index": self._frame_index,
                         },
                     )
-                    self._frame_index += 1
                 else:
                     model.inference_adapter.await_any()
             except Exception:

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -67,7 +67,7 @@ class PredictionReorderBuffer:
         result = []
         with self._lock:
             while self._expected_timestamps and self._expected_timestamps[0] in self._buffer:
-                timestamp = self._expected_timestamps[0]
+                timestamp = self._expected_timestamps.pop(0)
                 stream_data = self._buffer.pop(timestamp)
                 result.append(stream_data)
         return result

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -55,32 +55,42 @@ class InferenceWorker(BaseProcessWorker):
         self._loaded_model: LoadedModel | None = None
         self._last_model_obj_id = 0  # track the id of the Model object to install the callback only once
 
+        # To ensure broadcasting frames in order
+        self._frame_index = 0
+        self._next_to_broadcast = 0
+        self._result_buffer = {}
+
     def setup(self) -> None:
         super().setup()
         self._metrics_service = MetricsService(self._shm_name, self._shm_lock)
         self._model_service = ActiveModelService(get_settings().data_dir)
 
     def _on_inference_completed(self, inf_result: Result, userdata: dict[str, Any]) -> None:
-        start_time = float(userdata["inference_start_time"])
-        model_id = userdata["model_id"]
-        self._metrics_service.record_inference_end(model_id=model_id, start_time=start_time)  # type: ignore
+        frame_index = userdata["frame_index"]
+        self._result_buffer[frame_index] = (inf_result, userdata)
+        while self._next_to_broadcast in self._result_buffer:
+            result, ud = self._result_buffer.pop(self._next_to_broadcast)
+            start_time = float(ud["inference_start_time"])
+            model_id = ud["model_id"]
+            self._metrics_service.record_inference_end(model_id=model_id, start_time=start_time)  # type: ignore
 
-        stream_data: StreamData = userdata["stream_data"]
-        frame_with_predictions = Visualizer.overlay_predictions(
-            original_image=stream_data.frame_data, predictions=inf_result
-        )
-        inference_data = InferenceData(
-            prediction=inf_result,
-            visualized_prediction=frame_with_predictions,
-            model_id=model_id,
-        )
-        stream_data.inference_data = inference_data
-        while not self.should_stop():
-            try:
-                self._pred_queue.put(stream_data, timeout=1)
-                break
-            except queue.Full:
-                logger.debug("Prediction queue is full, retrying...")
+            stream_data: StreamData = ud["stream_data"]
+            frame_with_predictions = Visualizer.overlay_predictions(
+                original_image=stream_data.frame_data, predictions=result
+            )
+            inference_data = InferenceData(
+                prediction=result,
+                visualized_prediction=frame_with_predictions,
+                model_id=model_id,
+            )
+            stream_data.inference_data = inference_data
+            while not self.should_stop():
+                try:
+                    self._pred_queue.put(stream_data, timeout=1)
+                    break
+                except queue.Full:
+                    logger.debug("Prediction queue is full, retrying...")
+            self._next_to_broadcast += 1
 
     def _install_callback_if_needed(self, model: Model) -> None:
         """Install inference completion callback once per model object instance."""
@@ -132,8 +142,10 @@ class InferenceWorker(BaseProcessWorker):
                             "stream_data": item,
                             "model_id": self._loaded_model.id,
                             "inference_start_time": inference_start_time,
+                            "frame_index": self._frame_index,
                         },
                     )
+                    self._frame_index += 1
                 else:
                     model.inference_adapter.await_any()
             except Exception:

--- a/application/backend/tests/unit/workers/test_inference.py
+++ b/application/backend/tests/unit/workers/test_inference.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+import numpy as np
+import pytest
+from loguru import logger
+
+from app.stream.stream_data import StreamData
+from app.workers.inference import PredictionReorderBuffer
+
+
+@pytest.fixture(autouse=True)
+def fxt_loguru_caplog(caplog):
+    class PropagateHandler(logging.Handler):
+        def emit(self, record):
+            logging.getLogger(record.name).handle(record)
+
+    handler_id = logger.add(PropagateHandler(), format="{message}")
+    yield
+    logger.remove(handler_id)
+
+
+@pytest.fixture
+def fxt_create_stream_data():
+    def create_sample(ts):
+        return StreamData(
+            frame_data=np.random.randint(0, 255, (1, 1, 3), dtype=np.uint8),
+            timestamp=ts,
+            source_metadata={},
+        )
+
+    return create_sample
+
+
+class TestPredictionReorderBuffer:
+    def test_register_timestamp_and_add_prediction(self, fxt_create_stream_data):
+        buffer = PredictionReorderBuffer(max_size=5)
+        ts1, ts2, ts3, ts4, ts5 = 1.0, 2.0, 3.0, 4.0, 5.0
+        sd1 = fxt_create_stream_data(ts1)
+        sd2 = fxt_create_stream_data(ts2)
+        sd3 = fxt_create_stream_data(ts3)
+        sd5 = fxt_create_stream_data(ts5)
+
+        # Register timestamps in order 1-5, add stream data out of order and with gaps
+        for ts in [ts1, ts2, ts3, ts4, ts5]:
+            buffer.register_expected_timestamp(ts)
+        buffer.add_prediction_for_timestamp(ts2, sd2)
+        buffer.add_prediction_for_timestamp(ts1, sd1)
+        buffer.add_prediction_for_timestamp(ts3, sd3)
+        buffer.add_prediction_for_timestamp(ts5, sd5)
+
+        # Buffer should output predictions in registration order and without gaps
+        ready = buffer.get_ready_predictions()
+        assert ready == [sd1, sd2, sd3]
+
+    def test_full_register(self, fxt_create_stream_data):
+        # Buffer should only hold 3 expected timestamps
+        buffer = PredictionReorderBuffer(max_size=3)
+
+        # Prepare timstamps and stream data
+        ts1, ts2, ts3, ts4, ts5 = 1.0, 2.0, 3.0, 4.0, 5.0
+        sd1 = fxt_create_stream_data(ts1)
+        sd2 = fxt_create_stream_data(ts2)
+        sd3 = fxt_create_stream_data(ts3)
+        sd4 = fxt_create_stream_data(ts4)
+        sd5 = fxt_create_stream_data(ts5)
+
+        # Register first three and add stream data for ts1 and ts3
+        for ts in [ts1, ts2, ts3]:
+            buffer.register_expected_timestamp(ts)
+        buffer.add_prediction_for_timestamp(ts1, sd1)
+        buffer.add_prediction_for_timestamp(ts3, sd3)
+
+        # Register last two, first two should be dropped, including stream data
+        buffer.register_expected_timestamp(ts4)
+        buffer.register_expected_timestamp(ts5)
+
+        # Add stream data for ts2, ts4, ts5. Stream data for ts2 should be dropped
+        buffer.add_prediction_for_timestamp(ts2, sd2)
+        buffer.add_prediction_for_timestamp(ts5, sd5)
+        buffer.add_prediction_for_timestamp(ts4, sd4)
+
+        assert buffer.get_ready_predictions() == [sd3, sd4, sd5]
+
+    def test_add_unexpected_prediction_warns(self, fxt_create_stream_data, fxt_loguru_caplog, caplog):
+        buffer = PredictionReorderBuffer(max_size=3)
+        ts = 42.0
+        sd = fxt_create_stream_data(ts)
+        with caplog.at_level("WARNING"):
+            buffer.add_prediction_for_timestamp(ts, sd)
+        assert "unexpected timestamp" in caplog.text
+        assert buffer.get_ready_predictions() == []
+
+    def test_clear(self, fxt_create_stream_data):
+        buffer = PredictionReorderBuffer(max_size=2)
+        ts = 1.0
+        buffer.register_expected_timestamp(ts)
+        buffer.add_prediction_for_timestamp(ts, fxt_create_stream_data(ts))
+        buffer.clear()
+        assert buffer.get_ready_predictions() == []


### PR DESCRIPTION
### Summary

This PR ensures the predicitons generated async from the source, are added to the prediction queue for the sink and the webstream in order. This fixes a bug where the webstream (and also the sink) is jumping back and forth in a video, like a stuttering effect.

Adds a `PredictionBuffer` to the `InferenceWorker` that has a list of timestamps (inference start time) in the expected order, and a dictionary of timestamps - predictions (`StreamData`). When a prediction is finished:
-  it is first added to the buffer, 
- then `get_ready_predictions` outputs the predictions in the order it was requested, until a prediction is not found in the buffer,
- if too many (10 by default) predictions are expected, without the first expected being generated, the oldest expected is dropped
- if a prediction is generated, but the timestamp is not expected, the prediction is dropped. A warning will be logged

When a new model is loaded, the `PredictionBuffer` is cleared. However, the prediction queue is not cleared, or the webstream queue is not cleared, so one will still see frames from previous streams, before the new stream starts.
 
Resolves #5437

### How to test

To test, run the server with demos, go to the project with airplanes, or horses, setup a pipeline and enable it. When the webstream is started, the video runs smoothly, that is, the video never jumps backwards a couple of frames.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
