### PR TITLE
Fix small CI issues

### DIFF
--- a/application/backend/tests/integration/services/dispatchers/test_mqtt.py
+++ b/application/backend/tests/integration/services/dispatchers/test_mqtt.py
@@ -14,6 +14,7 @@ import cv2
 import numpy as np
 import paho.mqtt.client as mqtt
 import pytest
+from loguru import logger
 from paho.mqtt.enums import CallbackAPIVersion
 from testcontainers.compose import DockerCompose
 
@@ -33,7 +34,7 @@ def mqtt_broker():
     mqtt_logs = compose.get_logs("mqtt")
 
     # Wait for the broker to start
-    timeout = 30
+    timeout = 60
     start_time = time.time()
     while time.time() - start_time < timeout:
         if re.search(r"mosquitto version .* starting", mqtt_logs[0] if mqtt_logs else ""):
@@ -41,6 +42,8 @@ def mqtt_broker():
         time.sleep(1)
     else:
         raise TimeoutError("MQTT broker did not start within timeout")
+
+    logger.info("MQTT broker is ready (start took {} seconds)", time.time() - start_time)
 
     # Get the exposed port
     mqtt_port = compose.get_service_port("mqtt", 1883)

--- a/application/recipes.justfile
+++ b/application/recipes.justfile
@@ -18,7 +18,13 @@ install-uv:
     UV_VERSION=$(grep -A 3 '\[tool\.uv\]' "${REPO_ROOT}/application/backend/pyproject.toml" | grep 'required-version' | sed 's/.*= "[~=<>]*\(.*\)"/\1/')
     if command -v uv > /dev/null; then
         INSTALLED_VERSION=$(uv --version | awk '{print $2}')
-        if [[ "$INSTALLED_VERSION" == "$UV_VERSION" ]]; then
+        REQ_MAJOR=$(echo "$UV_VERSION" | cut -d. -f1)
+        REQ_MINOR=$(echo "$UV_VERSION" | cut -d. -f2)
+        REQ_PATCH=$(echo "$UV_VERSION" | cut -d. -f3)
+        INST_MAJOR=$(echo "$INSTALLED_VERSION" | cut -d. -f1)
+        INST_MINOR=$(echo "$INSTALLED_VERSION" | cut -d. -f2)
+        INST_PATCH=$(echo "$INSTALLED_VERSION" | cut -d. -f3)
+        if [[ "$INST_MAJOR" == "$REQ_MAJOR" && "$INST_MINOR" == "$REQ_MINOR" && "$INST_PATCH" -ge "$REQ_PATCH" ]]; then
             exit 0
         else
             echo "uv version mismatch: installed=${INSTALLED_VERSION}, required=${UV_VERSION}. Reinstalling..."


### PR DESCRIPTION
### Summary

Changes:

- Avoid reinstalling uv when a compatible patch version is already available
- Increase the timeout to start the MQTT broker

### How to test

Try `just install-uv` with different pre-installed uv versions.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
