### PR TITLE
Add more training parameters

### DIFF
--- a/application/backend/app/api/schemas/training_configuration.py
+++ b/application/backend/app/api/schemas/training_configuration.py
@@ -2,7 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 from enum import StrEnum
-from typing import Annotated, Literal, Union, cast
+from typing import Annotated, Literal, Union, cast, get_args, get_origin
 
 from pydantic import BaseModel, Discriminator, Field, Tag
 from pydantic.fields import FieldInfo
@@ -22,6 +22,15 @@ class _BaseConfigurableParameterView(BaseModel):
     key: str = Field(title="Key to identify the parameter")
     name: str = Field(title="User-friendly name of the parameter")
     description: str = Field(title="Extended description of the parameter", default="")
+    depends_on: dict[str, str] | None = Field(
+        default=None,
+        title="Dependency condition",
+        description=(
+            "If set, this parameter is only applicable when the specified sibling parameter has the given value. "
+            "For example, {'type': 'cosine_annealing'} means this parameter only applies when the 'type' "
+            "parameter in the same group is set to 'cosine_annealing'."
+        ),
+    )
 
 
 class BoolParameterView(_BaseConfigurableParameterView):
@@ -126,6 +135,16 @@ class TrainingConfigurationView(BaseModel):
     )
 
     @classmethod
+    def _get_literal_strenum_class(cls, annotation: type) -> type[StrEnum] | None:
+        """If annotation is Literal[<StrEnum member>, ...], return the StrEnum class. Otherwise return None."""
+        if get_origin(annotation) is not Literal:
+            return None
+        args = get_args(annotation)
+        if args and isinstance(args[0], StrEnum):
+            return type(args[0])
+        return None
+
+    @classmethod
     def _extract_constraints(cls, field_info: FieldInfo) -> tuple[float | None, float | None]:
         """Extract min/max constraints from field metadata."""
         min_value = None
@@ -145,14 +164,12 @@ class TrainingConfigurationView(BaseModel):
         return min_value, max_value
 
     @classmethod
-    def _get_value_type(cls, field_info: FieldInfo) -> Literal["bool", "int", "float", "str", "float_range"]:
+    def _get_value_type(cls, field_info: FieldInfo) -> Literal["bool", "int", "float", "str", "float_range"]:  # noqa: C901, PLR0911
         """Determine the value type from field annotation."""
         annotation = field_info.annotation
 
         # Handle Optional/Union types by extracting the non-None type
         if hasattr(annotation, "__origin__"):
-            from typing import get_args, get_origin
-
             origin = get_origin(annotation)
             if origin is Union:
                 args = [arg for arg in get_args(annotation) if arg is not type(None)]
@@ -160,11 +177,19 @@ class TrainingConfigurationView(BaseModel):
                     annotation = args[0]
                     origin = get_origin(annotation)
 
+            # Detect Literal[StrEnum member] -> treat as str
+            if cls._get_literal_strenum_class(annotation) is not None:  # pyrefly: ignore[bad-argument-type]
+                return "str"
+
             # Detect tuple[float, float]
             if origin is tuple:
                 args = get_args(annotation)
                 if len(args) == 2 and all(a is float for a in args):
                     return "float_range"
+
+        # Check if annotation is a StrEnum subclass -> treat as str
+        if isinstance(annotation, type) and issubclass(annotation, StrEnum):
+            return "str"
 
         # Map Python types to string representations
         if annotation is bool:
@@ -179,6 +204,15 @@ class TrainingConfigurationView(BaseModel):
         return "str"
 
     @classmethod
+    def _extract_depends_on(cls, field_info: FieldInfo) -> dict[str, str] | None:
+        """Extract depends_on condition from field's json_schema_extra."""
+        if isinstance(field_info.json_schema_extra, dict):
+            depends_on = field_info.json_schema_extra.get("depends_on")
+            if isinstance(depends_on, dict):
+                return depends_on  # pyrefly: ignore[bad-return]
+        return None
+
+    @classmethod
     def _field_to_configurable_parameter(
         cls,
         key: str,
@@ -190,18 +224,48 @@ class TrainingConfigurationView(BaseModel):
         """Convert a single field to the appropriate ConfigurableParameterView variant."""
         value_type = cls._get_value_type(field_info)
 
-        if field_info.title is None:
+        # For StrEnum fields, derive title and description from the enum class
+        annotation = field_info.annotation
+        enum_class = None
+
+        # Check Literal[StrEnum member]
+        if annotation is not None:
+            enum_class = cls._get_literal_strenum_class(annotation)
+
+        # Check plain StrEnum subclass
+        if enum_class is None and isinstance(annotation, type) and issubclass(annotation, StrEnum):
+            enum_class = annotation
+
+        if enum_class is not None:
+            # Try to get title/description from enum member instance
+            literal_args = get_args(annotation) if get_origin(annotation) is Literal else None
+            if literal_args and isinstance(literal_args[0], StrEnum):
+                member = literal_args[0]
+                title = getattr(member, "title", None) or field_info.title
+                description = getattr(member, "description", None) or field_info.description or ""
+            else:
+                # Plain StrEnum annotation — try class-level attributes or field info
+                title = field_info.title
+                description = field_info.description or ""
+        else:
+            title = field_info.title
+            description = field_info.description or ""
+
+        if title is None:
             raise ValueError(
                 f"Field '{key}' is missing a title in its FieldInfo, "
                 f"which is required to associate a user-friendly name to the parameter."
             )
 
+        depends_on = cls._extract_depends_on(field_info)
+
         common_kwargs = {
             "key": key,
-            "name": field_info.title,
-            "description": field_info.description or "",
+            "name": title,
+            "description": description,
             "value": value,
             "default_value": default_value,
+            "depends_on": depends_on,
         }
 
         if value_type == "int":
@@ -237,11 +301,18 @@ class TrainingConfigurationView(BaseModel):
             if allowed_values_from is not None:
                 allowed_values = getattr(model, allowed_values_from, None)
 
-        # Check if annotation is a StrEnum subclass
         if allowed_values is None:
             annotation = field_info.annotation
+
+            # Check if annotation is a plain StrEnum subclass
             if isinstance(annotation, type) and issubclass(annotation, StrEnum):
                 allowed_values = [member.value for member in annotation]
+
+            # Check if annotation is Literal[<StrEnum member>, ...]
+            elif annotation is not None:
+                enum_class = cls._get_literal_strenum_class(annotation)
+                if enum_class is not None:
+                    allowed_values = [member.value for member in enum_class]
 
         return allowed_values
 
@@ -278,7 +349,7 @@ class TrainingConfigurationView(BaseModel):
 
                 # Get the default value from the default model, falling back to field_info.default
                 if default_model is not None:
-                    default_value = getattr(default_model, field_name)
+                    default_value = getattr(default_model, field_name, child_field_info.default)
                 else:
                     default_value = child_field_info.default
 

--- a/application/backend/app/models/training_configuration/training.py
+++ b/application/backend/app/models/training_configuration/training.py
@@ -27,17 +27,17 @@ class SchedulerType(StrEnum):
     COSINE_ANNEALING = "cosine_annealing"
 
 
-class LearningRateWarmupParameters(BaseModel):
+class LrLinearWarmupParameters(BaseModel):
     enable: bool = Field(
         default=False,
         title="Enable",
-        description="Toggle to enable or disable a warmup phase at the beginning of training.",
+        description="Toggle to enable or disable the LR linear warmup phase at the beginning of training.",
     )
     epochs: int = Field(
         default=5,
         ge=1,
         title="Warmup epochs",
-        description="Number of epochs for the warmup phase.",
+        description="Number of epochs for the LR linear warmup phase.",
     )
 
 
@@ -52,9 +52,9 @@ class SchedulerParameters(BaseModel):
             "gradually decreasing over the course of training."
         ),
     )
