### PR TITLE
Return 'device' in training job response metadata

### DIFF
--- a/application/backend/app/api/schemas/jobs/training.py
+++ b/application/backend/app/api/schemas/jobs/training.py
@@ -6,9 +6,9 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
+from app.api.schemas.system import DeviceInfoView
 from app.core.jobs.models import JobType
 from app.models import TrainingJob
-from app.models.system import DeviceInfo
 
 from .base import BaseJobRequest
 
@@ -87,7 +87,7 @@ class TrainingMetadata(BaseModel):
 
     project: ProjectMetadata = Field(..., description="Project associated with the training job")
     model: ModelMetadata = Field(..., description="Model being trained")
-    device: DeviceInfo = Field(..., description="Device associated with the training job")
+    device: DeviceInfoView = Field(..., description="Device associated with the training job")
 
     @model_validator(mode="before")
     @classmethod
@@ -101,6 +101,6 @@ class TrainingMetadata(BaseModel):
                     parent_revision_id=data.params.parent_model_revision_id,
                     dataset_revision_id=data.params.dataset_revision_id,
                 ),
-                "device": data.params.device,
+                "device": DeviceInfoView.model_validate(data.params.device, from_attributes=True),
             }
         return data

--- a/application/backend/app/api/schemas/jobs/training.py
+++ b/application/backend/app/api/schemas/jobs/training.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from app.core.jobs.models import JobType
 from app.models import TrainingJob
+from app.models.system import DeviceInfo
 
 from .base import BaseJobRequest
 
@@ -86,6 +87,7 @@ class TrainingMetadata(BaseModel):
 
     project: ProjectMetadata = Field(..., description="Project associated with the training job")
     model: ModelMetadata = Field(..., description="Model being trained")
+    device: DeviceInfo = Field(..., description="Device associated with the training job")
 
     @model_validator(mode="before")
     @classmethod
@@ -99,5 +101,6 @@ class TrainingMetadata(BaseModel):
                     parent_revision_id=data.params.parent_model_revision_id,
                     dataset_revision_id=data.params.dataset_revision_id,
                 ),
+                "device": data.params.device,
             }
         return data

--- a/application/backend/tests/unit/api/routers/test_jobs.py
+++ b/application/backend/tests/unit/api/routers/test_jobs.py
@@ -91,7 +91,9 @@ class TestJobEndpoints:
         response = fxt_client.post("/api/jobs", json=job_request.model_dump(mode="json"))
 
         assert response.status_code == status.HTTP_202_ACCEPTED
-        assert response.json()["job_id"]
+        response_json = response.json()
+        assert response_json["job_id"]
+        assert response_json["metadata"]["device"]["name"] == "CPU"
         job_request = cast(TrainingJob, job_request)
         fxt_project_service.get_project_by_id.assert_called_once_with(job_request.project_id)
         fxt_jobs_queue.submit.assert_called_once()

--- a/application/ui/mocks/mock-job.ts
+++ b/application/ui/mocks/mock-job.ts
@@ -17,6 +17,10 @@ export const getMockedJob = (job?: Partial<Job>): Job => {
                 parent_revision_id: null,
                 dataset_revision_id: '6f9f9g61-4fg1-7781-e082-e1113f371e01',
             },
+            device: {
+                type: 'cpu',
+                name: 'CPU',
+            },
         },
         status: 'RUNNING',
         progress: 45,

--- a/application/ui/src/features/models/model-listing/current-model-training/training-model-row.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/current-model-training/training-model-row.component.test.tsx
@@ -53,6 +53,10 @@ describe('TrainingModelRow', () => {
                     parent_revision_id: null,
                     dataset_revision_id: 'dataset-123',
                 },
+                device: {
+                    type: 'cpu',
+                    name: 'CPU',
+                },
             },
             status: 'RUNNING',
             message: 'Running...',
@@ -99,6 +103,10 @@ describe('TrainingModelRow', () => {
                     architecture: 'Custom_Object_Detection_Gen3_ATSS',
                     parent_revision_id: null,
                     dataset_revision_id: 'dataset-123',
+                },
+                device: {
+                    type: 'cpu',
+                    name: 'CPU',
                 },
             },
             status: 'RUNNING',
@@ -157,6 +165,10 @@ describe('TrainingModelRow', () => {
                     parent_revision_id: null,
                     dataset_revision_id: 'dataset-123',
                 },
+                device: {
+                    type: 'cpu',
+                    name: 'CPU',
+                },
             },
             status: 'RUNNING',
         });
@@ -186,6 +198,10 @@ describe('TrainingModelRow', () => {
                     architecture: 'Custom_Object_Detection_Gen3_ATSS',
                     parent_revision_id: null,
                     dataset_revision_id: 'dataset-123',
+                },
+                device: {
+                    type: 'cpu',
+                    name: 'CPU',
                 },
             },
             status: 'FINISHED',

--- a/application/ui/src/hooks/api/jobs/jobs.hook.test.ts
+++ b/application/ui/src/hooks/api/jobs/jobs.hook.test.ts
@@ -27,6 +27,10 @@ const createMockJobForProject = (overrides: Partial<ReturnType<typeof getMockedJ
                 architecture: 'SSD',
                 dataset_revision_id: 'ds-rev-1',
             },
+            device: {
+                type: 'cpu',
+                name: 'CPU',
+            },
         },
         ...overrides,
     });
@@ -111,6 +115,10 @@ describe('useGetCurrentTrainingJob', () => {
             metadata: {
                 project: { id: 'other-project' },
                 model: { id: 'model-1', architecture: 'SSD', dataset_revision_id: 'ds-rev-1' },
+                device: {
+                    type: 'cpu',
+                    name: 'CPU',
+                },
             },
         });
         server.use(http.get('/api/jobs', () => HttpResponse.json([otherProjectJob])));

--- a/application/ui/tests/jobs/jobs.spec.ts
+++ b/application/ui/tests/jobs/jobs.spec.ts
@@ -20,6 +20,10 @@ const mockedTrainingJob = getMockedJob({
             parent_revision_id: null,
             dataset_revision_id: 'dataset-1',
         },
+        device: {
+            type: 'cpu',
+            name: 'CPU',
+        },
     },
     started_at: '2026-01-19T08:15:00.000000+00:00',
     finished_at: null,

--- a/application/ui/tests/models/model-training.spec.ts
+++ b/application/ui/tests/models/model-training.spec.ts
@@ -76,6 +76,10 @@ const runningTrainingJob = getMockedJob({
             parent_revision_id: 'model-rev-1',
             dataset_revision_id: 'dataset-2',
         },
+        device: {
+            type: 'cpu',
+            name: 'CPU',
+        },
     },
     started_at: '2026-01-19T08:15:00.000000+00:00',
     finished_at: null,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Add `device` field into training job response metadata

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
