### PR TITLE
fix: Reset selected annotations on media change

### DIFF
--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -33,25 +33,23 @@ export const AnnotatorProviders = ({
 }: AnnotatorProvidersProps) => {
     return (
         <ZoomProvider>
-            <SelectAnnotationProvider>
-                <AnnotationVisibilityProvider>
-                    <CanvasSettingsProvider>
-                        <AnnotatorLabelsProvider>
-                            <AnnotationActionsProvider
-                                key={mediaItem.id}
-                                mediaItem={mediaItem}
-                                initialAnnotationsDTO={initialAnnotationsDTO}
-                                initialPredictionsDTO={initialPredictionsDTO}
-                                isUserReviewed={isUserReviewed}
-                                mode={mode}
-                                isReadOnly={isReadOnly}
-                            >
-                                {children}
-                            </AnnotationActionsProvider>
-                        </AnnotatorLabelsProvider>
-                    </CanvasSettingsProvider>
-                </AnnotationVisibilityProvider>
-            </SelectAnnotationProvider>
+            <AnnotationVisibilityProvider>
+                <CanvasSettingsProvider>
+                    <AnnotatorLabelsProvider>
+                        <AnnotationActionsProvider
+                            key={mediaItem.id}
+                            mediaItem={mediaItem}
+                            initialAnnotationsDTO={initialAnnotationsDTO}
+                            initialPredictionsDTO={initialPredictionsDTO}
+                            isUserReviewed={isUserReviewed}
+                            mode={mode}
+                            isReadOnly={isReadOnly}
+                        >
+                            <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
+                        </AnnotationActionsProvider>
+                    </AnnotatorLabelsProvider>
+                </CanvasSettingsProvider>
+            </AnnotationVisibilityProvider>
         </ZoomProvider>
     );
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue is that when we select an annotation and change media, selected annotation from the previous media is still in the memory but that's shouldn't be there. Annotation belong to the media so whenever media changes we need to reset the state there.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
