### PR TITLE
feat: Render video annotations while playing video

### DIFF
--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -17,30 +17,10 @@ export const VideoAnnotations = () => {
         frameNumber: videoFrame.frame_number,
         frameSkip: step,
         selector: (data) => {
-            /*
-            TODO: Decide which approach we want to go: exact mapping or with neighboring frames fallback.
-             The fallback approach is more user-friendly, but it can lead to confusion when annotations from
-             neighboring frames are shown.
             const frameAnnotations =
                 data.find((frame) => frame.frame_index === videoFrame.frame_number)?.annotation_data?.annotations ?? [];
 
-            return mapServerAnnotationsToLocal(frameAnnotations, labels);*/
-
-            const frameIdxToAnnotationMap = new Map(
-                data.map((frame) => [frame.frame_index, frame.annotation_data?.annotations ?? []])
-            );
-
-            for (let idx = 1; idx <= Math.max(1, step / 4); idx++) {
-                const nextFrameAnnotations = frameIdxToAnnotationMap.get(videoFrame.frame_number + idx);
-                if (nextFrameAnnotations) {
-                    return mapServerAnnotationsToLocal(nextFrameAnnotations, labels);
-                }
-
-                const previousFrameAnnotations = frameIdxToAnnotationMap.get(videoFrame.frame_number - idx);
-                if (previousFrameAnnotations) {
-                    return mapServerAnnotationsToLocal(previousFrameAnnotations, labels);
-                }
-            }
+            return mapServerAnnotationsToLocal(frameAnnotations, labels);
         },
     });
 

--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -1,0 +1,36 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { MediaVideoFrame } from '../../../constants/shared-types';
+import { Annotation } from '../../../shared/types';
+import { DEFAULT_ANNOTATION_STYLES } from '../utils';
+import { AnnotationShapeRenderer } from './annotation-shape-renderer.component';
+
+type VideoAnnotationsProps = {
+    videoFrame: MediaVideoFrame;
+};
+
+export const VideoAnnotations = ({ videoFrame }: VideoAnnotationsProps) => {
+    const annotations: Annotation[] = [];
+
+    return (
+        <svg
+            aria-label={'video annotations'}
+            data-testid={'annotation-layer'}
+            width={videoFrame.width}
+            height={videoFrame.height}
+            tabIndex={-1}
+            style={{
+                position: 'absolute',
+                inset: 0,
+                outline: 'none',
+                overflow: 'visible',
+                ...DEFAULT_ANNOTATION_STYLES,
+            }}
+        >
+            {annotations.map((annotation) => (
+                <AnnotationShapeRenderer key={annotation.id} annotation={annotation} />
+            ))}
+        </svg>
+    );
+};

--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -1,17 +1,48 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MediaVideoFrame } from '../../../constants/shared-types';
-import { Annotation } from '../../../shared/types';
+import { mapServerAnnotationsToLocal } from '../../../shared/annotator/annotation-mappers';
+import { useProjectLabelsWithEmptyLabel } from '../../../shared/annotator/labels';
 import { DEFAULT_ANNOTATION_STYLES } from '../utils';
+import { useVideoFramesAnnotations } from '../video-player/api/use-video-frames-annotations';
+import { useVideoPlayer } from '../video-player/video-player-provider.component';
 import { AnnotationShapeRenderer } from './annotation-shape-renderer.component';
 
