### PR TITLE
perf(training): Prefetch train model data to improve UX of training model flow [PART 15]

### DIFF
--- a/application/ui/src/features/models/hooks/api/use-get-model-architectures.hook.ts
+++ b/application/ui/src/features/models/hooks/api/use-get-model-architectures.hook.ts
@@ -3,6 +3,7 @@
 
 import { useMemo } from 'react';
 
+import { usePrefetchQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useProject } from 'hooks/api/project.hook';
 
 import { $api } from '../../../../api/client';
@@ -10,6 +11,7 @@ import {
     ModelArchitecture,
     ModelArchitectureWithPerformanceCategory,
     RecommendedModelArchitectures,
+    TaskType,
 } from '../../../../constants/shared-types';
 
 const getModelArchitectures = (
@@ -38,16 +40,22 @@ const getModelArchitectures = (
     });
 };
 
+const getTaskModelArchitecturesQueryOptions = (taskType: TaskType) => {
+    return $api.queryOptions('get', '/api/model_architectures', {
+        params: { query: { task: taskType } },
+    });
+};
+
+export const usePrefetchTaskModelArchitectures = () => {
+    const { data: projectData } = useProject();
+
+    return usePrefetchQuery(getTaskModelArchitecturesQueryOptions(projectData.task.task_type));
+};
+
 export const useGetTaskModelArchitectures = () => {
     const { data: projectData } = useProject();
 
-    const { data } = $api.useSuspenseQuery('get', '/api/model_architectures', {
-        params: {
-            query: {
-                task: projectData.task.task_type,
-            },
-        },
-    });
+    const { data } = useSuspenseQuery(getTaskModelArchitecturesQueryOptions(projectData.task.task_type));
 
     const modelArchitectures = useMemo(
         () => getModelArchitectures(data.model_architectures, data.top_picks),

--- a/application/ui/src/features/models/hooks/api/use-get-models.hook.ts
+++ b/application/ui/src/features/models/hooks/api/use-get-models.hook.ts
@@ -1,14 +1,25 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { usePrefetchQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../../api/client';
 
+const getModelsQueryOptions = (projectId: string) => {
+    return $api.queryOptions('get', '/api/projects/{project_id}/models', {
+        params: { path: { project_id: projectId } },
+    });
+};
+
 export const useGetModels = () => {
     const projectId = useProjectIdentifier();
 
-    return $api.useSuspenseQuery('get', '/api/projects/{project_id}/models', {
-        params: { path: { project_id: projectId } },
-    });
+    return useSuspenseQuery(getModelsQueryOptions(projectId));
+};
+
+export const usePrefetchModels = () => {
+    const projectId = useProjectIdentifier();
+
+    return usePrefetchQuery(getModelsQueryOptions(projectId));
 };

--- a/application/ui/src/features/models/train-model/api/use-get-training-devices.ts
+++ b/application/ui/src/features/models/train-model/api/use-get-training-devices.ts
@@ -1,8 +1,18 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { usePrefetchQuery, useSuspenseQuery } from '@tanstack/react-query';
+
 import { $api } from '../../../../api/client';
 
+const getTrainingDevicesQueryOptions = () => {
+    return $api.queryOptions('get', '/api/system/devices/training');
+};
+
 export const useGetTrainingDevices = () => {
-    return $api.useSuspenseQuery('get', '/api/system/devices/training');
+    return useSuspenseQuery(getTrainingDevicesQueryOptions());
+};
+
+export const usePrefetchTrainingDevices = () => {
+    return usePrefetchQuery(getTrainingDevicesQueryOptions());
 };

--- a/application/ui/src/features/models/train-model/api/use-prefetch-train-model-data.ts
+++ b/application/ui/src/features/models/train-model/api/use-prefetch-train-model-data.ts
@@ -1,0 +1,21 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { usePrefetchPipeline } from 'hooks/api/pipeline.hook';
+import { usePrefetchDatasetItems } from 'hooks/use-get-dataset-items.hook';
+import { usePrefetchDatasetRevisions } from 'hooks/use-get-dataset-revisions.hook';
+
+import { usePrefetchTaskModelArchitectures } from '../../hooks/api/use-get-model-architectures.hook';
+import { usePrefetchModels } from '../../hooks/api/use-get-models.hook';
+import { REVIEWED_DATASET_ITEMS_OPTIONS } from '../hooks/use-is-training-button-disabled';
+import { usePrefetchTrainingDevices } from './use-get-training-devices';
+
+export const usePrefetchTrainModelData = () => {
+    usePrefetchTaskModelArchitectures();
+    usePrefetchTrainingDevices();
+    usePrefetchDatasetRevisions();
+    usePrefetchModels();
+    usePrefetchPipeline();
+
+    usePrefetchDatasetItems(REVIEWED_DATASET_ITEMS_OPTIONS);
+};

--- a/application/ui/src/features/models/train-model/hooks/use-is-training-button-disabled.ts
+++ b/application/ui/src/features/models/train-model/hooks/use-is-training-button-disabled.ts
@@ -1,15 +1,17 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useGetDatasetItems } from '../../../hooks/use-get-dataset-items.hook';
+import { useGetDatasetItems } from 'hooks/use-get-dataset-items.hook';
 
 const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 
+export const REVIEWED_DATASET_ITEMS_OPTIONS = {
+    annotationStatus: 'reviewed',
+    limit: 1,
+} as const;
+
 export const useIsTrainingButtonDisabled = () => {
-    const { data: datasetItems } = useGetDatasetItems({
-        annotationStatus: 'reviewed',
-        limit: 1,
-    });
+    const { data: datasetItems } = useGetDatasetItems(REVIEWED_DATASET_ITEMS_OPTIONS);
     const count = datasetItems?.pagination.total ?? 0;
 
     return count < MIN_NUMBER_OF_ANNOTATED_ITEMS;

--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -19,9 +19,9 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useMatch } from 'react-router';
 
 import { paths } from '../../../constants/paths';
-import { useIsTrainingButtonDisabled } from '../hooks/use-is-training-button-disabled';
 import { AdvancedSettings } from './advanced-settings/advanced-settings.component';
 import { BasicTrainModelContent } from './basic-train-model-content.component';
+import { useIsTrainingButtonDisabled } from './hooks/use-is-training-button-disabled';
 import { useTrainModel } from './hooks/use-train-model';
 import { TrainModelDialogLayout } from './train-model-dialog-layout.component';
 import { useTrainModelState } from './train-model-provider.component';

--- a/application/ui/src/features/models/train-model/train-model.component.test.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.test.tsx
@@ -72,7 +72,7 @@ describe('TrainModel', () => {
 
         render(<TrainModel />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Train model' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Train model' }));
 
         expect(
             await screen.findByText(/In order to train a model, you need to annotate at least 3 items/)
@@ -113,7 +113,7 @@ describe('TrainModel', () => {
 
         render(<TrainModel />);
 
-        fireEvent.click(screen.getByRole('button', { name: 'Train model' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Train model' }));
 
         await waitFor(() => {
             expect(

--- a/application/ui/src/features/models/train-model/train-model.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model.component.tsx
@@ -5,10 +5,13 @@ import { Suspense } from 'react';
 
 import { Button, DialogTrigger, Loading, View } from '@geti/ui';
 
+import { usePrefetchTrainModelData } from './api/use-prefetch-train-model-data';
 import { TrainModelDialog } from './train-model-dialog.component';
 import { TrainModelProvider } from './train-model-provider.component';
 
 export const TrainModel = () => {
+    usePrefetchTrainModelData();
+
     return (
         <DialogTrigger>
             <Button margin={0}>Train model</Button>

--- a/application/ui/src/hooks/api/pipeline.hook.ts
+++ b/application/ui/src/hooks/api/pipeline.hook.ts
@@ -1,31 +1,36 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQueryClient } from '@tanstack/react-query';
+import { usePrefetchQuery, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../api/client';
 import { getQueryKey } from '../../query-client/query-client';
 
-export const usePipeline = () => {
-    const projectId = useProjectIdentifier();
-
-    return $api.useSuspenseQuery('get', '/api/projects/{project_id}/pipeline', {
-        params: { path: { project_id: projectId } },
+const getPipelineQueryOptions = (projectId: string) => {
+    return $api.queryOptions('get', '/api/projects/{project_id}/pipeline', {
+        params: {
+            path: {
+                project_id: projectId,
+            },
+        },
     });
 };
 
+export const usePipeline = () => {
+    const projectId = useProjectIdentifier();
+
+    return useSuspenseQuery(getPipelineQueryOptions(projectId));
+};
+
+export const usePrefetchPipeline = () => {
+    const projectId = useProjectIdentifier();
+
+    return usePrefetchQuery(getPipelineQueryOptions(projectId));
+};
+
 export const useProjectPipeline = (projectId: string) => {
-    return $api.useQuery(
-        'get',
-        '/api/projects/{project_id}/pipeline',
-        {
-            params: { path: { project_id: projectId } },
-        },
-        {
-            retry: false,
-        }
-    );
+    return useQuery({ ...getPipelineQueryOptions(projectId), retry: false });
 };
 
 const POLLING_INTERVAL = 5000;

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { usePrefetchQuery, useQuery } from '@tanstack/react-query';
+
 import { $api } from '../api/client';
 import type { DatasetItemAnnotationStatus, DatasetSubset } from '../constants/shared-types';
 import { useProjectIdentifier } from './use-project-identifier.hook';
@@ -11,12 +13,10 @@ type UseGetDatasetItemsOptions = {
     subset?: DatasetSubset;
 };
 
-export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
-    const project_id = useProjectIdentifier();
-
-    return $api.useQuery('get', '/api/projects/{project_id}/dataset/items', {
+const getDatasetItemsQueryOptions = (projectId: string, options?: UseGetDatasetItemsOptions) => {
+    return $api.queryOptions('get', '/api/projects/{project_id}/dataset/items', {
         params: {
-            path: { project_id },
+            path: { project_id: projectId },
             query: {
                 annotation_status: options?.annotationStatus,
                 limit: options?.limit,
@@ -24,4 +24,16 @@ export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
             },
         },
     });
+};
+
+export const useGetDatasetItems = (options?: UseGetDatasetItemsOptions) => {
+    const projectId = useProjectIdentifier();
+
+    return useQuery(getDatasetItemsQueryOptions(projectId, options));
+};
+
+export const usePrefetchDatasetItems = (options?: UseGetDatasetItemsOptions) => {
+    const projectId = useProjectIdentifier();
+
+    return usePrefetchQuery(getDatasetItemsQueryOptions(projectId, options));
 };

--- a/application/ui/src/hooks/use-get-dataset-revisions.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-revisions.hook.ts
@@ -1,17 +1,29 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { usePrefetchQuery, useQuery } from '@tanstack/react-query';
+
 import { $api } from '../api/client';
 import { useProjectIdentifier } from './use-project-identifier.hook';
 
-export const useGetDatasetRevisions = () => {
-    const project_id = useProjectIdentifier();
-
-    return $api.useQuery('get', '/api/projects/{project_id}/dataset_revisions', {
+const getDatasetRevisionsQueryOptions = (projectId: string) => {
+    return $api.queryOptions('get', '/api/projects/{project_id}/dataset_revisions', {
         params: {
             path: {
-                project_id,
+                project_id: projectId,
             },
         },
     });
+};
+
+export const useGetDatasetRevisions = () => {
+    const projectId = useProjectIdentifier();
+
+    return useQuery(getDatasetRevisionsQueryOptions(projectId));
+};
+
+export const usePrefetchDatasetRevisions = () => {
+    const projectId = useProjectIdentifier();
+
+    return usePrefetchQuery(getDatasetRevisionsQueryOptions(projectId));
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR adds a few prefetch queries to make UX of training model better. Previously we showed a loading spinner and flick of the "Not enough media to train" footer.


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
