### PR TITLE
Make submit logic less permissive

### DIFF
--- a/application/ui/src/features/annotator/tools/use-add-and-select-annotations.hook.ts
+++ b/application/ui/src/features/annotator/tools/use-add-and-select-annotations.hook.ts
@@ -23,6 +23,7 @@ export const useAddAndSelectAnnotations = () => {
 
             const newIds = addAnnotations(shapes, labels);
             setSelectedAnnotations(new Set(newIds));
+
             return newIds;
         },
         [addAnnotations, setSelectedAnnotations, annotations, deleteAnnotations]

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
@@ -11,10 +11,6 @@ export const VideoControls = () => {
     const { isPlaying, play, pause, previousFrame, nextFrame, canSelectPreviousFrame, canSelectNextFrame } =
         videoControls;
 
-    const handlePlay = async () => {
-        await play();
-    };
-
     return (
         <Flex alignItems={'center'} gap={'size-100'}>
             <Flex alignItems={'center'}>
@@ -31,7 +27,7 @@ export const VideoControls = () => {
                         <Pause />
                     </ActionButton>
                 ) : (
-                    <ActionButton isQuiet aria-label={'Play video'} onPress={handlePlay}>
+                    <ActionButton isQuiet aria-label={'Play video'} onPress={play}>
                         <Play />
                     </ActionButton>
                 )}

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
@@ -4,18 +4,15 @@
 import { ActionButton, Flex } from '@geti/ui';
 import { Pause, Play, SoundOff, SoundOn, StepBackward, StepForward } from '@geti/ui/icons';
 
-import { useAnnotationActions } from '../../../../shared/annotator/annotation-actions-provider.component';
 import { useVideoPlayer } from '../video-player-provider.component';
 
 export const VideoControls = () => {
     const { isMuted, toggleMute, videoControls } = useVideoPlayer();
     const { isPlaying, play, pause, previousFrame, nextFrame, canSelectPreviousFrame, canSelectNextFrame } =
         videoControls;
-    const { resetAnnotations } = useAnnotationActions();
 
     const handlePlay = async () => {
         await play();
-        resetAnnotations();
     };
 
     return (

--- a/application/ui/src/features/dataset/media-preview/use-submit-predictions.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-submit-predictions.hook.ts
@@ -1,17 +1,15 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { isEmpty } from 'lodash-es';
-
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
 
 export const useSubmitPredictions = ({ onSuccess }: { onSuccess?: () => void }) => {
-    const { annotations, isSaving, submitAnnotations } = useAnnotationActions();
+    const { canSubmit, isSaving, submitAnnotations } = useAnnotationActions();
 
     const handleSubmitPredictions = async () => {
         await submitAnnotations();
         onSuccess?.();
     };
 
-    return { canSubmit: !isEmpty(annotations), isSaving, submit: handleSubmitPredictions };
+    return { canSubmit, isSaving, submit: handleSubmitPredictions };
 };

--- a/application/ui/src/features/models/train-model/train-model.component.test.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { getMockedDatasetItem } from 'mocks/mock-dataset-item';
 import { getMockedPipeline } from 'mocks/mock-pipeline';
 import { getMockedProject } from 'mocks/mock-project';
+import { getMockedTrainingConfiguration } from 'mocks/mock-training-configuration';
 import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
@@ -26,6 +27,12 @@ describe('TrainModel', () => {
             }),
             http.get('/api/projects/{project_id}/models', () => {
                 return HttpResponse.json([]);
+            }),
+            http.get('/api/projects/{project_id}/models/{model_id}/training_configuration', () => {
+                return HttpResponse.json(getMockedTrainingConfiguration());
+            }),
+            http.get('/api/projects/{project_id}/training_configuration', () => {
+                return HttpResponse.json(getMockedTrainingConfiguration());
             }),
             http.get('/api/model_architectures', () => {
                 return HttpResponse.json({

--- a/application/ui/src/features/models/train-model/train-model.component.test.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.test.tsx
@@ -29,10 +29,10 @@ describe('TrainModel', () => {
                 return HttpResponse.json([]);
             }),
             http.get('/api/projects/{project_id}/models/{model_id}/training_configuration', () => {
-                return HttpResponse.json(getMockedTrainingConfiguration());
+                return HttpResponse.json({ parameters: getMockedTrainingConfiguration() });
             }),
             http.get('/api/projects/{project_id}/training_configuration', () => {
-                return HttpResponse.json(getMockedTrainingConfiguration());
+                return HttpResponse.json({ parameters: getMockedTrainingConfiguration() });
             }),
             http.get('/api/model_architectures', () => {
                 return HttpResponse.json({

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -56,6 +56,7 @@ export const AnnotationActionsProvider = ({
     mode,
     isReadOnly = false,
 }: AnnotationActionsProviderProps) => {
+    const mediaItemKey = isVideoFrame(mediaItem) ? `${mediaItem.id}-${mediaItem.frame_number}` : mediaItem.id;
     const projectId = useProjectIdentifier();
     const saveMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media/{media_id}/annotations', {
         meta: {
@@ -88,14 +89,27 @@ export const AnnotationActionsProvider = ({
         return mapServerAnnotationsToLocal(initialPredictionsDTO, projectLabels);
     }, [initialPredictionsDTO, projectLabels]);
 
-    const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>(() => {
+    const initialAnnotations = useMemo(() => {
         return mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels);
-    });
+    }, [initialAnnotationsDTO, projectLabels]);
+
+    const [annotations, setAnnotations, undoRedoActions] = useUndoRedoState<Annotation[]>(initialAnnotations);
+
+    const resetAnnotations = () => {
+        undoRedoActions.reset(initialAnnotations);
+    };
 
     const prevInitialAnnotationsDTORef = useRef(initialAnnotationsDTO);
+    const prevMediaItemKeyRef = useRef(mediaItemKey);
 
-    if (!isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)) {
-        setAnnotations(mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels), true);
+    // Reset annotations if the provider's props are updated
+    // or if we switch to a different media item (image or video frame)
+    if (
+        prevMediaItemKeyRef.current !== mediaItemKey ||
+        !isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)
+    ) {
+        resetAnnotations();
+        prevMediaItemKeyRef.current = mediaItemKey;
         prevInitialAnnotationsDTORef.current = initialAnnotationsDTO;
     }
 
@@ -144,10 +158,6 @@ export const AnnotationActionsProvider = ({
         );
     };
 
-    const resetAnnotations = () => {
-        undoRedoActions.reset();
-    };
-
     const saveAnnotations = async (annotationsDTO: AnnotationDTO[]) => {
         const query = isVideoFrame(mediaItem)
             ? {
@@ -189,7 +199,7 @@ export const AnnotationActionsProvider = ({
         return !isEqual(currentServerAnnotations, initialAnnotationsDTO);
     }, [annotations, initialAnnotationsDTO]);
 
-    const canSubmit = mode === 'prediction' ? !isUserReviewed && predictions.length > 0 : hasChangedAnnotations;
+    const canSubmit = mode === 'prediction' ? predictions.length > 0 : hasChangedAnnotations;
 
     const annotationsToRender = mode === 'annotation' ? annotations : predictions;
     const isReadOnlyMode = isReadOnly || mode === 'prediction';

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -19,6 +19,7 @@ import { EMPTY_LABEL_ID, useProjectLabelsWithEmptyLabel } from './labels';
 
 interface AnnotationsContextValue {
     annotations: Annotation[];
+    canSubmit: boolean;
     addAnnotations: (shapes: Shape[], labels: Label[]) => string[];
     addAnnotationWithEmptyLabel: (label: Label) => void;
     deleteAnnotations: (annotationIds: string[]) => void;
@@ -101,6 +102,7 @@ export const AnnotationActionsProvider = ({
     const updateAnnotations = (updatedAnnotations: Annotation[], labels?: Label[]) => {
         if (labels !== undefined) {
             const idsToUpdate = new Set(updatedAnnotations.map((a) => a.id));
+
             setAnnotations((prevAnnotations) =>
                 prevAnnotations.map((annotation) =>
                     idsToUpdate.has(annotation.id) ? { ...annotation, labels } : annotation
@@ -108,6 +110,7 @@ export const AnnotationActionsProvider = ({
             );
         } else {
             const updatedMap = new Map(updatedAnnotations.map((annotation) => [annotation.id, annotation]));
+
             setAnnotations((prevAnnotations) =>
                 prevAnnotations.map((annotation) => updatedMap.get(annotation.id) ?? annotation)
             );
@@ -142,7 +145,7 @@ export const AnnotationActionsProvider = ({
     };
 
     const resetAnnotations = () => {
-        undoRedoActions.reset([]);
+        undoRedoActions.reset();
     };
 
     const saveAnnotations = async (annotationsDTO: AnnotationDTO[]) => {
@@ -157,7 +160,7 @@ export const AnnotationActionsProvider = ({
             body: { annotations: annotationsDTO },
         });
 
-        resetAnnotations();
+        undoRedoActions.reset(mapServerAnnotationsToLocal(annotationsDTO, projectLabels));
     };
 
     const submitPredictions = async () => {
@@ -179,6 +182,15 @@ export const AnnotationActionsProvider = ({
         }
     };
 
+    const hasChangedAnnotations = useMemo(() => {
+        const filteredAnnotations = filterOutAnnotationWithEmptyLabel(annotations);
+        const currentServerAnnotations = mapLocalAnnotationsToServer(filteredAnnotations);
+
+        return !isEqual(currentServerAnnotations, initialAnnotationsDTO);
+    }, [annotations, initialAnnotationsDTO]);
+
+    const canSubmit = mode === 'prediction' ? !isUserReviewed && predictions.length > 0 : hasChangedAnnotations;
+
     const annotationsToRender = mode === 'annotation' ? annotations : predictions;
     const isReadOnlyMode = isReadOnly || mode === 'prediction';
 
@@ -187,6 +199,7 @@ export const AnnotationActionsProvider = ({
             value={{
                 isUserReviewed,
                 annotations: annotationsToRender,
+                canSubmit,
 
                 // Local
                 addAnnotations,

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -145,7 +145,7 @@ export const AnnotationActionsProvider = ({
     };
 
     const resetAnnotations = () => {
-        undoRedoActions.reset();
+        undoRedoActions.reset(mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels));
     };
 
     const saveAnnotations = async (annotationsDTO: AnnotationDTO[]) => {
@@ -160,7 +160,7 @@ export const AnnotationActionsProvider = ({
             body: { annotations: annotationsDTO },
         });
 
-        undoRedoActions.reset(mapServerAnnotationsToLocal(annotationsDTO, projectLabels));
+        resetAnnotations();
     };
 
     const submitPredictions = async () => {

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -145,7 +145,7 @@ export const AnnotationActionsProvider = ({
     };
 
     const resetAnnotations = () => {
-        undoRedoActions.reset(mapServerAnnotationsToLocal(initialAnnotationsDTO, projectLabels));
+        undoRedoActions.reset();
     };
 
     const saveAnnotations = async (annotationsDTO: AnnotationDTO[]) => {
@@ -160,7 +160,7 @@ export const AnnotationActionsProvider = ({
             body: { annotations: annotationsDTO },
         });
 
-        resetAnnotations();
+        undoRedoActions.reset(mapServerAnnotationsToLocal(annotationsDTO, projectLabels));
     };
 
     const submitPredictions = async () => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Submit only if
1) Annotation mode: The canvas is "dirty", i.e. if the current annotations are different from the initial ones
2) Prediction mode: we have predictions and the user did not review them
Closes https://github.com/open-edge-platform/training_extensions/issues/5704

BONUS: Fix sporadic failure on train-model unit test (missing handlers)




### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
