### PR TITLE
Delete deleted labels from annotations

### DIFF
--- a/application/backend/app/models/task.py
+++ b/application/backend/app/models/task.py
@@ -43,3 +43,7 @@ class Task(BaseEntity):
     exclusive_labels: bool = False
     task_type: TaskType
     labels: list[Label] = Field(default_factory=list)
+
+    @property
+    def is_multiclass(self) -> bool:
+        return self.task_type is TaskType.CLASSIFICATION and self.exclusive_labels

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -159,6 +159,8 @@ class DatasetItemRepository:
             .values(
                 annotation_data=None,
                 updated_at=datetime.now(UTC),
+                user_reviewed=False,
+                prediction_model_id=None,
             )
         )
         result = cast(CursorResult, self.db.execute(stmt))
@@ -200,6 +202,22 @@ class DatasetItemRepository:
 
     def delete_labels(self, dataset_item_id: str) -> None:
         stmt = delete(DatasetItemLabelDB).where(DatasetItemLabelDB.dataset_item_id == dataset_item_id)
+        self.db.execute(stmt)
+
+    def find_items_by_label_id(self, label_id: str) -> list[DatasetItemDB]:
+        """Find all dataset items that reference a given label via the dataset_items_labels table."""
+        stmt = (
+            self._base_select()
+            .join(DatasetItemLabelDB, DatasetItemLabelDB.dataset_item_id == DatasetItemDB.id)
+            .where(DatasetItemLabelDB.label_id == label_id)
+        )
+        return list(self.db.scalars(stmt).all())
+
+    def delete_label_from_items(self, label_id: str) -> None:
+        """Delete a label reference from the dataset_items_labels table for all items."""
+        stmt = delete(DatasetItemLabelDB).where(
+            DatasetItemLabelDB.label_id == label_id,
+        )
         self.db.execute(stmt)
 
     def list_unassigned_items(self) -> list[DatasetItemLabelDB]:

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -179,8 +179,6 @@ class LabelService(BaseSessionManagedService):
         # Find all dataset items that reference this label
         affected_items = dataset_item_repo.find_items_by_label_id(label_id_str)
 
-        is_multiclass = task.task_type is TaskType.CLASSIFICATION and task.exclusive_labels
-
         for item in affected_items:
             if item.annotation_data is None:
                 continue
@@ -200,7 +198,7 @@ class LabelService(BaseSessionManagedService):
                     user_reviewed=item.user_reviewed,
                     prediction_model_id=item.prediction_model_id,
                 )
-            elif is_multiclass:
+            elif task.is_multiclass:
                 dataset_item_repo.delete_annotation_data(obj_id=item.id)
             else:
                 dataset_item_repo.set_annotation_data(

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -9,8 +9,8 @@ from app.db.schema import LabelDB
 from app.models import Label
 from app.models.label import LabelReference, LabelUpdateInfo
 from app.models.project import Project
-from app.models.task import TaskType
-from app.repositories import LabelRepository
+from app.models.task import Task, TaskType
+from app.repositories import DatasetItemRepository, LabelRepository
 from app.repositories.base import PrimaryKeyIntegrityError, UniqueConstraintIntegrityError
 from app.utils.color import random_color
 
@@ -131,7 +131,7 @@ class LabelService(BaseSessionManagedService):
                 new_hotkey=label_to_edit.new_hotkey,
             )
         for label_to_remove in labels_to_remove:
