### PR TITLE
Add possibility to download logs

### DIFF
--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -4,8 +4,11 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getMockedModel } from 'mocks/mock-model';
+import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
+import { http } from '../../../../../api/utils';
+import { server } from '../../../../../msw-node-setup';
 import { ModelActions } from './model-actions.component';
 
 const mockModel = getMockedModel({
@@ -63,6 +66,20 @@ describe('ModelActions', () => {
     });
 
     it('should show download logs action in training logs dialog', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/models/{model_id}/logs', () => {
+                return new HttpResponse(
+                    '[2025-01-10 10:00:00][INFO ] Initializing\n[2025-01-10 10:00:01][INFO ] Training started',
+                    {
+                        status: 200,
+                        headers: {
+                            'content-type': 'text/plain',
+                        },
+                    }
+                );
+            })
+        );
+
         render(<ModelActions model={mockModel} />);
 
         const menuButton = screen.getByRole('button', { name: 'Model actions' });
@@ -70,9 +87,9 @@ describe('ModelActions', () => {
 
         await userEvent.click(screen.getByRole('menuitem', { name: 'View training logs' }));
 
-        (await screen.findByRole('button', { name: 'Download logs' })).click();
+        await userEvent.click(await screen.findByRole('button', { name: 'Download logs' }));
 
-        expect(screen.getByText('Training logs downloaded successfully')).toBeInTheDocument();
+        expect(await screen.findByText('Training logs downloaded successfully')).toBeInTheDocument();
     });
 
     it('should disable "Set as active" and "Rename" when model is currently training', async () => {

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -62,6 +62,19 @@ describe('ModelActions', () => {
         expect(screen.getByText(/Are you sure you want to delete/)).toBeInTheDocument();
     });
 
+    it('should show download logs action in training logs dialog', async () => {
+        render(<ModelActions model={mockModel} />);
+
+        const menuButton = screen.getByRole('button', { name: 'Model actions' });
+        await userEvent.click(menuButton);
+
+        await userEvent.click(screen.getByRole('menuitem', { name: 'View training logs' }));
+
+        (await screen.findByRole('button', { name: 'Download logs' })).click();
+
+        expect(screen.getByText('Training logs downloaded successfully')).toBeInTheDocument();
+    });
+
     it('should disable "Set as active" and "Rename" when model is currently training', async () => {
         const trainingModel = getMockedModel({
             ...mockModel,

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -9,7 +9,17 @@ import { render } from 'test-utils/render';
 
 import { http } from '../../../../../api/utils';
 import { server } from '../../../../../msw-node-setup';
+import { downloadFile } from '../../../../../shared/util';
 import { ModelActions } from './model-actions.component';
+
+vi.mock('../../../../../shared/util', async (importActual) => {
+    const actual = await importActual<typeof import('../../../../../shared/util')>();
+
+    return {
+        ...actual,
+        downloadFile: vi.fn(),
+    };
+});
 
 const mockModel = getMockedModel({
     id: 'model-123',
@@ -28,6 +38,10 @@ const mockModel = getMockedModel({
 });
 
 describe('ModelActions', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('should render menu with all items', async () => {
         render(<ModelActions model={mockModel} />);
 
@@ -69,7 +83,12 @@ describe('ModelActions', () => {
         server.use(
             http.get('/api/projects/{project_id}/models/{model_id}/logs', () => {
                 return new HttpResponse(
-                    '[2025-01-10 10:00:00][INFO ] Initializing\n[2025-01-10 10:00:01][INFO ] Training started',
+                    new Blob(
+                        ['[2025-01-10 10:00:00][INFO ] Initializing\n[2025-01-10 10:00:01][INFO ] Training started'],
+                        {
+                            type: 'text/plain',
+                        }
+                    ),
                     {
                         status: 200,
                         headers: {
@@ -89,6 +108,7 @@ describe('ModelActions', () => {
 
         await userEvent.click(await screen.findByRole('button', { name: 'Download logs' }));
 
+        expect(downloadFile).toHaveBeenCalledWith(expect.stringMatching(/^blob:/), `training-logs-${mockModel.id}.log`);
         expect(await screen.findByText('Training logs downloaded successfully')).toBeInTheDocument();
     });
 

--- a/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
+++ b/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
@@ -46,7 +46,7 @@ export const useModelLogs = (modelId: string | undefined) => {
 };
 
 const downloadModelLogsFile = async (projectId: string, modelId: string) => {
-    const { data, error } = await fetchClient.GET('/api/projects/{project_id}/models/{model_id}/logs', {
+    const { data, error, response } = await fetchClient.GET('/api/projects/{project_id}/models/{model_id}/logs', {
         params: {
             path: { project_id: projectId, model_id: modelId },
             header: { accept: 'text/plain' },
@@ -55,7 +55,7 @@ const downloadModelLogsFile = async (projectId: string, modelId: string) => {
     });
 
     if (error || !data) {
-        throw new Error('Unable to download logs');
+        throw new Error(`Failed to download model logs: ${response.status} ${response.statusText}`);
     }
 
     const url = URL.createObjectURL(data);

--- a/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
+++ b/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
@@ -1,11 +1,13 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQuery } from '@tanstack/react-query';
+import { toast } from '@geti/ui';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { fetchClient } from '../../../../api/client';
 import { getQueryKey } from '../../../../query-client/query-client';
+import { downloadFile } from '../../../../shared/util';
 import { type LogEntry } from '../log-types';
 import { parseLogLine } from '../log-utils';
 
@@ -41,4 +43,46 @@ export const useModelLogs = (modelId: string | undefined) => {
         enabled: !!modelId,
         staleTime: Infinity, // Completed/failed model logs don't change
     });
+};
+
+const downloadModelLogsFile = async (projectId: string, modelId: string) => {
+    const { data, error } = await fetchClient.GET('/api/projects/{project_id}/models/{model_id}/logs', {
+        params: {
+            path: { project_id: projectId, model_id: modelId },
+            header: { accept: 'text/plain' },
+        },
+        parseAs: 'blob',
+    });
+
+    if (error || !data) {
+        throw new Error('Unable to download logs');
+    }
+
+    const url = URL.createObjectURL(data);
+    downloadFile(url, `training-logs-${modelId}.log`);
+};
+
+export const useDownloadModelLogs = (modelId: string | undefined) => {
+    const projectId = useProjectIdentifier();
+
+    const mutation = useMutation({
+        mutationFn: async () => {
+            if (!modelId) {
+                throw new Error('Model id is required to download logs');
+            }
+
+            await downloadModelLogsFile(projectId, modelId);
+        },
+        onSuccess: () => {
+            toast({ type: 'success', message: 'Training logs downloaded successfully' });
+        },
+        onError: () => {
+            toast({ type: 'error', message: 'Failed to download training logs' });
+        },
+    });
+
+    return {
+        downloadModelLogs: () => mutation.mutate(),
+        isDownloading: mutation.isPending,
+    };
 };

--- a/application/ui/src/features/models/training-logs/training-logs-dialog.component.tsx
+++ b/application/ui/src/features/models/training-logs/training-logs-dialog.component.tsx
@@ -13,9 +13,9 @@ import {
     Text,
     useDialogContainer,
 } from '@geti/ui';
-import { CloseSemiBold } from '@geti/ui/icons';
+import { CloseSemiBold, DownloadIcon } from '@geti/ui/icons';
 
-import { useModelLogs } from './hooks/use-model-logs.hook';
+import { useDownloadModelLogs, useModelLogs } from './hooks/use-model-logs.hook';
 import { useStreamJobLogs } from './hooks/use-stream-job-logs.hook';
 import { LogViewer } from './log-viewer.component';
 
@@ -58,19 +58,32 @@ const HistoricalModelLogs = ({ modelId }: { modelId: string }) => {
 
 export const TrainingLogsDialog = ({ jobId, modelId }: TrainingLogsDialogProps) => {
     const dialogContainer = useDialogContainer();
+    const { downloadModelLogs, isDownloading } = useDownloadModelLogs(modelId);
 
     return (
         <Dialog aria-label={'Training logs'} UNSAFE_className={classes.dialog}>
             <Heading>Training Logs</Heading>
             <Header>
-                <ActionButton
-                    isQuiet
-                    onPress={dialogContainer.dismiss}
-                    aria-label={'Close dialog'}
-                    UNSAFE_className={classes.closeButton}
-                >
-                    <CloseSemiBold width={14} height={14} />
-                </ActionButton>
+                <Flex alignItems={'center'} gap={'size-100'} marginStart={'auto'}>
+                    {modelId && (
+                        <ActionButton
+                            isQuiet
+                            onPress={downloadModelLogs}
+                            aria-label={'Download logs'}
+                            isDisabled={isDownloading}
+                        >
+                            <DownloadIcon />
+                        </ActionButton>
+                    )}
+                    <ActionButton
+                        isQuiet
+                        onPress={dialogContainer.dismiss}
+                        aria-label={'Close dialog'}
+                        UNSAFE_className={classes.closeButton}
+                    >
+                        <CloseSemiBold width={14} height={14} />
+                    </ActionButton>
+                </Flex>
             </Header>
             <Divider />
             <Content UNSAFE_className={classes.contentArea}>

--- a/application/ui/src/setup-tests.ts
+++ b/application/ui/src/setup-tests.ts
@@ -37,6 +37,18 @@ Object.defineProperty(global, 'Request', {
     value: RequestPolyfill,
 });
 
+// For downloading logs and model files, we use URL.createObjectURL which is not
+// implemented in jsdom, so we need to mock it.
+Object.defineProperty(URL, 'createObjectURL', {
+    writable: true,
+    value: vi.fn(() => 'blob:mock-url'),
+});
+
+Object.defineProperty(URL, 'revokeObjectURL', {
+    writable: true,
+    value: vi.fn(),
+});
+
 // Mock ResizeObserver which is not available in jsdom
 class ResizeObserverMock {
     observe = vi.fn();
@@ -45,6 +57,17 @@ class ResizeObserverMock {
 }
 
 global.ResizeObserver = ResizeObserverMock;
+
+class IntersectionObserverMock {
+    constructor(_callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {}
+
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn(() => []);
+}
+
+global.IntersectionObserver = IntersectionObserverMock as unknown as typeof IntersectionObserver;
 
 const createLocalStorageMock = () => {
     let store: Record<string, string> = {};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* The user will now be able to download logs from the logs dialog

<img width="793" height="419" alt="Screenshot 2026-03-23 at 11 18 54" src="https://github.com/user-attachments/assets/a36b1d89-62bf-4454-be55-0e3257e3196d" />
<img width="1204" height="339" alt="Screenshot 2026-03-23 at 11 18 51" src="https://github.com/user-attachments/assets/08acacee-f624-46c0-b551-f03e7ebf6f45" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
