### PR TITLE
Increase thumbnail resolution for dataset revision items

### DIFF
--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -451,7 +451,7 @@ class DatasetRevisionService(BaseSessionManagedService):
         ).image_path
         try:
             with Image.open(binary_path) as image:
-                thumbnail = crop_to_thumbnail(image=image, target_width=64, target_height=64)
+                thumbnail = crop_to_thumbnail(image=image, target_width=128, target_height=128)
         except UnidentifiedImageError:
             logger.error("Failed to open image {} for thumbnail generation", binary_path)
             raise InvalidImageError("Failed to open image for thumbnail generation.")

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -27,7 +27,7 @@ from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
 from .media_service import InvalidImageError
 
 # Thumbnails for dataset revisions are generated on the fly and need to be smaller than pregenerated thumbnails
-DS_REV_THUMBNAIL_SIZE = 128
+DATASET_REVISION_ITEM_THUMBNAIL_SIZE = 128
 
 
 class DatasetRevisionService(BaseSessionManagedService):
@@ -455,7 +455,9 @@ class DatasetRevisionService(BaseSessionManagedService):
         try:
             with Image.open(binary_path) as image:
                 thumbnail = crop_to_thumbnail(
-                    image=image, target_width=DS_REV_THUMBNAIL_SIZE, target_height=DS_REV_THUMBNAIL_SIZE
+                    image=image,
+                    target_width=DATASET_REVISION_ITEM_THUMBNAIL_SIZE,
+                    target_height=DATASET_REVISION_ITEM_THUMBNAIL_SIZE,
                 )
             # Ensure thumbnail is in a JPEG-compatible mode before it is encoded downstream.
             if thumbnail.mode not in ("RGB", "L"):

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -452,6 +452,9 @@ class DatasetRevisionService(BaseSessionManagedService):
         try:
             with Image.open(binary_path) as image:
                 thumbnail = crop_to_thumbnail(image=image, target_width=128, target_height=128)
+            # Ensure thumbnail is in a JPEG-compatible mode before it is encoded downstream.
+            if thumbnail.mode not in ("RGB", "L"):
+                thumbnail = thumbnail.convert("RGB")
         except UnidentifiedImageError:
             logger.error("Failed to open image {} for thumbnail generation", binary_path)
             raise InvalidImageError("Failed to open image for thumbnail generation.")

--- a/application/backend/app/services/dataset_revision_service.py
+++ b/application/backend/app/services/dataset_revision_service.py
@@ -26,6 +26,9 @@ from app.utils.images import crop_to_thumbnail
 from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
 from .media_service import InvalidImageError
 
+# Thumbnails for dataset revisions are generated on the fly and need to be smaller than pregenerated thumbnails
+DS_REV_THUMBNAIL_SIZE = 128
+
 
 class DatasetRevisionService(BaseSessionManagedService):
     def __init__(self, data_dir: Path, db_session: Session | None = None) -> None:
@@ -451,7 +454,9 @@ class DatasetRevisionService(BaseSessionManagedService):
         ).image_path
         try:
             with Image.open(binary_path) as image:
-                thumbnail = crop_to_thumbnail(image=image, target_width=128, target_height=128)
+                thumbnail = crop_to_thumbnail(
+                    image=image, target_width=DS_REV_THUMBNAIL_SIZE, target_height=DS_REV_THUMBNAIL_SIZE
+                )
             # Ensure thumbnail is in a JPEG-compatible mode before it is encoded downstream.
             if thumbnail.mode not in ("RGB", "L"):
                 thumbnail = thumbnail.convert("RGB")

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -22,7 +22,7 @@ from app.services import (
     SystemService,
 )
 from app.services.base import ResourceNotFoundError, ResourceType
-from app.services.dataset_revision_service import DS_REV_THUMBNAIL_SIZE
+from app.services.dataset_revision_service import DATASET_REVISION_ITEM_THUMBNAIL_SIZE
 from app.services.event.event_bus import EventBus
 
 
@@ -805,7 +805,7 @@ class TestDatasetRevisionServiceIntegration:
         )
 
         assert isinstance(thumbnail, Image.Image)
-        assert thumbnail.width == thumbnail.height == DS_REV_THUMBNAIL_SIZE
+        assert thumbnail.width == thumbnail.height == DATASET_REVISION_ITEM_THUMBNAIL_SIZE
 
     def test_get_dataset_revision_item_thumbnail_not_found(
         self,

--- a/application/backend/tests/integration/services/test_dataset_revision_service.py
+++ b/application/backend/tests/integration/services/test_dataset_revision_service.py
@@ -22,6 +22,7 @@ from app.services import (
     SystemService,
 )
 from app.services.base import ResourceNotFoundError, ResourceType
+from app.services.dataset_revision_service import DS_REV_THUMBNAIL_SIZE
 from app.services.event.event_bus import EventBus
 
 
@@ -804,7 +805,7 @@ class TestDatasetRevisionServiceIntegration:
         )
 
         assert isinstance(thumbnail, Image.Image)
-        assert thumbnail.width == thumbnail.height == 64
+        assert thumbnail.width == thumbnail.height == DS_REV_THUMBNAIL_SIZE
 
     def test_get_dataset_revision_item_thumbnail_not_found(
         self,


### PR DESCRIPTION
Increaded thumbnail resolution to 128

Resolves #5394 

### How to test

Manually open a training revision on the model page. Performance seems to be okay.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
