### PR TITLE
feat: Display video predictions and use latest prediction endpoint to get image/frame predictions

### DIFF
--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -82,7 +82,12 @@ export type AnnotationDTO = components['schemas']['DatasetItemAnnotation-Input']
 export type DatasetItemAnnotationStatus = components['schemas']['DatasetItemAnnotationStatus'];
 
 export type AnnotatedVideoFrame = components['schemas']['AnnotatedVideoFrame'];
-export type VideoFramePrediction = components['schemas']['MediaListPredictionRequest'];
+export type VideoFramePrediction = {
+    media: components['schemas']['BatchInferenceMedia'];
+    prediction: components['schemas']['DatasetItemAnnotation-Output'][];
+};
+
+export type PredictionVideoRangePayload = components['schemas']['VideoRange'];
 
 export type AnnotationType = components['schemas']['AnnotationType'];
 

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -79,6 +79,7 @@ export type SourceConfig =
 export type SourceConfigPayload = Exclude<SourceConfig, DisconnectedSourceConfig>;
 
 export type AnnotationDTO = components['schemas']['DatasetItemAnnotation-Input'];
+export type PredictionDTO = components['schemas']['DatasetItemAnnotation-Output'];
 export type DatasetItemAnnotationStatus = components['schemas']['DatasetItemAnnotationStatus'];
 
 export type AnnotatedVideoFrame = components['schemas']['AnnotatedVideoFrame'];

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -82,6 +82,7 @@ export type AnnotationDTO = components['schemas']['DatasetItemAnnotation-Input']
 export type DatasetItemAnnotationStatus = components['schemas']['DatasetItemAnnotationStatus'];
 
 export type AnnotatedVideoFrame = components['schemas']['AnnotatedVideoFrame'];
+export type VideoFramePrediction = components['schemas']['MediaListPredictionRequest'];
 
 export type AnnotationType = components['schemas']['AnnotationType'];
 

