### PR TITLE
chore(training configuration): Display only dependent parameters in the trained model learning parameters [PART 17]

### DIFF
--- a/application/ui/src/features/models/model-listing/model-training-parameters/model-training-parameters.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-parameters/model-training-parameters.component.tsx
@@ -7,6 +7,7 @@ import { Grid, Text } from '@geti/ui';
 
 import { TrainingConfigurationParameter } from '../../../../constants/shared-types';
 import { useGetModelTrainingConfiguration } from '../../hooks/api/use-get-model-training-configuration.hook';
+import { reorderDependentParameters } from '../../train-model/advanced-settings/training/learning-parameters/utils';
 import { Box } from '../components/box/box.component';
 import { findGroupByKey, flattenParameters } from './utils';
 
@@ -54,13 +55,15 @@ export const ModelTrainingParameters = ({ modelId }: ModelTrainingParametersProp
     const filteringGroup = findGroupByKey(datasetPreparationGroup?.parameters, 'filtering');
     const augmentationGroup = findGroupByKey(datasetPreparationGroup?.parameters, 'augmentation');
 
+    const learningParameters = reorderDependentParameters(trainingGroup?.parameters ?? []);
+
     return (
         <Grid columns={['1fr', '1fr', '1fr']} gap={'size-200'}>
             <Box
                 testId={'Box-LEARNING PARAMETERS'}
                 customClasses={classes.box}
                 title={'LEARNING PARAMETERS'}
-                content={<TrainingConfigurationParametersList parameters={trainingGroup?.parameters || []} />}
+                content={<TrainingConfigurationParametersList parameters={learningParameters} />}
             />
             <Box
                 testId={'Box-FILTERS'}

--- a/application/ui/src/features/models/model-listing/model-training-parameters/model-training-parameters.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-parameters/model-training-parameters.component.tsx
@@ -7,7 +7,7 @@ import { Grid, Text } from '@geti/ui';
 
 import { TrainingConfigurationParameter } from '../../../../constants/shared-types';
 import { useGetModelTrainingConfiguration } from '../../hooks/api/use-get-model-training-configuration.hook';
-import { reorderDependentParameters } from '../../train-model/advanced-settings/training/learning-parameters/utils';
+import { filterDependentParameters } from '../../train-model/advanced-settings/training/learning-parameters/utils';
 import { Box } from '../components/box/box.component';
 import { findGroupByKey, flattenParameters } from './utils';
 
@@ -55,7 +55,7 @@ export const ModelTrainingParameters = ({ modelId }: ModelTrainingParametersProp
     const filteringGroup = findGroupByKey(datasetPreparationGroup?.parameters, 'filtering');
     const augmentationGroup = findGroupByKey(datasetPreparationGroup?.parameters, 'augmentation');
 
-    const learningParameters = reorderDependentParameters(trainingGroup?.parameters ?? []);
+    const learningParameters = filterDependentParameters(trainingGroup?.parameters ?? []);
 
     return (
         <Grid columns={['1fr', '1fr', '1fr']} gap={'size-200'}>

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/learning-parameters-list.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/learning-parameters-list.component.tsx
@@ -10,7 +10,7 @@ import { ConfigurableParameter, TrainingConfiguration } from '../../../../../../
 import { Parameters } from '../../components/parameters.component';
 import { deepReplaceParameters } from '../../utils';
 import { InputSizeParameters } from './input-size-parameters.component';
-import { isInputSizeParameter, LearningConfigurationGroup, reorderDependentParameters } from './utils';
+import { filterDependentParameters, isInputSizeParameter, LearningConfigurationGroup } from './utils';
 
 const changeLearningParameters = (
     trainingConfiguration: TrainingConfiguration,
@@ -40,7 +40,7 @@ export const LearningParametersListContainer = ({
     const [inputSizeParameters, restParameters] = partition(learningParameters.parameters, isInputSizeParameter);
 
     const learningParametersBasedOnDependency = useMemo(
-        () => reorderDependentParameters(restParameters),
+        () => filterDependentParameters(restParameters),
         [restParameters]
     );
 

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.test.ts
@@ -10,10 +10,10 @@ import { TrainingConfigurationParameter } from '../../../../../../constants/shar
 import { isParameter, isParameterGroup } from '../../../../model-listing/model-training-parameters/utils';
 import { learningParameters } from './mocks';
 import {
+    filterDependentParameters,
     isInputSizeHeightParameter,
     isInputSizeWidthParameter,
     LearningConfigurationGroup,
-    reorderDependentParameters,
 } from './utils';
 
 const buildEnumNumberParameter = (key: string): TrainingConfigurationParameter =>
@@ -91,9 +91,9 @@ describe('isInputSizeHeightParameter', () => {
     });
 });
 
-describe('reorderDependentParameters', () => {
+describe('filterDependentParameters', () => {
     it('keeps independent parameters in their original order', () => {
-        const result = reorderDependentParameters(learningParameters.parameters);
+        const result = filterDependentParameters(learningParameters.parameters);
         const keys = result.filter(isParameter).map((p) => p.key);
 
         expect(keys).toContain('max_epochs');
@@ -105,7 +105,7 @@ describe('reorderDependentParameters', () => {
         const schedulerGroup = learningParameters.parameters.find(
             (p) => isParameterGroup(p) && p.key === 'scheduler'
         ) as LearningConfigurationGroup;
-        const result = reorderDependentParameters(schedulerGroup.parameters);
+        const result = filterDependentParameters(schedulerGroup.parameters);
         const keys = result.filter(isParameter).map((p) => p.key);
 
         const typeIndex = keys.indexOf('type');
@@ -122,7 +122,7 @@ describe('reorderDependentParameters', () => {
         const schedulerGroup = learningParameters.parameters.find(
             (p) => isParameterGroup(p) && p.key === 'scheduler'
         ) as LearningConfigurationGroup;
-        const result = reorderDependentParameters(schedulerGroup.parameters);
+        const result = filterDependentParameters(schedulerGroup.parameters);
         const keys = result.filter(isParameter).map((p) => p.key);
 
         // 'min_lr' depends on type === 'cosine_annealing', but type === 'reduce_lr_on_plateau'
@@ -130,7 +130,7 @@ describe('reorderDependentParameters', () => {
     });
 
     it('preserves parameter groups in the output', () => {
-        const result = reorderDependentParameters(learningParameters.parameters);
+        const result = filterDependentParameters(learningParameters.parameters);
         const groupKeys = result.filter(isParameterGroup).map((p) => p.key);
 
         expect(groupKeys).toContain('early_stopping');
@@ -140,12 +140,12 @@ describe('reorderDependentParameters', () => {
     });
 
     it('returns an empty array when given an empty array', () => {
-        expect(reorderDependentParameters([])).toEqual([]);
+        expect(filterDependentParameters([])).toEqual([]);
     });
 
     it('returns a single independent parameter unchanged', () => {
         const param = getMockedConfigurationParameter({ value_type: 'int', key: 'solo', depends_on: null });
-        const result = reorderDependentParameters([param]);
+        const result = filterDependentParameters([param]);
 
         expect(result).toEqual([param]);
     });
@@ -156,7 +156,7 @@ describe('reorderDependentParameters', () => {
             key: 'orphan',
             depends_on: { some_key: 'some_value' },
         });
-        const result = reorderDependentParameters([dependent]);
+        const result = filterDependentParameters([dependent]);
 
         expect(result).toEqual([]);
     });

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.ts
@@ -44,7 +44,7 @@ export const getInputSizeHeightParameter = (
     parameters: TrainingConfigurationParameter[]
 ): NumberEnumConfigurableParameter | undefined => parameters.find(isInputSizeHeightParameter);
 
-export const reorderDependentParameters = (
+export const filterDependentParameters = (
     parameters: LearningConfigurationParameters[]
 ): LearningConfigurationParameters[] => {
     return parameters
@@ -66,7 +66,7 @@ export const reorderDependentParameters = (
             }
 
             if (isParameterGroup(curr)) {
-                const groupedParameters = reorderDependentParameters(curr.parameters);
+                const groupedParameters = filterDependentParameters(curr.parameters);
 
                 return [...acc, [{ ...curr, parameters: groupedParameters }]];
             }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