-type VideoAnnotationsProps = {
-    videoFrame: MediaVideoFrame;
-};
+export const VideoAnnotations = () => {
+    const { step, videoFrame } = useVideoPlayer();
 
-export const VideoAnnotations = ({ videoFrame }: VideoAnnotationsProps) => {
-    const annotations: Annotation[] = [];
+    const labels = useProjectLabelsWithEmptyLabel();
+
+    const { data: annotations = [] } = useVideoFramesAnnotations({
+        frameNumber: videoFrame.frame_number,
+        frameSkip: step,
+        selector: (data) => {
+            /*
+            TODO: Decide which approach we want to go: exact mapping or with neighboring frames fallback.
+             The fallback approach is more user-friendly, but it can lead to confusion when annotations from
+             neighboring frames are shown.
+            const frameAnnotations =
+                data.find((frame) => frame.frame_index === videoFrame.frame_number)?.annotation_data?.annotations ?? [];
+
+            return mapServerAnnotationsToLocal(frameAnnotations, labels);*/
+
+            const frameIdxToAnnotationMap = new Map(
+                data.map((frame) => [frame.frame_index, frame.annotation_data?.annotations ?? []])
+            );
+
+            for (let idx = 1; idx <= Math.max(1, step / 4); idx++) {
+                const nextFrameAnnotations = frameIdxToAnnotationMap.get(videoFrame.frame_number + idx);
+                if (nextFrameAnnotations) {
+                    return mapServerAnnotationsToLocal(nextFrameAnnotations, labels);
+                }
+
+                const previousFrameAnnotations = frameIdxToAnnotationMap.get(videoFrame.frame_number - idx);
+                if (previousFrameAnnotations) {
+                    return mapServerAnnotationsToLocal(previousFrameAnnotations, labels);
+                }
+            }
+        },
+    });
 
     return (
         <svg

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -10,9 +10,11 @@ import { useAnnotationVisibility } from '../../../shared/annotator/annotation-vi
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
+import { VideoAnnotations } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
 import { ToolManager } from '../tools/tool-manager.component';
 import { VideoFrame } from '../video-player/video-frame.component';
+import { useVideoPlayerContext } from '../video-player/video-player-provider.component';
 
 import classes from './annotator-canvas.module.scss';
 
@@ -48,6 +50,42 @@ const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
     );
 };
 
+type ImageAnnotationsProps = {
+    mediaItem: Media;
+};
+
+const ImageAnnotations = ({ mediaItem }: ImageAnnotationsProps) => {
+    const { isFocussed } = useAnnotationVisibility();
+    const { annotations } = useAnnotationActions();
+    const { selectedAnnotations } = useSelectedAnnotations();
+
+    // Order annotations by selection. Selected annotation should always be on top.
+    const orderedAnnotations = [
+        ...annotations.filter((a) => !selectedAnnotations.has(a.id)),
+        ...annotations.filter((a) => selectedAnnotations.has(a.id)),
+    ];
+
+    const size = { width: mediaItem.width, height: mediaItem.height };
+
+    return (
+        <Annotations width={size.width} height={size.height} isFocussed={isFocussed} annotations={orderedAnnotations} />
+    );
+};
+
+type AnnotationsFactoryProps = {
+    mediaItem: Media;
+};
+
+const AnnotationsFactory = ({ mediaItem }: AnnotationsFactoryProps) => {
+    const videoPlayerContext = useVideoPlayerContext();
+
+    if (isVideoFrame(mediaItem) && videoPlayerContext?.videoControls?.isPlaying) {
+        return <VideoAnnotations videoFrame={mediaItem} />;
+    }
+
+    return <ImageAnnotations mediaItem={mediaItem} />;
+};
+
 type AnnotatorCanvasProps = {
     mediaItem: Media;
     image: ImageData;
@@ -55,18 +93,9 @@ type AnnotatorCanvasProps = {
 };
 
 export const AnnotatorCanvas = ({ mediaItem, image, isReadOnly = false }: AnnotatorCanvasProps) => {
-    const { annotations } = useAnnotationActions();
-    const { selectedAnnotations } = useSelectedAnnotations();
-    const { isFocussed } = useAnnotationVisibility();
     const isSceneBusy = useIsAnnotatorSceneBusy();
 
     const areToolsDisabled = isSceneBusy || isReadOnly;
-
-    // Order annotations by selection. Selected annotation should always be on top.
-    const orderedAnnotations = [
-        ...annotations.filter((a) => !selectedAnnotations.has(a.id)),
-        ...annotations.filter((a) => selectedAnnotations.has(a.id)),
-    ];
 
     const size = { width: mediaItem.width, height: mediaItem.height };
 
@@ -78,12 +107,8 @@ export const AnnotatorCanvas = ({ mediaItem, image, isReadOnly = false }: Annota
             >
                 <MediaImage image={image} mediaItem={mediaItem} />
 
-                <Annotations
-                    width={size.width}
-                    height={size.height}
-                    isFocussed={isFocussed}
-                    annotations={orderedAnnotations}
-                />
+                <AnnotationsFactory mediaItem={mediaItem} />
+
                 {!areToolsDisabled && <ToolManager />}
             </div>
         </ZoomTransform>

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -72,15 +72,15 @@ const ImageAnnotations = ({ mediaItem }: ImageAnnotationsProps) => {
     );
 };
 
-type AnnotationsFactoryProps = {
+type MediaAnnotationsProps = {
     mediaItem: Media;
 };
 
-const AnnotationsFactory = ({ mediaItem }: AnnotationsFactoryProps) => {
+const MediaAnnotations = ({ mediaItem }: MediaAnnotationsProps) => {
     const videoPlayerContext = useVideoPlayerContext();
 
     if (isVideoFrame(mediaItem) && videoPlayerContext?.videoControls?.isPlaying) {
-        return <VideoAnnotations videoFrame={mediaItem} />;
+        return <VideoAnnotations />;
     }
 
     return <ImageAnnotations mediaItem={mediaItem} />;
@@ -107,7 +107,7 @@ export const AnnotatorCanvas = ({ mediaItem, image, isReadOnly = false }: Annota
             >
                 <MediaImage image={image} mediaItem={mediaItem} />
 
-                <AnnotationsFactory mediaItem={mediaItem} />
+                <MediaAnnotations mediaItem={mediaItem} />
 
                 {!areToolsDisabled && <ToolManager />}
             </div>

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
@@ -45,8 +45,8 @@ export const useVideoFramesAnnotations = <T>({
         },
         {
             select: selector,
-            // We invalidate cache manually when the user annotates a frame, so we can set infinite cache and stale
-            // time to avoid unnecessary refetches
+            // We invalidate cache manually when the user annotates a frame, so we can set an infinite stale time to
+            // avoid unnecessary refetches
             staleTime: Infinity,
         }
     );

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
@@ -45,6 +45,9 @@ export const useVideoFramesAnnotations = <T>({
         },
         {
             select: selector,
+            // We invalidate cache manually when the user annotates a frame, so we can set infinite cache and stale
+            // time to avoid unnecessary refetches
+            staleTime: Infinity,
         }
     );
 };

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
@@ -4,12 +4,19 @@
 import { ActionButton, Flex } from '@geti/ui';
 import { Pause, Play, SoundOff, SoundOn, StepBackward, StepForward } from '@geti/ui/icons';
 
+import { useAnnotationActions } from '../../../../shared/annotator/annotation-actions-provider.component';
 import { useVideoPlayer } from '../video-player-provider.component';
 
 export const VideoControls = () => {
     const { isMuted, toggleMute, videoControls } = useVideoPlayer();
     const { isPlaying, play, pause, previousFrame, nextFrame, canSelectPreviousFrame, canSelectNextFrame } =
         videoControls;
+    const { resetAnnotations } = useAnnotationActions();
+
+    const handlePlay = async () => {
+        await play();
+        resetAnnotations();
+    };
 
     return (
         <Flex alignItems={'center'} gap={'size-100'}>
@@ -27,7 +34,7 @@ export const VideoControls = () => {
                         <Pause />
                     </ActionButton>
                 ) : (
-                    <ActionButton isQuiet aria-label={'Play video'} onPress={play}>
+                    <ActionButton isQuiet aria-label={'Play video'} onPress={handlePlay}>
                         <Play />
                     </ActionButton>
                 )}

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -14,34 +14,8 @@ import useUndoRedoState from '../../features/dataset/media-preview/primary-toolb
 import { AnnotatorMode } from '../../features/dataset/media-preview/secondary-toolbar/annotator-modes/mode';
 import { isVideoFrame } from '../media-item-utils';
 import type { Annotation, Shape } from '../types';
+import { mapLocalAnnotationsToServer, mapServerAnnotationsToLocal } from './annotation-mappers';
 import { EMPTY_LABEL_ID, useProjectLabelsWithEmptyLabel } from './labels';
-
-const mapServerAnnotationsToLocal = (serverAnnotations: AnnotationDTO[], projectLabels: Label[]): Annotation[] => {
-    const labelMap = new Map(projectLabels.map((label) => [label.id, label]));
-
-    return serverAnnotations.map((annotation) => {
-        // We only get the ids of the labels
-        const labels = (annotation.labels ?? [])
-            .map((labelRef) => labelMap.get(labelRef.id))
-            .filter((label): label is Label => label !== undefined)
-            .map((label, idx) => ({ ...label, probability: annotation.confidences?.at(idx) }));
-
-        return {
-            ...annotation,
-            id: uuid(),
-            labels,
-        };
-    });
-};
-
-const mapLocalAnnotationsToServer = (localAnnotations: Annotation[]): AnnotationDTO[] => {
-    return localAnnotations.map((annotation) => ({
-        // We only want to send the ids of the labels
-        labels: annotation.labels.map((label) => ({ id: label.id })),
-        shape: annotation.shape,
-        ...(annotation.confidences !== undefined && { confidences: annotation.confidences }),
-    }));
-};
 
 interface AnnotationsContextValue {
     annotations: Annotation[];

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -24,6 +24,7 @@ interface AnnotationsContextValue {
     deleteAnnotations: (annotationIds: string[]) => void;
     updateAnnotations: (updatedAnnotations: Annotation[], labels?: Label[]) => void;
     submitAnnotations: () => Promise<void>;
+    resetAnnotations: () => void;
     isUserReviewed: boolean;
     isSaving: boolean;
     isReadOnlyMode: boolean;
@@ -140,6 +141,10 @@ export const AnnotationActionsProvider = ({
         );
     };
 
+    const resetAnnotations = () => {
+        undoRedoActions.reset([]);
+    };
+
     const saveAnnotations = async (annotationsDTO: AnnotationDTO[]) => {
         const query = isVideoFrame(mediaItem)
             ? {
@@ -152,7 +157,7 @@ export const AnnotationActionsProvider = ({
             body: { annotations: annotationsDTO },
         });
 
-        undoRedoActions.reset([]);
+        resetAnnotations();
     };
 
     const submitPredictions = async () => {
@@ -188,6 +193,7 @@ export const AnnotationActionsProvider = ({
                 updateAnnotations,
                 deleteAnnotations,
                 addAnnotationWithEmptyLabel,
+                resetAnnotations,
 
                 // Remote
                 submitAnnotations,

--- a/application/ui/src/shared/annotator/annotation-mappers.ts
+++ b/application/ui/src/shared/annotator/annotation-mappers.ts
@@ -4,7 +4,7 @@
 import { v4 as uuid } from 'uuid';
 
 import type { AnnotationDTO, Label } from '../../constants/shared-types';
-import type { Annotation } from '../types';
+import { Annotation, AnnotationLabel } from '../types';
 
 export const mapServerAnnotationsToLocal = (
     serverAnnotations: AnnotationDTO[],
@@ -15,9 +15,25 @@ export const mapServerAnnotationsToLocal = (
     return serverAnnotations.map((annotation) => {
         // We only get the ids of the labels
         const labels = (annotation.labels ?? [])
-            .map((labelRef) => labelMap.get(labelRef.id))
-            .filter((label): label is Label => label !== undefined)
-            .map((label, idx) => ({ ...label, probability: annotation.confidences?.at(idx) }));
+            .map((labelRef, idx) => {
+                const label = labelMap.get(labelRef.id);
+
+                if (label === undefined) {
+                    return undefined;
+                }
+
+                const probability = annotation.confidences?.at(idx);
+
+                if (probability === undefined) {
+                    return label;
+                }
+
+                return {
+                    ...label,
+                    probability,
+                };
+            })
+            .filter((label): label is AnnotationLabel => label !== undefined);
 
         return {
             ...annotation,

--- a/application/ui/src/shared/annotator/annotation-mappers.ts
+++ b/application/ui/src/shared/annotator/annotation-mappers.ts
@@ -1,0 +1,37 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { v4 as uuid } from 'uuid';
+
+import type { AnnotationDTO, Label } from '../../constants/shared-types';
+import type { Annotation } from '../types';
+
+export const mapServerAnnotationsToLocal = (
+    serverAnnotations: AnnotationDTO[],
+    projectLabels: Label[]
+): Annotation[] => {
+    const labelMap = new Map(projectLabels.map((label) => [label.id, label]));
+
+    return serverAnnotations.map((annotation) => {
+        // We only get the ids of the labels
+        const labels = (annotation.labels ?? [])
+            .map((labelRef) => labelMap.get(labelRef.id))
+            .filter((label): label is Label => label !== undefined)
+            .map((label, idx) => ({ ...label, probability: annotation.confidences?.at(idx) }));
+
+        return {
+            ...annotation,
+            id: uuid(),
+            labels,
+        };
+    });
+};
+
+export const mapLocalAnnotationsToServer = (localAnnotations: Annotation[]): AnnotationDTO[] => {
+    return localAnnotations.map((annotation) => ({
+        // We only want to send the ids of the labels
+        labels: annotation.labels.map((label) => ({ id: label.id })),
+        shape: annotation.shape,
+        ...(annotation.confidences !== undefined && { confidences: annotation.confidences }),
+    }));
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Based on the feedback from presentation during which I showed this, we decided to render annotations accurately, i.e. if frame X has annotations, we render it, we don't do any logic to render neighbouring frames' annotations.
Moreover when we play, we clear annotations, i.e. we won't display any confirmation dialogs, we want to keep the UX as simple as possible.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
