### PR TITLE
Fix datasetItem query limit

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -48,7 +48,7 @@ export const Gallery = ({
     const projectId = useProjectIdentifier();
     const { selectedMediaItem, onSelectedMediaItemChange } = useSelectDatasetItem();
     const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
-    const { datasetItemsById } = useGetDatasetItemsById();
+    const { datasetItemsById } = useGetDatasetItemsById({ limit: items.length });
 
     const isSetSelectedKeys = selectedKeys instanceof Set;
 

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -10,7 +10,7 @@ import { ReactComponent as EmptyDataset } from '../../../assets/empty-dataset.sv
 import { MediaItem } from '../../../components/media-item/media-item.component';
 import { MediaThumbnail } from '../../../components/media-thumbnail/media-thumbnail.component';
 import { VirtualizerGridLayout } from '../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
-import type { Media } from '../../../constants/shared-types';
+import type { DatasetItemAnnotationStatus, Media } from '../../../constants/shared-types';
 import { useGetDatasetItemsById } from '../../../hooks/use-get-dataset-items-by-id.hook';
 import { getMediaBinaryUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
 import { MediaPreview } from '../media-preview/media-preview.component';
@@ -21,6 +21,7 @@ import { MediaItemActions } from './media-item-actions/media-item-actions.compon
 
 type GalleryProps = {
     items: Media[];
+    annotationStatus?: DatasetItemAnnotationStatus;
     viewMode: ViewModes;
     isPending: boolean;
     hasActiveFilter: boolean;
@@ -38,6 +39,7 @@ const VIEW_MODE_SETTINGS = {
 
 export const Gallery = ({
     items,
+    annotationStatus,
     viewMode,
     isPending,
     hasActiveFilter,
@@ -48,7 +50,7 @@ export const Gallery = ({
     const projectId = useProjectIdentifier();
     const { selectedMediaItem, onSelectedMediaItemChange } = useSelectDatasetItem();
     const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
-    const { datasetItemsById } = useGetDatasetItemsById({ limit: items.length });
+    const { datasetItemsById } = useGetDatasetItemsById({ limit: items.length, annotationStatus });
 
     const isSetSelectedKeys = selectedKeys instanceof Set;
 

--- a/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/sidebar-items/sidebar-items.component.tsx
@@ -39,7 +39,7 @@ export const SidebarItems = ({
 }: SidebarItemsProps) => {
     const ref = useRef(null);
     const unwrapRef = useUnwrapDOMRef(ref);
-    const { datasetItemsById } = useGetDatasetItemsById();
+    const { datasetItemsById } = useGetDatasetItemsById({ limit: items.length });
 
     const selectedIndex = items.findIndex((item) => item.id === mediaItem.id);
 

--- a/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/hooks/use-is-training-button-disabled.ts
@@ -8,6 +8,7 @@ const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 export const useIsTrainingButtonDisabled = () => {
     const { data: datasetItems } = useGetDatasetItems({
         annotationStatus: 'reviewed',
+        limit: 1,
     });
     const count = datasetItems?.pagination.total ?? 0;
 

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -10,7 +10,8 @@ type UseGetDatasetItemsByIdOptions = {
 };
 
 export const useGetDatasetItemsById = (options?: UseGetDatasetItemsByIdOptions) => {
-    const { data } = useGetDatasetItems({ limit: options?.limit });
+    const limit = options?.limit ?? 1;
+    const { data } = useGetDatasetItems({ limit: Math.max(limit, 1) });
 
     const datasetItemsById = useMemo(() => {
         const datasetItems = data?.items ?? [];

--- a/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items-by-id.hook.ts
@@ -3,15 +3,16 @@
 
 import { useMemo } from 'react';
 
+import type { DatasetItemAnnotationStatus } from '../constants/shared-types';
 import { useGetDatasetItems } from './use-get-dataset-items.hook';
 
 type UseGetDatasetItemsByIdOptions = {
-    limit?: number;
+    limit: number;
+    annotationStatus?: DatasetItemAnnotationStatus;
 };
 
-export const useGetDatasetItemsById = (options?: UseGetDatasetItemsByIdOptions) => {
-    const limit = options?.limit ?? 1;
-    const { data } = useGetDatasetItems({ limit: Math.max(limit, 1) });
+export const useGetDatasetItemsById = ({ limit, annotationStatus }: UseGetDatasetItemsByIdOptions) => {
+    const { data } = useGetDatasetItems({ limit, annotationStatus });
 
     const datasetItemsById = useMemo(() => {
         const datasetItems = data?.items ?? [];

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -6,7 +6,7 @@ import type { DatasetItemAnnotationStatus } from '../constants/shared-types';
 import { useProjectIdentifier } from './use-project-identifier.hook';
 
 type UseGetDatasetItemsOptions = {
-    limit?: number;
+    limit: number;
     annotationStatus?: DatasetItemAnnotationStatus;
 };
 

--- a/application/ui/src/routes/dataset/dataset.component.tsx
+++ b/application/ui/src/routes/dataset/dataset.component.tsx
@@ -54,6 +54,7 @@ export const Dataset = () => {
             <View gridRow='3'>
                 <Gallery
                     items={items}
+                    annotationStatus={filterStatus ?? undefined}
                     viewMode={viewMode}
                     isPending={isPending}
                     hasActiveFilter={filterStatus !== null}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* We now send `limit` equal to the number of items instead of no value (which defaults to 10)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
