### PR TITLE
Add training start and finish time to model revision

### DIFF
--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -4,7 +4,7 @@ import shutil
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 from uuid import UUID
@@ -485,7 +485,7 @@ class OTXTrainer(Execution[TrainingJobParams]):
         logger.info("Cleaned up OTX work directory at {}", otx_work_dir)
 
     def execute(self, params: TrainingJobParams) -> None:
-        training_start_time = datetime.now()
+        training_start_time = datetime.now(UTC)
         project_id = params.project_id
         task = params.task
         model_dir = self.__base_model_path(
@@ -535,7 +535,7 @@ class OTXTrainer(Execution[TrainingJobParams]):
                 trained_model_path=trained_model_path,
                 exported_model_paths=exported_model_paths,
             )
-            training_finish_time = datetime.now()
+            training_finish_time = datetime.now(UTC)
             self.__update_model_revision_training_status(
                 project_id=project_id,
                 model_id=params.model_id,
@@ -543,7 +543,7 @@ class OTXTrainer(Execution[TrainingJobParams]):
                 training_finished_at=training_finish_time,
             )
         except Exception:
-            training_finish_time = datetime.now()
+            training_finish_time = datetime.now(UTC)
             self.__update_model_revision_training_status(
                 project_id=project_id,
                 model_id=params.model_id,

--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -4,6 +4,7 @@ import shutil
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import cast
 from uuid import UUID
@@ -484,6 +485,7 @@ class OTXTrainer(Execution[TrainingJobParams]):
         logger.info("Cleaned up OTX work directory at {}", otx_work_dir)
 
     def execute(self, params: TrainingJobParams) -> None:
+        training_start_time = datetime.now()
         project_id = params.project_id
         task = params.task
         model_dir = self.__base_model_path(
@@ -506,7 +508,10 @@ class OTXTrainer(Execution[TrainingJobParams]):
         )
         try:
             self.__update_model_revision_training_status(
-                project_id=project_id, model_id=params.model_id, status=TrainingStatus.IN_PROGRESS
+                project_id=project_id,
+                model_id=params.model_id,
+                status=TrainingStatus.IN_PROGRESS,
+                training_started_at=training_start_time,
             )
             trained_model_path, otx_engine = self.train_model(
                 training_config=otx_training_config,
@@ -530,12 +535,20 @@ class OTXTrainer(Execution[TrainingJobParams]):
                 trained_model_path=trained_model_path,
                 exported_model_paths=exported_model_paths,
             )
+            training_finish_time = datetime.now()
             self.__update_model_revision_training_status(
-                project_id=project_id, model_id=params.model_id, status=TrainingStatus.SUCCESSFUL
+                project_id=project_id,
+                model_id=params.model_id,
+                status=TrainingStatus.SUCCESSFUL,
+                training_finished_at=training_finish_time,
             )
         except Exception:
+            training_finish_time = datetime.now()
             self.__update_model_revision_training_status(
-                project_id=project_id, model_id=params.model_id, status=TrainingStatus.FAILED
+                project_id=project_id,
+                model_id=params.model_id,
+                status=TrainingStatus.FAILED,
+                training_finished_at=training_finish_time,
             )
             raise
 
@@ -595,7 +608,20 @@ class OTXTrainer(Execution[TrainingJobParams]):
         except KeyError:
             raise ValueError(f"Unsupported OTX task type: {otx_task_type}")
 
-    def __update_model_revision_training_status(self, project_id: UUID, model_id: UUID, status: TrainingStatus):
+    def __update_model_revision_training_status(
+        self,
+        project_id: UUID,
+        model_id: UUID,
+        status: TrainingStatus,
+        training_started_at: datetime | None = None,
+        training_finished_at: datetime | None = None,
+    ):
         with self._db_session_factory() as db:
             self._model_service.set_db_session(db)
-            self._model_service.update_revision_status(project_id=project_id, model_id=model_id, training_status=status)
+            self._model_service.update_revision_status(
+                project_id=project_id,
+                model_id=model_id,
+                training_status=status,
+                training_started_at=training_started_at,
+                training_finished_at=training_finished_at,
+            )

--- a/application/backend/app/repositories/model_revision_repo.py
+++ b/application/backend/app/repositories/model_revision_repo.py
@@ -58,7 +58,7 @@ class ModelRevisionRepository(BaseRepository[ModelRevisionDB]):
         training_finished_at: datetime | None = None,
     ) -> None:
         """
-        Update the training status and trainig start and finish time of a model revision.
+        Update the training status and training start and finish time of a model revision.
 
         Args:
             obj_id (str): Unique identifier of the model revision to update.

--- a/application/backend/app/repositories/model_revision_repo.py
+++ b/application/backend/app/repositories/model_revision_repo.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Sequence
-from typing import cast
+from datetime import datetime
+from typing import Any, cast
 
 from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy.orm import Session
@@ -49,17 +50,31 @@ class ModelRevisionRepository(BaseRepository[ModelRevisionDB]):
         result = cast(CursorResult, self.db.execute(stmt))
         return result.rowcount > 0
 
-    def update_training_status(self, obj_id: str, training_status: str) -> None:
+    def update_training_status(
+        self,
+        obj_id: str,
+        training_status: str,
+        training_started_at: datetime | None = None,
+        training_finished_at: datetime | None = None,
+    ) -> None:
         """
-        Update the training status of a model revision.
+        Update the training status and trainig start and finish time of a model revision.
 
         Args:
             obj_id (str): Unique identifier of the model revision to update.
             training_status (str): New training status value to set.
