### PR TITLE
Create worker processes with 'spawn' instead of 'fork'

### DIFF
--- a/application/backend/app/lifecycle.py
+++ b/application/backend/app/lifecycle.py
@@ -135,10 +135,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         logger.error("Failed to initialize database. Application cannot start.")
         raise RuntimeError("Database initialization failed")
 
+    # Worker processes are created with the "spawn" method to ensure a clean state and avoid issues with shared
+    # resources, especially when the workers involve GPU usage or complex libraries that may not be fork-safe.
+    # See https://github.com/open-edge-platform/training_extensions/issues/5701 for more details.
+    mp_ctx = mp.get_context("spawn")
+
     # Condition to notify processes about source updates
-    source_changed_condition: Condition = mp.Condition()
+    source_changed_condition: Condition = mp_ctx.Condition()
     # Event to signal that the model has to be reloaded
-    model_reload_event = mp.Event()
+    model_reload_event = mp_ctx.Event()
 
     event_bus = EventBus(source_changed_condition=source_changed_condition, model_reload_event=model_reload_event)
     app.state.event_bus = event_bus
@@ -147,7 +152,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     app.state.data_collector = data_collector
 
     # Initialize Scheduler
-    app_scheduler = Scheduler(event_bus=event_bus, data_collector=data_collector)
+    app_scheduler = Scheduler(event_bus=event_bus, data_collector=data_collector, mp_ctx=mp_ctx)
     app_scheduler.start_workers()
     app.state.scheduler = app_scheduler
 

--- a/application/backend/app/scheduler.py
+++ b/application/backend/app/scheduler.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import multiprocessing as mp
 import os
 import threading
+from multiprocessing.context import BaseContext
+from multiprocessing.process import BaseProcess
 from multiprocessing.shared_memory import SharedMemory
 
 import numpy as np
@@ -23,25 +24,26 @@ class Scheduler:
     FRAME_QUEUE_SIZE = 5
     PREDICTION_QUEUE_SIZE = 5
 
-    def __init__(self, event_bus: EventBus, data_collector: DataCollector) -> None:
+    def __init__(self, event_bus: EventBus, data_collector: DataCollector, mp_ctx: BaseContext) -> None:
+        logger.info("Initializing Scheduler...")
         self._event_bus = event_bus
         self._data_collector = data_collector
+        self._mp_ctx = mp_ctx
 
-        logger.info("Initializing Scheduler...")
         # Queue for the frames acquired from the stream source and decoded
-        self.frame_queue: mp.Queue = mp.Queue(maxsize=self.FRAME_QUEUE_SIZE)
+        self.frame_queue = self._mp_ctx.Queue(maxsize=self.FRAME_QUEUE_SIZE)
         # Queue for the inference results (predictions)
-        self.pred_queue: mp.Queue = mp.Queue(maxsize=self.PREDICTION_QUEUE_SIZE)
+        self.pred_queue = self._mp_ctx.Queue(maxsize=self.PREDICTION_QUEUE_SIZE)
         # Broadcaster for pushing predictions to the visualization stream (WebRTC)
         self.rtc_stream_broadcaster: FrameBroadcaster[np.ndarray] = FrameBroadcaster[np.ndarray]()
         # Event to sync all processes on application shutdown
-        self.mp_stop_event = mp.Event()
+        self.mp_stop_event = self._mp_ctx.Event()
 
         # Shared memory for metrics collector
         self.shm_metrics = SharedMemory(create=True, size=SIZE)
-        self.shm_metrics_lock = mp.Lock()
+        self.shm_metrics_lock = self._mp_ctx.Lock()
 
-        self.processes: list[mp.Process] = []
+        self.processes: list[BaseProcess] = []
         self.threads: list[threading.Thread] = []
         logger.info("Scheduler initialized")
 

--- a/application/backend/app/workers/base.py
+++ b/application/backend/app/workers/base.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-import multiprocessing as mp
 import os
 import signal
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
+from multiprocessing.context import SpawnProcess
 from multiprocessing.queues import Queue
 from multiprocessing.synchronize import Event
 
