### PR TITLE
Bugfix for issues with assigning subset to small set of unassigned dataset items

### DIFF
--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -175,7 +175,8 @@ class OTXTrainer(Execution[TrainingJobParams]):
             logger.info("Target subset ratios for unassigned items: {}", target_ratios)
 
             self.update_message("Computing optimal subset assignments")
-            assignments = self._subset_assigner.assign(unassigned_items, target_ratios)
+            has_all_subsets_assigned = self._subset_service.has_all_subsets_assigned(project_id)
+            assignments = self._subset_assigner.assign(unassigned_items, target_ratios, has_all_subsets_assigned)
 
             # Persist assignments
             self.update_message("Persisting subset assignments")

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -213,6 +213,15 @@ class DatasetItemRepository:
         )
         return list(self.db.scalars(stmt).all())
 
+    def has_all_subsets_assigned(self) -> bool:
+        """Return True if there is at least one dataset item for each of TRAINING, VALIDATION, and TESTING subsets."""
+        stmt = select(func.distinct(DatasetItemDB.subset)).where(
+            DatasetItemDB.project_id == self.project_id,
+        )
+        present_subsets = set(self.db.scalars(stmt).all())
+        required_subsets = {DatasetItemSubset.TRAINING, DatasetItemSubset.VALIDATION, DatasetItemSubset.TESTING}
+        return required_subsets.issubset(present_subsets)
+
     def get_subset_distribution(self) -> dict[str, int]:
         stmt = (
             select(DatasetItemDB.subset, func.count(DatasetItemDB.id).label("count"))

--- a/application/backend/app/services/subset_assignment/assigner.py
+++ b/application/backend/app/services/subset_assignment/assigner.py
@@ -41,13 +41,19 @@ class SubsetAssigner:
         Returns:
             list[SubsetAssignment]: List of subset assignments for each item.
         """
-        if not items:
-            return []
-        if not has_all_subsets_assigned and len(items) < 3:
-            raise ValueError(
-                "Not all subsets have items assigned, but number of unassigned dataset items is less than number of "
-                "subsets: Training, Validation and Testing."
-            )
+        if len(items) < 3:
+            if not has_all_subsets_assigned:
+                raise ValueError(
+                    "Not all subsets have items assigned, but number of unassigned dataset items is less than number "
+                    "of subsets: Training, Validation and Testing. Each subset requires at least 1 item before "
+                    "training can start."
+                )
+            # If less items are available than subsets, we cannot use stratification, so assign in order to subsets.
+            assignments = []
+            subsets = [DatasetItemSubset.TRAINING, DatasetItemSubset.VALIDATION, DatasetItemSubset.TESTING]
+            for idx in range(len(items)):
+                assignments.append(SubsetAssignment(item_id=items[idx].item_id, subset=subsets[idx]))
+            return assignments
 
         label_matrix = self._mlb.fit_transform([item.labels for item in items])
 

--- a/application/backend/app/services/subset_assignment/assigner.py
+++ b/application/backend/app/services/subset_assignment/assigner.py
@@ -29,7 +29,9 @@ class SubsetAssigner:
     def __init__(self) -> None:
         self._mlb = MultiLabelBinarizer()
 
-    def assign(self, items: list[DatasetItemWithLabels], target_ratios: SplitRatios) -> list[SubsetAssignment]:
+    def assign(
+        self, items: list[DatasetItemWithLabels], target_ratios: SplitRatios, has_all_subsets_assigned: bool
+    ) -> list[SubsetAssignment]:
         """
         Assigns dataset items to subsets based on target ratios.
 
@@ -41,6 +43,11 @@ class SubsetAssigner:
         """
         if not items:
             return []
+        if not has_all_subsets_assigned and len(items) < 3:
+            raise ValueError(
+                "Not all subsets have items assigned, but number of unassigned dataset items is less than number of "
+                "subsets: Training, Validation and Testing."
+            )
 
         label_matrix = self._mlb.fit_transform([item.labels for item in items])
 
@@ -64,9 +71,23 @@ class SubsetAssigner:
             DatasetItemSubset.TESTING: test_indices,
         }
 
+        if not has_all_subsets_assigned:
+            self._ensure_all_subsets_nonempty(indices_by_subset)
+
         assignments = []
         for subset, indices in indices_by_subset.items():
             for idx in indices:
                 assignments.append(SubsetAssignment(item_id=items[idx].item_id, subset=subset))
 
         return assignments
+
+    @staticmethod
+    def _ensure_all_subsets_nonempty(
+        indices_by_subset: dict[DatasetItemSubset, list[int]],
+    ) -> None:
+        """Ensure every subset has at least one index by moving items from the largest subset."""
+        empty_subsets = [s for s, idx in indices_by_subset.items() if len(idx) == 0]
+        for empty_subset in empty_subsets:
+            largest_subset = max(indices_by_subset, key=lambda s: len(indices_by_subset[s]))
+            moved = indices_by_subset[largest_subset].pop()
+            indices_by_subset[empty_subset].append(moved)

--- a/application/backend/app/services/subset_assignment/assigner.py
+++ b/application/backend/app/services/subset_assignment/assigner.py
@@ -38,6 +38,16 @@ class SubsetAssigner:
         Args:
             items (list[DatasetItemWithLabels]): List of dataset items to assign.
             target_ratios (SplitRatios): Desired split ratios for subsets.
+            has_all_subsets_assigned (bool): Whether the project already has at least one item
+                assigned to each of the TRAINING, VALIDATION, and TESTING subsets.
+                - If ``False`` and fewer than 3 items are provided, a ``ValueError`` is raised
+                  because there are not enough items to populate every subset.  After stratification,
+                  ``_ensure_all_subsets_nonempty`` is called to guarantee no subset is left empty.
+                - If ``True``, the minimum-item guard is bypassed (the caller guarantees that each
+                  subset is already covered).  When fewer than 3 items are provided they are
+                  assigned sequentially (TRAINING first, then VALIDATION, then TESTING).
+                  ``_ensure_all_subsets_nonempty`` is *not* called, so stratification may produce
+                  empty folds without raising.
         Returns:
             list[SubsetAssignment]: List of subset assignments for each item.
         """

--- a/application/backend/app/services/subset_assignment/subset_service.py
+++ b/application/backend/app/services/subset_assignment/subset_service.py
@@ -23,6 +23,11 @@ class SubsetService(BaseSessionManagedService):
 
         return [DatasetItemWithLabels(item_id=UUID(item_id), labels=labels) for item_id, labels in items_dict.items()]
 
+    def has_all_subsets_assigned(self, project_id: UUID) -> bool:
+        """Return True if there is at least one dataset item for each of TRAINING, VALIDATION, and TESTING subsets."""
+        repo = DatasetItemRepository(project_id=str(project_id), db=self.db_session)
+        return repo.has_all_subsets_assigned()
+
     def update_subset_assignments(self, project_id: UUID, assignments: list[SubsetAssignment]) -> None:
         """Update subset assignments for dataset items."""
         repo = DatasetItemRepository(project_id=str(project_id), db=self.db_session)

--- a/application/backend/tests/integration/services/training/steps/subset_assignment/test_subset_service.py
+++ b/application/backend/tests/integration/services/training/steps/subset_assignment/test_subset_service.py
@@ -102,3 +102,118 @@ class TestSubsetServiceIntegration:
                 db_session.scalar(select(func.count()).select_from(DatasetItemDB).where(DatasetItemDB.subset == subset))
                 == fxt_default_distribution.get(subset, 0) + count
             )
