### PR TITLE
Improve sam ux

### DIFF
--- a/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
+++ b/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
@@ -9,24 +9,28 @@ import { isVideoFrame } from '../../../shared/media-item-utils';
 import { getMediaBinaryUrl, getVideoFrameBinaryUrl } from '../../../shared/media-url.utils';
 import { getImageData, loadImage } from '../tools/utils';
 
+export const getLoadImageQueryKey = (projectId: string, media: Media) => {
+    return isVideoFrame(media)
+        ? ['mediaItem', projectId, media.id, media.frame_number]
+        : ['mediaItem', projectId, media.id];
+};
+
+export const loadImageQueryFn = async (projectId: string, media: Media) => {
+    const url = isVideoFrame(media)
+        ? getVideoFrameBinaryUrl(projectId, media.id, media.frame_number)
+        : getMediaBinaryUrl(projectId, media.id);
+
+    const image = await loadImage(url);
+
+    return getImageData(image);
+};
+
 export const useLoadImageQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
 
-    const queryKey = isVideoFrame(media)
-        ? ['mediaItem', projectId, media.id, media.frame_number]
-        : ['mediaItem', projectId, media.id];
-
     return useQuery({
-        queryKey,
-        queryFn: async () => {
-            const url = isVideoFrame(media)
-                ? getVideoFrameBinaryUrl(projectId, media.id, media.frame_number)
-                : getMediaBinaryUrl(projectId, media.id);
-
-            const image = await loadImage(url);
-
-            return getImageData(image);
-        },
+        queryKey: getLoadImageQueryKey(projectId, media),
+        queryFn: () => loadImageQueryFn(projectId, media),
         placeholderData: keepPreviousData,
         // The image of a media item never changes so we don't want to refetch stale data
         staleTime: Infinity,

--- a/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
+++ b/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, queryOptions, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { Media } from '../../../constants/shared-types';
@@ -9,31 +9,29 @@ import { isVideoFrame } from '../../../shared/media-item-utils';
 import { getMediaBinaryUrl, getVideoFrameBinaryUrl } from '../../../shared/media-url.utils';
 import { getImageData, loadImage } from '../tools/utils';
 
-export const getLoadImageQueryKey = (projectId: string, media: Media) => {
-    return isVideoFrame(media)
-        ? ['mediaItem', projectId, media.id, media.frame_number]
-        : ['mediaItem', projectId, media.id];
-};
+export const loadImageQueryOptions = (projectId: string, media: Media) =>
+    queryOptions({
+        queryKey: isVideoFrame(media)
+            ? ['mediaItem', projectId, media.id, media.frame_number]
+            : ['mediaItem', projectId, media.id],
+        queryFn: async () => {
+            const url = isVideoFrame(media)
+                ? getVideoFrameBinaryUrl(projectId, media.id, media.frame_number)
+                : getMediaBinaryUrl(projectId, media.id);
 
-export const loadImageQueryFn = async (projectId: string, media: Media) => {
-    const url = isVideoFrame(media)
-        ? getVideoFrameBinaryUrl(projectId, media.id, media.frame_number)
-        : getMediaBinaryUrl(projectId, media.id);
+            const image = await loadImage(url);
 
-    const image = await loadImage(url);
-
-    return getImageData(image);
-};
+            return getImageData(image);
+        },
+        staleTime: Infinity,
+        retry: 0,
+    });
 
 export const useLoadImageQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
 
     return useQuery({
-        queryKey: getLoadImageQueryKey(projectId, media),
-        queryFn: () => loadImageQueryFn(projectId, media),
+        ...loadImageQueryOptions(projectId, media),
         placeholderData: keepPreviousData,
-        // The image of a media item never changes so we don't want to refetch stale data
-        staleTime: Infinity,
-        retry: 0,
     });
 };

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -10,7 +10,7 @@ import selectionCursor from '../../../../assets/icons/selection.svg?url';
 import { useZoom } from '../../../../components/zoom/zoom.provider';
 import type { Label } from '../../../../constants/shared-types';
 import type { Annotation, RegionOfInterest, Shape } from '../../../../shared/types';
-import { useNextMediaPrefetch } from '../../../dataset/media-preview/utils';
+import { useNextMediaItem } from '../../../dataset/media-preview/utils';
 import { AnnotationShape } from '../../annotations/annotation-shape/annotation-shape.component';
 import { MaskAnnotations } from '../../annotations/mask-annotations.component';
 import { useAnnotatorLabels } from '../../annotator-labels-provider.component';
@@ -62,10 +62,10 @@ export const SegmentAnythingTool = () => {
     const zoom = useZoom();
     const { roi, image, mediaItem } = useSelectedMediaItem();
     const { items } = useGetDatasetMediaItems();
-    const { nextMediaItem, nextImage, isNextImageReady } = useNextMediaPrefetch(mediaItem, items);
+    const nextMediaItem = useNextMediaItem(mediaItem, items);
     const { selectedLabel } = useAnnotatorLabels();
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
-    const { isLoading, decodingQueryFn } = useSegmentAnythingModel({ nextMediaItem, nextImage, isNextImageReady });
+    const { isLoading, decodingQueryFn } = useSegmentAnythingModel({ nextMediaItem });
     const throttledDecodingQueryFn = useSingleStackFn(decodingQueryFn);
     const cancellableThrottledDecodingQueryFn = useWithCancel(throttledDecodingQueryFn);
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -4,11 +4,13 @@
 import { PointerEvent, useRef, useState } from 'react';
 
 import { clampPointBetweenImage } from '@geti/smart-tools/utils';
+import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
 import selectionCursor from '../../../../assets/icons/selection.svg?url';
 import { useZoom } from '../../../../components/zoom/zoom.provider';
 import type { Label } from '../../../../constants/shared-types';
 import type { Annotation, RegionOfInterest, Shape } from '../../../../shared/types';
+import { useNextMediaPrefetch } from '../../../dataset/media-preview/utils';
 import { AnnotationShape } from '../../annotations/annotation-shape/annotation-shape.component';
 import { MaskAnnotations } from '../../annotations/mask-annotations.component';
 import { useAnnotatorLabels } from '../../annotator-labels-provider.component';
@@ -58,10 +60,12 @@ export const SegmentAnythingTool = () => {
     const ref = useRef<SVGSVGElement>(null);
 
     const zoom = useZoom();
-    const { roi, image } = useSelectedMediaItem();
+    const { roi, image, mediaItem } = useSelectedMediaItem();
+    const { items } = useGetDatasetMediaItems();
+    const { nextMediaItem, nextImage, isNextImageReady } = useNextMediaPrefetch(mediaItem, items);
     const { selectedLabel } = useAnnotatorLabels();
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
-    const { isLoading, decodingQueryFn } = useSegmentAnythingModel();
+    const { isLoading, decodingQueryFn } = useSegmentAnythingModel({ nextMediaItem, nextImage, isNextImageReady });
     const throttledDecodingQueryFn = useSingleStackFn(decodingQueryFn);
     const cancellableThrottledDecodingQueryFn = useWithCancel(throttledDecodingQueryFn);
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EncodingOutput } from '@geti/smart-tools/segment-anything';
-import { queryOptions, useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Remote, wrap } from 'comlink';
 import { useProject } from 'hooks/api/project.hook';
 
 import type { Media } from '../../../../constants/shared-types';
 import { isVideoFrame } from '../../../../shared/media-item-utils';
 import { isDetectionTask } from '../../../project/task-type-guards';
+import { loadImageQueryOptions } from '../../hooks/use-load-image-query.hook';
 import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import type {
     SegmentAnythingWorkerApi,
@@ -82,6 +83,33 @@ const useSegmentAnythingWorker = (
 export const usePreloadSAMWorkers = (enabled = true) => {
     useSegmentAnythingWorker('SEGMENT_ANYTHING_ENCODER', enabled);
     useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER', enabled);
+};
+
+export const prefetchNextSAMEncodingData = ({
+    queryClient,
+    projectId,
+    getNextMediaItem,
+}: {
+    queryClient: ReturnType<typeof useQueryClient>;
+    projectId: string;
+    getNextMediaItem: () => Media | undefined;
+}) => {
+    const prefetch = async () => {
+        const nextItem = getNextMediaItem();
+
+        if (nextItem === undefined) {
+            return;
+        }
+
+        const nextImage = await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
+        const encoderModel = await queryClient.ensureQueryData(
+            segmentAnythingWorkerQueryOptions('SEGMENT_ANYTHING_ENCODER')
+        );
+
+        queryClient.prefetchQuery(segmentAnythingEncodingQueryOptions(nextItem, encoderModel, nextImage));
+    };
+
+    prefetch();
 };
 
 const useEncodingQuery = (

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -5,10 +5,12 @@ import { EncodingOutput } from '@geti/smart-tools/segment-anything';
 import { queryOptions, useQuery } from '@tanstack/react-query';
 import { Remote, wrap } from 'comlink';
 import { useProject } from 'hooks/api/project.hook';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../../constants/shared-types';
 import { isVideoFrame } from '../../../../shared/media-item-utils';
 import { isDetectionTask } from '../../../project/task-type-guards';
+import { loadImageQueryOptions } from '../../hooks/use-load-image-query.hook';
 import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import type {
     SegmentAnythingWorkerApi,
@@ -153,27 +155,26 @@ const useDecodingFn = (model: SegmentAnythingRemoteModel | undefined, encoding: 
 
 type SegmentAnythingModelOptions = {
     nextMediaItem?: Media;
-    nextImage?: ImageData;
-    isNextImageReady?: boolean;
 };
 
-export const useSegmentAnythingModel = ({
-    nextMediaItem,
-    nextImage,
-    isNextImageReady = false,
-}: SegmentAnythingModelOptions = {}) => {
+export const useSegmentAnythingModel = ({ nextMediaItem }: SegmentAnythingModelOptions = {}) => {
     const encoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_ENCODER');
     const decoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER');
     const isLoadingWorkers = encoderModel === undefined || decoderModel === undefined;
+    const projectId = useProjectIdentifier();
 
     const { mediaItem, image, isImageReady } = useSelectedMediaItem();
+    const nextImageQuery = useQuery({
+        ...loadImageQueryOptions(projectId, nextMediaItem ?? mediaItem),
+        enabled: nextMediaItem !== undefined,
+    });
 
     // First we get the encoding for the CURRENT image
     const encodingQuery = useEncodingQuery(encoderModel, mediaItem, image, isImageReady);
     // At the same time we start prefetching the encoding for the NEXT image,
     // so when the user moves to the next media item the decoding will be faster.
     // We don't need to get the decoding query result for the next image, we just want to cache the encoding result.
-    useEncodingQuery(encoderModel, nextMediaItem, nextImage, isNextImageReady);
+    useEncodingQuery(encoderModel, nextMediaItem, nextImageQuery.data, nextImageQuery.isSuccess);
 
     const decodingQueryFn = useDecodingFn(decoderModel, encodingQuery.data);
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -44,17 +44,10 @@ export const segmentAnythingWorkerQueryOptions = (
         enabled,
     });
 
-export const getSegmentAnythingEncodingQueryKey = (mediaItem: Media) => {
+const getSegmentAnythingEncodingQueryKey = (mediaItem: Media) => {
     return isVideoFrame(mediaItem)
         ? ['segment-anything-model', 'encoding', mediaItem.id, mediaItem.frame_number]
         : ['segment-anything-model', 'encoding', mediaItem.id];
-};
-
-export const segmentAnythingEncodingQueryFn = (
-    model: SegmentAnythingRemoteModel,
-    image: ImageData
-): Promise<EncodingOutput> => {
-    return model.processEncoder(image);
 };
 
 export const segmentAnythingEncodingQueryOptions = (
@@ -70,7 +63,7 @@ export const segmentAnythingEncodingQueryOptions = (
                 throw new Error('Model not yet initialized');
             }
 
-            return segmentAnythingEncodingQueryFn(model, image);
+            return model.processEncoder(image);
         },
         staleTime: Infinity,
         gcTime: 3600 * 15,

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EncodingOutput } from '@geti/smart-tools/segment-anything';
-import { queryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { Remote, wrap } from 'comlink';
 import { useProject } from 'hooks/api/project.hook';
 
 import type { Media } from '../../../../constants/shared-types';
 import { isVideoFrame } from '../../../../shared/media-item-utils';
 import { isDetectionTask } from '../../../project/task-type-guards';
-import { loadImageQueryOptions } from '../../hooks/use-load-image-query.hook';
 import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import type {
     SegmentAnythingWorkerApi,
@@ -85,40 +84,30 @@ export const usePreloadSAMWorkers = (enabled = true) => {
     useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER', enabled);
 };
 
-export const prefetchNextSAMEncodingData = ({
-    queryClient,
-    projectId,
-    getNextMediaItem,
-}: {
-    queryClient: ReturnType<typeof useQueryClient>;
-    projectId: string;
-    getNextMediaItem: () => Media | undefined;
-}) => {
-    const prefetch = async () => {
-        const nextItem = getNextMediaItem();
-
-        if (nextItem === undefined) {
-            return;
-        }
-
-        const nextImage = await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
-        const encoderModel = await queryClient.ensureQueryData(
-            segmentAnythingWorkerQueryOptions('SEGMENT_ANYTHING_ENCODER')
-        );
-
-        queryClient.prefetchQuery(segmentAnythingEncodingQueryOptions(nextItem, encoderModel, nextImage));
-    };
-
-    prefetch();
-};
-
 const useEncodingQuery = (
     model: SegmentAnythingRemoteModel | undefined,
-    mediaItem: Media,
-    image: ImageData,
+    mediaItem: Media | undefined,
+    image: ImageData | undefined,
     isImageReady: boolean
 ) => {
-    return useQuery(segmentAnythingEncodingQueryOptions(mediaItem, model, image, model !== undefined && isImageReady));
+    const isEnabled = model !== undefined && mediaItem !== undefined && image !== undefined && isImageReady;
+
+    return useQuery({
+        queryKey:
+            mediaItem === undefined
+                ? ['segment-anything-model', 'encoding', 'disabled']
+                : getSegmentAnythingEncodingQueryKey(mediaItem),
+        queryFn: async () => {
+            if (model === undefined || image === undefined) {
+                throw new Error('Model not yet initialized');
+            }
+
+            return model.processEncoder(image);
+        },
+        staleTime: Infinity,
+        gcTime: 3600 * 15,
+        enabled: isEnabled,
+    });
 };
 
 const useDecoderOutputType = () => {
@@ -162,13 +151,30 @@ const useDecodingFn = (model: SegmentAnythingRemoteModel | undefined, encoding: 
     };
 };
 
-export const useSegmentAnythingModel = () => {
+type SegmentAnythingModelOptions = {
+    nextMediaItem?: Media;
+    nextImage?: ImageData;
+    isNextImageReady?: boolean;
+};
+
+export const useSegmentAnythingModel = ({
+    nextMediaItem,
+    nextImage,
+    isNextImageReady = false,
+}: SegmentAnythingModelOptions = {}) => {
     const encoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_ENCODER');
     const decoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER');
     const isLoadingWorkers = encoderModel === undefined || decoderModel === undefined;
 
     const { mediaItem, image, isImageReady } = useSelectedMediaItem();
+
+    // First we get the encoding for the CURRENT image
     const encodingQuery = useEncodingQuery(encoderModel, mediaItem, image, isImageReady);
+    // At the same time we start prefetching the encoding for the NEXT image,
+    // so when the user moves to the next media item the decoding will be faster.
+    // We don't need to get the decoding query result for the next image, we just want to cache the encoding result.
+    useEncodingQuery(encoderModel, nextMediaItem, nextImage, isNextImageReady);
+
     const decodingQueryFn = useDecodingFn(decoderModel, encodingQuery.data);
 
     const isLoading = isLoadingWorkers || encodingQuery.isLoading;

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { EncodingOutput } from '@geti/smart-tools/segment-anything';
-import { useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { Remote, wrap } from 'comlink';
 import { useProject } from 'hooks/api/project.hook';
 
@@ -23,18 +23,26 @@ export const getSegmentAnythingWorkerQueryKey = (
     algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER'
 ) => ['workers', algorithmType] as const;
 
-export const segmentAnythingWorkerQueryFn =
-    (algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER') => async () => {
-        const baseWorker = new Worker(new URL('../../webworkers/segment-anything.worker', import.meta.url), {
-            type: 'module',
-        });
-        const samWorker = wrap<SegmentAnythingWorkerApi>(baseWorker);
-        const model = await samWorker.build();
+export const segmentAnythingWorkerQueryOptions = (
+    algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER',
+    enabled = true
+) =>
+    queryOptions({
+        queryKey: getSegmentAnythingWorkerQueryKey(algorithmType),
+        queryFn: async () => {
+            const baseWorker = new Worker(new URL('../../webworkers/segment-anything.worker', import.meta.url), {
+                type: 'module',
+            });
+            const samWorker = wrap<SegmentAnythingWorkerApi>(baseWorker);
+            const model = await samWorker.build();
 
-        await model.init(algorithmType);
+            await model.init(algorithmType);
 
-        return model;
-    };
+            return model;
+        },
+        staleTime: Infinity,
+        enabled,
+    });
 
 export const getSegmentAnythingEncodingQueryKey = (mediaItem: Media) => {
     return isVideoFrame(mediaItem)
@@ -49,16 +57,31 @@ export const segmentAnythingEncodingQueryFn = (
     return model.processEncoder(image);
 };
 
+export const segmentAnythingEncodingQueryOptions = (
+    mediaItem: Media,
+    model: SegmentAnythingRemoteModel | undefined,
+    image: ImageData,
+    enabled = true
+) =>
+    queryOptions({
+        queryKey: getSegmentAnythingEncodingQueryKey(mediaItem),
+        queryFn: async () => {
+            if (model === undefined) {
+                throw new Error('Model not yet initialized');
+            }
+
+            return segmentAnythingEncodingQueryFn(model, image);
+        },
+        staleTime: Infinity,
+        gcTime: 3600 * 15,
+        enabled,
+    });
+
 const useSegmentAnythingWorker = (
     algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER',
     enabled = true
 ) => {
-    const { data } = useQuery<SegmentAnythingRemoteModel>({
-        queryKey: getSegmentAnythingWorkerQueryKey(algorithmType),
-        queryFn: segmentAnythingWorkerQueryFn(algorithmType),
-        staleTime: Infinity,
-        enabled,
-    });
+    const { data } = useQuery(segmentAnythingWorkerQueryOptions(algorithmType, enabled));
 
     return data;
 };
@@ -74,19 +97,7 @@ const useEncodingQuery = (
     image: ImageData,
     isImageReady: boolean
 ) => {
-    return useQuery({
-        queryKey: getSegmentAnythingEncodingQueryKey(mediaItem),
-        queryFn: async () => {
-            if (model === undefined) {
-                throw new Error('Model not yet initialized');
-            }
-
-            return await segmentAnythingEncodingQueryFn(model, image);
-        },
-        staleTime: Infinity,
-        gcTime: 3600 * 15,
-        enabled: model !== undefined && isImageReady,
-    });
+    return useQuery(segmentAnythingEncodingQueryOptions(mediaItem, model, image, model !== undefined && isImageReady));
 };
 
 const useDecoderOutputType = () => {

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -1,9 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useRef, useState } from 'react';
-
-import { EncodingOutput, SegmentAnythingModel } from '@geti/smart-tools/segment-anything';
+import { EncodingOutput } from '@geti/smart-tools/segment-anything';
 import { useQuery } from '@tanstack/react-query';
 import { Remote, wrap } from 'comlink';
 import { useProject } from 'hooks/api/project.hook';
@@ -12,66 +10,78 @@ import type { Media } from '../../../../constants/shared-types';
 import { isVideoFrame } from '../../../../shared/media-item-utils';
 import { isDetectionTask } from '../../../project/task-type-guards';
 import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
+import type {
+    SegmentAnythingWorkerApi,
+    SegmentAnythingWorkerModel,
+} from '../../webworkers/segment-anything.worker.interface';
 import { convertToolShapeToGetiShape } from '../utils';
 import { InteractiveAnnotationPoint } from './segment-anything.interface';
 
-const useSegmentAnythingWorker = (algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER') => {
-    const { data } = useQuery<Remote<SegmentAnythingModel>>({
-        queryKey: ['workers', algorithmType],
-        queryFn: async () => {
-            const baseWorker = new Worker(new URL('../../webworkers/segment-anything.worker', import.meta.url), {
-                type: 'module',
-            });
-            const samWorker = wrap(baseWorker);
+type SegmentAnythingRemoteModel = Remote<SegmentAnythingWorkerModel>;
 
-            // @ts-expect-error build exists on every worker
-            return samWorker.build();
-        },
+export const getSegmentAnythingWorkerQueryKey = (
+    algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER'
+) => ['workers', algorithmType] as const;
+
+export const segmentAnythingWorkerQueryFn =
+    (algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER') => async () => {
+        const baseWorker = new Worker(new URL('../../webworkers/segment-anything.worker', import.meta.url), {
+            type: 'module',
+        });
+        const samWorker = wrap<SegmentAnythingWorkerApi>(baseWorker);
+        const model = await samWorker.build();
+
+        await model.init(algorithmType);
+
+        return model;
+    };
+
+export const getSegmentAnythingEncodingQueryKey = (mediaItem: Media) => {
+    return isVideoFrame(mediaItem)
+        ? ['segment-anything-model', 'encoding', mediaItem.id, mediaItem.frame_number]
+        : ['segment-anything-model', 'encoding', mediaItem.id];
+};
+
+export const segmentAnythingEncodingQueryFn = (
+    model: SegmentAnythingRemoteModel,
+    image: ImageData
+): Promise<EncodingOutput> => {
+    return model.processEncoder(image);
+};
+
+const useSegmentAnythingWorker = (
+    algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER',
+    enabled = true
+) => {
+    const { data } = useQuery<SegmentAnythingRemoteModel>({
+        queryKey: getSegmentAnythingWorkerQueryKey(algorithmType),
+        queryFn: segmentAnythingWorkerQueryFn(algorithmType),
         staleTime: Infinity,
+        enabled,
     });
 
-    const modelRef = useRef<Remote<SegmentAnythingModel>>(undefined);
-    const [modelIsLoading, setModelIsLoading] = useState(false);
+    return data;
+};
 
-    useEffect(() => {
-        const loadWorker = async () => {
-            setModelIsLoading(true);
-
-            if (data) {
-                const model = data;
-
-                await model.init(algorithmType);
-
-                modelRef.current = model;
-            }
-
-            setModelIsLoading(false);
-        };
-
-        if (data && modelRef.current === undefined && !modelIsLoading) {
-            loadWorker();
-        }
-    }, [data, modelIsLoading, algorithmType]);
-
-    return modelRef.current;
+export const usePreloadSAMWorkers = (enabled = true) => {
+    useSegmentAnythingWorker('SEGMENT_ANYTHING_ENCODER', enabled);
+    useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER', enabled);
 };
 
 const useEncodingQuery = (
-    model: Remote<SegmentAnythingModel> | undefined,
+    model: SegmentAnythingRemoteModel | undefined,
     mediaItem: Media,
     image: ImageData,
     isImageReady: boolean
 ) => {
     return useQuery({
-        queryKey: isVideoFrame(mediaItem)
-            ? ['segment-anything-model', 'encoding', mediaItem.id, mediaItem.frame_number]
-            : ['segment-anything-model', 'encoding', mediaItem.id],
+        queryKey: getSegmentAnythingEncodingQueryKey(mediaItem),
         queryFn: async () => {
             if (model === undefined) {
                 throw new Error('Model not yet initialized');
             }
 
-            return await model.processEncoder(image);
+            return await segmentAnythingEncodingQueryFn(model, image);
         },
         staleTime: Infinity,
         gcTime: 3600 * 15,
@@ -89,7 +99,7 @@ const useDecoderOutputType = () => {
     return 'polygon';
 };
 
-const useDecodingFn = (model: Remote<SegmentAnythingModel> | undefined, encoding: EncodingOutput | undefined) => {
+const useDecodingFn = (model: SegmentAnythingRemoteModel | undefined, encoding: EncodingOutput | undefined) => {
     const decoderOutput = useDecoderOutputType();
 
     // TODO: look into returning a new "decoder model" instance that already has the encoding data

--- a/application/ui/src/features/annotator/tools/tool-manager.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool-manager.component.tsx
@@ -15,7 +15,7 @@ export const ToolManager = () => {
     const { activeTool } = useTool();
     const { data: project } = useProject();
 
-    const isPreloadEnabled = project !== undefined && isPrefetchEnabledForTask(project.task.task_type);
+    const isPreloadEnabled = isPrefetchEnabledForTask(project.task.task_type);
 
     // Preload SAM workers when the tool manager is mounted, so that the tool is ready
     // to use as soon as the user selects it. Not a huge performance gain but

--- a/application/ui/src/features/annotator/tools/tool-manager.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool-manager.component.tsx
@@ -6,9 +6,15 @@ import { BoundingBoxTool } from './bounding-box-tool/bounding-box-tool.component
 import { MagneticLasso } from './magnetic-lasso/magnetic-lasso.component';
 import { PolygonTool } from './polygon-tool/polygon-tool.component';
 import { SegmentAnythingTool } from './segment-anything-tool/segment-anything-tool.component';
+import { usePreloadSAMWorkers } from './segment-anything-tool/use-segment-anything.hook';
 
 export const ToolManager = () => {
     const { activeTool } = useTool();
+
+    // Preload SAM workers when the tool manager is mounted, so that the tool is ready
+    // to use as soon as the user selects it. Not a huge performance gain but
+    // it helps a bit.
+    usePreloadSAMWorkers();
 
     if (activeTool === 'bounding-box') {
         return <BoundingBoxTool />;

--- a/application/ui/src/features/annotator/tools/tool-manager.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool-manager.component.tsx
@@ -1,7 +1,10 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useProject } from 'hooks/api/project.hook';
+
 import { useTool } from '../../../shared/annotator/tool-provider.component';
+import { isPrefetchEnabledForTask } from '../../project/task-type-guards';
 import { BoundingBoxTool } from './bounding-box-tool/bounding-box-tool.component';
 import { MagneticLasso } from './magnetic-lasso/magnetic-lasso.component';
 import { PolygonTool } from './polygon-tool/polygon-tool.component';
@@ -10,11 +13,14 @@ import { usePreloadSAMWorkers } from './segment-anything-tool/use-segment-anythi
 
 export const ToolManager = () => {
     const { activeTool } = useTool();
+    const { data: project } = useProject();
+
+    const isPreloadEnabled = project !== undefined && isPrefetchEnabledForTask(project.task.task_type);
 
     // Preload SAM workers when the tool manager is mounted, so that the tool is ready
     // to use as soon as the user selects it. Not a huge performance gain but
     // it helps a bit.
-    usePreloadSAMWorkers();
+    usePreloadSAMWorkers(isPreloadEnabled);
 
     if (activeTool === 'bounding-box') {
         return <BoundingBoxTool />;

--- a/application/ui/src/features/annotator/webworkers/segment-anything.worker.interface.ts
+++ b/application/ui/src/features/annotator/webworkers/segment-anything.worker.interface.ts
@@ -1,0 +1,11 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { buildSegmentAnythingInstance } from '@geti/smart-tools/segment-anything';
+import type { ProxyMarked } from 'comlink';
+
+export type SegmentAnythingWorkerModel = Awaited<ReturnType<typeof buildSegmentAnythingInstance>> & ProxyMarked;
+
+export type SegmentAnythingWorkerApi = {
+    build: () => Promise<SegmentAnythingWorkerModel>;
+};

--- a/application/ui/src/features/annotator/webworkers/segment-anything.worker.ts
+++ b/application/ui/src/features/annotator/webworkers/segment-anything.worker.ts
@@ -4,7 +4,9 @@
 import { buildSegmentAnythingInstance } from '@geti/smart-tools/segment-anything';
 import { expose, proxy } from 'comlink';
 
-const WorkerApi = {
+import type { SegmentAnythingWorkerApi } from './segment-anything.worker.interface';
+
+const WorkerApi: SegmentAnythingWorkerApi = {
     build: async () => {
         const instance = await buildSegmentAnythingInstance();
 

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -5,16 +5,16 @@ import { useEffect } from 'react';
 
 import { View } from '@geti/ui';
 import { useQueryClient } from '@tanstack/react-query';
-import { useProject } from 'hooks/api/project.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
+import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
+import { prefetchNextSAMEncodingData } from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
-import { isPrefetchEnabledForTask } from '../../project/task-type-guards';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { PrimaryToolbar } from './primary-toolbar/primary-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';
@@ -22,7 +22,7 @@ import { ReadOnlyAnnotator } from './read-only-annotator.component';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
 import { useNextMedia } from './secondary-toolbar/util';
-import { prefetchNextMediaItemData } from './utils';
+import { prefetchNextMediaAndAnnotationsData } from './utils';
 
 type AnnotatorProps = {
     image: ImageData;
@@ -43,24 +43,27 @@ const Annotator = ({
     items,
     onClose,
 }: AnnotatorProps) => {
+    const { activeTool } = useTool();
     const getNextMediaItem = useNextMedia(mediaItem, items);
     const queryClient = useQueryClient();
     const projectId = useProjectIdentifier();
-    const { data: project } = useProject();
-
-    const isPrefetchEnabled = project !== undefined && isPrefetchEnabledForTask(project.task.task_type);
+    const isSAMContext = activeTool === 'sam';
 
     useEffect(() => {
-        if (!isPrefetchEnabled) {
-            return;
-        }
-
-        prefetchNextMediaItemData({
+        prefetchNextMediaAndAnnotationsData({
             queryClient,
             projectId,
             getNextMediaItem,
         });
-    }, [getNextMediaItem, isPrefetchEnabled, projectId, queryClient]);
+
+        if (isSAMContext) {
+            prefetchNextSAMEncodingData({
+                queryClient,
+                projectId,
+                getNextMediaItem,
+            });
+        }
+    }, [getNextMediaItem, isSAMContext, projectId, queryClient]);
 
     const handleSubmitAnnotations = async () => {
         const nextMediaItem = getNextMediaItem();

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -1,7 +1,11 @@
-// Copyright (C) 2025-2026 Intel Corporation
+// Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useEffect } from 'react';
+
 import { View } from '@geti/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
@@ -16,6 +20,7 @@ import { ReadOnlyAnnotator } from './read-only-annotator.component';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
 import { useNextMedia } from './secondary-toolbar/util';
+import { prefetchNextMediaItemData } from './utils';
 
 type AnnotatorProps = {
     image: ImageData;
@@ -37,6 +42,16 @@ const Annotator = ({
     onClose,
 }: AnnotatorProps) => {
     const getNextMediaItem = useNextMedia(mediaItem, items);
+    const queryClient = useQueryClient();
+    const projectId = useProjectIdentifier();
+
+    useEffect(() => {
+        prefetchNextMediaItemData({
+            queryClient,
+            projectId,
+            getNextMediaItem,
+        });
+    }, [getNextMediaItem, projectId, queryClient]);
 
     const handleSubmitAnnotations = async () => {
         const nextMediaItem = getNextMediaItem();

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -41,6 +41,10 @@ const Annotator = ({
     const handleSubmitAnnotations = async () => {
         const nextMediaItem = getNextMediaItem();
 
+        if (nextMediaItem === undefined) {
+            return;
+        }
+
         onSelectedMediaItem(nextMediaItem);
     };
 

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -1,18 +1,12 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
-
 import { View } from '@geti/ui';
-import { useQueryClient } from '@tanstack/react-query';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
-import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
-import { prefetchNextSAMEncodingData } from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
@@ -21,8 +15,7 @@ import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-ca
 import { ReadOnlyAnnotator } from './read-only-annotator.component';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
-import { useNextMedia } from './secondary-toolbar/util';
-import { prefetchNextMediaAndAnnotationsData } from './utils';
+import { useNextMediaItem } from './utils';
 
 type AnnotatorProps = {
     image: ImageData;
@@ -43,31 +36,9 @@ const Annotator = ({
     items,
     onClose,
 }: AnnotatorProps) => {
-    const { activeTool } = useTool();
-    const getNextMediaItem = useNextMedia(mediaItem, items);
-    const queryClient = useQueryClient();
-    const projectId = useProjectIdentifier();
-    const isSAMContext = activeTool === 'sam';
-
-    useEffect(() => {
-        prefetchNextMediaAndAnnotationsData({
-            queryClient,
-            projectId,
-            getNextMediaItem,
-        });
-
-        if (isSAMContext) {
-            prefetchNextSAMEncodingData({
-                queryClient,
-                projectId,
-                getNextMediaItem,
-            });
-        }
-    }, [getNextMediaItem, isSAMContext, projectId, queryClient]);
+    const nextMediaItem = useNextMediaItem(mediaItem, items);
 
     const handleSubmitAnnotations = async () => {
-        const nextMediaItem = getNextMediaItem();
-
         if (nextMediaItem === undefined) {
             return;
         }

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 
 import { View } from '@geti/ui';
 import { useQueryClient } from '@tanstack/react-query';
+import { useProject } from 'hooks/api/project.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
@@ -13,6 +14,7 @@ import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canv
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
+import { isPrefetchEnabledForTask } from '../../project/task-type-guards';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { PrimaryToolbar } from './primary-toolbar/primary-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';
@@ -44,14 +46,21 @@ const Annotator = ({
     const getNextMediaItem = useNextMedia(mediaItem, items);
     const queryClient = useQueryClient();
     const projectId = useProjectIdentifier();
+    const { data: project } = useProject();
+
+    const isPrefetchEnabled = project !== undefined && isPrefetchEnabledForTask(project.task.task_type);
 
     useEffect(() => {
+        if (!isPrefetchEnabled) {
+            return;
+        }
+
         prefetchNextMediaItemData({
             queryClient,
             projectId,
             getNextMediaItem,
         });
-    }, [getNextMediaItem, projectId, queryClient]);
+    }, [getNextMediaItem, isPrefetchEnabled, projectId, queryClient]);
 
     const handleSubmitAnnotations = async () => {
         const nextMediaItem = getNextMediaItem();

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -15,7 +15,7 @@ import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-ca
 import { ReadOnlyAnnotator } from './read-only-annotator.component';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
-import { useNextMediaItem } from './utils';
+import { useNextMediaPrefetch } from './utils';
 
 type AnnotatorProps = {
     image: ImageData;
@@ -36,7 +36,7 @@ const Annotator = ({
     items,
     onClose,
 }: AnnotatorProps) => {
-    const nextMediaItem = useNextMediaItem(mediaItem, items);
+    const { nextMediaItem } = useNextMediaPrefetch(mediaItem, items);
 
     const handleSubmitAnnotations = async () => {
         if (nextMediaItem === undefined) {

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery, type QueryKey } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isObject } from 'lodash-es';
 
@@ -23,7 +23,13 @@ const getAnnotationsQueryParams = (media: Media) => {
         : undefined;
 };
 
-export const getAnnotationsQueryKey = (projectId: string, media: Media) => {
+export const annotationsQueryOptions = (projectId: string, media: Media) =>
+    queryOptions({
+        queryKey: getAnnotationsQueryKey(projectId, media),
+        queryFn: () => annotationsQueryFn(projectId, media),
+    });
+
+export const getAnnotationsQueryKey = (projectId: string, media: Media): QueryKey => {
     return getQueryKey([
         'get',
         `/api/projects/{project_id}/dataset/media/{media_id}/annotations`,

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -86,7 +86,5 @@ export const annotationsQueryFn = async (projectId: string, media: Media) => {
 export const useAnnotationsQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
 
-    return useQuery({
-        ...annotationsQueryOptions(projectId, media),
-    });
+    return useQuery(annotationsQueryOptions(projectId, media));
 };

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -15,64 +15,73 @@ const isUnannotatedError = (error: unknown): boolean => {
     return isObject(error) && 'detail' in error && /Media has not been annotated yet/i.test(String(error.detail));
 };
 
-export const useAnnotationsQuery = (media: Media) => {
-    const projectId = useProjectIdentifier();
-
-    const queryParams = isVideoFrame(media)
+const getAnnotationsQueryParams = (media: Media) => {
+    return isVideoFrame(media)
         ? {
               frame_index: media.frame_number,
           }
         : undefined;
+};
+
+export const getAnnotationsQueryKey = (projectId: string, media: Media) => {
+    return getQueryKey([
+        'get',
+        `/api/projects/{project_id}/dataset/media/{media_id}/annotations`,
+        {
+            params: {
+                path: { project_id: projectId, media_id: media.id },
+                query: getAnnotationsQueryParams(media),
+            },
+        },
+    ]);
+};
+
+export const annotationsQueryFn = async (projectId: string, media: Media) => {
+    const queryParams = getAnnotationsQueryParams(media);
+
+    const { data, error, response } = await fetchClient.GET(
+        '/api/projects/{project_id}/dataset/media/{media_id}/annotations',
+        {
+            params: {
+                path: {
+                    project_id: projectId,
+                    media_id: media.id,
+                },
+                query: queryParams,
+            },
+        }
+    );
+
+    if (isUnannotatedError(error) || response.status === 404) {
+        return { annotations: [], user_reviewed: false };
+    }
+
+    if (error) {
+        throw error;
+    }
+
+    if (data?.annotations.length === 0) {
+        const annotationDTO = {
+            shape: {
+                type: 'full_image',
+            },
+            labels: [{ id: EMPTY_LABEL_ID }],
+        } satisfies AnnotationDTO;
+
+        return {
+            annotations: [annotationDTO],
+            user_reviewed: true,
+        };
+    }
+
+    return data;
+};
+
+export const useAnnotationsQuery = (media: Media) => {
+    const projectId = useProjectIdentifier();
 
     return useQuery({
-        queryKey: getQueryKey([
-            'get',
-            `/api/projects/{project_id}/dataset/media/{media_id}/annotations`,
-            {
-                params: {
-                    path: { project_id: projectId, media_id: media.id },
-                    query: queryParams,
-                },
-            },
-        ]),
-        queryFn: async () => {
-            const { data, error, response } = await fetchClient.GET(
-                '/api/projects/{project_id}/dataset/media/{media_id}/annotations',
-                {
-                    params: {
-                        path: {
-                            project_id: projectId,
-                            media_id: media.id,
-                        },
-                        query: queryParams,
-                    },
-                }
-            );
-
-            if (isUnannotatedError(error) || response.status === 404) {
-                return { annotations: [], user_reviewed: false };
-            }
-
-            if (error) {
-                throw error;
-            }
-
-            // If there are no annotations, it means that the user annotated the whole image with the empty label.
-            if (data?.annotations.length === 0) {
-                const annotationDTO = {
-                    shape: {
-                        type: 'full_image',
-                    },
-                    labels: [{ id: EMPTY_LABEL_ID }],
-                } satisfies AnnotationDTO;
-
-                return {
-                    annotations: [annotationDTO],
-                    user_reviewed: true,
-                };
-            }
-
-            return data;
-        },
+        queryKey: getAnnotationsQueryKey(projectId, media),
+        queryFn: () => annotationsQueryFn(projectId, media),
     });
 };

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -87,7 +87,6 @@ export const useAnnotationsQuery = (media: Media) => {
     const projectId = useProjectIdentifier();
 
     return useQuery({
-        queryKey: getAnnotationsQueryKey(projectId, media),
-        queryFn: () => annotationsQueryFn(projectId, media),
+        ...annotationsQueryOptions(projectId, media),
     });
 };

--- a/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
+++ b/application/ui/src/features/dataset/media-preview/api/use-annotations-query.ts
@@ -23,13 +23,7 @@ const getAnnotationsQueryParams = (media: Media) => {
         : undefined;
 };
 
-export const annotationsQueryOptions = (projectId: string, media: Media) =>
-    queryOptions({
-        queryKey: getAnnotationsQueryKey(projectId, media),
-        queryFn: () => annotationsQueryFn(projectId, media),
-    });
-
-export const getAnnotationsQueryKey = (projectId: string, media: Media): QueryKey => {
+const getAnnotationsQueryKey = (projectId: string, media: Media): QueryKey => {
     return getQueryKey([
         'get',
         `/api/projects/{project_id}/dataset/media/{media_id}/annotations`,
@@ -41,6 +35,12 @@ export const getAnnotationsQueryKey = (projectId: string, media: Media): QueryKe
         },
     ]);
 };
+
+export const annotationsQueryOptions = (projectId: string, media: Media) =>
+    queryOptions({
+        queryKey: getAnnotationsQueryKey(projectId, media),
+        queryFn: () => annotationsQueryFn(projectId, media),
+    });
 
 export const annotationsQueryFn = async (projectId: string, media: Media) => {
     const queryParams = getAnnotationsQueryParams(media);

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -1,31 +1,22 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Content, Dialog, Grid, View } from '@geti/ui';
-import { useQueryClient } from '@tanstack/react-query';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
-import { isVideoFrame } from '../../../shared/media-item-utils';
-import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
 import {
     SelectedMediaItemProvider,
     useSelectedMediaItem,
 } from '../../annotator/selected-media-item-provider.component';
-import {
-    segmentAnythingEncodingQueryOptions,
-    segmentAnythingWorkerQueryOptions,
-} from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
 import { AnnotatorProviders } from './annotator-providers.component';
 import { AnnotatorContainer } from './annotator.component';
-import { annotationsQueryOptions, useAnnotationsQuery } from './api/use-annotations-query';
+import { useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
-import { getNextMediaItem } from './secondary-toolbar/util';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { getInitialAnnotations, getInitialPredictions } from './utils';
 
@@ -41,56 +32,9 @@ type MediaPreviewContentProps = {
     onSelectedMediaItem: (item: Media) => void;
 };
 
-const getNextMediaItemForPrefetch = (selectedItem: Media, items: Media[]): Media | undefined => {
-    const step = isVideoFrame(selectedItem) ? selectedItem.frame_stride : 1;
-
-    return getNextMediaItem(selectedItem, items, step);
-};
-
-// When the user navigates to next media, the most expensive data, like the SAM encoding,
-// along with image data and annotations, will be already in React Query cache, so the UI will feel smoother
-// whenever the user switches image. Unless he/she changes to a random or item. We could also consider
-// those cases but I feel like it's overkill. Let's see how this improvement performs and then we can iterate on it.
-//
-// ensureQueryData will get the data from cache if it's there, or call the queryFn and cache the result if it's not.
-// prefetchQuery will fetch the data and cache it
-const prefetchNextMediaItemData = ({
-    queryClient,
-    projectId,
-    items,
-    selectedItem,
-}: {
-    queryClient: ReturnType<typeof useQueryClient>;
-    projectId: string;
-    items: Media[];
-    selectedItem: Media;
-}) => {
-    const prefetch = async () => {
-        const nextItem = getNextMediaItemForPrefetch(selectedItem, items);
-
-        if (nextItem === undefined) {
-            return;
-        }
-
-        const nextImage = await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
-
-        queryClient.prefetchQuery(annotationsQueryOptions(projectId, nextItem));
-
-        const encoderModel = await queryClient.ensureQueryData(
-            segmentAnythingWorkerQueryOptions('SEGMENT_ANYTHING_ENCODER')
-        );
-
-        queryClient.prefetchQuery(segmentAnythingEncodingQueryOptions(nextItem, encoderModel, nextImage));
-    };
-
-    prefetch();
-};
-
 const MediaPreviewContent = ({ items, onSelectedMediaItem, onClose }: MediaPreviewContentProps) => {
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
     const { mediaItem } = useSelectedMediaItem();
-    const queryClient = useQueryClient();
-    const projectId = useProjectIdentifier();
 
     const { data: annotationsData } = useAnnotationsQuery(mediaItem);
 
@@ -103,15 +47,6 @@ const MediaPreviewContent = ({ items, onSelectedMediaItem, onClose }: MediaPrevi
     const initialPredictions = useMemo(() => {
         return getInitialPredictions(isUserReviewed, annotationsData?.annotations ?? []);
     }, [isUserReviewed, annotationsData?.annotations]);
-
-    useEffect(() => {
-        prefetchNextMediaItemData({
-            queryClient,
-            projectId,
-            items,
-            selectedItem: mediaItem,
-        });
-    }, [items, mediaItem, projectId, queryClient]);
 
     return (
         <ToolProvider mode={mode}>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -11,6 +11,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
+import { isVideoFrame } from '../../../shared/media-item-utils';
 import { getLoadImageQueryKey, loadImageQueryFn } from '../../annotator/hooks/use-load-image-query.hook';
 import {
     SelectedMediaItemProvider,
@@ -28,6 +29,7 @@ import { AnnotatorContainer } from './annotator.component';
 import { annotationsQueryFn, getAnnotationsQueryKey, useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
+import { getNextMediaItem } from './secondary-toolbar/util';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { getInitialAnnotations, getInitialPredictions } from './utils';
 
@@ -41,6 +43,23 @@ type MediaPreviewContentProps = {
     items: Media[];
     onClose: () => void;
     onSelectedMediaItem: (item: Media) => void;
+};
+
+const isSameMediaItem = (firstItem: Media, secondItem: Media): boolean => {
+    if (isVideoFrame(firstItem) && isVideoFrame(secondItem)) {
+        return firstItem.id === secondItem.id && firstItem.frame_number === secondItem.frame_number;
+    }
+
+    return firstItem.id === secondItem.id;
+};
+
+const getNextMediaItemForPrefetch = (selectedItem: Media, items: Media[]): Media | undefined => {
+    const nextItem = getNextMediaItem(selectedItem, items, 1);
+
+    // getNextMediaItem never returns undefined. When there is no next item, it returns the same item.
+    // We want to avoid prefetching data for the same item, so in that case we return undefined.
+
+    return isSameMediaItem(nextItem, selectedItem) ? undefined : nextItem;
 };
 
 // When the user navigates to next media, the most expensive data, like the SAM encoding,
@@ -62,8 +81,7 @@ const prefetchNextMediaItemData = ({
     selectedItem: Media;
 }) => {
     const prefetch = async () => {
-        const selectedIndex = items.findIndex((item) => item.id === selectedItem.id);
-        const nextItem = selectedIndex >= 0 ? items[selectedIndex + 1] : undefined;
+        const nextItem = getNextMediaItemForPrefetch(selectedItem, items);
 
         if (nextItem === undefined) {
             return;

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -5,30 +5,27 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Content, Dialog, Grid, View } from '@geti/ui';
 import { useQueryClient } from '@tanstack/react-query';
-import { Remote } from 'comlink';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
-import { getLoadImageQueryKey, loadImageQueryFn } from '../../annotator/hooks/use-load-image-query.hook';
+import { isVideoFrame } from '../../../shared/media-item-utils';
+import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
 import {
     SelectedMediaItemProvider,
     useSelectedMediaItem,
 } from '../../annotator/selected-media-item-provider.component';
 import {
-    getSegmentAnythingEncodingQueryKey,
-    getSegmentAnythingWorkerQueryKey,
-    segmentAnythingEncodingQueryFn,
-    segmentAnythingWorkerQueryFn,
+    segmentAnythingEncodingQueryOptions,
+    segmentAnythingWorkerQueryOptions,
 } from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
-import type { SegmentAnythingWorkerModel } from '../../annotator/webworkers/segment-anything.worker.interface';
 import { AnnotatorProviders } from './annotator-providers.component';
 import { AnnotatorContainer } from './annotator.component';
-import { annotationsQueryFn, getAnnotationsQueryKey, useAnnotationsQuery } from './api/use-annotations-query';
+import { annotationsQueryOptions, useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
-import { getNextMediaItem, isSameMediaItem } from './secondary-toolbar/util';
+import { getNextMediaItem } from './secondary-toolbar/util';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { getInitialAnnotations, getInitialPredictions } from './utils';
 
@@ -45,12 +42,9 @@ type MediaPreviewContentProps = {
 };
 
 const getNextMediaItemForPrefetch = (selectedItem: Media, items: Media[]): Media | undefined => {
-    const step = selectedItem.type === 'video_frame' ? selectedItem.frame_stride : 1;
-    const nextItem = getNextMediaItem(selectedItem, items, step);
+    const step = isVideoFrame(selectedItem) ? selectedItem.frame_stride : 1;
 
-    // getNextMediaItem never returns undefined. When there is no next item, it returns the same item.
-    // We want to avoid prefetching data for the same item, so in that case we return undefined.
-    return isSameMediaItem(nextItem, selectedItem) ? undefined : nextItem;
+    return getNextMediaItem(selectedItem, items, step);
 };
 
 // When the user navigates to next media, the most expensive data, like the SAM encoding,
@@ -78,30 +72,15 @@ const prefetchNextMediaItemData = ({
             return;
         }
 
-        const nextImage = await queryClient.ensureQueryData({
-            queryKey: getLoadImageQueryKey(projectId, nextItem),
-            queryFn: () => loadImageQueryFn(projectId, nextItem),
-            staleTime: Infinity,
-            retry: 0,
-        });
+        const nextImage = await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
 
-        queryClient.prefetchQuery({
-            queryKey: getAnnotationsQueryKey(projectId, nextItem),
-            queryFn: () => annotationsQueryFn(projectId, nextItem),
-        });
+        queryClient.prefetchQuery(annotationsQueryOptions(projectId, nextItem));
 
-        const encoderModel = await queryClient.ensureQueryData<Remote<SegmentAnythingWorkerModel>>({
-            queryKey: getSegmentAnythingWorkerQueryKey('SEGMENT_ANYTHING_ENCODER'),
-            queryFn: segmentAnythingWorkerQueryFn('SEGMENT_ANYTHING_ENCODER'),
-            staleTime: Infinity,
-        });
+        const encoderModel = await queryClient.ensureQueryData(
+            segmentAnythingWorkerQueryOptions('SEGMENT_ANYTHING_ENCODER')
+        );
 
-        queryClient.prefetchQuery({
-            queryKey: getSegmentAnythingEncodingQueryKey(nextItem),
-            queryFn: () => segmentAnythingEncodingQueryFn(encoderModel, nextImage),
-            staleTime: Infinity,
-            gcTime: 3600 * 15,
-        });
+        queryClient.prefetchQuery(segmentAnythingEncodingQueryOptions(nextItem, encoderModel, nextImage));
     };
 
     prefetch();

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -11,7 +11,6 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
-import { isVideoFrame } from '../../../shared/media-item-utils';
 import { getLoadImageQueryKey, loadImageQueryFn } from '../../annotator/hooks/use-load-image-query.hook';
 import {
     SelectedMediaItemProvider,
@@ -29,7 +28,7 @@ import { AnnotatorContainer } from './annotator.component';
 import { annotationsQueryFn, getAnnotationsQueryKey, useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
-import { getNextMediaItem } from './secondary-toolbar/util';
+import { getNextMediaItem, isSameMediaItem } from './secondary-toolbar/util';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { getInitialAnnotations, getInitialPredictions } from './utils';
 
@@ -45,20 +44,12 @@ type MediaPreviewContentProps = {
     onSelectedMediaItem: (item: Media) => void;
 };
 
-const isSameMediaItem = (firstItem: Media, secondItem: Media): boolean => {
-    if (isVideoFrame(firstItem) && isVideoFrame(secondItem)) {
-        return firstItem.id === secondItem.id && firstItem.frame_number === secondItem.frame_number;
-    }
-
-    return firstItem.id === secondItem.id;
-};
-
 const getNextMediaItemForPrefetch = (selectedItem: Media, items: Media[]): Media | undefined => {
-    const nextItem = getNextMediaItem(selectedItem, items, 1);
+    const step = selectedItem.type === 'video_frame' ? selectedItem.frame_stride : 1;
+    const nextItem = getNextMediaItem(selectedItem, items, step);
 
     // getNextMediaItem never returns undefined. When there is no next item, it returns the same item.
     // We want to avoid prefetching data for the same item, so in that case we return undefined.
-
     return isSameMediaItem(nextItem, selectedItem) ? undefined : nextItem;
 };
 

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -1,20 +1,31 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Content, Dialog, Grid, View } from '@geti/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { Remote } from 'comlink';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
+import { getLoadImageQueryKey, loadImageQueryFn } from '../../annotator/hooks/use-load-image-query.hook';
 import {
     SelectedMediaItemProvider,
     useSelectedMediaItem,
 } from '../../annotator/selected-media-item-provider.component';
+import {
+    getSegmentAnythingEncodingQueryKey,
+    getSegmentAnythingWorkerQueryKey,
+    segmentAnythingEncodingQueryFn,
+    segmentAnythingWorkerQueryFn,
+} from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
+import type { SegmentAnythingWorkerModel } from '../../annotator/webworkers/segment-anything.worker.interface';
 import { AnnotatorProviders } from './annotator-providers.component';
 import { AnnotatorContainer } from './annotator.component';
-import { useAnnotationsQuery } from './api/use-annotations-query';
+import { annotationsQueryFn, getAnnotationsQueryKey, useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { AnnotatorMode } from './secondary-toolbar/annotator-modes/mode';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
@@ -32,9 +43,66 @@ type MediaPreviewContentProps = {
     onSelectedMediaItem: (item: Media) => void;
 };
 
+// When the user navigates to next media, the most expensive data, like the SAM encoding,
+// along with image data and annotations, will be already in React Query cache, so the UI will feel smoother
+// whenever the user switches image. Unless he/she changes to a random or item. We could also consider
+// those cases but I feel like it's overkill. Let's see how this improvement performs and then we can iterate on it.
+//
+// ensureQueryData will get the data from cache if it's there, or call the queryFn and cache the result if it's not.
+// prefetchQuery will fetch the data and cache it
+const prefetchNextMediaItemData = ({
+    queryClient,
+    projectId,
+    items,
+    selectedItem,
+}: {
+    queryClient: ReturnType<typeof useQueryClient>;
+    projectId: string;
+    items: Media[];
+    selectedItem: Media;
+}) => {
+    const prefetch = async () => {
+        const selectedIndex = items.findIndex((item) => item.id === selectedItem.id);
+        const nextItem = selectedIndex >= 0 ? items[selectedIndex + 1] : undefined;
+
+        if (nextItem === undefined) {
+            return;
+        }
+
+        const nextImage = await queryClient.ensureQueryData({
+            queryKey: getLoadImageQueryKey(projectId, nextItem),
+            queryFn: () => loadImageQueryFn(projectId, nextItem),
+            staleTime: Infinity,
+            retry: 0,
+        });
+
+        queryClient.prefetchQuery({
+            queryKey: getAnnotationsQueryKey(projectId, nextItem),
+            queryFn: () => annotationsQueryFn(projectId, nextItem),
+        });
+
+        const encoderModel = await queryClient.ensureQueryData<Remote<SegmentAnythingWorkerModel>>({
+            queryKey: getSegmentAnythingWorkerQueryKey('SEGMENT_ANYTHING_ENCODER'),
+            queryFn: segmentAnythingWorkerQueryFn('SEGMENT_ANYTHING_ENCODER'),
+            staleTime: Infinity,
+        });
+
+        queryClient.prefetchQuery({
+            queryKey: getSegmentAnythingEncodingQueryKey(nextItem),
+            queryFn: () => segmentAnythingEncodingQueryFn(encoderModel, nextImage),
+            staleTime: Infinity,
+            gcTime: 3600 * 15,
+        });
+    };
+
+    prefetch();
+};
+
 const MediaPreviewContent = ({ items, onSelectedMediaItem, onClose }: MediaPreviewContentProps) => {
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
     const { mediaItem } = useSelectedMediaItem();
+    const queryClient = useQueryClient();
+    const projectId = useProjectIdentifier();
 
     const { data: annotationsData } = useAnnotationsQuery(mediaItem);
 
@@ -47,6 +115,15 @@ const MediaPreviewContent = ({ items, onSelectedMediaItem, onClose }: MediaPrevi
     const initialPredictions = useMemo(() => {
         return getInitialPredictions(isUserReviewed, annotationsData?.annotations ?? []);
     }, [isUserReviewed, annotationsData?.annotations]);
+
+    useEffect(() => {
+        prefetchNextMediaItemData({
+            queryClient,
+            projectId,
+            items,
+            selectedItem: mediaItem,
+        });
+    }, [items, mediaItem, projectId, queryClient]);
 
     return (
         <ToolProvider mode={mode}>

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.test.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.test.ts
@@ -3,10 +3,9 @@
 
 import { getMockedAnnotation } from 'mocks/mock-annotation';
 import { getMockedLabel } from 'mocks/mock-labels';
-import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage } from 'mocks/mock-media';
 import { describe, expect, it } from 'vitest';
 
-import { getNextMediaItem, toggleLabel } from './util';
+import { toggleLabel } from './util';
 
 describe('secondary toolbar utils', () => {
     describe('toggleLabel', () => {
@@ -50,69 +49,6 @@ describe('secondary toolbar utils', () => {
             const result = toggleLabel(mockLabel1, annotation.labels);
 
             expect(result).toEqual([]);
-        });
-    });
-
-    describe('getNextMediaItem', () => {
-        describe('image media items', () => {
-            it('returns the next image in the list', () => {
-                const items = getMultipleMockedMediaImage(3);
-                const result = getNextMediaItem(items[0], items, 1);
-                expect(result).toEqual(items[1]);
-            });
-
-            it('returns undefined when current item is the last one', () => {
-                const items = getMultipleMockedMediaImage(3);
-                const result = getNextMediaItem(items[2], items, 1);
-                expect(result).toBeUndefined();
-            });
-
-            it('returns the first item when current item is not found in the list', () => {
-                const items = getMultipleMockedMediaImage(3);
-                const unknownItem = getMockedMediaImage({ id: 'unknown' });
-                const result = getNextMediaItem(unknownItem, items, 1);
-                expect(result).toEqual(items[0]);
-            });
-        });
-
-        describe('video frame media items', () => {
-            it('returns the next video frame based on step', () => {
-                const frame = getMockedVideoFrame({ frame_number: 0, frame_count: 10 });
-                const result = getNextMediaItem(frame, [], 1);
-                expect(result).toEqual({ ...frame, frame_number: 1 });
-            });
-
-            it('advances by the given step size', () => {
-                const frame = getMockedVideoFrame({ frame_number: 0, frame_count: 10 });
-                const result = getNextMediaItem(frame, [], 3);
-                expect(result).toEqual({ ...frame, frame_number: 3 });
-            });
-
-            it('advances to the next media item when already at the last video frame', () => {
-                const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
-                const nextImage = getMockedMediaImage({ id: 'image-1' });
-                const result = getNextMediaItem(frame, [frame, nextImage], 1);
-                expect(result).toEqual(nextImage);
-            });
-
-            it('returns undefined when it is the last media item and already at the last frame', () => {
-                const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
-                const result = getNextMediaItem(frame, [frame], 1);
-                expect(result).toBeUndefined();
-            });
-
-            it('advances to the next media item when at the last frame', () => {
-                const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
-                const nextImage = getMockedMediaImage({ id: 'image-1' });
-                const result = getNextMediaItem(frame, [frame, nextImage], 3);
-                expect(result).toEqual(nextImage);
-            });
-
-            it('handles a frame_number that is not aligned with the step', () => {
-                const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 5, frame_count: 10 });
-                const result = getNextMediaItem(frame, [frame], 3);
-                expect(result).toEqual({ ...frame, frame_number: 6 });
-            });
         });
     });
 });

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.test.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.test.ts
@@ -61,10 +61,10 @@ describe('secondary toolbar utils', () => {
                 expect(result).toEqual(items[1]);
             });
 
-            it('returns the last item when current item is the last one', () => {
+            it('returns undefined when current item is the last one', () => {
                 const items = getMultipleMockedMediaImage(3);
                 const result = getNextMediaItem(items[2], items, 1);
-                expect(result).toEqual(items[2]);
+                expect(result).toBeUndefined();
             });
 
             it('returns the first item when current item is not found in the list', () => {
@@ -95,10 +95,10 @@ describe('secondary toolbar utils', () => {
                 expect(result).toEqual(nextImage);
             });
 
-            it('stays on the same video when it is the last media item and already at the last frame', () => {
+            it('returns undefined when it is the last media item and already at the last frame', () => {
                 const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
                 const result = getNextMediaItem(frame, [frame], 1);
-                expect(result).toEqual(frame);
+                expect(result).toBeUndefined();
             });
 
             it('advances to the next media item when at the last frame', () => {

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
@@ -54,6 +54,14 @@ export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]
     return allMediaItems[nextIndex];
 };
 
+export const isSameMediaItem = (firstItem: Media, secondItem: Media): boolean => {
+    if (isVideoFrame(firstItem) && isVideoFrame(secondItem)) {
+        return firstItem.id === secondItem.id && firstItem.frame_number === secondItem.frame_number;
+    }
+
+    return firstItem.id === secondItem.id;
+};
+
 export const useNextMedia = (currentMediaItem: Media, allMediaItems: Media[]) => {
     const context = useVideoPlayerContext();
 

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
@@ -21,7 +21,7 @@ export const getNextItem = (totalItems: number, newIndex: number) => {
     return Math.min(totalItems, newIndex + 1);
 };
 
-export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[], step: number) => {
+export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[], step: number): Media | undefined => {
     if (isVideoFrame(currentMediaItem)) {
         const videoFrames = range(0, currentMediaItem.frame_count, step);
         const currentIndex = videoFrames.findIndex((frame) => frame === currentMediaItem.frame_number);
@@ -49,9 +49,11 @@ export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]
         return allMediaItems[0];
     }
 
-    const nextIndex = Math.min(currentIndex + 1, allMediaItems.length - 1);
+    if (currentIndex >= allMediaItems.length - 1) {
+        return undefined;
+    }
 
-    return allMediaItems[nextIndex];
+    return allMediaItems[currentIndex + 1];
 };
 
 export const isSameMediaItem = (firstItem: Media, secondItem: Media): boolean => {

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
@@ -1,13 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback } from 'react';
-
-import { range } from 'lodash-es';
-
-import { Label, Media } from '../../../../constants/shared-types';
-import { isVideoFrame } from '../../../../shared/media-item-utils';
-import { useVideoPlayerContext } from '../../../annotator/video-player/video-player-provider.component';
+import { Label } from '../../../../constants/shared-types';
 
 export const toggleLabel = (newLabel: Label, labels: Label[]): Label[] => {
     const isExistingLabel = labels.some(({ id }) => id === newLabel.id);
@@ -21,48 +15,4 @@ export const toggleLabel = (newLabel: Label, labels: Label[]): Label[] => {
 
 export const getNextItem = (totalItems: number, newIndex: number) => {
     return Math.min(totalItems, newIndex + 1);
-};
-
-export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[], step: number): Media | undefined => {
-    if (isVideoFrame(currentMediaItem)) {
-        const videoFrames = range(0, currentMediaItem.frame_count, step);
-        const currentIndex = videoFrames.findIndex((frame) => frame === currentMediaItem.frame_number);
-
-        if (currentIndex >= 0 && currentIndex < videoFrames.length - 1) {
-            return {
-                ...currentMediaItem,
-                frame_number: videoFrames[currentIndex + 1],
-            };
-        } else {
-            const nextFrame = videoFrames.find((frame) => frame > currentMediaItem.frame_number);
-
-            if (nextFrame !== undefined) {
-                return {
-                    ...currentMediaItem,
-                    frame_number: nextFrame ?? 0,
-                };
-            }
-        }
-    }
-
-    const currentIndex = allMediaItems.findIndex(({ id }) => id === currentMediaItem.id);
-
-    if (currentIndex < 0) {
-        return allMediaItems[0];
-    }
-
-    if (currentIndex >= allMediaItems.length - 1) {
-        return undefined;
-    }
-
-    return allMediaItems[currentIndex + 1];
-};
-
-export const useNextMedia = (currentMediaItem: Media, allMediaItems: Media[]) => {
-    const context = useVideoPlayerContext();
-    const step = context?.step ?? 1;
-
-    return useCallback(() => {
-        return getNextMediaItem(currentMediaItem, allMediaItems, step);
-    }, [allMediaItems, currentMediaItem, step]);
 };

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
@@ -1,6 +1,8 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useCallback } from 'react';
+
 import { range } from 'lodash-es';
 
 import { Label, Media } from '../../../../constants/shared-types';
@@ -66,6 +68,9 @@ export const isSameMediaItem = (firstItem: Media, secondItem: Media): boolean =>
 
 export const useNextMedia = (currentMediaItem: Media, allMediaItems: Media[]) => {
     const context = useVideoPlayerContext();
+    const step = context?.step ?? 1;
 
-    return () => getNextMediaItem(currentMediaItem, allMediaItems, context?.step ?? 1);
+    return useCallback(() => {
+        return getNextMediaItem(currentMediaItem, allMediaItems, step);
+    }, [allMediaItems, currentMediaItem, step]);
 };

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/util.ts
@@ -58,14 +58,6 @@ export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]
     return allMediaItems[currentIndex + 1];
 };
 
-export const isSameMediaItem = (firstItem: Media, secondItem: Media): boolean => {
-    if (isVideoFrame(firstItem) && isVideoFrame(secondItem)) {
-        return firstItem.id === secondItem.id && firstItem.frame_number === secondItem.frame_number;
-    }
-
-    return firstItem.id === secondItem.id;
-};
-
 export const useNextMedia = (currentMediaItem: Media, allMediaItems: Media[]) => {
     const context = useVideoPlayerContext();
     const step = context?.step ?? 1;

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -1,8 +1,10 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage } from 'mocks/mock-media';
+
 import type { AnnotationDTO } from '../../../constants/shared-types';
-import { getInitialAnnotations, getInitialPredictions } from './utils';
+import { getInitialAnnotations, getInitialPredictions, getNextMediaItem } from './utils';
 
 describe('getInitialAnnotations', () => {
     const mockAnnotations: AnnotationDTO[] = [
@@ -67,5 +69,68 @@ describe('getInitialPredictions', () => {
     it('returns annotations when user has not reviewed', () => {
         const result = getInitialPredictions(false, mockAnnotations);
         expect(result).toEqual(mockAnnotations);
+    });
+});
+
+describe('getNextMediaItem', () => {
+    describe('image media items', () => {
+        it('returns the next image in the list', () => {
+            const items = getMultipleMockedMediaImage(3);
+            const result = getNextMediaItem(items[0], items, 1);
+            expect(result).toEqual(items[1]);
+        });
+
+        it('returns undefined when current item is the last one', () => {
+            const items = getMultipleMockedMediaImage(3);
+            const result = getNextMediaItem(items[2], items, 1);
+            expect(result).toBeUndefined();
+        });
+
+        it('returns the first item when current item is not found in the list', () => {
+            const items = getMultipleMockedMediaImage(3);
+            const unknownItem = getMockedMediaImage({ id: 'unknown' });
+            const result = getNextMediaItem(unknownItem, items, 1);
+            expect(result).toEqual(items[0]);
+        });
+    });
+
+    describe('video frame media items', () => {
+        it('returns the next video frame based on step', () => {
+            const frame = getMockedVideoFrame({ frame_number: 0, frame_count: 10 });
+            const result = getNextMediaItem(frame, [], 1);
+            expect(result).toEqual({ ...frame, frame_number: 1 });
+        });
+
+        it('advances by the given step size', () => {
+            const frame = getMockedVideoFrame({ frame_number: 0, frame_count: 10 });
+            const result = getNextMediaItem(frame, [], 3);
+            expect(result).toEqual({ ...frame, frame_number: 3 });
+        });
+
+        it('advances to the next media item when already at the last video frame', () => {
+            const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
+            const nextImage = getMockedMediaImage({ id: 'image-1' });
+            const result = getNextMediaItem(frame, [frame, nextImage], 1);
+            expect(result).toEqual(nextImage);
+        });
+
+        it('returns undefined when it is the last media item and already at the last frame', () => {
+            const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
+            const result = getNextMediaItem(frame, [frame], 1);
+            expect(result).toBeUndefined();
+        });
+
+        it('advances to the next media item when at the last frame', () => {
+            const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 9, frame_count: 10 });
+            const nextImage = getMockedMediaImage({ id: 'image-1' });
+            const result = getNextMediaItem(frame, [frame, nextImage], 3);
+            expect(result).toEqual(nextImage);
+        });
+
+        it('handles a frame_number that is not aligned with the step', () => {
+            const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 5, frame_count: 10 });
+            const result = getNextMediaItem(frame, [frame], 3);
+            expect(result).toEqual({ ...frame, frame_number: 6 });
+        });
     });
 });

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -1,10 +1,16 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { range } from 'lodash-es';
 
 import type { AnnotationDTO, Media } from '../../../constants/shared-types';
+import { isVideoFrame } from '../../../shared/media-item-utils';
 import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
+import { useVideoPlayerContext } from '../../annotator/video-player/video-player-provider.component';
 import { annotationsQueryOptions } from './api/use-annotations-query';
 
 export const getInitialAnnotations = (isUserReviewed: boolean, annotationsDTO: AnnotationDTO[]): AnnotationDTO[] => {
@@ -15,33 +21,74 @@ export const getInitialPredictions = (isUserReviewed: boolean, annotationsDTO: A
     return isUserReviewed ? [] : annotationsDTO;
 };
 
-// When the user navigates to next media, image data and annotations will be already in React Query cache,
-// so the UI will feel smoother
-// whenever the user switches image. Unless he/she changes to a random or item. We could also consider
-// those cases but I feel like it's overkill. Let's see how this improvement performs and then we can iterate on it.
-//
-// ensureQueryData will get the data from cache if it's there, or call the queryFn and cache the result if it's not.
-// prefetchQuery will fetch the data and cache it
-export const prefetchNextMediaAndAnnotationsData = ({
-    queryClient,
-    projectId,
-    getNextMediaItem,
-}: {
-    queryClient: ReturnType<typeof useQueryClient>;
-    projectId: string;
-    getNextMediaItem: () => Media | undefined;
-}) => {
-    const prefetch = async () => {
-        const nextItem = getNextMediaItem();
+export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[], step: number): Media | undefined => {
+    if (isVideoFrame(currentMediaItem)) {
+        const videoFrames = range(0, currentMediaItem.frame_count, step);
+        const currentIndex = videoFrames.findIndex((frame) => frame === currentMediaItem.frame_number);
 
-        if (nextItem === undefined) {
-            return;
+        if (currentIndex >= 0 && currentIndex < videoFrames.length - 1) {
+            return {
+                ...currentMediaItem,
+                frame_number: videoFrames[currentIndex + 1],
+            };
+        } else {
+            const nextFrame = videoFrames.find((frame) => frame > currentMediaItem.frame_number);
+
+            if (nextFrame !== undefined) {
+                return {
+                    ...currentMediaItem,
+                    frame_number: nextFrame ?? 0,
+                };
+            }
         }
+    }
 
-        await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
+    const currentIndex = allMediaItems.findIndex(({ id }) => id === currentMediaItem.id);
 
-        queryClient.prefetchQuery(annotationsQueryOptions(projectId, nextItem));
+    if (currentIndex < 0) {
+        return allMediaItems[0];
+    }
+
+    if (currentIndex >= allMediaItems.length - 1) {
+        return undefined;
+    }
+
+    return allMediaItems[currentIndex + 1];
+};
+
+export const useNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[]) => {
+    const context = useVideoPlayerContext();
+    const step = context?.step ?? 1;
+
+    return useMemo(() => {
+        return getNextMediaItem(currentMediaItem, allMediaItems, step);
+    }, [allMediaItems, currentMediaItem, step]);
+};
+
+// When the user navigates to next media, image data and annotations will be already in React Query cache,
+// so the UI will feel smoother whenever the user switches image unless the user changes to a random or item.
+// We could also consider those cases but I feel like it's overkill.
+// Let's see how this improvement performs and then we can iterate on it.
+//
+// We trigger next-item data prefetch through disabled/conditional query hooks,
+// so data is resolved from cache when available and fetched when needed.
+export const useNextMediaPrefetch = (currentMediaItem: Media, allMediaItems: Media[]) => {
+    const projectId = useProjectIdentifier();
+    const nextMediaItem = useNextMediaItem(currentMediaItem, allMediaItems);
+
+    const nextImageQuery = useQuery({
+        ...loadImageQueryOptions(projectId, nextMediaItem ?? currentMediaItem),
+        enabled: nextMediaItem !== undefined,
+    });
+
+    useQuery({
+        ...annotationsQueryOptions(projectId, nextMediaItem ?? currentMediaItem),
+        enabled: nextMediaItem !== undefined,
+    });
+
+    return {
+        nextMediaItem,
+        nextImage: nextImageQuery.data,
+        isNextImageReady: nextImageQuery.isSuccess,
     };
-
-    prefetch();
 };

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -5,10 +5,6 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import type { AnnotationDTO, Media } from '../../../constants/shared-types';
 import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
-import {
-    segmentAnythingEncodingQueryOptions,
-    segmentAnythingWorkerQueryOptions,
-} from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
 import { annotationsQueryOptions } from './api/use-annotations-query';
 
 export const getInitialAnnotations = (isUserReviewed: boolean, annotationsDTO: AnnotationDTO[]): AnnotationDTO[] => {
@@ -19,14 +15,14 @@ export const getInitialPredictions = (isUserReviewed: boolean, annotationsDTO: A
     return isUserReviewed ? [] : annotationsDTO;
 };
 
-// When the user navigates to next media, the most expensive data, like the SAM encoding,
-// along with image data and annotations, will be already in React Query cache, so the UI will feel smoother
+// When the user navigates to next media, image data and annotations will be already in React Query cache,
+// so the UI will feel smoother
 // whenever the user switches image. Unless he/she changes to a random or item. We could also consider
 // those cases but I feel like it's overkill. Let's see how this improvement performs and then we can iterate on it.
 //
 // ensureQueryData will get the data from cache if it's there, or call the queryFn and cache the result if it's not.
 // prefetchQuery will fetch the data and cache it
-export const prefetchNextMediaItemData = ({
+export const prefetchNextMediaAndAnnotationsData = ({
     queryClient,
     projectId,
     getNextMediaItem,
@@ -42,15 +38,9 @@ export const prefetchNextMediaItemData = ({
             return;
         }
 
-        const nextImage = await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
+        await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
 
         queryClient.prefetchQuery(annotationsQueryOptions(projectId, nextItem));
-
-        const encoderModel = await queryClient.ensureQueryData(
-            segmentAnythingWorkerQueryOptions('SEGMENT_ANYTHING_ENCODER')
-        );
-
-        queryClient.prefetchQuery(segmentAnythingEncodingQueryOptions(nextItem, encoderModel, nextImage));
     };
 
     prefetch();

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -1,7 +1,15 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AnnotationDTO } from '../../../constants/shared-types';
+import { useQueryClient } from '@tanstack/react-query';
+
+import type { AnnotationDTO, Media } from '../../../constants/shared-types';
+import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
+import {
+    segmentAnythingEncodingQueryOptions,
+    segmentAnythingWorkerQueryOptions,
+} from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
+import { annotationsQueryOptions } from './api/use-annotations-query';
 
 export const getInitialAnnotations = (isUserReviewed: boolean, annotationsDTO: AnnotationDTO[]): AnnotationDTO[] => {
     return isUserReviewed ? annotationsDTO : [];
@@ -9,4 +17,41 @@ export const getInitialAnnotations = (isUserReviewed: boolean, annotationsDTO: A
 
 export const getInitialPredictions = (isUserReviewed: boolean, annotationsDTO: AnnotationDTO[]): AnnotationDTO[] => {
     return isUserReviewed ? [] : annotationsDTO;
+};
+
+// When the user navigates to next media, the most expensive data, like the SAM encoding,
+// along with image data and annotations, will be already in React Query cache, so the UI will feel smoother
+// whenever the user switches image. Unless he/she changes to a random or item. We could also consider
+// those cases but I feel like it's overkill. Let's see how this improvement performs and then we can iterate on it.
+//
+// ensureQueryData will get the data from cache if it's there, or call the queryFn and cache the result if it's not.
+// prefetchQuery will fetch the data and cache it
+export const prefetchNextMediaItemData = ({
+    queryClient,
+    projectId,
+    getNextMediaItem,
+}: {
+    queryClient: ReturnType<typeof useQueryClient>;
+    projectId: string;
+    getNextMediaItem: () => Media | undefined;
+}) => {
+    const prefetch = async () => {
+        const nextItem = getNextMediaItem();
+
+        if (nextItem === undefined) {
+            return;
+        }
+
+        const nextImage = await queryClient.ensureQueryData(loadImageQueryOptions(projectId, nextItem));
+
+        queryClient.prefetchQuery(annotationsQueryOptions(projectId, nextItem));
+
+        const encoderModel = await queryClient.ensureQueryData(
+            segmentAnythingWorkerQueryOptions('SEGMENT_ANYTHING_ENCODER')
+        );
+
+        queryClient.prefetchQuery(segmentAnythingEncodingQueryOptions(nextItem, encoderModel, nextImage));
+    };
+
+    prefetch();
 };

--- a/application/ui/src/features/project/task-type-guards.ts
+++ b/application/ui/src/features/project/task-type-guards.ts
@@ -14,3 +14,7 @@ export const isDetectionTask = (taskType: TaskType | null): boolean => {
 export const isSegmentationTask = (taskType: TaskType | null): boolean => {
     return taskType === 'instance_segmentation';
 };
+
+export const isPrefetchEnabledForTask = (taskType: TaskType | null): boolean => {
+    return isDetectionTask(taskType) || isSegmentationTask(taskType);
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Improve readability of some queries (on top of what Dawid already had improved)
* Replace SAM useEffect (to load the worker/instantiate the class) with a RQ approach
* Add hook to fetch/prefetch data/annotations (images or video frames)
* Leverage encodingQuery to fetch/prefetch SAM encoding

On the video you can see the awesome speed if the user selected the NEXT media item, but if the user selects stuff at random the speed will be more or less the same.

Closes https://github.com/open-edge-platform/training_extensions/issues/5646

Video:
![rec](https://github.com/user-attachments/assets/306d88f0-759a-4949-9e6a-5aaaeafbebf4)

Image:
![rec](https://github.com/user-attachments/assets/617645d0-be38-4a6a-a38a-21474b4ca3a1)


I thought about tests but if i added unit tests, then we would be testing react-query (useless), and if i added component maybe we could check speed or if the loading didnt even show? I think that would be veeeery flaky so if you have any suggestions lmk

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
