### PR TITLE
Update sink rate limit fields

### DIFF
--- a/application/ui/src/features/inference/sinks/hooks/use-sink-action.test.tsx
+++ b/application/ui/src/features/inference/sinks/hooks/use-sink-action.test.tsx
@@ -18,14 +18,17 @@ const mockedConfig: LocalFolderSinkConfig = {
     output_formats: [],
     sink_type: 'folder',
     folder_path: '',
-    rate_limit: 0,
+    rate_limit: null,
 };
 
 const bodyFormatter = (formData: FormData) => ({
     id: String(formData.get('id')),
     name: String(formData.get('name')),
     sink_type: 'folder' as const,
-    rate_limit: formData.get('rate_limit') ? Number(formData.get('rate_limit')) : 0,
+    rate_limit:
+        formData.get('rate_limit_samples') && formData.get('rate_limit_seconds')
+            ? Number(formData.get('rate_limit_samples')) / Number(formData.get('rate_limit_seconds'))
+            : null,
     folder_path: String(formData.get('folder_path')),
     output_formats: formData.getAll('output_formats') as SinkOutputFormats,
 });
@@ -48,7 +51,12 @@ const renderApp = async ({
     const formData = new FormData();
     formData.append('name', config.name);
     formData.append('sink_type', config.sink_type);
-    formData.append('rate_limit', String(config.rate_limit));
+
+    if (config.rate_limit !== null && config.rate_limit !== undefined) {
+        formData.append('rate_limit_samples', String(config.rate_limit));
+        formData.append('rate_limit_seconds', '1');
+    }
+
     formData.append('folder_path', config.folder_path);
     formData.append('output_formats', config.output_formats.join(','));
 

--- a/application/ui/src/features/inference/sinks/local-folder/local-folder.component.tsx
+++ b/application/ui/src/features/inference/sinks/local-folder/local-folder.component.tsx
@@ -1,10 +1,11 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Flex, NumberField, TextField } from '@geti/ui';
+import { Flex, TextField } from '@geti/ui';
 
 import { ReactComponent as Folder } from '../../../../assets/icons/folder.svg';
 import { OutputFormats } from '../output-formats/output-formats.component';
+import { RateLimitFields } from '../rate-limit/rate-limit-fields.component';
 import { LocalFolderSinkConfig } from '../utils';
 
 import classes from './local-folder.module.scss';
@@ -18,18 +19,15 @@ export const LocalFolder = ({ defaultState }: LocalFolderProps) => {
         <Flex direction='column' gap='size-200'>
             <TextField isHidden label='id' name='id' defaultValue={defaultState.id} />
 
-            <Flex direction={'row'} gap='size-200'>
+            <Flex gap='size-200'>
                 <TextField isRequired label='Name' name='name' defaultValue={defaultState.name} />
-                <NumberField
-                    label='Rate Limit'
-                    name='rate_limit'
-                    minValue={0}
-                    step={0.1}
-                    defaultValue={defaultState.rate_limit ?? undefined}
-                />
             </Flex>
 
-            <Flex direction='row' gap='size-200'>
+            <Flex>
+                <RateLimitFields rateLimit={defaultState.rate_limit} />
+            </Flex>
+
+            <Flex gap='size-50'>
                 <TextField
                     isRequired
                     width={'100%'}

--- a/application/ui/src/features/inference/sinks/local-folder/local-folder.module.scss
+++ b/application/ui/src/features/inference/sinks/local-folder/local-folder.module.scss
@@ -8,8 +8,4 @@
     svg {
         stroke: var(--spectrum-global-color-gray-50);
     }
-
-    &:hover {
-        background-color: var(var(--spectrum-accent-background-color-hover));
-    }
 }

--- a/application/ui/src/features/inference/sinks/local-folder/utils.ts
+++ b/application/ui/src/features/inference/sinks/local-folder/utils.ts
@@ -1,13 +1,13 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { LocalFolderSinkConfig, SinkOutputFormats } from '../utils';
+import { LocalFolderSinkConfig, rateLimitFromFormData, SinkOutputFormats } from '../utils';
 
 export const getLocalFolderInitialConfig = (): LocalFolderSinkConfig => ({
     id: '',
     name: '',
     sink_type: 'folder',
-    rate_limit: 0,
+    rate_limit: null,
     folder_path: '',
     output_formats: [],
 });
@@ -16,7 +16,7 @@ export const localFolderBodyFormatter = (formData: FormData): LocalFolderSinkCon
     id: String(formData.get('id')),
     name: String(formData.get('name')),
     sink_type: 'folder',
-    rate_limit: formData.get('rate_limit') ? Number(formData.get('rate_limit')) : 0,
+    rate_limit: rateLimitFromFormData(formData),
     folder_path: String(formData.get('folder_path')),
     output_formats: formData.getAll('output_formats') as SinkOutputFormats,
 });