-    warmup: LearningRateWarmupParameters = Field(
-        default_factory=LearningRateWarmupParameters,
-        title="Learning rate warmup",
+    warmup: LrLinearWarmupParameters = Field(
+        default_factory=LrLinearWarmupParameters,
+        title="Learning rate linear warmup",
         description=(
             "Learning rate warmup is a technique where the learning rate starts at a lower value and gradually "
             "increases to the initial learning rate over a specified number of epochs at the beginning of training. "
@@ -94,8 +94,11 @@ class GradientAccumulationParameters(BaseModel):
     batches: int = Field(
         ge=1,
         default=1,
-        title="Accumulation batches",
-        description="Number of batches to accumulate gradients before performing a weight update.",
+        title="Gradient accumulation batches",
+        description=(
+            "Number of steps (batches) to accumulate gradients before performing gradient descent step. "
+            "Effective batch size during training: batch_size * accumulate_grad_batches."
+        ),
     )
 
 
@@ -108,8 +111,8 @@ class GradientClipParameters(BaseModel):
     max_grad_norm: float = Field(
         gt=0,
         default=1.0,
-        title="Maximum gradient norm",
-        description="Maximum norm of the gradients. Gradients with norm larger than this value will be clipped.",
+        title="Maximum gradient L2 norm",
+        description="Maximum L2 norm of the gradients. Gradients with norm larger than this value will be clipped.",
     )
 
 
@@ -131,7 +134,8 @@ class AlgoLevelTrainingParameters(BaseModel):
         description=(
             "Number of training samples processed before the model's internal parameters are updated. "
             "A larger batch size can speed up training but may require more memory, while a smaller batch size "
-            "can lead to more stable convergence but may take longer to train."
+            "can help avoid OOM (Out of Memory) errors at the cost of longer training times and potentially noisier "
+            "gradient estimates."
         ),
     )
     early_stopping: EarlyStopping = Field(
@@ -159,7 +163,8 @@ class AlgoLevelTrainingParameters(BaseModel):
         title="Weight decay",
         description=(
             "Weight decay is a regularization technique that adds a penalty to the loss function based on the "
-            "magnitude of the model weights. It helps prevent overfitting by discouraging large weight values."
+            "squared magnitude of the model weights (L2 regularization). "
+            "It helps prevent overfitting by discouraging large weight values."
         ),
     )
     scheduler: SchedulerParameters = Field(

--- a/application/backend/app/models/training_configuration/training.py
+++ b/application/backend/app/models/training_configuration/training.py
@@ -94,8 +94,8 @@ class GradientAccumulationParameters(BaseModel):
     batches: int = Field(
         ge=1,
         default=1,
-        title="Accumulation steps",
-        description="Number of steps to accumulate gradients before performing a weight update.",
+        title="Accumulation batches",
+        description="Number of batches to accumulate gradients before performing a weight update.",
     )
 
 

--- a/application/backend/app/models/training_configuration/training.py
+++ b/application/backend/app/models/training_configuration/training.py
@@ -1,20 +1,115 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import StrEnum
+
 from pydantic import BaseModel, Field, model_validator
 
 
 class EarlyStopping(BaseModel):
     enable: bool = Field(
         default=False,
-        title="Toggle early stopping",
-        description="Whether to stop training early when performance stops improving",
+        title="Enable",
+        description="Toggle to enable or disable early stopping during training.",
     )
     patience: int = Field(
-        gt=0,
+        ge=1,
         default=1,
         title="Patience",
-        description="Number of epochs with no improvement after which training will be stopped",
+        description="Number of epochs with no improvement after which training will be stopped.",
+    )
+
+
+class SchedulerType(StrEnum):
+    """Learning rate scheduler type"""
+
+    REDUCE_LR_ON_PLATEAU = "reduce_lr_on_plateau"
+    COSINE_ANNEALING = "cosine_annealing"
+
+
+class LearningRateWarmupParameters(BaseModel):
+    enable: bool = Field(
+        default=False,
+        title="Enable",
+        description="Toggle to enable or disable a warmup phase at the beginning of training.",
+    )
+    epochs: int = Field(
+        default=5,
+        ge=1,
+        title="Warmup epochs",
+        description="Number of epochs for the warmup phase.",
+    )
+
+
+class SchedulerParameters(BaseModel):
+    type: SchedulerType = Field(
+        default=SchedulerType.REDUCE_LR_ON_PLATEAU,
+        title="Scheduler type",
+        description=(
+            "Type of learning rate scheduler to use during training. "
+            "With ReduceLROnPlateau, the learning rate will be reduced by a predetermined factor when the validation "
+            "metric stops improving. With CosineAnnealing, the learning rate will follow a cosine decay schedule, "
+            "gradually decreasing over the course of training."
+        ),
+    )
+    warmup: LearningRateWarmupParameters = Field(
+        default_factory=LearningRateWarmupParameters,
+        title="Learning rate warmup",
+        description=(
+            "Learning rate warmup is a technique where the learning rate starts at a lower value and gradually "
+            "increases to the initial learning rate over a specified number of epochs at the beginning of training. "
+            "This can help stabilize training and improve convergence, especially when using large learning rates "
+            "or training on complex datasets."
+        ),
+    )
+    factor: float = Field(
+        default=0.5,
+        gt=0,
+        lt=1,
+        title="Factor",
+        description="Factor by which the learning rate will be reduced. new_lr = lr * factor.",
+        json_schema_extra={"depends_on": {"type": "reduce_lr_on_plateau"}},
+    )
+    patience: int = Field(
+        default=5,
+        ge=1,
+        title="Patience",
+        description="Number of epochs with no improvement after which learning rate will be reduced.",
+        json_schema_extra={"depends_on": {"type": "reduce_lr_on_plateau"}},
+    )
+    min_lr: float = Field(
+        default=0,
+        ge=0,
+        lt=1,
+        title="Minimum learning rate",
+        description="Minimum learning rate after annealing.",
+        json_schema_extra={"depends_on": {"type": "cosine_annealing"}},
+    )
+
+
+class GradientAccumulationParameters(BaseModel):
+    enable: bool = Field(
+        default=False, title="Enable", description="Toggle to enable or disable gradient accumulation during training."
+    )
+    batches: int = Field(
+        ge=1,
+        default=1,
+        title="Accumulation steps",
+        description="Number of steps to accumulate gradients before performing a weight update.",
+    )
+
+
+class GradientClipParameters(BaseModel):
+    enable: bool = Field(
+        default=False,
+        title="Enable",
+        description="Toggle to enable or disable gradient clipping during training.",
+    )
+    max_grad_norm: float = Field(
+        gt=0,
+        default=1.0,
+        title="Maximum gradient norm",
+        description="Maximum norm of the gradients. Gradients with norm larger than this value will be clipped.",
     )
 
 
@@ -22,11 +117,21 @@ class AlgoLevelTrainingParameters(BaseModel):
     """Hyperparameters for model training process."""
 
     max_epochs: int = Field(
-        gt=0,
+        ge=1,
         default=200,
         title="Maximum epochs",
         description=(
             "Maximum number of epochs to train the model. An epoch is one complete pass through the training dataset."
+        ),
+    )
+    batch_size: int = Field(
+        ge=1,
+        default=4,
+        title="Batch size",
+        description=(
+            "Number of training samples processed before the model's internal parameters are updated. "
+            "A larger batch size can speed up training but may require more memory, while a smaller batch size "
+            "can lead to more stable convergence but may take longer to train."
         ),
     )
     early_stopping: EarlyStopping = Field(
@@ -45,6 +150,39 @@ class AlgoLevelTrainingParameters(BaseModel):
             "Learning rate for the optimizer, controlling the step size during model weight updates. "
             "A smaller learning rate may lead to more stable convergence, while a larger learning rate may speed up "
             "training but risk overshooting minima in the loss landscape."
+        ),
+    )
+    weight_decay: float = Field(
+        ge=0,
+        lt=1,
+        default=1e-4,
+        title="Weight decay",
+        description=(
+            "Weight decay is a regularization technique that adds a penalty to the loss function based on the "
+            "magnitude of the model weights. It helps prevent overfitting by discouraging large weight values."
+        ),
+    )
+    scheduler: SchedulerParameters = Field(
+        default_factory=SchedulerParameters,
+        title="Learning rate scheduler",
+        description=(
+            "The learning rate scheduler adjusts the learning rate during training according to a predefined schedule "
+            "or based on validation performance, helping to improve convergence and training stability."
+        ),
+    )
+    gradient_accumulation: GradientAccumulationParameters = Field(
+        default_factory=GradientAccumulationParameters,
+        title="Gradient accumulation",
+        description=(
+            "Gradient accumulation allows simulating larger batch sizes by accumulating gradients "
+            "over multiple forward/backward passes before updating the model weights."
+        ),
+    )
+    gradient_clip: GradientClipParameters = Field(
+        default_factory=GradientClipParameters,
+        title="Gradient clipping",
+        description=(
+            "Gradient clipping prevents exploding gradients by capping gradient norms during backpropagation."
         ),
     )
     input_size_width: int = Field(

--- a/application/backend/app/supported_models/manifests/classification/base.yaml
+++ b/application/backend/app/supported_models/manifests/classification/base.yaml
@@ -56,9 +56,20 @@ hyperparameters:
     metric: accuracy
   training:
     max_epochs: 100
+    batch_size: 64
     early_stopping:
       enable: true
       patience: 7
+    scheduler:
+      type: reduce_lr_on_plateau
+      factor: 0.5
+      patience: 3
+      warmup:
+        enable: false
+    gradient_clip:
+      enable: false
+    gradient_accumulation:
+      enable: false
     allowed_values_input_size:
       - 64
       - 128

--- a/application/backend/app/supported_models/manifests/classification/deit_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/classification/deit_tiny.yaml
@@ -17,3 +17,4 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0001
+    weight_decay: 0.05

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
@@ -17,3 +17,4 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0049
+    weight_decay: 0.0001

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
@@ -16,5 +16,9 @@ stats:
 
 hyperparameters:
   training:
-    learning_rate: 0.01
     max_epochs: 90
+    learning_rate: 0.01
+    weight_decay: 0.0001
+    scheduler:
+      type: cosine_annealing
+      min_lr: 0

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
@@ -17,3 +17,4 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0071
+    weight_decay: 0.0001

--- a/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
+++ b/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
@@ -17,3 +17,8 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0058
+    weight_decay: 0.0001
+    scheduler:
+      warmup:
+        enable: true
+        epochs: 10

--- a/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
@@ -17,3 +17,10 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.004
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+    gradient_clip:
+      enable: true
+      max_grad_norm: 35.0

--- a/application/backend/app/supported_models/manifests/detection/base.yaml
+++ b/application/backend/app/supported_models/manifests/detection/base.yaml
@@ -56,10 +56,18 @@ hyperparameters:
   evaluation:
     metric: f_measure
   training:
-    max_epochs: 200
+    batch_size: 8
     early_stopping:
       enable: true
       patience: 10
+    scheduler:
+      type: reduce_lr_on_plateau
+      warmup:
+        enable: false
+    gradient_clip:
+      enable: false
+    gradient_accumulation:
+      enable: false
     allowed_values_input_size:
       - 128
       - 256

--- a/application/backend/app/supported_models/manifests/detection/deim_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_l.yaml
@@ -17,6 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0005
+    weight_decay: 0.000125
+    scheduler:
+      factor: 0.5
+      patience: 10
+      warmup:
+        enable: true
+        epochs: 30
     allowed_values_input_size:
       - 640
     input_size_width: 640

--- a/application/backend/app/supported_models/manifests/detection/deim_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_m.yaml
@@ -17,6 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0004
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.5
+      patience: 15
+      warmup:
+        enable: true
+        epochs: 30
     allowed_values_input_size:
       - 640
     input_size_width: 640

--- a/application/backend/app/supported_models/manifests/detection/deim_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/deim_x.yaml
@@ -17,6 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0005
+    weight_decay: 0.000125
+    scheduler:
+      factor: 0.5
+      patience: 6
+      warmup:
+        enable: true
+        epochs: 30
     allowed_values_input_size:
       - 640
     input_size_width: 640

--- a/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
@@ -17,6 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.00025
+    weight_decay: 0.000125
+    scheduler:
+      factor: 0.1
+      patience: 6
+      warmup:
+        enable: true
+        epochs: 100
     input_size_width: 640
     input_size_height: 640
   dataset_preparation:

--- a/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
@@ -17,5 +17,12 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0001
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 6
+      warmup:
+        enable: true
+        epochs: 100
     input_size_width: 640
     input_size_height: 640

--- a/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
@@ -17,6 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.01
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+    gradient_clip:
+      enable: true
+      max_grad_norm: 35.0
     allowed_values_input_size:
       - 128
       - 256

--- a/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
@@ -72,5 +72,12 @@ hyperparameters:
         probability: 0.5
   training:
     learning_rate: 0.001
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+    gradient_clip:
+      enable: true
+      max_grad_norm: 35.0
     input_size_width: 640
     input_size_height: 640

--- a/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
@@ -72,5 +72,12 @@ hyperparameters:
         probability: 0.5
   training:
     learning_rate: 0.001
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+    gradient_clip:
+      enable: true
+      max_grad_norm: 35.0
     input_size_width: 640
     input_size_height: 640

--- a/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
@@ -17,6 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0002
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+    gradient_clip:
+      enable: true
+      max_grad_norm: 35.0
     allowed_values_input_size:
       - 128
       - 256

--- a/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
@@ -72,5 +72,12 @@ hyperparameters:
         probability: 0.5
   training:
     learning_rate: 0.001
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+    gradient_clip:
+      enable: true
+      max_grad_norm: 35.0
     input_size_width: 640
     input_size_height: 640

--- a/application/backend/app/supported_models/manifests/instance_segmentation/base.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/base.yaml
@@ -54,10 +54,18 @@ hyperparameters:
   evaluation:
     metric: dice
   training:
-    max_epochs: 200
+    batch_size: 4
     early_stopping:
       enable: true
       patience: 10
+    scheduler:
+      type: reduce_lr_on_plateau
+      warmup:
+        enable: false
+    gradient_clip:
+      enable: false
+    gradient_accumulation:
+      enable: false
     allowed_values_input_size:
       - 512
       - 640

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
@@ -17,3 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.007
+    weight_decay: 0.001
+    scheduler:
+      factor: 0.1
+      patience: 4
+      warmup:
+        enable: true
+        epochs: 100
+    gradient_clip:
+      enable: true
+      max_grad_norm: 0.1

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
@@ -17,3 +17,13 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.007
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 4
+      warmup:
+        enable: true
+        epochs: 100
+    gradient_clip:
+      enable: true
+      max_grad_norm: 0.1

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
@@ -17,5 +17,12 @@ stats:
 hyperparameters:
   training:
     learning_rate: 0.0001
+    weight_decay: 0.05
+    scheduler:
+      factor: 0.1
+      patience: 4
+      warmup:
+        enable: true
+        epochs: 100
     input_size_width: 1344
     input_size_height: 1344

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -79,6 +79,6 @@ hyperparameters:
         epochs: 20
     gradient_clip:
       enable: true
-      max_grad_norm: 0.1
+      max_grad_norm: 35.0
     input_size_width: 640
     input_size_height: 640

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -70,5 +70,15 @@ hyperparameters:
         probability: 0.5
   training:
     learning_rate: 0.001
+    weight_decay: 0.0001
+    scheduler:
+      factor: 0.1
+      patience: 9
+      warmup:
+        enable: true
+        epochs: 20
+    gradient_clip:
+      enable: true
+      max_grad_norm: 0.1
     input_size_width: 640
     input_size_height: 640

--- a/application/backend/tests/unit/api/schemas/test_training_configuration_view.py
+++ b/application/backend/tests/unit/api/schemas/test_training_configuration_view.py
@@ -19,7 +19,14 @@ from app.models.training_configuration.dataset_preparation import (
     MinAnnotationPixels,
     SubsetSplit,
 )
-from app.models.training_configuration.training import EarlyStopping
+from app.models.training_configuration.training import (
+    EarlyStopping,
+    GradientAccumulationParameters,
+    GradientClipParameters,
+    LearningRateWarmupParameters,
+    SchedulerParameters,
+    SchedulerType,
+)
 
 
 @pytest.fixture
@@ -51,8 +58,19 @@ def fxt_training_configuration() -> TrainingConfiguration:
             ),
             training=AlgoLevelTrainingParameters(
                 max_epochs=120,
+                batch_size=8,
                 early_stopping=EarlyStopping(enable=True, patience=5),
                 learning_rate=0.001,
+                weight_decay=0.01,
+                scheduler=SchedulerParameters(
+                    type=SchedulerType.COSINE_ANNEALING,
+                    warmup=LearningRateWarmupParameters(enable=True, epochs=3),
+                    factor=0.5,
+                    patience=7,
+                    min_lr=1e-5,
+                ),
+                gradient_accumulation=GradientAccumulationParameters(enable=True, steps=4),
+                gradient_clip=GradientClipParameters(enable=True, max_grad_norm=2.0),
                 input_size_width=256,
                 input_size_height=256,
                 allowed_values_input_size=[128, 256, 512],
@@ -81,8 +99,19 @@ def fxt_default_training_configuration() -> TrainingConfiguration:
             ),
             training=AlgoLevelTrainingParameters(
                 max_epochs=250,
+                batch_size=4,
                 early_stopping=EarlyStopping(enable=False, patience=1),
                 learning_rate=0.0015,
+                weight_decay=1e-4,
+                scheduler=SchedulerParameters(
+                    type=SchedulerType.REDUCE_LR_ON_PLATEAU,
+                    warmup=LearningRateWarmupParameters(enable=False, epochs=5),
+                    factor=0.1,
+                    patience=10,
+                    min_lr=1e-6,
+                ),
+                gradient_accumulation=GradientAccumulationParameters(enable=False, steps=1),
+                gradient_clip=GradientClipParameters(enable=False, max_grad_norm=1.0),
                 input_size_width=512,
                 input_size_height=512,
                 allowed_values_input_size=[128, 256, 512],
@@ -126,6 +155,7 @@ def fxt_training_configuration_view_json() -> dict:
                                 "min_value": 1,
                                 "max_value": 100,
                                 "allowed_values": None,
+                                "depends_on": None,
                             },
                             {
                                 "type": "parameter",
@@ -138,6 +168,7 @@ def fxt_training_configuration_view_json() -> dict:
                                 "min_value": 1,
                                 "max_value": 100,
                                 "allowed_values": None,
+                                "depends_on": None,
                             },
                             {
                                 "type": "parameter",
@@ -150,6 +181,7 @@ def fxt_training_configuration_view_json() -> dict:
                                 "min_value": 1,
                                 "max_value": 100,
                                 "allowed_values": None,
+                                "depends_on": None,
                             },
                         ],
                     },
