### PR TITLE
Improve media upload part 2

### DIFF
--- a/application/ui/src/components/add-media-button/add-media-button.component.test.tsx
+++ b/application/ui/src/components/add-media-button/add-media-button.component.test.tsx
@@ -26,7 +26,18 @@ describe('AddMediaButton', () => {
         render(<AddMediaButton onFilesSelected={vi.fn()} />);
 
         const input = screen.getByLabelText(/Upload media files/);
+        const folderInput = screen.getByLabelText(/Upload media folder/);
 
         expect(input).toHaveAttribute('accept', acceptedExtensions);
+        expect(folderInput).toHaveAttribute('accept', acceptedExtensions);
+    });
+
+    it('enables directory selection attributes on input', () => {
+        render(<AddMediaButton onFilesSelected={vi.fn()} />);
+
+        const input = screen.getByLabelText(/Upload media folder/);
+
+        expect(input).toHaveAttribute('webkitdirectory');
+        expect(input).toHaveAttribute('directory');
     });
 });

--- a/application/ui/src/components/add-media-button/add-media-button.component.tsx
+++ b/application/ui/src/components/add-media-button/add-media-button.component.tsx
@@ -3,11 +3,10 @@
 
 import { ChangeEvent, useRef } from 'react';
 
-import { Button } from '@geti/ui';
+import { Button, Item, Key, Menu, MenuTrigger } from '@geti/ui';
 
 type AddMediaButtonProps = {
     onFilesSelected: (files: File[]) => void;
-    multiple?: boolean;
 };
 
 const VALID_VIDEO_EXT = ['mp4', 'avi', 'mkv', 'mov', 'webm', 'm4v'];
@@ -16,8 +15,20 @@ const VALID_EXT = [...VALID_VIDEO_EXT, ...VALID_IMAGE_EXT];
 
 export const acceptedExtensions = VALID_EXT.map((ext) => `.${ext}`).join(',');
 
