### PR TITLE
Fix regression when fetching dataset items info

### DIFF
--- a/application/ui/src/features/dataset/import-export/export-dataset/dataset-statistics.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-dataset/dataset-statistics.component.tsx
@@ -5,8 +5,8 @@ import { DatasetStatistics } from '../../../../components/dataset-statistics/dat
 import { useGetDatasetItems } from '../../../../hooks/use-get-dataset-items.hook';
 
 export const MainDatasetStatistics = () => {
-    const { data: annotatedItems } = useGetDatasetItems({ annotationStatus: 'reviewed' });
-    const { data: mediaItems } = useGetDatasetItems();
+    const { data: annotatedItems } = useGetDatasetItems({ annotationStatus: 'reviewed', limit: 1 });
+    const { data: mediaItems } = useGetDatasetItems({ limit: 1 });
 
     const totalMediaItems = mediaItems?.pagination.total ?? 0;
     const totalAnnotatedItems = annotatedItems?.pagination.total ?? 0;

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -39,7 +39,7 @@ export const SidebarItems = ({
 }: SidebarItemsProps) => {
     const ref = useRef(null);
     const unwrapRef = useUnwrapDOMRef(ref);
-    const { datasetItemsById } = useGetDatasetItemsById({ limit: Math.max(items.length, 1) });
+    const { datasetItemsById } = useGetDatasetItemsById();
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 

--- a/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
@@ -6,7 +6,9 @@ import { useGetDatasetItems } from '../../../hooks/use-get-dataset-items.hook';
 const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 
 export const useIsTrainingButtonDisabled = () => {
-    const { data: datasetItems } = useGetDatasetItems({ annotationStatus: 'reviewed' });
+    const { data: datasetItems } = useGetDatasetItems({
+        annotationStatus: 'reviewed',
+    });
     const count = datasetItems?.pagination.total ?? 0;
 
     return count < MIN_NUMBER_OF_ANNOTATED_ITEMS;

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -5,8 +5,12 @@ import { useMemo } from 'react';
 
 import { useGetDatasetItems } from './use-get-dataset-items.hook';
 
-export const useGetDatasetItemsById = () => {
-    const { data } = useGetDatasetItems();
+type UseGetDatasetItemsByIdOptions = {
+    limit?: number;
+};
+
+export const useGetDatasetItemsById = (options?: UseGetDatasetItemsByIdOptions) => {
+    const { data } = useGetDatasetItems({ limit: options?.limit });
 
     const datasetItemsById = useMemo(() => {
         const datasetItems = data?.items ?? [];

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -5,8 +5,8 @@ import { useMemo } from 'react';
 
 import { useGetDatasetItems } from './use-get-dataset-items.hook';
 
-export const useGetDatasetItemsById = (options?: Parameters<typeof useGetDatasetItems>[0]) => {
-    const { data } = useGetDatasetItems(options);
+export const useGetDatasetItemsById = () => {
+    const { data } = useGetDatasetItems();
 
     const datasetItemsById = useMemo(() => {
         const datasetItems = data?.items ?? [];

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -19,6 +19,7 @@ export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
                 project_id,
             },
             query: {
+                limit: options?.limit,
                 annotation_status: options?.annotationStatus,
             },
         },

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -19,7 +19,6 @@ export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
                 project_id,
             },
             query: {
-                limit: options?.limit ?? 1,
                 annotation_status: options?.annotationStatus,
             },
         },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Add `limit: 1` to the query only when we just need the `total` items, such as dataset statistics
* Remove any limit otherwise, such as for gallery or sidebar items

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
