### PR TITLE
Remove unlabeled global annotation

### DIFF
--- a/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.test.tsx
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { fireEvent, screen } from '@testing-library/react';
+import { getMockedAnnotation } from 'mocks/mock-annotation';
+import { getMockedLabel } from 'mocks/mock-labels';
+import { render } from 'test-utils/render';
+
+import { AnnotationShapeWithLabels } from './annotation-shape-with-labels.component';
+
+const mockDeleteAnnotations = vi.fn();
+const mockUpdateAnnotations = vi.fn();
+
+vi.mock('hooks/api/project.hook', () => ({
+    useProject: () => ({
+        data: {
+            task: {
+                task_type: 'detection',
+            },
+        },
+    }),
+}));
+
+vi.mock('../../../shared/annotator/annotation-visibility-provider.component', () => ({
+    useAnnotationVisibility: () => ({
+        isVisible: true,
+    }),
+}));
+
+vi.mock('../../../shared/annotator/annotation-actions-provider.component', () => ({
+    useAnnotationActions: () => ({
+        updateAnnotations: mockUpdateAnnotations,
+        deleteAnnotations: mockDeleteAnnotations,
+        isReadOnlyMode: false,
+    }),
+}));
+
+vi.mock('../selected-media-item-provider.component', () => ({
+    useSelectedMediaItem: () => ({
+        mediaItem: {
+            width: 100,
+            height: 100,
+        },
+    }),
+}));
+
+describe('AnnotationShapeWithLabels', () => {
+    beforeEach(() => {
+        mockDeleteAnnotations.mockClear();
+        mockUpdateAnnotations.mockClear();
+    });
+
+    it('deletes full-image annotation when removing its last label in detection projects', () => {
+        const annotation = getMockedAnnotation({
+            id: 'full-image-annotation',
+            shape: { type: 'full_image' },
+            labels: [getMockedLabel({ id: 'label-1', name: 'No object' })],
+        });
+
+        render(<AnnotationShapeWithLabels annotation={annotation} />);
+
+        fireEvent.pointerDown(screen.getByRole('button', { name: 'Remove No object' }));
+
+        expect(mockDeleteAnnotations).toHaveBeenCalledWith(['full-image-annotation']);
+        expect(mockUpdateAnnotations).not.toHaveBeenCalled();
+    });
+
+    it('keeps non-full-image behavior unchanged in detection projects', () => {
+        const annotation = getMockedAnnotation({
+            id: 'rect-annotation',
+            labels: [getMockedLabel({ id: 'label-1', name: 'Person' })],
+        });
+
+        render(<AnnotationShapeWithLabels annotation={annotation} />);
+
+        fireEvent.pointerDown(screen.getByRole('button', { name: 'Remove Person' }));
+
+        expect(mockDeleteAnnotations).not.toHaveBeenCalled();
+        expect(mockUpdateAnnotations).toHaveBeenCalledWith([
+            {
+                ...annotation,
+                labels: [],
+            },
+        ]);
+    });
+});

--- a/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.test.tsx
@@ -4,22 +4,16 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { getMockedAnnotation } from 'mocks/mock-annotation';
 import { getMockedLabel } from 'mocks/mock-labels';
+import { getMockedProject } from 'mocks/mock-project';
+import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
+import { http } from '../../../api/utils';
+import { server } from '../../../msw-node-setup';
 import { AnnotationShapeWithLabels } from './annotation-shape-with-labels.component';
 
 const mockDeleteAnnotations = vi.fn();
 const mockUpdateAnnotations = vi.fn();