@@ -177,6 +209,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": True,
                                         "default_value": False,
                                         "value_type": "bool",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -189,6 +222,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "min_value": 0,
                                         "max_value": 200000000,
                                         "allowed_values": None,
+                                        "depends_on": None,
                                     },
                                 ],
                             },
@@ -206,6 +240,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": False,
                                         "default_value": False,
                                         "value_type": "bool",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -218,6 +253,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "min_value": 0,
                                         "max_value": None,
                                         "allowed_values": None,
+                                        "depends_on": None,
                                     },
                                 ],
                             },
@@ -235,6 +271,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": False,
                                         "default_value": False,
                                         "value_type": "bool",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -247,6 +284,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "min_value": 0,
                                         "max_value": None,
                                         "allowed_values": None,
+                                        "depends_on": None,
                                     },
                                 ],
                             },
@@ -279,6 +317,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": True,
                                         "default_value": False,
                                         "value_type": "bool",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -293,6 +332,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": [0.9, 1.1],
                                         "default_value": [0.8, 1.2],
                                         "value_type": "float_range",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -307,6 +347,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": [0.85, 1.15],
                                         "default_value": [0.75, 1.25],
                                         "value_type": "float_range",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -321,6 +362,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": [0.8, 1.2],
                                         "default_value": [0.9, 1.1],
                                         "value_type": "float_range",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -334,6 +376,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "value": [-0.05, 0.05],
                                         "default_value": [-0.1, 0.1],
                                         "value_type": "float_range",
