### PR TITLE
Bugfix: initialize reorder buffer in child process

### DIFF
--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -100,13 +100,22 @@ class InferenceWorker(BaseProcessWorker):
         self._loaded_model: LoadedModel | None = None
         self._last_model_obj_id = 0  # track the id of the Model object to install the callback only once
 
-        # To ensure broadcasting frames in order
-        self._prediction_buffer = PredictionReorderBuffer()
+        # The reorder buffer ensures that frames are broadcast in order, even if inference results are produced
+        # out of order due to async processing. It is initialized in setup() to ensure it's created after the process
+        # fork, since it contains a threading.Lock that can't be pickled.
+        self.__prediction_buffer: PredictionReorderBuffer | None = None
 
     def setup(self) -> None:
         super().setup()
         self._metrics_service = MetricsService(self._shm_name, self._shm_lock)
         self._model_service = ActiveModelService(get_settings().data_dir)
+        self.__prediction_buffer = PredictionReorderBuffer()
+
+    @property
+    def _prediction_buffer(self) -> PredictionReorderBuffer:
+        if self.__prediction_buffer is None:
+            raise RuntimeError("Prediction buffer not initialized (method 'setup' not called?)")
+        return self.__prediction_buffer
 
     def _on_inference_completed(self, inf_result: Result, userdata: dict[str, Any]) -> None:
         start_time = float(userdata["inference_start_time"])


### PR DESCRIPTION
### Summary

The `PredictionReorderBuffer` contains a `Lock`, which is a non-pickleable object, so its initialization should be done in the child process (within the `setup` method) instead of the main process (`InferenceWorker` constructor).

### How to test

Start the server with `run.sh` and try the inference pipeline.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