-export const AddMediaButton = ({ onFilesSelected, multiple = true }: AddMediaButtonProps) => {
+export const AddMediaButton = ({ onFilesSelected }: AddMediaButtonProps) => {
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const folderInputRef = useRef<HTMLInputElement>(null);
+
+    const setFolderInputRef = (input: HTMLInputElement | null) => {
+        folderInputRef.current = input;
+
+        if (input === null) {
+            return;
+        }
+
+        input.setAttribute('webkitdirectory', '');
+        input.setAttribute('directory', '');
+    };
 
     const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
         const files = event.target.files;
@@ -33,8 +44,12 @@ export const AddMediaButton = ({ onFilesSelected, multiple = true }: AddMediaBut
         }
     };
 
-    const handleClick = () => {
-        fileInputRef.current?.click();
+    const handleMenuAction = (action: Key) => {
+        if (action === 'files') {
+            fileInputRef.current?.click();
+        } else if (action === 'folder') {
+            folderInputRef.current?.click();
+        }
     };
 
     return (
@@ -42,15 +57,28 @@ export const AddMediaButton = ({ onFilesSelected, multiple = true }: AddMediaBut
             <input
                 ref={fileInputRef}
                 type='file'
-                multiple={multiple}
+                multiple
                 onChange={handleFileChange}
                 style={{ display: 'none' }}
                 aria-label={'Upload media files'}
                 accept={acceptedExtensions}
             />
-            <Button variant={'secondary'} onPress={handleClick}>
-                Upload Files
-            </Button>
+            <input
+                ref={setFolderInputRef}
+                type='file'
+                multiple
+                onChange={handleFileChange}
+                style={{ display: 'none' }}
+                aria-label={'Upload media folder'}
+                accept={acceptedExtensions}
+            />
+            <MenuTrigger>
+                <Button variant={'secondary'}>Upload media</Button>
+                <Menu onAction={handleMenuAction} aria-label={'Upload menu'}>
+                    <Item key={'files'}>Files</Item>
+                    <Item key={'folder'}>Folder</Item>
+                </Menu>
+            </MenuTrigger>
         </>
     );
 };

--- a/application/ui/src/features/dataset/api/use-media-upload.test.tsx
+++ b/application/ui/src/features/dataset/api/use-media-upload.test.tsx
@@ -5,10 +5,11 @@ import { act, screen } from '@testing-library/react';
 import { getMockedMediaImage } from 'mocks/mock-media';
 import { HttpResponse } from 'msw';
 import { renderHook } from 'test-utils/render';
+import { v4 as uuid } from 'uuid';
 
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
-import { useMediaUpload } from './use-media-upload';
+import { MEDIA_UPLOAD_CONCURRENCY, useMediaUpload } from './use-media-upload';
 
 describe('useMediaUpload', () => {
     it('uploads all selected files and shows a success toast', async () => {
@@ -42,18 +43,17 @@ describe('useMediaUpload', () => {
     });
 
     it('shows a warning toast when some uploads fail', async () => {
-        server.use(
-            http.post('/api/projects/{project_id}/dataset/media', async ({ request }) => {
-                const formData = await request.formData();
-                const file = formData.get('file') as File;
+        let requestCount = 0;
 
-                if (file.name === 'broken.jpg') {
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-expect-error
-                    return HttpResponse.json({ detail: 'Upload failed' }, { status: 500 });
+        server.use(
+            http.post('/api/projects/{project_id}/dataset/media', async () => {
+                requestCount += 1;
+
+                if (requestCount === 2) {
+                    return HttpResponse.error();
                 }
 
-                return HttpResponse.json(getMockedMediaImage({ id: crypto.randomUUID() }), { status: 201 });
+                return HttpResponse.json(getMockedMediaImage({ id: uuid() }), { status: 201 });
             })
         );
 
@@ -69,5 +69,60 @@ describe('useMediaUpload', () => {
         });
 
         expect(await screen.findByText('Uploaded 1 item(s), 1 failed')).toBeVisible();
+    });
+
+    it('shows an error toast when all uploads fail', async () => {
+        server.use(
+            http.post('/api/projects/{project_id}/dataset/media', async () => {
+                return HttpResponse.error();
+            })
+        );
+
+        const { result } = renderHook(() => useMediaUpload());
+
+        const files = [
+            new File(['broken-file-1'], 'broken-1.jpg', { type: 'image/jpeg' }),
+            new File(['broken-file-2'], 'broken-2.jpg', { type: 'image/jpeg' }),
+        ];
+
+        await act(async () => {
+            await result.current.uploadMedia(files);
+        });
+
+        expect(await screen.findByText('Failed to upload 2 item(s)')).toBeVisible();
+    });
+
+    it('does not exceed configured upload concurrency', async () => {
+        let runningUploads = 0;
+        let maxRunningUploads = 0;
+
+        server.use(
+            http.post('/api/projects/{project_id}/dataset/media', async () => {
+                runningUploads += 1;
+                maxRunningUploads = Math.max(maxRunningUploads, runningUploads);
+
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 20);
+                });
+
+                runningUploads -= 1;
+
+                return HttpResponse.json(getMockedMediaImage({ id: uuid() }), { status: 201 });
+            })
+        );
+
+        const { result } = renderHook(() => useMediaUpload());
+
+        const mockFiles = Array.from(
+            { length: 12 },
+            (_, index) => new File([`file-${index}`], `image-${index}.jpg`, { type: 'image/jpeg' })
+        );
+
+        await act(async () => {
+            await result.current.uploadMedia(mockFiles);
+        });
+
+        expect(maxRunningUploads).toBeLessThanOrEqual(MEDIA_UPLOAD_CONCURRENCY);
+        expect(await screen.findByText('Uploaded 12 item(s)')).toBeVisible();
     });
 });

--- a/application/ui/src/features/dataset/api/use-media-upload.ts
+++ b/application/ui/src/features/dataset/api/use-media-upload.ts
@@ -4,11 +4,20 @@
 import { toast } from '@geti/ui';
 import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { isFunction } from 'lodash-es';
 
 import { $api } from '../../../api/client';
 import { getQueryKey } from '../../../query-client/query-client';
 
 export const MEDIA_UPLOAD_CONCURRENCY = 5;
+
+type UploadMutationVariables = {
+    params?: {
+        path?: {
+            project_id?: string;
+        };
+    };
+};
 
 // Runs ${batchSize} promises at a time until all promises have been executed,
 // returning an array of settled results.
@@ -25,7 +34,7 @@ const executeInBatches = async <T>(
 
         settledResults.push(...batchResults);
 
-        if (onBatchCompleted !== undefined) {
+        if (isFunction(onBatchCompleted)) {
             await onBatchCompleted();
         }
     }
@@ -40,6 +49,11 @@ export const useMediaUpload = () => {
     const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media');
     const currentlyUploading = useIsMutating({
         mutationKey: ['post', '/api/projects/{project_id}/dataset/media'],
+        predicate: ({ state }) => {
+            const variables = state.variables as UploadMutationVariables | undefined;
+
+            return variables?.params?.path?.project_id === projectId;
+        },
     });
     const invalidateMediaQuery = () =>
         queryClient.invalidateQueries({

--- a/application/ui/src/features/dataset/api/use-media-upload.ts
+++ b/application/ui/src/features/dataset/api/use-media-upload.ts
@@ -8,36 +8,63 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { $api } from '../../../api/client';
 import { getQueryKey } from '../../../query-client/query-client';
 
+export const MEDIA_UPLOAD_CONCURRENCY = 5;
+
+// Runs ${batchSize} promises at a time until all promises have been executed,
+// returning an array of settled results.
+const executeInBatches = async <T>(
+    promises: Array<() => Promise<T>>,
+    batchSize: number,
+    onBatchCompleted?: () => Promise<void>
+) => {
+    const settledResults: PromiseSettledResult<T>[] = [];
+
+    for (let index = 0; index < promises.length; index += batchSize) {
+        const batchPromises = promises.slice(index, index + batchSize).map((promise) => promise());
+        const batchResults = await Promise.allSettled(batchPromises);
+
+        settledResults.push(...batchResults);
+
+        if (onBatchCompleted !== undefined) {
+            await onBatchCompleted();
+        }
+    }
+
+    return settledResults;
+};
+
 export const useMediaUpload = () => {
     const projectId = useProjectIdentifier();
     const queryClient = useQueryClient();
 
     const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media');
-
-    const uploadMedia = async (files: File[]) => {
-        const uploadPromises = files.map((file) => {
-            const formData = new FormData();
-            formData.append('file', file);
-
-            return addItemMutation.mutateAsync({
-                params: { path: { project_id: projectId } },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                body: formData as any,
-            });
-        });
-
-        const promises = await Promise.allSettled(uploadPromises);
-
-        const succeeded = promises.filter((result) => result.status === 'fulfilled').length;
-        const failed = promises.filter((result) => result.status === 'rejected').length;
-
-        await queryClient.invalidateQueries({
+    const invalidateMediaQuery = () =>
+        queryClient.invalidateQueries({
             queryKey: getQueryKey([
                 'get',
                 '/api/projects/{project_id}/dataset/media',
                 { params: { path: { project_id: projectId } } },
             ]),
         });
+
+    const uploadMedia = async (files: File[]) => {
+        const uploadPromises = files.map((file) => {
+            return () => {
+                const formData = new FormData();
+                formData.append('file', file);
+
+                return addItemMutation.mutateAsync({
+                    params: { path: { project_id: projectId } },
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    body: formData as any,
+                });
+            };
+        });
+
+        const settledResults = await executeInBatches(uploadPromises, MEDIA_UPLOAD_CONCURRENCY, invalidateMediaQuery);
+
+        const succeeded = settledResults.filter((result) => result.status === 'fulfilled').length;
+        const failed = settledResults.filter((result) => result.status === 'rejected').length;
 
         if (failed === 0) {
             toast({ type: 'success', message: `Uploaded ${succeeded} item(s)` });

--- a/application/ui/src/features/dataset/api/use-media-upload.ts
+++ b/application/ui/src/features/dataset/api/use-media-upload.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { toast } from '@geti/ui';
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../api/client';
@@ -38,6 +38,9 @@ export const useMediaUpload = () => {
     const queryClient = useQueryClient();
 
     const addItemMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media');
+    const currentlyUploading = useIsMutating({
+        mutationKey: ['post', '/api/projects/{project_id}/dataset/media'],
+    });
     const invalidateMediaQuery = () =>
         queryClient.invalidateQueries({
             queryKey: getQueryKey([
@@ -80,6 +83,6 @@ export const useMediaUpload = () => {
 
     return {
         uploadMedia,
-        isUploading: addItemMutation.isPending,
+        isUploading: currentlyUploading > 0,
     };
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Allow uploading folders
* Add concurrency for media uploading (i think we should do the same for DELETING media, but maybe ill request an endpoint to bulk delete). I also invalidate the query for each chunk uploaded, if we dont want that it will be easy to remove
* On the next PR i will make the UI changes (show "in progress" etc)

Example uploading 12 images:
<img width="2398" height="675" alt="Screenshot 2026-03-09 at 13 38 57" src="https://github.com/user-attachments/assets/a535e7e6-7bdb-42ed-821e-033e21901392" />
<img width="1183" height="435" alt="Screenshot 2026-03-09 at 13 39 05" src="https://github.com/user-attachments/assets/b028c1f5-9c4a-49f7-ae79-32201072cf8c" />
<img width="1248" height="410" alt="Screenshot 2026-03-09 at 13 39 15" src="https://github.com/user-attachments/assets/efff85fa-fbe7-446c-b6e8-223e2a52a72b" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
