### PR TITLE
Pack rfdetr sources in the pyinstaller package

### DIFF
--- a/application/backend/geti-tune.spec
+++ b/application/backend/geti-tune.spec
@@ -27,6 +27,9 @@ datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('otx')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
+tmp_ret = collect_all('rfdetr')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+
 runtime_hooks = []
 
 system = platform.system()


### PR DESCRIPTION
Pack rfdetr sources in the pyinstaller package. Fixes issue with files missing for Torch JIT
Resolves #5802