### PR TITLE
Add validation for the minimum number of labels for all project types

### DIFF
--- a/application/backend/app/api/routers/projects.py
+++ b/application/backend/app/api/routers/projects.py
@@ -13,7 +13,8 @@ from starlette.responses import FileResponse
 from app.api.dependencies import get_data_collector, get_label_service, get_project, get_project_service
 from app.api.schemas import LabelView, PatchLabels, ProjectCreate, ProjectUpdateName, ProjectView
 from app.api.validators import ProjectID
-from app.models import Label, Task
+from app.models import Label, LabelReference, LabelUpdateInfo, Task
+from app.models.project import Project
 from app.services import LabelService, ProjectService, ResourceInUseError, ResourceWithIdAlreadyExistsError
 from app.services.data_collect import DataCollector
 from app.services.label_service import DuplicateLabelsError
@@ -177,7 +178,7 @@ def delete_project(
     },
 )
 def update_labels(
-    project: Annotated[ProjectView, Depends(get_project)],
+    project: Annotated[Project, Depends(get_project)],
     labels: Annotated[
         PatchLabels,
         Body(
@@ -188,43 +189,16 @@ def update_labels(
 ) -> list[LabelView]:
     """Update labels for a given project"""
     try:
-        existing_ids = label_service.list_ids(project_id=project.id)
-        if labels.labels_to_remove:
-            ids_to_remove = [label.id for label in labels.labels_to_remove]
-            if not all(label_id in existing_ids for label_id in ids_to_remove):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="One or more labels to remove do not exist in the project",
-                )
-        if labels.labels_to_edit:
-            ids_to_edit = [label.id for label in labels.labels_to_edit]
-            if not all(label_id in existing_ids for label_id in ids_to_edit):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="One or more labels to edit do not exist in the project",
-                )
-        for label_to_edit in labels.labels_to_edit:
-            label_service.update_label(
-                project_id=project.id,
-                label_id=label_to_edit.id,
-                new_name=label_to_edit.new_name,
-                new_color=label_to_edit.new_color,
-                new_hotkey=label_to_edit.new_hotkey,
-            )
-        for label_to_remove in labels.labels_to_remove:
-            label_service.delete_label(project_id=project.id, label_id=label_to_remove.id)
-        for label_to_add in labels.labels_to_add:
-            label_service.create_label(
-                project_id=project.id,
-                label_id=label_to_add.id,
-                name=label_to_add.name,
-                color=label_to_add.color,
-                hotkey=label_to_add.hotkey,
-            )
-        updated_labels = label_service.list_all(project_id=project.id)
-        return [LabelView.model_validate(label, from_attributes=True) for label in updated_labels]
+        updated_labels = label_service.update_labels(
+            project=project,
+            labels_to_add=[Label.model_validate(lbl) for lbl in labels.labels_to_add],
+            labels_to_edit=[LabelUpdateInfo.model_validate(lbl) for lbl in labels.labels_to_edit],
+            labels_to_remove=[LabelReference.model_validate(lbl) for lbl in labels.labels_to_remove],
+        )
     except (ResourceWithIdAlreadyExistsError, DuplicateLabelsError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+
+    return [LabelView.model_validate(label, from_attributes=True) for label in updated_labels]
 
 
 @router.get(

--- a/application/backend/app/api/routers/projects.py
+++ b/application/backend/app/api/routers/projects.py
@@ -174,7 +174,10 @@ def delete_project(
         status.HTTP_200_OK: {"description": "Labels updated successfully"},
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid project ID or request body"},
         status.HTTP_404_NOT_FOUND: {"description": "Project or label not found"},
-        status.HTTP_409_CONFLICT: {"description": "Label(s) already exists or have duplicated names or hotkeys"},
+        status.HTTP_409_CONFLICT: {
+            "description": "Label(s) already exists or have duplicated names or hotkeys, "
+            "or minimum number of labels for project will be violated after update."
+        },
     },
 )
 def update_labels(
@@ -191,11 +194,13 @@ def update_labels(
     try:
         updated_labels = label_service.update_labels(
             project=project,
-            labels_to_add=[Label.model_validate(lbl) for lbl in labels.labels_to_add],
-            labels_to_edit=[LabelUpdateInfo.model_validate(lbl) for lbl in labels.labels_to_edit],
-            labels_to_remove=[LabelReference.model_validate(lbl) for lbl in labels.labels_to_remove],
+            labels_to_add=[Label.model_validate(lbl, from_attributes=True) for lbl in labels.labels_to_add],
+            labels_to_edit=[LabelUpdateInfo.model_validate(lbl, from_attributes=True) for lbl in labels.labels_to_edit],
+            labels_to_remove=[
+                LabelReference.model_validate(lbl, from_attributes=True) for lbl in labels.labels_to_remove
+            ],
         )
-    except (ResourceWithIdAlreadyExistsError, DuplicateLabelsError) as e:
+    except (ResourceWithIdAlreadyExistsError, DuplicateLabelsError, ValueError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
     return [LabelView.model_validate(label, from_attributes=True) for label in updated_labels]

--- a/application/backend/app/api/schemas/project.py
+++ b/application/backend/app/api/schemas/project.py
@@ -29,7 +29,7 @@ class TaskCreate(TaskBase):
     @model_validator(mode="after")
     def validate_labels(self) -> "TaskCreate":
         if self.task_type is TaskType.CLASSIFICATION and self.exclusive_labels and len(self.labels) < 2:
-            raise ValueError("Multi-class classifications requires at least two labels.")
+            raise ValueError("Multi-class classification requires at least two labels.")
         if len(self.labels) == 0:
             raise ValueError("A project requires at least one label.")
         return self

--- a/application/backend/app/api/schemas/project.py
+++ b/application/backend/app/api/schemas/project.py
@@ -3,7 +3,7 @@
 
 from typing import Generic, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.core.models import HasID, RequiresID
 from app.models import TaskType
@@ -25,6 +25,14 @@ class TaskView(TaskBase):
 
 class TaskCreate(TaskBase):
     labels: list[LabelCreate] = Field(default_factory=list, description="List of task labels to create.")
+
+    @model_validator(mode="after")
+    def validate_labels(self) -> "TaskCreate":
+        if self.task_type is TaskType.CLASSIFICATION and self.exclusive_labels and len(self.labels) < 2:
+            raise ValueError("Multi-class classifications requires at least two labels.")
+        if len(self.labels) == 0:
+            raise ValueError("A project requires at least one label.")
+        return self
 
 
 class ProjectUpdateName(BaseModel):

--- a/application/backend/app/models/__init__.py
+++ b/application/backend/app/models/__init__.py
@@ -14,7 +14,7 @@ from .dataset_item import DatasetItem, DatasetItemAnnotation, DatasetItemAnnotat
 from .dataset_revision import DatasetRevision
 from .evaluation import EvaluationResult
 from .jobs import ExportDatasetJob, ExportDatasetJobParams, TrainingJob, TrainingJobParams
-from .label import Label, LabelReference
+from .label import Label, LabelReference, LabelUpdateInfo
 from .media import Image, Media, MediaFormat, MediaType, Video, VideoFrame
 from .model_manifest import ModelManifest
 from .model_revision import ModelRevision, ModelVariant, TrainingInfo, TrainingStatus
@@ -70,6 +70,7 @@ __all__ = [
     "ImagesFolderSourceConfig",
     "Label",
     "LabelReference",
+    "LabelUpdateInfo",
     "Media",
     "MediaFormat",
     "MediaType",

--- a/application/backend/app/models/label.py
+++ b/application/backend/app/models/label.py
@@ -24,3 +24,10 @@ class Label(BaseEntity):
     name: str
     color: str
     hotkey: str | None = None
+
+
+class LabelUpdateInfo(BaseEntity):
+    id: UUID
+    new_name: str | None = None
+    new_color: str | None = None
+    new_hotkey: str | None = None

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -99,7 +99,7 @@ class LabelService(BaseSessionManagedService):
             and new_number_of_labels < 2
         ):
             raise ValueError(
-                f"Multi-class classifications requires at least two labels, but after this label update the total "
+                f"Multi-class classification requires at least two labels, but after this label update the total "
                 f"number of labels is {new_number_of_labels}."
             )
         if new_number_of_labels == 0:

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -102,7 +102,7 @@ class LabelService(BaseSessionManagedService):
                 f"Multi-class classification requires at least two labels, but after this label update the total "
                 f"number of labels is {new_number_of_labels}."
             )
-        if new_number_of_labels == 0:
+        if new_number_of_labels < 1:
             raise ValueError(
                 f"A project requires at least one label, but after this label update the total number of labels is "
                 f"{new_number_of_labels}."

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -7,6 +7,9 @@ from sqlalchemy.orm import Session
 
 from app.db.schema import LabelDB
 from app.models import Label
+from app.models.label import LabelReference, LabelUpdateInfo
+from app.models.project import Project
+from app.models.task import TaskType
 from app.repositories import LabelRepository
 from app.repositories.base import PrimaryKeyIntegrityError, UniqueConstraintIntegrityError
 from app.utils.color import random_color
@@ -56,7 +59,88 @@ class LabelService(BaseSessionManagedService):
         db_ids = label_repo.list_ids()
         return [UUID(db_id) for db_id in db_ids]
 
-    def update_label(
+    def update_labels(
+        self,
+        project: Project,
+        labels_to_add: list[Label],
+        labels_to_remove: list[LabelReference],
+        labels_to_edit: list[LabelUpdateInfo],
+    ) -> list[Label]:
+        """
+        Update labels for a given project by adding, removing, and editing labels.
+
+        Validates that the resulting number of labels satisfies project task constraints
+        (e.g., multi-class classification requires at least two labels, and every project
+        requires at least one label). Also validates that labels to remove or edit exist
+        in the project before applying changes.
+
+        Args:
+            project (Project): The project whose labels to update.
+            labels (PatchLabels): The patch object containing labels to add, remove, and edit.
+
+        Returns:
+            list[Label]: The full list of labels for the project after all updates have been applied.
+
+        Raises:
+            ValueError: If the resulting number of labels violates project task constraints.
+            ResourceNotFoundError: If any labels to remove or edit do not exist in the project.
+            DuplicateLabelsError: If any label names or hotkeys conflict with existing labels.
+            ResourceWithIdAlreadyExistsError: If a label to add has an ID that already exists.
+        """
+
+        # Validate minimal number of labels satisfies project task constraints
+        existing_ids = self.list_ids(project_id=project.id)
+        new_number_of_labels = len(existing_ids) - len(labels_to_remove) + len(labels_to_add)
+        if (
+            project.task.task_type is TaskType.CLASSIFICATION
+            and project.task.exclusive_labels
+            and new_number_of_labels < 2
+        ):
+            raise ValueError(
+                f"Multi-class classifications requires at least two labels, but after this label update the total "
+                f"number of labels is {new_number_of_labels}."
+            )
+        if new_number_of_labels == 0:
+            raise ValueError(
+                f"A project requires at least one label, but after this label update the total number of labels is "
+                f"{new_number_of_labels}."
+            )
+
+        # Validate labels to remove or edit exist in project
+        if missing_ids_to_remove := [label.id for label in labels_to_remove if label.id not in existing_ids]:
+            raise ResourceNotFoundError(
+                resource_type=ResourceType.LABEL,
+                resource_id=str(missing_ids_to_remove[0]),
+                message="One or more labels to remove do not exist in the project",
+            )
+        if missing_ids_to_edit := [label.id for label in labels_to_edit if label.id not in existing_ids]:
+            raise ResourceNotFoundError(
+                resource_type=ResourceType.LABEL,
+                resource_id=str(missing_ids_to_edit[0]),
+                message="One or more labels to edit do not exist in the project",
+            )
+
+        for label_to_edit in labels_to_edit:
+            self._update_label(
+                project_id=project.id,
+                label_id=label_to_edit.id,
+                new_name=label_to_edit.new_name,
+                new_color=label_to_edit.new_color,
+                new_hotkey=label_to_edit.new_hotkey,
+            )
+        for label_to_remove in labels_to_remove:
+            self._delete_label(project_id=project.id, label_id=label_to_remove.id)
+        for label_to_add in labels_to_add:
+            self.create_label(
+                project_id=project.id,
+                label_id=label_to_add.id,
+                name=label_to_add.name,
+                color=label_to_add.color,
+                hotkey=label_to_add.hotkey,
+            )
+        return self.list_all(project_id=project.id)
+
+    def _update_label(
         self, project_id: UUID, label_id: UUID, new_name: str | None, new_color: str | None, new_hotkey: str | None
     ) -> Label:
         label_repo = LabelRepository(str(project_id), self.db_session)
@@ -77,7 +161,7 @@ class LabelService(BaseSessionManagedService):
         except UniqueConstraintIntegrityError:
             raise DuplicateLabelsError
 
-    def delete_label(self, project_id: UUID, label_id: UUID) -> None:
+    def _delete_label(self, project_id: UUID, label_id: UUID) -> None:
         label_repo = LabelRepository(str(project_id), self.db_session)
         if not label_repo.delete(str(label_id)):
             raise ResourceNotFoundError(ResourceType.LABEL, str(label_id))

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -76,7 +76,9 @@ class LabelService(BaseSessionManagedService):
 
         Args:
             project (Project): The project whose labels to update.
-            labels (PatchLabels): The patch object containing labels to add, remove, and edit.
+            labels_to_add (list[Label]): Labels to be added to the project.
+            labels_to_remove (list[LabelReference]): Labels to be removed from the project.
+            labels_to_edit (list[LabelUpdateInfo]): Labels within the project to be edited.
 
         Returns:
             list[Label]: The full list of labels for the project after all updates have been applied.

--- a/application/backend/tests/integration/services/test_label_service.py
+++ b/application/backend/tests/integration/services/test_label_service.py
@@ -7,6 +7,10 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.db.schema import LabelDB, ProjectDB
+from app.models import Label
+from app.models.label import LabelReference, LabelUpdateInfo
+from app.models.project import Project
+from app.models.task import Task, TaskType
 from app.services import ResourceNotFoundError, ResourceType, ResourceWithIdAlreadyExistsError
 from app.services.label_service import DuplicateLabelsError, LabelService
 
@@ -32,6 +36,17 @@ def fxt_stored_project_with_labels(
     db_session.flush()
 
     return db_project, fxt_db_labels
+
+
+def _db_project_to_project(db_project: ProjectDB) -> Project:
+    return Project(
+        id=UUID(db_project.id),
+        name=db_project.name,
+        task=Task(
+            task_type=TaskType(db_project.task_type),
+            labels=[],
+        ),
+    )
 
 
 class TestLabelServiceIntegration:
@@ -117,138 +132,183 @@ class TestLabelServiceIntegration:
         assert exc_info.value.resource_type == ResourceType.LABEL
         assert exc_info.value.resource_id == existing_label_id
 
-    def test_update_label(
+    def test_update_labels_add_edit_delete(
         self,
         fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
         fxt_label_service: LabelService,
         db_session: Session,
     ) -> None:
         """
-        Test updating a label for the project.
+        Test combined add, edit, and delete via update_labels.
 
         Verifies that:
-        - An existing label can be updated for the existing project
+        - All three operations are applied in a single call
         """
         db_project, db_labels = fxt_stored_project_with_labels
-        updated_label = fxt_label_service._update_label(
-            project_id=UUID(db_project.id),
-            label_id=UUID(db_labels[0].id),
-            new_name="bird",
-            new_color="#4500FF",
-            new_hotkey="b",
+        project = _db_project_to_project(db_project)
+        edit_id = UUID(db_labels[0].id)
+        remove_id = UUID(db_labels[1].id)
+        new_label_id = uuid4()
+
+        result = fxt_label_service.update_labels(
+            project=project,
+            labels_to_add=[Label(id=new_label_id, project_id=project.id, name="bird", color="#0000FF", hotkey="b")],
+            labels_to_remove=[LabelReference(id=remove_id)],
+            labels_to_edit=[LabelUpdateInfo(id=edit_id, new_name="updated_cat", new_color="#121212", new_hotkey=None)],
         )
 
-        assert updated_label.name == "bird" and updated_label.color == "#4500FF" and updated_label.hotkey == "b"
+        result_ids = {lbl.id for lbl in result}
+        assert edit_id in result_ids
+        assert remove_id not in result_ids
+        assert new_label_id in result_ids
 
-        updated_db_label = db_session.query(LabelDB).filter(LabelDB.id == db_labels[0].id).one()
-        assert (
-            updated_db_label.name == "bird" and updated_db_label.color == "#4500FF" and updated_db_label.hotkey == "b"
-        )
+        edited = next(lbl for lbl in result if lbl.id == edit_id)
+        assert edited.name == "updated_cat" and edited.color == "#121212"
 
-    def test_update_label_non_existent(
+        added = next(lbl for lbl in result if lbl.id == new_label_id)
+        assert added.name == "bird" and added.color == "#0000FF" and added.hotkey == "b"
+
+        assert db_session.query(LabelDB).filter(LabelDB.id == str(remove_id)).one_or_none() is None
+
+    def test_update_labels_edit_duplicate_name(
         self,
         fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
         fxt_label_service: LabelService,
-        db_session: Session,
     ) -> None:
         """
-        Test updating a non-existing label for the project causes an error.
+        Test editing a label to have a duplicate name raises DuplicateLabelsError.
+        """
+        db_project, db_labels = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+
+        with pytest.raises(DuplicateLabelsError):
+            fxt_label_service.update_labels(
+                project=project,
+                labels_to_add=[],
+                labels_to_remove=[],
+                labels_to_edit=[
+                    LabelUpdateInfo(
+                        id=UUID(db_labels[0].id),
+                        new_name=db_labels[1].name,
+                        new_color="#4500FF",
+                        new_hotkey="b",
+                    )
+                ],
+            )
+
+    def test_update_labels_edit_duplicate_hotkey(
+        self,
+        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
+        fxt_label_service: LabelService,
+    ) -> None:
+        """
+        Test editing a label to have a duplicate hotkey raises DuplicateLabelsError.
+        """
+        db_project, db_labels = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+
+        with pytest.raises(DuplicateLabelsError):
+            fxt_label_service.update_labels(
+                project=project,
+                labels_to_add=[],
+                labels_to_remove=[],
+                labels_to_edit=[
+                    LabelUpdateInfo(
+                        id=UUID(db_labels[0].id),
+                        new_name="bird",
+                        new_color="#4500FF",
+                        new_hotkey=db_labels[1].hotkey,
+                    )
+                ],
+            )
+
+    def test_update_labels_edit_nonexistent(
+        self,
+        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
+        fxt_label_service: LabelService,
+    ) -> None:
+        """
+        Test editing a non-existent label raises ResourceNotFoundError.
         """
         db_project, _ = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+        nonexistent_id = uuid4()
 
         with pytest.raises(ResourceNotFoundError) as exc_info:
-            label_id = uuid4()
-            fxt_label_service._update_label(
-                project_id=UUID(db_project.id),
-                label_id=label_id,
-                new_name="bird",
-                new_color="#4500FF",
-                new_hotkey="b",
+            fxt_label_service.update_labels(
+                project=project,
+                labels_to_add=[],
+                labels_to_remove=[],
+                labels_to_edit=[
+                    LabelUpdateInfo(id=nonexistent_id, new_name="bird", new_color="#4500FF", new_hotkey="b")
+                ],
             )
 
         assert exc_info.value.resource_type == ResourceType.LABEL
-        assert exc_info.value.resource_id == str(label_id)
+        assert exc_info.value.resource_id == str(nonexistent_id)
 
-    def test_update_label_duplicate_name(
+    def test_update_labels_delete_nonexistent(
         self,
         fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
         fxt_label_service: LabelService,
-        db_session: Session,
     ) -> None:
         """
-        Test updating a label to have a duplicating name for the project.
-
-        Verifies that:
-        - A label cannot be updated to have a duplicating name
+        Test deleting a non-existent label raises ResourceNotFoundError.
         """
-        db_project, db_labels = fxt_stored_project_with_labels
-        with pytest.raises(DuplicateLabelsError):
-            fxt_label_service._update_label(
-                project_id=UUID(db_project.id),
-                label_id=UUID(db_labels[0].id),
-                new_name=db_labels[1].name,
-                new_color="#4500FF",
-                new_hotkey="b",
-            )
-
-    def test_update_label_duplicate_hotkey(
-        self,
-        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
-        fxt_label_service: LabelService,
-        db_session: Session,
-    ) -> None:
-        """
-        Test updating a label to have a duplicating hotkey for the project.
-
-        Verifies that:
-        - A label cannot be updated to have a duplicating hotkey
-        """
-        db_project, db_labels = fxt_stored_project_with_labels
-        with pytest.raises(DuplicateLabelsError):
-            fxt_label_service._update_label(
-                project_id=UUID(db_project.id),
-                label_id=UUID(db_labels[0].id),
-                new_name="bird",
-                new_color="#4500FF",
-                new_hotkey=db_labels[1].hotkey,
-            )
-
-    def test_delete_label(
-        self,
-        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
-        fxt_label_service: LabelService,
-        db_session: Session,
-    ) -> None:
-        """
-        Test deleting a label for the project.
-
-        Verifies that:
-        - An existing label can be deleted for the existing project
-        """
-        db_project, db_labels = fxt_stored_project_with_labels
-        fxt_label_service._delete_label(project_id=UUID(db_project.id), label_id=UUID(db_labels[0].id))
-
-        assert db_session.query(LabelDB).filter(LabelDB.id == db_labels[0].id).one_or_none() is None
-
-    def test_delete_non_existing_label(
-        self,
-        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
-        fxt_label_service: LabelService,
-        db_session: Session,
-    ) -> None:
-        """
-        Test deleting a label for the project.
-
-        Verifies that:
-        - An existing label can be deleted for the existing project
-        """
-        non_existing_label_id = uuid4()
         db_project, _ = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+        nonexistent_id = uuid4()
+
         with pytest.raises(ResourceNotFoundError) as exc_info:
-            fxt_label_service._delete_label(project_id=UUID(db_project.id), label_id=non_existing_label_id)
+            fxt_label_service.update_labels(
+                project=project,
+                labels_to_add=[],
+                labels_to_remove=[LabelReference(id=nonexistent_id)],
+                labels_to_edit=[],
+            )
 
         assert exc_info.value.resource_type == ResourceType.LABEL
-        assert exc_info.value.resource_id == str(non_existing_label_id)
+        assert exc_info.value.resource_id == str(nonexistent_id)
+
+    def test_update_labels_remove_all_raises_value_error(
+        self,
+        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
+        fxt_label_service: LabelService,
+    ) -> None:
+        """
+        Test removing all labels raises ValueError (project requires at least one label).
+        """
+        db_project, db_labels = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+
+        with pytest.raises(ValueError, match="A project requires at least one label"):
+            fxt_label_service.update_labels(
+                project=project,
+                labels_to_add=[],
+                labels_to_remove=[LabelReference(id=UUID(lbl.id)) for lbl in db_labels],
+                labels_to_edit=[],
+            )
+
+    def test_update_labels_empty(
+        self,
+        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
+        fxt_label_service: LabelService,
+    ) -> None:
+        """
+        Test update_labels with no changes returns all existing labels unchanged.
+        """
+        db_project, db_labels = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+
+        result = fxt_label_service.update_labels(
+            project=project,
+            labels_to_add=[],
+            labels_to_remove=[],
+            labels_to_edit=[],
+        )
+
+        assert len(result) == len(db_labels)
+        assert {lbl.id for lbl in result} == {UUID(lbl.id) for lbl in db_labels}
 
     def test_list_all(
         self,
@@ -279,7 +339,7 @@ class TestLabelServiceIntegration:
         Verifies that:
         - In case of non-existing project empty labels list is returned
         """
-        db_project, _ = fxt_stored_project_with_labels
+        fxt_stored_project_with_labels  # ensure fixture runs
 
         labels = fxt_label_service.list_all(uuid4())
 
@@ -314,7 +374,7 @@ class TestLabelServiceIntegration:
         Verifies that:
         - In case of non-existing project empty labels ID's list is returned
         """
-        db_project, _ = fxt_stored_project_with_labels
+        fxt_stored_project_with_labels  # ensure fixture runs
 
         ids = fxt_label_service.list_ids(uuid4())
 

--- a/application/backend/tests/integration/services/test_label_service.py
+++ b/application/backend/tests/integration/services/test_label_service.py
@@ -130,7 +130,7 @@ class TestLabelServiceIntegration:
         - An existing label can be updated for the existing project
         """
         db_project, db_labels = fxt_stored_project_with_labels
-        updated_label = fxt_label_service.update_label(
+        updated_label = fxt_label_service._update_label(
             project_id=UUID(db_project.id),
             label_id=UUID(db_labels[0].id),
             new_name="bird",
@@ -158,7 +158,7 @@ class TestLabelServiceIntegration:
 
         with pytest.raises(ResourceNotFoundError) as exc_info:
             label_id = uuid4()
-            fxt_label_service.update_label(
+            fxt_label_service._update_label(
                 project_id=UUID(db_project.id),
                 label_id=label_id,
                 new_name="bird",
@@ -183,7 +183,7 @@ class TestLabelServiceIntegration:
         """
         db_project, db_labels = fxt_stored_project_with_labels
         with pytest.raises(DuplicateLabelsError):
-            fxt_label_service.update_label(
+            fxt_label_service._update_label(
                 project_id=UUID(db_project.id),
                 label_id=UUID(db_labels[0].id),
                 new_name=db_labels[1].name,
@@ -205,7 +205,7 @@ class TestLabelServiceIntegration:
         """
         db_project, db_labels = fxt_stored_project_with_labels
         with pytest.raises(DuplicateLabelsError):
-            fxt_label_service.update_label(
+            fxt_label_service._update_label(
                 project_id=UUID(db_project.id),
                 label_id=UUID(db_labels[0].id),
                 new_name="bird",
@@ -226,7 +226,7 @@ class TestLabelServiceIntegration:
         - An existing label can be deleted for the existing project
         """
         db_project, db_labels = fxt_stored_project_with_labels
-        fxt_label_service.delete_label(project_id=UUID(db_project.id), label_id=UUID(db_labels[0].id))
+        fxt_label_service._delete_label(project_id=UUID(db_project.id), label_id=UUID(db_labels[0].id))
 
         assert db_session.query(LabelDB).filter(LabelDB.id == db_labels[0].id).one_or_none() is None
 
@@ -245,7 +245,7 @@ class TestLabelServiceIntegration:
         non_existing_label_id = uuid4()
         db_project, _ = fxt_stored_project_with_labels
         with pytest.raises(ResourceNotFoundError) as exc_info:
-            fxt_label_service.delete_label(project_id=UUID(db_project.id), label_id=non_existing_label_id)
+            fxt_label_service._delete_label(project_id=UUID(db_project.id), label_id=non_existing_label_id)
 
         assert exc_info.value.resource_type == ResourceType.LABEL
         assert exc_info.value.resource_id == str(non_existing_label_id)

--- a/application/backend/tests/unit/api/routers/test_projects.py
+++ b/application/backend/tests/unit/api/routers/test_projects.py
@@ -145,8 +145,7 @@ class TestProjectEndpoints:
             labels_to_add=labels_to_add, labels_to_edit=labels_to_edit, labels_to_remove=labels_to_remove
         )
 
-        fxt_label_service.list_ids.return_value = [fxt_get_project.task.labels[0].id, fxt_get_project.task.labels[1].id]
-        fxt_label_service.list_all.return_value = [
+        fxt_label_service.update_labels.return_value = [
             Label(
                 id=fxt_get_project.task.labels[0].id,
                 project_id=fxt_get_project.id,
@@ -164,24 +163,25 @@ class TestProjectEndpoints:
 
         # Assert
         assert response.status_code == status.HTTP_200_OK
-        fxt_label_service.update_label.assert_called_once_with(
-            project_id=fxt_get_project.id,
-            label_id=fxt_get_project.task.labels[0].id,
-            new_name="updated_cat",
-            new_color="#121212",
-            new_hotkey=None,
-        )
-        fxt_label_service.delete_label.assert_called_once_with(
-            project_id=fxt_get_project.id,
-            label_id=fxt_get_project.task.labels[1].id,
-        )
-        fxt_label_service.create_label.assert_called_once_with(
-            project_id=fxt_get_project.id,
-            label_id=new_label_id,
-            name="mouse",
-            color="#0000FF",
-            hotkey="m",
-        )
+        fxt_label_service.update_labels.assert_called_once()
+        call_kwargs = fxt_label_service.update_labels.call_args[1]
+        assert call_kwargs["project"].id == fxt_get_project.id
+
+        assert len(call_kwargs["labels_to_add"]) == 1
+        assert call_kwargs["labels_to_add"][0].id == new_label_id
+        assert call_kwargs["labels_to_add"][0].name == "mouse"
+        assert call_kwargs["labels_to_add"][0].color == "#0000FF"
+        assert call_kwargs["labels_to_add"][0].hotkey == "m"
+
+        assert len(call_kwargs["labels_to_edit"]) == 1
+        assert call_kwargs["labels_to_edit"][0].id == fxt_get_project.task.labels[0].id
+        assert call_kwargs["labels_to_edit"][0].new_name == "updated_cat"
+        assert call_kwargs["labels_to_edit"][0].new_color == "#121212"
+        assert call_kwargs["labels_to_edit"][0].new_hotkey is None
+
+        assert len(call_kwargs["labels_to_remove"]) == 1
+        assert call_kwargs["labels_to_remove"][0].id == fxt_get_project.task.labels[1].id
+
         assert response.json() == [
             {
                 "id": str(fxt_get_project.task.labels[0].id),
@@ -201,8 +201,7 @@ class TestProjectEndpoints:
         # Setup
         patch_labels = PatchLabels()
 
-        fxt_label_service.list_ids.return_value = []
-        fxt_label_service.list_all.return_value = []
+        fxt_label_service.update_labels.return_value = []
 
         # Execute
         response = fxt_client.patch(
@@ -211,53 +210,24 @@ class TestProjectEndpoints:
 
         # Assert
         assert response.status_code == status.HTTP_200_OK
-        fxt_label_service.update_label.assert_not_called()
-        fxt_label_service.delete_label.assert_not_called()
-        fxt_label_service.create_label.assert_not_called()
+        fxt_label_service.update_labels.assert_called_once()
+        call_kwargs = fxt_label_service.update_labels.call_args[1]
+        assert call_kwargs["labels_to_add"] == []
+        assert call_kwargs["labels_to_edit"] == []
+        assert call_kwargs["labels_to_remove"] == []
 
-    def test_update_labels_create_conflict(self, fxt_get_project, fxt_label_service, fxt_client):
+    def test_update_labels_duplicate_labels_error(self, fxt_get_project, fxt_label_service, fxt_client):
         """Test label update with duplicate attributes returns 409."""
         new_label_id = uuid4()
         labels_to_add = [LabelCreate(id=new_label_id, name="cat", color="#FF0000", hotkey="c")]
         patch_labels = PatchLabels(labels_to_add=labels_to_add)
 
-        fxt_label_service.list_ids.return_value = []
-        fxt_label_service.create_label.side_effect = DuplicateLabelsError
+        fxt_label_service.update_labels.side_effect = DuplicateLabelsError()
 
         response = fxt_client.patch(
             f"/api/projects/{str(fxt_get_project.id)}/labels", json=patch_labels.model_dump(mode="json")
         )
 
-        fxt_label_service.create_label.assert_called_once_with(
-            project_id=fxt_get_project.id,
-            label_id=new_label_id,
-            name="cat",
-            color="#FF0000",
-            hotkey="c",
-        )
-        assert response.status_code == status.HTTP_409_CONFLICT
-        assert response.json()["detail"] == "Either label names or hotkeys have duplicates"
-
-    def test_update_labels_update_conflict(self, fxt_get_project, fxt_label_service, fxt_client):
-        """Test label update with duplicate attributes returns 409."""
-        label_id = uuid4()
-        labels_to_edit = [LabelEdit(id=label_id, new_name="cat", new_color="#FF0000", new_hotkey="c")]
-        patch_labels = PatchLabels(labels_to_edit=labels_to_edit)
-
-        fxt_label_service.list_ids.return_value = [label_id]
-        fxt_label_service.update_label.side_effect = DuplicateLabelsError
-
-        response = fxt_client.patch(
-            f"/api/projects/{str(fxt_get_project.id)}/labels", json=patch_labels.model_dump(mode="json")
-        )
-
-        fxt_label_service.update_label.assert_called_once_with(
-            project_id=fxt_get_project.id,
-            label_id=label_id,
-            new_name="cat",
-            new_color="#FF0000",
-            new_hotkey="c",
-        )
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json()["detail"] == "Either label names or hotkeys have duplicates"
 
@@ -272,7 +242,11 @@ class TestProjectEndpoints:
     )
     def test_update_labels_remove_edit_nonexistent(self, patch_labels, fxt_get_project, fxt_label_service, fxt_client):
         """Test editing or removing labels that don't exist returns 404."""
-        fxt_label_service.list_ids.return_value = []
+        fxt_label_service.update_labels.side_effect = ResourceNotFoundError(
+            resource_type=ResourceType.LABEL,
+            resource_id=str(uuid4()),
+            message="One or more labels to remove do not exist in the project",
+        )
 
         response = fxt_client.patch(
             f"/api/projects/{str(fxt_get_project.id)}/labels", json=patch_labels.model_dump(mode="json")
@@ -280,8 +254,39 @@ class TestProjectEndpoints:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "do not exist" in response.json()["detail"]
-        fxt_label_service.update_label.assert_not_called()
-        fxt_label_service.delete_label.assert_not_called()
+
+    def test_update_labels_id_already_exists(self, fxt_get_project, fxt_label_service, fxt_client):
+        """Test label update with existing label ID returns 409."""
+        existing_label_id = uuid4()
+        labels_to_add = [LabelCreate(id=existing_label_id, name="new_label", color="#FF0000", hotkey="n")]
+        patch_labels = PatchLabels(labels_to_add=labels_to_add)
+
+        fxt_label_service.update_labels.side_effect = ResourceWithIdAlreadyExistsError(
+            resource_type=ResourceType.LABEL, resource_id=str(existing_label_id)
+        )
+
+        response = fxt_client.patch(
+            f"/api/projects/{str(fxt_get_project.id)}/labels", json=patch_labels.model_dump(mode="json")
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+
+    def test_update_labels_value_error(self, fxt_get_project, fxt_label_service, fxt_client):
+        """Test label update that violates label count constraints returns 409."""
+        labels_to_remove = [LabelRemove(id=fxt_get_project.task.labels[0].id)]
+        patch_labels = PatchLabels(labels_to_remove=labels_to_remove)
+
+        fxt_label_service.update_labels.side_effect = ValueError(
+            "Multi-class classifications requires at least two labels, but after this label update the total "
+            "number of labels is 1."
+        )
+
+        response = fxt_client.patch(
+            f"/api/projects/{str(fxt_get_project.id)}/labels", json=patch_labels.model_dump(mode="json")
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "at least two labels" in response.json()["detail"]
 
     def test_update_labels_invalid_project_id(self, fxt_project_service, fxt_client):
         """Test update with invalid project ID returns 400."""


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add validation for the minimum number of labels for each project type (at least 1 for all types and at least 2 if it is multi-class classification).
- Moved business logic from project router to label service
- Added validation for the minimum number of labels to both `update_labels` and `TaskCreate`
- Updated unit tests for project router and integration tests for label service to reflect changes

Resolves #5715 

### How to test

All changes are covered by automated tests

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