-            self._delete_label(project_id=project.id, label_id=label_to_remove.id)
+            self._delete_label(project_id=project.id, label_id=label_to_remove.id, task=project.task)
         for label_to_add in labels_to_add:
             self.create_label(
                 project_id=project.id,
@@ -163,7 +163,60 @@ class LabelService(BaseSessionManagedService):
         except UniqueConstraintIntegrityError:
             raise DuplicateLabelsError
 
-    def _delete_label(self, project_id: UUID, label_id: UUID) -> None:
+    def _delete_label(self, project_id: UUID, label_id: UUID, task: Task) -> None:
+        """Delete a label and clean up all annotations that reference it.
+
+        For each dataset item that uses this label:
+        - Remove the label from all annotation shapes.
+        - Remove shapes that have no labels left.
+        - If no shapes remain, set annotation_data=[].
+        - For multi-class classification (which doesn't support empty labels),
+          set annotation_data=None and user_reviewed=False.
+        """
+        dataset_item_repo = DatasetItemRepository(project_id=str(project_id), db=self.db_session)
+        label_id_str = str(label_id)
+
+        # Find all dataset items that reference this label
+        affected_items = dataset_item_repo.find_items_by_label_id(label_id_str)
+
+        is_multiclass = task.task_type is TaskType.CLASSIFICATION and task.exclusive_labels
+
+        for item in affected_items:
+            if item.annotation_data is None:
+                continue
+
+            # Remove the label from each annotation shape
+            updated_annotations = []
+            for annotation in item.annotation_data:
+                filtered_labels = [label for label in annotation.get("labels", []) if label.get("id") != label_id_str]
+                if filtered_labels:
+                    annotation["labels"] = filtered_labels
+                    updated_annotations.append(annotation)
+                # else: shape has no labels left, drop it entirely
+
+            if updated_annotations:
+                dataset_item_repo.set_annotation_data(
+                    obj_id=item.id,
+                    annotation_data=updated_annotations,
+                    user_reviewed=item.user_reviewed,
+                    prediction_model_id=item.prediction_model_id,
+                )
+            elif is_multiclass:
+                dataset_item_repo.delete_annotation_data(
+                    obj_id=item.id,
+                )
+            else:
+                dataset_item_repo.set_annotation_data(
+                    obj_id=item.id,
+                    annotation_data=[],
+                    user_reviewed=item.user_reviewed,
+                    prediction_model_id=item.prediction_model_id,
+                )
+
+        # Remove label references from the dataset_items_labels join table
+        dataset_item_repo.delete_label_from_items(label_id_str)
+
+        # Delete the label itself
         label_repo = LabelRepository(str(project_id), self.db_session)
-        if not label_repo.delete(str(label_id)):
-            raise ResourceNotFoundError(ResourceType.LABEL, str(label_id))
+        if not label_repo.delete(label_id_str):
+            raise ResourceNotFoundError(ResourceType.LABEL, label_id_str)

--- a/application/backend/app/services/label_service.py
+++ b/application/backend/app/services/label_service.py
@@ -185,14 +185,13 @@ class LabelService(BaseSessionManagedService):
             if item.annotation_data is None:
                 continue
 
-            # Remove the label from each annotation shape
+            # Build a fresh list of annotations with the deleted label removed.
+            # Shapes that have no remaining labels are dropped entirely.
             updated_annotations = []
             for annotation in item.annotation_data:
-                filtered_labels = [label for label in annotation.get("labels", []) if label.get("id") != label_id_str]
+                filtered_labels = [lbl for lbl in annotation.get("labels", []) if lbl.get("id") != label_id_str]
                 if filtered_labels:
-                    annotation["labels"] = filtered_labels
-                    updated_annotations.append(annotation)
-                # else: shape has no labels left, drop it entirely
+                    updated_annotations.append({**annotation, "labels": filtered_labels})
 
             if updated_annotations:
                 dataset_item_repo.set_annotation_data(
@@ -202,9 +201,7 @@ class LabelService(BaseSessionManagedService):
                     prediction_model_id=item.prediction_model_id,
                 )
             elif is_multiclass:
-                dataset_item_repo.delete_annotation_data(
-                    obj_id=item.id,
-                )
+                dataset_item_repo.delete_annotation_data(obj_id=item.id)
             else:
                 dataset_item_repo.set_annotation_data(
                     obj_id=item.id,

--- a/application/backend/tests/integration/services/test_label_service.py
+++ b/application/backend/tests/integration/services/test_label_service.py
@@ -6,11 +6,13 @@ from uuid import UUID, uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from app.db.schema import LabelDB, ProjectDB
+from app.db.schema import DatasetItemDB, DatasetItemLabelDB, LabelDB, MediaDB, ProjectDB
 from app.models import Label
 from app.models.label import LabelReference, LabelUpdateInfo
+from app.models.media import ImageFormat, MediaType
 from app.models.project import Project
 from app.models.task import Task, TaskType
+from app.repositories import DatasetItemRepository
 from app.services import ResourceNotFoundError, ResourceType, ResourceWithIdAlreadyExistsError
 from app.services.label_service import DuplicateLabelsError, LabelService
 
@@ -47,6 +49,23 @@ def _db_project_to_project(db_project: ProjectDB) -> Project:
             labels=[],
         ),
     )
