### PR TITLE
Handle worker failure & other improvements

### DIFF
--- a/application/ui/src/features/annotator/labels/use-labels.hook.ts
+++ b/application/ui/src/features/annotator/labels/use-labels.hook.ts
@@ -93,9 +93,9 @@ export const useLabels = ({ isClassification = false, isMultiLabel = false }: Us
             return;
         }
 
-        if (selectedAnnotations.size > 0) {
-            const selectedAnnotationsList = annotations.filter((a) => selectedAnnotations.has(a.id));
+        const selectedAnnotationsList = annotations.filter((a) => selectedAnnotations.has(a.id));
 
+        if (selectedAnnotationsList.length > 0) {
             const allAnnotationsHaveLabel = selectedAnnotationsList.every((annotation) =>
                 annotation.labels.some((l) => l.id === label.id)
             );

--- a/application/ui/src/features/annotator/tools/execute-with-timeout.test.ts
+++ b/application/ui/src/features/annotator/tools/execute-with-timeout.test.ts
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { executeWithTimeout } from './execute-with-timeout';
+
+describe('executeWithTimeout', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns resolved value before timeout', async () => {
+        const promise = executeWithTimeout(Promise.resolve('ok'), 'SAM encoder', 1000);
+
+        await expect(promise).resolves.toBe('ok');
+    });
+
+    it('rejects when operation exceeds timeout', async () => {
+        const neverResolvingPromise = new Promise<string>(() => undefined);
+        const promise = executeWithTimeout(neverResolvingPromise, 'SAM encoder', 10);
+        const rejectionExpectation = expect(promise).rejects.toThrow('SAM encoder timed out after 10ms');
+
+        await vi.advanceTimersByTimeAsync(11);
+
+        await rejectionExpectation;
+    });
+});

--- a/application/ui/src/features/annotator/tools/execute-with-timeout.ts
+++ b/application/ui/src/features/annotator/tools/execute-with-timeout.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+const DEFAULT_WORKER_TIMEOUT_MS = 5000;
+
+export const executeWithTimeout = async <T>(
+    promise: Promise<T>,
+    operation: string,
+    timeoutMs = DEFAULT_WORKER_TIMEOUT_MS
+): Promise<T> => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<T>((_, reject) => {
+                timeoutId = setTimeout(() => {
+                    reject(new Error(`${operation} timed out after ${timeoutMs}ms`));
+                }, timeoutMs);
+            }),
+        ]);
+    } finally {
+        if (timeoutId !== null) {
+            clearTimeout(timeoutId);
+        }
+    }
+};