+
+    def test_has_all_subsets_assigned_returns_true_when_all_three_subsets_present(
+        self,
+        fxt_project_id: UUID,
+        fxt_subset_service: SubsetService,
+        fxt_default_distribution: dict[DatasetItemSubset, int],
+    ) -> None:
+        """Test that has_all_subsets_assigned returns True when TRAINING, VALIDATION, and TESTING each
+        have at least one item - which is the case with the default fixture distribution."""
+        # The default distribution already contains TRAINING, VALIDATION, and TESTING items
+        for subset in (DatasetItemSubset.TRAINING, DatasetItemSubset.VALIDATION, DatasetItemSubset.TESTING):
+            assert fxt_default_distribution.get(subset, 0) > 0, (
+                f"Prerequisite: default distribution must have {subset} items"
+            )
+
+        assert fxt_subset_service.has_all_subsets_assigned(fxt_project_id) is True
+
+    def test_has_all_subsets_assigned_returns_false_when_a_subset_is_missing(
+        self,
+        fxt_db_projects: list[ProjectDB],
+        fxt_db_labels: list[LabelDB],
+        db_session: Session,
+        fxt_subset_service: SubsetService,
+    ) -> None:
+        """Test that has_all_subsets_assigned returns False when at least one required subset has no items.
+
+          We create a second project that only has TRAINING and VALIDATION items - no TESTING items -
+        so has_all_subsets_assigned must return False for it.
+        """
+        from uuid import uuid4 as _uuid4
+
+        from app.db.schema import ProjectDB as ProjectDBAlias
+        from app.models import TaskType
+
+        # Build a second project with only TRAINING + VALIDATION items (no TESTING)
+        partial_project = ProjectDBAlias(
+            id=str(_uuid4()),
+            name="Partial Subsets Project",
+            task_type=TaskType.DETECTION,
+            exclusive_labels=False,
+        )
+        db_session.add(partial_project)
+        db_session.flush()
+
+        fxt_db_labels[0]
+
+        incomplete_distribution = {
+            DatasetItemSubset.TRAINING: 3,
+            DatasetItemSubset.VALIDATION: 2,
+            # DatasetItemSubset.TESTING intentionally absent
+        }
+
+        from tests.integration.project_factory import ProjectTestDataFactory
+
+        ProjectTestDataFactory(db_session).with_project(partial_project).with_media_and_dataset_items(
+            incomplete_distribution
+        ).build()
+
+        partial_project_id = UUID(partial_project.id)
+        partial_service = SubsetService(db_session)
+        assert partial_service.has_all_subsets_assigned(partial_project_id) is False
+
+    def test_has_all_subsets_assigned_returns_false_for_all_unassigned_project(
+        self,
+        fxt_db_projects: list[ProjectDB],
+        db_session: Session,
+    ) -> None:
+        """Test that has_all_subsets_assigned returns False when all items are UNASSIGNED."""
+        from uuid import uuid4 as _uuid4
+
+        from app.db.schema import ProjectDB as ProjectDBAlias
+        from app.models import TaskType
+
+        unassigned_project = ProjectDBAlias(
+            id=str(_uuid4()),
+            name="All Unassigned Project",
+            task_type=TaskType.DETECTION,
+            exclusive_labels=False,
+        )
+        db_session.add(unassigned_project)
+        db_session.flush()
+
+        only_unassigned = {DatasetItemSubset.UNASSIGNED: 5}
+        from tests.integration.project_factory import ProjectTestDataFactory
+
+        ProjectTestDataFactory(db_session).with_project(unassigned_project).with_media_and_dataset_items(
+            only_unassigned
+        ).build()
+
+        unassigned_project_id = UUID(unassigned_project.id)
+        service = SubsetService(db_session)
+        assert service.has_all_subsets_assigned(unassigned_project_id) is False
+
+    def test_has_all_subsets_assigned_returns_false_for_empty_project(
+        self,
+        db_session: Session,
+    ) -> None:
+        """Test that has_all_subsets_assigned returns False when the project has no dataset items at all."""
+        from uuid import uuid4 as _uuid4
+
+        from app.db.schema import ProjectDB as ProjectDBAlias
+        from app.models import TaskType
+
+        empty_project = ProjectDBAlias(
+            id=str(_uuid4()),
+            name="Empty Project",
+            task_type=TaskType.DETECTION,
+            exclusive_labels=False,
+        )
+        db_session.add(empty_project)
+        db_session.flush()
+
+        empty_project_id = UUID(empty_project.id)
+        service = SubsetService(db_session)
+        assert service.has_all_subsets_assigned(empty_project_id) is False

