### PR TITLE
Add benchmark metrics to model manifest (and remove performance ratings)

### DIFF
--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -21,36 +21,41 @@ class ModelManifestDeprecationStatus(str, Enum):
         return str(self.name)
 
 
-class PerformanceRatings(BaseModel):
-    """Ratings for different performance aspects of a model."""
+class BenchmarkMetrics(BaseModel):
+    """Benchmark metrics for different model tasks."""
 
     model_config = ConfigDict(extra="forbid")
-    accuracy: int = Field(
-        ge=1,
-        le=3,
-        default=1,
-        title="Accuracy rating",
-        description="Rating of the model accuracy. "
-        "The value should be interpreted relatively to the other available models, "
-        "and it ranges from 1 (below average) to 3 (above average).",
+
+    # Classification metrics
+    imagenet_top1_accuracy: float | None = Field(
+        default=None,
+        title="ImageNet Top-1 Accuracy",
+        description="Top-1 accuracy on ImageNet (percentage)",
+        ge=0,
+        le=100,
     )
-    training_time: int = Field(
-        ge=1,
-        le=3,
-        default=1,
-        title="Training time rating",
-        description="Rating of the model training time. "
-        "The value should be interpreted relatively to the other available models, "
-        "and it ranges from 1 (below average/slower) to 3 (above average/faster).",
+    imagenet_top5_accuracy: float | None = Field(
+        default=None,
+        title="ImageNet Top-5 Accuracy",
+        description="Top-5 accuracy on ImageNet (percentage, optional)",
+        ge=0,
+        le=100,
     )
-    inference_speed: int = Field(
-        ge=1,
-        le=3,
-        default=1,
-        title="Inference speed rating",
-        description="Rating of the model inference speed. "
-        "The value should be interpreted relatively to the other available models, "
-        "and it ranges from 1 (below average/slower) to 3 (above average/faster).",
+
+    # Detection/Segmentation metrics
+    coco_map_50_95: float | None = Field(
+        default=None,
+        title="COCO mAP 50-95",
+        description="COCO mean Average Precision at IoU=0.50:0.95 (percentage)",
+        ge=0,
+        le=100,
+    )
+    coco_map_50: float | None = Field(
+        default=None,
+        title="COCO mAP 50",
+        description="COCO mean Average Precision at IoU=0.50 (percentage, optional)",
+        ge=0,
+        le=100,
     )
 
 
@@ -67,8 +72,8 @@ class ModelStats(BaseModel):
         title="Trainable parameters (millions)",
         description="Number of trainable parameters in the model, expressed in millions",
     )
-    performance_ratings: PerformanceRatings = Field(
-        title="Performance ratings", description="Standardized ratings for model performance metrics"
+    benchmark_metrics: BenchmarkMetrics = Field(
+        title="Benchmark metrics", description="Standardized benchmark metrics for model performance"
     )
 
 

--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -58,23 +58,6 @@ class BenchmarkMetrics(BaseModel):
         le=100,
     )
 
-    @model_validator(mode="after")
-    def validate_metrics(self) -> "BenchmarkMetrics":
-        if self.imagenet_top1_accuracy is None and self.coco_map_50_95 is None:
-            raise ValueError(
-                f"For classification 'imagenet_top1_accuracy' is required, for detection and segmentation "
-                f"'coco_map_50_95' is required. However, both or 'None': {self}"
-            )
-        if (self.imagenet_top1_accuracy is not None or self.imagenet_top5_accuracy is not None) and (
-            self.coco_map_50 is not None or self.coco_map_50_95 is not None
-        ):
-            raise ValueError(
-                f"For classification, only 'imagenet_top*_accuracy' metric type can be set. For detection and "
-                f"segmentation, only 'coco_map_*' metric type can be set. However, both metric types have been set: "
-                f"{self}"
-            )
-        return self
-
 
 class ModelStats(BaseModel):
     """Information about a machine learning model."""
@@ -139,3 +122,29 @@ class ModelManifest(BaseModel):
     hyperparameters: AlgoLevelParameters = Field(
         title="Hyperparameters", description="Configuration parameters for model training"
     )
+
+    @model_validator(mode="after")
+    def validate_metrics(self) -> "ModelManifest":
+        if self.task in {TaskType.CLASSIFICATION}:
+            if self.stats.benchmark_metrics.imagenet_top1_accuracy is None:
+                raise ValueError("For classification 'imagenet_top1_accuracy' benchmark metric is required")
+            if (
+                self.stats.benchmark_metrics.coco_map_50 is not None
+                or self.stats.benchmark_metrics.coco_map_50_95 is not None
+            ):
+                raise ValueError(
+                    "For classification, only ImageNet Accuracy benchmark metrics can be set. However, one of the COCO "
+                    "mAP benchmark metrics was not 'None'."
+                )
+        if self.task in {TaskType.DETECTION, TaskType.INSTANCE_SEGMENTATION}:
+            if self.stats.benchmark_metrics.coco_map_50_95 is None:
+                raise ValueError("For detection or instance segmentation 'coco_map_50_95' benchmark metric is required")
+            if (
+                self.stats.benchmark_metrics.imagenet_top1_accuracy is not None
+                or self.stats.benchmark_metrics.imagenet_top5_accuracy is not None
+            ):
+                raise ValueError(
+                    "For detection or instance segmentation, only COCO mAP benchmark metrics can be set. However, one "
+                    "of the ImageNet Accuracy benchmark metrics was not 'None'."
+                )
+        return self

--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -37,7 +37,7 @@ class BenchmarkMetrics(BaseModel):
     imagenet_top5_accuracy: float | None = Field(
         default=None,
         title="ImageNet Top-5 Accuracy",
-        description="Top-5 accuracy on ImageNet (percentage, optional)",
+        description="Top-5 accuracy on ImageNet (percentage, null if N/A)",
         ge=0,
         le=100,
     )

--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -53,7 +53,7 @@ class BenchmarkMetrics(BaseModel):
     coco_map_50: float | None = Field(
         default=None,
         title="COCO mAP 50",
-        description="COCO mean Average Precision at IoU=0.50 (percentage, optional)",
+        description="COCO mean Average Precision at IoU=0.50 (percentage, null if N/A)",
         ge=0,
         le=100,
     )

--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -3,7 +3,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .task import TaskType
 from .training_configuration import AlgoLevelParameters
@@ -57,6 +57,23 @@ class BenchmarkMetrics(BaseModel):
         ge=0,
         le=100,
     )
+
+    @model_validator(mode="after")
+    def validate_metrics(self) -> "BenchmarkMetrics":
+        if self.imagenet_top1_accuracy is None and self.coco_map_50_95 is None:
+            raise ValueError(
+                f"For classification 'imagenet_top1_accuracy' is required, for detection and segmentation "
+                f"'coco_map_50_95' is required. However, both or 'None': {self}"
+            )
+        if (self.imagenet_top1_accuracy is not None or self.imagenet_top5_accuracy is not None) and (
+            self.coco_map_50 is not None or self.coco_map_50_95 is not None
+        ):
+            raise ValueError(
+                f"For classification, only 'imagenet_top*_accuracy' metric type can be set. For detection and "
+                f"segmentation, only 'coco_map_*' metric type can be set. However, both metric types have been set: "
+                f"{self}"
+            )
+        return self
 
 
 class ModelStats(BaseModel):

--- a/application/backend/app/supported_models/manifests/classification/deit_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/classification/deit_tiny.yaml
@@ -9,10 +9,9 @@ description: "DeiT (Data-efficient Image Transformers) is a vision transformer m
 stats:
   gigaflops: 1.26
   trainable_parameters: 5.2
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    imagenet_top1_accuracy: 72.2 # percentage
+    imagenet_top5_accuracy: 91.1 # percentage (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/deit_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/classification/deit_tiny.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 1.26
   trainable_parameters: 5.2
   benchmark_metrics:
-    imagenet_top1_accuracy: 72.2 # percentage
-    imagenet_top5_accuracy: 91.1 # percentage (optional)
+    imagenet_top1_accuracy: 72.2
+    imagenet_top5_accuracy: 91.1
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
@@ -9,10 +9,9 @@ description: "EfficientNet-B0 is the baseline model of the EfficientNet family, 
 stats:
   gigaflops: 0.81
   trainable_parameters: 5.3
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 2
-    inference_speed: 2
+  benchmark_metrics:
+    imagenet_top1_accuracy: 77.1 # percentage
+    imagenet_top5_accuracy: 93.3 # percentage (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 0.81
   trainable_parameters: 5.3
   benchmark_metrics:
-    imagenet_top1_accuracy: 77.1 # percentage
-    imagenet_top5_accuracy: 93.3 # percentage (optional)
+    imagenet_top1_accuracy: 77.1
+    imagenet_top5_accuracy: 93.3
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
@@ -9,10 +9,9 @@ description: "EfficientNet-B3 is a scaled-up version of EfficientNet-B0, offerin
 stats:
   gigaflops: 1.92
   trainable_parameters: 12.0
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 2
-    inference_speed: 2
+  benchmark_metrics:
+    imagenet_top1_accuracy: 81.6 # percentage
+    imagenet_top5_accuracy: 95.7 # percentage (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 1.92
   trainable_parameters: 12.0
   benchmark_metrics:
-    imagenet_top1_accuracy: 81.6 # percentage
-    imagenet_top5_accuracy: 95.7 # percentage (optional)
+    imagenet_top1_accuracy: 81.6
+    imagenet_top5_accuracy: 95.7
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
@@ -10,7 +10,7 @@ stats:
   gigaflops: 5.76
   trainable_parameters: 22
   benchmark_metrics:
-    imagenet_top1_accuracy: 83.9 # percentage
+    imagenet_top1_accuracy: 83.9
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
@@ -9,10 +9,8 @@ description: "EfficientNetV2-Small is a compact and fast classification model th
 stats:
   gigaflops: 5.76
   trainable_parameters: 22
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 1
-    inference_speed: 1
+  benchmark_metrics:
+    imagenet_top1_accuracy: 83.9 # percentage
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
+++ b/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 0.44
   trainable_parameters: 5.4
   benchmark_metrics:
-    imagenet_top1_accuracy: 75.2 # percentage
-    imagenet_top5_accuracy: 91.3 # percentage (optional)
+    imagenet_top1_accuracy: 75.2
+    imagenet_top5_accuracy: 91.3
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
+++ b/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
@@ -9,10 +9,9 @@ description: "MobileNetV3-Large is a lightweight and efficient image classificat
 stats:
   gigaflops: 0.44
   trainable_parameters: 5.4
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    imagenet_top1_accuracy: 75.2 # percentage
+    imagenet_top5_accuracy: 91.3 # percentage (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
@@ -9,10 +9,9 @@ description: "ATSS (Adaptive Training Sample Selection) is an anchor-based objec
 stats:
   gigaflops: 20.6
   trainable_parameters: 3.9
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    coco_map_50_95: 31.5 # mAP at IoU=0.50:0.95
+    coco_map_50: 51.0 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 20.6
   trainable_parameters: 3.9
   benchmark_metrics:
-    coco_map_50_95: 31.5 # mAP at IoU=0.50:0.95
-    coco_map_50: 51.0 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 31.5
+    coco_map_50: 51.0
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_l.yaml
@@ -9,10 +9,9 @@ description: "DEIM is an advanced training framework designed to enhance the mat
 stats:
   gigaflops: 91
   trainable_parameters: 31
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 2
-    inference_speed: 2
+  benchmark_metrics:
+    coco_map_50_95: 54.0 # mAP at IoU=0.50:0.95
+    coco_map_50: 71.6 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_l.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 91
   trainable_parameters: 31
   benchmark_metrics:
-    coco_map_50_95: 54.0
-    coco_map_50: 71.6
+    coco_map_50_95: 54.7
+    coco_map_50: 72.4
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_l.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 91
   trainable_parameters: 31
   benchmark_metrics:
-    coco_map_50_95: 54.0 # mAP at IoU=0.50:0.95
-    coco_map_50: 71.6 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 54.0
+    coco_map_50: 71.6
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_m.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 57
   trainable_parameters: 19
   benchmark_metrics:
-    coco_map_50_95: 52.3 # mAP at IoU=0.50:0.95
-    coco_map_50: 69.8 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 52.3
+    coco_map_50: 69.8
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_m.yaml
@@ -10,8 +10,7 @@ stats:
   gigaflops: 57
   trainable_parameters: 19
   benchmark_metrics:
-    coco_map_50_95: 52.3
-    coco_map_50: 69.8
+    coco_map_50_95: 52.7
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_m.yaml
@@ -9,10 +9,9 @@ description: "DEIM is an advanced training framework designed to enhance the mat
 stats:
   gigaflops: 57
   trainable_parameters: 19
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 2
-    inference_speed: 2
+  benchmark_metrics:
+    coco_map_50_95: 52.3 # mAP at IoU=0.50:0.95
+    coco_map_50: 69.8 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_x.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 202
   trainable_parameters: 62
   benchmark_metrics:
-    coco_map_50_95: 55.8
-    coco_map_50: 73.7
+    coco_map_50_95: 56.5
+    coco_map_50: 74.0
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_x.yaml
@@ -9,10 +9,9 @@ description: "DEIM is an advanced training framework designed to enhance the mat
 stats:
   gigaflops: 202
   trainable_parameters: 62
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 1
-    inference_speed: 1
+  benchmark_metrics:
+    coco_map_50_95: 55.8 # mAP at IoU=0.50:0.95
+    coco_map_50: 73.7 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/deim_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_x.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 202
   trainable_parameters: 62
   benchmark_metrics:
-    coco_map_50_95: 55.8 # mAP at IoU=0.50:0.95
-    coco_map_50: 73.7 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 55.8
+    coco_map_50: 73.7
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
@@ -9,10 +9,9 @@ description: "D-FINE is a powerful real-time object detector that redefines the 
 stats:
   gigaflops: 202
   trainable_parameters: 240
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 1
-    inference_speed: 1
+  benchmark_metrics:
+    coco_map_50_95: 55.8 # mAP at IoU=0.50:0.95
+    coco_map_50: 73.7 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 202
   trainable_parameters: 240
   benchmark_metrics:
-    coco_map_50_95: 55.8 # mAP at IoU=0.50:0.95
-    coco_map_50: 73.7 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 55.8
+    coco_map_50: 73.7
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
@@ -9,10 +9,9 @@ description: "RT-DETR is a real-time object detection algorithm based on the tra
 stats:
   gigaflops: 136
   trainable_parameters: 42
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 1
-    inference_speed: 2
+  benchmark_metrics:
+    coco_map_50_95: 53.1 # mAP at IoU=0.50:0.95
+    coco_map_50: 71.3 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 136
   trainable_parameters: 42
   benchmark_metrics:
-    coco_map_50_95: 53.1 # mAP at IoU=0.50:0.95
-    coco_map_50: 71.3 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 53.1
+    coco_map_50: 71.3
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 9.4
   trainable_parameters: 7.6
   benchmark_metrics:
-    coco_map_50_95: 21.9 # mAP at IoU=0.50:0.95
-    coco_map_50: 35.1 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 21.9
+    coco_map_50: 35.1
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
@@ -9,10 +9,9 @@ description: "SSD (Single Shot MultiBox Detector) is a real-time, anchor-based o
 stats:
   gigaflops: 9.4
   trainable_parameters: 7.6
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 1
-    training_time: 2
-    inference_speed: 3
+  benchmark_metrics:
+    coco_map_50_95: 21.9 # mAP at IoU=0.50:0.95
+    coco_map_50: 35.1 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
@@ -9,10 +9,9 @@ description: "YOLOX is a high-performance, anchor-free object detection algorith
 stats:
   gigaflops: 155.6
   trainable_parameters: 54.2
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 3
-    inference_speed: 2
+  benchmark_metrics:
+    coco_map_50_95: 50.2 # mAP at IoU=0.50:0.95
+    coco_map_50: 68.5 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 155.6
   trainable_parameters: 54.2
   benchmark_metrics:
-    coco_map_50_95: 50.2 # mAP at IoU=0.50:0.95
-    coco_map_50: 68.5 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 50.2
+    coco_map_50: 68.5
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
@@ -9,10 +9,8 @@ description: "YOLOX is a high-performance, anchor-free object detection algorith
 stats:
   gigaflops: 26.8
   trainable_parameters: 9.0
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    coco_map_50_95: 40.5 # mAP at IoU=0.50:0.95
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
@@ -10,7 +10,7 @@ stats:
   gigaflops: 26.8
   trainable_parameters: 9.0
   benchmark_metrics:
-    coco_map_50_95: 40.5 # mAP at IoU=0.50:0.95
+    coco_map_50_95: 40.5
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
@@ -10,7 +10,7 @@ stats:
   gigaflops: 6.45
   trainable_parameters: 5.06
   benchmark_metrics:
-    coco_map_50_95: 32.8 # mAP at IoU=0.50:0.95
+    coco_map_50_95: 32.8
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
@@ -9,10 +9,8 @@ description: "YOLOX is a high-performance, anchor-free object detection algorith
 stats:
   gigaflops: 6.45
   trainable_parameters: 5.06
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 1
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    coco_map_50_95: 32.8 # mAP at IoU=0.50:0.95
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 281.9
   trainable_parameters: 99.1
   benchmark_metrics:
-    coco_map_50_95: 51.5 # mAP at IoU=0.50:0.95
-    coco_map_50: 69.6 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 51.5
+    coco_map_50: 69.6
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
@@ -9,10 +9,9 @@ description: "YOLOX is a high-performance, anchor-free object detection algorith
 stats:
   gigaflops: 281.9
   trainable_parameters: 99.1
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 2
-    inference_speed: 1
+  benchmark_metrics:
+    coco_map_50_95: 51.5 # mAP at IoU=0.50:0.95
+    coco_map_50: 69.6 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
@@ -10,7 +10,7 @@ stats:
   gigaflops: 68.48
   trainable_parameters: 12.9
   benchmark_metrics:
-    coco_map_50_95: 31.2 # mAP at IoU=0.50:0.95
+    coco_map_50_95: 31.2
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
@@ -9,10 +9,8 @@ description: "This model integrates Mask R-CNN with an EfficientNet-B2B backbone
 stats:
   gigaflops: 68.48
   trainable_parameters: 12.9
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    coco_map_50_95: 31.2 # mAP at IoU=0.50:0.95
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
@@ -9,10 +9,9 @@ description: "Mask R-CNN with a ResNet-50 backbone is a widely used instance seg
 stats:
   gigaflops: 200.0
   trainable_parameters: 45.9
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 2
-    training_time: 2
-    inference_speed: 2
+  benchmark_metrics:
+    coco_map_50_95: 32.0 # mAP at IoU=0.50:0.95
+    coco_map_50: 58.1 # mAP at IoU=0.50 (optional)
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
@@ -10,8 +10,8 @@ stats:
   gigaflops: 200.0
   trainable_parameters: 45.9
   benchmark_metrics:
-    coco_map_50_95: 32.0 # mAP at IoU=0.50:0.95
-    coco_map_50: 58.1 # mAP at IoU=0.50 (optional)
+    coco_map_50_95: 32.0
+    coco_map_50: 58.1
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
@@ -9,10 +9,8 @@ description: "This model combines the Mask R-CNN framework with a Swin-Tiny tran
 stats:
   gigaflops: 264.0
   trainable_parameters: 47.4
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 3
-    training_time: 1
-    inference_speed: 1
+  benchmark_metrics:
+    coco_map_50_95: 39.6 # mAP at IoU=0.50:0.95
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
@@ -10,7 +10,7 @@ stats:
   gigaflops: 264.0
   trainable_parameters: 47.4
   benchmark_metrics:
-    coco_map_50_95: 39.6 # mAP at IoU=0.50:0.95
+    coco_map_50_95: 39.6
 
 hyperparameters:
   training:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -9,10 +9,8 @@ description: "RTMDet for instance segmentation extends the real-time object dete
 stats:
   gigaflops: 11.8
   trainable_parameters: 5.6
-  performance_ratings: # scores range from 1 (below average) to 3 (excellent)
-    accuracy: 1
-    training_time: 3
-    inference_speed: 3
+  benchmark_metrics:
+    coco_map_50_95: 35.4 # mAP at IoU=0.50:0.95
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -10,7 +10,7 @@ stats:
   gigaflops: 11.8
   trainable_parameters: 5.6
   benchmark_metrics:
-    coco_map_50_95: 35.4 # mAP at IoU=0.50:0.95
+    coco_map_50_95: 35.4
 
 hyperparameters:
   dataset_preparation:

--- a/application/backend/tests/integration/services/dummy_model_manifest.yaml
+++ b/application/backend/tests/integration/services/dummy_model_manifest.yaml
@@ -8,10 +8,9 @@ task: classification
 stats:
   gigaflops: 0.39
   trainable_parameters: 5288548
-  performance_ratings:
-    accuracy: 1
-    training_time: 2
-    inference_speed: 3
+  benchmark_metrics:
+    imagenet_top1_accuracy: 76.2
+    imagenet_top5_accuracy: 95.3
 
 support_status: obsolete
 

--- a/application/backend/tests/integration/services/test_model_manifest_service.py
+++ b/application/backend/tests/integration/services/test_model_manifest_service.py
@@ -108,10 +108,7 @@ class TestModelManifestService:
             "stats": {
                 "gigaflops": 1.0,
                 "trainable_parameters": 1000,
-                "benchmark_metrics": {
-                    "imagenet_top1_accuracy": 76.2,
-                    "imagenet_top5_accuracy": 95.3,
-                },
+                "benchmark_metrics": {"coco_map_50_95": 54.0, "coco_map_50": 71.6},
             },
             "support_status": "active",
             "hyperparameters": {

--- a/application/backend/tests/integration/services/test_model_manifest_service.py
+++ b/application/backend/tests/integration/services/test_model_manifest_service.py
@@ -11,11 +11,11 @@ import pytest
 
 from app.models import TaskType
 from app.models.model_manifest import (
+    BenchmarkMetrics,
     Capabilities,
     ModelManifest,
     ModelManifestDeprecationStatus,
     ModelStats,
-    PerformanceRatings,
     PretrainedWeights,
 )
 from app.models.training_configuration import (
@@ -38,10 +38,9 @@ def fxt_dummy_model_stats():
     yield ModelStats(
         gigaflops=0.39,
         trainable_parameters=5288548,
-        performance_ratings=PerformanceRatings(
-            accuracy=1,
-            training_time=2,
-            inference_speed=3,
+        benchmark_metrics=BenchmarkMetrics(
+            imagenet_top1_accuracy=76.2,
+            imagenet_top5_accuracy=95.3,
         ),
     )
 
@@ -109,10 +108,9 @@ class TestModelManifestService:
             "stats": {
                 "gigaflops": 1.0,
                 "trainable_parameters": 1000,
-                "performance_ratings": {
-                    "accuracy": 1,
-                    "training_time": 2,
-                    "inference_speed": 3,
+                "benchmark_metrics": {
+                    "imagenet_top1_accuracy": 76.2,
+                    "imagenet_top5_accuracy": 95.3,
                 },
             },
             "support_status": "active",

--- a/application/backend/tests/unit/api/routers/test_model_architectures.py
+++ b/application/backend/tests/unit/api/routers/test_model_architectures.py
@@ -45,7 +45,7 @@ class TestModelArchitecturesEndpoint:
         assert "stats" in detection_model
         assert detection_model["stats"]["gigaflops"] == 20.6
         assert detection_model["stats"]["trainable_parameters"] == 3.9
-        assert "performance_ratings" in detection_model["stats"]
+        assert "benchmark_metrics" in detection_model["stats"]
 
         # Verify top picks
         assert "top_picks" in data

--- a/application/ui/mocks/mock-model.ts
+++ b/application/ui/mocks/mock-model.ts
@@ -42,10 +42,11 @@ export const getMockedModelArchitecture = (
     stats: {
         gigaflops: 91,
         trainable_parameters: 31,
-        performance_ratings: {
-            accuracy: 2,
-            training_time: 2,
-            inference_speed: 2,
+        benchmark_metrics: {
+            imagenet_top1_accuracy: 2,
+            imagenet_top5_accuracy: 5,
+            coco_map_50_95: 2,
+            coco_map_50: 2,
         },
     },
     support_status: 'active',

--- a/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
+++ b/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
@@ -20,15 +20,17 @@ type SortingHandler = (
     modelArchitectures: ModelArchitectureWithPerformanceCategory[]
 ) => ModelArchitectureWithPerformanceCategory[];
 
+const getAccuracyMetricBasedOnTask = ({
+    stats: { benchmark_metrics: benchmarkMetrics },
+}: ModelArchitectureWithPerformanceCategory) => {
+    return benchmarkMetrics.imagenet_top1_accuracy ?? benchmarkMetrics.coco_map_50_95 ?? benchmarkMetrics.coco_map_50;
+};
+
 export const SORTING_HANDLERS: Record<SortingOptions, SortingHandler> = {
     [SortingOptions.ACCURACY_ASC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats.performance_ratings.accuracy, 'asc'),
+        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'asc'),
     [SortingOptions.ACCURACY_DESC]: (modelArchitectures) =>
-        orderBy(
-            modelArchitectures,
-            (modelArchitecture) => modelArchitecture.stats.performance_ratings.accuracy,
-            'desc'
-        ),
+        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'desc'),
     [SortingOptions.NAME_ASC]: (modelArchitectures) =>
         orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'asc'),
     [SortingOptions.NAME_DESC]: (modelArchitectures) =>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add benchmark metrics to model manifests: top 1 and top 5 accuracy on imagenet for classificaiton and mAP@0.5 and mAP@0.5;0.95 for detection and segmentation.
Remove subjective performance ratings from the model manifest 

Resolves #5676 

### How to test

Adjusted tests to new layout

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
