### PR TITLE
General fixes

### DIFF
--- a/application/ui/src/features/annotator/annotations/annotation-shape-renderer.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-renderer.component.tsx
@@ -8,12 +8,13 @@ import { AnnotationShapeWithoutLabels } from './annotation-shape-without-labels.
 
 interface AnnotationShapeRendererProps {
     annotation: Annotation;
+    hideLabels?: boolean;
 }
 
-export const AnnotationShapeRenderer = ({ annotation }: AnnotationShapeRendererProps) => {
+export const AnnotationShapeRenderer = ({ annotation, hideLabels = false }: AnnotationShapeRendererProps) => {
     const { canvasSettings } = useCanvasSettings();
 
-    if (canvasSettings.hideLabels.value) {
+    if (hideLabels || canvasSettings.hideLabels.value) {
         return <AnnotationShapeWithoutLabels annotation={annotation} />;
     }
 

--- a/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.test.tsx
@@ -10,10 +10,12 @@ import { render } from 'test-utils/render';
 
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
+import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
 import { AnnotationShapeWithLabels } from './annotation-shape-with-labels.component';
 
 const mockDeleteAnnotations = vi.fn();
 const mockUpdateAnnotations = vi.fn();
+const mockSetSelectedLabelId = vi.fn();
 
 vi.mock('../../../shared/annotator/annotation-visibility-provider.component', () => ({
     useAnnotationVisibility: () => ({
@@ -26,6 +28,15 @@ vi.mock('../../../shared/annotator/annotation-actions-provider.component', () =>
         updateAnnotations: mockUpdateAnnotations,
         deleteAnnotations: mockDeleteAnnotations,
         isReadOnlyMode: false,
+    }),
+}));
+
+vi.mock('../annotator-labels-provider.component', () => ({
+    useAnnotatorLabels: () => ({
+        labels: [],
+        selectedLabel: null,
+        selectedLabelId: 'empty-label',
+        setSelectedLabelId: mockSetSelectedLabelId,
     }),
 }));
 
@@ -61,7 +72,7 @@ describe('AnnotationShapeWithLabels', () => {
         const annotation = getMockedAnnotation({
             id: 'full-image-annotation',
             shape: { type: 'full_image' },
-            labels: [getMockedLabel({ id: 'label-1', name: 'No object' })],
+            labels: [getMockedLabel({ id: EMPTY_LABEL_ID, name: 'No object' })],
         });
 
         render(<AnnotationShapeWithLabels annotation={annotation} />);
@@ -69,6 +80,7 @@ describe('AnnotationShapeWithLabels', () => {
 
         expect(mockDeleteAnnotations).toHaveBeenCalledWith(['full-image-annotation']);
         expect(mockUpdateAnnotations).not.toHaveBeenCalled();
+        expect(mockSetSelectedLabelId).toHaveBeenCalledWith(null);
     });
 
     it('keeps non-full-image behavior unchanged in detection projects', async () => {

--- a/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-shape-with-labels.component.tsx
@@ -9,8 +9,10 @@ import polylabel from 'polylabel';
 import type { Label } from '../../../constants/shared-types';
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
+import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
 import type { Annotation } from '../../../shared/types';
 import { isClassificationTask } from '../../project/task-type-guards';
+import { useAnnotatorLabels } from '../annotator-labels-provider.component';
 import { AnnotationLabels } from './annotation-labels/annotation-labels.component';
 import { AnnotationShape } from './annotation-shape/annotation-shape.component';
 
@@ -22,12 +24,17 @@ export const AnnotationShapeWithLabels = ({ annotation }: AnnotationShapeProps) 
     const { data: selectedProject } = useProject();
     const { isVisible } = useAnnotationVisibility();
     const { updateAnnotations, deleteAnnotations, isReadOnlyMode } = useAnnotationActions();
+    const { selectedLabelId, setSelectedLabelId } = useAnnotatorLabels();
 
     const { shape, labels } = annotation;
 
     const removeLabels = (labelId: Key | null) => {
         if (isReadOnlyMode) {
             return;
+        }
+
+        if (labelId === EMPTY_LABEL_ID && selectedLabelId === EMPTY_LABEL_ID) {
+            setSelectedLabelId(null);
         }
 
         const updatedLabels = annotation.labels.filter((label) => label.id !== labelId) as Label[];

--- a/application/ui/src/features/annotator/tools/edit-bounding-box/edit-bounding-box.component.tsx
+++ b/application/ui/src/features/annotator/tools/edit-bounding-box/edit-bounding-box.component.tsx
@@ -47,7 +47,7 @@ export const EditBoundingBox = ({ annotation, zoom }: EditBoundingBoxProps) => {
                 translateShape={translate}
                 onComplete={onComplete}
             >
-                <AnnotationShapeRenderer annotation={{ ...annotation, shape }} />
+                <AnnotationShapeRenderer annotation={{ ...annotation, shape }} hideLabels />
             </TranslateShape>
 
             <g

--- a/application/ui/src/features/annotator/tools/edit-bounding-box/edit-bounding-box.component.tsx
+++ b/application/ui/src/features/annotator/tools/edit-bounding-box/edit-bounding-box.component.tsx
@@ -47,7 +47,7 @@ export const EditBoundingBox = ({ annotation, zoom }: EditBoundingBoxProps) => {
                 translateShape={translate}
                 onComplete={onComplete}
             >
-                <AnnotationShapeRenderer annotation={{ ...annotation, shape }} hideLabels />
+                <AnnotationShapeRenderer annotation={{ ...annotation, shape }} />
             </TranslateShape>
 
             <g

--- a/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.component.tsx
+++ b/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.component.tsx
@@ -93,7 +93,7 @@ export const EditPolygon = ({ annotation, zoom }: EditPolygonProps) => {
                     annotation={{ ...annotation, shape }}
                     onComplete={() => onComplete(shape)}
                 >
-                    <AnnotationShapeRenderer annotation={{ ...annotation, shape }} />
+                    <AnnotationShapeRenderer annotation={{ ...annotation, shape }} hideLabels />
                 </TranslateShape>
             </svg>
 

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.module.scss
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.module.scss
@@ -36,6 +36,7 @@
 .modelBadge {
     color: var(--spectrum-global-color-gray-800);
     background-color: var(--spectrum-global-color-gray-200);
+    font-weight: normal;
 
     & span[class*='Badge-label'] {
         padding-inline-end: var(--spectrum-global-dimension-size-75);

--- a/application/ui/src/features/models/model-listing/model-metrics/metric-graph.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-metrics/metric-graph.component.tsx
@@ -43,6 +43,8 @@ export const MetricGraph = ({ title, data, xAxisLabel, yAxisLabel }: MetricGraph
                             <CartesianGrid />
                             <XAxis
                                 dataKey='x'
+                                type='number'
+                                domain={[0, 'auto']}
                                 label={{ value: xAxisLabel ?? 'x', position: 'bottom', fill: '#666', offset: 12 }}
                                 tickCount={X_AXIS_TICK_COUNT}
                                 tickMargin={12}

--- a/application/ui/src/features/models/model-listing/model-metrics/metric-graph.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-metrics/metric-graph.component.tsx
@@ -50,7 +50,7 @@ export const MetricGraph = ({ title, data, xAxisLabel, yAxisLabel }: MetricGraph
                                 tickMargin={12}
                             />
                             <YAxis
-                                label={{ value: yAxisLabel, angle: -90, position: 'center', dx: -38 }}
+                                label={{ value: yAxisLabel, angle: -90, position: 'center', dx: -38, fill: '#666' }}
                                 tickCount={Y_AXIS_TICK_COUNT}
                                 tickMargin={12}
                                 tickFormatter={(value) => Number(value).toFixed(4)}

--- a/application/ui/src/features/models/model-listing/model-metrics/model-evaluations.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-metrics/model-evaluations.component.tsx
@@ -1,9 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Fragment } from 'react';
-
-import { Divider, Flex, Text } from '@geti/ui';
+import { Grid, Text } from '@geti/ui';
 
 import type { Evaluation } from '../../../../constants/shared-types';
 import { Box } from '../components/box/box.component';
@@ -20,28 +18,32 @@ type ModelEvaluationMetrics = {
 export const ModelEvaluations = ({ evaluations }: ModelEvaluationMetrics) => {
     const testingMetrics = getTestingMetrics(evaluations);
 
-    return (
-        <Box
-            title={'Evaluations'}
-            content={
-                <Flex alignItems={'center'}>
-                    {testingMetrics.length > 0 ? (
-                        testingMetrics.map(({ name, value }, index) => (
-                            <Fragment key={name}>
-                                {index > 0 && <Divider marginX={'size-300'} orientation={'vertical'} size={'S'} />}
+    if (testingMetrics.length === 0) {
+        return (
+            <Box
+                title={'Evaluations'}
+                content={
+                    <Text UNSAFE_style={{ color: 'var(--spectrum-global-color-gray-900)' }}>
+                        Testing evaluation metrics are not available
+                    </Text>
+                }
+            />
+        );
+    }
 
-                                <Text UNSAFE_style={{ color: 'var(--spectrum-global-color-gray-900)' }}>
-                                    {`${name}: ${formatEvaluationValue(value)}`}
-                                </Text>
-                            </Fragment>
-                        ))
-                    ) : (
+    return (
+        <Grid columns={['1fr', '1fr', '1fr']} gap={'size-200'}>
+            {testingMetrics.map(({ name, value }) => (
+                <Box
+                    key={name}
+                    title={name}
+                    content={
                         <Text UNSAFE_style={{ color: 'var(--spectrum-global-color-gray-900)' }}>
-                            Testing evaluation metrics are not available
+                            {formatEvaluationValue(value)}
                         </Text>
-                    )}
-                </Flex>
-            }
-        />
+                    }
+                />
+            ))}
+        </Grid>
     );
 };

--- a/application/ui/src/features/project/create/classification-label-selection/classification-task-type-selection.component.tsx
+++ b/application/ui/src/features/project/create/classification-label-selection/classification-task-type-selection.component.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Flex, Radio, RadioGroup, Text } from '@geti/ui';
+import { InfoOutline } from '@geti/ui/icons';
 
-import styles from './classification-task-type-selection.module.scss';
+import classes from './classification-task-type-selection.module.scss';
 
 export type ClassificationTaskType = 'single-label' | 'multi-label';
 
@@ -12,14 +13,27 @@ type ClassificationTaskTypeItemProps = {
     label: string;
     description: string;
     onSelect: (type: ClassificationTaskType) => void;
+    warning?: string;
 };
 
-const ClassificationTaskTypeItem = ({ type, label, description, onSelect }: ClassificationTaskTypeItemProps) => {
+const ClassificationTaskTypeItem = ({
+    type,
+    label,
+    description,
+    onSelect,
+    warning,
+}: ClassificationTaskTypeItemProps) => {
     return (
-        <div onClick={() => onSelect(type)} className={styles.itemType}>
+        <div onClick={() => onSelect(type)} className={classes.itemType}>
             <Radio value={type}>{label}</Radio>
 
-            <Text UNSAFE_className={styles.typeDescription}>{description}</Text>
+            <Text UNSAFE_className={classes.typeDescription}>{description}</Text>
+            {warning && (
+                <Flex alignItems={'center'} gap={'size-50'} marginTop={'size-100'}>
+                    <InfoOutline />
+                    <Text UNSAFE_className={classes.warning}>{warning}</Text>
+                </Flex>
+            )}
         </div>
     );
 };
@@ -35,7 +49,7 @@ export const ClassificationTaskSelection = ({
 }: ClassificationTaskSelectionProps) => {
     return (
         <Flex direction={'column'} gap={'size-250'}>
-            <Text UNSAFE_className={styles.title}>What classification type should the model use?</Text>
+            <Text UNSAFE_className={classes.title}>What classification type should the model use?</Text>
             <RadioGroup
                 isEmphasized
                 aria-label={'Classification type'}
@@ -49,6 +63,7 @@ export const ClassificationTaskSelection = ({
                             label={'Single-label'}
                             description={'Assign one label from mutually exclusive labels'}
                             onSelect={onSelectedTypeChange}
+                            warning={'Requires at least 2 labels'}
                         />
                         <ClassificationTaskTypeItem
                             type={'multi-label'}

--- a/application/ui/src/features/project/create/classification-label-selection/classification-task-type-selection.module.scss
+++ b/application/ui/src/features/project/create/classification-label-selection/classification-task-type-selection.module.scss
@@ -22,3 +22,7 @@
         background-color: var(--selection-dark-blue);
     }
 }
+
+.warning {
+    font-size: var(--spectrum-global-dimension-font-size-75);
+}

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -3,7 +3,7 @@
 
 import { FormEvent, useState } from 'react';
 
-import { Button, ButtonGroup, Content, Divider, Flex, Form, InlineAlert, Text, TextField } from '@geti/ui';
+import { Button, ButtonGroup, Divider, Flex, Form, Text, TextField, toast } from '@geti/ui';
 import { Link, useNavigate } from 'react-router-dom';
 import { v4 as uuid } from 'uuid';
 
@@ -42,21 +42,25 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
         projects.map((project) => project.name)
     );
 
-    const isMultiLabelClassification = isClassificationTask(selectedTask) && classificationTaskType === 'multi-label';
-
-    const needsMinimumNumberOfLabels = isMultiLabelClassification && labels.length < 2;
-    const multiLabelClassificationErrorMessage = 'At least 2 labels are required for multi-label classification';
+    const isMultiClassProject = isClassificationTask(selectedTask) && classificationTaskType === 'single-label';
+    const needsMinimumNumberOfLabels = isMultiClassProject && labels.length < 2;
 
     const isCreateProjectDisabled =
-        selectedTask === null ||
-        validationErrorMessage !== undefined ||
-        labels.length === 0 ||
-        needsMinimumNumberOfLabels;
+        selectedTask === null || validationErrorMessage !== undefined || labels.length === 0;
 
     const createProject = (e: FormEvent) => {
         e.preventDefault();
 
         if (isCreateProjectDisabled) {
+            return;
+        }
+
+        if (needsMinimumNumberOfLabels) {
+            toast({
+                message: 'At least 2 labels are required for single-label classification',
+                type: 'warning',
+            });
+
             return;
         }
 
@@ -132,14 +136,6 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
                                 </Text>
                             </Flex>
                             <LabelSelection labels={labels} setLabels={setLabels} taskType={selectedTask} />
-
-                            {needsMinimumNumberOfLabels && (
-                                <InlineAlert variant={'notice'}>
-                                    <Content>
-                                        <Text>{multiLabelClassificationErrorMessage}</Text>
-                                    </Content>
-                                </InlineAlert>
-                            )}
                         </Flex>
                     )}
                 </Flex>

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -3,7 +3,7 @@
 
 import { FormEvent, useState } from 'react';
 
-import { Button, ButtonGroup, Divider, Flex, Form, Text, TextField } from '@geti/ui';
+import { Button, ButtonGroup, Content, Divider, Flex, Form, InlineAlert, Text, TextField } from '@geti/ui';
 import { Link, useNavigate } from 'react-router-dom';
 import { v4 as uuid } from 'uuid';
 
@@ -42,8 +42,16 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
         projects.map((project) => project.name)
     );
 
+    const isMultiLabelClassification = isClassificationTask(selectedTask) && classificationTaskType === 'multi-label';
+
+    const needsMinimumNumberOfLabels = isMultiLabelClassification && labels.length < 2;
+    const multiLabelClassificationErrorMessage = 'At least 2 labels are required for multi-label classification';
+
     const isCreateProjectDisabled =
-        selectedTask === null || validationErrorMessage !== undefined || labels.length === 0;
+        selectedTask === null ||
+        validationErrorMessage !== undefined ||
+        labels.length === 0 ||
+        needsMinimumNumberOfLabels;
 
     const createProject = (e: FormEvent) => {
         e.preventDefault();
@@ -124,6 +132,14 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
                                 </Text>
                             </Flex>
                             <LabelSelection labels={labels} setLabels={setLabels} taskType={selectedTask} />
+
+                            {needsMinimumNumberOfLabels && (
+                                <InlineAlert variant={'notice'}>
+                                    <Content>
+                                        <Text>{multiLabelClassificationErrorMessage}</Text>
+                                    </Content>
+                                </InlineAlert>
+                            )}
                         </Flex>
                     )}
                 </Flex>

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -59,7 +59,8 @@ test.describe('Annotator', () => {
         await test.step('Draw an annotation', async () => {
             await boundingBoxTool.selectTool();
             await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
-            await expect(page.getByLabel(`label ${redLabel.name}`).nth(1)).toBeInViewport();
+
+            await expect(page.getByLabel(`label ${redLabel.name} background`)).toHaveCount(1);
         });
 
         await test.step('Change annotation label by clicking label badge', async () => {
@@ -73,7 +74,7 @@ test.describe('Annotator', () => {
 
             await page.getByRole('button', { name: `Label ${blueLabel.name}` }).click();
 
-            await expect(page.getByLabel(`label ${blueLabel.name}`).nth(1)).toBeInViewport();
+            await expect(page.getByLabel(`label ${blueLabel.name} background`)).toHaveCount(1);
             await expect(page.getByRole('button', { name: `Label ${blueLabel.name}` })).toHaveAttribute(
                 'aria-pressed',
                 'true'
@@ -84,7 +85,7 @@ test.describe('Annotator', () => {
             await boundingBoxTool.selectTool();
             await boundingBoxTool.drawBoundingBox({ x: 300, y: 200, width: 150, height: 150 });
 
-            await expect(page.getByLabel(`label ${blueLabel.name}`).nth(1)).toBeInViewport();
+            await expect(page.getByLabel(`label ${blueLabel.name} background`)).toHaveCount(2);
         });
 
         await test.step('Change second annotation to red label', async () => {
@@ -92,15 +93,12 @@ test.describe('Annotator', () => {
             await page.getByLabel('annotation rect').nth(3).click();
             await page.getByRole('button', { name: `Label ${redLabel.name}` }).click();
 
-            await expect(page.getByLabel(`label ${redLabel.name}`).nth(1)).toBeInViewport();
+            await expect(page.getByLabel(`label ${redLabel.name} background`)).toHaveCount(1);
         });
 
         await test.step('Verify both annotations have correct labels', async () => {
-            await page.getByLabel('annotation rect').nth(2).click();
-            await expect(page.getByLabel(`label ${blueLabel.name}`).nth(1)).toBeInViewport();
-
-            await page.getByLabel('annotation rect').nth(3).click();
-            await expect(page.getByLabel(`label ${redLabel.name}`).nth(1)).toBeInViewport();
+            await expect(page.getByLabel(`label ${blueLabel.name} background`)).toHaveCount(1);
+            await expect(page.getByLabel(`label ${redLabel.name} background`)).toHaveCount(1);
         });
     });
 
@@ -346,7 +344,7 @@ test.describe('Annotator', () => {
             // If polygon tool persisted, we should be able to draw immediately without reselecting
             await polygonTool.drawPolygon(smallPolygon);
 
-            await expect(page.getByLabel(`label ${redLabel.name}`).nth(1)).toBeInViewport();
+            expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(1);
         });
 
         await test.step('Navigate back to first media item', async () => {
@@ -360,7 +358,7 @@ test.describe('Annotator', () => {
             // Draw another polygon to verify tool is still active
             await polygonTool.drawPolygon(smallPolygon);
 
-            await expect(page.getByLabel(`label ${redLabel.name}`).nth(1)).toBeInViewport();
+            expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(1);
         });
 
         await test.step('Verify tool resets when switching modes', async () => {
@@ -377,7 +375,7 @@ test.describe('Annotator', () => {
 
             // Verify polygon tool is active by drawing a polygon without manually selecting it
             await polygonTool.drawPolygon(smallPolygon);
-            await expect(page.getByLabel(`label ${redLabel.name}`).nth(2)).toBeInViewport();
+            expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
         });
     });
 

--- a/application/ui/tests/datasets/annotator-page.ts
+++ b/application/ui/tests/datasets/annotator-page.ts
@@ -93,7 +93,7 @@ export class AnnotatorPage {
         return this.page.getByTestId('annotation-layer');
     }
 
-    async getAnnotationsListItems(label: 'annotation rect' | 'prediction rect') {
+    async getAnnotationsListItems(label: 'annotation rect' | 'prediction rect' | 'annotation polygon') {
         return this.getAnnotationsList()
             .getByLabel(label)
             .evaluateAll((nodes) => nodes.filter((node) => !node.closest('mask')));

--- a/application/ui/tests/e2e/new-project.spec.ts
+++ b/application/ui/tests/e2e/new-project.spec.ts
@@ -51,7 +51,7 @@ test('Project creation', async ({ page }) => {
         await page.getByRole('button', { name: /Create project/ }).scrollIntoViewIfNeeded();
         await page.getByRole('button', { name: /Create project/ }).click();
 
-        await page.waitForURL(/inference/);
+        await page.waitForURL(/dataset/);
     });
 
     await test.step('Verify project appears in project list', async () => {

--- a/application/ui/tests/general.spec.ts
+++ b/application/ui/tests/general.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Page } from '@playwright/test';
+import { HttpResponse } from 'msw';
+
+import { getMockedProject } from '../mocks/mock-project';
+import { expect, http, test } from './fixtures';
+
+const expectToastToBeInteractive = async (page: Page, message: string) => {
+    const toastMessage = page.getByText(message);
+
+    await expect(toastMessage).toBeVisible();
+    await toastMessage.click();
+};
+
+test.describe('Toast Rendering', () => {
+    test('shows toast from create-project form context', async ({ page }) => {
+        await page.goto('/projects/new');
+
+        await page.getByLabel('detection', { exact: true }).click();
+        await page.getByRole('textbox', { name: 'Create label input' }).fill('Object');
+        await page.getByRole('button', { name: /Create label/i }).click();
+        await page.getByRole('button', { name: /delete label object/i }).click();
+
+        await expectToastToBeInteractive(page, 'At least one object is required');
+    });
+
+    test('shows toast from dialog context', async ({ page, network }) => {
+        network.use(
+            http.get('/api/projects', () => {
+                return HttpResponse.json([
+                    getMockedProject({ id: 'id-1', name: 'Project 1' }),
+                    getMockedProject({ id: 'id-2', name: 'Project 2' }),
+                ]);
+            })
+        );
+
+        await page.goto('/projects');
+
+        await page.getByTestId('id-1').click();
+        await page.getByText(/Delete/).click();
+        await page.getByRole('button', { name: 'Delete' }).click();
+
+        await expectToastToBeInteractive(page, 'Project deleted successfully');
+    });
+
+    test('shows toast from inference page context', async ({ page, network }) => {
+        network.use(
+            http.get('/api/projects/{project_id}/pipeline', () => {
+                return HttpResponse.json({
+                    project_id: 'id-1',
+                    status: 'running',
+                    source: null,
+                    sink: null,
+                    model: null,
+                    device: 'cpu',
+                });
+            })
+        );
+
+        await page.goto('/projects/id-1/inference');
+        await page.getByRole('button', { name: 'Disable Pipeline' }).click();
+
+        await expectToastToBeInteractive(page, 'Pipeline disabled successfully');
+    });
+});

--- a/application/ui/tests/general.spec.ts
+++ b/application/ui/tests/general.spec.ts
@@ -8,10 +8,12 @@ import { getMockedProject } from '../mocks/mock-project';
 import { expect, http, test } from './fixtures';
 
 const expectToastToBeInteractive = async (page: Page, message: string) => {
-    const toastMessage = page.getByText(message);
+    const toast = page.getByLabel('toast').filter({ hasText: message });
+    const dismissButton = toast.getByRole('button').first();
 
-    await expect(toastMessage).toBeVisible();
-    await toastMessage.click();
+    await expect(toast).toBeVisible();
+    await expect(dismissButton).toBeVisible();
+    await dismissButton.click();
 };
 
 test.describe('Toast Rendering', () => {

--- a/application/ui/tests/projects/project-page.ts
+++ b/application/ui/tests/projects/project-page.ts
@@ -28,7 +28,7 @@ export class ProjectPage {
     }
 
     getMultiLabelValidationMessage() {
-        return this.page.getByText('At least 2 labels are required for multi-label classification');
+        return this.page.getByText('At least 2 labels are required for single-label classification');
     }
 
     async setProjectName(name: string) {

--- a/application/ui/tests/projects/project-page.ts
+++ b/application/ui/tests/projects/project-page.ts
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Page } from '@playwright/test';
+
+import { paths } from '../../src/constants/paths';
+
+type ProjectFormOptions = {
+    name: string;
+    task: string;
+    classificationType?: 'Single-label' | 'Multi-label';
+    labelNames: string[];
+};
+
+export class ProjectPage {
+    constructor(private page: Page) {}
+
+    async gotoList() {
+        await this.page.goto(paths.project.index({}));
+    }
+
+    async gotoCreate() {
+        await this.page.goto(paths.project.new({}));
+    }
+
+    getCreateProjectButton() {
+        return this.page.getByRole('button', { name: /Create project/ });
+    }
+
+    getMultiLabelValidationMessage() {
+        return this.page.getByText('At least 2 labels are required for multi-label classification');
+    }
+
+    async setProjectName(name: string) {
+        await this.page.getByRole('textbox', { name: 'Project name input' }).fill(name);
+    }
+
+    async selectTask(task: string) {
+        await this.page.getByLabel(task, { exact: true }).click();
+    }
+
+    async selectClassificationType(type: 'Single-label' | 'Multi-label') {
+        await this.page.getByRole('radio', { name: type }).click();
+    }
+
+    async addLabel(labelName: string) {
+        await this.page.getByRole('textbox', { name: 'Create label input' }).fill(labelName);
+        await this.page.getByRole('button', { name: /Create label/ }).click();
+    }
+
+    async fillProjectForm({ name, task, classificationType, labelNames }: ProjectFormOptions) {
+        await this.setProjectName(name);
+        await this.selectTask(task);
+
+        if (classificationType !== undefined) {
+            await this.selectClassificationType(classificationType);
+        }
+
+        for (const labelName of labelNames) {
+            await this.addLabel(labelName);
+        }
+    }
+
+    async openProjectMenu(projectId: string) {
+        await this.page.getByTestId(projectId).click();
+    }
+
+    async clickDeleteMenuAction() {
+        await this.page.getByText(/Delete/).click();
+    }
+
+    async confirmDeleteProject() {
+        await this.page.getByRole('button', { name: /Delete/ }).click();
+    }
+}

--- a/application/ui/tests/projects/project.spec.ts
+++ b/application/ui/tests/projects/project.spec.ts
@@ -1,35 +1,11 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Page } from '@playwright/test';
 import { HttpResponse } from 'msw';
 
 import { getMockedProject } from '../../mocks/mock-project';
 import { expect, http, test } from '../fixtures';
-
-const fillProjectForm = async ({
-    page,
-    name,
-    task,
-    labelNames,
-}: {
-    page: Page;
-    name: string;
-    task: string;
-    labelNames: string[];
-}) => {
-    // Set the project name
-    await page.getByRole('textbox', { name: 'Project name input' }).fill(name);
-
-    // Select task
-    await page.getByLabel(task, { exact: true }).click();
-
-    // Add the rest of the labels
-    for (let i = 0; i < labelNames.length; i++) {
-        await page.getByRole('textbox', { name: 'Create label input' }).fill(labelNames[i]);
-        await page.getByRole('button', { name: /Create label/ }).click();
-    }
-};
+import { ProjectPage } from './project-page';
 
 test.describe('Project', () => {
     test.beforeEach(({ network }) => {
@@ -45,7 +21,9 @@ test.describe('Project', () => {
     });
 
     test('displays the list of projects', async ({ page }) => {
-        await page.goto('/projects');
+        const projectPage = new ProjectPage(page);
+
+        await projectPage.gotoList();
 
         await expect(page.getByText('Project 1')).toBeVisible();
         await expect(page.getByText('Project 2')).toBeVisible();
@@ -53,10 +31,11 @@ test.describe('Project', () => {
     });
 
     test('creates a project', async ({ page, network }) => {
-        await page.goto('/projects/new');
+        const projectPage = new ProjectPage(page);
 
-        await fillProjectForm({
-            page,
+        await projectPage.gotoCreate();
+
+        await projectPage.fillProjectForm({
             name: 'New Project',
             task: 'instance_segmentation',
             labelNames: ['Person', 'Animal'],
@@ -106,22 +85,45 @@ test.describe('Project', () => {
         await expect(page.getByText('Person')).toBeVisible();
         await expect(page.getByText('Animal')).toBeVisible();
 
-        await page.getByRole('button', { name: /Create project/ }).click();
+        await projectPage.getCreateProjectButton().click();
 
         // Correctly navigated to dataset page
         await page.waitForURL(/dataset/);
 
         // Go back to project list and confirm the project was created
-        await page.goto('/projects');
+        await projectPage.gotoList();
 
         await expect(page.getByText('New Project')).toBeVisible();
     });
 
+    test('toggles create button for multi-label classification based on label count', async ({ page }) => {
+        const projectPage = new ProjectPage(page);
+
+        await projectPage.gotoCreate();
+
+        await projectPage.fillProjectForm({
+            name: 'Multi-label project labels check',
+            task: 'classification',
+            classificationType: 'Multi-label',
+            labelNames: ['Person'],
+        });
+
+        await expect(projectPage.getCreateProjectButton()).toBeDisabled();
+        await expect(projectPage.getMultiLabelValidationMessage()).toBeVisible();
+
+        await projectPage.addLabel('Car');
+
+        await expect(projectPage.getCreateProjectButton()).toBeEnabled();
+        await expect(projectPage.getMultiLabelValidationMessage()).toBeHidden();
+    });
+
     test('deletes a project', async ({ page, network }) => {
-        await page.goto('/projects');
+        const projectPage = new ProjectPage(page);
+
+        await projectPage.gotoList();
 
         // Open menu options
-        await page.getByTestId('id-3').click();
+        await projectPage.openProjectMenu('id-3');
 
         network.use(
             http.get('/api/projects', () => {
@@ -138,8 +140,8 @@ test.describe('Project', () => {
             })
         );
 
-        await page.getByText(/Delete/).click();
-        await page.getByRole('button', { name: /Delete/ }).click();
+        await projectPage.clickDeleteMenuAction();
+        await projectPage.confirmDeleteProject();
 
         await expect(page.getByText('Project deleted successfully')).toBeVisible();
 

--- a/application/ui/tests/projects/project.spec.ts
+++ b/application/ui/tests/projects/project.spec.ts
@@ -96,25 +96,52 @@ test.describe('Project', () => {
         await expect(page.getByText('New Project')).toBeVisible();
     });
 
-    test('toggles create button for multi-label classification based on label count', async ({ page }) => {
+    test('shows warning for multi-class classification based on label count', async ({ page, network }) => {
         const projectPage = new ProjectPage(page);
 
         await projectPage.gotoCreate();
 
         await projectPage.fillProjectForm({
-            name: 'Multi-label project labels check',
+            name: 'Multi-class project labels check',
             task: 'classification',
-            classificationType: 'Multi-label',
+            classificationType: 'Single-label',
             labelNames: ['Person'],
         });
 
-        await expect(projectPage.getCreateProjectButton()).toBeDisabled();
+        await expect(projectPage.getCreateProjectButton()).toBeEnabled();
+        await projectPage.getCreateProjectButton().click();
+
         await expect(projectPage.getMultiLabelValidationMessage()).toBeVisible();
+
+        // Close the notification
+        const toast = page
+            .getByLabel('toast')
+            .filter({ hasText: 'At least 2 labels are required for single-label classification' });
+        await toast.getByRole('button').first().click();
 
         await projectPage.addLabel('Car');
 
-        await expect(projectPage.getCreateProjectButton()).toBeEnabled();
-        await expect(projectPage.getMultiLabelValidationMessage()).toBeHidden();
+        network.use(
+            http.post('/api/projects', ({ response }) => {
+                return response(201).json(
+                    getMockedProject({
+                        id: 'single-label-project-id',
+                        name: 'Multi-class project labels check',
+                        task: {
+                            task_type: 'classification',
+                            exclusive_labels: true,
+                            labels: [
+                                { id: '1', color: 'red', name: 'Person' },
+                                { id: '2', color: 'blue', name: 'Car' },
+                            ],
+                        },
+                    })
+                );
+            })
+        );
+
+        await projectPage.getCreateProjectButton().click();
+        await page.waitForURL(/dataset/);
     });
 
     test('deletes a project', async ({ page, network }) => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary


Closes a few issues from https://github.com/open-edge-platform/training_extensions/issues/5674

* Show evaluations separately (screenshot)
* X-axis for all charts now starts at 0 (model metrics)
* X and Y labels now have the same color (model metrics)
* For classification multi-label, require at least 2 labels
* Add component tests for the point above
* Hide labels from annotations if they're being edited (preventing the anchors to be on top of the label, or the label being on top of anchors). For now only applied to polygon tool (Bugfix) but we should disable for all of them imho
* If we remove a label with EMPTY_LABEL, we need to remove the selected label, or else if we annotate after that, then we will use the EMPTY_LABEL as pre-selected label
* Add general.spec to host random tests that dont fit in any feature spec


<img width="1335" height="895" alt="Screenshot 2026-03-13 at 13 16 26" src="https://github.com/user-attachments/assets/141aac33-379b-4204-83fb-c40b8c64ce7f" />
<img width="1355" height="825" alt="Screenshot 2026-03-13 at 13 17 33" src="https://github.com/user-attachments/assets/2aef4e22-968b-4e98-ac8b-86f35f7c1cd6" />
<img width="1086" height="751" alt="Screenshot 2026-03-13 at 13 46 58" src="https://github.com/user-attachments/assets/31ea0741-20bf-4f78-925f-75b5727c5b56" />
<img width="969" height="702" alt="Screenshot 2026-03-13 at 15 22 45" src="https://github.com/user-attachments/assets/83486499-5048-4e6f-8c86-86cae01a5d3c" />



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