+                                        "depends_on": None,
                                     },
                                     {
                                         "type": "parameter",
@@ -349,6 +392,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "min_value": 0.0,
                                         "max_value": 1.0,
                                         "allowed_values": None,
+                                        "depends_on": None,
                                     },
                                 ],
                             }
@@ -367,47 +411,67 @@ def fxt_training_configuration_view_json() -> dict:
                         "key": "max_epochs",
                         "name": "Maximum epochs",
                         "description": (
-                            "Maximum number of epochs to train the model. "
-                            "An epoch is one complete pass through the training dataset."
+                            "Maximum number of epochs to train the model. An epoch is one complete pass through the "
+                            "training dataset."
                         ),
                         "value": 120,
                         "default_value": 250,
                         "value_type": "int",
-                        "min_value": 0,
+                        "min_value": 1,
                         "max_value": None,
                         "allowed_values": None,
+                        "depends_on": None,
+                    },
+                    {
+                        "type": "parameter",
+                        "key": "batch_size",
+                        "name": "Batch size",
+                        "description": (
+                            "Number of training samples processed before the model's internal parameters are updated. "
+                            "A larger batch size can speed up training but may require more memory, while a smaller "
+                            "batch size can lead to more stable convergence but may take longer to train."
+                        ),
+                        "value": 8,
+                        "default_value": 4,
+                        "value_type": "int",
+                        "min_value": 1,
+                        "max_value": None,
+                        "allowed_values": None,
+                        "depends_on": None,
                     },
                     {
                         "type": "parameter_group",
                         "key": "early_stopping",
                         "name": "Early stopping",
                         "description": (
-                            "Early stopping is a technique to prevent overfitting by stopping training "
-                            "when performance on a validation set stops improving."
+                            "Early stopping is a technique to prevent overfitting by stopping training when "
+                            "performance on a validation set stops improving."
                         ),
                         "parameters": [
                             {
                                 "type": "parameter",
                                 "key": "enable",
-                                "name": "Toggle early stopping",
-                                "description": "Whether to stop training early when performance stops improving",
+                                "name": "Enable",
+                                "description": "Toggle to enable or disable early stopping during training.",
                                 "value": True,
                                 "default_value": False,
                                 "value_type": "bool",
+                                "depends_on": None,
                             },
                             {
                                 "type": "parameter",
                                 "key": "patience",
                                 "name": "Patience",
                                 "description": (
-                                    "Number of epochs with no improvement after which training will be stopped"
+                                    "Number of epochs with no improvement after which training will be stopped."
                                 ),
                                 "value": 5,
                                 "default_value": 1,
                                 "value_type": "int",
-                                "min_value": 0,
+                                "min_value": 1,
                                 "max_value": None,
                                 "allowed_values": None,
+                                "depends_on": None,
                             },
                         ],
                     },
