### PR TITLE
Fix description in windows installer

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -7,7 +7,7 @@ on:
         type: string
         required: true
       device:
-        description: "Specifies the device to build the backend for (cpu, xpu, gpu)"
+        description: "Specifies the device to build the backend for (cpu, xpu, cuda)"
         type: string
         required: true
         default: "xpu"
@@ -25,12 +25,12 @@ on:
         type: string
         required: true
       device:
-        description: "Specifies the device to build the backend for (cpu, xpu, gpu)"
+        description: "Specifies the device to build the backend for (cpu, xpu, cuda)"
         required: true
         options:
           - xpu
           - cpu
-          - gpu
+          - cuda
         default: "xpu"
       debug_build:
         description: "If the debug build should be produced"


### PR DESCRIPTION
### Summary

The workflow description incorrectly referenced the target device as `gpu` instead of `cuda`.

### How to test

Run the `windows-installer.yml` GHA workflow.

Test run: https://github.com/open-edge-platform/training_extensions/actions/runs/22627355424

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
