### PR TITLE
Only allow activation of pipeline/model if model is successfully trained

### DIFF
--- a/application/backend/app/repositories/model_revision_repo.py
+++ b/application/backend/app/repositories/model_revision_repo.py
@@ -18,7 +18,9 @@ class ModelRevisionRepository(BaseRepository[ModelRevisionDB]):
         super().__init__(db, ModelRevisionDB)
         self.project_id = project_id
 
-    def list_all(self, training_dataset_id: str | None = None) -> Sequence[ModelRevisionDB]:
+    def list_all(
+        self, training_dataset_id: str | None = None, training_status: str | None = None
+    ) -> Sequence[ModelRevisionDB]:
         """
         List all model revisions for a given project.
 
@@ -26,6 +28,7 @@ class ModelRevisionRepository(BaseRepository[ModelRevisionDB]):
 
         Args:
             training_dataset_id (str): Optional unique id of the training dataset to filter on
+            training_status (str): Optional training status to filter on
 
         Returns:
             Sequence[ModelRevisionDB]: A list of model revisions associated with the project.
@@ -33,6 +36,8 @@ class ModelRevisionRepository(BaseRepository[ModelRevisionDB]):
         stmt = select(ModelRevisionDB).where(ModelRevisionDB.project_id == self.project_id)
         if training_dataset_id is not None:
             stmt = stmt.where(ModelRevisionDB.training_dataset_id == training_dataset_id)
+        if training_status is not None:
+            stmt = stmt.where(ModelRevisionDB.training_status == training_status)
         return self.db.execute(stmt).scalars().all()
 
     def get_by_id(self, obj_id: str) -> ModelRevisionDB | None:

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -11,7 +11,7 @@ from model_api.models import Model
 
 from app.db.engine import get_db_session
 from app.models.model_activation import ModelActivationState
-from app.models.model_revision import ModelFormat, ModelPrecision
+from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
 from app.repositories import ModelRevisionRepository, ModelVariantRepository
 from app.repositories.active_model_repo import ActiveModelRepo
 
@@ -85,7 +85,7 @@ class ActiveModelService:
                     device="",
                 )
             model_rev_repo = ModelRevisionRepository(project_id=str(active_model.project_id), db=db)
-            available_models = model_rev_repo.list_all()
+            available_models = model_rev_repo.list_all(training_status=TrainingStatus.SUCCESSFUL)
             model_variants_repo = ModelVariantRepository(db=db)
             model_variants = model_variants_repo.list_by_model_revision(str(active_model.id))
             active_variant_id = next(

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -8,7 +8,9 @@ from sqlalchemy.orm import Session
 
 from app.db.schema import PipelineDB
 from app.models import Pipeline, PipelineStatus
+from app.models.model_revision import TrainingStatus
 from app.repositories import PipelineRepository
+from app.repositories.model_revision_repo import ModelRevisionRepository
 from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.event.event_bus import EventBus, EventType
 from app.services.parent_process_guard import parent_process_only
@@ -100,6 +102,8 @@ class PipelineService(BaseSessionManagedService):
             data_collection=to_update.data_collection.model_dump(),
             device=to_update.device,
         )
+
+        # Validate pipeline data
         if to_update_db.is_running:
             # Only one pipeline can run at the same time. Note that only one pipeline per project exists.
             active_pipeline_db = pipeline_repo.get_active_pipeline()
@@ -107,6 +111,20 @@ class PipelineService(BaseSessionManagedService):
                 raise OtherProjectActiveError(
                     requested_project_id=to_update_db.project_id, active_project_id=active_pipeline_db.project_id
                 )
+        if to_update_db.model_revision_id is not None:
+            # Only successfully trained models can be part of a pipeline
+            model_revision_repo = ModelRevisionRepository(project_id=to_update_db.project_id, db=self.db_session)
+            model_revision_db = model_revision_repo.get_by_id(to_update_db.model_revision_id)
+            if model_revision_db is None:
+                raise ResourceNotFoundError(
+                    resource_type=ResourceType.MODEL, resource_id=to_update_db.model_revision_id
+                )
+            if model_revision_db.training_status != TrainingStatus.SUCCESSFUL:
+                raise ValueError(
+                    f"Provided model id ({to_update_db.model_revision_id}) points to a model that was not successfully "
+                    f"trained (status is {model_revision_db.training_status})."
+                )
+
         pipeline_db = pipeline_repo.update(to_update_db)
         updated = Pipeline.model_validate(pipeline_db)
         self.__emit_event(pipeline, updated)

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -49,7 +49,7 @@ def fxt_db_models() -> list[ModelRevisionDB]:
         ModelRevisionDB(
             id=str(uuid4()),
             name="YOLOX-S (abc123)",
-            training_status=TrainingStatus.NOT_STARTED,
+            training_status=TrainingStatus.SUCCESSFUL,
             architecture="object-detection-yolox-s",
             training_configuration={},
             label_schema_revision={},
@@ -57,7 +57,7 @@ def fxt_db_models() -> list[ModelRevisionDB]:
         ModelRevisionDB(
             id=str(uuid4()),
             name="YOLOX-X (def456)",
-            training_status=TrainingStatus.NOT_STARTED,
+            training_status=TrainingStatus.SUCCESSFUL,
             architecture="object-detection-yolox-x",
             training_configuration={},
             label_schema_revision={},

--- a/application/backend/tests/integration/services/test_active_model_service.py
+++ b/application/backend/tests/integration/services/test_active_model_service.py
@@ -138,6 +138,6 @@ class TestActiveModelServiceLoadState:
         state = service._model_activation_state
 
         assert len(state.available_models) == 2
-        assert state.available_models == [UUID(fxt_successful_model.id), UUID(second_successful.id)]
+        assert set(state.available_models) == {UUID(fxt_successful_model.id), UUID(second_successful.id)}
         assert str(state.active_model_id) == fxt_successful_model.id
         assert str(state.active_model_variant_id) == fxt_fp16_openvino_variant.id

--- a/application/backend/tests/integration/services/test_active_model_service.py
+++ b/application/backend/tests/integration/services/test_active_model_service.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import contextmanager
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.db.schema import ModelRevisionDB, ModelVariantDB, PipelineDB, ProjectDB
+from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
+from app.services.active_model_service import ActiveModelService
+from tests.integration.project_factory import ProjectTestDataFactory
+
+
+@pytest.fixture
+def fxt_project(fxt_db_projects, db_session) -> ProjectDB:
+    """Fixture to create a project in the database."""
+    return ProjectTestDataFactory(db_session).with_project(fxt_db_projects[0]).build()
+
+
+@pytest.fixture
+def fxt_successful_model(fxt_project) -> ModelRevisionDB:
+    """Fixture providing a successfully trained model revision."""
+    return ModelRevisionDB(
+        id=str(uuid4()),
+        project_id=fxt_project.id,
+        name="YOLOX-S (successful)",
+        architecture="object-detection-yolox-s",
+        training_status=TrainingStatus.SUCCESSFUL,
+        training_configuration={},
+        label_schema_revision={},
+    )
+
+
+@pytest.fixture
+def fxt_failed_model(fxt_project) -> ModelRevisionDB:
+    """Fixture providing a failed model revision."""
+    return ModelRevisionDB(
+        id=str(uuid4()),
+        project_id=fxt_project.id,
+        name="YOLOX-S (failed)",
+        architecture="object-detection-yolox-s",
+        training_status=TrainingStatus.FAILED,
+        training_configuration={},
+        label_schema_revision={},
+    )
+
+
+@pytest.fixture
+def fxt_in_progress_model(fxt_project) -> ModelRevisionDB:
+    """Fixture providing an in-progress model revision."""
+    return ModelRevisionDB(
+        id=str(uuid4()),
+        project_id=fxt_project.id,
+        name="YOLOX-S (in_progress)",
+        architecture="object-detection-yolox-s",
+        training_status=TrainingStatus.IN_PROGRESS,
+        training_configuration={},
+        label_schema_revision={},
+    )
+
+
+@pytest.fixture
+def fxt_fp16_openvino_variant(fxt_successful_model) -> ModelVariantDB:
+    """Fixture providing an FP16 OpenVINO model variant for the successful model."""
+    return ModelVariantDB(
+        id=str(uuid4()),
+        model_revision_id=fxt_successful_model.id,
+        format=ModelFormat.OPENVINO,
+        precision=ModelPrecision.FP16,
+    )
+
+
+def _make_db_session_patcher(db_session):
+    """Return a context manager that patches get_db_session to yield the test db_session."""
+
+    @contextmanager
+    def _patched_get_db_session():
+        yield db_session
+
+    return patch("app.services.active_model_service.get_db_session", side_effect=_patched_get_db_session)
+
+
+class TestActiveModelServiceLoadState:
+    """Integration tests for ActiveModelService._load_state."""
+
+    def test_load_state_no_active_pipeline_returns_empty_state(self, db_session, tmp_path):
+        """When no pipeline is running, load_state returns an empty ModelActivationState."""
+        with _make_db_session_patcher(db_session):
+            service = ActiveModelService(data_dir=tmp_path)
+
+        state = service._model_activation_state
+
+        assert state.project_id is None
+        assert state.active_model_id is None
+        assert state.active_model_variant_id is None
+        assert state.available_models == []
+
+    def test_load_state_only_includes_successful_models(
+        self,
+        fxt_project,
+        fxt_successful_model,
+        fxt_failed_model,
+        fxt_in_progress_model,
+        fxt_fp16_openvino_variant,
+        db_session,
+        tmp_path,
+    ):
+        """available_models must only contain successfully trained model revisions."""
+        # Persist models with different statuses and the active variant
+        second_successful = ModelRevisionDB(
+            id=str(uuid4()),
+            project_id=fxt_project.id,
+            name="YOLOX-X (successful)",
+            architecture="object-detection-yolox-x",
+            training_status=TrainingStatus.SUCCESSFUL,
+            training_configuration={},
+            label_schema_revision={},
+        )
+        db_session.add_all([fxt_successful_model, second_successful, fxt_failed_model, fxt_in_progress_model])
+        db_session.add(fxt_fp16_openvino_variant)
+        db_session.flush()
+
+        # Create a running pipeline pointing at the successful model
+        pipeline = PipelineDB(
+            project_id=fxt_project.id,
+            is_running=True,
+            model_revision_id=fxt_successful_model.id,
+            device="cpu",
+        )
+        db_session.add(pipeline)
+        db_session.flush()
+
+        with _make_db_session_patcher(db_session):
+            service = ActiveModelService(data_dir=tmp_path)
+
+        state = service._model_activation_state
+
+        assert len(state.available_models) == 2
+        assert state.available_models == [UUID(fxt_successful_model.id), UUID(second_successful.id)]
+        assert str(state.active_model_id) == fxt_successful_model.id
+        assert str(state.active_model_variant_id) == fxt_fp16_openvino_variant.id

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -10,6 +10,7 @@ import pytest
 from app.db.schema import PipelineDB, ProjectDB
 from app.models import DataCollectionConfig, PipelineStatus
 from app.models.data_collection_policy import FixedRateDataCollectionPolicy
+from app.models.model_revision import TrainingStatus
 from app.services import PipelineService, ResourceNotFoundError, ResourceType, SystemService
 from app.services.event.event_bus import EventType
 from app.services.pipeline_service import OtherProjectActiveError
@@ -192,12 +193,59 @@ class TestPipelineServiceIntegration:
         _, db_pipeline = fxt_project_with_pipeline(is_running=True)
 
         model_id = fxt_db_models[1].id
+
+        # The service requires the target model to have SUCCESSFUL training status
+        fxt_db_models[1].training_status = TrainingStatus.SUCCESSFUL
+        db_session.flush()
+
         updated = fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {model_attr: model_id})
 
         fxt_event_bus.emit_event.assert_called_once_with(EventType.MODEL_CHANGED)
         db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
         assert str(updated.model_id) == model_id
         assert str(updated.model_id) == db_updated.model_revision_id
+
+    @pytest.mark.parametrize(
+        "training_status",
+        [TrainingStatus.NOT_STARTED, TrainingStatus.IN_PROGRESS, TrainingStatus.FAILED],
+    )
+    def test_update_model_raises_when_not_successfully_trained(
+        self,
+        training_status,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """Test that updating the pipeline model raises ValueError when the target model is not successfully trained."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        new_model = fxt_db_models[1]
+        new_model.training_status = training_status
+        db_session.flush()
+
+        with pytest.raises(ValueError, match="points to a model that was not successfully trained"):
+            fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"model_id": new_model.id})
+
+        # Pipeline model should remain unchanged
+        db_unchanged = db_session.get(PipelineDB, db_pipeline.project_id)
+        assert db_unchanged.model_revision_id == db_pipeline.model_revision_id
+
+    def test_update_model_raises_when_model_not_found(
+        self,
+        fxt_project_with_pipeline,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """Test that updating the pipeline model raises ResourceNotFoundError when the model ID does not exist."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+        non_existent_model_id = str(uuid4())
+
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"model_id": non_existent_model_id})
+
+        assert exc_info.value.resource_type == ResourceType.MODEL
+        assert exc_info.value.resource_id == non_existent_model_id
 
     @pytest.mark.parametrize("pipeline_status", [PipelineStatus.IDLE, PipelineStatus.RUNNING])
     def test_enable_disable_pipeline(

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -194,10 +194,6 @@ class TestPipelineServiceIntegration:
 
         model_id = fxt_db_models[1].id
 
-        # The service requires the target model to have SUCCESSFUL training status
-        fxt_db_models[1].training_status = TrainingStatus.SUCCESSFUL
-        db_session.flush()
-
         updated = fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {model_attr: model_id})
 
         fxt_event_bus.emit_event.assert_called_once_with(EventType.MODEL_CHANGED)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

During pipeline update (activation) check that provided model id corresponds to a model that was succsessfully trained (not failed or in progress). Also, only list successfully trained models in the active model state as possible candidates for activation.

Resolves #5857 

### How to test

Added integration tests for all changes

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