+
+
+@pytest.fixture
+def fxt_db_images() -> list[MediaDB]:
+    return [
+        MediaDB(
+            id=str(uuid4()),
+            type=MediaType.IMAGE,
+            project_id=str(uuid4()),
+            name=f"test_image_{i}",
+            format=ImageFormat.JPG,
+            width=1024,
+            height=768,
+            size=2048,
+        )
+        for i in range(3)
+    ]
 
 
 class TestLabelServiceIntegration:
@@ -376,6 +395,270 @@ class TestLabelServiceIntegration:
         """
         fxt_stored_project_with_labels  # ensure fixture runs
 
+        fxt_label_service.list_ids(uuid4())
+
+    def test_list_ids_non_existing_project(
+        self,
+        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
+        fxt_label_service: LabelService,
+    ) -> None:
+        """
+        Test getting a list of labels ID's for non-existing project.
+
+        Verifies that:
+        - In case of non-existing project empty labels ID's list is returned
+        """
+        fxt_stored_project_with_labels  # ensure fixture runs
+
         ids = fxt_label_service.list_ids(uuid4())
 
         assert len(ids) == 0
+
+    def test_delete_label_removes_annotations_detection(
+        self,
+        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
+        fxt_label_service: LabelService,
+        fxt_db_images: list[MediaDB],
+        db_session: Session,
+    ) -> None:
+        """
+        Test deleting a label cleans up annotations for a detection project.
+
+        Sets up three dataset items:
+        - item1: has two shapes, one with the deleted label only (dropped),
+          the other with a different label (kept) -> annotation_data has one shape left.
+        - item2: has one shape with only the deleted label -> annotation_data becomes [].
+        - item3: has one shape with only the other label -> annotation_data is unchanged.
+
+        Verifies that:
+        - Shapes that lose all labels are removed.
+        - Items that lose all shapes get annotation_data=[].
+        - Items with remaining shapes keep them intact.
+        - The label is removed from the labels join table.
+        - The label itself is deleted.
+        """
+        db_project, db_labels = fxt_stored_project_with_labels
+        project = _db_project_to_project(db_project)
+        label_to_delete = db_labels[0]
+        label_to_keep = db_labels[1]
+
+        # Store media
+        for media in fxt_db_images:
+            media.project_id = db_project.id
+            db_session.add(media)
+            db_session.flush()
+
+        # item1: two shapes — one with deleted label only, one with kept label only
+        item1 = DatasetItemDB(
+            id=fxt_db_images[0].id,
+            project_id=db_project.id,
+            annotation_data=[
+                {"type": "rect", "labels": [{"id": label_to_delete.id, "probability": 1.0}]},
+                {"type": "rect", "labels": [{"id": label_to_keep.id, "probability": 1.0}]},
+            ],
+            user_reviewed=True,
+            prediction_model_id=None,
+            subset="training",
+        )
+        # item2: one shape with only the deleted label
+        item2 = DatasetItemDB(
+            id=fxt_db_images[1].id,
+            project_id=db_project.id,
+            annotation_data=[
+                {"type": "rect", "labels": [{"id": label_to_delete.id, "probability": 1.0}]},
+            ],
+            user_reviewed=True,
+            prediction_model_id=None,
+            subset="training",
+        )
+        # item3: one shape with only the kept label (unaffected)
+        item3 = DatasetItemDB(
+            id=fxt_db_images[2].id,
+            project_id=db_project.id,
+            annotation_data=[
+                {"type": "rect", "labels": [{"id": label_to_keep.id, "probability": 1.0}]},
+            ],
+            user_reviewed=True,
+            prediction_model_id=None,
+            subset="training",
+        )
+        db_session.add_all([item1, item2, item3])
+        db_session.flush()
+
+        # Sync label join table entries
+        dataset_item_repo = DatasetItemRepository(project_id=db_project.id, db=db_session)
+        for item in [item1, item2, item3]:
+            dataset_item_repo.set_annotation_data(
+                obj_id=item.id,
+                annotation_data=item.annotation_data,
+                user_reviewed=item.user_reviewed,
+                prediction_model_id=item.prediction_model_id,
+            )
+        db_session.flush()
+
+        # Add a third label so we can remove one and still have >=1
+        fxt_label_service.create_label(project_id=UUID(db_project.id), name="extra", color="#999999", hotkey="e")
+
+        # Delete the label via update_labels
+        fxt_label_service.update_labels(
+            project=project,
+            labels_to_add=[],
+            labels_to_remove=[LabelReference(id=UUID(label_to_delete.id))],
+            labels_to_edit=[],
+        )
+
+        db_session.expire_all()
+
+        # Verify the label is deleted
+        assert db_session.query(LabelDB).filter(LabelDB.id == label_to_delete.id).one_or_none() is None
+
+        # item1: should have one shape left (the one with label_to_keep)
+        refreshed_item1 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item1.id).one()
+        assert refreshed_item1.annotation_data is not None
+        assert len(refreshed_item1.annotation_data) == 1
+        assert refreshed_item1.annotation_data[0]["labels"][0]["id"] == label_to_keep.id
+        assert refreshed_item1.user_reviewed is True
+
+        # item2: should have empty annotation_data (not None, since this is detection)
+        refreshed_item2 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item2.id).one()
+        assert refreshed_item2.annotation_data == []
+        assert refreshed_item2.user_reviewed is True
+
+        # item3: should be unchanged
+        refreshed_item3 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item3.id).one()
+        assert refreshed_item3.annotation_data is not None
+        assert len(refreshed_item3.annotation_data) == 1
+        assert refreshed_item3.annotation_data[0]["labels"][0]["id"] == label_to_keep.id
+
+        # Verify label is removed from dataset_items_labels join table
+        remaining_join_entries = (
+            db_session.query(DatasetItemLabelDB).filter(DatasetItemLabelDB.label_id == label_to_delete.id).all()
+        )
+        assert len(remaining_join_entries) == 0
+
+    def test_delete_label_removes_annotations_multiclass_classification(
+        self,
+        fxt_db_projects: list[ProjectDB],
+        fxt_label_service: LabelService,
+        fxt_db_images: list[MediaDB],
+        db_session: Session,
+    ) -> None:
+        """
+        Test deleting a label cleans up annotations for a multi-class classification project.
+
+        Sets up two dataset items:
+        - item1: has one shape with only the deleted label -> annotation_data becomes None,
+          user_reviewed becomes False (multi-class classification behavior).
+        - item2: has one shape with both the deleted label and a kept label ->
+          annotation_data keeps the shape with the remaining label.
+
+        Verifies that:
+        - Multi-class classification items that lose all shapes get annotation_data=None
+          and user_reviewed=False.
+        - Items with remaining labels keep their annotation data.
+        - The label is removed from the labels join table.
+        - The label itself is deleted.
+        """
+        # Use a classification project
+        db_project = fxt_db_projects[1]  # classification project
+        db_project.task_type = TaskType.CLASSIFICATION.value
+        db_session.add(db_project)
+        db_session.flush()
+
+        # Create labels for this project
+        label1 = LabelDB(project_id=db_project.id, name="cat", color="#FF0000", hotkey="c")
+        label2 = LabelDB(project_id=db_project.id, name="dog", color="#00FF00", hotkey="d")
+        label3 = LabelDB(project_id=db_project.id, name="bird", color="#0000FF", hotkey="b")
+        db_session.add_all([label1, label2, label3])
+        db_session.flush()
+
+        # Store media
+        for media in fxt_db_images:
+            media.project_id = db_project.id
+            db_session.add(media)
+            db_session.flush()
+
+        # item1: one shape with only the label to delete
+        item1 = DatasetItemDB(
+            id=fxt_db_images[0].id,
+            project_id=db_project.id,
+            annotation_data=[
+                {"type": "label", "labels": [{"id": label1.id, "probability": 1.0}]},
+            ],
+            user_reviewed=True,
+            prediction_model_id=None,
+            subset="training",
+        )
+        # item2: one shape with both label1 (to delete) and label2 (to keep)
+        item2 = DatasetItemDB(
+            id=fxt_db_images[1].id,
+            project_id=db_project.id,
+            annotation_data=[
+                {
+                    "type": "label",
+                    "labels": [
+                        {"id": label1.id, "probability": 0.8},
+                        {"id": label2.id, "probability": 0.2},
+                    ],
+                },
+            ],
+            user_reviewed=True,
+            prediction_model_id=None,
+            subset="training",
+        )
+        db_session.add_all([item1, item2])
+        db_session.flush()
+
+        # Sync label join table
+        dataset_item_repo = DatasetItemRepository(project_id=db_project.id, db=db_session)
+        for item in [item1, item2]:
+            dataset_item_repo.set_annotation_data(
+                obj_id=item.id,
+                annotation_data=item.annotation_data,
+                user_reviewed=item.user_reviewed,
+                prediction_model_id=item.prediction_model_id,
+            )
+        db_session.flush()
+
+        # Build the project model with exclusive_labels=True for multi-class
+        project = Project(
+            id=UUID(db_project.id),
+            name=db_project.name,
+            task=Task(
+                task_type=TaskType.CLASSIFICATION,
+                labels=[],
+                exclusive_labels=True,
+            ),
+        )
+
+        # Delete label1
+        fxt_label_service.update_labels(
+            project=project,
+            labels_to_add=[],
+            labels_to_remove=[LabelReference(id=UUID(label1.id))],
+            labels_to_edit=[],
+        )
+
+        db_session.expire_all()
+
+        # Verify label is deleted
+        assert db_session.query(LabelDB).filter(LabelDB.id == label1.id).one_or_none() is None
+
+        # item1: multi-class with no shapes left -> annotation_data=None, user_reviewed=False
+        refreshed_item1 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item1.id).one()
+        assert refreshed_item1.annotation_data is None
+        assert refreshed_item1.user_reviewed is False
+
+        # item2: should still have the shape with label2
+        refreshed_item2 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item2.id).one()
+        assert refreshed_item2.annotation_data is not None
+        assert len(refreshed_item2.annotation_data) == 1
+        assert len(refreshed_item2.annotation_data[0]["labels"]) == 1
+        assert refreshed_item2.annotation_data[0]["labels"][0]["id"] == label2.id
+        assert refreshed_item2.user_reviewed is True
+
+        # Verify label is removed from join table
+        remaining_join_entries = (
+            db_session.query(DatasetItemLabelDB).filter(DatasetItemLabelDB.label_id == label1.id).all()
+        )
+        assert len(remaining_join_entries) == 0

--- a/application/backend/tests/integration/services/test_label_service.py
+++ b/application/backend/tests/integration/services/test_label_service.py
@@ -1,25 +1,35 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, DatasetItemLabelDB, LabelDB, MediaDB, ProjectDB
-from app.models import Label
+from app.models import DatasetItemAnnotation, Label
 from app.models.label import LabelReference, LabelUpdateInfo
 from app.models.media import ImageFormat, MediaType
 from app.models.project import Project
+from app.models.shape import FullImage, Rectangle
 from app.models.task import Task, TaskType
-from app.repositories import DatasetItemRepository
 from app.services import ResourceNotFoundError, ResourceType, ResourceWithIdAlreadyExistsError
+from app.services.dataset_service import DatasetService
 from app.services.label_service import DuplicateLabelsError, LabelService
+from app.services.media_service import MediaService
 
 
 @pytest.fixture
 def fxt_label_service(db_session: Session) -> LabelService:
     return LabelService(db_session)
+
+
+@pytest.fixture
+def fxt_dataset_service(db_session: Session) -> DatasetService:
+    label_service = LabelService(db_session)
+    media_service = MagicMock(spec=MediaService)
+    return DatasetService(label_service=label_service, media_service=media_service, db_session=db_session)
 
 
 @pytest.fixture
@@ -395,21 +405,6 @@ class TestLabelServiceIntegration:
         """
         fxt_stored_project_with_labels  # ensure fixture runs
 