@@ -426,14 +490,215 @@ def fxt_training_configuration_view_json() -> dict:
                         "min_value": 0,
                         "max_value": 1,
                         "allowed_values": None,
+                        "depends_on": None,
+                    },
+                    {
+                        "type": "parameter",
+                        "key": "weight_decay",
+                        "name": "Weight decay",
+                        "description": (
+                            "Weight decay is a regularization technique that adds a penalty to the loss function "
+                            "based on the magnitude of the model weights. It helps prevent overfitting by discouraging "
+                            "large weight values."
+                        ),
+                        "value": 0.01,
+                        "default_value": 1e-4,
+                        "value_type": "float",
+                        "min_value": 0,
+                        "max_value": 1,
+                        "allowed_values": None,
+                        "depends_on": None,
+                    },
+                    {
+                        "type": "parameter_group",
+                        "key": "scheduler",
+                        "name": "Learning rate scheduler",
+                        "description": (
+                            "The learning rate scheduler adjusts the learning rate during training according to a "
+                            "predefined schedule or based on validation performance, helping to improve convergence "
+                            "and training stability."
+                        ),
+                        "parameters": [
+                            {
+                                "type": "parameter",
+                                "key": "type",
+                                "name": "Scheduler type",
+                                "description": (
+                                    "Type of learning rate scheduler to use during training. With ReduceLROnPlateau, "
+                                    "the learning rate will be reduced by a predetermined factor when the validation "
+                                    "metric stops improving. With CosineAnnealing, the learning rate will follow a "
+                                    "cosine decay schedule, gradually decreasing over the course of training."
+                                ),
+                                "value": "cosine_annealing",
+                                "default_value": "reduce_lr_on_plateau",
+                                "value_type": "str",
+                                "allowed_values": ["reduce_lr_on_plateau", "cosine_annealing"],
+                                "depends_on": None,
+                            },
+                            {
+                                "type": "parameter_group",
+                                "key": "warmup",
+                                "name": "Learning rate warmup",
+                                "description": (
+                                    "Learning rate warmup is a technique where the learning rate starts at a lower "
+                                    "value and gradually increases to the initial learning rate over a specified "
+                                    "number of epochs at the beginning of training. This can help stabilize training "
+                                    "and improve convergence, especially when using large learning rates or training "
+                                    "on complex datasets."
+                                ),
+                                "parameters": [
+                                    {
+                                        "type": "parameter",
+                                        "key": "enable",
+                                        "name": "Enable",
+                                        "description": (
+                                            "Toggle to enable or disable a warmup phase at the beginning of training."
+                                        ),
+                                        "value": True,
+                                        "default_value": False,
+                                        "value_type": "bool",
+                                        "depends_on": None,
+                                    },
+                                    {
+                                        "type": "parameter",
+                                        "key": "epochs",
+                                        "name": "Warmup epochs",
+                                        "description": ("Number of epochs for the warmup phase."),
+                                        "value": 3,
+                                        "default_value": 5,
+                                        "value_type": "int",
+                                        "min_value": 1,
+                                        "max_value": None,
+                                        "allowed_values": None,
+                                        "depends_on": None,
+                                    },
+                                ],
+                            },
+                            {
+                                "type": "parameter",
+                                "key": "factor",
+                                "name": "Factor",
+                                "description": (
+                                    "Factor by which the learning rate will be reduced. new_lr = lr * factor."
+                                ),
+                                "value": 0.5,
+                                "default_value": 0.1,
+                                "value_type": "float",
+                                "min_value": 0,
+                                "max_value": 1,
+                                "allowed_values": None,
+                                "depends_on": {"type": "reduce_lr_on_plateau"},
+                            },
+                            {
+                                "type": "parameter",
+                                "key": "patience",
+                                "name": "Patience",
+                                "description": (
+                                    "Number of epochs with no improvement after which learning rate will be reduced."
+                                ),
+                                "value": 7,
+                                "default_value": 10,
+                                "value_type": "int",
+                                "min_value": 1,
+                                "max_value": None,
+                                "allowed_values": None,
+                                "depends_on": {"type": "reduce_lr_on_plateau"},
+                            },
+                            {
+                                "type": "parameter",
+                                "key": "min_lr",
+                                "name": "Minimum learning rate",
+                                "description": ("Minimum learning rate after annealing."),
+                                "value": 1e-5,
+                                "default_value": 1e-6,
+                                "value_type": "float",
+                                "min_value": 0,
+                                "max_value": 1,
+                                "allowed_values": None,
+                                "depends_on": {"type": "cosine_annealing"},
+                            },
+                        ],
+                    },
+                    {
+                        "type": "parameter_group",
+                        "key": "gradient_accumulation",
+                        "name": "Gradient accumulation",
+                        "description": (
+                            "Gradient accumulation allows simulating larger batch sizes by accumulating gradients "
+                            "over multiple forward/backward passes before updating the model weights."
+                        ),
+                        "parameters": [
+                            {
+                                "type": "parameter",
+                                "key": "enable",
+                                "name": "Enable",
+                                "description": ("Toggle to enable or disable gradient accumulation during training."),
+                                "value": True,
+                                "default_value": False,
+                                "value_type": "bool",
+                                "depends_on": None,
+                            },
+                            {
+                                "type": "parameter",
+                                "key": "batches",
+                                "name": "Accumulation steps",
+                                "description": (
+                                    "Number of steps to accumulate gradients before performing a weight update."
+                                ),
+                                "value": 1,
+                                "default_value": 1,
+                                "value_type": "int",
+                                "min_value": 1,
+                                "max_value": None,
+                                "allowed_values": None,
+                                "depends_on": None,
+                            },
+                        ],
+                    },
+                    {
+                        "type": "parameter_group",
+                        "key": "gradient_clip",
+                        "name": "Gradient clipping",
+                        "description": (
+                            "Gradient clipping prevents exploding gradients by capping gradient norms during "
+                            "backpropagation."
+                        ),
+                        "parameters": [
+                            {
+                                "type": "parameter",
+                                "key": "enable",
+                                "name": "Enable",
+                                "description": ("Toggle to enable or disable gradient clipping during training."),
+                                "value": True,
+                                "default_value": False,
+                                "value_type": "bool",
+                                "depends_on": None,
+                            },
+                            {
+                                "type": "parameter",
+                                "key": "max_grad_norm",
+                                "name": "Maximum gradient norm",
+                                "description": (
+                                    "Maximum norm of the gradients. Gradients with norm larger than this value will "
+                                    "be clipped."
+                                ),
+                                "value": 2.0,
+                                "default_value": 1.0,
+                                "value_type": "float",
+                                "min_value": 0,
+                                "max_value": None,
+                                "allowed_values": None,
+                                "depends_on": None,
+                            },
+                        ],
                     },
                     {
                         "type": "parameter",
                         "key": "input_size_width",
                         "name": "Input size width",
                         "description": (
-                            "Width size in pixels for model input images. "
-                            "Determines the horizontal resolution at which images are processed."
+                            "Width size in pixels for model input images. Determines the horizontal resolution at "
+                            "which images are processed."
                         ),
                         "value": 256,
                         "default_value": 512,
@@ -441,14 +706,15 @@ def fxt_training_configuration_view_json() -> dict:
                         "min_value": 0,
                         "max_value": None,
                         "allowed_values": [128, 256, 512],
+                        "depends_on": None,
                     },
                     {
                         "type": "parameter",
                         "key": "input_size_height",
                         "name": "Input size height",
                         "description": (
-                            "Height size in pixels for model input images. "
-                            "Determines the vertical resolution at which images are processed."
+                            "Height size in pixels for model input images. Determines the vertical resolution at "
+                            "which images are processed."
                         ),
                         "value": 256,
                         "default_value": 512,
@@ -456,10 +722,12 @@ def fxt_training_configuration_view_json() -> dict:
                         "min_value": 0,
                         "max_value": None,
                         "allowed_values": [128, 256, 512],
+                        "depends_on": None,
                     },
                 ],
             },
             {
+                "type": "parameter_group",
                 "key": "evaluation",
                 "name": "Evaluation parameters",
                 "description": "Configurable parameters related to the model evaluation.",
@@ -473,9 +741,9 @@ def fxt_training_configuration_view_json() -> dict:
                         "default_value": "default",
                         "value_type": "str",
                         "allowed_values": ["default"],
+                        "depends_on": None,
                     },
                 ],