@@ -53,7 +53,7 @@ class StoppableMixin:
         return self._stop_event.wait(seconds)  # type: ignore
 
 
-class BaseProcessWorker(mp.Process, StoppableMixin, ABC):
+class BaseProcessWorker(SpawnProcess, StoppableMixin, ABC):
     """
     Reusable worker with a clean lifecycle: setup() -> run_loop() [until stop_event] -> teardown()
     Subclasses only implement what's specific to their job.

--- a/application/backend/tests/unit/workers/test_stream_loading.py
+++ b/application/backend/tests/unit/workers/test_stream_loading.py
@@ -3,144 +3,129 @@
 
 import multiprocessing as mp
 import queue
-import sys
 import time
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from uuid import uuid4
 
 import numpy as np
 import pytest
 
-from app.models import Source
+from app.models import SourceType, VideoFileSourceConfig
+from app.models.source import VideoFileConfig
 from app.stream.stream_data import StreamData
-from app.stream.video_stream import VideoStream
 from app.workers import StreamLoader
 
 
+class _FakeVideoStream:
+    """Minimal picklable stand-in for VideoStream."""
+
+    def __init__(self, frame: np.ndarray) -> None:
+        self._frame = frame
+
+    def get_data(self) -> StreamData:
+        return StreamData(frame_data=self._frame, timestamp=time.time(), source_metadata={})
+
+    def is_real_time(self) -> bool:
+        return True
+
+    def release(self) -> None:
+        pass
+
+
+class _TestableStreamLoader(StreamLoader):
+    def __init__(self, frame_queue, stop_event, source_changed_condition, fake_video_stream):
+        super().__init__(
+            frame_queue=frame_queue,
+            stop_event=stop_event,
+            source_changed_condition=source_changed_condition,
+            logger_=Mock(),  # Mock is only used in the parent; child re-creates via super().__init__
+        )
+        self._fake_video_stream = fake_video_stream
+
+    def setup(self) -> None:
+        self._source = VideoFileSourceConfig(
+            source_type=SourceType.VIDEO_FILE,
+            id=uuid4(),
+            name="Test Video File Source",
+            config_data=VideoFileConfig(video_path="fake_path.mp4"),
+        )
+        self._video_stream = self._fake_video_stream
+
+
+@pytest.fixture(scope="module")
+def mp_ctx():
+    """Use the same 'spawn' context as production code."""
+    return mp.get_context("spawn")
+
+
 @pytest.fixture
-def mp_manager():
-    """Multiprocessing manager fixture"""
-    manager = mp.Manager()
+def mp_manager(mp_ctx):
+    manager = mp_ctx.Manager()
     yield manager
     manager.shutdown()
 
 
 @pytest.fixture
 def frame_queue(mp_manager):
-    """Frame queue fixture"""
     return mp_manager.Queue(maxsize=2)
 
 
 @pytest.fixture
-def stop_event():
-    """Stop event fixture"""
-    return mp.Event()
+def stop_event(mp_ctx):
+    return mp_ctx.Event()
 
 
 @pytest.fixture
-def source_changed_condition():
-    """Source changed condition fixture"""
-    return mp.Condition()
+def source_changed_condition(mp_ctx):
+    return mp_ctx.Condition()
 
 
 @pytest.fixture
-def mock_config():
-    """Mock configuration fixture"""
-    config = Mock(spec=Source)
-    config.source = "test_camera"
-    config.resolution = (1920, 1080)
-    return config
+def sample_frame() -> np.ndarray:
+    return np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8)
 
 
 @pytest.fixture
-def mock_stream_data():
-    def create_sample():
-        return StreamData(
-            frame_data=np.random.randint(0, 255, (480, 640, 3), dtype=np.uint8),
-            timestamp=time.time(),
-            source_metadata={},
-        )
-
-    yield create_sample
+def fake_video_stream(sample_frame) -> _FakeVideoStream:
+    return _FakeVideoStream(frame=sample_frame)
 
 
-@pytest.fixture
-def mock_video_stream(mock_stream_data):
-    """Mock video stream fixture"""
-    stream = Mock(spec=VideoStream)
-    stream.get_data.return_value = mock_stream_data()
-    stream.is_real_time.return_value = True
-    stream.release.return_value = None
-    return stream
-
-
-@pytest.fixture
-def mock_services(mock_config, mock_video_stream):
-    with (
-        patch("app.workers.stream_loading.SourceService") as mock_source_service,
-        patch("app.workers.stream_loading.VideoStreamService") as mock_video_service,
-    ):
-        # Set up the mocks
-        mock_source_service.get_active_source.return_value = mock_config
-        mock_video_service.get_video_stream.return_value = mock_video_stream
-
-        yield {
-            "video_service": mock_video_service,
-            "video_stream": mock_video_stream,
-        }
-
-
-@pytest.mark.skipif(sys.platform == "win32", reason="Multiprocessing 'fork' start method not available on Windows")
 class TestStreamLoader:
-    """Unit tests for the StreamLoader routine"""
-
-    @pytest.fixture(scope="session", autouse=True)
-    def set_multiprocessing_start_method(self):
-        # Set multiprocessing start method to 'fork' to ensure mocked objects and patches
-        # from the parent process are inherited by child processes. The default 'spawn'
-        # method creates isolated child processes that don't inherit mocked state.
-        mp.set_start_method("fork", force=True)
-
-    def test_queue_full(self, frame_queue, mock_stream_data, stop_event, source_changed_condition, mock_services):
-        """Test that stream frames are not acquired when queue is full"""
-
-        data1, data2 = mock_stream_data(), mock_stream_data()
+    def test_queue_full(self, frame_queue, stop_event, source_changed_condition, fake_video_stream, sample_frame):
+        """Test that stream frames are not acquired when queue is full."""
+        data1 = StreamData(frame_data=sample_frame.copy(), timestamp=time.time(), source_metadata={})
+        data2 = StreamData(frame_data=sample_frame.copy(), timestamp=time.time(), source_metadata={})
         frame_queue.put(data1)
         frame_queue.put(data2)
 
-        # Start the process
-        process = StreamLoader(frame_queue, stop_event, source_changed_condition, Mock())
+        process = _TestableStreamLoader(frame_queue, stop_event, source_changed_condition, fake_video_stream)
         process.start()
 
-        # Let it run for a short time to attempt frame acquisition
         time.sleep(1)
 
-        # Stop the process
         stop_event.set()
-        process.join(timeout=1)
+        process.join(timeout=3)
 
         queue_contents = []
         while not frame_queue.empty():
             try:
-                queue_contents.append(frame_queue.get())
+                queue_contents.append(frame_queue.get_nowait())
             except queue.Empty:
                 break
 
-        # Should still have our initial frames, proving new frames were ignored
         assert len(queue_contents) == 2
         assert all(np.array_equal(el1.frame_data, el2.frame_data) for el1, el2 in zip(queue_contents, [data1, data2]))
         assert not process.is_alive(), "Process should terminate cleanly"
 
-    def test_queue_empty(self, frame_queue, stop_event, source_changed_condition, mock_services):
-        """Test that stream frames are acquired when queue is empty"""
-
-        # Start the process
-        process = StreamLoader(frame_queue, stop_event, source_changed_condition, Mock())
+    def test_queue_empty(self, frame_queue, stop_event, source_changed_condition, fake_video_stream):
+        """Test that stream frames are acquired when queue is empty."""
+        process = _TestableStreamLoader(frame_queue, stop_event, source_changed_condition, fake_video_stream)
         process.start()
 
         time.sleep(1)
 
         stop_event.set()
-        process.join(timeout=1)
+        process.join(timeout=3)
 
         assert frame_queue.qsize() == 2
         assert not process.is_alive(), "Process should terminate cleanly"


### PR DESCRIPTION
### Summary

Fixes #5701

Using 'spawn' prevents issues with invalid/corrupt shared context, for example when the workers need GPU or complex libraries. Refer to the issue linked above for more details.

### How to test

Create a project and enable the inference pipeline with XPU device.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
