### PR TITLE
chore: Disable advanced settings when model architecture is not selected [PART 9]

### DIFF
--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -118,13 +118,23 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
                     <Button variant={'secondary'} onPress={onClose}>
                         Cancel
                     </Button>
-                    <Button
-                        variant={'primary'}
-                        isDisabled={isAdvancedSettingsModeDisabled}
-                        onPress={() => onToggleAdvancedSettingsMode(!isAdvancedSettingsMode)}
-                    >
-                        {isAdvancedSettingsMode ? 'Back' : 'Advanced settings'}
-                    </Button>
+                    {isAdvancedSettingsMode ? (
+                        <Button
+                            variant={'primary'}
+                            onPress={() => onToggleAdvancedSettingsMode(!isAdvancedSettingsMode)}
+                        >
+                            Back
+                        </Button>
+                    ) : (
+                        <Button
+                            variant={'primary'}
+                            isDisabled={isAdvancedSettingsModeDisabled}
+                            onPress={() => onToggleAdvancedSettingsMode(!isAdvancedSettingsMode)}
+                        >
+                            Advanced settings
+                        </Button>
+                    )}
+
                     <Button variant={'accent'} onPress={trainModel} isDisabled={isStartButtonDisabled}>
                         Start
                     </Button>

--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -40,6 +40,7 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
         modelRevisions,
         isAdvancedSettingsMode,
         onToggleAdvancedSettingsMode,
+        trainingConfiguration,
     } = useTrainModel();
     const trainModelMutation = useTrainModelMutation();
     const projectId = useProjectIdentifier();
@@ -48,6 +49,8 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
 
     const isStartButtonDisabled =
         isTrainingDisabled || selectedModelArchitectureId === null || selectedTrainingDevice === null;
+
+    const isAdvancedSettingsModeDisabled = selectedModelArchitectureId === null || trainingConfiguration === undefined;
 
     const trainModel = () => {
         if (isStartButtonDisabled) return;
@@ -115,7 +118,11 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
                     <Button variant={'secondary'} onPress={onClose}>
                         Cancel
                     </Button>
-                    <Button variant={'primary'} onPress={() => onToggleAdvancedSettingsMode(!isAdvancedSettingsMode)}>
+                    <Button
+                        variant={'primary'}
+                        isDisabled={isAdvancedSettingsModeDisabled}
+                        onPress={() => onToggleAdvancedSettingsMode(!isAdvancedSettingsMode)}
+                    >
                         {isAdvancedSettingsMode ? 'Back' : 'Advanced settings'}
                     </Button>
                     <Button variant={'accent'} onPress={trainModel} isDisabled={isStartButtonDisabled}>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

We only want to show advanced settings configuration only when model architecture id is selected so we have any data to display.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