--- a/application/backend/tests/integration/services/training/steps/subset_assignment/test_subset_service.py
+++ b/application/backend/tests/integration/services/training/steps/subset_assignment/test_subset_service.py
@@ -1,14 +1,14 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.schema import DatasetItemDB, LabelDB, ProjectDB
-from app.models import DatasetItemSubset
+from app.models import DatasetItemSubset, TaskType
 from app.services.subset_assignment import SubsetAssignment, SubsetService
 from tests.integration.project_factory import ProjectTestDataFactory
 
@@ -122,7 +122,6 @@ class TestSubsetServiceIntegration:
     def test_has_all_subsets_assigned_returns_false_when_a_subset_is_missing(
         self,
         fxt_db_projects: list[ProjectDB],
-        fxt_db_labels: list[LabelDB],
         db_session: Session,
         fxt_subset_service: SubsetService,
     ) -> None:
@@ -131,14 +130,9 @@ class TestSubsetServiceIntegration:
           We create a second project that only has TRAINING and VALIDATION items - no TESTING items -
         so has_all_subsets_assigned must return False for it.
         """
-        from uuid import uuid4 as _uuid4
-
-        from app.db.schema import ProjectDB as ProjectDBAlias
-        from app.models import TaskType
-
         # Build a second project with only TRAINING + VALIDATION items (no TESTING)
-        partial_project = ProjectDBAlias(
-            id=str(_uuid4()),
+        partial_project = ProjectDB(
+            id=str(uuid4()),
             name="Partial Subsets Project",
             task_type=TaskType.DETECTION,
             exclusive_labels=False,
@@ -146,15 +140,11 @@ class TestSubsetServiceIntegration:
         db_session.add(partial_project)
         db_session.flush()
 
-        fxt_db_labels[0]
-
         incomplete_distribution = {
             DatasetItemSubset.TRAINING: 3,
             DatasetItemSubset.VALIDATION: 2,
             # DatasetItemSubset.TESTING intentionally absent
         }
-
-        from tests.integration.project_factory import ProjectTestDataFactory
 
         ProjectTestDataFactory(db_session).with_project(partial_project).with_media_and_dataset_items(
             incomplete_distribution
@@ -170,13 +160,8 @@ class TestSubsetServiceIntegration:
         db_session: Session,
     ) -> None:
         """Test that has_all_subsets_assigned returns False when all items are UNASSIGNED."""
-        from uuid import uuid4 as _uuid4
-
-        from app.db.schema import ProjectDB as ProjectDBAlias
-        from app.models import TaskType
-
-        unassigned_project = ProjectDBAlias(
-            id=str(_uuid4()),
+        unassigned_project = ProjectDB(
+            id=str(uuid4()),
             name="All Unassigned Project",
             task_type=TaskType.DETECTION,
             exclusive_labels=False,
@@ -185,7 +170,6 @@ class TestSubsetServiceIntegration:
         db_session.flush()
 
         only_unassigned = {DatasetItemSubset.UNASSIGNED: 5}
-        from tests.integration.project_factory import ProjectTestDataFactory
 
         ProjectTestDataFactory(db_session).with_project(unassigned_project).with_media_and_dataset_items(
             only_unassigned
@@ -200,13 +184,8 @@ class TestSubsetServiceIntegration:
         db_session: Session,
     ) -> None:
         """Test that has_all_subsets_assigned returns False when the project has no dataset items at all."""
-        from uuid import uuid4 as _uuid4
-
-        from app.db.schema import ProjectDB as ProjectDBAlias
-        from app.models import TaskType
-
-        empty_project = ProjectDBAlias(
-            id=str(_uuid4()),
+        empty_project = ProjectDB(
+            id=str(uuid4()),
             name="Empty Project",
             task_type=TaskType.DETECTION,
             exclusive_labels=False,

--- a/application/backend/tests/unit/execution/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_otx_trainer.py
@@ -374,7 +374,6 @@ class TestOTXTrainerAssignSubsets:
 
         # … and the returned value is forwarded verbatim as the third positional argument
         call_args = fxt_assigner.assign.call_args
-        call_args.args[1] if len(call_args.args) >= 2 else call_args.kwargs.get("target_ratios")
         actual_flag = (
             call_args.args[2] if len(call_args.args) >= 3 else call_args.kwargs.get("has_all_subsets_assigned")
         )
@@ -901,8 +900,6 @@ class TestOTXTrainerStoreModelArtifacts:
         otx_trainer = fxt_otx_trainer()
         project_id = uuid4()
         model_id = uuid4()
-
-        from app.models.model_revision import ModelFormat
 
         pytorch_variant_id = uuid4()
         openvino_variant_id = uuid4()

--- a/application/backend/tests/unit/execution/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_otx_trainer.py
@@ -291,6 +291,7 @@ class TestOTXTrainerAssignSubsets:
             DatasetItemWithLabels(item_id=uuid4(), labels={label_1, label_2, label_3}),
         ]
         fxt_subset_service.get_unassigned_items_with_labels.return_value = unassigned_items
+        fxt_subset_service.has_all_subsets_assigned.return_value = False
 
         # Mock configuration
         training_config = TrainingConfiguration(
@@ -334,6 +335,50 @@ class TestOTXTrainerAssignSubsets:
         fxt_subset_service.get_unassigned_items_with_labels.assert_called_once_with(project_id)
         fxt_assigner.assign.assert_not_called()
         fxt_subset_service.update_subset_assignments.assert_not_called()
+
+    @pytest.mark.parametrize("has_all_subsets_assigned", [True, False], ids=["all-assigned", "not-all-assigned"])
+    def test_assign_subsets_passes_has_all_subsets_assigned_to_assigner(
+        self,
+        fxt_otx_trainer: Callable[[], OTXTrainer],
+        fxt_subset_service: Mock,
+        fxt_assigner: Mock,
+        has_all_subsets_assigned: bool,
+    ):
+        """Test that the result of SubsetService.has_all_subsets_assigned is forwarded to SubsetAssigner.assign."""
+        # Arrange
+        otx_trainer = fxt_otx_trainer()
+        project_id = uuid4()
+        label = uuid4()
+
+        unassigned_items = [
+            DatasetItemWithLabels(item_id=uuid4(), labels={label}),
+            DatasetItemWithLabels(item_id=uuid4(), labels={label}),
+            DatasetItemWithLabels(item_id=uuid4(), labels={label}),
+        ]
+        fxt_subset_service.get_unassigned_items_with_labels.return_value = unassigned_items
+        fxt_subset_service.has_all_subsets_assigned.return_value = has_all_subsets_assigned
+        fxt_assigner.assign.return_value = [
+            SubsetAssignment(item_id=item.item_id, subset=DatasetItemSubset.TRAINING) for item in unassigned_items
+        ]
+
+        training_config = TrainingConfiguration(
+            task_level_parameters=TaskLevelParameters(),
+            algo_level_parameters=MagicMock(spec=AlgoLevelParameters),
+        )
+
+        # Act
+        otx_trainer.assign_subsets(training_config=training_config, project_id=project_id)
+
+        # Assert - has_all_subsets_assigned is queried from the service ...
+        fxt_subset_service.has_all_subsets_assigned.assert_called_once_with(project_id)
+
+        # … and the returned value is forwarded verbatim as the third positional argument
+        call_args = fxt_assigner.assign.call_args
+        call_args.args[1] if len(call_args.args) >= 2 else call_args.kwargs.get("target_ratios")
+        actual_flag = (
+            call_args.args[2] if len(call_args.args) >= 3 else call_args.kwargs.get("has_all_subsets_assigned")
+        )
+        assert actual_flag is has_all_subsets_assigned
 
 
 class TestOTXTrainerCreateTrainingDataset:

--- a/application/backend/tests/unit/services/subset_assignment/test_assigner.py
+++ b/application/backend/tests/unit/services/subset_assignment/test_assigner.py
@@ -84,22 +84,11 @@ class TestSubsetAssigner:
     ):
         """Test that the 3-item minimum guard is skipped when all subsets already have at least one item assigned.
 
