### PR TITLE
Remove useEffects and fix label selection regression

### DIFF
--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -23,7 +23,9 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
 
     if (isSelected && selectedAnnotations.size === 1) {
         if (isPolygon(annotation)) {
-            return <EditPolygon annotation={annotation} zoom={scale} />;
+            const polygonKey = annotation.shape.points.map(({ x, y }) => `${x}-${y}`).join('_');
+
+            return <EditPolygon key={`polygon-${annotation.id}-${polygonKey}`} annotation={annotation} zoom={scale} />;
         }
 
         if (isRectangle(annotation)) {

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -23,9 +23,7 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
 
     if (isSelected && selectedAnnotations.size === 1) {
         if (isPolygon(annotation)) {
-            const polygonKey = annotation.shape.points.map(({ x, y }) => `${x}-${y}`).join('_');
-
-            return <EditPolygon key={`polygon-${annotation.id}-${polygonKey}`} annotation={annotation} zoom={scale} />;
+            return <EditPolygon key={`polygon-${annotation.id}`} annotation={annotation} zoom={scale} />;
         }
 
         if (isRectangle(annotation)) {

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -23,7 +23,7 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
 
     if (isSelected && selectedAnnotations.size === 1) {
         if (isPolygon(annotation)) {
-            return <EditPolygon key={`polygon-${annotation.id}`} annotation={annotation} zoom={scale} />;
+            return <EditPolygon annotation={annotation} zoom={scale} />;
         }
 
         if (isRectangle(annotation)) {

--- a/application/ui/src/features/annotator/annotations/selectable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/selectable-annotation.component.tsx
@@ -100,6 +100,7 @@ export const SelectableAnnotation = ({ children }: { children: ReactNode }) => {
     return (
         <g
             ref={elementRef}
+            aria-label={isSelected ? 'selected annotation' : 'annotation'}
             tabIndex={isSelected ? 0 : -1}
             onClick={handleSelectAnnotation}
             style={{

--- a/application/ui/src/features/annotator/labels/labels.component.test.tsx
+++ b/application/ui/src/features/annotator/labels/labels.component.test.tsx
@@ -6,13 +6,17 @@ import { getMockedLabel } from 'mocks/mock-labels';
 import { render } from 'test-utils/render';
 
 import type { Label } from '../../../constants/shared-types';
+import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
 import { Labels } from './labels.component';
 
 const mockLabels: Label[] = [
     getMockedLabel({ id: 'label-1', name: 'Person', color: '#FF0000', hotkey: 'p' }),
     getMockedLabel({ id: 'label-2', name: 'Car', color: '#00FF00' }),
     getMockedLabel({ id: 'label-3', name: 'Dog', color: '#0000FF' }),
+    getMockedLabel({ id: EMPTY_LABEL_ID, name: 'No object', color: '#FFFFFF' }),
 ];
+
+const mockSelectedLabelId = { current: 'label-1' };
 
 const mockSetSelectedLabelId = vi.fn();
 const mockUpdateAnnotations = vi.fn();
@@ -24,7 +28,7 @@ const mockAnnotations = { current: [] as { id: string; labels: Label[]; shape: {
 vi.mock('../annotator-labels-provider.component', () => ({
     useAnnotatorLabels: () => ({
         labels: mockLabels,
-        selectedLabelId: 'label-1',
+        selectedLabelId: mockSelectedLabelId.current,
         setSelectedLabelId: mockSetSelectedLabelId,
     }),
 }));
@@ -57,6 +61,7 @@ describe('Labels', () => {
         mockUpdateAnnotations.mockClear();
         mockAddAnnotations.mockClear();
         mockDeleteAnnotations.mockClear();
+        mockSelectedLabelId.current = 'label-1';
         mockSelectedAnnotations.current = new Set();
         mockAnnotations.current = [];
     });
@@ -77,6 +82,16 @@ describe('Labels', () => {
 
         expect(personButton).toHaveAttribute('aria-pressed', 'true');
         expect(carButton).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('shows No object as selected when it is the active label', () => {
+        mockSelectedLabelId.current = EMPTY_LABEL_ID;
+
+        render(<Labels />);
+
+        const noObjectButton = screen.getByRole('button', { name: 'Label No object' });
+
+        expect(noObjectButton).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('calls setSelectedLabelId when clicking a label', () => {

--- a/application/ui/src/features/annotator/labels/labels.component.test.tsx
+++ b/application/ui/src/features/annotator/labels/labels.component.test.tsx
@@ -84,16 +84,6 @@ describe('Labels', () => {
         expect(carButton).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it('shows No object as selected when it is the active label', () => {
-        mockSelectedLabelId.current = EMPTY_LABEL_ID;
-
-        render(<Labels />);
-
-        const noObjectButton = screen.getByRole('button', { name: 'Label No object' });
-
-        expect(noObjectButton).toHaveAttribute('aria-pressed', 'true');
-    });
-
     it('calls setSelectedLabelId when clicking a label', () => {
         render(<Labels />);
 

--- a/application/ui/src/features/annotator/labels/use-labels.hook.ts
+++ b/application/ui/src/features/annotator/labels/use-labels.hook.ts
@@ -127,9 +127,14 @@ export const useLabels = ({ isClassification = false, isMultiLabel = false }: Us
     };
 
     const isLabelActive = (label: Label): boolean => {
+        if (label.id === EMPTY_LABEL_ID) {
+            return false;
+        }
+
         if (isClassification) {
             return annotations.some((annotation) => annotation.labels.some((l) => l.id === label.id));
         }
+
         return selectedLabelId === label.id;
     };
 

--- a/application/ui/src/features/annotator/labels/use-labels.hook.ts
+++ b/application/ui/src/features/annotator/labels/use-labels.hook.ts
@@ -127,10 +127,6 @@ export const useLabels = ({ isClassification = false, isMultiLabel = false }: Us
     };
 
     const isLabelActive = (label: Label): boolean => {
-        if (label.id === EMPTY_LABEL_ID) {
-            return false;
-        }
-
         if (isClassification) {
             return annotations.some((annotation) => annotation.labels.some((l) => l.id === label.id));
         }

--- a/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.component.tsx
+++ b/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { isPolygonValid } from '@geti/smart-tools/utils';
 
@@ -23,6 +23,10 @@ export const EditPolygon = ({ annotation, zoom }: EditPolygonProps) => {
     const isAddPoint = useRef(false);
     const [shape, setShape] = useState(annotation.shape);
     const { updateAnnotations, deleteAnnotations } = useAnnotationActions();
+
+    useEffect(() => {
+        setShape(annotation.shape);
+    }, [annotation.shape]);
 
     // "removeOffLimitPoints" not only remove offlimit points but also in-between ones,
     // a new point is considered "in-between," and so it gets removed,

--- a/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.component.tsx
+++ b/application/ui/src/features/annotator/tools/edit-polygon/edit-polygon.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { isPolygonValid } from '@geti/smart-tools/utils';
 
@@ -23,8 +23,6 @@ export const EditPolygon = ({ annotation, zoom }: EditPolygonProps) => {
     const isAddPoint = useRef(false);
     const [shape, setShape] = useState(annotation.shape);
     const { updateAnnotations, deleteAnnotations } = useAnnotationActions();
-
-    useEffect(() => setShape(annotation.shape), [annotation.shape]);
 
     // "removeOffLimitPoints" not only remove offlimit points but also in-between ones,
     // a new point is considered "in-between," and so it gets removed,

--- a/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
+++ b/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { PointerEvent, RefObject, useEffect, useRef, useState } from 'react';
+import { PointerEvent, RefObject, useEffect, useMemo, useRef, useState } from 'react';
 
 import { clampPointBetweenImage, getIntersectionPoint } from '@geti/smart-tools/utils';
 import { differenceWith, isEmpty, isEqual, isNil } from 'lodash-es';
@@ -24,7 +24,6 @@ export const usePolygonConfig = ({
     const isMounted = useRef(true);
     const { worker } = useIntelligentScissorsWorker();
 
-    const [polygon, setPolygon] = useState<Polygon | null>(null);
     const [pointerLine, setPointerLine] = useState<Point[]>([]);
     const [lassoSegment, setLassoSegment] = useState<Point[]>([]);
     const [segments, setSegments, undoRedoActions] = useUndoRedoState<Point[][]>([]);
@@ -44,8 +43,11 @@ export const usePolygonConfig = ({
         }
     }, [image, worker]);
 
-    useEffect((): void => setPolygon({ type: 'polygon', points: segments?.flat() }), [segments]);
-    useEffect((): void => setPolygon({ type: 'polygon', points: pointerLine }), [pointerLine]);
+    const polygon = useMemo<Polygon | null>(() => {
+        const points = pointerLine.length > 0 ? pointerLine : segments.flat();
+
+        return points.length > 0 ? { type: 'polygon', points } : null;
+    }, [pointerLine, segments]);
 
     const optimizePolygonOrSegments = async (iPolygon: Polygon): Promise<Polygon> => {
         if (isNil(worker)) {
@@ -86,7 +88,6 @@ export const usePolygonConfig = ({
 
         setPointerLine([]);
         setLassoSegment([]);
-        setPolygon(null);
     };
 
     return {

--- a/application/ui/src/features/annotator/tools/ssim-tool/use-ssim.hook.ts
+++ b/application/ui/src/features/annotator/tools/ssim-tool/use-ssim.hook.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import type { RunSSIMProps as ToolRunSSIMProps, SSIMMatch as ToolSSIMMatch } from '@geti/smart-tools';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -157,12 +157,12 @@ export const useSSIM = (enabled = true) => {
     const [previewThreshold, setPreviewThreshold] = useState<number | null>(null);
     const [ssimProps, setSSIMProps] = useState<RunSSIMProps | null>(null);
 
-    useEffect(() => {
-        setPreviewThreshold(null);
-    }, [toolState.threshold]);
-
     const updateToolState = useCallback(
         (updatedProperties: Partial<SSIMState>, shapeType: SSIMShapeType = 'rectangle') => {
+            if (updatedProperties.threshold !== undefined) {
+                setPreviewThreshold(null);
+            }
+
             setToolState((currentState) => {
                 const newState = { ...currentState, ...updatedProperties };
                 const matches = newState.matches.slice(0, newState.threshold);

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -44,14 +44,14 @@ type VideoPlayerContextProps = {
 const useSynchronizeVideoTimeWithVideoFrame = ({
     videoFrame,
     videoRef,
+    currentFrameIndex,
     onUpdateCurrentFrameIndex,
 }: {
     videoRef: RefObject<HTMLVideoElement | null>;
     videoFrame: MediaVideoFrame | undefined;
+    currentFrameIndex: number;
     onUpdateCurrentFrameIndex: (index: number) => void;
 }) => {
-    const previousVideoFrame = usePreviousVideoFrame(videoFrame);
-
     /*
      * This part is responsible for updating video time on the initial load when the frame number is not 0.
      * In that case we need to move the video to the correct frame number.
@@ -95,22 +95,12 @@ const useSynchronizeVideoTimeWithVideoFrame = ({
             return;
         }
 
-        if (previousVideoFrame?.id === videoFrame.id && previousVideoFrame?.frame_number !== videoFrame.frame_number) {
+        if (currentFrameIndex !== videoFrame.frame_number) {
             onUpdateCurrentFrameIndex(videoFrame.frame_number);
 
             videoRef.current.currentTime = (videoFrame.frame_number + 1) / videoFrame.fps;
         }
-    }, [videoFrame, previousVideoFrame, videoRef, onUpdateCurrentFrameIndex]);
-};
-
-const usePreviousVideoFrame = (videoFrame: MediaVideoFrame | undefined) => {
-    const previousVideoFrameRef = useRef<MediaVideoFrame | undefined>(videoFrame);
-
-    useEffect(() => {
-        previousVideoFrameRef.current = videoFrame;
-    }, [videoFrame]);
-
-    return previousVideoFrameRef.current;
+    }, [currentFrameIndex, onUpdateCurrentFrameIndex, videoFrame, videoRef]);
 };
 
 const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
@@ -131,6 +121,7 @@ export const VideoPlayerProvider = ({ children, videoFrame, changeSelectedMediaI
     useSynchronizeVideoTimeWithVideoFrame({
         videoRef,
         videoFrame,
+        currentFrameIndex,
         onUpdateCurrentFrameIndex: setCurrentFrameIndex,
     });
 

--- a/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-player-provider.component.tsx
@@ -44,14 +44,13 @@ type VideoPlayerContextProps = {
 const useSynchronizeVideoTimeWithVideoFrame = ({
     videoFrame,
     videoRef,
-    currentFrameIndex,
     onUpdateCurrentFrameIndex,
 }: {
     videoRef: RefObject<HTMLVideoElement | null>;
     videoFrame: MediaVideoFrame | undefined;
-    currentFrameIndex: number;
     onUpdateCurrentFrameIndex: (index: number) => void;
 }) => {
+    const previousVideoFrame = usePreviousVideoFrame(videoFrame);
     /*
      * This part is responsible for updating video time on the initial load when the frame number is not 0.
      * In that case we need to move the video to the correct frame number.
@@ -95,12 +94,22 @@ const useSynchronizeVideoTimeWithVideoFrame = ({
             return;
         }
 
-        if (currentFrameIndex !== videoFrame.frame_number) {
+        if (previousVideoFrame?.frame_number !== videoFrame.frame_number) {
             onUpdateCurrentFrameIndex(videoFrame.frame_number);
 
             videoRef.current.currentTime = (videoFrame.frame_number + 1) / videoFrame.fps;
         }
-    }, [currentFrameIndex, onUpdateCurrentFrameIndex, videoFrame, videoRef]);
+    }, [videoFrame, previousVideoFrame, videoRef, onUpdateCurrentFrameIndex]);
+};
+
+const usePreviousVideoFrame = (videoFrame: MediaVideoFrame | undefined) => {
+    const previousVideoFrameRef = useRef<MediaVideoFrame | undefined>(videoFrame);
+
+    useEffect(() => {
+        previousVideoFrameRef.current = videoFrame;
+    }, [videoFrame]);
+
+    return previousVideoFrameRef.current;
 };
 
 const VideoPlayerContext = createContext<VideoPlayerContextProps | null>(null);
@@ -121,7 +130,6 @@ export const VideoPlayerProvider = ({ children, videoFrame, changeSelectedMediaI
     useSynchronizeVideoTimeWithVideoFrame({
         videoRef,
         videoFrame,
-        currentFrameIndex,
         onUpdateCurrentFrameIndex: setCurrentFrameIndex,
     });
 

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/video-player-slider.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-player-slider/video-player-slider.component.tsx
@@ -101,9 +101,8 @@ export const VideoPlayerSlider = ({
     selectFrame,
     frameOffset = 0,
 }: VideoPlayerSliderProps) => {
-    const [sliderValue, setSliderValue] = useState<number>(frameNumber);
-
-    useEffect(() => setSliderValue(frameNumber), [frameNumber]);
+    const [dragFrameNumber, setDragFrameNumber] = useState<number | null>(null);
+    const sliderValue = dragFrameNumber ?? frameNumber;
 
     const {
         hoverProps,
@@ -153,14 +152,14 @@ export const VideoPlayerSlider = ({
                 showValueLabel={false}
                 minValue={minValue}
                 maxValue={maxValue}
-                defaultValue={sliderValue}
                 value={sliderValue}
                 onChange={(newFrameNumber) => {
-                    setSliderValue(newFrameNumber);
+                    setDragFrameNumber(newFrameNumber);
                     onShowThumbnail(true);
                 }}
                 onChangeEnd={(newFrameNumber) => {
                     selectFrame(newFrameNumber);
+                    setDragFrameNumber(null);
                     blurActiveInput(true);
                 }}
                 step={step}

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -46,8 +46,9 @@ export const AnnotatorProviders = ({
                             isUserReviewed={isUserReviewed}
                             mode={mode}
                             isReadOnly={isReadOnly}
+                            key={mediaSelectionResetKey}
                         >
-                            <SelectAnnotationProvider key={mediaSelectionResetKey}>{children}</SelectAnnotationProvider>
+                            <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
                         </AnnotationActionsProvider>
                     </AnnotatorLabelsProvider>
                 </CanvasSettingsProvider>

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -9,6 +9,7 @@ import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-
 import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { SelectAnnotationProvider } from '../../../shared/annotator/select-annotation-provider.component';
+import { isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorLabelsProvider } from '../../annotator/annotator-labels-provider.component';
 import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settings-provider.component';
 
@@ -31,6 +32,8 @@ export const AnnotatorProviders = ({
     isReadOnly = false,
     children,
 }: AnnotatorProvidersProps) => {
+    const mediaSelectionResetKey = isVideoFrame(mediaItem) ? `${mediaItem.id}-${mediaItem.frame_number}` : mediaItem.id;
+
     return (
         <ZoomProvider>
             <AnnotationVisibilityProvider>
@@ -44,7 +47,7 @@ export const AnnotatorProviders = ({
                             mode={mode}
                             isReadOnly={isReadOnly}
                         >
-                            <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
+                            <SelectAnnotationProvider key={mediaSelectionResetKey}>{children}</SelectAnnotationProvider>
                         </AnnotationActionsProvider>
                     </AnnotatorLabelsProvider>
                 </CanvasSettingsProvider>

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -9,7 +9,6 @@ import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-
 import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { SelectAnnotationProvider } from '../../../shared/annotator/select-annotation-provider.component';
-import { isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorLabelsProvider } from '../../annotator/annotator-labels-provider.component';
 import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settings-provider.component';
 
@@ -32,8 +31,6 @@ export const AnnotatorProviders = ({
     isReadOnly = false,
     children,
 }: AnnotatorProvidersProps) => {
-    const mediaSelectionResetKey = isVideoFrame(mediaItem) ? `${mediaItem.id}-${mediaItem.frame_number}` : mediaItem.id;
-
     return (
         <ZoomProvider>
             <AnnotationVisibilityProvider>
@@ -46,7 +43,6 @@ export const AnnotatorProviders = ({
                             isUserReviewed={isUserReviewed}
                             mode={mode}
                             isReadOnly={isReadOnly}
-                            key={mediaSelectionResetKey}
                         >
                             <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
                         </AnnotationActionsProvider>

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -9,7 +9,6 @@ import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-
 import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { SelectAnnotationProvider } from '../../../shared/annotator/select-annotation-provider.component';
-import { isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorLabelsProvider } from '../../annotator/annotator-labels-provider.component';
 import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settings-provider.component';
 
@@ -32,28 +31,24 @@ export const AnnotatorProviders = ({
     isReadOnly = false,
     children,
 }: AnnotatorProvidersProps) => {
-    const mediaSelectionResetKey = isVideoFrame(mediaItem) ? `${mediaItem.id}-${mediaItem.frame_number}` : mediaItem.id;
-
     return (
         <ZoomProvider>
-            <SelectAnnotationProvider resetKey={mediaSelectionResetKey}>
-                <AnnotationVisibilityProvider>
-                    <CanvasSettingsProvider>
-                        <AnnotatorLabelsProvider>
-                            <AnnotationActionsProvider
-                                mediaItem={mediaItem}
-                                initialAnnotationsDTO={initialAnnotationsDTO}
-                                initialPredictionsDTO={initialPredictionsDTO}
-                                isUserReviewed={isUserReviewed}
-                                mode={mode}
-                                isReadOnly={isReadOnly}
-                            >
-                                {children}
-                            </AnnotationActionsProvider>
-                        </AnnotatorLabelsProvider>
-                    </CanvasSettingsProvider>
-                </AnnotationVisibilityProvider>
-            </SelectAnnotationProvider>
+            <AnnotationVisibilityProvider>
+                <CanvasSettingsProvider>
+                    <AnnotatorLabelsProvider>
+                        <AnnotationActionsProvider
+                            mediaItem={mediaItem}
+                            initialAnnotationsDTO={initialAnnotationsDTO}
+                            initialPredictionsDTO={initialPredictionsDTO}
+                            isUserReviewed={isUserReviewed}
+                            mode={mode}
+                            isReadOnly={isReadOnly}
+                        >
+                            <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
+                        </AnnotationActionsProvider>
+                    </AnnotatorLabelsProvider>
+                </CanvasSettingsProvider>
+            </AnnotationVisibilityProvider>
         </ZoomProvider>
     );
 };

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -111,17 +111,12 @@ export const AnnotatorContainer = ({
     items,
     onSelectedMediaItem,
 }: AnnotatorContainerProps) => {
-    const { mediaItem, setMediaItem, image } = useSelectedMediaItem();
-
-    const selectMediaItem = (item: Media) => {
-        setMediaItem(item);
-        onSelectedMediaItem(item);
-    };
+    const { mediaItem, image } = useSelectedMediaItem();
 
     return (
         <VideoPlayerProvider
             videoFrame={isVideoFrame(mediaItem) ? mediaItem : undefined}
-            changeSelectedMediaItem={selectMediaItem}
+            changeSelectedMediaItem={onSelectedMediaItem}
         >
             <Annotator
                 mode={mode}
@@ -130,7 +125,7 @@ export const AnnotatorContainer = ({
                 onClose={onClose}
                 mediaItem={mediaItem}
                 changeAnnotatorMode={changeAnnotatorMode}
-                onSelectedMediaItem={selectMediaItem}
+                onSelectedMediaItem={onSelectedMediaItem}
             />
         </VideoPlayerProvider>
     );

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -36,7 +36,7 @@ type MediaPreviewContentProps = {
     fetchNextPage: () => void;
 };
 
-type MediaPreviewScopedContentProps = {
+type MediaPreviewPanelsProps = {
     mode: AnnotatorMode;
     changeAnnotatorMode: (mode: AnnotatorMode) => void;
     items: Media[];
@@ -47,7 +47,7 @@ type MediaPreviewScopedContentProps = {
     fetchNextPage: () => void;
 };
 
-const MediaPreviewScopedContent = ({
+const MediaPreviewPanels = ({
     mode,
     changeAnnotatorMode,
     items,
@@ -56,9 +56,9 @@ const MediaPreviewScopedContent = ({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-}: MediaPreviewScopedContentProps) => {
+}: MediaPreviewPanelsProps) => {
     const { mediaItem } = useSelectedMediaItem();
-    const handleMediaTransition = useAnnotatorMediaTransition(onSelectedMediaItem);
+    const handleMediaTransition = useAnnotatorMediaTransition({ onSelectedMediaItem });
 
     return (
         <>
@@ -116,7 +116,7 @@ const MediaPreviewContent = ({
                 isUserReviewed={isUserReviewed}
                 mode={mode}
             >
-                <MediaPreviewScopedContent
+                <MediaPreviewPanels
                     mode={mode}
                     changeAnnotatorMode={setMode}
                     items={items}

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -18,6 +18,7 @@ import { AnnotatorContainer } from './annotator.component';
 import { useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
+import { useAnnotatorMediaTransition } from './use-annotator-media-transition.hook';
 import { getInitialAnnotations, getInitialPredictions } from './utils';
 
 type MediaPreviewProps = {
@@ -30,9 +31,67 @@ type MediaPreviewContentProps = {
     items: Media[];
     onClose: () => void;
     onSelectedMediaItem: (item: Media) => void;
+    hasNextPage: boolean;
+    isFetchingNextPage: boolean;
+    fetchNextPage: () => void;
 };
 
-const MediaPreviewContent = ({ items, onSelectedMediaItem, onClose }: MediaPreviewContentProps) => {
+type MediaPreviewScopedContentProps = {
+    mode: AnnotatorMode;
+    changeAnnotatorMode: (mode: AnnotatorMode) => void;
+    items: Media[];
+    onClose: () => void;
+    onSelectedMediaItem: (item: Media) => void;
+    hasNextPage: boolean;
+    isFetchingNextPage: boolean;
+    fetchNextPage: () => void;
+};
+
+const MediaPreviewScopedContent = ({
+    mode,
+    changeAnnotatorMode,
+    items,
+    onClose,
+    onSelectedMediaItem,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+}: MediaPreviewScopedContentProps) => {
+    const { mediaItem } = useSelectedMediaItem();
+    const handleMediaTransition = useAnnotatorMediaTransition(onSelectedMediaItem);
+
+    return (
+        <>
+            <AnnotatorContainer
+                mode={mode}
+                items={items}
+                onClose={onClose}
+                changeAnnotatorMode={changeAnnotatorMode}
+                onSelectedMediaItem={handleMediaTransition}
+            />
+
+            <View gridArea={'aside'}>
+                <SidebarItems
+                    items={items}
+                    mediaItem={mediaItem}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
+                    fetchNextPage={fetchNextPage}
+                    onSelectedMediaItem={handleMediaTransition}
+                />
+            </View>
+        </>
+    );
+};
+
+const MediaPreviewContent = ({
+    items,
+    onSelectedMediaItem,
+    onClose,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+}: MediaPreviewContentProps) => {
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
     const { mediaItem } = useSelectedMediaItem();
 
@@ -57,12 +116,15 @@ const MediaPreviewContent = ({ items, onSelectedMediaItem, onClose }: MediaPrevi
                 isUserReviewed={isUserReviewed}
                 mode={mode}
             >
-                <AnnotatorContainer
+                <MediaPreviewScopedContent
                     mode={mode}
+                    changeAnnotatorMode={setMode}
                     items={items}
                     onClose={onClose}
-                    changeAnnotatorMode={setMode}
                     onSelectedMediaItem={onSelectedMediaItem}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
+                    fetchNextPage={fetchNextPage}
                 />
             </AnnotatorProviders>
         </ToolProvider>
@@ -95,19 +157,15 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                     ]}
                 >
                     <SelectedMediaItemProvider mediaItem={mediaItem}>
-                        <MediaPreviewContent items={items} onClose={close} onSelectedMediaItem={onSelectedMediaItem} />
-                    </SelectedMediaItemProvider>
-
-                    <View gridArea={'aside'}>
-                        <SidebarItems
+                        <MediaPreviewContent
                             items={items}
-                            mediaItem={mediaItem}
+                            onClose={close}
+                            onSelectedMediaItem={onSelectedMediaItem}
                             hasNextPage={hasNextPage}
                             isFetchingNextPage={isFetchingNextPage}
                             fetchNextPage={fetchNextPage}
-                            onSelectedMediaItem={onSelectedMediaItem}
                         />
-                    </View>
+                    </SelectedMediaItemProvider>
                 </Grid>
             </Content>
         </Dialog>

--- a/application/ui/src/features/dataset/media-preview/use-annotator-media-transition.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-annotator-media-transition.hook.ts
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback } from 'react';
+
+import type { Media } from '../../../constants/shared-types';
+import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
+import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
+import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
+
+export const useAnnotatorMediaTransition = (onSelectedMediaItem: (item: Media) => void) => {
+    const { setMediaItem } = useSelectedMediaItem();
+    const { setSelectedAnnotations } = useSelectedAnnotations();
+    const { resetAnnotations } = useAnnotationActions();
+
+    return useCallback(
+        (item: Media) => {
+            setSelectedAnnotations(new Set());
+            resetAnnotations();
+            setMediaItem(item);
+            onSelectedMediaItem(item);
+        },
+        [onSelectedMediaItem, resetAnnotations, setMediaItem, setSelectedAnnotations]
+    );
+};

--- a/application/ui/src/features/dataset/media-preview/use-annotator-media-transition.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-annotator-media-transition.hook.ts
@@ -8,7 +8,10 @@ import { useAnnotationActions } from '../../../shared/annotator/annotation-actio
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 
-export const useAnnotatorMediaTransition = (onSelectedMediaItem: (item: Media) => void) => {
+type UseAnnotatorMediaTransitionProps = {
+    onSelectedMediaItem: (item: Media) => void;
+};
+export const useAnnotatorMediaTransition = ({ onSelectedMediaItem }: UseAnnotatorMediaTransitionProps) => {
     const { setMediaItem } = useSelectedMediaItem();
     const { setSelectedAnnotations } = useSelectedAnnotations();
     const { resetAnnotations } = useAnnotationActions();

--- a/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Flex, NumberField, Slider } from '@geti/ui';
 
@@ -54,19 +54,16 @@ export const NumberParameterField = ({
     name,
     step,
 }: NumberGroupParamsProps) => {
-    const [parameterValue, setParameterValue] = useState<number>(value);
+    const [draftValue, setDraftValue] = useState<number | null>(null);
+    const parameterValue = draftValue ?? value;
 
     const fieldStep = getStep({ step, type, maxValue, minValue });
     const formatOptions = type === 'float' ? { maximumFractionDigits: Math.abs(Math.log10(fieldStep)) } : undefined;
 
     const handleValueChange = (inputValue: number): void => {
-        setParameterValue(inputValue);
+        setDraftValue(null);
         onChange(inputValue);
     };
-
-    useEffect(() => {
-        setParameterValue(value);
-    }, [value]);
 
     if (maxValue === null || minValue === null) {
         return (
@@ -76,7 +73,7 @@ export const NumberParameterField = ({
                 value={parameterValue}
                 minValue={minValue === null ? undefined : minValue}
                 maxValue={maxValue === null ? undefined : maxValue}
-                onChange={handleValueChange}
+                onChange={onChange}
                 isDisabled={isDisabled}
             />
         );
@@ -89,7 +86,7 @@ export const NumberParameterField = ({
                 value={parameterValue}
                 minValue={minValue}
                 maxValue={maxValue}
-                onChange={setParameterValue}
+                onChange={setDraftValue}
                 onChangeEnd={handleValueChange}
                 step={fieldStep}
                 isFilled

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
@@ -41,13 +41,11 @@ export const RangeParameterField = ({
     const fieldStep = getStep({ step, maxValue: defaultValue[1], minValue: defaultValue[0] });
     const decimalPlaces = (fieldStep.toString().split('.')[1] || '').length;
 
-    const handleRangeChangeEnd = (): void => {
-        if (draftRange === null) {
-            return;
-        }
+    const handleRangeChangeEnd = (inputValue: RangeValue<number>): void => {
+        const { start, end } = inputValue;
 
         setDraftRange(null);
-        onChange([draftRange.start, draftRange.end]);
+        onChange([start, end]);
     };
 
     const handleRangeChange = (inputValue: RangeValue<number>): void => {

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Flex, NumberField, RangeSlider, type RangeValue } from '@geti/ui';
 
@@ -35,21 +35,8 @@ export const RangeParameterField = ({
     name,
     step,
 }: RangeParameterFieldProps) => {
-    const [parameterValue, setParameterValue] = useState<RangeValue<number>>({
-        start: value[0],
-        end: value[1],
-    });
-
-    useEffect(() => {
-        if (value === null) {
-            setParameterValue(value);
-        } else {
-            setParameterValue({
-                start: value[0],
-                end: value[1],
-            });
-        }
-    }, [value]);
+    const [draftRange, setDraftRange] = useState<RangeValue<number> | null>(null);
+    const parameterValue = draftRange ?? (value === null ? null : { start: value[0], end: value[1] });
 
     const fieldStep = getStep({ step, maxValue: defaultValue[1], minValue: defaultValue[0] });
     const decimalPlaces = (fieldStep.toString().split('.')[1] || '').length;
@@ -59,6 +46,7 @@ export const RangeParameterField = ({
             return;
         }
 
+        setDraftRange(null);
         onChange([parameterValue.start, parameterValue.end]);
     };
 
@@ -66,14 +54,14 @@ export const RangeParameterField = ({
         const { start, end } = inputValue;
         // Prevent start and end from being equal
         if (end - start >= fieldStep) {
-            setParameterValue({ start, end });
+            setDraftRange({ start, end });
         }
     };
 
     const handleNumberChange = (start: number, end: number): void => {
         // Prevent start and end from being equal
         if (end - start >= fieldStep) {
-            setParameterValue({ start, end });
+            setDraftRange(null);
             onChange([start, end]);
         }
     };
@@ -86,13 +74,13 @@ export const RangeParameterField = ({
                 value={parameterValue?.start}
                 minValue={defaultValue[0]}
                 maxValue={defaultValue[1]}
-                onChange={(start) => handleNumberChange(start, parameterValue.end)}
+                onChange={(start) => handleNumberChange(start, parameterValue?.end ?? defaultValue[1])}
                 isDisabled={isDisabled}
                 aria-label={`Change ${name} start range value`}
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}
             />
             <RangeSlider
-                value={parameterValue}
+                value={parameterValue ?? undefined}
                 minValue={defaultValue[0]}
                 maxValue={defaultValue[1]}
                 defaultValue={{ start: defaultValue[0], end: defaultValue[1] }}
@@ -107,10 +95,10 @@ export const RangeParameterField = ({
             <NumberField
                 isQuiet
                 step={fieldStep}
-                value={parameterValue.end}
+                value={parameterValue?.end}
                 minValue={defaultValue[0]}
                 maxValue={defaultValue[1]}
-                onChange={(end) => handleNumberChange(parameterValue.start, end)}
+                onChange={(end) => handleNumberChange(parameterValue?.start ?? defaultValue[0], end)}
                 isDisabled={isDisabled}
                 aria-label={`Change ${name} end range value`}
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
@@ -36,18 +36,18 @@ export const RangeParameterField = ({
     step,
 }: RangeParameterFieldProps) => {
     const [draftRange, setDraftRange] = useState<RangeValue<number> | null>(null);
-    const parameterValue = draftRange ?? (value === null ? null : { start: value[0], end: value[1] });
+    const parameterValue = draftRange ?? { start: value[0], end: value[1] };
 
     const fieldStep = getStep({ step, maxValue: defaultValue[1], minValue: defaultValue[0] });
     const decimalPlaces = (fieldStep.toString().split('.')[1] || '').length;
 
     const handleRangeChangeEnd = (): void => {
-        if (parameterValue === null) {
+        if (draftRange === null) {
             return;
         }
 
         setDraftRange(null);
-        onChange([parameterValue.start, parameterValue.end]);
+        onChange([draftRange.start, draftRange.end]);
     };
 
     const handleRangeChange = (inputValue: RangeValue<number>): void => {
@@ -71,16 +71,16 @@ export const RangeParameterField = ({
             <NumberField
                 isQuiet
                 step={fieldStep}
-                value={parameterValue?.start}
+                value={parameterValue.start}
                 minValue={defaultValue[0]}
                 maxValue={defaultValue[1]}
-                onChange={(start) => handleNumberChange(start, parameterValue?.end ?? defaultValue[1])}
+                onChange={(start) => handleNumberChange(start, parameterValue.end)}
                 isDisabled={isDisabled}
                 aria-label={`Change ${name} start range value`}
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}
             />
             <RangeSlider
-                value={parameterValue ?? undefined}
+                value={parameterValue}
                 minValue={defaultValue[0]}
                 maxValue={defaultValue[1]}
                 defaultValue={{ start: defaultValue[0], end: defaultValue[1] }}
@@ -95,10 +95,10 @@ export const RangeParameterField = ({
             <NumberField
                 isQuiet
                 step={fieldStep}
-                value={parameterValue?.end}
+                value={parameterValue.end}
                 minValue={defaultValue[0]}
                 maxValue={defaultValue[1]}
-                onChange={(end) => handleNumberChange(parameterValue?.start ?? defaultValue[0], end)}
+                onChange={(end) => handleNumberChange(parameterValue.start, end)}
                 isDisabled={isDisabled}
                 aria-label={`Change ${name} end range value`}
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}

--- a/application/ui/src/providers.tsx
+++ b/application/ui/src/providers.tsx
@@ -13,7 +13,12 @@ export const Providers = () => {
     return (
         <QueryClientProvider client={queryClient}>
             <ThemeProvider router={router}>
-                <RouterProvider router={router} />
+                <RouterProvider
+                    router={router}
+                    future={{
+                        v7_startTransition: true,
+                    }}
+                />
                 <div data-react-aria-top-layer='true'>
                     <Toast />
                 </div>

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -200,7 +200,11 @@ export const AnnotationActionsProvider = ({
         return !isEqual(currentServerAnnotations, initialAnnotationsDTO);
     }, [annotations, initialAnnotationsDTO]);
 
-    const canSubmit = mode === 'prediction' ? predictions.length > 0 : hasChangedAnnotations;
+    const hasEmptyLabelSelection = useMemo(() => {
+        return annotations.some((annotation) => annotation.labels.some((label) => label.id === EMPTY_LABEL_ID));
+    }, [annotations]);
+
+    const canSubmit = mode === 'prediction' ? predictions.length > 0 : hasChangedAnnotations || hasEmptyLabelSelection;
 
     const annotationsToRender = mode === 'annotation' ? annotations : predictions;
     const isReadOnlyMode = isReadOnly || mode === 'prediction';

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -56,7 +56,6 @@ export const AnnotationActionsProvider = ({
     mode,
     isReadOnly = false,
 }: AnnotationActionsProviderProps) => {
-    const mediaItemKey = isVideoFrame(mediaItem) ? `${mediaItem.id}-${mediaItem.frame_number}` : mediaItem.id;
     const projectId = useProjectIdentifier();
     const saveMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media/{media_id}/annotations', {
         meta: {
@@ -100,15 +99,10 @@ export const AnnotationActionsProvider = ({
     };
 
     const prevInitialAnnotationsDTORef = useRef(initialAnnotationsDTO);
-    const prevMediaItemKeyRef = useRef(mediaItemKey);
 
-    // Reset annotations when source annotations change or when switching media/frame.
-    if (
-        prevMediaItemKeyRef.current !== mediaItemKey ||
-        !isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)
-    ) {
+    // Reset annotations when source annotations change.
+    if (!isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)) {
         undoRedoActions.reset(initialAnnotations);
-        prevMediaItemKeyRef.current = mediaItemKey;
         prevInitialAnnotationsDTORef.current = initialAnnotationsDTO;
     }
 

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useEffect, useMemo, useRef } from 'react';
+import { createContext, ReactNode, useContext, useMemo, useRef } from 'react';
 
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isEqual } from 'lodash-es';
@@ -102,17 +102,15 @@ export const AnnotationActionsProvider = ({
     const prevInitialAnnotationsDTORef = useRef(initialAnnotationsDTO);
     const prevMediaItemKeyRef = useRef(mediaItemKey);
 
-    useEffect(() => {
-        // Reset annotations when source annotations change or when switching media/frame.
-        if (
-            prevMediaItemKeyRef.current !== mediaItemKey ||
-            !isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)
-        ) {
-            undoRedoActions.reset(initialAnnotations);
-            prevMediaItemKeyRef.current = mediaItemKey;
-            prevInitialAnnotationsDTORef.current = initialAnnotationsDTO;
-        }
-    }, [mediaItemKey, initialAnnotationsDTO, initialAnnotations, undoRedoActions]);
+    // Reset annotations when source annotations change or when switching media/frame.
+    if (
+        prevMediaItemKeyRef.current !== mediaItemKey ||
+        !isEqual(prevInitialAnnotationsDTORef.current, initialAnnotationsDTO)
+    ) {
+        undoRedoActions.reset(initialAnnotations);
+        prevMediaItemKeyRef.current = mediaItemKey;
+        prevInitialAnnotationsDTORef.current = initialAnnotationsDTO;
+    }
 
     const updateAnnotations = (updatedAnnotations: Annotation[], labels?: Label[]) => {
         if (labels !== undefined) {

--- a/application/ui/src/shared/annotator/select-annotation-provider.component.tsx
+++ b/application/ui/src/shared/annotator/select-annotation-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { createContext, ReactNode, useContext, useState, type Dispatch, type SetStateAction } from 'react';
 
 type SelectedAnnotationContextProps = {
     selectedAnnotations: Set<string>;
@@ -20,12 +20,8 @@ export const useSelectedAnnotations = () => {
     return ctx;
 };
 
-export const SelectAnnotationProvider = ({ children, resetKey }: { children: ReactNode; resetKey?: string }) => {
+export const SelectAnnotationProvider = ({ children }: { children: ReactNode }) => {
     const [selectedAnnotations, setSelectedAnnotations] = useState<Set<string>>(new Set());
-
-    useEffect(() => {
-        setSelectedAnnotations(new Set());
-    }, [resetKey]);
 
     return (
         <SelectedAnnotationContext.Provider value={{ selectedAnnotations, setSelectedAnnotations }}>

--- a/application/ui/src/test-utils/render.tsx
+++ b/application/ui/src/test-utils/render.tsx
@@ -55,7 +55,14 @@ export const render = (ui: ReactNode, options: RenderOptions = {}) => {
     const testQueryClient = options.queryClient ?? createQueryClient();
     const router = createTestRouter(ui, options, testQueryClient);
 
-    return rtlRender(<RouterProvider router={router} />);
+    return rtlRender(
+        <RouterProvider
+            router={router}
+            future={{
+                v7_startTransition: true,
+            }}
+        />
+    );
 };
 
 export const renderHook = <TProps, TResult>(callback: (props: TProps) => TResult, options: RenderOptions = {}) => {
@@ -64,7 +71,14 @@ export const renderHook = <TProps, TResult>(callback: (props: TProps) => TResult
     const Wrapper = ({ children }: { children: ReactNode }) => {
         const router = createTestRouter(children, options, testQueryClient);
 
-        return <RouterProvider router={router} />;
+        return (
+            <RouterProvider
+                router={router}
+                future={{
+                    v7_startTransition: true,
+                }}
+            />
+        );
     };
 
     return rtlRenderHook(callback, { wrapper: Wrapper });

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -493,16 +493,24 @@ test.describe('Annotator', () => {
         await test.step('Select annotation on media 1', async () => {
             await page.getByRole('button', { name: 'selection tool' }).click();
             await page.getByLabel('annotation rect').nth(1).click();
+
+            const selectedAnnotations = annotatorPage.getAnnotationsList().getByLabel('selected annotation');
+            await expect(selectedAnnotations).toHaveCount(1);
         });
 
-        await test.step('Switch to media 2 and back to media 1', async () => {
+        await test.step('Switch to media 2 and back to media 1 resets selection', async () => {
             const sidebarItems = page.getByRole('listbox', { name: 'sidebar-items' });
             await sidebarItems.getByRole('img', { name: 'item-2.jpg' }).click();
             await expect(annotatorPage.getAnnotationsList()).toBeVisible();
+            expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(0);
 
             await sidebarItems.getByRole('img', { name: 'item-1.jpg' }).click();
             await expect(annotatorPage.getAnnotationsList()).toBeVisible();
+
             expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(1);
+
+            const selectedAnnotations = annotatorPage.getAnnotationsList().getByLabel('selected annotation');
+            await expect(selectedAnnotations).toHaveCount(0);
         });
     });
 

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -381,12 +381,12 @@ test.describe('Annotator', () => {
 
     test('Annotations reset correctly when switching media items', async ({ page, annotatorPage, network }) => {
         const mediaItems = [
-            getMockedMediaImage({ id: 'media-1', name: 'item-1.jpg', width: 1920, height: 1080 }),
-            getMockedMediaImage({ id: 'media-2', name: 'item-2.jpg', width: 1920, height: 1080 }),
+            getMockedMediaImage({ id: 'media-reset-1', name: 'item-1.jpg', width: 1920, height: 1080 }),
+            getMockedMediaImage({ id: 'media-reset-2', name: 'item-2.jpg', width: 1920, height: 1080 }),
         ];
 
         const mediaAnnotations: Record<string, AnnotationDTO[]> = {
-            'media-1': [
+            'media-reset-1': [
                 {
                     shape: {
                         type: 'rectangle',
@@ -398,7 +398,7 @@ test.describe('Annotator', () => {
                     labels: [{ id: redLabel.id }],
                 },
             ],
-            'media-2': [],
+            'media-reset-2': [],
         };
 
         network.use(
@@ -440,6 +440,67 @@ test.describe('Annotator', () => {
             const sidebarItems = page.getByRole('listbox', { name: 'sidebar-items' });
             await sidebarItems.getByRole('img', { name: 'item-1.jpg' }).click();
 
+            await expect(annotatorPage.getAnnotationsList()).toBeVisible();
+            expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(1);
+        });
+    });
+
+    test('Selected annotations reset when switching media items', async ({ page, annotatorPage, network }) => {
+        const mediaItems = [
+            getMockedMediaImage({ id: 'media-selection-reset-1', name: 'item-1.jpg', width: 1920, height: 1080 }),
+            getMockedMediaImage({ id: 'media-selection-reset-2', name: 'item-2.jpg', width: 1920, height: 1080 }),
+        ];
+
+        const mediaAnnotations: Record<string, AnnotationDTO[]> = {
+            'media-selection-reset-1': [
+                {
+                    shape: {
+                        type: 'rectangle',
+                        x: 80,
+                        y: 120,
+                        width: 140,
+                        height: 120,
+                    },
+                    labels: [{ id: redLabel.id }],
+                },
+            ],
+            'media-selection-reset-2': [],
+        };
+
+        network.use(
+            http.get('/api/projects/{project_id}/dataset/media', () => {
+                return HttpResponse.json({
+                    items: mediaItems,
+                    pagination: {
+                        offset: 0,
+                        limit: 10,
+                        count: mediaItems.length,
+                        total: mediaItems.length,
+                    },
+                });
+            }),
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', ({ params }) => {
+                return HttpResponse.json({
+                    annotations: mediaAnnotations[params.media_id] ?? [],
+                    user_reviewed: true,
+                });
+            })
+        );
+
+        await page.goto(`/projects/${mockedDetectionProject.id}/dataset`);
+        await page.getByRole('img', { name: 'item-1.jpg' }).dblclick();
+
+        await test.step('Select annotation on media 1', async () => {
+            await page.getByRole('button', { name: 'selection tool' }).click();
+            await page.getByLabel('annotation rect').nth(1).click();
+        });
+
+        await test.step('Switch to media 2 and back to media 1', async () => {
+            const sidebarItems = page.getByRole('listbox', { name: 'sidebar-items' });
+            await sidebarItems.getByRole('img', { name: 'item-2.jpg' }).click();
+            await expect(annotatorPage.getAnnotationsList()).toBeVisible();
+
+            await sidebarItems.getByRole('img', { name: 'item-1.jpg' }).click();
             await expect(annotatorPage.getAnnotationsList()).toBeVisible();
             expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(1);
         });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Remove a few unnecessary useEffects after revisiting https://react.dev/learn/you-might-not-need-an-effect which will cut renders in at least half
* Add new hook to handle media transition
* Remove annoying react router v7 warning from tests. We still have a warning from --localstorage flag but that comes from node 25 so i didnt bother fixing it
* Fix selection label regression. When we selected "No object" we couldnt submit
* Requirements checked: Tool persists across media item; Selected label persists across media item; Changing media item resets both annotations and selected annotations


Tested manually but feel free to double check

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