-
-vi.mock('hooks/api/project.hook', () => ({
-    useProject: () => ({
-        data: {
-            task: {
-                task_type: 'detection',
-            },
-        },
-    }),
-}));
 
 vi.mock('../../../shared/annotator/annotation-visibility-provider.component', () => ({
     useAnnotationVisibility: () => ({
@@ -46,11 +40,24 @@ vi.mock('../selected-media-item-provider.component', () => ({
 
 describe('AnnotationShapeWithLabels', () => {
     beforeEach(() => {
-        mockDeleteAnnotations.mockClear();
-        mockUpdateAnnotations.mockClear();
+        const project = getMockedProject({});
+
+        server.use(
+            http.get('/api/projects/{project_id}', () => {
+                return HttpResponse.json({
+                    ...project,
+                    task: {
+                        ...project.task,
+                        task_type: 'detection',
+                    },
+                });
+            })
+        );
+
+        vi.clearAllMocks();
     });
 
-    it('deletes full-image annotation when removing its last label in detection projects', () => {
+    it('deletes full-image annotation when removing its last label in detection projects', async () => {
         const annotation = getMockedAnnotation({
             id: 'full-image-annotation',
             shape: { type: 'full_image' },
@@ -58,22 +65,20 @@ describe('AnnotationShapeWithLabels', () => {
         });
 
         render(<AnnotationShapeWithLabels annotation={annotation} />);
-
-        fireEvent.pointerDown(screen.getByRole('button', { name: 'Remove No object' }));
+        fireEvent.pointerDown(await screen.findByRole('button', { name: 'Remove No object' }));
 
         expect(mockDeleteAnnotations).toHaveBeenCalledWith(['full-image-annotation']);
         expect(mockUpdateAnnotations).not.toHaveBeenCalled();
     });
 
-    it('keeps non-full-image behavior unchanged in detection projects', () => {
+    it('keeps non-full-image behavior unchanged in detection projects', async () => {
         const annotation = getMockedAnnotation({
             id: 'rect-annotation',
             labels: [getMockedLabel({ id: 'label-1', name: 'Person' })],
         });
 
         render(<AnnotationShapeWithLabels annotation={annotation} />);
-
-        fireEvent.pointerDown(screen.getByRole('button', { name: 'Remove Person' }));
+        fireEvent.pointerDown(await screen.findByRole('button', { name: 'Remove Person' }));
 
         expect(mockDeleteAnnotations).not.toHaveBeenCalled();
         expect(mockUpdateAnnotations).toHaveBeenCalledWith([

--- a/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.tsx
@@ -32,8 +32,11 @@ export const AnnotationShapeWithLabels = ({ annotation }: AnnotationShapeProps) 
 
         const updatedLabels = annotation.labels.filter((label) => label.id !== labelId) as Label[];
         const hasNoLabels = updatedLabels.length === 0;
+        const shouldDeleteAnnotation =
+            hasNoLabels &&
+            (isClassificationTask(selectedProject.task.task_type) || annotation.shape.type === 'full_image');
 
-        if (isClassificationTask(selectedProject.task.task_type) && hasNoLabels) {
+        if (shouldDeleteAnnotation) {
             deleteAnnotations([annotation.id]);
         } else {
             updateAnnotations([{ ...annotation, labels: updatedLabels }]);

--- a/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.test.tsx
+++ b/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.test.tsx
@@ -3,11 +3,14 @@
 
 import '@wessberg/pointer-events';
 
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { getMockedAnnotation } from 'mocks/mock-annotation';
 import { getMockedProject } from 'mocks/mock-project';
+import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
+import { http } from '../../../../api/utils';
+import { server } from '../../../../msw-node-setup';
 import { AnnotationVisibilityProvider } from '../../../../shared/annotator/annotation-visibility-provider.component';
 import { Annotation, Point, Polygon } from '../../../../shared/types';
 import { CanvasSettingsProvider } from '../../../dataset/media-preview/primary-toolbar/settings/canvas-settings-provider.component';
@@ -16,7 +19,6 @@ import { removeOffLimitPointsPolygon } from '../utils';
 import { EditPolygon } from './edit-polygon.component';
 
 const mockROI = { x: 0, y: 0, width: 1000, height: 1000 };
-vi.mock('hooks/api/project.hook', () => ({ useProject: () => ({ data: getMockedProject({}) }) }));
 
 vi.mock('../../selected-media-item-provider.component', () => ({
     useSelectedMediaItem: vi.fn(() => ({ roi: mockROI })),
@@ -70,7 +72,7 @@ const renderApp = async (
         };
     }
 ) => {
-    return render(
+    const app = render(
         <SelectedDataProvider>
             <AnnotationVisibilityProvider>
                 <CanvasSettingsProvider>
@@ -79,6 +81,12 @@ const renderApp = async (
             </AnnotationVisibilityProvider>
         </SelectedDataProvider>
     );
+
+    await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    return app;
 };
 
 describe('EditPolygonTool', () => {
@@ -96,6 +104,12 @@ describe('EditPolygonTool', () => {
     const shape = annotation.shape;
 
     beforeEach(() => {
+        server.use(
+            http.get('/api/projects/{project_id}', () => {
+                return HttpResponse.json(getMockedProject({}));
+            })
+        );
+
         vi.clearAllMocks();
     });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Found this bug randomly when testing SAM

When “No object” is applied, we create a full-image annotation (global shape) and when we removed that label, we did not delete the full-image annotation for detection/segmentation, so, when selecting a normal label, it would assign to the whole media item.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
