### PR TITLE
Add endpoint to bulk delete media

### DIFF
--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -13,6 +13,7 @@ from app.api.dependencies import get_dataset_service, get_file_name_and_extensio
 from app.api.io_utils import write_file_to_response, write_image_to_response
 from app.api.schemas.media import (
     AnnotatedVideoFrame,
+    BulkDeleteMedia,
     MediaAnnotations,
     MediaView,
     MediaViewAdapter,
@@ -24,6 +25,7 @@ from app.core.models import Pagination
 from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Media, Project, Video
 from app.models.media import ImageFormat, MediaType, NotAnnotatedVideoFrame, VideoFormat
 from app.services import DatasetService, MediaService
+from app.services.base import ResourceNotFoundError
 from app.services.dataset_service import AnnotationValidationError
 from app.services.media_service import InvalidImageError, MediaFilters
 
@@ -94,6 +96,13 @@ SET_MEDIA_ANNOTATIONS_BODY_EXAMPLES = {
             "annotations": [],
         },
     ),
+}
+
+BULK_MEDIA_DELETE_EXAMPLE = {
+    "list_of_media_ids": Example(
+        summary="List of Media IDs",
+        value={"media_ids": ["d476573e-d43c-42a6-9327-199a9aa75c33", "bbb782b7-8322-44e8-b6a9-90a5c9ee4bad"]},
+    )
 }
 
 
@@ -367,6 +376,28 @@ def delete_media(
 ) -> None:
     """Delete media from the dataset"""
     media_service.delete_media(project=project, media_id=media_id)
+
+
+@router.delete(
+    "",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        status.HTTP_204_NO_CONTENT: {"description": "Requested media has been deleted"},
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid media ID or invalid annotation content"},
+        status.HTTP_404_NOT_FOUND: {"description": "Project not found"},
+    },
+)
+def bulk_delete_media(
+    project: Annotated[Project, Depends(get_project)],
+    media_ids_list: Annotated[BulkDeleteMedia, Body(openapi_examples=BULK_MEDIA_DELETE_EXAMPLE)],
+    media_service: Annotated[MediaService, Depends(get_media_service)],
+) -> None:
+    """Bulk delete media"""
+    for media_id in media_ids_list.media_ids:
+        try:
+            media_service.delete_media(project=project, media_id=media_id)
+        except ResourceNotFoundError:
+            pass
 
 
 @router.post(

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -25,7 +25,7 @@ from app.core.models import Pagination
 from app.models import DatasetItemAnnotationStatus, DatasetItemSubset, Media, Project, Video
 from app.models.media import ImageFormat, MediaType, NotAnnotatedVideoFrame, VideoFormat
 from app.services import DatasetService, MediaService
-from app.services.base import ResourceNotFoundError
+from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.dataset_service import AnnotationValidationError
 from app.services.media_service import InvalidImageError, MediaFilters
 
@@ -396,8 +396,10 @@ def bulk_delete_media(
     for media_id in media_ids_list.media_ids:
         try:
             media_service.delete_media(project=project, media_id=media_id)
-        except ResourceNotFoundError:
-            pass
+        except ResourceNotFoundError as error:
+            # Ignore not-found errors only for media resources; re-raise for others (e.g., project)
+            if getattr(error, "resource_type", None) != ResourceType.MEDIA:
+                raise
 
 
 @router.post(

--- a/application/backend/app/api/schemas/media.py
+++ b/application/backend/app/api/schemas/media.py
@@ -136,6 +136,18 @@ class SetMediaAnnotations(BaseModel):
     }
 
 
+class BulkDeleteMedia(BaseModel):
+    """Schema for deleting multiple media at once"""
+
+    media_ids: list[UUID]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {"media_ids": ["d476573e-d43c-42a6-9327-199a9aa75c33", "bbb782b7-8322-44e8-b6a9-90a5c9ee4bad"]}
+        }
+    }
+
+
 class MediaAnnotations(BaseModel):
     """
     Media annotations with information about source

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -5,7 +5,7 @@ import tempfile
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, PropertyMock
+from unittest.mock import ANY, MagicMock, PropertyMock, call
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
@@ -755,6 +755,33 @@ class TestMediaEndpoints:
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         fxt_media_service.delete_media.assert_called_once_with(project=fxt_get_project, media_id=media_id)
+
+    def test_bulk_delete_media_skips_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
+        media_id_1 = uuid4()
+        media_id_2 = uuid4()
+        media_id_3 = uuid4()
+
+        fxt_media_service.delete_media.side_effect = [
+            None,
+            ResourceNotFoundError(ResourceType.MEDIA, str(media_id_2)),
+            None,
+        ]
+
+        response = fxt_client.request(
+            "DELETE",
+            f"/api/projects/{str(uuid4())}/dataset/media",
+            json={"media_ids": [str(media_id_1), str(media_id_2), str(media_id_3)]},
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert fxt_media_service.delete_media.call_count == 3
+        fxt_media_service.delete_media.assert_has_calls(
+            [
+                call(project=fxt_get_project, media_id=media_id_1),
+                call(project=fxt_get_project, media_id=media_id_2),
+                call(project=fxt_get_project, media_id=media_id_3),
+            ]
+        )
 
     @pytest.mark.parametrize(
         "media",


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add endpoint to bulk delete media. Simply loops over media ids and uses the existing logic to delete one media. Ignores `ResourceNotFoundError` and returns nothing. Note that `ResourceNotFoundError` is still triggered for non-existing project.

Resolves #5732 

### How to test

Added unit test to automatically test behaviour.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