-        fxt_label_service.list_ids(uuid4())
-
-    def test_list_ids_non_existing_project(
-        self,
-        fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
-        fxt_label_service: LabelService,
-    ) -> None:
-        """
-        Test getting a list of labels ID's for non-existing project.
-
-        Verifies that:
-        - In case of non-existing project empty labels ID's list is returned
-        """
-        fxt_stored_project_with_labels  # ensure fixture runs
-
         ids = fxt_label_service.list_ids(uuid4())
 
         assert len(ids) == 0
@@ -418,6 +413,7 @@ class TestLabelServiceIntegration:
         self,
         fxt_stored_project_with_labels: tuple[ProjectDB, list[LabelDB]],
         fxt_label_service: LabelService,
+        fxt_dataset_service: DatasetService,
         fxt_db_images: list[MediaDB],
         db_session: Session,
     ) -> None:
@@ -442,61 +438,64 @@ class TestLabelServiceIntegration:
         label_to_delete = db_labels[0]
         label_to_keep = db_labels[1]
 
-        # Store media
+        # Store media directly in the DB (no file I/O needed)
         for media in fxt_db_images:
             media.project_id = db_project.id
             db_session.add(media)
-            db_session.flush()
-
-        # item1: two shapes — one with deleted label only, one with kept label only
-        item1 = DatasetItemDB(
-            id=fxt_db_images[0].id,
-            project_id=db_project.id,
-            annotation_data=[
-                {"type": "rect", "labels": [{"id": label_to_delete.id, "probability": 1.0}]},
-                {"type": "rect", "labels": [{"id": label_to_keep.id, "probability": 1.0}]},
-            ],
-            user_reviewed=True,
-            prediction_model_id=None,
-            subset="training",
-        )
-        # item2: one shape with only the deleted label
-        item2 = DatasetItemDB(
-            id=fxt_db_images[1].id,
-            project_id=db_project.id,
-            annotation_data=[
-                {"type": "rect", "labels": [{"id": label_to_delete.id, "probability": 1.0}]},
-            ],
-            user_reviewed=True,
-            prediction_model_id=None,
-            subset="training",
-        )
-        # item3: one shape with only the kept label (unaffected)
-        item3 = DatasetItemDB(
-            id=fxt_db_images[2].id,
-            project_id=db_project.id,
-            annotation_data=[
-                {"type": "rect", "labels": [{"id": label_to_keep.id, "probability": 1.0}]},
-            ],
-            user_reviewed=True,
-            prediction_model_id=None,
-            subset="training",
-        )
-        db_session.add_all([item1, item2, item3])
         db_session.flush()
 
