### PR TITLE
chore: Reduce network calls to `dataset/media`

### DIFF
--- a/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.test.tsx
@@ -6,7 +6,6 @@ import { getMockedAnnotation } from 'mocks/mock-annotation';
 import { render } from 'test-utils/render';
 
 import type { Annotation, Polygon, Rect } from '../../../../shared/types';
-import { SelectedDataProvider } from '../../../dataset/providers/selected-data-provider.component';
 import { AnnotationShape } from './annotation-shape.component';
 
 type AnnotationRect = Annotation & { shape: Rect };
@@ -15,11 +14,7 @@ type AnnotationPolygon = Annotation & { shape: Polygon };
 describe('AnnotationShape', () => {
     it('bounding box as a rect', () => {
         const annotation = getMockedAnnotation() as AnnotationRect;
-        render(
-            <SelectedDataProvider>
-                <AnnotationShape annotation={annotation} />
-            </SelectedDataProvider>
-        );
+        render(<AnnotationShape annotation={annotation} />);
 
         const rect = screen.getByLabelText('annotation rect');
 
@@ -38,11 +33,7 @@ describe('AnnotationShape', () => {
         ];
         const annotation = getMockedAnnotation({ shape: { type: 'polygon', points } }) as AnnotationPolygon;
 
-        render(
-            <SelectedDataProvider>
-                <AnnotationShape annotation={annotation} />
-            </SelectedDataProvider>
-        );
+        render(<AnnotationShape annotation={annotation} />);
         const polygon = screen.getByLabelText('annotation polygon');
 
         expect(polygon).toHaveAttribute('points', '1,2 3,4 5,6');

--- a/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.tsx
@@ -5,13 +5,32 @@ import type { Annotation } from '../../../../shared/types';
 import { useSelectDatasetItem } from '../../../dataset/gallery/hooks/use-select-dataset-item.hook';
 import { getFormattedPoints, isPrediction } from '../utils';
 
+type FullImageShapeProps = {
+    color: string;
+    ariaLabel: string;
+    strokeDasharray: string | undefined;
+};
+
+const FullImageShape = ({ color, ariaLabel, strokeDasharray }: FullImageShapeProps) => {
+    const { selectedMediaItem } = useSelectDatasetItem();
+
+    return (
+        <rect
+            fill={'none'}
+            stroke={color}
+            aria-label={ariaLabel}
+            width={selectedMediaItem?.width}
+            height={selectedMediaItem?.height}
+            strokeDasharray={strokeDasharray}
+        />
+    );
+};
+
 type AnnotationShapeProps = {
     annotation: Annotation;
 };
 
 export const AnnotationShape = ({ annotation }: AnnotationShapeProps) => {
-    const { selectedMediaItem } = useSelectDatasetItem();
-
     const { shape, labels } = annotation;
     const hasMultipleLabels = labels.length > 1;
     const color = hasMultipleLabels ? 'white' : labels.length ? labels[0].color : '--annotation-fill';
@@ -20,13 +39,10 @@ export const AnnotationShape = ({ annotation }: AnnotationShapeProps) => {
 
     if (shape.type === 'full_image') {
         return (
-            <rect
-                fill={'none'}
-                stroke={color}
-                aria-label={`${hasPredictionLabel ? 'prediction' : 'annotation'} full image`}
-                width={selectedMediaItem?.width}
-                height={selectedMediaItem?.height}
+            <FullImageShape
+                color={color}
                 strokeDasharray={strokeDasharray}
+                ariaLabel={`${hasPredictionLabel ? 'prediction' : 'annotation'} rect`}
             />
         );
     }

--- a/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Annotation } from '../../../../shared/types';
-import { useSelectDatasetItem } from '../../../dataset/gallery/hooks/use-select-dataset-item.hook';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { getFormattedPoints, isPrediction } from '../utils';
 
 type FullImageShapeProps = {
@@ -12,15 +12,15 @@ type FullImageShapeProps = {
 };
 
 const FullImageShape = ({ color, ariaLabel, strokeDasharray }: FullImageShapeProps) => {
-    const { selectedMediaItem } = useSelectDatasetItem();
+    const { mediaItem } = useSelectedMediaItem();
 
     return (
         <rect
             fill={'none'}
             stroke={color}
             aria-label={ariaLabel}
-            width={selectedMediaItem?.width}
-            height={selectedMediaItem?.height}
+            width={mediaItem?.width}
+            height={mediaItem?.height}
             strokeDasharray={strokeDasharray}
         />
     );

--- a/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape/annotation-shape.component.tsx
@@ -42,7 +42,7 @@ export const AnnotationShape = ({ annotation }: AnnotationShapeProps) => {
             <FullImageShape
                 color={color}
                 strokeDasharray={strokeDasharray}
-                ariaLabel={`${hasPredictionLabel ? 'prediction' : 'annotation'} rect`}
+                ariaLabel={`${hasPredictionLabel ? 'prediction' : 'annotation'} full image`}
             />
         );
     }

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -4,51 +4,30 @@
 import { ActionButton, Button, ButtonGroup, Flex, Text } from '@geti/ui';
 import { Checkmark, CloseSemiBold } from '@geti/ui/icons';
 
-import type { Media } from '../../../../constants/shared-types';
 import { useProject } from '../../../../hooks/api/project.hook';
 import { Labels } from '../../../annotator/labels/labels.component';
 import { isClassificationTask } from '../../../project/task-type-guards';
-import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-item.component';
 import { Toolbar } from '../toolbar-container/toolbar-container.component';
 import { useSubmitPredictions } from '../use-submit-predictions.hook';
 import { AnnotatorModes } from './annotator-modes/annotator-modes-toggle.component';
 import type { AnnotatorMode } from './annotator-modes/mode';
-import { getNextItem } from './util';
 
 import classes from './secondary-toolbar.module.scss';
 
 type SecondaryToolbarProps = {
-    items: Media[];
-    mediaItem: Media;
     mode: AnnotatorMode;
     onClose: () => void;
-    onSelectedMediaItem: (item: Media) => void;
     onModeChange: (mode: AnnotatorMode) => void;
     onAcceptPrediction: () => void;
 };
 
-export const SecondaryToolbar = ({
-    items,
-    mediaItem,
-    mode,
-    onClose,
-    onSelectedMediaItem,
-    onModeChange,
-    onAcceptPrediction,
-}: SecondaryToolbarProps) => {
+export const SecondaryToolbar = ({ mode, onClose, onModeChange, onAcceptPrediction }: SecondaryToolbarProps) => {
     const { data: selectedProject } = useProject();
 
     const { canSubmit, isSaving, submit } = useSubmitPredictions({ onSuccess: onAcceptPrediction });
 
     const isMultiLabel = selectedProject.task.exclusive_labels === false;
     const isClassification = isClassificationTask(selectedProject.task.task_type);
-
-    const handleDeleteItem = ([deletedItem]: string[], totalItems: number) => {
-        const deletedIndex = items.findIndex((item) => item.id === deletedItem);
-        const nextItem = getNextItem(totalItems - 1, deletedIndex);
-
-        onSelectedMediaItem(items[nextItem]);
-    };
 
     return (
         <Flex
@@ -71,10 +50,6 @@ export const SecondaryToolbar = ({
             <Toolbar.Container>
                 <Toolbar.Section>
                     <ButtonGroup>
-                        <DeleteMediaItem
-                            itemsIds={[String(mediaItem.id)]}
-                            onDeleted={([deletedItem]: string[]) => handleDeleteItem([deletedItem], items.length - 1)}
-                        />
                         <Button
                             variant='accent'
                             onPress={submit}

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -4,30 +4,51 @@
 import { ActionButton, Button, ButtonGroup, Flex, Text } from '@geti/ui';
 import { Checkmark, CloseSemiBold } from '@geti/ui/icons';
 
+import type { Media } from '../../../../constants/shared-types';
 import { useProject } from '../../../../hooks/api/project.hook';
 import { Labels } from '../../../annotator/labels/labels.component';
 import { isClassificationTask } from '../../../project/task-type-guards';
+import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-item.component';
 import { Toolbar } from '../toolbar-container/toolbar-container.component';
 import { useSubmitPredictions } from '../use-submit-predictions.hook';
 import { AnnotatorModes } from './annotator-modes/annotator-modes-toggle.component';
 import type { AnnotatorMode } from './annotator-modes/mode';
+import { getNextItem } from './util';
 
 import classes from './secondary-toolbar.module.scss';
 
 type SecondaryToolbarProps = {
+    items: Media[];
+    mediaItem: Media;
     mode: AnnotatorMode;
     onClose: () => void;
+    onSelectedMediaItem: (item: Media) => void;
     onModeChange: (mode: AnnotatorMode) => void;
     onAcceptPrediction: () => void;
 };
 
-export const SecondaryToolbar = ({ mode, onClose, onModeChange, onAcceptPrediction }: SecondaryToolbarProps) => {
+export const SecondaryToolbar = ({
+    items,
+    mediaItem,
+    mode,
+    onClose,
+    onSelectedMediaItem,
+    onModeChange,
+    onAcceptPrediction,
+}: SecondaryToolbarProps) => {
     const { data: selectedProject } = useProject();
 
     const { canSubmit, isSaving, submit } = useSubmitPredictions({ onSuccess: onAcceptPrediction });
 
     const isMultiLabel = selectedProject.task.exclusive_labels === false;
     const isClassification = isClassificationTask(selectedProject.task.task_type);
+
+    const handleDeleteItem = ([deletedItem]: string[], totalItems: number) => {
+        const deletedIndex = items.findIndex((item) => item.id === deletedItem);
+        const nextItem = getNextItem(totalItems - 1, deletedIndex);
+
+        onSelectedMediaItem(items[nextItem]);
+    };
 
     return (
         <Flex
@@ -50,6 +71,10 @@ export const SecondaryToolbar = ({ mode, onClose, onModeChange, onAcceptPredicti
             <Toolbar.Container>
                 <Toolbar.Section>
                     <ButtonGroup>
+                        <DeleteMediaItem
+                            itemsIds={[String(mediaItem.id)]}
+                            onDeleted={([deletedItem]: string[]) => handleDeleteItem([deletedItem], items.length - 1)}
+                        />
                         <Button
                             variant='accent'
                             onPress={submit}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Each time when new annotation was drawn, we called `/dataset/media` endpoint.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
