### PR TITLE
Webrtc pause resume behavior

### DIFF
--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useState } from 'react';
 
-import { Button, Flex, Loading, toast, View } from '@geti/ui';
+import { Flex, Loading, toast, View } from '@geti/ui';
 import { Pause, Play } from '@geti/ui/icons';
 
 import { Stream } from './stream';
@@ -27,17 +27,13 @@ export const StreamContainer = () => {
 
     return (
         <View gridArea={'canvas'} overflow={'hidden'} maxHeight={'100%'}>
-            <div className={classes.canvasContainer} onClick={isConnected ? stop : undefined}>
+            <div className={classes.canvasContainer} onClick={isConnected ? stop : isStopped ? start : undefined}>
                 <View backgroundColor={'gray-200'} width='90%' height='90%'>
                     {isStopped && (
                         <Flex alignItems={'center'} justifyContent={'center'} height='100%'>
-                            <Button
-                                onPress={start}
-                                UNSAFE_className={classes.playPauseButton}
-                                aria-label={'Start stream'}
-                            >
-                                <Play width='64px' height='64px' />
-                            </Button>
+                            <Flex UNSAFE_className={classes.playPauseButton}>
+                                <Play width='64px' height='64px' aria-label={'Start stream'} />
+                            </Flex>
                         </Flex>
                     )}
 
@@ -59,7 +55,9 @@ export const StreamContainer = () => {
                                 height='100%'
                                 UNSAFE_className={classes.pauseOverlay}
                             >
-                                <Pause width='64px' height='64px' aria-label={'Stop stream'} />
+                                <Flex UNSAFE_className={classes.playPauseButton}>
+                                    <Pause width='64px' height='64px' aria-label={'Stop stream'} />
+                                </Flex>
                             </Flex>
                         </View>
                     )}

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 
 import { Button, Flex, Loading, toast, View } from '@geti/ui';
-import { Play } from '@geti/ui/icons';
+import { Pause, Play } from '@geti/ui/icons';
 
 import { Stream } from './stream';
 import { useWebRTCConnection } from './web-rtc-connection-provider';
@@ -13,7 +13,11 @@ import classes from './stream.module.scss';
 
 export const StreamContainer = () => {
     const [size, setSize] = useState({ height: 608, width: 892 });
-    const { start, status } = useWebRTCConnection();
+    const { start, stop, status } = useWebRTCConnection();
+
+    const isStopped = status === 'idle' || status === 'failed';
+    const isConnecting = status === 'connecting';
+    const isConnected = status === 'connected';
 
     useEffect(() => {
         if (status === 'failed') {
@@ -23,33 +27,50 @@ export const StreamContainer = () => {
 
     return (
         <View gridArea={'canvas'} overflow={'hidden'} maxHeight={'100%'}>
-            {status === 'idle' && (
-                <div className={classes.canvasContainer}>
-                    <View backgroundColor={'gray-200'} width='90%' height='90%'>
+            <div className={classes.canvasContainer} onClick={isConnected ? stop : undefined}>
+                <View backgroundColor={'gray-200'} width='90%' height='90%'>
+                    {isStopped && (
                         <Flex alignItems={'center'} justifyContent={'center'} height='100%'>
-                            <Button onPress={start} UNSAFE_className={classes.playButton} aria-label={'Start stream'}>
+                            <Button
+                                onPress={start}
+                                UNSAFE_className={classes.playPauseButton}
+                                aria-label={'Start stream'}
+                            >
                                 <Play width='64px' height='64px' />
                             </Button>
                         </Flex>
-                    </View>
-                </div>
-            )}
+                    )}
 
-            {status === 'connecting' && (
-                <div className={classes.canvasContainer}>
-                    <View backgroundColor={'gray-200'} width='90%' height='90%'>
+                    {isConnecting && (
                         <Flex alignItems={'center'} justifyContent={'center'} height='100%'>
                             <Loading mode='inline' />
                         </Flex>
-                    </View>
-                </div>
-            )}
+                    )}
 
-            {status === 'connected' && (
-                <div className={classes.canvasContainer}>
-                    <Stream size={size} setSize={setSize} />
-                </div>
-            )}
+                    {isConnected && (
+                        <View position='relative' width='100%' height='100%'>
+                            <Stream size={size} setSize={setSize} />
+
+                            <Flex
+                                position='absolute'
+                                alignItems='center'
+                                justifyContent='center'
+                                width='100%'
+                                height='100%'
+                                UNSAFE_className={classes.pauseOverlay}
+                            >
+                                <Button
+                                    onPress={stop}
+                                    aria-label={'Stop stream'}
+                                    UNSAFE_className={classes.playPauseButton}
+                                >
+                                    <Pause width='64px' height='64px' />
+                                </Button>
+                            </Flex>
+                        </View>
+                    )}
+                </View>
+            </div>
         </View>
     );
 };

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -48,7 +48,7 @@ export const StreamContainer = () => {
                     )}
 
                     {isConnected && (
-                        <View position='relative' width='100%' height='100%'>
+                        <View position='relative' width='100%' height='100%' UNSAFE_className={classes.streamWrapper}>
                             <Stream size={size} setSize={setSize} />
 
                             <Flex
@@ -59,13 +59,15 @@ export const StreamContainer = () => {
                                 height='100%'
                                 UNSAFE_className={classes.pauseOverlay}
                             >
-                                <Button
-                                    onPress={stop}
-                                    aria-label={'Stop stream'}
-                                    UNSAFE_className={classes.playPauseButton}
-                                >
-                                    <Pause width='64px' height='64px' />
-                                </Button>
+                                <div onClick={(event) => event.stopPropagation()}>
+                                    <Button
+                                        onPress={stop}
+                                        aria-label={'Stop stream'}
+                                        UNSAFE_className={classes.playPauseButton}
+                                    >
+                                        <Pause width='64px' height='64px' />
+                                    </Button>
+                                </div>
                             </Flex>
                         </View>
                     )}

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -59,15 +59,7 @@ export const StreamContainer = () => {
                                 height='100%'
                                 UNSAFE_className={classes.pauseOverlay}
                             >
-                                <div onClick={(event) => event.stopPropagation()}>
-                                    <Button
-                                        onPress={stop}
-                                        aria-label={'Stop stream'}
-                                        UNSAFE_className={classes.playPauseButton}
-                                    >
-                                        <Pause width='64px' height='64px' />
-                                    </Button>
-                                </div>
+                                <Pause width='64px' height='64px' aria-label={'Stop stream'} />
                             </Flex>
                         </View>
                     )}

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -28,7 +28,7 @@ export const StreamContainer = () => {
                     <View backgroundColor={'gray-200'} width='90%' height='90%'>
                         <Flex alignItems={'center'} justifyContent={'center'} height='100%'>
                             <Button onPress={start} UNSAFE_className={classes.playButton} aria-label={'Start stream'}>
-                                <Play width='128px' height='128px' />
+                                <Play width='64px' height='64px' />
                             </Button>
                         </Flex>
                     </View>

--- a/application/ui/src/features/inference/stream/stream.module.scss
+++ b/application/ui/src/features/inference/stream/stream.module.scss
@@ -6,17 +6,14 @@
     align-items: center;
     width: 100%;
     height: 100%;
-}
-
-.canvasItem {
-    grid-area: innercanvas;
+    cursor: pointer;
 }
 
 .playButton {
     display: flex;
     gap: var(--spectrum-global-dimension-size-400);
     align-items: center;
-    padding: var(--spectrum-global-dimension-size-1200);
+    padding: var(--spectrum-global-dimension-size-600);
     position: relative;
     border-radius: var(--spectrum-alias-border-radius-medium);
 }

--- a/application/ui/src/features/inference/stream/stream.module.scss
+++ b/application/ui/src/features/inference/stream/stream.module.scss
@@ -10,10 +10,10 @@
 }
 
 .playPauseButton {
-    display: flex;
-    align-items: center;
-    padding: var(--spectrum-global-dimension-size-600);
+    padding: var(--spectrum-global-dimension-size-400);
     border-radius: var(--spectrum-alias-border-radius-medium);
+    background-color: var(--energy-blue);
+    cursor: pointer;
 }
 
 .streamWrapper:hover .pauseOverlay,

--- a/application/ui/src/features/inference/stream/stream.module.scss
+++ b/application/ui/src/features/inference/stream/stream.module.scss
@@ -16,13 +16,18 @@
     border-radius: var(--spectrum-alias-border-radius-medium);
 }
 
+.streamWrapper:hover .pauseOverlay,
+.streamWrapper:focus-within .pauseOverlay {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
 .pauseOverlay {
     inset: 0;
     background-color: rgba(255, 255, 255, 0.22);
     opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
     transition: opacity 120ms ease-in-out;
-}
-
-.pauseOverlay:hover {
-    opacity: 1;
 }

--- a/application/ui/src/features/inference/stream/stream.module.scss
+++ b/application/ui/src/features/inference/stream/stream.module.scss
@@ -9,11 +9,20 @@
     cursor: pointer;
 }
 
-.playButton {
+.playPauseButton {
     display: flex;
-    gap: var(--spectrum-global-dimension-size-400);
     align-items: center;
     padding: var(--spectrum-global-dimension-size-600);
-    position: relative;
     border-radius: var(--spectrum-alias-border-radius-medium);
+}
+
+.pauseOverlay {
+    inset: 0;
+    background-color: rgba(255, 255, 255, 0.22);
+    opacity: 0;
+    transition: opacity 120ms ease-in-out;
+}
+
+.pauseOverlay:hover {
+    opacity: 1;
 }

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -65,6 +65,12 @@ test('Inference', async ({ streamPage, page, network }) => {
         expect(streamPage.isConnected()).toBeTruthy();
     });
 
+    await test.step('stops stream', async () => {
+        await streamPage.stopStream();
+
+        await expect(page.getByRole('button', { name: 'Start stream' })).toBeVisible();
+    });
+
     await test.step('toggles pipeline', async () => {
         await page.goto('/projects/id-1/inference');
 

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -65,12 +65,6 @@ test('Inference', async ({ streamPage, page, network }) => {
         expect(streamPage.isConnected()).toBeTruthy();
     });
 
-    await test.step('stops stream', async () => {
-        await streamPage.stopStream();
-
-        await expect(page.getByRole('button', { name: 'Start stream' })).toBeVisible();
-    });
-
     await test.step('toggles pipeline', async () => {
         await page.goto('/projects/id-1/inference');
 

--- a/application/ui/tests/inference/stream-page.ts
+++ b/application/ui/tests/inference/stream-page.ts
@@ -7,7 +7,7 @@ export class StreamPage {
     constructor(private page: Page) {}
 
     async startStream() {
-        await this.page.getByRole('button', { name: 'Start Stream' }).click();
+        await this.page.getByRole('button', { name: 'Start stream' }).click();
     }
 
     async isConnected() {
@@ -15,6 +15,6 @@ export class StreamPage {
     }
 
     async stopStream() {
-        await this.page.getByRole('button', { name: 'Stop' }).click();
+        await this.page.getByRole('button', { name: 'Stop stream' }).click();
     }
 }

--- a/application/ui/tests/inference/stream-page.ts
+++ b/application/ui/tests/inference/stream-page.ts
@@ -7,7 +7,7 @@ export class StreamPage {
     constructor(private page: Page) {}
 
     async startStream() {
-        await this.page.getByRole('button', { name: 'Start stream' }).click();
+        await this.page.getByLabel('Start stream').click();
     }
 
     async isConnected() {
@@ -15,6 +15,6 @@ export class StreamPage {
     }
 
     async stopStream() {
-        await this.page.getByRole('button', { name: 'Stop stream' }).click();
+        await this.page.getByLabel('Stop stream').click();
     }
 }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Add play/pause behavior youtube-like
* Update test and locator

Closes https://github.com/open-edge-platform/training_extensions/issues/5794

<img width="1194" height="1036" alt="Screenshot 2026-03-23 at 14 10 29" src="https://github.com/user-attachments/assets/3565f64f-7e33-478a-a069-10beb920ed02" />
<img width="1138" height="1016" alt="Screenshot 2026-03-23 at 14 53 43" src="https://github.com/user-attachments/assets/a164a8fc-b53e-4276-9a18-032d5af2b25c" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
