### PR TITLE
fix: Validate the frame number from path param

### DIFF
--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash-es';
 import { useParams } from 'react-router';
 
 import type { Media } from '../../constants/shared-types';
-import { isVideo } from '../../shared/media-item-utils';
+import { isVideo, isVideoFrame } from '../../shared/media-item-utils';
 import type { RegionOfInterest } from '../../shared/types';
 import { useLoadImageQuery } from './hooks/use-load-image-query.hook';
 import { getImageData } from './tools/utils';
@@ -55,7 +55,7 @@ const convertMediaItem = (mediaItem: Media, frameNumber: number): Media => {
 const useMediaItem = (initialMediaItem: Media) => {
     const frameNumberFromPathParam = useVideoFrameNumberPathParam();
     const maxFrameNumber =
-        isVideo(initialMediaItem) || isVideo(initialMediaItem) ? initialMediaItem.frame_count - 1 : 0;
+        isVideo(initialMediaItem) || isVideoFrame(initialMediaItem) ? initialMediaItem.frame_count - 1 : 0;
     const frameNumber = Math.max(0, Math.min(frameNumberFromPathParam, maxFrameNumber));
 
     const [mediaItem, setMediaItem] = useState<Media>(() => convertMediaItem(initialMediaItem, frameNumber));

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -27,7 +27,7 @@ type SelectedMediaItemProviderProps = {
     children: ReactNode;
 };
 
-const useVideoFrameNumberQueryParam = () => {
+const useVideoFrameNumberPathParam = () => {
     const { frameNumber } = useParams<{ frameNumber?: string }>();
 
     if (frameNumber === undefined) {
@@ -53,7 +53,9 @@ const convertMediaItem = (mediaItem: Media, frameNumber: number): Media => {
 };
 
 const useMediaItem = (initialMediaItem: Media) => {
-    const frameNumber = useVideoFrameNumberQueryParam();
+    const frameNumberFromPathParam = useVideoFrameNumberPathParam();
+    const frames = isVideo(initialMediaItem) || isVideo(initialMediaItem) ? initialMediaItem.frame_count - 1 : 0;
+    const frameNumber = Math.max(0, Math.min(frameNumberFromPathParam, frames));
 
     const [mediaItem, setMediaItem] = useState<Media>(() => convertMediaItem(initialMediaItem, frameNumber));
     const prevInitialMediaItem = useRef(initialMediaItem);

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -54,8 +54,9 @@ const convertMediaItem = (mediaItem: Media, frameNumber: number): Media => {
 
 const useMediaItem = (initialMediaItem: Media) => {
     const frameNumberFromPathParam = useVideoFrameNumberPathParam();
-    const frames = isVideo(initialMediaItem) || isVideo(initialMediaItem) ? initialMediaItem.frame_count - 1 : 0;
-    const frameNumber = Math.max(0, Math.min(frameNumberFromPathParam, frames));
+    const maxFrameNumber =
+        isVideo(initialMediaItem) || isVideo(initialMediaItem) ? initialMediaItem.frame_count - 1 : 0;
+    const frameNumber = Math.max(0, Math.min(frameNumberFromPathParam, maxFrameNumber));
 
     const [mediaItem, setMediaItem] = useState<Media>(() => convertMediaItem(initialMediaItem, frameNumber));
     const prevInitialMediaItem = useRef(initialMediaItem);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that we didn't validate if the path param was negative or larger than number of frames. Should never happen until user tries to break the app but just in case :).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