-        # Sync label join table entries
-        dataset_item_repo = DatasetItemRepository(project_id=db_project.id, db=db_session)
-        for item in [item1, item2, item3]:
-            dataset_item_repo.set_annotation_data(
-                obj_id=item.id,
-                annotation_data=item.annotation_data,
-                user_reviewed=item.user_reviewed,
-                prediction_model_id=item.prediction_model_id,
-            )
-        db_session.flush()
+        def _media(db_media: MediaDB) -> MagicMock:
+            m = MagicMock()
+            m.id = UUID(db_media.id)
+            m.width = db_media.width
+            m.height = db_media.height
+            return m
 
-        # Add a third label so we can remove one and still have >=1
+        # item1: two rectangles — one with the deleted label, one with the kept label
+        item1 = fxt_dataset_service.create_dataset_item(
+            project_id=UUID(db_project.id),
+            task=project.task,
+            media=_media(fxt_db_images[0]),
+            user_reviewed=True,
+            annotations=[
+                DatasetItemAnnotation(
+                    shape=Rectangle(x=0, y=0, width=10, height=10),
+                    labels=[LabelReference(id=UUID(label_to_delete.id))],
+                ),
+                DatasetItemAnnotation(
+                    shape=Rectangle(x=20, y=20, width=10, height=10),
+                    labels=[LabelReference(id=UUID(label_to_keep.id))],
+                ),
+            ],
+        )
+        # item2: one rectangle with only the deleted label
+        item2 = fxt_dataset_service.create_dataset_item(
+            project_id=UUID(db_project.id),
+            task=project.task,
+            media=_media(fxt_db_images[1]),
+            user_reviewed=True,
+            annotations=[
+                DatasetItemAnnotation(
+                    shape=Rectangle(x=0, y=0, width=10, height=10),
+                    labels=[LabelReference(id=UUID(label_to_delete.id))],
+                ),
+            ],
+        )
+        # item3: one rectangle with only the kept label (unaffected)
+        item3 = fxt_dataset_service.create_dataset_item(
+            project_id=UUID(db_project.id),
+            task=project.task,
+            media=_media(fxt_db_images[2]),
+            user_reviewed=True,
+            annotations=[
+                DatasetItemAnnotation(
+                    shape=Rectangle(x=0, y=0, width=10, height=10),
+                    labels=[LabelReference(id=UUID(label_to_keep.id))],
+                ),
+            ],
+        )
+
+        # Add a third label so we can remove one and still have >= 2 (multiclass min) / >= 1
         fxt_label_service.create_label(project_id=UUID(db_project.id), name="extra", color="#999999", hotkey="e")
 
         # Delete the label via update_labels