--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -75,11 +75,9 @@ export const VideoPredictions = () => {
         frameSkip: step,
         selector: (data) => {
             const framePredictions =
-                data
-                    .find((prediction) => {
-                        return prediction.media.frame_index === videoFrame.frame_number;
-                    })
-                    ?.prediction?.map((prediction) => prediction) ?? [];
+                data.find((prediction) => {
+                    return prediction.media.frame_index === videoFrame.frame_number;
+                })?.prediction ?? [];
 
             return mapServerAnnotationsToLocal(framePredictions, labels);
         },

--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -73,14 +73,17 @@ export const VideoPredictions = () => {
     const { data: predictions = [] } = useVideoFramesPredictions({
         frameNumber: videoFrame.frame_number,
         frameSkip: step,
+        // To provide the best user experience, we should get predictions for each single frame
+        rangeStride: 1,
         selector: (data) => {
-            const framePredictions = data
-                .find((prediction) => {
-                    return prediction.media.frame_index === videoFrame.frame_number;
-                })
-                ?.prediction?.map((prediction) => prediction);
+            const framePredictions =
+                data
+                    .find((prediction) => {
+                        return prediction.media.frame_index === videoFrame.frame_number;
+                    })
+                    ?.prediction?.map((prediction) => prediction) ?? [];
 
-            return mapServerAnnotationsToLocal(framePredictions ?? [], labels);
+            return mapServerAnnotationsToLocal(framePredictions, labels);
         },
     });
 

--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -73,8 +73,6 @@ export const VideoPredictions = () => {
     const { data: predictions = [] } = useVideoFramesPredictions({
         frameNumber: videoFrame.frame_number,
         frameSkip: step,
-        // To provide the best user experience, we should get predictions for each single frame
-        rangeStride: 1,
         selector: (data) => {
             const framePredictions =
                 data

--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -3,10 +3,42 @@
 
 import { mapServerAnnotationsToLocal } from '../../../shared/annotator/annotation-mappers';
 import { useProjectLabelsWithEmptyLabel } from '../../../shared/annotator/labels';
+import { Annotation } from '../../../shared/types';
 import { DEFAULT_ANNOTATION_STYLES } from '../utils';
 import { useVideoFramesAnnotations } from '../video-player/api/use-video-frames-annotations';
+import { useVideoFramesPredictions } from '../video-player/api/use-video-frames-predictions';
 import { useVideoPlayer } from '../video-player/video-player-provider.component';
 import { AnnotationShapeRenderer } from './annotation-shape-renderer.component';
+
+type AnnotationsRendererProps = {
+    annotations: Annotation[];
+    height: number;
+    width: number;
+    ariaLabel: string;
+};
+
+const AnnotationsRenderer = ({ annotations, width, height, ariaLabel }: AnnotationsRendererProps) => {
+    return (
+        <svg
+            aria-label={ariaLabel}
+            data-testid={'annotation-layer'}
+            width={width}
+            height={height}
+            tabIndex={-1}
+            style={{
+                position: 'absolute',
+                inset: 0,
+                outline: 'none',
+                overflow: 'visible',
+                ...DEFAULT_ANNOTATION_STYLES,
+            }}
+        >
+            {annotations.map((annotation) => (
+                <AnnotationShapeRenderer key={annotation.id} annotation={annotation} />
+            ))}
+        </svg>
+    );
+};
 
 export const VideoAnnotations = () => {
     const { step, videoFrame } = useVideoPlayer();
@@ -25,23 +57,39 @@ export const VideoAnnotations = () => {
     });
 
     return (
-        <svg
-            aria-label={'video annotations'}
-            data-testid={'annotation-layer'}
-            width={videoFrame.width}
+        <AnnotationsRenderer
+            annotations={annotations}
             height={videoFrame.height}
-            tabIndex={-1}
-            style={{
-                position: 'absolute',
-                inset: 0,
-                outline: 'none',
-                overflow: 'visible',
-                ...DEFAULT_ANNOTATION_STYLES,
-            }}
-        >
-            {annotations.map((annotation) => (
-                <AnnotationShapeRenderer key={annotation.id} annotation={annotation} />
-            ))}
-        </svg>
+            width={videoFrame.width}
+            ariaLabel={'video annotations'}
+        />
+    );
+};
+
+export const VideoPredictions = () => {
+    const { step, videoFrame } = useVideoPlayer();
+
+    const labels = useProjectLabelsWithEmptyLabel();
+    const { data: predictions = [] } = useVideoFramesPredictions({
+        frameNumber: videoFrame.frame_number,
+        frameSkip: step,
+        selector: (data) => {
+            const framePredictions = data
+                .find((prediction) => {
+                    return prediction.media.frame_index === videoFrame.frame_number;
+                })
+                ?.prediction?.map((prediction) => prediction);
+
+            return mapServerAnnotationsToLocal(framePredictions ?? [], labels);
+        },
+    });
+
+    return (
+        <AnnotationsRenderer
+            annotations={predictions}
+            height={videoFrame.height}
+            width={videoFrame.width}
+            ariaLabel={'video predictions'}
+        />
     );
 };

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -11,7 +11,7 @@ import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
-import { VideoAnnotations } from '../annotations/video-annotations.component';
+import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
 import { ToolManager } from '../tools/tool-manager.component';
 import { VideoFrame } from '../video-player/video-frame.component';
@@ -84,8 +84,9 @@ const MediaAnnotations = ({ mediaItem, mode }: MediaAnnotationsProps) => {
     if (isVideoFrame(mediaItem) && videoPlayerContext?.videoControls?.isPlaying) {
         if (mode === 'annotation') {
             return <VideoAnnotations />;
+        } else if (mode === 'prediction') {
+            return <VideoPredictions />;
         }
-        // TODO: Render VideoPredictions
     }
 
     return <ImageAnnotations mediaItem={mediaItem} />;

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -5,8 +5,7 @@ import { queryOptions, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { fetchClient } from '../../../api/client';
-import { Media, PredictionVideoRangePayload } from '../../../constants/shared-types';
-import { useGetActiveModel } from '../../models/hooks/api/use-get-active-model.hook';
+import { PredictionVideoRangePayload } from '../../../constants/shared-types';
 
 export const mediaPredictionsQueryOptions = ({
     projectId,
@@ -27,7 +26,7 @@ export const mediaPredictionsQueryOptions = ({
             const response = await fetchClient.POST('/api/projects/{project_id}/dataset/media/media:predict', {
                 params: { path: { project_id: projectId } },
                 body: {
-                    device: 'auto',
+                    device: 'AUTO',
                     model_id: modelId,
                     save_predictions: false,
                     media: [{ media_id: mediaId, range }],
@@ -40,9 +39,16 @@ export const mediaPredictionsQueryOptions = ({
         enabled: modelId !== undefined,
     });
 
-export const useMediaPredictions = ({ media }: { media: Media }) => {
+export const useMediaPredictions = ({
+    mediaId,
+    modelId,
+    range,
+}: {
+    mediaId: string;
+    modelId: string | undefined;
+    range?: PredictionVideoRangePayload | null;
+}) => {
     const projectId = useProjectIdentifier();
-    const activeModel = useGetActiveModel();
 
-    return useQuery(mediaPredictionsQueryOptions({ projectId, modelId: activeModel?.id, mediaId: media.id }));
+    return useQuery(mediaPredictionsQueryOptions({ projectId, modelId, mediaId, range }));
 };

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -1,0 +1,48 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { fetchClient } from '../../../api/client';
+import { Media, PredictionVideoRangePayload } from '../../../constants/shared-types';
+import { useGetActiveModel } from '../../models/hooks/api/use-get-active-model.hook';
+
+export const mediaPredictionsQueryOptions = ({
+    projectId,
+    modelId,
+    mediaId,
+    range = null,
+}: {
+    projectId: string;
+    modelId: string | undefined;
+    mediaId: string;
+    range?: PredictionVideoRangePayload | null;
+}) =>
+    queryOptions({
+        queryKey: [projectId, 'media-predictions', mediaId, modelId, range],
+        queryFn: async () => {
+            if (modelId === undefined) return [];
+
+            const response = await fetchClient.POST('/api/projects/{project_id}/dataset/media/media:predict', {
+                params: { path: { project_id: projectId } },
+                body: {
+                    device: 'auto',
+                    model_id: modelId,
+                    save_predictions: false,
+                    media: [{ media_id: mediaId, range }],
+                },
+            });
+
+            if (response.error) return [];
+            return response.data?.predictions ?? [];
+        },
+        enabled: modelId !== undefined,
+    });
+
+export const useMediaPredictions = ({ media }: { media: Media }) => {
+    const projectId = useProjectIdentifier();
+    const activeModel = useGetActiveModel();
+
+    return useQuery(mediaPredictionsQueryOptions({ projectId, modelId: activeModel?.id, mediaId: media.id }));
+};

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
@@ -6,8 +6,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { $api } from '../../../../api/client';
 import { AnnotatedVideoFrame } from '../../../../constants/shared-types';
 import { useVideoPlayer } from '../video-player-provider.component';
-
-const CHUNK_SIZE = 30;
+import { getVideoFrameRangeIndexes } from './utils';
 
 export const useVideoFramesAnnotations = <T>({
     frameNumber,
@@ -21,12 +20,9 @@ export const useVideoFramesAnnotations = <T>({
     const projectId = useProjectIdentifier();
     const { videoFrame } = useVideoPlayer();
 
-    const annotationChunkSize = CHUNK_SIZE * frameSkip;
-
     const frames = videoFrame.frame_count - 1;
 
-    const startFrameIndex = Math.floor(frameNumber / annotationChunkSize) * annotationChunkSize;
-    const endFrameIndex = Math.min(startFrameIndex + annotationChunkSize - 1, frames);
+    const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({ frames, frameSkip, frameNumber });
 
     return $api.useQuery(
         'get',

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -14,9 +14,11 @@ export const useVideoFramesPredictions = <T>({
     frameNumber,
     frameSkip,
     selector,
+    rangeStride,
 }: {
     frameNumber: number;
     frameSkip: number;
+    rangeStride?: number;
     selector: (data: VideoFramePrediction[]) => T;
 }) => {
     const projectId = useProjectIdentifier();
@@ -34,7 +36,7 @@ export const useVideoFramesPredictions = <T>({
             projectId,
             modelId: selectedModelId,
             mediaId: videoFrame.id,
-            range: { stride: frameSkip, start_frame: startFrameIndex, end_frame: endFrameIndex },
+            range: { stride: rangeStride ?? frameSkip, start_frame: startFrameIndex, end_frame: endFrameIndex },
         }),
         select: selector,
     });

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -1,0 +1,40 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useQuery } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { $api, fetchClient } from '../../../../api/client';
+import { AnnotatedVideoFrame } from '../../../../constants/shared-types';
+import { useVideoPlayer } from '../video-player-provider.component';
+
+const getVideoFramesPredictionsQueryOptions = async () =>
+    $api.queryOptions('post', '/api/projects/{project_id}/dataset/media/media:predict');
+
+export const useVideoFramesPredictions = <T>({
+    frameNumber,
+    frameSkip,
+    selector,
+}: {
+    frameNumber: number;
+    frameSkip: number;
+    selector: (data: AnnotatedVideoFrame[]) => T;
+}) => {
+    const projectId = useProjectIdentifier();
+    const { videoFrame } = useVideoPlayer();
+    useQuery({
+        queryKey: ['video-frames-predictions'],
+        queryFn: async () => {
+            const response = await fetchClient.POST('/api/projects/{project_id}/dataset/media/media:predict', {
+                params: {
+                    path: {
+                        project_id: projectId,
+                    },
+                },
+                body: {
+                    device: 'cpu',
+                },
+            });
+        },
+    });
+};

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -39,5 +39,7 @@ export const useVideoFramesPredictions = <T>({
             range: { stride: rangeStride ?? frameSkip, start_frame: startFrameIndex, end_frame: endFrameIndex },
         }),
         select: selector,
+        refetchOnMount: false,
+        staleTime: Infinity,
     });
 };

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -4,12 +4,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
-import { $api, fetchClient } from '../../../../api/client';
-import { AnnotatedVideoFrame } from '../../../../constants/shared-types';
+import { VideoFramePrediction } from '../../../../constants/shared-types';
+import { useGetActiveModel } from '../../../models/hooks/api/use-get-active-model.hook';
+import { mediaPredictionsQueryOptions } from '../../api/use-media-predictions';
 import { useVideoPlayer } from '../video-player-provider.component';
-
-const getVideoFramesPredictionsQueryOptions = async () =>
-    $api.queryOptions('post', '/api/projects/{project_id}/dataset/media/media:predict');
+import { getVideoFrameRangeIndexes } from './utils';
 
 export const useVideoFramesPredictions = <T>({
     frameNumber,
@@ -18,23 +17,25 @@ export const useVideoFramesPredictions = <T>({
 }: {
     frameNumber: number;
     frameSkip: number;
-    selector: (data: AnnotatedVideoFrame[]) => T;
+    selector: (data: VideoFramePrediction[]) => T;
 }) => {
     const projectId = useProjectIdentifier();
     const { videoFrame } = useVideoPlayer();
-    useQuery({
-        queryKey: ['video-frames-predictions'],
-        queryFn: async () => {
-            const response = await fetchClient.POST('/api/projects/{project_id}/dataset/media/media:predict', {
-                params: {
-                    path: {
-                        project_id: projectId,
-                    },
-                },
-                body: {
-                    device: 'cpu',
-                },
-            });
-        },
+    const activeModel = useGetActiveModel();
+
+    const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({
+        frames: videoFrame.frame_count - 1,
+        frameSkip,
+        frameNumber,
+    });
+
+    return useQuery({
+        ...mediaPredictionsQueryOptions({
+            projectId,
+            modelId: activeModel?.id,
+            mediaId: videoFrame.id,
+            range: { stride: 1, start_frame: startFrameIndex, end_frame: endFrameIndex },
+        }),
+        select: selector,
     });
 };

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -5,8 +5,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { VideoFramePrediction } from '../../../../constants/shared-types';
-import { useGetActiveModel } from '../../../models/hooks/api/use-get-active-model.hook';
 import { mediaPredictionsQueryOptions } from '../../api/use-media-predictions';
+import { usePredictionSetup } from '../../predictions-setup-provider.component';
 import { useVideoPlayer } from '../video-player-provider.component';
 import { getVideoFrameRangeIndexes } from './utils';
 
@@ -21,7 +21,7 @@ export const useVideoFramesPredictions = <T>({
 }) => {
     const projectId = useProjectIdentifier();
     const { videoFrame } = useVideoPlayer();
-    const activeModel = useGetActiveModel();
+    const { selectedModelId } = usePredictionSetup();
 
     const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({
         frames: videoFrame.frame_count - 1,
@@ -32,9 +32,9 @@ export const useVideoFramesPredictions = <T>({
     return useQuery({
         ...mediaPredictionsQueryOptions({
             projectId,
-            modelId: activeModel?.id,
+            modelId: selectedModelId,
             mediaId: videoFrame.id,
-            range: { stride: 1, start_frame: startFrameIndex, end_frame: endFrameIndex },
+            range: { stride: frameSkip, start_frame: startFrameIndex, end_frame: endFrameIndex },
         }),
         select: selector,
     });

--- a/application/ui/src/features/annotator/video-player/api/utils.test.ts
+++ b/application/ui/src/features/annotator/video-player/api/utils.test.ts
@@ -1,0 +1,123 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { getVideoFrameRangeIndexes } from './utils';
+
+describe('getVideoFrameRangeIndexes', () => {
+    describe('startFrameIndex', () => {
+        it('returns 0 as startFrameIndex when frameNumber is 0', () => {
+            const result = getVideoFrameRangeIndexes({ frameNumber: 0, frames: 100, frameSkip: 1 });
+
+            expect(result.startFrameIndex).toBe(0);
+        });
+
+        it('returns 0 as startFrameIndex when frameNumber is within the first chunk', () => {
+            const result = getVideoFrameRangeIndexes({ frameNumber: 15, frames: 100, frameSkip: 1 });
+
+            expect(result.startFrameIndex).toBe(0);
+        });
+
+        it('returns the chunk boundary as startFrameIndex when frameNumber is exactly at a chunk boundary', () => {
+            // chunkSize=30, frameSkip=1 → annotationChunkSize=30
+            const result = getVideoFrameRangeIndexes({ frameNumber: 30, frames: 100, frameSkip: 1 });
+
+            expect(result.startFrameIndex).toBe(30);
+        });
+
+        it('returns the correct startFrameIndex when frameNumber is in the middle of a later chunk', () => {
+            // chunkSize=30, frameSkip=1 → annotationChunkSize=30; frame 45 falls in chunk [30, 59]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 45, frames: 100, frameSkip: 1 });
+
+            expect(result.startFrameIndex).toBe(30);
+        });
+
+        it('returns a startFrameIndex scaled by frameSkip', () => {
+            // chunkSize=30, frameSkip=60 → annotationChunkSize=1800; frame 1900 falls in chunk [1800, 3599]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 1900, frames: 5000, frameSkip: 60 });
+
+            expect(result.startFrameIndex).toBe(1800);
+        });
+
+        it('returns 0 as startFrameIndex for a custom chunkSize when frameNumber is within the first chunk', () => {
+            // chunkSize=10, frameSkip=1 → annotationChunkSize=10; frame 5 is in [0, 9]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 5, frames: 100, frameSkip: 1, chunkSize: 10 });
+
+            expect(result.startFrameIndex).toBe(0);
+        });
+
+        it('returns the correct startFrameIndex for a custom chunkSize', () => {
+            // chunkSize=10, frameSkip=1 → annotationChunkSize=10; frame 25 falls in chunk [20, 29]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 25, frames: 100, frameSkip: 1, chunkSize: 10 });
+
+            expect(result.startFrameIndex).toBe(20);
+        });
+    });
+
+    describe('endFrameIndex', () => {
+        it('returns annotationChunkSize - 1 as endFrameIndex when the chunk does not exceed total frames', () => {
+            // chunkSize=30, frameSkip=1 → annotationChunkSize=30; chunk [0, 29], frames=100
+            const result = getVideoFrameRangeIndexes({ frameNumber: 0, frames: 100, frameSkip: 1 });
+
+            expect(result.endFrameIndex).toBe(29);
+        });
+
+        it('returns frames as endFrameIndex when the chunk would exceed total frames', () => {
+            // chunkSize=30, frameSkip=1 → annotationChunkSize=30; chunk [90, 119] clipped to [90, 100]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 95, frames: 100, frameSkip: 1 });
+
+            expect(result.endFrameIndex).toBe(100);
+        });
+
+        it('returns frames as endFrameIndex when frameNumber equals frames', () => {
+            const result = getVideoFrameRangeIndexes({ frameNumber: 100, frames: 100, frameSkip: 1 });
+
+            expect(result.endFrameIndex).toBe(100);
+        });
+
+        it('returns the correct endFrameIndex scaled by frameSkip', () => {
+            // chunkSize=30, frameSkip=60 → annotationChunkSize=1800; chunk [0, 1799], frames=5000
+            const result = getVideoFrameRangeIndexes({ frameNumber: 0, frames: 5000, frameSkip: 60 });
+
+            expect(result.endFrameIndex).toBe(1799);
+        });
+
+        it('returns the correct endFrameIndex for a custom chunkSize', () => {
+            // chunkSize=5, frameSkip=3 → annotationChunkSize=15; chunk [0, 14], frames=100
+            const result = getVideoFrameRangeIndexes({ frameNumber: 0, frames: 100, frameSkip: 3, chunkSize: 5 });
+
+            expect(result.endFrameIndex).toBe(14);
+        });
+    });
+
+    describe('combined startFrameIndex and endFrameIndex', () => {
+        it('returns the correct range for a mid-video frame with default chunkSize', () => {
+            // chunkSize=30, frameSkip=1 → annotationChunkSize=30; frame 60 is in [60, 89]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 60, frames: 200, frameSkip: 1 });
+
+            expect(result).toEqual({ startFrameIndex: 60, endFrameIndex: 89 });
+        });
+
+        it('returns a single-frame range when chunkSize is 1 and frameSkip is 1', () => {
+            // annotationChunkSize=1; frame 7 is in [7, 7]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 7, frames: 100, frameSkip: 1, chunkSize: 1 });
+
+            expect(result).toEqual({ startFrameIndex: 7, endFrameIndex: 7 });
+        });
+
+        it('returns the correct range when chunkSize is 1 and the chunk is at the end of the video', () => {
+            // annotationChunkSize=1; frame 100 clipped to frames=100
+            const result = getVideoFrameRangeIndexes({ frameNumber: 100, frames: 100, frameSkip: 1, chunkSize: 1 });
+
+            expect(result).toEqual({ startFrameIndex: 100, endFrameIndex: 100 });
+        });
+
+        it('returns the correct range for a large frameSkip value', () => {
+            // chunkSize=30, frameSkip=60 → annotationChunkSize=1800; frame 0 is in [0, 1799] clipped to [0, 500]
+            const result = getVideoFrameRangeIndexes({ frameNumber: 0, frames: 2000, frameSkip: 60 });
+
+            expect(result).toEqual({ startFrameIndex: 0, endFrameIndex: 1799 });
+        });
+    });
+});

--- a/application/ui/src/features/annotator/video-player/api/utils.ts
+++ b/application/ui/src/features/annotator/video-player/api/utils.ts
@@ -7,12 +7,14 @@ export const getVideoFrameRangeIndexes = ({
     frameSkip,
     frames,
     frameNumber,
+    chunkSize = CHUNK_SIZE,
 }: {
     frameNumber: number;
     frames: number;
     frameSkip: number;
+    chunkSize?: number;
 }) => {
-    const annotationChunkSize = CHUNK_SIZE * frameSkip;
+    const annotationChunkSize = chunkSize * frameSkip;
 
     const startFrameIndex = Math.floor(frameNumber / annotationChunkSize) * annotationChunkSize;
     const endFrameIndex = Math.min(startFrameIndex + annotationChunkSize - 1, frames);

--- a/application/ui/src/features/annotator/video-player/api/utils.ts
+++ b/application/ui/src/features/annotator/video-player/api/utils.ts
@@ -1,0 +1,21 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+const CHUNK_SIZE = 30;
+
+export const getVideoFrameRangeIndexes = ({
+    frameSkip,
+    frames,
+    frameNumber,
+}: {
+    frameNumber: number;
+    frames: number;
+    frameSkip: number;
+}) => {
+    const annotationChunkSize = CHUNK_SIZE * frameSkip;
+
+    const startFrameIndex = Math.floor(frameNumber / annotationChunkSize) * annotationChunkSize;
+    const endFrameIndex = Math.min(startFrameIndex + annotationChunkSize - 1, frames);
+
+    return { startFrameIndex, endFrameIndex };
+};

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
@@ -9,6 +9,7 @@ import { useNumberFormatter } from 'react-aria';
 import { AnnotatedVideoFrame, Label } from '../../../../../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../../../../../shared/annotator/annotator-mode';
 import { useVideoFramesAnnotations } from '../../../../api/use-video-frames-annotations';
+import { useVideoFramesPredictions } from '../../../../api/use-video-frames-predictions';
 import { useVideoPlayer } from '../../../../video-player-provider.component';
 
 import classes from './video-frame-segment.module.scss';
@@ -91,10 +92,18 @@ const useVideoTimelineAnnotations = ({ frameNumber }: { frameNumber: number }) =
     };
 };
 
-// TODO: Implement this properly.
-// This hook should return the annotations and predictions for the current frame. Moreover we should fetch annotations
-// and predictions for the previous and next frames as well (using start-end frame).
-const useVideoTimelinePredictions = (_: { frameNumber: number }) => {
+const useVideoTimelinePredictions = ({ frameNumber }: { frameNumber: number }) => {
+    const { step } = useVideoPlayer();
+    const { data } = useVideoFramesPredictions({
+        frameNumber,
+        frameSkip: step,
+        selector: (data) => {
+            return data;
+        },
+    });
+
+    console.log({ data });
+
     return {
         predictedLabels: [] as string[],
         isPredictionLoading: false,

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
@@ -6,7 +6,7 @@ import { ReactNode } from 'react';
 import { Flex, View } from '@geti/ui';
 import { useNumberFormatter } from 'react-aria';
 
-import { AnnotatedVideoFrame, Label } from '../../../../../../../constants/shared-types';
+import { AnnotatedVideoFrame, Label, VideoFramePrediction } from '../../../../../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../../../../../shared/annotator/annotator-mode';
 import { useVideoFramesAnnotations } from '../../../../api/use-video-frames-annotations';
 import { useVideoFramesPredictions } from '../../../../api/use-video-frames-predictions';
@@ -92,21 +92,22 @@ const useVideoTimelineAnnotations = ({ frameNumber }: { frameNumber: number }) =
     };
 };
 
+const selectPredictionsForFrame = (frameNumber: number) => (data: VideoFramePrediction[]) =>
+    data.find(({ media }) => media.frame_index === frameNumber);
+
 const useVideoTimelinePredictions = ({ frameNumber }: { frameNumber: number }) => {
     const { step } = useVideoPlayer();
-    const { data } = useVideoFramesPredictions({
+    const { data, isPending } = useVideoFramesPredictions({
         frameNumber,
         frameSkip: step,
-        selector: (data) => {
-            return data;
-        },
+        selector: selectPredictionsForFrame(frameNumber),
     });
 
-    console.log({ data });
+    const predictedLabels = data?.prediction?.flatMap((prediction) => prediction.labels.map(({ id }) => id)) ?? [];
 
     return {
-        predictedLabels: [] as string[],
-        isPredictionLoading: false,
+        predictedLabels,
+        isPredictionLoading: isPending,
     };
 };
 

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -9,6 +9,9 @@ import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook'
 import type { Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
+import { isVideoFrame } from '../../../shared/media-item-utils';
+import { useMediaPredictions } from '../../annotator/api/use-media-predictions';
+import { PredictionsSetupProvider, usePredictionSetup } from '../../annotator/predictions-setup-provider.component';
 import {
     SelectedMediaItemProvider,
     useSelectedMediaItem,
@@ -94,8 +97,16 @@ const MediaPreviewContent = ({
 }: MediaPreviewContentProps) => {
     const [mode, setMode] = useState<AnnotatorMode>('annotation');
     const { mediaItem } = useSelectedMediaItem();
+    const { selectedModelId } = usePredictionSetup();
 
     const { data: annotationsData } = useAnnotationsQuery(mediaItem);
+    const { data: predictionsData } = useMediaPredictions({
+        mediaId: mediaItem.id,
+        modelId: selectedModelId,
+        range: isVideoFrame(mediaItem)
+            ? { start_frame: mediaItem.frame_number, end_frame: mediaItem.frame_number, stride: mediaItem.frame_stride }
+            : null,
+    });
 
     const isUserReviewed = annotationsData?.user_reviewed ?? false;
 
@@ -104,8 +115,8 @@ const MediaPreviewContent = ({
     }, [isUserReviewed, annotationsData?.annotations]);
 
     const initialPredictions = useMemo(() => {
-        return getInitialPredictions(isUserReviewed, annotationsData?.annotations ?? []);
-    }, [isUserReviewed, annotationsData?.annotations]);
+        return getInitialPredictions(predictionsData?.flatMap((predictionData) => predictionData.prediction));
+    }, [predictionsData]);
 
     return (
         <ToolProvider mode={mode}>
@@ -157,14 +168,16 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                     ]}
                 >
                     <SelectedMediaItemProvider mediaItem={mediaItem}>
-                        <MediaPreviewContent
-                            items={items}
-                            onClose={close}
-                            onSelectedMediaItem={onSelectedMediaItem}
-                            hasNextPage={hasNextPage}
-                            isFetchingNextPage={isFetchingNextPage}
-                            fetchNextPage={fetchNextPage}
-                        />
+                        <PredictionsSetupProvider>
+                            <MediaPreviewContent
+                                items={items}
+                                onClose={close}
+                                onSelectedMediaItem={onSelectedMediaItem}
+                                hasNextPage={hasNextPage}
+                                isFetchingNextPage={isFetchingNextPage}
+                                fetchNextPage={fetchNextPage}
+                            />
+                        </PredictionsSetupProvider>
                     </SelectedMediaItemProvider>
                 </Grid>
             </Content>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -22,7 +22,7 @@ import { useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { useAnnotatorMediaTransition } from './use-annotator-media-transition.hook';
-import { getInitialAnnotations, getInitialPredictions } from './utils';
+import { getInitialAnnotations } from './utils';
 
 type MediaPreviewProps = {
     mediaItem: Media;
@@ -115,7 +115,7 @@ const MediaPreviewContent = ({
     }, [isUserReviewed, annotationsData?.annotations]);
 
     const initialPredictions = useMemo(() => {
-        return getInitialPredictions(predictionsData?.flatMap((predictionData) => predictionData.prediction));
+        return predictionsData?.flatMap((predictionData) => predictionData.prediction) ?? [];
     }, [predictionsData]);
 
     return (

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -50,7 +50,7 @@ export const ReadOnlyAnnotator = ({
     const { canSubmit, isSaving, submit } = useSubmitPredictions({ onSuccess: onAcceptPrediction });
 
     return (
-        <PredictionsSetupProvider>
+        <>
             <View gridArea={'header'} UNSAFE_className={classes.toolbarContainer}>
                 <Flex alignItems={'center'} justifyContent={'space-between'} width={'100%'}>
                     {onModeChange && (
@@ -102,6 +102,6 @@ export const ReadOnlyAnnotator = ({
             <View gridArea={'bottom'}>
                 <BottomToolbar mediaItem={mediaItem} hideHotkeys />
             </View>
-        </PredictionsSetupProvider>
+        </>
     );
 };

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -8,7 +8,6 @@ import type { Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { PredictionsSetupProvider } from '../../annotator/predictions-setup-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -4,7 +4,7 @@
 import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage } from 'mocks/mock-media';
 
 import type { AnnotationDTO } from '../../../constants/shared-types';
-import { getInitialAnnotations, getInitialPredictions, getNextMediaItem } from './utils';
+import { getInitialAnnotations, getNextMediaItem } from './utils';
 
 describe('getInitialAnnotations', () => {
     const mockAnnotations: AnnotationDTO[] = [
@@ -36,39 +36,6 @@ describe('getInitialAnnotations', () => {
     it('returns empty array when user has not reviewed', () => {
         const result = getInitialAnnotations(false, mockAnnotations);
         expect(result).toEqual([]);
-    });
-});
-
-describe('getInitialPredictions', () => {
-    const mockAnnotations: AnnotationDTO[] = [
-        {
-            shape: { type: 'rectangle', x: 0, y: 0, width: 100, height: 100 },
-            labels: [{ id: '1' }],
-        },
-        {
-            shape: {
-                type: 'polygon',
-                points: [
-                    { x: 0, y: 0 },
-                    { x: 100, y: 100 },
-                ],
-            },
-            labels: [{ id: '2' }],
-        },
-        {
-            shape: { type: 'full_image' },
-            labels: [{ id: '3' }],
-        },
-    ];
-
-    it('returns empty array when user has reviewed', () => {
-        const result = getInitialPredictions(true, mockAnnotations);
-        expect(result).toEqual([]);
-    });
-
-    it('returns annotations when user has not reviewed', () => {
-        const result = getInitialPredictions(false, mockAnnotations);
-        expect(result).toEqual(mockAnnotations);
     });
 });
 

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { range } from 'lodash-es';
 
-import type { AnnotationDTO, Media, PredictionDTO } from '../../../constants/shared-types';
+import type { AnnotationDTO, Media } from '../../../constants/shared-types';
 import { isVideoFrame } from '../../../shared/media-item-utils';
 import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
 import { useVideoPlayerContext } from '../../annotator/video-player/video-player-provider.component';

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { range } from 'lodash-es';
 
-import type { AnnotationDTO, Media } from '../../../constants/shared-types';
+import type { AnnotationDTO, Media, PredictionDTO } from '../../../constants/shared-types';
 import { isVideoFrame } from '../../../shared/media-item-utils';
 import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
 import { useVideoPlayerContext } from '../../annotator/video-player/video-player-provider.component';
@@ -17,8 +17,8 @@ export const getInitialAnnotations = (isUserReviewed: boolean, annotationsDTO: A
     return isUserReviewed ? annotationsDTO : [];
 };
 
-export const getInitialPredictions = (isUserReviewed: boolean, annotationsDTO: AnnotationDTO[]): AnnotationDTO[] => {
-    return isUserReviewed ? [] : annotationsDTO;
+export const getInitialPredictions = (predictions: PredictionDTO[] | undefined): AnnotationDTO[] => {
+    return predictions ?? [];
 };
 
 export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[], step: number): Media | undefined => {

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -17,10 +17,6 @@ export const getInitialAnnotations = (isUserReviewed: boolean, annotationsDTO: A
     return isUserReviewed ? annotationsDTO : [];
 };
 
-export const getInitialPredictions = (predictions: PredictionDTO[] | undefined): AnnotationDTO[] => {
-    return predictions ?? [];
-};
-
 export const getNextMediaItem = (currentMediaItem: Media, allMediaItems: Media[], step: number): Media | undefined => {
     if (isVideoFrame(currentMediaItem)) {
         const videoFrames = range(0, currentMediaItem.frame_count, step);

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -8,10 +8,11 @@ import { fileURLToPath } from 'url';
 import { expect } from '@playwright/test';
 import { getMockedLabel } from 'mocks/mock-labels';
 import { getMockedMediaImage } from 'mocks/mock-media';
+import { getMockedModel } from 'mocks/mock-model';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
 
-import { AnnotationDTO } from '../../src/constants/shared-types';
+import { AnnotationDTO, PredictionDTO } from '../../src/constants/shared-types';
 import { Polygon } from '../../src/shared/types';
 import { http, test } from '../fixtures';
 
@@ -224,14 +225,28 @@ test.describe('Annotator', () => {
                 labels: [{ id: blueLabel.id }],
                 confidences: [0.904296875],
             },
-        ] satisfies AnnotationDTO[];
+        ] satisfies PredictionDTO[];
 
         network.use(
+            http.get('/api/projects/{project_id}/models', async () => {
+                return HttpResponse.json([getMockedModel()]);
+            }),
             http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', async () => {
                 return HttpResponse.json({
-                    annotations: predictions,
-                    user_reviewed: false,
-                    prediction_model_id: '123',
+                    annotations: [],
+                    user_reviewed: true,
+                });
+            }),
+            http.post('/api/projects/{project_id}/dataset/media/media:predict', async () => {
+                return HttpResponse.json({
+                    predictions: [
+                        {
+                            media: {
+                                id: '123',
+                            },
+                            prediction: predictions,
+                        },
+                    ],
                 });
             })
         );


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR includes:
- predictions for the video timeline;
- predictions while playing a video (hardly visible, inference server hangs really often, 500 errors etc).
- predictions for the image/frame - previously we used `/annotations` endpoint to get them.

Close #5660

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
