### PR TITLE
GSoC 2026 - added custom classifier (ShuffleNetV2)

### DIFF
--- a/lib/src/otx/backend/native/models/__init__.py
+++ b/lib/src/otx/backend/native/models/__init__.py
@@ -7,6 +7,7 @@ from .anomaly import Padim, Stfpm, Uflow
 from .classification import (
     EfficientNet,
     MobileNetV3,
+    ShuffleNetV2,
     TimmModel,
     TVModel,
     VisionTransformer,
@@ -23,6 +24,7 @@ __all__ = [
     "EfficientNet",
     "TimmModel",
     "MobileNetV3",
+    "ShuffleNetV2",
     "TVModel",
     "VisionTransformer",
     "ATSS",

--- a/lib/src/otx/backend/native/models/classification/__init__.py
+++ b/lib/src/otx/backend/native/models/classification/__init__.py
@@ -6,6 +6,7 @@
 from .factory import (
     EfficientNet,
     MobileNetV3,
+    ShuffleNetV2,
     TimmModel,
     TVModel,
     VisionTransformer,
@@ -15,6 +16,7 @@ __all__ = [
     "EfficientNet",
     "TimmModel",
     "MobileNetV3",
+    "ShuffleNetV2",
     "TVModel",
     "VisionTransformer",
 ]

--- a/lib/src/otx/backend/native/models/classification/backbones/__init__.py
+++ b/lib/src/otx/backend/native/models/classification/backbones/__init__.py
@@ -5,6 +5,7 @@
 
 from .efficientnet import EfficientNetBackbone
 from .mobilenet_v3 import MobileNetV3Backbone
+from .shufflenet_v2 import ShuffleNetV2Backbone
 from .timm import TimmBackbone
 from .torchvision import TorchvisionBackbone
 from .vision_transformer import VisionTransformerBackbone
@@ -13,6 +14,7 @@ __all__ = [
     "EfficientNetBackbone",
     "TimmBackbone",
     "MobileNetV3Backbone",
+    "ShuffleNetV2Backbone",
     "VisionTransformerBackbone",
     "TorchvisionBackbone",
 ]

--- a/lib/src/otx/backend/native/models/classification/backbones/shufflenet_v2.py
+++ b/lib/src/otx/backend/native/models/classification/backbones/shufflenet_v2.py
@@ -1,0 +1,252 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Implementation of ShuffleNetV2.
+
+Original paper:
+- 'ShuffleNet V2: Practical Guidelines for Efficient CNN Architecture Design,'
+  https://arxiv.org/abs/1807.11164.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, ClassVar
+
+import torch
+from torch import nn
+
+
+def channel_shuffle(x: torch.Tensor, groups: int) -> torch.Tensor:
+    """Channel shuffle operation from ShuffleNet.
+
+    Rearranges channels so that information flows between groups.
+
+    Args:
+        x: Input tensor of shape (batch, channels, height, width).
+        groups: Number of groups for the shuffle.
+
+    Returns:
+        Tensor with shuffled channels.
+    """
+    batch_size, num_channels, height, width = x.size()
+    channels_per_group = num_channels // groups
+    x = x.view(batch_size, groups, channels_per_group, height, width)
+    x = torch.transpose(x, 1, 2).contiguous()
+    return x.view(batch_size, -1, height, width)
+
+
+class InvertedResidual(nn.Module):
+    """ShuffleNetV2 building block (inverted residual with channel shuffle).
+
+    When stride=1: channel split -> right branch (1x1 conv, DW conv, 1x1 conv) -> concat -> channel shuffle.
+    When stride=2: both branches active -> concat -> channel shuffle (doubles channels).
+
+    Args:
+        inp: Number of input channels.
+        oup: Number of output channels.
+        stride: Stride for depthwise convolution (1 or 2).
+    """
+
+    def __init__(self, inp: int, oup: int, stride: int) -> None:
+        super().__init__()
+
+        if stride not in (1, 2):
+            msg = f"Stride must be 1 or 2, got {stride}"
+            raise ValueError(msg)
+
+        self.stride = stride
+        branch_features = oup // 2
+
+        if self.stride == 2:
+            # Left branch: depthwise conv + 1x1 conv (processes all input channels)
+            self.branch1 = nn.Sequential(
+                # Depthwise conv
+                nn.Conv2d(inp, inp, kernel_size=3, stride=self.stride, padding=1, groups=inp, bias=False),
+                nn.BatchNorm2d(inp),
+                # Pointwise conv
+                nn.Conv2d(inp, branch_features, kernel_size=1, stride=1, padding=0, bias=False),
+                nn.BatchNorm2d(branch_features),
+                nn.ReLU(inplace=True),
+            )
+        else:
+            self.branch1 = nn.Sequential()
+
+        # Right branch
+        inp_right = inp if self.stride == 2 else branch_features
+        self.branch2 = nn.Sequential(
+            # Pointwise conv
+            nn.Conv2d(inp_right, branch_features, kernel_size=1, stride=1, padding=0, bias=False),
+            nn.BatchNorm2d(branch_features),
+            nn.ReLU(inplace=True),
+            # Depthwise conv
+            nn.Conv2d(branch_features, branch_features, kernel_size=3, stride=self.stride, padding=1, groups=branch_features, bias=False),
+            nn.BatchNorm2d(branch_features),
+            # Pointwise conv
+            nn.Conv2d(branch_features, branch_features, kernel_size=1, stride=1, padding=0, bias=False),
+            nn.BatchNorm2d(branch_features),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass."""
+        if self.stride == 1:
+            x1, x2 = x.chunk(2, dim=1)
+            out = torch.cat((x1, self.branch2(x2)), dim=1)
+        else:
+            out = torch.cat((self.branch1(x), self.branch2(x)), dim=1)
+        return channel_shuffle(out, 2)
+
+
+class ShuffleNetV2FeatureExtractor(nn.Module):
+    """ShuffleNetV2 feature extractor.
+
+    Args:
+        stages_repeats: Number of repeats for each stage.
+        stages_out_channels: Output channels for each stage.
+            [input_channels, stage2, stage3, stage4, conv5].
+        input_size: Spatial input size as (H, W).
+    """
+
+    def __init__(
+        self,
+        stages_repeats: list[int],
+        stages_out_channels: list[int],
+        input_size: tuple[int, int] = (224, 224),
+    ) -> None:
+        super().__init__()
+
+        if len(stages_repeats) != 3:
+            msg = f"Expected 3 stage repeats, got {len(stages_repeats)}"
+            raise ValueError(msg)
+        if len(stages_out_channels) != 5:
+            msg = f"Expected 5 stage output channel counts, got {len(stages_out_channels)}"
+            raise ValueError(msg)
+
+        self.in_size = input_size
+        input_channels = 3
+        output_channels = stages_out_channels[0]
+
+        stride = 1 if input_size[0] < 100 else 2
+
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(input_channels, output_channels, kernel_size=3, stride=stride, padding=1, bias=False),
+            nn.BatchNorm2d(output_channels),
+            nn.ReLU(inplace=True),
+        )
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+
+        # Build stages
+        self.stage2: nn.Sequential
+        self.stage3: nn.Sequential
+        self.stage4: nn.Sequential
+        input_channels = output_channels
+        for i, (repeats, out_ch) in enumerate(
+            zip(stages_repeats, stages_out_channels[1:4]),
+        ):
+            seq = [InvertedResidual(input_channels, out_ch, stride=2)]
+            for _ in range(repeats - 1):
+                seq.append(InvertedResidual(out_ch, out_ch, stride=1))
+            setattr(self, f"stage{i + 2}", nn.Sequential(*seq))
+            input_channels = out_ch
+
+        output_channels = stages_out_channels[-1]
+        self.conv5 = nn.Sequential(
+            nn.Conv2d(input_channels, output_channels, kernel_size=1, stride=1, padding=0, bias=False),
+            nn.BatchNorm2d(output_channels),
+            nn.ReLU(inplace=True),
+        )
+
+        # Collect feature layers into a single Sequential for compatibility
+        self.features = nn.Sequential(
+            self.conv1,
+            self.maxpool,
+            self.stage2,
+            self.stage3,
+            self.stage4,
+            self.conv5,
+        )
+
+        self._initialize_weights()
+
+    def extract_features(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        """Extract features from input tensor."""
+        y = self.features(x)
+        return (y,)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor]:
+        """Forward pass."""
+        return self.extract_features(x)
+
+    def _initialize_weights(self) -> None:
+        """Initialize model weights."""
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                n = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+                m.weight.data.normal_(0, math.sqrt(2.0 / n))
+                if m.bias is not None:
+                    m.bias.data.zero_()
+            elif isinstance(m, nn.BatchNorm2d):
+                m.weight.data.fill_(1)
+                m.bias.data.zero_()
+            elif isinstance(m, nn.Linear):
+                n = m.weight.size(1)
+                m.weight.data.normal_(0, 0.01)
+                m.bias.data.zero_()
+
+
+class ShuffleNetV2Backbone:
+    """Factory class for ShuffleNetV2 backbone.
+
+    Creates a ShuffleNetV2FeatureExtractor based on the specified model variant.
+
+    Args:
+        model_name: Model variant name. One of "shufflenetv2_small" (x0.5) or
+            "shufflenetv2_large" (x1.0).
+        input_size: Spatial input size as (H, W). Defaults to (224, 224).
+
+    Returns:
+        ShuffleNetV2FeatureExtractor instance.
+    """
+
+    SHUFFLENETV2_CFG: ClassVar[dict[str, Any]] = {
+        "shufflenetv2_small": {
+            # x0.5 variant
+            "stages_repeats": [4, 8, 4],
+            "stages_out_channels": [24, 48, 96, 192, 1024],
+            "out_channels": 1024,
+        },
+        "shufflenetv2_large": {
+            # x1.0 variant
+            "stages_repeats": [4, 8, 4],
+            "stages_out_channels": [24, 116, 232, 464, 1024],
+            "out_channels": 1024,
+        },
+    }
+
+    def __new__(
+        cls,
+        model_name: str = "shufflenetv2_large",
+        input_size: tuple[int, int] = (224, 224),
+        **kwargs,
+    ) -> ShuffleNetV2FeatureExtractor:
+        """Create a new ShuffleNetV2 feature extractor.
+
+        Args:
+            model_name: Model variant name. Defaults to "shufflenetv2_large".
+            input_size: Spatial input size. Defaults to (224, 224).
+            **kwargs: Additional keyword arguments (unused, for API compatibility).
+
+        Returns:
+            A ShuffleNetV2FeatureExtractor instance.
+        """
+        if model_name not in cls.SHUFFLENETV2_CFG:
+            msg = f"Unknown ShuffleNetV2 model: {model_name}. Available: {list(cls.SHUFFLENETV2_CFG.keys())}"
+            raise ValueError(msg)
+
+        cfg = cls.SHUFFLENETV2_CFG[model_name]
+        return ShuffleNetV2FeatureExtractor(
+            stages_repeats=cfg["stages_repeats"],
+            stages_out_channels=cfg["stages_out_channels"],
+            input_size=input_size,
+        )

--- a/lib/src/otx/backend/native/models/classification/factory.py
+++ b/lib/src/otx/backend/native/models/classification/factory.py
@@ -22,6 +22,7 @@ from .hlabel_models import (
 from .multiclass_models import (
     EfficientNetMulticlassCls,
     MobileNetV3MulticlassCls,
+    ShuffleNetV2MulticlassCls,
     TimmModelMulticlassCls,
     TVModelMulticlassCls,
     VisionTransformerMulticlassCls,
@@ -109,6 +110,59 @@ class MobileNetV3:
             return MobileNetV3MultilabelCls(**kwargs)
         if task == "h_label":
             return MobileNetV3HLabelCls(**kwargs)
+        msg = f"Unsupported task type: {task}"
+        raise ValueError(msg)
+
+
+class ShuffleNetV2:
+    """Factory class for ShuffleNetV2 models."""
+
+    @overload
+    def __new__(
+        cls,
+        label_info: LabelInfoTypes,
+        data_input_params: DataInputParams | dict,
+        task: Literal["multi_class"] = "multi_class",
+        freeze_backbone: bool = False,
+        model_name: Literal["shufflenetv2_large", "shufflenetv2_small"] = "shufflenetv2_large",
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
+        metric: MetricCallable = MultiClassClsMetricCallable,
+        torch_compile: bool = False,
+    ) -> ShuffleNetV2MulticlassCls: ...
+
+    def __new__(
+        cls,
+        task: Literal["multi_class"] = "multi_class",
+        **kwargs,
+    ) -> ShuffleNetV2MulticlassCls:
+        """Factory method to create ShuffleNetV2 models based on the task type.
+
+        Args:
+            label_info (LabelInfoTypes): The label information.
+            data_input_params (DataInputParams | dict): The data input parameters that consists
+                of input size, mean and std.
+            freeze_backbone (bool, optional): Whether to freeze the backbone during training. Defaults to False.
+            model_name (str, optional): The model name. Defaults to "shufflenetv2_large".
+            task (Literal["multi_class"], optional): The task type. Defaults to "multi_class".
+            optimizer (OptimizerCallable, optional): The optimizer callable. Defaults to DefaultOptimizerCallable.
+            scheduler (LRSchedulerCallable | LRSchedulerListCallable, optional): The learning rate scheduler callable.
+                Defaults to DefaultSchedulerCallable.
+            metric (MetricCallable, optional): The metric callable. Defaults to MultiClassClsMetricCallable.
+            torch_compile (bool, optional): Whether to compile the model using TorchScript. Defaults to False.
+
+        Examples:
+            >>> model = ShuffleNetV2(
+            ...     task="multi_class",
+            ...     label_info=10,
+            ...     data_input_params={"input_size": (224, 224),
+            ...                        "mean": [123.675, 116.28, 103.53],
+            ...                        "std": [58.395, 57.12, 57.375]},
+            ...     model_name="shufflenetv2_large",
+            ... )
+        """
+        if task == "multi_class":
+            return ShuffleNetV2MulticlassCls(**kwargs)
         msg = f"Unsupported task type: {task}"
         raise ValueError(msg)
 

--- a/lib/src/otx/backend/native/models/classification/multiclass_models/__init__.py
+++ b/lib/src/otx/backend/native/models/classification/multiclass_models/__init__.py
@@ -5,6 +5,7 @@
 
 from .efficientnet import EfficientNetMulticlassCls
 from .mobilenet_v3 import MobileNetV3MulticlassCls
+from .shufflenet_v2 import ShuffleNetV2MulticlassCls
 from .timm_model import TimmModelMulticlassCls
 from .torchvision_model import TVModelMulticlassCls
 from .vit import VisionTransformerMulticlassCls
@@ -12,6 +13,7 @@ from .vit import VisionTransformerMulticlassCls
 __all__ = [
     "EfficientNetMulticlassCls",
     "MobileNetV3MulticlassCls",
+    "ShuffleNetV2MulticlassCls",
     "TimmModelMulticlassCls",
     "TVModelMulticlassCls",
     "VisionTransformerMulticlassCls",

--- a/lib/src/otx/backend/native/models/classification/multiclass_models/shufflenet_v2.py
+++ b/lib/src/otx/backend/native/models/classification/multiclass_models/shufflenet_v2.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""ShuffleNetV2 model implementation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from torch import Tensor, nn
+
+from otx.backend.native.models.base import DataInputParams, DefaultOptimizerCallable, DefaultSchedulerCallable
+from otx.backend.native.models.classification.backbones import ShuffleNetV2Backbone
+from otx.backend.native.models.classification.classifier import ImageClassifier
+from otx.backend.native.models.classification.heads import LinearClsHead
+from otx.backend.native.models.classification.multiclass_models.base import OTXMulticlassClsModel
+from otx.backend.native.models.classification.necks.gap import GlobalAveragePooling
+from otx.backend.native.schedulers import LRSchedulerListCallable
+from otx.metrics.accuracy import MultiClassClsMetricCallable
+from otx.types.label import LabelInfoTypes
+
+if TYPE_CHECKING:
+    from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+
+    from otx.metrics import MetricCallable
+
+
+class ShuffleNetV2MulticlassCls(OTXMulticlassClsModel):
+    """ShuffleNetV2MulticlassCls is a class that represents a ShuffleNetV2 model for multiclass classification.
+
+    Args:
+        label_info (LabelInfoTypes): The label information.
+        data_input_params (DataInputParams): The data input parameters such as input size and normalization.
+        model_name (Literal["shufflenetv2_large", "shufflenetv2_small"], optional): The model name.
+            Defaults to "shufflenetv2_large".
+        optimizer (OptimizerCallable, optional): The optimizer callable. Defaults to DefaultOptimizerCallable.
+        scheduler (LRSchedulerCallable | LRSchedulerListCallable, optional): The learning rate scheduler callable.
+            Defaults to DefaultSchedulerCallable.
+        metric (MetricCallable, optional): The metric callable. Defaults to MultiClassClsMetricCallable.
+        torch_compile (bool, optional): Whether to compile the model using TorchScript. Defaults to False.
+    """
+
+    def __init__(
+        self,
+        label_info: LabelInfoTypes,
+        data_input_params: DataInputParams,
+        model_name: Literal["shufflenetv2_large", "shufflenetv2_small"] = "shufflenetv2_large",
+        freeze_backbone: bool = False,
+        optimizer: OptimizerCallable = DefaultOptimizerCallable,
+        scheduler: LRSchedulerCallable | LRSchedulerListCallable = DefaultSchedulerCallable,
+        metric: MetricCallable = MultiClassClsMetricCallable,
+        torch_compile: bool = False,
+    ) -> None:
+        super().__init__(
+            label_info=label_info,
+            data_input_params=data_input_params,
+            model_name=model_name,
+            freeze_backbone=freeze_backbone,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            metric=metric,
+            torch_compile=torch_compile,
+        )
+
+    def _create_model(self, num_classes: int | None = None) -> nn.Module:
+        num_classes = num_classes if num_classes is not None else self.num_classes
+        backbone = ShuffleNetV2Backbone(model_name=self.model_name, input_size=self.data_input_params.input_size)
+        backbone_out_chennels = ShuffleNetV2Backbone.SHUFFLENETV2_CFG[self.model_name]["out_channels"]
+        neck = GlobalAveragePooling(dim=2)
+
+        return ImageClassifier(
+            backbone=backbone,
+            neck=neck,
+            head=LinearClsHead(
+                num_classes=num_classes,
+                in_channels=backbone_out_chennels,
+            ),
+            loss=nn.CrossEntropyLoss(),
+        )
+
+    def load_from_otx_v1_ckpt(self, state_dict: dict, add_prefix: str = "model.") -> dict:
+        """Load the previous OTX ckpt according to OTX2.0."""
+        return state_dict
+
+    def forward_for_tracing(self, image: Tensor) -> Tensor | dict[str, Tensor]:
+        """Model forward function used for the model tracing during model exportation."""
+        if self.explain_mode:
+            return self.model(images=image, mode="explain")
+
+        return self.model(images=image, mode="tensor")

--- a/lib/src/otx/recipe/classification/multi_class_cls/shufflenet_v2.yaml
+++ b/lib/src/otx/recipe/classification/multi_class_cls/shufflenet_v2.yaml
@@ -1,0 +1,50 @@
+task: MULTI_CLASS_CLS
+model:
+  class_path: otx.backend.native.models.classification.multiclass_models.shufflenet_v2.ShuffleNetV2MulticlassCls
+  init_args:
+    model_name: shufflenetv2_large
+    label_info: 1000
+    freeze_backbone: False
+
+    optimizer:
+      class_path: torch.optim.SGD
+      init_args:
+        lr: 0.0058
+        momentum: 0.9
+        weight_decay: 0.0001
+
+    scheduler:
+      class_path: otx.backend.native.schedulers.LinearWarmupSchedulerCallable
+      init_args:
+        num_warmup_steps: 10
+        main_scheduler_callable:
+          class_path: lightning.pytorch.cli.ReduceLROnPlateau
+          init_args:
+            mode: max
+            factor: 0.5
+            patience: 3
+            monitor: val/accuracy
+
+engine:
+  device: auto
+
+callback_monitor: val/accuracy
+
+data: ../../_base_/data/classification.yaml
+
+callbacks:
+  - class_path: otx.backend.native.callbacks.adaptive_early_stopping.EarlyStoppingWithWarmup
+    init_args:
+      patience: 5
+  - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+    init_args:
+      dirpath: "" # use engine.work_dir
+      monitor: val/accuracy
+      mode: max
+      save_top_k: 1
+      save_last: true
+      auto_insert_metric_name: false
+      filename: "checkpoints/epoch_{epoch:03d}"
+
+overrides:
+  max_epochs: 90

--- a/lib/tests/unit/backend/native/models/classification/backbones/test_otx_shufflenet_v2.py
+++ b/lib/tests/unit/backend/native/models/classification/backbones/test_otx_shufflenet_v2.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from otx.backend.native.models.classification.backbones.shufflenet_v2 import ShuffleNetV2Backbone
+
+
+class TestOTXShuffleNetV2:
+    def test_forward_large(self):
+        model = ShuffleNetV2Backbone(model_name="shufflenetv2_large")
+        output = model(torch.randn(1, 3, 224, 224))
+        assert output[0].shape == torch.Size([1, 1024, 7, 7])
+
+    def test_forward_small(self):
+        model = ShuffleNetV2Backbone(model_name="shufflenetv2_small")
+        output = model(torch.randn(1, 3, 224, 224))
+        assert output[0].shape == torch.Size([1, 1024, 7, 7])
+
+    def test_input_size_respected(self):
+        model = ShuffleNetV2Backbone(model_name="shufflenetv2_large", input_size=(64, 64))
+        assert model.in_size == (64, 64)
+        # Small input: first conv stride=1 instead of 2
+        output = model(torch.randn(1, 3, 64, 64))
+        assert output[0].shape[0] == 1
+        assert output[0].shape[1] == 1024
+
+    def test_invalid_model_name(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="Unknown ShuffleNetV2 model"):
+            ShuffleNetV2Backbone(model_name="invalid_model")

--- a/lib/tests/unit/backend/native/models/classification/test_shufflenet_v2.py
+++ b/lib/tests/unit/backend/native/models/classification/test_shufflenet_v2.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from otx.backend.native.models.base import DataInputParams
+from otx.backend.native.models.classification.classifier import ImageClassifier
+from otx.backend.native.models.classification.multiclass_models.shufflenet_v2 import ShuffleNetV2MulticlassCls
+from otx.data.entity.base import OTXBatchLossEntity
+from otx.data.entity.torch import OTXPredBatch
+
+
+@pytest.fixture()
+def fxt_multi_class_cls_model():
+    return ShuffleNetV2MulticlassCls(
+        model_name="shufflenetv2_large",
+        label_info=10,
+        data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+    )
+
+
+class TestShuffleNetV2MulticlassCls:
+    def test_create_model(self, fxt_multi_class_cls_model):
+        assert isinstance(fxt_multi_class_cls_model.model, ImageClassifier)
+
+    def test_customize_inputs(self, fxt_multi_class_cls_model, fxt_multiclass_cls_batch_data_entity):
+        outputs = fxt_multi_class_cls_model._customize_inputs(fxt_multiclass_cls_batch_data_entity)
+        assert "images" in outputs
+        assert "labels" in outputs
+        assert "mode" in outputs
+
+    def test_customize_outputs(self, fxt_multi_class_cls_model, fxt_multiclass_cls_batch_data_entity):
+        outputs = torch.randn(2, 10)
+        fxt_multi_class_cls_model.training = True
+        preds = fxt_multi_class_cls_model._customize_outputs(outputs, fxt_multiclass_cls_batch_data_entity)
+        assert isinstance(preds, OTXBatchLossEntity)
+
+        fxt_multi_class_cls_model.training = False
+        preds = fxt_multi_class_cls_model._customize_outputs(outputs, fxt_multiclass_cls_batch_data_entity)
+        assert isinstance(preds, OTXPredBatch)
+
+    @pytest.mark.parametrize("explain_mode", [True, False])
+    def test_predict_step(self, fxt_multi_class_cls_model, fxt_multiclass_cls_batch_data_entity, explain_mode):
+        fxt_multi_class_cls_model.eval()
+        fxt_multi_class_cls_model.explain_mode = explain_mode
+        outputs = fxt_multi_class_cls_model.predict_step(batch=fxt_multiclass_cls_batch_data_entity, batch_idx=0)
+
+        assert isinstance(outputs, OTXPredBatch)
+        assert outputs.has_xai_outputs == explain_mode
+
+    def test_set_input_size(self):
+        data_input_params = DataInputParams((300, 300), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+        model = ShuffleNetV2MulticlassCls(
+            model_name="shufflenetv2_large",
+            label_info=10,
+            data_input_params=data_input_params,
+        )
+        assert model.model.backbone.in_size == data_input_params.input_size[-2:]
+
+    def test_freeze_backbone(self):
+        data_input_params = DataInputParams((300, 300), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+
+        model = ShuffleNetV2MulticlassCls(
+            model_name="shufflenetv2_large",
+            label_info=10,
+            data_input_params=data_input_params,
+            freeze_backbone=True,
+        )
+
+        classification_layers = model._identify_classification_layers()
+        assert all(param.requires_grad == (name in classification_layers) for name, param in model.named_parameters())
+
+        model = ShuffleNetV2MulticlassCls(
+            model_name="shufflenetv2_large",
+            label_info=10,
+            data_input_params=data_input_params,
+            freeze_backbone=False,
+        )
+
+        assert all(param.requires_grad for param in model.parameters())
+
+    def test_small_variant(self):
+        model = ShuffleNetV2MulticlassCls(
+            model_name="shufflenetv2_small",
+            label_info=10,
+            data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+        )
+        assert isinstance(model.model, ImageClassifier)


### PR DESCRIPTION
# GSoC 2026 pre-requisite task

  Integrated ShuffleNetV2 (x0.5 small, x1.0 large variants) as a multiclass classification model into the OTX
  codebase, as a pre-requisite task for GSoC 2026.

  ## What was added
  - **Backbone**: ShuffleNetV2 architecture with channel shuffle and inverted residual blocks
  - **Multiclass model**: `ShuffleNetV2MulticlassCls` with GAP neck + linear head
  - **Factory**: `ShuffleNetV2` factory class for model instantiation
  - **Recipe**: `shufflenet_v2.yaml` for CLI training
  - **Unit tests**: Backbone forward pass, model creation, inputs/outputs, freeze backbone, etc.
  - **Registration**: All relevant `__init__.py` and `factory.py` exports

  ## Training results

  Trained on a small 3-class synthetic dataset (shapes) for 10 epochs on CPU. 33.3% accuracy matches random chance
  on 3 classes — the model trains and evaluates correctly, but needs more epochs/data to converge.

  | Metric | Value |
  |---|---|
  | lr-SGD | 0.0058 |
  | lr-SGD-momentum | 0.9 |
  | train/loss | 1.0078 |
  | train/total_loss | 1.0078 |
  | train/data_time | 0.0005s |
  | train/iter_time | 2.4139s |
  | validation/data_time | 0.0s |
  | validation/iter_time | 0.2779s |
  | **val/accuracy** | **0.3333** |