@@ -513,19 +512,19 @@ class TestLabelServiceIntegration:
         assert db_session.query(LabelDB).filter(LabelDB.id == label_to_delete.id).one_or_none() is None
 
         # item1: should have one shape left (the one with label_to_keep)
-        refreshed_item1 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item1.id).one()
+        refreshed_item1 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == str(item1.id)).one()
         assert refreshed_item1.annotation_data is not None
         assert len(refreshed_item1.annotation_data) == 1
         assert refreshed_item1.annotation_data[0]["labels"][0]["id"] == label_to_keep.id
         assert refreshed_item1.user_reviewed is True
 
         # item2: should have empty annotation_data (not None, since this is detection)
-        refreshed_item2 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item2.id).one()
+        refreshed_item2 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == str(item2.id)).one()
         assert refreshed_item2.annotation_data == []
         assert refreshed_item2.user_reviewed is True
 
         # item3: should be unchanged
-        refreshed_item3 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item3.id).one()
+        refreshed_item3 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == str(item3.id)).one()
         assert refreshed_item3.annotation_data is not None
         assert len(refreshed_item3.annotation_data) == 1
         assert refreshed_item3.annotation_data[0]["labels"][0]["id"] == label_to_keep.id
@@ -540,6 +539,7 @@ class TestLabelServiceIntegration:
         self,
         fxt_db_projects: list[ProjectDB],
         fxt_label_service: LabelService,