-                "type": "parameter_group",
             },
         ]
     }

--- a/application/backend/tests/unit/api/schemas/test_training_configuration_view.py
+++ b/application/backend/tests/unit/api/schemas/test_training_configuration_view.py
@@ -69,7 +69,7 @@ def fxt_training_configuration() -> TrainingConfiguration:
                     patience=7,
                     min_lr=1e-5,
                 ),
-                gradient_accumulation=GradientAccumulationParameters(enable=True, steps=4),
+                gradient_accumulation=GradientAccumulationParameters(enable=True, batches=4),
                 gradient_clip=GradientClipParameters(enable=True, max_grad_norm=2.0),
                 input_size_width=256,
                 input_size_height=256,
@@ -110,7 +110,7 @@ def fxt_default_training_configuration() -> TrainingConfiguration:
                     patience=10,
                     min_lr=1e-6,
                 ),
-                gradient_accumulation=GradientAccumulationParameters(enable=False, steps=1),
+                gradient_accumulation=GradientAccumulationParameters(enable=False, batches=1),
                 gradient_clip=GradientClipParameters(enable=False, max_grad_norm=1.0),
                 input_size_width=512,
                 input_size_height=512,
@@ -641,11 +641,11 @@ def fxt_training_configuration_view_json() -> dict:
                             {
                                 "type": "parameter",
                                 "key": "batches",
-                                "name": "Accumulation steps",
+                                "name": "Accumulation batches",
                                 "description": (
-                                    "Number of steps to accumulate gradients before performing a weight update."
+                                    "Number of batches to accumulate gradients before performing a weight update."
                                 ),
-                                "value": 1,
+                                "value": 4,
                                 "default_value": 1,
                                 "value_type": "int",
                                 "min_value": 1,

--- a/application/backend/tests/unit/api/schemas/test_training_configuration_view.py
+++ b/application/backend/tests/unit/api/schemas/test_training_configuration_view.py
@@ -23,7 +23,7 @@ from app.models.training_configuration.training import (
     EarlyStopping,
     GradientAccumulationParameters,
     GradientClipParameters,
-    LearningRateWarmupParameters,
+    LrLinearWarmupParameters,
     SchedulerParameters,
     SchedulerType,
 )
@@ -64,7 +64,7 @@ def fxt_training_configuration() -> TrainingConfiguration:
                 weight_decay=0.01,
                 scheduler=SchedulerParameters(
                     type=SchedulerType.COSINE_ANNEALING,
-                    warmup=LearningRateWarmupParameters(enable=True, epochs=3),
+                    warmup=LrLinearWarmupParameters(enable=True, epochs=3),
                     factor=0.5,
                     patience=7,
                     min_lr=1e-5,
@@ -105,7 +105,7 @@ def fxt_default_training_configuration() -> TrainingConfiguration:
                 weight_decay=1e-4,
                 scheduler=SchedulerParameters(
                     type=SchedulerType.REDUCE_LR_ON_PLATEAU,
-                    warmup=LearningRateWarmupParameters(enable=False, epochs=5),
+                    warmup=LrLinearWarmupParameters(enable=False, epochs=5),
                     factor=0.1,
                     patience=10,
                     min_lr=1e-6,
@@ -429,7 +429,8 @@ def fxt_training_configuration_view_json() -> dict:
                         "description": (
                             "Number of training samples processed before the model's internal parameters are updated. "
                             "A larger batch size can speed up training but may require more memory, while a smaller "
-                            "batch size can lead to more stable convergence but may take longer to train."
+                            "batch size can help avoid OOM (Out of Memory) errors at the cost of longer training times "
+                            "and potentially noisier gradient estimates."
                         ),
                         "value": 8,
                         "default_value": 4,
@@ -498,8 +499,8 @@ def fxt_training_configuration_view_json() -> dict:
                         "name": "Weight decay",
                         "description": (
                             "Weight decay is a regularization technique that adds a penalty to the loss function "
-                            "based on the magnitude of the model weights. It helps prevent overfitting by discouraging "
-                            "large weight values."
+                            "based on the squared magnitude of the model weights (L2 regularization). "
+                            "It helps prevent overfitting by discouraging large weight values."
                         ),
                         "value": 0.01,
                         "default_value": 1e-4,
@@ -538,7 +539,7 @@ def fxt_training_configuration_view_json() -> dict:
                             {
                                 "type": "parameter_group",
                                 "key": "warmup",
-                                "name": "Learning rate warmup",
+                                "name": "Learning rate linear warmup",
                                 "description": (
                                     "Learning rate warmup is a technique where the learning rate starts at a lower "
                                     "value and gradually increases to the initial learning rate over a specified "
@@ -552,7 +553,8 @@ def fxt_training_configuration_view_json() -> dict:
                                         "key": "enable",
                                         "name": "Enable",
                                         "description": (
-                                            "Toggle to enable or disable a warmup phase at the beginning of training."
+                                            "Toggle to enable or disable the LR linear warmup phase at the "
+                                            "beginning of training."
                                         ),
                                         "value": True,
                                         "default_value": False,
@@ -563,7 +565,7 @@ def fxt_training_configuration_view_json() -> dict:
                                         "type": "parameter",
                                         "key": "epochs",
                                         "name": "Warmup epochs",
-                                        "description": ("Number of epochs for the warmup phase."),
+                                        "description": "Number of epochs for the LR linear warmup phase.",
                                         "value": 3,
                                         "default_value": 5,
                                         "value_type": "int",
@@ -608,7 +610,7 @@ def fxt_training_configuration_view_json() -> dict:
                                 "type": "parameter",
                                 "key": "min_lr",
                                 "name": "Minimum learning rate",
-                                "description": ("Minimum learning rate after annealing."),
+                                "description": "Minimum learning rate after annealing.",
                                 "value": 1e-5,
                                 "default_value": 1e-6,
                                 "value_type": "float",
@@ -632,7 +634,7 @@ def fxt_training_configuration_view_json() -> dict:
                                 "type": "parameter",
                                 "key": "enable",
                                 "name": "Enable",
-                                "description": ("Toggle to enable or disable gradient accumulation during training."),
+                                "description": "Toggle to enable or disable gradient accumulation during training.",
                                 "value": True,
                                 "default_value": False,
                                 "value_type": "bool",
@@ -641,9 +643,11 @@ def fxt_training_configuration_view_json() -> dict:
                             {
                                 "type": "parameter",
                                 "key": "batches",
-                                "name": "Accumulation batches",
+                                "name": "Gradient accumulation batches",
                                 "description": (
-                                    "Number of batches to accumulate gradients before performing a weight update."
+                                    "Number of steps (batches) to accumulate gradients before performing gradient "
+                                    "descent step. Effective batch size during training: "
+                                    "batch_size * accumulate_grad_batches."
                                 ),
                                 "value": 4,
                                 "default_value": 1,
@@ -668,7 +672,7 @@ def fxt_training_configuration_view_json() -> dict:
                                 "type": "parameter",
                                 "key": "enable",
                                 "name": "Enable",
-                                "description": ("Toggle to enable or disable gradient clipping during training."),
+                                "description": "Toggle to enable or disable gradient clipping during training.",
                                 "value": True,
                                 "default_value": False,
                                 "value_type": "bool",
@@ -677,9 +681,9 @@ def fxt_training_configuration_view_json() -> dict:
                             {
                                 "type": "parameter",
                                 "key": "max_grad_norm",
-                                "name": "Maximum gradient norm",
+                                "name": "Maximum gradient L2 norm",
                                 "description": (
-                                    "Maximum norm of the gradients. Gradients with norm larger than this value will "
+                                    "Maximum L2 norm of the gradients. Gradients with norm larger than this value will "
                                     "be clipped."
                                 ),
                                 "value": 2.0,


### PR DESCRIPTION
### Summary

This PR exposes a bunch of new parameters in the training configuration:
- `training.batch_size` (int)
- `training.weight_decay` (float 0-1)
- `training.scheduler.type` (str enum, ["reduce_lr_on_plateau", "cosine_annealing"])
- `training.scheduler.warmup.enable` (bool)
- `training.scheduler.warmup.epochs` (int)
- `training.scheduler.factor` (float 0-1) (only for reduce_lr_on_plateau)
- `training.scheduler.patience` (int) (only for reduce_lr_on_plateau)
- `training.scheduler.min_lr` (float 0-1) (only for cosine_annealing)
- `training.gradient_accumulation.enable` (bool)
- `training.gradient_accumulation.batches` (int)
- `training.gradient_clip.enable` (bool)
- `training.gradient_clip.max_grad_norm` (float)

Model manifests are updated accordingly, however the OTX configuration converter will be updated in another PR to avoid conflicts with #5021. This means that these parameters are not functional yet, but they will be very soon.

Besides, the parameters in the `TrainingConfigurationView` now have an additional property `depends_on`, which should be used by the frontend to conditionally display/hide certain parameters based on the value of other params.

Resolves #5711

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