--- a/application/ui/src/features/inference/sinks/mqtt/mqtt.component.tsx
+++ b/application/ui/src/features/inference/sinks/mqtt/mqtt.component.tsx
@@ -4,6 +4,7 @@
 import { Flex, NumberField, Switch, TextField } from '@geti/ui';
 
 import { OutputFormats } from '../output-formats/output-formats.component';
+import { RateLimitFields } from '../rate-limit/rate-limit-fields.component';
 import { MqttSinkConfig } from '../utils';
 
 type MqttProps = {
@@ -22,7 +23,7 @@ export const Mqtt = ({ defaultState }: MqttProps) => {
                 name='broker_host'
                 defaultValue={defaultState.broker_host}
             />
-            <Flex direction='row' gap='size-200'>
+            <Flex gap='size-200'>
                 <TextField flex='1' label='Topic' name='topic' defaultValue={defaultState.topic} />
                 <NumberField
                     label='Broker Port'
@@ -32,14 +33,11 @@ export const Mqtt = ({ defaultState }: MqttProps) => {
                     defaultValue={defaultState.broker_port}
                 />
             </Flex>
-            <Flex direction='row' gap='size-200' justifyContent='space-between'>
-                <NumberField
-                    label='Rate Limit'
-                    name='rate_limit'
-                    minValue={0}
-                    step={0.1}
-                    defaultValue={defaultState.rate_limit ?? undefined}
-                />
+            <Flex gap='size-200' justifyContent='space-between' alignItems={'center'}>
+                <RateLimitFields rateLimit={defaultState.rate_limit} />
+            </Flex>
+
+            <Flex>
                 <Switch
                     name='auth_required'
                     alignSelf='end'
@@ -50,6 +48,7 @@ export const Mqtt = ({ defaultState }: MqttProps) => {
                     Auth Required
                 </Switch>
             </Flex>
+
             <OutputFormats config={defaultState.output_formats} />
         </Flex>
     );

--- a/application/ui/src/features/inference/sinks/mqtt/utils.ts
+++ b/application/ui/src/features/inference/sinks/mqtt/utils.ts
@@ -1,14 +1,14 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MqttSinkConfig, SinkOutputFormats } from '../utils';
+import { MqttSinkConfig, rateLimitFromFormData, SinkOutputFormats } from '../utils';
 
 export const getMqttInitialConfig = (): MqttSinkConfig => ({
     id: '',
     name: '',
     topic: '',
     sink_type: 'mqtt',
-    rate_limit: 0,
+    rate_limit: null,
     broker_host: '',
     broker_port: 0,
     auth_required: false,
@@ -20,7 +20,7 @@ export const mqttBodyFormatter = (formData: FormData): MqttSinkConfig => ({
     name: String(formData.get('name')),
     topic: String(formData.get('topic')),
     sink_type: 'mqtt',
-    rate_limit: formData.get('rate_limit') ? Number(formData.get('rate_limit')) : 0,
+    rate_limit: rateLimitFromFormData(formData),
     broker_host: String(formData.get('broker_host')),
     broker_port: formData.get('broker_port') ? Number(formData.get('broker_port')) : 0,
     auth_required: formData.get('auth_required') === 'on' ? true : false,

--- a/application/ui/src/features/inference/sinks/rate-limit/rate-limit-fields.component.tsx
+++ b/application/ui/src/features/inference/sinks/rate-limit/rate-limit-fields.component.tsx
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Flex, NumberField, Text } from '@geti/ui';
+
+import { positiveNumberOrUndefined } from '../utils';
+
+type RateLimitFieldsProps = {
+    rateLimit: number | null | undefined;
+};
+
+export const RateLimitFields = ({ rateLimit }: RateLimitFieldsProps) => {
+    const samples = positiveNumberOrUndefined(rateLimit);
+    const seconds = samples !== undefined ? 1 : undefined;
+
+    return (
+        <Flex direction='row' gap='size-100' alignItems={'end'}>
+            <NumberField label='Samples' name='rate_limit_samples' minValue={1} step={1} defaultValue={samples} />
+            <Text>every</Text>
+            <NumberField label='Seconds' name='rate_limit_seconds' minValue={0.1} step={0.1} defaultValue={seconds} />
+        </Flex>
+    );
+};

--- a/application/ui/src/features/inference/sinks/rate-limit/rate-limit-fields.component.tsx
+++ b/application/ui/src/features/inference/sinks/rate-limit/rate-limit-fields.component.tsx
@@ -15,7 +15,7 @@ export const RateLimitFields = ({ rateLimit }: RateLimitFieldsProps) => {
 
     return (
         <Flex direction='row' gap='size-100' alignItems={'end'}>
-            <NumberField label='Samples' name='rate_limit_samples' minValue={1} step={1} defaultValue={samples} />
+            <NumberField label='Samples' name='rate_limit_samples' minValue={0.1} step={0.1} defaultValue={samples} />
             <Text>every</Text>
             <NumberField label='Seconds' name='rate_limit_seconds' minValue={0.1} step={0.1} defaultValue={seconds} />
         </Flex>

--- a/application/ui/src/features/inference/sinks/sink-list/settings-list/settings-list.component.tsx
+++ b/application/ui/src/features/inference/sinks/sink-list/settings-list/settings-list.component.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { removeUnderscore } from '../../../util';
-import { SinkConfig, SinkOutputFormats, WebhookSinkConfig } from '../../utils';
+import { formatRateLimit, SinkConfig, SinkOutputFormats, WebhookSinkConfig } from '../../utils';
 import { getPairsFromObject } from '../../webhook/utils';
 
 import classes from './settings-list.module.scss';
@@ -38,7 +38,7 @@ export const SettingsList = ({ sink }: SettingsListProps) => {
         return (
             <ul className={classes.list}>
                 <li>Folder path: {sink.folder_path}</li>
-                <li>Rate limit: {sink.rate_limit}</li>
+                <li>Rate limit: {formatRateLimit(sink.rate_limit)}</li>
                 <li>
                     Output formats: <OutputFormats outputFormats={sink.output_formats} />
                 </li>
@@ -49,7 +49,7 @@ export const SettingsList = ({ sink }: SettingsListProps) => {
     if (sink.sink_type === 'webhook') {
         return (
             <ul className={classes.list}>
-                <li>Rate limit: {sink.rate_limit}</li>
+                <li>Rate limit: {formatRateLimit(sink.rate_limit)}</li>
                 <li>HTTP method: {sink.http_method}</li>
                 <li>Timeout: {sink.timeout}</li>
                 <li>Webhook URL: {sink.webhook_url}</li>
@@ -67,7 +67,7 @@ export const SettingsList = ({ sink }: SettingsListProps) => {
         return (
             <ul className={classes.list}>
                 <li>Topic: {sink.topic}</li>
-                <li>Rate limit: {sink.rate_limit}</li>
+                <li>Rate limit: {formatRateLimit(sink.rate_limit)}</li>
                 <li>Auth required: {sink.auth_required ? 'Yes' : 'No'}</li>
                 <li>Broker host: {sink.broker_host}</li>
                 <li>Broker port: {sink.broker_port}</li>
@@ -82,7 +82,7 @@ export const SettingsList = ({ sink }: SettingsListProps) => {
         return (
             <ul className={classes.list}>
                 <li>Topic: {sink.topic}</li>
-                <li>Rate limit: {sink.rate_limit}</li>
+                <li>Rate limit: {formatRateLimit(sink.rate_limit)}</li>
                 <li>
                     Output formats: <OutputFormats outputFormats={sink.output_formats} />
                 </li>

--- a/application/ui/src/features/inference/sinks/utils.test.ts
+++ b/application/ui/src/features/inference/sinks/utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { getObjectFromFormData } from './utils';
+import { formatRateLimit, getObjectFromFormData, rateLimitFromFormData } from './utils';
 
 describe('getObjectFromFormData', () => {
     it('return an object mapping keys to values', () => {
@@ -44,5 +44,85 @@ describe('getObjectFromFormData', () => {
         const keys = [' ', 'b', 'c'];
         const values = ['1', ' ', '3'];
         expect(getObjectFromFormData(keys, values)).toEqual({ c: '3' });
+    });
+});
+
+describe('rateLimitFromFormData', () => {
+    it('returns null when fields are missing', () => {
+        const formData = new FormData();
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+
+    it('returns null for non-numeric values', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', 'abc');
+        formData.set('rate_limit_seconds', '1');
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+
+    it('returns null when values are not finite numbers', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', 'Infinity');
+        formData.set('rate_limit_seconds', '2');
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+
+    it('returns null for non-positive values', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', '0');
+        formData.set('rate_limit_seconds', '2');
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+
+    it('returns computed rate for valid values', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', '10');
+        formData.set('rate_limit_seconds', '2');
+
+        expect(rateLimitFromFormData(formData)).toBe(5);
+    });
+
+    it('parses decimal comma values', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', '0,1');
+        formData.set('rate_limit_seconds', '1');
+
+        expect(rateLimitFromFormData(formData)).toBe(0.1);
+    });
+
+    it('returns null for invalid mixed separators', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', '1,2.3');
+        formData.set('rate_limit_seconds', '1');
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+});
+
+describe('formatRateLimit', () => {
+    it('returns "Not set" for nullish or non-positive values', () => {
+        expect(formatRateLimit(undefined)).toBe('Not set');
+        expect(formatRateLimit(null)).toBe('Not set');
+        expect(formatRateLimit(0)).toBe('Not set');
+    });
+
+    it('formats singular sample and second labels', () => {
+        expect(formatRateLimit(1)).toBe('1 sample every 1 second');
+    });
+
+    it('formats plural samples for rates above one', () => {
+        expect(formatRateLimit(2)).toBe('2 samples every 1 second');
+    });
+
+    it('formats rates below one as canonical ratio', () => {
+        expect(formatRateLimit(0.5)).toBe('1 sample every 2 seconds');
+    });
+
+    it('rounds canonical ratio seconds to two decimals', () => {
+        expect(formatRateLimit(0.3)).toBe('1 sample every 3.33 seconds');
     });
 });

--- a/application/ui/src/features/inference/sinks/utils.test.ts
+++ b/application/ui/src/features/inference/sinks/utils.test.ts
@@ -62,6 +62,22 @@ describe('rateLimitFromFormData', () => {
         expect(rateLimitFromFormData(formData)).toBeNull();
     });
 
+    it('returns null for NaN values', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', 'NaN');
+        formData.set('rate_limit_seconds', '1');
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+
+    it('returns null for empty string values', () => {
+        const formData = new FormData();
+        formData.set('rate_limit_samples', '');
+        formData.set('rate_limit_seconds', '2');
+
+        expect(rateLimitFromFormData(formData)).toBeNull();
+    });
+
     it('returns null when values are not finite numbers', () => {
         const formData = new FormData();
         formData.set('rate_limit_samples', 'Infinity');
@@ -86,12 +102,12 @@ describe('rateLimitFromFormData', () => {
         expect(rateLimitFromFormData(formData)).toBe(5);
     });
 
-    it('parses decimal comma values', () => {
+    it('returns null for decimal comma values', () => {
         const formData = new FormData();
         formData.set('rate_limit_samples', '0,1');
         formData.set('rate_limit_seconds', '1');
 
-        expect(rateLimitFromFormData(formData)).toBe(0.1);
+        expect(rateLimitFromFormData(formData)).toBeNull();
     });
 
     it('returns null for invalid mixed separators', () => {
@@ -108,6 +124,7 @@ describe('formatRateLimit', () => {
         expect(formatRateLimit(undefined)).toBe('Not set');
         expect(formatRateLimit(null)).toBe('Not set');
         expect(formatRateLimit(0)).toBe('Not set');
+        expect(formatRateLimit(Number.NaN)).toBe('Not set');
     });
 
     it('formats singular sample and second labels', () => {
@@ -120,9 +137,5 @@ describe('formatRateLimit', () => {
 
     it('formats rates below one as canonical ratio', () => {
         expect(formatRateLimit(0.5)).toBe('1 sample every 2 seconds');
-    });
-
-    it('rounds canonical ratio seconds to two decimals', () => {
-        expect(formatRateLimit(0.3)).toBe('1 sample every 3.33 seconds');
     });
 });

--- a/application/ui/src/features/inference/sinks/utils.ts
+++ b/application/ui/src/features/inference/sinks/utils.ts
@@ -40,6 +40,10 @@ export enum WebhookHttpMethod {
 
 const toStringAndTrim = (value: unknown) => String(value).trim();
 
+export const positiveNumberOrUndefined = (value: number | null | undefined): number | undefined => {
+    return typeof value === 'number' && value > 0 ? value : undefined;
+};
+
 export const getObjectFromFormData = (keys: FormDataEntryValue[], values: FormDataEntryValue[]) => {
     const entries = keys.map((key, index) => [key, values[index]]);
     const validEntries = entries.filter(
@@ -47,4 +51,32 @@ export const getObjectFromFormData = (keys: FormDataEntryValue[], values: FormDa
     );
 
     return Object.fromEntries(validEntries);
+};
+
+export const rateLimitFromFormData = (formData: FormData): number | null => {
+    const samplesRaw = toStringAndTrim(formData.get('rate_limit_samples'));
+    const secondsRaw = toStringAndTrim(formData.get('rate_limit_seconds'));
+
+    if (isEmpty(samplesRaw) || isEmpty(secondsRaw)) {
+        return null;
+    }
+
+    const samples = Number(samplesRaw);
+    const seconds = Number(secondsRaw);
+
+    if (samples <= 0 || seconds <= 0) {
+        return null;
+    }
+
+    return samples / seconds;
+};
+
+export const formatRateLimit = (rateLimit: number | null | undefined): string => {
+    const normalizedRateLimit = positiveNumberOrUndefined(rateLimit);
+
+    if (normalizedRateLimit === undefined) {
+        return 'Not set';
+    }
+
+    return `${normalizedRateLimit} samples every 1 second`;
 };

--- a/application/ui/src/features/inference/sinks/utils.ts
+++ b/application/ui/src/features/inference/sinks/utils.ts
@@ -39,28 +39,6 @@ export enum WebhookHttpMethod {
 }
 
 const toStringAndTrim = (value: unknown) => String(value).trim();
-const parseFiniteNumber = (value: string): number | null => {
-    const compactValue = value.replace(/\s/g, '');
-
-    if (isEmpty(compactValue)) {
-        return null;
-    }
-
-    if (compactValue.includes(',') && compactValue.includes('.')) {
-        return null;
-    }
-
-    const normalizedValue = compactValue.replace(',', '.');
-    const parsedValue = Number(normalizedValue);
-
-    return Number.isFinite(parsedValue) ? parsedValue : null;
-};
-
-const toDisplayNumber = (value: number) => {
-    const roundedValue = Number(value.toFixed(2));
-
-    return String(roundedValue);
-};
 
 export const positiveNumberOrUndefined = (value: number | null | undefined): number | undefined => {
     return typeof value === 'number' && value > 0 ? value : undefined;
@@ -83,20 +61,17 @@ export const rateLimitFromFormData = (formData: FormData): number | null => {
         return null;
     }
 
-    const samplesRaw = toStringAndTrim(samplesValue);
-    const secondsRaw = toStringAndTrim(secondsValue);
+    const samples = Number(samplesValue);
+    const seconds = Number(secondsValue);
 
-    const samples = parseFiniteNumber(samplesRaw);
-    const seconds = parseFiniteNumber(secondsRaw);
-
-    if (samples === null || seconds === null || samples <= 0 || seconds <= 0) {
+    if (!Number.isFinite(samples) || !Number.isFinite(seconds) || samples <= 0 || seconds <= 0) {
         return null;
     }
 
     return samples / seconds;
 };
 
-export const formatRateLimit = (rateLimit: number | null | undefined): string => {
+export const formatRateLimit = (rateLimit?: number | null): string => {
     const normalizedRateLimit = positiveNumberOrUndefined(rateLimit);
 
     if (normalizedRateLimit === undefined) {
@@ -105,14 +80,14 @@ export const formatRateLimit = (rateLimit: number | null | undefined): string =>
 
     if (normalizedRateLimit < 1) {
         const seconds = 1 / normalizedRateLimit;
-        const normalizedSeconds = toDisplayNumber(seconds);
-        const secondsLabel = normalizedSeconds === '1' ? 'second' : 'seconds';
+        const normalizedSeconds = Math.round(seconds);
+        const secondsLabel = normalizedSeconds === 1 ? 'second' : 'seconds';
 
         return `1 sample every ${normalizedSeconds} ${secondsLabel}`;
     }
 
-    const normalizedSamples = toDisplayNumber(normalizedRateLimit);
-    const sampleLabel = normalizedSamples === '1' ? 'sample' : 'samples';
+    const normalizedSamples = Math.round(normalizedRateLimit);
+    const sampleLabel = normalizedSamples === 1 ? 'sample' : 'samples';
 
     return `${normalizedSamples} ${sampleLabel} every 1 second`;
 };

--- a/application/ui/src/features/inference/sinks/utils.ts
+++ b/application/ui/src/features/inference/sinks/utils.ts
@@ -39,6 +39,28 @@ export enum WebhookHttpMethod {
 }
 
 const toStringAndTrim = (value: unknown) => String(value).trim();
+const parseFiniteNumber = (value: string): number | null => {
+    const compactValue = value.replace(/\s/g, '');
+
+    if (isEmpty(compactValue)) {
+        return null;
+    }
+
+    if (compactValue.includes(',') && compactValue.includes('.')) {
+        return null;
+    }
+
+    const normalizedValue = compactValue.replace(',', '.');
+    const parsedValue = Number(normalizedValue);
+
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+};
+
+const toDisplayNumber = (value: number) => {
+    const roundedValue = Number(value.toFixed(2));
+
+    return String(roundedValue);
+};
 
 export const positiveNumberOrUndefined = (value: number | null | undefined): number | undefined => {
     return typeof value === 'number' && value > 0 ? value : undefined;
@@ -54,17 +76,20 @@ export const getObjectFromFormData = (keys: FormDataEntryValue[], values: FormDa
 };
 
 export const rateLimitFromFormData = (formData: FormData): number | null => {
-    const samplesRaw = toStringAndTrim(formData.get('rate_limit_samples'));
-    const secondsRaw = toStringAndTrim(formData.get('rate_limit_seconds'));
+    const samplesValue = formData.get('rate_limit_samples');
+    const secondsValue = formData.get('rate_limit_seconds');
 
-    if (isEmpty(samplesRaw) || isEmpty(secondsRaw)) {
+    if (samplesValue === null || secondsValue === null) {
         return null;
     }
 
-    const samples = Number(samplesRaw);
-    const seconds = Number(secondsRaw);
+    const samplesRaw = toStringAndTrim(samplesValue);
+    const secondsRaw = toStringAndTrim(secondsValue);
 
-    if (samples <= 0 || seconds <= 0) {
+    const samples = parseFiniteNumber(samplesRaw);
+    const seconds = parseFiniteNumber(secondsRaw);
+
+    if (samples === null || seconds === null || samples <= 0 || seconds <= 0) {
         return null;
     }
 
@@ -78,5 +103,16 @@ export const formatRateLimit = (rateLimit: number | null | undefined): string =>
         return 'Not set';
     }
 
-    return `${normalizedRateLimit} samples every 1 second`;
+    if (normalizedRateLimit < 1) {
+        const seconds = 1 / normalizedRateLimit;
+        const normalizedSeconds = toDisplayNumber(seconds);
+        const secondsLabel = normalizedSeconds === '1' ? 'second' : 'seconds';
+
+        return `1 sample every ${normalizedSeconds} ${secondsLabel}`;
+    }
+
+    const normalizedSamples = toDisplayNumber(normalizedRateLimit);
+    const sampleLabel = normalizedSamples === '1' ? 'sample' : 'samples';
+
+    return `${normalizedSamples} ${sampleLabel} every 1 second`;
 };

--- a/application/ui/src/features/inference/sinks/webhook/utils.ts
+++ b/application/ui/src/features/inference/sinks/webhook/utils.ts
@@ -1,7 +1,13 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { getObjectFromFormData, SinkOutputFormats, WebhookHttpMethod, WebhookSinkConfig } from '../utils';
+import {
+    getObjectFromFormData,
+    rateLimitFromFormData,
+    SinkOutputFormats,
+    WebhookHttpMethod,
+    WebhookSinkConfig,
+} from '../utils';
 
 export type Pair = Record<Fields, string>;
 
@@ -19,7 +25,7 @@ export const getWebhookInitialConfig = (): WebhookSinkConfig => ({
     name: '',
     timeout: 0,
     sink_type: 'webhook',
-    rate_limit: 0,
+    rate_limit: null,
     webhook_url: '',
     http_method: WebhookHttpMethod.POST,
     output_formats: [],
@@ -32,7 +38,7 @@ export const webhookBodyFormatter = (formData: FormData): WebhookSinkConfig => (
     headers: getObjectFromFormData(formData.getAll('headers-keys'), formData.getAll('headers-values')),
     timeout: Number(formData.get('timeout')),
     sink_type: 'webhook',
-    rate_limit: Number(formData.get('rate_limit')),
+    rate_limit: rateLimitFromFormData(formData),
     webhook_url: String(formData.get('webhook_url')),
     http_method: formData.get('http_method') as WebhookHttpMethod,
     output_formats: formData.getAll('output_formats') as SinkOutputFormats,

--- a/application/ui/src/features/inference/sinks/webhook/webhook.component.tsx
+++ b/application/ui/src/features/inference/sinks/webhook/webhook.component.tsx
@@ -4,6 +4,7 @@
 import { Flex, Item, NumberField, Picker, TextField } from '@geti/ui';
 
 import { OutputFormats } from '../output-formats/output-formats.component';
+import { RateLimitFields } from '../rate-limit/rate-limit-fields.component';
 import { WebhookHttpMethod, WebhookSinkConfig } from '../utils';
 import { HeaderKeyValueBuilder } from './header-key-value-builder.component';
 
@@ -16,15 +17,10 @@ export const Webhook = ({ defaultState }: WebhookProps) => {
         <Flex direction='column' gap='size-200'>
             <Flex direction={'row'} gap='size-200'>
                 <TextField isHidden label='id' name='id' defaultValue={defaultState.id} />
-
                 <TextField isRequired flex='1' label='Name' name='name' defaultValue={defaultState.name} />
-                <NumberField
-                    label='Rate Limit'
-                    name='rate_limit'
-                    minValue={0}
-                    step={0.1}
-                    defaultValue={defaultState.rate_limit ?? undefined}
-                />
+            </Flex>
+            <Flex>
+                <RateLimitFields rateLimit={defaultState.rate_limit} />
             </Flex>
 
             <Flex direction={'row'} gap='size-200'>

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -314,7 +314,8 @@ test('Inference', async ({ streamPage, page, network }) => {
         await page.getByRole('button', { name: 'Add new sink' }).click();
         await page.getByRole('button', { name: 'Folder' }).click();
         await page.locator('input[name="name"]').fill('New Folder');
-        await page.locator('input[aria-roledescription="Number field"]').fill('5');
+        await page.locator('input[aria-roledescription="Number field"]').first().fill('5');
+        await page.locator('input[aria-roledescription="Number field"]').nth(1).fill('5');
 
         await page.locator('input[name="folder_path"]').fill('some/path');
         await page.locator('input[name="output_formats"][value="predictions"]').click();
@@ -344,7 +345,7 @@ test('Inference', async ({ streamPage, page, network }) => {
 
         await expect(page.getByText('New Folder')).toBeVisible();
         await expect(page.getByText('Folder path: some/path')).toBeVisible();
-        await expect(page.getByText('Rate limit: 5')).toBeVisible();
+        await expect(page.getByText('Rate limit: 5 samples every 1 second')).toBeVisible();
         await expect(page.getByText('Output formats: predictions')).toBeVisible();
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Fix last bug of https://github.com/open-edge-platform/training_extensions/issues/5532
* Add rate limit fields as requested

<img width="497" height="421" alt="Screenshot 2026-03-04 at 15 23 19" src="https://github.com/user-attachments/assets/4615ddb2-c125-4505-9de8-d22394c3ce59" />
<img width="519" height="359" alt="Screenshot 2026-03-04 at 15 41 03" src="https://github.com/user-attachments/assets/2a20e90b-1ecc-4b03-9da9-041bda1e2f03" />
<img width="504" height="712" alt="Screenshot 2026-03-04 at 15 41 08" src="https://github.com/user-attachments/assets/f60c4e66-d65f-4744-93bd-5e470d0b2ac2" />
<img width="482" height="483" alt="Screenshot 2026-03-04 at 15 41 11" src="https://github.com/user-attachments/assets/4a6245f2-053f-4b63-b75b-a057230bf595" />
<img width="498" height="676" alt="Screenshot 2026-03-04 at 15 42 45" src="https://github.com/user-attachments/assets/5d5c57aa-977a-43f7-8522-6cc6f16fa08c" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