+        fxt_dataset_service: DatasetService,
         fxt_db_images: list[MediaDB],
         db_session: Session,
     ) -> None:
@@ -572,66 +572,59 @@ class TestLabelServiceIntegration:
         db_session.add_all([label1, label2, label3])
         db_session.flush()
 
-        # Store media
+        # Store media directly in the DB (no file I/O needed)
         for media in fxt_db_images:
             media.project_id = db_project.id
             db_session.add(media)
-            db_session.flush()
-
-        # item1: one shape with only the label to delete
-        item1 = DatasetItemDB(
-            id=fxt_db_images[0].id,
-            project_id=db_project.id,
-            annotation_data=[
-                {"type": "label", "labels": [{"id": label1.id, "probability": 1.0}]},
-            ],
-            user_reviewed=True,
-            prediction_model_id=None,
-            subset="training",
-        )
-        # item2: one shape with both label1 (to delete) and label2 (to keep)
-        item2 = DatasetItemDB(
-            id=fxt_db_images[1].id,
-            project_id=db_project.id,
-            annotation_data=[
-                {
-                    "type": "label",
-                    "labels": [
-                        {"id": label1.id, "probability": 0.8},
-                        {"id": label2.id, "probability": 0.2},
-                    ],
-                },
-            ],
-            user_reviewed=True,
-            prediction_model_id=None,
-            subset="training",
-        )
-        db_session.add_all([item1, item2])
-        db_session.flush()
-
-        # Sync label join table
-        dataset_item_repo = DatasetItemRepository(project_id=db_project.id, db=db_session)
-        for item in [item1, item2]:
-            dataset_item_repo.set_annotation_data(
-                obj_id=item.id,
-                annotation_data=item.annotation_data,
-                user_reviewed=item.user_reviewed,
-                prediction_model_id=item.prediction_model_id,
-            )
         db_session.flush()
 
         # Build the project model with exclusive_labels=True for multi-class
         project = Project(
             id=UUID(db_project.id),
             name=db_project.name,
-            task=Task(
-                task_type=TaskType.CLASSIFICATION,
-                labels=[],
-                exclusive_labels=True,
-            ),
+            task=Task(task_type=TaskType.CLASSIFICATION, labels=[], exclusive_labels=True),
         )
 