+            training_started_at (datetime): Date and time when the training was started
+            training_finished_at (datetime): Date and time when the training was finished
         """
+        values: dict[str, Any] = {"training_status": training_status}
+        if training_started_at is not None:
+            values["training_started_at"] = training_started_at
+        if training_finished_at is not None:
+            values["training_finished_at"] = training_finished_at
+
         stmt = (
             update(ModelRevisionDB)
             .where((ModelRevisionDB.id == obj_id) & (ModelRevisionDB.project_id == self.project_id))
-            .values(training_status=training_status)
+            .values(**values)
         )
         self.db.execute(stmt)

--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -5,6 +5,7 @@ import json
 import shutil
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 from uuid import UUID
@@ -345,7 +346,14 @@ class ModelService(BaseSessionManagedService):
             )
         )
 
-    def update_revision_status(self, project_id: UUID, model_id: UUID, training_status: TrainingStatus) -> None:
+    def update_revision_status(
+        self,
+        project_id: UUID,
+        model_id: UUID,
+        training_status: TrainingStatus,
+        training_started_at: datetime | None = None,
+        training_finished_at: datetime | None = None,
+    ) -> None:
         """
         Updates the training status of a model revision for the given project.
 
@@ -353,9 +361,16 @@ class ModelService(BaseSessionManagedService):
             project_id (UUID): Identifier of the project that owns the model revision.
             model_id (UUID): Identifier of the model revision to update.
             training_status (TrainingStatus): New training status to set for the model revision.
+            training_started_at (datetime): Date and time when the training was started
+            training_finished_at (datetime): Date and time when the training was finished
         """
         model_revision_repo = ModelRevisionRepository(project_id=str(project_id), db=self.db_session)
-        model_revision_repo.update_training_status(obj_id=str(model_id), training_status=training_status)
+        model_revision_repo.update_training_status(
+            obj_id=str(model_id),
+            training_status=training_status,
+            training_started_at=training_started_at,
+            training_finished_at=training_finished_at,
+        )
 
     def get_model_binary_files(
         self, project_id: UUID, model_id: UUID, format: ModelFormat

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterator
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -443,15 +444,37 @@ class TestModelServiceIntegration:
         self, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService, db_session: Session
     ):
         """Test updating an existing model revision succeeds."""
+        started_at = datetime.now()
+        finished_at = started_at + timedelta(hours=1)
+
+        # Test that we can update status, start and finish time
         fxt_model_service.update_revision_status(
             project_id=fxt_project_id,
             model_id=fxt_model_id,
             training_status=TrainingStatus.IN_PROGRESS,
+            training_started_at=started_at,
+            training_finished_at=finished_at,
+        )
+
+        model_db = db_session.get(ModelRevisionDB, str(fxt_model_id))
+        db_session.refresh(model_db)
+        assert model_db is not None
+        assert model_db.training_status == TrainingStatus.IN_PROGRESS
+        assert model_db.training_started_at == started_at
+        assert model_db.training_finished_at == finished_at
+
+        # Test that not providing start and/or finish time won't affect currently set times
+        fxt_model_service.update_revision_status(
+            project_id=fxt_project_id,
+            model_id=fxt_model_id,
+            training_status=TrainingStatus.SUCCESSFUL,
         )
 
         model_db = db_session.get(ModelRevisionDB, str(fxt_model_id))
         assert model_db is not None
-        assert model_db.training_status == TrainingStatus.IN_PROGRESS
+        assert model_db.training_status == TrainingStatus.SUCCESSFUL
+        assert model_db.training_started_at == started_at
+        assert model_db.training_finished_at == finished_at
 
     def test_save_evaluation_result(
         self, fxt_model_id: UUID, fxt_project_id: UUID, fxt_model_service: ModelService, db_session: Session

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Iterator
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -444,7 +444,7 @@ class TestModelServiceIntegration:
         self, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService, db_session: Session
     ):
         """Test updating an existing model revision succeeds."""
-        started_at = datetime.now()
+        started_at = datetime.now(UTC)
         finished_at = started_at + timedelta(hours=1)
 
         # Test that we can update status, start and finish time
@@ -460,8 +460,8 @@ class TestModelServiceIntegration:
         db_session.refresh(model_db)
         assert model_db is not None
         assert model_db.training_status == TrainingStatus.IN_PROGRESS
-        assert model_db.training_started_at == started_at
-        assert model_db.training_finished_at == finished_at
+        assert model_db.training_started_at == started_at.replace(tzinfo=None)
+        assert model_db.training_finished_at == finished_at.replace(tzinfo=None)
 
         # Test that not providing start and/or finish time won't affect currently set times
         fxt_model_service.update_revision_status(
@@ -471,10 +471,11 @@ class TestModelServiceIntegration:
         )
 
         model_db = db_session.get(ModelRevisionDB, str(fxt_model_id))
+        db_session.refresh(model_db)
         assert model_db is not None
         assert model_db.training_status == TrainingStatus.SUCCESSFUL
-        assert model_db.training_started_at == started_at
-        assert model_db.training_finished_at == finished_at
+        assert model_db.training_started_at == started_at.replace(tzinfo=None)
+        assert model_db.training_finished_at == finished_at.replace(tzinfo=None)
 
     def test_save_evaluation_result(
         self, fxt_model_id: UUID, fxt_project_id: UUID, fxt_model_service: ModelService, db_session: Session


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Store trainig start and finish time in model revision DB. 
The start time is updated together with the training status being moved to IN_PROGRESS.
The end time is updated together with the training status being moved to FAILED or SUCCESSFUL

Resolves #5671 

### How to test

Train any model in any project and check that the start and finish times are returned at the end of the training.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
