### PR TITLE
Allow toast click regardless of zIndex

### DIFF
--- a/application/ui/src/providers.tsx
+++ b/application/ui/src/providers.tsx
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { Toast } from '@geti/ui';
 import { ThemeProvider } from '@geti/ui/theme';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router';
@@ -13,6 +14,9 @@ export const Providers = () => {
         <QueryClientProvider client={queryClient}>
             <ThemeProvider router={router}>
                 <RouterProvider router={router} />
+                <div data-react-aria-top-layer='true'>
+                    <Toast />
+                </div>
             </ThemeProvider>
         </QueryClientProvider>
     );

--- a/application/ui/src/routes/root/root.tsx
+++ b/application/ui/src/routes/root/root.tsx
@@ -3,7 +3,7 @@
 
 import { ReactNode, Suspense } from 'react';
 
-import { Button, Heading, IllustratedMessage, IntelBrandedLoading, Toast, View } from '@geti/ui';
+import { Button, Heading, IllustratedMessage, IntelBrandedLoading, View } from '@geti/ui';
 import { CloudErrorIcon } from '@geti/ui/icons';
 import { Outlet } from 'react-router';
 
@@ -52,7 +52,6 @@ export const RootLayout = () => {
         <Suspense fallback={<IntelBrandedLoading />}>
             <HealthCheck>
                 <Outlet />
-                <Toast />
             </HealthCheck>
         </Suspense>
     );


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Leverage `data-react-aria-top-layer` prop to make sure we can always click on the toast regardless of the context or zIndex
Closes https://github.com/open-edge-platform/training_extensions/issues/5654

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