-        # Delete label1
+        def _media(db_media: MediaDB) -> MagicMock:
+            m = MagicMock()
+            m.id = UUID(db_media.id)
+            m.width = db_media.width
+            m.height = db_media.height
+            return m
+
+        # item1: one full_image annotation with only the label to delete.
+        # DatasetService validates multiclass correctly (one label per annotation).
+        item1 = fxt_dataset_service.create_dataset_item(
+            project_id=UUID(db_project.id),
+            task=project.task,
+            media=_media(fxt_db_images[0]),
+            user_reviewed=True,
+            annotations=[
+                DatasetItemAnnotation(
+                    shape=FullImage(),
+                    labels=[LabelReference(id=UUID(label1.id))],
+                ),
+            ],
+        )
+
+        # item2: one full_image annotation with both label1 and label2.
+        # A multilabel task is used for creation because multiclass forbids >1 label per annotation.
+        # The join table is populated explicitly afterwards to match the actual annotation_data.
+        multilabel_task = Task(task_type=TaskType.CLASSIFICATION, labels=[], exclusive_labels=False)
+        item2 = fxt_dataset_service.create_dataset_item(
+            project_id=UUID(db_project.id),
+            task=multilabel_task,
+            media=_media(fxt_db_images[1]),
+            user_reviewed=True,
+            annotations=[
+                DatasetItemAnnotation(
+                    shape=FullImage(),
+                    labels=[LabelReference(id=UUID(label1.id)), LabelReference(id=UUID(label2.id))],
+                ),
+            ],
+        )
+
+        # Delete label1 using the multiclass project
         fxt_label_service.update_labels(
             project=project,
             labels_to_add=[],
@@ -645,12 +638,12 @@ class TestLabelServiceIntegration:
         assert db_session.query(LabelDB).filter(LabelDB.id == label1.id).one_or_none() is None
 
         # item1: multi-class with no shapes left -> annotation_data=None, user_reviewed=False
-        refreshed_item1 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item1.id).one()
+        refreshed_item1 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == str(item1.id)).one()
         assert refreshed_item1.annotation_data is None
         assert refreshed_item1.user_reviewed is False
 
         # item2: should still have the shape with label2
-        refreshed_item2 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == item2.id).one()
+        refreshed_item2 = db_session.query(DatasetItemDB).filter(DatasetItemDB.id == str(item2.id)).one()
         assert refreshed_item2.annotation_data is not None
         assert len(refreshed_item2.annotation_data) == 1
         assert len(refreshed_item2.annotation_data[0]["labels"]) == 1


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

After deleting a label, we now also delete this label from any annotation that contains this label. If no labels remain, the annotation is removed as well. If no annotation remains, the annotation data is set to None if a project does not support the empty label, otherwise it is left as an empty list.

Because the `DatasetService` depends on `LabelService` and `MediaService`, the code is implemented in the `LabelService` completely to avoid weird circular dependencies.

Resolves #5773 

### How to test

New integration tests have been added

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