--- a/application/ui/src/features/annotator/tools/execute-with-timeout.ts
+++ b/application/ui/src/features/annotator/tools/execute-with-timeout.ts
@@ -8,7 +8,7 @@ export const executeWithTimeout = async <T>(
     operation: string,
     timeoutMs = DEFAULT_WORKER_TIMEOUT_MS
 ): Promise<T> => {
-    let timeoutId: NodeJS.Timeout | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     try {
         return await Promise.race([

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -94,7 +94,7 @@ export const SegmentAnythingTool = () => {
             .catch(() => {
                 // If getting decoding went wrong we set an empty preview and
                 // start to compute the next decoding
-                return [];
+                setPreviewShapes([]);
             });
     };
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { PointerEvent, useRef, useState } from 'react';
+import { PointerEvent, useEffect, useRef, useState } from 'react';
 
 import { clampPointBetweenImage } from '@geti/smart-tools/utils';
 import { toast } from '@geti/ui';
@@ -71,6 +71,7 @@ export const SegmentAnythingTool = () => {
     const cancellableThrottledDecodingQueryFn = useWithCancel(throttledDecodingQueryFn);
 
     const canvasRef = useRef<SVGRectElement>(null);
+    const hasShownErrorToastRef = useRef(false);
 
     const clampPoint = clampPointBetweenImage(image);
 
@@ -139,13 +140,21 @@ export const SegmentAnythingTool = () => {
         };
     });
 
-    if (isError) {
-        toast({
-            type: 'error',
-            message: `
-            Error in Segment Anything tool: ${error?.message ?? 'Unknown error, please try refreshing the page.'}`,
-        });
-    }
+    useEffect(() => {
+        if (isError && !hasShownErrorToastRef.current) {
+            toast({
+                type: 'error',
+                message: `
+                Error in Segment Anything tool: ${error?.message ?? 'Unknown error, please try refreshing the page.'}`,
+            });
+
+            hasShownErrorToastRef.current = true;
+        }
+
+        if (!isError) {
+            hasShownErrorToastRef.current = false;
+        }
+    }, [isError, error]);
 
     if (isLoading) {
         return <SAMLoading isLoading={isLoading} />;

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -142,7 +142,8 @@ export const SegmentAnythingTool = () => {
     if (isError) {
         toast({
             type: 'error',
-            message: `Error in Segment Anything tool: ${error?.message ?? 'Unknown error'}`,
+            message: `
+            Error in Segment Anything tool: ${error?.message ?? 'Unknown error, please try refreshing the page.'}`,
         });
     }
 

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -4,6 +4,7 @@
 import { PointerEvent, useRef, useState } from 'react';
 
 import { clampPointBetweenImage } from '@geti/smart-tools/utils';
+import { toast } from '@geti/ui';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
 
 import selectionCursor from '../../../../assets/icons/selection.svg?url';
@@ -65,7 +66,7 @@ export const SegmentAnythingTool = () => {
     const nextMediaItem = useNextMediaItem(mediaItem, items);
     const { selectedLabel } = useAnnotatorLabels();
     const { addAndSelectAnnotations } = useAddAndSelectAnnotations();
-    const { isLoading, decodingQueryFn } = useSegmentAnythingModel({ nextMediaItem });
+    const { isLoading, isError, error, decodingQueryFn } = useSegmentAnythingModel({ nextMediaItem });
     const throttledDecodingQueryFn = useSingleStackFn(decodingQueryFn);
     const cancellableThrottledDecodingQueryFn = useWithCancel(throttledDecodingQueryFn);
 
@@ -137,6 +138,13 @@ export const SegmentAnythingTool = () => {
             id: `${idx}`,
         };
     });
+
+    if (isError) {
+        toast({
+            type: 'error',
+            message: `Error in Segment Anything tool: ${error?.message ?? 'Unknown error'}`,
+        });
+    }
 
     if (isLoading) {
         return <SAMLoading isLoading={isLoading} />;

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -16,10 +16,12 @@ import type {
     SegmentAnythingWorkerApi,
     SegmentAnythingWorkerInstance,
 } from '../../webworkers/segment-anything.worker.interface';
+import { executeWithTimeout } from '../execute-with-timeout';
 import { convertToolShapeToGetiShape } from '../utils';
 import { InteractiveAnnotationPoint } from './segment-anything.interface';
 
 type SegmentAnythingRemoteInstance = Remote<SegmentAnythingWorkerInstance>;
+const SAM_TIMEOUT_MS = 5000;
 
 const getSegmentAnythingWorkerQueryKey = (algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER') =>
     ['workers', algorithmType] as const;
@@ -35,9 +37,9 @@ const segmentAnythingWorkerQueryOptions = (
                 type: 'module',
             });
             const samWorker = wrap<SegmentAnythingWorkerApi>(baseWorker);
-            const model = await samWorker.build();
+            const model = await executeWithTimeout(samWorker.build(), 'SAM worker build', SAM_TIMEOUT_MS);
 
-            await model.init(algorithmType);
+            await executeWithTimeout(model.init(algorithmType), 'SAM worker init', SAM_TIMEOUT_MS);
 
             return model;
         },
@@ -75,9 +77,7 @@ export const useSegmentAnythingWorker = (
     algorithmType: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER',
     enabled = true
 ) => {
-    const { data } = useQuery(segmentAnythingWorkerQueryOptions(algorithmType, enabled));
-
-    return data;
+    return useQuery(segmentAnythingWorkerQueryOptions(algorithmType, enabled));
 };
 
 const useEncodingQuery = (
@@ -98,7 +98,7 @@ const useEncodingQuery = (
                 throw new Error('Model not yet initialized');
             }
 
-            return model.processEncoder(image);
+            return executeWithTimeout(model.processEncoder(image), 'SAM encoder', SAM_TIMEOUT_MS);
         },
         staleTime: Infinity,
         gcTime: 3600 * 15,
@@ -134,14 +134,18 @@ const useDecodingFn = (model: SegmentAnythingRemoteInstance | undefined, encodin
             return [];
         }
 
-        const { shapes } = await model.processDecoder(encoding, {
-            points,
-            boxes: [],
-            ouputConfig: {
-                type: decoderOutput,
-            },
-            image: undefined,
-        });
+        const { shapes } = await executeWithTimeout(
+            model.processDecoder(encoding, {
+                points,
+                boxes: [],
+                ouputConfig: {
+                    type: decoderOutput,
+                },
+                image: undefined,
+            }),
+            'SAM decoder',
+            SAM_TIMEOUT_MS
+        );
 
         return shapes.map(convertToolShapeToGetiShape);
     };
@@ -152,9 +156,12 @@ type SegmentAnythingModelOptions = {
 };
 
 export const useSegmentAnythingModel = ({ nextMediaItem }: SegmentAnythingModelOptions = {}) => {
-    const encoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_ENCODER');
-    const decoderModel = useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER');
-    const isLoadingWorkers = encoderModel === undefined || decoderModel === undefined;
+    const encoderWorkerQuery = useSegmentAnythingWorker('SEGMENT_ANYTHING_ENCODER');
+    const decoderWorkerQuery = useSegmentAnythingWorker('SEGMENT_ANYTHING_DECODER');
+    const encoderModel = encoderWorkerQuery.data;
+    const decoderModel = decoderWorkerQuery.data;
+    const hasWorkerError = encoderWorkerQuery.isError || decoderWorkerQuery.isError;
+    const isLoadingWorkers = encoderWorkerQuery.isLoading || decoderWorkerQuery.isLoading;
     const projectId = useProjectIdentifier();
 
     const { mediaItem, image, isImageReady } = useSelectedMediaItem();
@@ -172,12 +179,16 @@ export const useSegmentAnythingModel = ({ nextMediaItem }: SegmentAnythingModelO
 
     const decodingQueryFn = useDecodingFn(decoderModel, encodingQuery.data);
 
-    const isLoading = isLoadingWorkers || encodingQuery.isLoading;
+    const isLoading = !hasWorkerError && (isLoadingWorkers || encodingQuery.isLoading);
     const isProcessing = encodingQuery.isFetching;
+    const isError = hasWorkerError || encodingQuery.isError;
+    const error = encoderWorkerQuery.error ?? decoderWorkerQuery.error ?? encodingQuery.error;
 
     return {
         isLoading,
         isProcessing,
+        isError,
+        error,
         encodingQuery,
         decodingQueryFn,
     };

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -36,12 +36,17 @@ const segmentAnythingWorkerQueryOptions = (
             const baseWorker = new Worker(new URL('../../webworkers/segment-anything.worker', import.meta.url), {
                 type: 'module',
             });
-            const samWorker = wrap<SegmentAnythingWorkerApi>(baseWorker);
-            const model = await executeWithTimeout(samWorker.build(), 'SAM worker build', SAM_TIMEOUT_MS);
+            try {
+                const samWorker = wrap<SegmentAnythingWorkerApi>(baseWorker);
+                const model = await executeWithTimeout(samWorker.build(), 'SAM worker build', SAM_TIMEOUT_MS);
 
-            await executeWithTimeout(model.init(algorithmType), 'SAM worker init', SAM_TIMEOUT_MS);
+                await executeWithTimeout(model.init(algorithmType), 'SAM worker init', SAM_TIMEOUT_MS);
 
-            return model;
+                return model;
+            } catch (error) {
+                baseWorker.terminate();
+                throw error;
+            }
         },
         staleTime: Infinity,
         enabled,

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -9,6 +9,7 @@ import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-
 import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { SelectAnnotationProvider } from '../../../shared/annotator/select-annotation-provider.component';
+import { isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorLabelsProvider } from '../../annotator/annotator-labels-provider.component';
 import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settings-provider.component';
 
@@ -31,14 +32,15 @@ export const AnnotatorProviders = ({
     isReadOnly = false,
     children,
 }: AnnotatorProvidersProps) => {
+    const mediaSelectionResetKey = isVideoFrame(mediaItem) ? `${mediaItem.id}-${mediaItem.frame_number}` : mediaItem.id;
+
     return (
         <ZoomProvider>
-            <SelectAnnotationProvider>
+            <SelectAnnotationProvider resetKey={mediaSelectionResetKey}>
                 <AnnotationVisibilityProvider>
                     <CanvasSettingsProvider>
                         <AnnotatorLabelsProvider>
                             <AnnotationActionsProvider
-                                key={mediaItem.id}
                                 mediaItem={mediaItem}
                                 initialAnnotationsDTO={initialAnnotationsDTO}
                                 initialPredictionsDTO={initialPredictionsDTO}

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useMemo, useRef } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useMemo, useRef } from 'react';
 
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isEqual } from 'lodash-es';
@@ -102,16 +102,17 @@ export const AnnotationActionsProvider = ({
     const prevInitialAnnotationsDTORef = useRef(initialAnnotationsDTO);
     const prevMediaItemKeyRef = useRef(mediaItemKey);
 
-    // Reset annotations if the provider's props are updated
-    // or if we switch to a different media item (image or video frame)
-    if (
-        prevMediaItemKeyRef.current !== mediaItemKey ||
-        !isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)
-    ) {
-        resetAnnotations();
-        prevMediaItemKeyRef.current = mediaItemKey;
-        prevInitialAnnotationsDTORef.current = initialAnnotationsDTO;
-    }
+    useEffect(() => {
+        // Reset annotations when source annotations change or when switching media/frame.
+        if (
+            prevMediaItemKeyRef.current !== mediaItemKey ||
+            !isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)
+        ) {
+            undoRedoActions.reset(initialAnnotations);
+            prevMediaItemKeyRef.current = mediaItemKey;
+            prevInitialAnnotationsDTORef.current = initialAnnotationsDTO;
+        }
+    }, [mediaItemKey, initialAnnotationsDTO, initialAnnotations, undoRedoActions]);
 
     const updateAnnotations = (updatedAnnotations: Annotation[], labels?: Label[]) => {
         if (labels !== undefined) {

--- a/application/ui/src/shared/annotator/select-annotation-provider.component.tsx
+++ b/application/ui/src/shared/annotator/select-annotation-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useState, type Dispatch, type SetStateAction } from 'react';
+import { createContext, ReactNode, useContext, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 
 type SelectedAnnotationContextProps = {
     selectedAnnotations: Set<string>;
@@ -20,8 +20,12 @@ export const useSelectedAnnotations = () => {
     return ctx;
 };
 
-export const SelectAnnotationProvider = ({ children }: { children: ReactNode }) => {
+export const SelectAnnotationProvider = ({ children, resetKey }: { children: ReactNode; resetKey?: string }) => {
     const [selectedAnnotations, setSelectedAnnotations] = useState<Set<string>>(new Set());
+
+    useEffect(() => {
+        setSelectedAnnotations(new Set());
+    }, [resetKey]);
 
     return (
         <SelectedAnnotationContext.Provider value={{ selectedAnnotations, setSelectedAnnotations }}>

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -417,7 +417,7 @@ test.describe('Annotator', () => {
             }),
             http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', ({ params }) => {
                 return HttpResponse.json({
-                    annotations: mediaAnnotations[params.media_id as string] ?? [],
+                    annotations: mediaAnnotations[params.media_id] ?? [],
                     user_reviewed: true,
                 });
             })
@@ -426,7 +426,7 @@ test.describe('Annotator', () => {
         await page.goto(`/projects/${mockedDetectionProject.id}/dataset`);
         await page.getByRole('img', { name: 'item-1.jpg' }).dblclick();
 
-        await test.step('Media 1 renders its annotations', async () => {
+        await test.step('Check first media annotations', async () => {
             expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(1);
         });
 
@@ -479,6 +479,7 @@ test.describe('Annotator', () => {
         await test.step('Select non-default label on first media item', async () => {
             const blueLabelButton = page.getByRole('button', { name: `Label ${blueLabel.name}` });
             await blueLabelButton.click();
+
             await expect(blueLabelButton).toHaveAttribute('aria-pressed', 'true');
         });
 

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -380,4 +380,116 @@ test.describe('Annotator', () => {
             await expect(page.getByLabel(`label ${redLabel.name}`).nth(2)).toBeInViewport();
         });
     });
+
+    test('Annotations reset correctly when switching media items', async ({ page, annotatorPage, network }) => {
+        const mediaItems = [
+            getMockedMediaImage({ id: 'media-1', name: 'item-1.jpg', width: 1920, height: 1080 }),
+            getMockedMediaImage({ id: 'media-2', name: 'item-2.jpg', width: 1920, height: 1080 }),
+        ];
+
+        const mediaAnnotations: Record<string, AnnotationDTO[]> = {
+            'media-1': [
+                {
+                    shape: {
+                        type: 'rectangle',
+                        x: 80,
+                        y: 120,
+                        width: 140,
+                        height: 120,
+                    },
+                    labels: [{ id: redLabel.id }],
+                },
+            ],
+            'media-2': [],
+        };
+
+        network.use(
+            http.get('/api/projects/{project_id}/dataset/media', () => {
+                return HttpResponse.json({
+                    items: mediaItems,
+                    pagination: {
+                        offset: 0,
+                        limit: 10,
+                        count: mediaItems.length,
+                        total: mediaItems.length,
+                    },
+                });
+            }),
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', ({ params }) => {
+                return HttpResponse.json({
+                    annotations: mediaAnnotations[params.media_id as string] ?? [],
+                    user_reviewed: true,
+                });
+            })
+        );
+
+        await page.goto(`/projects/${mockedDetectionProject.id}/dataset`);
+        await page.getByRole('img', { name: 'item-1.jpg' }).dblclick();
+
+        await test.step('Media 1 renders its annotations', async () => {
+            expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(1);
+        });
+
+        await test.step('Switching to media 2 clears media 1 annotations', async () => {
+            const sidebarItems = page.getByRole('listbox', { name: 'sidebar-items' });
+            await sidebarItems.getByRole('img', { name: 'item-2.jpg' }).click();
+
+            await expect(annotatorPage.getAnnotationsList()).toBeVisible();
+            expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(0);
+        });
+
+        await test.step('Switching back restores media 1 annotations', async () => {
+            const sidebarItems = page.getByRole('listbox', { name: 'sidebar-items' });
+            await sidebarItems.getByRole('img', { name: 'item-1.jpg' }).click();
+
+            await expect(annotatorPage.getAnnotationsList()).toBeVisible();
+            expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(1);
+        });
+    });
+
+    test('Selected label persists when switching media items', async ({ page, network }) => {
+        const mediaItems = [
+            getMockedMediaImage({ id: 'media-1', name: 'item-1.jpg', width: 1920, height: 1080 }),
+            getMockedMediaImage({ id: 'media-2', name: 'item-2.jpg', width: 1920, height: 1080 }),
+        ];
+
+        network.use(
+            http.get('/api/projects/{project_id}/dataset/media', () => {
+                return HttpResponse.json({
+                    items: mediaItems,
+                    pagination: {
+                        offset: 0,
+                        limit: 10,
+                        count: mediaItems.length,
+                        total: mediaItems.length,
+                    },
+                });
+            }),
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', () => {
+                return HttpResponse.json({
+                    annotations: [],
+                    user_reviewed: true,
+                });
+            })
+        );
+
+        await page.goto(`/projects/${mockedDetectionProject.id}/dataset`);
+        await page.getByRole('img', { name: 'item-1.jpg' }).dblclick();
+
+        await test.step('Select non-default label on first media item', async () => {
+            const blueLabelButton = page.getByRole('button', { name: `Label ${blueLabel.name}` });
+            await blueLabelButton.click();
+            await expect(blueLabelButton).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        await test.step('Switching media keeps selected label active', async () => {
+            const sidebarItems = page.getByRole('listbox', { name: 'sidebar-items' });
+            await sidebarItems.getByRole('img', { name: 'item-2.jpg' }).click();
+
+            await expect(page.getByRole('button', { name: `Label ${blueLabel.name}` })).toHaveAttribute(
+                'aria-pressed',
+                'true'
+            );
+        });
+    });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* When worker initialisation fails or when encoding fails, the worker would fail silently and the app would hung. We now set a timeout and throw an error accordingly. In the future we can add a "Retry" button if the user wants to retry, but for now i kept it simple and just show a notification.
* The other issues are related with resetting annotations and persisting select label, when we had an annotation & label selected and changed media item, the selectedAnnotation set size would contain annotations, but from another media item, which means the selected label was stale. We now reset this properly. Not only labels but also annotations. TLDR; We reset annotations if media item changes, and we correctly persist the selected label properly. You can also check the component test descriptions

Closes https://github.com/open-edge-platform/training_extensions/issues/5703

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