-        When has_all_subsets_assigned=False, fewer than 3 items raises a ValueError before the
-        stratifier is ever called.  When has_all_subsets_assigned=True, that guard is bypassed and
-        the call succeeds as long as the stratifier itself is satisfied (n_samples >= n_splits=3).
-        We therefore use exactly 3 items: it would raise with has_all_subsets_assigned=False but
-        not with True.
+        When has_all_subsets_assigned=True, the guard is bypassed and the call succeeds even with
+        fewer items than subsets.
         """
-        # Exactly 3 items: skipped by our guard when False → ValueError; allowed when True
-        items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(3)]
+        items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(2)]
 
-        # With has_all_subsets_assigned=False and 3 items, the guard is NOT triggered (3 >= 3),
-        # so we need a case that would fail. Use 2 items to confirm the guard fires:
-        two_items = items[:2]
-        with pytest.raises(ValueError, match="number of unassigned dataset items is less than number of subsets"):
-            fxt_assigner.assign(two_items, fxt_default_ratios, has_all_subsets_assigned=False)
-
-        # With has_all_subsets_assigned=True, the guard is bypassed entirely - no ValueError
         result = fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=True)
         assert len(result) == len(items)
 

--- a/application/backend/tests/unit/services/subset_assignment/test_assigner.py
+++ b/application/backend/tests/unit/services/subset_assignment/test_assigner.py
@@ -24,7 +24,7 @@ class TestSubsetAssigner:
 
     def test_assign_empty_list(self, fxt_assigner, fxt_default_ratios):
         """Test that assigning empty list returns empty list"""
-        result = fxt_assigner.assign([], fxt_default_ratios, has_all_subsets_assigned=False)
+        result = fxt_assigner.assign([], fxt_default_ratios, has_all_subsets_assigned=True)
         assert result == []
 
     def test_assign_returns_all_items(self, fxt_assigner, fxt_default_ratios):
@@ -138,3 +138,28 @@ class TestSubsetAssigner:
 
         # All items are assigned (no items lost)
         assert len(result) == len(items)
+
+    @pytest.mark.parametrize(
+        "num_items, expected_subsets",
+        [
+            (1, [DatasetItemSubset.TRAINING]),
+            (2, [DatasetItemSubset.TRAINING, DatasetItemSubset.VALIDATION]),
+        ],
+    )
+    def test_assign_fewer_than_three_items_assigns_in_subset_order(
+        self, fxt_assigner, fxt_default_ratios, num_items, expected_subsets
+    ):
+        """Test that when fewer than 3 items are provided and all subsets are already assigned,
+        items are assigned in order: TRAINING, VALIDATION, TESTING."""
+        items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(num_items)]
+
+        result = fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=True)
+
+        assert len(result) == num_items
+        # Verify items are assigned to subsets in the expected order
+        for assignment, expected_subset in zip(result, expected_subsets):
+            assert assignment.subset == expected_subset
+        # Verify all input item IDs are present in the result
+        result_item_ids = {a.item_id for a in result}
+        input_item_ids = {item.item_id for item in items}
+        assert result_item_ids == input_item_ids

--- a/application/backend/tests/unit/services/subset_assignment/test_assigner.py
+++ b/application/backend/tests/unit/services/subset_assignment/test_assigner.py
@@ -82,7 +82,7 @@ class TestSubsetAssigner:
     def test_assign_allows_fewer_than_three_items_when_all_subsets_already_assigned(
         self, fxt_assigner, fxt_default_ratios
     ):
-        """Test that the 3-item minimum guard is skipped when all subsets already have at least one item assigned.
+        """When has_all_subsets_assigned=True, the minimum-unassigned-items guard is bypassed.
 
         When has_all_subsets_assigned=True, the guard is bypassed and the call succeeds even with
         fewer items than subsets.
@@ -127,6 +127,11 @@ class TestSubsetAssigner:
 
         # All items are assigned (no items lost)
         assert len(result) == len(items)
+        # With no redistribution, all items stay in TRAINING; val and test remain empty
+        assigned_subsets = {assignment.subset for assignment in result}
+        assert DatasetItemSubset.TRAINING in assigned_subsets
+        assert DatasetItemSubset.VALIDATION not in assigned_subsets
+        assert DatasetItemSubset.TESTING not in assigned_subsets
 
     @pytest.mark.parametrize(
         "num_items, expected_subsets",

--- a/application/backend/tests/unit/services/subset_assignment/test_assigner.py
+++ b/application/backend/tests/unit/services/subset_assignment/test_assigner.py
@@ -24,14 +24,14 @@ class TestSubsetAssigner:
 
     def test_assign_empty_list(self, fxt_assigner, fxt_default_ratios):
         """Test that assigning empty list returns empty list"""
-        result = fxt_assigner.assign([], fxt_default_ratios)
+        result = fxt_assigner.assign([], fxt_default_ratios, has_all_subsets_assigned=False)
         assert result == []
 
     def test_assign_returns_all_items(self, fxt_assigner, fxt_default_ratios):
         """Test that all input items are assigned to a subset"""
         items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(100)]
 
-        result = fxt_assigner.assign(items, fxt_default_ratios)
+        result = fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=False)
 
         assert len(result) == len(items)
 
@@ -52,7 +52,7 @@ class TestSubsetAssigner:
         for _ in range(40):
             items.append(DatasetItemWithLabels(item_id=uuid4(), labels={label_b}))
 
-        result = fxt_assigner.assign(items, fxt_default_ratios)
+        result = fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=False)
 
         item_labels_map = {item.item_id: item.labels for item in items}
 
@@ -68,3 +68,73 @@ class TestSubsetAssigner:
                 # Label A should be ~60% and label B ~40% in each subset
                 assert label_a_count / total_in_subset == 0.6
                 assert label_b_count / total_in_subset == 0.4
+
+    def test_assign_raises_when_too_few_items_and_not_all_subsets_assigned(self, fxt_assigner, fxt_default_ratios):
+        """Test that a ValueError is raised when fewer than 3 items exist and not all subsets are already assigned."""
+        items = [
+            DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}),
+            DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}),
+        ]
+
+        with pytest.raises(ValueError, match="number of unassigned dataset items is less than number of subsets"):
+            fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=False)
+
+    def test_assign_allows_fewer_than_three_items_when_all_subsets_already_assigned(
+        self, fxt_assigner, fxt_default_ratios
+    ):
+        """Test that the 3-item minimum guard is skipped when all subsets already have at least one item assigned.
+
+        When has_all_subsets_assigned=False, fewer than 3 items raises a ValueError before the
+        stratifier is ever called.  When has_all_subsets_assigned=True, that guard is bypassed and
+        the call succeeds as long as the stratifier itself is satisfied (n_samples >= n_splits=3).
+        We therefore use exactly 3 items: it would raise with has_all_subsets_assigned=False but
+        not with True.
+        """
+        # Exactly 3 items: skipped by our guard when False → ValueError; allowed when True
+        items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(3)]
+
+        # With has_all_subsets_assigned=False and 3 items, the guard is NOT triggered (3 >= 3),
+        # so we need a case that would fail. Use 2 items to confirm the guard fires:
+        two_items = items[:2]
+        with pytest.raises(ValueError, match="number of unassigned dataset items is less than number of subsets"):
+            fxt_assigner.assign(two_items, fxt_default_ratios, has_all_subsets_assigned=False)
+
+        # With has_all_subsets_assigned=True, the guard is bypassed entirely - no ValueError
+        result = fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=True)
+        assert len(result) == len(items)
+
+    def test_assign_ensures_all_subsets_nonempty_when_not_all_subsets_assigned(self, fxt_assigner, fxt_default_ratios):
+        """Test that every subset receives at least one item when not all subsets are pre-assigned.
+
+        With has_all_subsets_assigned=False and enough items, _ensure_all_subsets_nonempty
+        must guarantee each of TRAINING, VALIDATION, and TESTING has at least one assignment.
+        """
+        # Use exactly 3 items - minimum allowed when has_all_subsets_assigned=False
+        items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(3)]
+
+        result = fxt_assigner.assign(items, fxt_default_ratios, has_all_subsets_assigned=False)
+
+        assigned_subsets = {assignment.subset for assignment in result}
+        assert DatasetItemSubset.TRAINING in assigned_subsets
+        assert DatasetItemSubset.VALIDATION in assigned_subsets
+        assert DatasetItemSubset.TESTING in assigned_subsets
+
+    def test_assign_does_not_enforce_nonempty_subsets_when_all_subsets_already_assigned(
+        self, fxt_assigner, fxt_default_ratios
+    ):
+        """Test that _ensure_all_subsets_nonempty is NOT called when all subsets are pre-assigned.
+
+        When has_all_subsets_assigned=True the assigner trusts that the existing data already
+        covers all three subsets, so it does not forcibly move items between subsets.
+        Use a pathological ratio (1/0/0) to produce an empty val/test fold and verify no
+        redistribution occurs.
+        """
+        skewed_ratios = SplitRatios(train=0.98, val=0.01, test=0.01)
+        # 3 items with a heavily skewed ratio - stratifier will put all 3 in train, leaving
+        # val and test empty.  With has_all_subsets_assigned=True this must NOT raise.
+        items = [DatasetItemWithLabels(item_id=uuid4(), labels={uuid4()}) for _ in range(3)]
+
+        result = fxt_assigner.assign(items, skewed_ratios, has_all_subsets_assigned=True)
+
+        # All items are assigned (no items lost)
+        assert len(result) == len(items)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

When less than 3 unassigned dataset items need to be assigned, the usual stratification methods fails, as it expects at least as many items as subsets. We now assign the items to the subsets in order (Training first, then Validation if available). If not all subsets have at least 1 item (in the whole dataset including those already assigned) the `SubsetAssigner` will raise an error.

Resolves #5821 and #5826

### How to test

Unit and integration tests have been added

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
