### PR TITLE
Add a work-around for OV inference

### DIFF
--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from uuid import UUID
 
 from loguru import logger
-from model_api.adapters import OpenvinoAdapter, create_core
+from model_api.adapters import create_core
 from model_api.models import Model
 
 from app.db.engine import get_db_session
@@ -15,7 +15,7 @@ from app.models.model_activation import ModelActivationState
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.repositories import ModelRevisionRepository, ModelVariantRepository
 from app.repositories.active_model_repo import ActiveModelRepo
-from app.utils.ir_format import FP32OpenvinoAdapter, needs_float32_input
+from app.utils.ir_format import FP32OpenvinoAdapter
 
 MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
 
@@ -26,7 +26,6 @@ class LoadedModel:
     model_variant_id: UUID
     model: Model
     device: str
-    float32_input: bool  # True → InferenceWorker must scale images to [0,1] float32
 
 
 @dataclass(frozen=True)
@@ -161,15 +160,8 @@ class ActiveModelService:
                     variant_id=active_variant_id,
                     extension="bin",
                 )
-                use_float32 = needs_float32_input(model_xml_path)
                 ie = create_core()
-                adapter_cls = FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
-                logger.info(
-                    "IR format detected: {} (float32_input={})",
-                    model_xml_path.name,
-                    use_float32,
-                )
-                adapter = adapter_cls(
+                adapter = FP32OpenvinoAdapter(
                     ie,
                     str(model_xml_path),
                     device=device,
@@ -185,6 +177,5 @@ class ActiveModelService:
                 model=mapi_model,
                 model_variant_id=active_variant_id,
                 device=device,
-                float32_input=use_float32,
             )
         return self._loaded_model

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -15,21 +15,9 @@ from app.models.model_activation import ModelActivationState
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.repositories import ModelRevisionRepository, ModelVariantRepository
 from app.repositories.active_model_repo import ActiveModelRepo
-from app.utils.ir_format import needs_float32_input
+from app.utils.ir_format import FP32OpenvinoAdapter, needs_float32_input
 
 MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
-
-
-class _FP32OpenvinoAdapter(OpenvinoAdapter):
-    """OpenvinoAdapter that forces float32 input tensors.
-
-    Used when the IR embeds mean/std in the 0-1 scale (new OTX format).
-    Overrides ``embed_preprocessing`` so ModelAPI sets the input tensor to f32.
-    """
-
-    def embed_preprocessing(self, *args, **kwargs) -> None:
-        kwargs["dtype"] = float
-        super().embed_preprocessing(*args, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -175,7 +163,7 @@ class ActiveModelService:
                 )
                 use_float32 = needs_float32_input(model_xml_path)
                 ie = create_core()
-                adapter_cls = _FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
+                adapter_cls = FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
                 logger.info(
                     "IR format detected: {} (float32_input={})",
                     model_xml_path.name,

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from uuid import UUID
 
 from loguru import logger
+from model_api.adapters import OpenvinoAdapter, create_core
 from model_api.models import Model
 
 from app.db.engine import get_db_session
@@ -14,8 +15,21 @@ from app.models.model_activation import ModelActivationState
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.repositories import ModelRevisionRepository, ModelVariantRepository
 from app.repositories.active_model_repo import ActiveModelRepo
+from app.utils.ir_format import needs_float32_input
 
 MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
+
+
+class _FP32OpenvinoAdapter(OpenvinoAdapter):
+    """OpenvinoAdapter that forces float32 input tensors.
+
+    Used when the IR embeds mean/std in the 0-1 scale (new OTX format).
+    Overrides ``embed_preprocessing`` so ModelAPI sets the input tensor to f32.
+    """
+
+    def embed_preprocessing(self, *args, **kwargs) -> None:
+        kwargs["dtype"] = float
+        super().embed_preprocessing(*args, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -24,6 +38,7 @@ class LoadedModel:
     model_variant_id: UUID
     model: Model
     device: str
+    float32_input: bool  # True → InferenceWorker must scale images to [0,1] float32
 
 
 @dataclass(frozen=True)
@@ -158,11 +173,20 @@ class ActiveModelService:
                     variant_id=active_variant_id,
                     extension="bin",
                 )
-                mapi_model = Model.create_model(
-                    model=str(model_xml_path),
-                    device=device,
-                    nstreams=MODELAPI_NSTREAMS,
+                use_float32 = needs_float32_input(model_xml_path)
+                ie = create_core()
+                adapter_cls = _FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
+                logger.info(
+                    "IR format detected: {} (float32_input={})",
+                    model_xml_path.name, use_float32,
                 )
+                adapter = adapter_cls(
+                    ie,
+                    str(model_xml_path),
+                    device=device,
+                    max_num_requests=int(MODELAPI_NSTREAMS),
+                )
+                mapi_model = Model.create_model(adapter)
             except FileNotFoundError:
                 logger.exception("Failed to load model with ID '{}'", active_model_id)
                 return None
@@ -172,5 +196,6 @@ class ActiveModelService:
                 model=mapi_model,
                 model_variant_id=active_variant_id,
                 device=device,
+                float32_input=use_float32,
             )
         return self._loaded_model

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -178,7 +178,8 @@ class ActiveModelService:
                 adapter_cls = _FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
                 logger.info(
                     "IR format detected: {} (float32_input={})",
-                    model_xml_path.name, use_float32,
+                    model_xml_path.name,
+                    use_float32,
                 )
                 adapter = adapter_cls(
                     ie,

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -18,21 +18,9 @@ from app.models.inference import InferenceModel, InferenceState, InferenceStatus
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.services import ResourceNotFoundError, ResourceType
 from app.services.data_collect.prediction_converter import convert_prediction
-from app.utils.ir_format import needs_float32_input
+from app.utils.ir_format import FP32OpenvinoAdapter, needs_float32_input
 
 MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
-
-
-class _FP32OpenvinoAdapter(OpenvinoAdapter):
-    """OpenvinoAdapter that forces float32 input tensors.
-
-    Used when the IR embeds mean/std in the 0-1 scale (new OTX format).
-    Overrides ``embed_preprocessing`` so ModelAPI sets the input tensor to f32.
-    """
-
-    def embed_preprocessing(self, *args, **kwargs) -> None:
-        kwargs["dtype"] = float
-        super().embed_preprocessing(*args, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -114,7 +102,7 @@ class InferenceServer:
 
                 use_float32 = needs_float32_input(model_xml_path)
                 ie = create_core()
-                adapter_cls = _FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
+                adapter_cls = FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
                 logger.info(
                     "IR format detected: {} (float32_input={})",
                     model_xml_path.name,

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -7,7 +7,9 @@ from datetime import datetime
 from pathlib import Path
 from uuid import UUID
 
+import numpy as np
 from loguru import logger
+from model_api.adapters import OpenvinoAdapter, create_core
 from model_api.models import Model
 
 from app.db import get_db_session
@@ -16,8 +18,21 @@ from app.models.inference import InferenceModel, InferenceState, InferenceStatus
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.services import ResourceNotFoundError, ResourceType
 from app.services.data_collect.prediction_converter import convert_prediction
+from app.utils.ir_format import needs_float32_input
 
 MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
+
+
+class _FP32OpenvinoAdapter(OpenvinoAdapter):
+    """OpenvinoAdapter that forces float32 input tensors.
+
+    Used when the IR embeds mean/std in the 0-1 scale (new OTX format).
+    Overrides ``embed_preprocessing`` so ModelAPI sets the input tensor to f32.
+    """
+
+    def embed_preprocessing(self, *args, **kwargs) -> None:
+        kwargs["dtype"] = float
+        super().embed_preprocessing(*args, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -26,6 +41,7 @@ class _LoadedModel:
     model: Model
     device: str
     load_timestamp: datetime
+    float32_input: bool  # True → scale images to [0,1] float32 before inference
 
 
 class InferenceServer:
@@ -96,13 +112,23 @@ class InferenceServer:
                     )
                 model_xml_path, _ = paths
 
-                model = Model.create_model(
-                    model=str(model_xml_path),
-                    device=device,
-                    nstreams=MODELAPI_NSTREAMS,
+                use_float32 = needs_float32_input(model_xml_path)
+                ie = create_core()
+                adapter_cls = _FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
+                logger.info(
+                    "IR format detected: {} (float32_input={})",
+                    model_xml_path.name, use_float32,
                 )
+                adapter = adapter_cls(
+                    ie,
+                    str(model_xml_path),
+                    device=device,
+                    max_num_requests=int(MODELAPI_NSTREAMS),
+                )
+                model = Model.create_model(adapter)
                 self._loaded_model = _LoadedModel(
-                    id=model_id, model=model, device=device, load_timestamp=datetime.now()
+                    id=model_id, model=model, device=device,
+                    load_timestamp=datetime.now(), float32_input=use_float32,
                 )
                 return True
         finally:
@@ -151,7 +177,12 @@ class InferenceServer:
                 raise RuntimeError("No model loaded for inference")
             logger.debug("Running inference on batch of {} inputs", len(inputs))
 
-            input_data = [input.data for input in inputs]
+            if self._loaded_model.float32_input:
+                # New OTX format: IR mean/std in 0-1 scale → pre-scale images to float32 [0, 1].
+                input_data = [inp.data.astype(np.float32) / 255.0 for inp in inputs]
+            else:
+                # Old OTX format: IR mean/std in uint8 (0-255) scale → pass raw uint8 images.
+                input_data = [inp.data for inp in inputs]
             inference_result = self._loaded_model.model.infer_batch(input_data)
         finally:
             self._lock.release()

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -117,7 +117,8 @@ class InferenceServer:
                 adapter_cls = _FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
                 logger.info(
                     "IR format detected: {} (float32_input={})",
-                    model_xml_path.name, use_float32,
+                    model_xml_path.name,
+                    use_float32,
                 )
                 adapter = adapter_cls(
                     ie,
@@ -127,8 +128,11 @@ class InferenceServer:
                 )
                 model = Model.create_model(adapter)
                 self._loaded_model = _LoadedModel(
-                    id=model_id, model=model, device=device,
-                    load_timestamp=datetime.now(), float32_input=use_float32,
+                    id=model_id,
+                    model=model,
+                    device=device,
+                    load_timestamp=datetime.now(),
+                    float32_input=use_float32,
                 )
                 return True
         finally:

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 import numpy as np
 from loguru import logger
-from model_api.adapters import OpenvinoAdapter, create_core
+from model_api.adapters import create_core
 from model_api.models import Model
 
 from app.db import get_db_session
@@ -18,7 +18,7 @@ from app.models.inference import InferenceModel, InferenceState, InferenceStatus
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.services import ResourceNotFoundError, ResourceType
 from app.services.data_collect.prediction_converter import convert_prediction
-from app.utils.ir_format import FP32OpenvinoAdapter, needs_float32_input
+from app.utils.ir_format import FP32OpenvinoAdapter
 
 MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
 
@@ -29,7 +29,6 @@ class _LoadedModel:
     model: Model
     device: str
     load_timestamp: datetime
-    float32_input: bool  # True → scale images to [0,1] float32 before inference
 
 
 class InferenceServer:
@@ -100,15 +99,8 @@ class InferenceServer:
                     )
                 model_xml_path, _ = paths
 
-                use_float32 = needs_float32_input(model_xml_path)
                 ie = create_core()
-                adapter_cls = FP32OpenvinoAdapter if use_float32 else OpenvinoAdapter
-                logger.info(
-                    "IR format detected: {} (float32_input={})",
-                    model_xml_path.name,
-                    use_float32,
-                )
-                adapter = adapter_cls(
+                adapter = FP32OpenvinoAdapter(
                     ie,
                     str(model_xml_path),
                     device=device,
@@ -120,7 +112,6 @@ class InferenceServer:
                     model=model,
                     device=device,
                     load_timestamp=datetime.now(),
-                    float32_input=use_float32,
                 )
                 return True
         finally:
@@ -169,12 +160,7 @@ class InferenceServer:
                 raise RuntimeError("No model loaded for inference")
             logger.debug("Running inference on batch of {} inputs", len(inputs))
 
-            if self._loaded_model.float32_input:
-                # New OTX format: IR mean/std in 0-1 scale → pre-scale images to float32 [0, 1].
-                input_data = [inp.data.astype(np.float32) / 255.0 for inp in inputs]
-            else:
-                # Old OTX format: IR mean/std in uint8 (0-255) scale → pass raw uint8 images.
-                input_data = [inp.data for inp in inputs]
+            input_data = [inp.data.astype(np.float32) / 255.0 for inp in inputs]
             inference_result = self._loaded_model.model.infer_batch(input_data)
         finally:
             self._lock.release()

--- a/application/backend/app/utils/ir_format.py
+++ b/application/backend/app/utils/ir_format.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for inspecting OpenVINO IR model metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import defusedxml.ElementTree as ET
+
+# Values above this threshold mean the IR stores mean/std in uint8 (0-255) scale.
+_UINT8_SCALE_THRESHOLD = 1.0
+
+
+def needs_float32_input(model_xml_path: str | Path) -> bool:
+    """Return True if the IR expects float32 [0, 1] inputs (new OTX format).
+
+    Reads ``mean_values`` and ``scale_values`` from the IR's ``<rt_info>``
+    block.  If all values are <= 1.0 the model was exported with the new
+    0-1 normalisation scale and callers must:
+
+    * Pass images pre-scaled to ``float32 / 255``.
+    * Load the model via ``_FP32OpenvinoAdapter`` so that ModelAPI sets the
+      input tensor type to ``f32``.
+
+    If any value exceeds the threshold the IR uses the old uint8 scale
+    (e.g. ``mean_values = 123.675 116.28 103.53``), and raw ``uint8``
+    images should be passed as usual with the default ``OpenvinoAdapter``.
+
+    When no ``mean_values`` / ``scale_values`` are present in the IR, the
+    model has no embedded normalisation and raw ``uint8`` images are safe
+    (returns ``False``).
+
+    Args:
+        model_xml_path: Path to the ``.xml`` file of the OpenVINO IR model.
+
+    Returns:
+        ``True``  → new 0-1 scale → use ``_FP32OpenvinoAdapter`` + scale to float32.
+        ``False`` → old uint8 scale (or no normalisation) → use default adapter + uint8 input.
+    """
+    tree = ET.parse(str(model_xml_path))
+    rt_info = tree.getroot().find("rt_info")
+    if rt_info is None:
+        return False
+
+    def _parse_values(tag: str) -> list[float]:
+        el = rt_info.find(f".//{tag}")
+        if el is None:
+            return []
+        raw = el.attrib.get("value", "").strip()
+        if not raw:
+            return []
+        try:
+            return [float(v) for v in raw.split()]
+        except ValueError:
+            return []
+
+    mean_values  = _parse_values("mean_values")
+    scale_values = _parse_values("scale_values")
+
+    all_values = mean_values + scale_values
+    if not all_values:
+        # No normalisation embedded — treat as uint8.
+        return False
+
+    return all(v <= _UINT8_SCALE_THRESHOLD for v in all_values)

--- a/application/backend/app/utils/ir_format.py
+++ b/application/backend/app/utils/ir_format.py
@@ -1,18 +1,12 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Utilities for inspecting OpenVINO IR model metadata."""
+"""OpenVINO IR adapter for float32 [0-1] input models."""
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
-import defusedxml.ElementTree as ET  # noqa: N817
-from loguru import logger
 from model_api.adapters import OpenvinoAdapter
-
-# Values above this threshold mean the IR stores mean/std in uint8 (0-255) scale.
-_UINT8_SCALE_THRESHOLD = 1.0
 
 
 class FP32OpenvinoAdapter(OpenvinoAdapter):
@@ -55,47 +49,3 @@ def _patch_pad_constant_type(embed_fn: Any, *args: Any, **kwargs: Any) -> None:
         embed_fn(*args, **kwargs)
     finally:
         _opset.pad = _orig_pad
-
-
-def needs_float32_input(model_xml_path: str | Path) -> bool:
-    """Check whether the IR uses 0-1 normalisation scale (new OTX format).
-
-    Args:
-        model_xml_path: Path to the ``.xml`` IR file.
-
-    Returns:
-        True if all mean/scale values in rt_info are <= 1.0, False otherwise.
-    """
-    try:
-        tree = ET.parse(str(model_xml_path))
-    except (OSError, ET.ParseError):
-        logger.warning("Failed to parse IR XML '{}'; assuming uint8 input format", model_xml_path)
-        return False
-    root = tree.getroot()
-    if root is None:
-        return False
-    rt_info = root.find("rt_info")
-    if rt_info is None:
-        return False
-
-    def _parse_values(node: ET.Element, tag: str) -> list[float]:
-        el = node.find(f".//{tag}")
-        if el is None:
-            return []
-        raw = el.attrib.get("value", "").strip()
-        if not raw:
-            return []
-        try:
-            return [float(v) for v in raw.split()]
-        except ValueError:
-            return []
-
-    mean_values = _parse_values(rt_info, "mean_values")
-    scale_values = _parse_values(rt_info, "scale_values")
-
-    all_values = mean_values + scale_values
-    if not all_values:
-        # No normalisation embedded — treat as uint8.
-        return False
-
-    return all(v <= _UINT8_SCALE_THRESHOLD for v in all_values)

--- a/application/backend/app/utils/ir_format.py
+++ b/application/backend/app/utils/ir_format.py
@@ -5,11 +5,27 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import defusedxml.ElementTree as ET  # noqa: N817
+from loguru import logger
+from model_api.adapters import OpenvinoAdapter
 
 # Values above this threshold mean the IR stores mean/std in uint8 (0-255) scale.
 _UINT8_SCALE_THRESHOLD = 1.0
+
+
+class FP32OpenvinoAdapter(OpenvinoAdapter):
+    """OpenvinoAdapter that forces float32 input tensors.
+
+    Used when the IR embeds mean/std in the 0-1 scale (new OTX format).
+    Overrides ``embed_preprocessing`` so ModelAPI sets the input tensor to f32.
+    """
+
+    def embed_preprocessing(self, *args: Any, **kwargs: Any) -> None:
+        """Force dtype to float so ModelAPI creates an f32 input tensor."""
+        kwargs["dtype"] = float
+        super().embed_preprocessing(*args, **kwargs)
 
 
 def needs_float32_input(model_xml_path: str | Path) -> bool:
@@ -20,7 +36,7 @@ def needs_float32_input(model_xml_path: str | Path) -> bool:
     0-1 normalisation scale and callers must:
 
     * Pass images pre-scaled to ``float32 / 255``.
-    * Load the model via ``_FP32OpenvinoAdapter`` so that ModelAPI sets the
+        * Load the model via ``FP32OpenvinoAdapter`` so that ModelAPI sets the
       input tensor type to ``f32``.
 
     If any value exceeds the threshold the IR uses the old uint8 scale
@@ -35,10 +51,14 @@ def needs_float32_input(model_xml_path: str | Path) -> bool:
         model_xml_path: Path to the ``.xml`` file of the OpenVINO IR model.
 
     Returns:
-        ``True``  → new 0-1 scale → use ``_FP32OpenvinoAdapter`` + scale to float32.
+        ``True``  → new 0-1 scale → use ``FP32OpenvinoAdapter`` + scale to float32.
         ``False`` → old uint8 scale (or no normalisation) → use default adapter + uint8 input.
     """
-    tree = ET.parse(str(model_xml_path))
+    try:
+        tree = ET.parse(str(model_xml_path))
+    except (OSError, ET.ParseError):
+        logger.warning("Failed to parse IR XML '{}'; assuming uint8 input format", model_xml_path)
+        return False
     root = tree.getroot()
     if root is None:
         return False

--- a/application/backend/app/utils/ir_format.py
+++ b/application/backend/app/utils/ir_format.py
@@ -16,43 +16,55 @@ _UINT8_SCALE_THRESHOLD = 1.0
 
 
 class FP32OpenvinoAdapter(OpenvinoAdapter):
-    """OpenvinoAdapter that forces float32 input tensors.
-
-    Used when the IR embeds mean/std in the 0-1 scale (new OTX format).
-    Overrides ``embed_preprocessing`` so ModelAPI sets the input tensor to f32.
-    """
+    """OpenvinoAdapter that forces float32 input tensors (0-1 scale IRs)."""
 
     def embed_preprocessing(self, *args: Any, **kwargs: Any) -> None:
-        """Force dtype to float so ModelAPI creates an f32 input tensor."""
         kwargs["dtype"] = float
-        super().embed_preprocessing(*args, **kwargs)
+        _patch_pad_constant_type(super().embed_preprocessing, *args, **kwargs)
+
+
+def _patch_pad_constant_type(embed_fn: Any, *args: Any, **kwargs: Any) -> None:
+    """Call ``embed_fn`` while monkey-patching ``opset.pad`` to fix pad-value dtype.
+
+    ModelAPI hardcodes pad constants as ``uint8``.  With f32 input this causes
+    a type-mismatch error, so we temporarily wrap ``opset.pad`` to insert a
+    ``Convert`` when the element types differ.
+    """
+    import model_api.adapters.utils as _mapi_utils
+
+    _opset = _mapi_utils.opset
+    _orig_pad = _opset.pad
+
+    def _pad_with_type_cast(
+        arg: Any,
+        pads_begin: Any,
+        pads_end: Any,
+        pad_mode: str,
+        arg_pad_value: Any = None,
+        name: Any = None,
+    ) -> Any:
+        if arg_pad_value is not None:
+            data_et = arg.get_element_type()
+            pad_et = arg_pad_value.get_element_type()
+            if data_et != pad_et:
+                arg_pad_value = _opset.convert(arg_pad_value, data_et)
+        return _orig_pad(arg, pads_begin, pads_end, pad_mode, arg_pad_value, name)
+
+    _opset.pad = _pad_with_type_cast  # pyrefly: ignore[bad-assignment]
+    try:
+        embed_fn(*args, **kwargs)
+    finally:
+        _opset.pad = _orig_pad
 
 
 def needs_float32_input(model_xml_path: str | Path) -> bool:
-    """Return True if the IR expects float32 [0, 1] inputs (new OTX format).
-
-    Reads ``mean_values`` and ``scale_values`` from the IR's ``<rt_info>``
-    block.  If all values are <= 1.0 the model was exported with the new
-    0-1 normalisation scale and callers must:
-
-    * Pass images pre-scaled to ``float32 / 255``.
-        * Load the model via ``FP32OpenvinoAdapter`` so that ModelAPI sets the
-      input tensor type to ``f32``.
-
-    If any value exceeds the threshold the IR uses the old uint8 scale
-    (e.g. ``mean_values = 123.675 116.28 103.53``), and raw ``uint8``
-    images should be passed as usual with the default ``OpenvinoAdapter``.
-
-    When no ``mean_values`` / ``scale_values`` are present in the IR, the
-    model has no embedded normalisation and raw ``uint8`` images are safe
-    (returns ``False``).
+    """Check whether the IR uses 0-1 normalisation scale (new OTX format).
 
     Args:
-        model_xml_path: Path to the ``.xml`` file of the OpenVINO IR model.
+        model_xml_path: Path to the ``.xml`` IR file.
 
     Returns:
-        ``True``  → new 0-1 scale → use ``FP32OpenvinoAdapter`` + scale to float32.
-        ``False`` → old uint8 scale (or no normalisation) → use default adapter + uint8 input.
+        True if all mean/scale values in rt_info are <= 1.0, False otherwise.
     """
     try:
         tree = ET.parse(str(model_xml_path))

--- a/application/backend/app/utils/ir_format.py
+++ b/application/backend/app/utils/ir_format.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import defusedxml.ElementTree as ET
+import defusedxml.ElementTree as ET  # noqa: N817
 
 # Values above this threshold mean the IR stores mean/std in uint8 (0-255) scale.
 _UINT8_SCALE_THRESHOLD = 1.0
@@ -39,12 +39,15 @@ def needs_float32_input(model_xml_path: str | Path) -> bool:
         ``False`` → old uint8 scale (or no normalisation) → use default adapter + uint8 input.
     """
     tree = ET.parse(str(model_xml_path))
-    rt_info = tree.getroot().find("rt_info")
+    root = tree.getroot()
+    if root is None:
+        return False
+    rt_info = root.find("rt_info")
     if rt_info is None:
         return False
 
-    def _parse_values(tag: str) -> list[float]:
-        el = rt_info.find(f".//{tag}")
+    def _parse_values(node: ET.Element, tag: str) -> list[float]:
+        el = node.find(f".//{tag}")
         if el is None:
             return []
         raw = el.attrib.get("value", "").strip()
@@ -55,8 +58,8 @@ def needs_float32_input(model_xml_path: str | Path) -> bool:
         except ValueError:
             return []
 
-    mean_values  = _parse_values("mean_values")
-    scale_values = _parse_values("scale_values")
+    mean_values = _parse_values(rt_info, "mean_values")
+    scale_values = _parse_values(rt_info, "scale_values")
 
     all_values = mean_values + scale_values
     if not all_values:

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -194,8 +194,13 @@ class InferenceWorker(BaseProcessWorker):
 
                     inference_start_time = self._metrics_service.record_inference_start()  # type: ignore
                     self._prediction_buffer.register_expected_timestamp(inference_start_time)
+                    rgb_frame = cv2.cvtColor(item.frame_data, cv2.COLOR_BGR2RGB)
+                    if self._loaded_model.float32_input:
+                        # New OTX format: IR mean/std in 0-1 scale → pre-scale to float32 [0, 1].
+                        rgb_frame = rgb_frame.astype("float32") / 255.0
+                    # else: old OTX format → pass raw uint8 as-is.
                     model.infer_async(
-                        cv2.cvtColor(item.frame_data, cv2.COLOR_BGR2RGB),  # models expect RGB input
+                        rgb_frame,
                         user_data={
                             "stream_data": item,
                             "model_id": self._loaded_model.model_revision_id,

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -195,10 +195,7 @@ class InferenceWorker(BaseProcessWorker):
                     inference_start_time = self._metrics_service.record_inference_start()  # type: ignore
                     self._prediction_buffer.register_expected_timestamp(inference_start_time)
                     rgb_frame = cv2.cvtColor(item.frame_data, cv2.COLOR_BGR2RGB)
-                    if self._loaded_model.float32_input:
-                        # New OTX format: IR mean/std in 0-1 scale → pre-scale to float32 [0, 1].
-                        rgb_frame = rgb_frame.astype("float32") / 255.0
-                    # else: old OTX format → pass raw uint8 as-is.
+                    rgb_frame = rgb_frame.astype("float32") / 255.0
                     model.infer_async(
                         rgb_frame,
                         user_data={

--- a/application/backend/tests/unit/services/inference/test_inference_server.py
+++ b/application/backend/tests/unit/services/inference/test_inference_server.py
@@ -123,7 +123,7 @@ class TestInferenceServer:
             ),
             patch("app.services.inference.inference_server.needs_float32_input", return_value=True),
             patch("app.services.inference.inference_server.create_core"),
-            patch("app.services.inference.inference_server._FP32OpenvinoAdapter") as mock_fp32_adapter,
+            patch("app.services.inference.inference_server.FP32OpenvinoAdapter") as mock_fp32_adapter,
         ):
             model_loaded = inference_server.set_inference_model(
                 project_id=project_id, model_id=model_id, device=device, ttl=60

--- a/application/backend/tests/unit/services/inference/test_inference_server.py
+++ b/application/backend/tests/unit/services/inference/test_inference_server.py
@@ -48,6 +48,9 @@ class TestInferenceServer:
                 attribute="get_model_binary_files",
                 return_value=(True, (tmp_path / "model.xml", tmp_path / "model.bin")),
             ) as mock_get_model_binary_files,
+            patch("app.services.inference.inference_server.needs_float32_input", return_value=False) as mock_needs_fp32,
+            patch("app.services.inference.inference_server.create_core") as mock_create_core,
+            patch("app.services.inference.inference_server.OpenvinoAdapter") as mock_ov_adapter,
         ):
             model_loaded = inference_server.set_inference_model(
                 project_id=project_id, model_id=model_id, device=device, ttl=60
@@ -59,13 +62,21 @@ class TestInferenceServer:
                 and inference_server._loaded_model.id == model_id
                 and inference_server._loaded_model.model == model
                 and inference_server._loaded_model.device == device
+                and inference_server._loaded_model.float32_input is False
             )
 
             mock_get_model_variants.assert_called_once_with(project_id=project_id, model_id=model_id)
             mock_get_model_binary_files.assert_called_once_with(
                 project_id=project_id, model_id=model_id, model_variant_id=model_variant_id
             )
-            mock_create_model.assert_called_once_with(model=str(tmp_path / "model.xml"), device=device, nstreams="2")
+            mock_needs_fp32.assert_called_once_with(tmp_path / "model.xml")
+            mock_ov_adapter.assert_called_once_with(
+                mock_create_core.return_value,
+                str(tmp_path / "model.xml"),
+                device=device,
+                max_num_requests=2,
+            )
+            mock_create_model.assert_called_once_with(mock_ov_adapter.return_value)
 
     def test_set_inference_model_already_loaded(self, tmp_path) -> None:
         project_id = uuid4()
@@ -76,7 +87,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=model_id, model=model, device=device, load_timestamp=datetime.now()
+            id=model_id, model=model, device=device, load_timestamp=datetime.now(), float32_input=False
         )
 
         model_loaded = inference_server.set_inference_model(
@@ -87,6 +98,41 @@ class TestInferenceServer:
         assert inference_server._loaded_model.id == model_id
         assert inference_server._loaded_model.model == model
         assert inference_server._loaded_model.device == device
+
+    def test_set_inference_model_fp32(self, tmp_path) -> None:
+        """IR with 0-1 normalisation scale → float32_input=True and _FP32OpenvinoAdapter is used."""
+        project_id = uuid4()
+        model_id = uuid4()
+        model_variant_id = uuid4()
+        device = "AUTO"
+
+        model_variant = MagicMock(
+            spec=ModelVariant, id=model_variant_id, format=ModelFormat.OPENVINO, precision=ModelPrecision.FP16
+        )
+
+        inference_server = InferenceServer(data_dir=Path(tmp_path))
+        model = MagicMock(spec=Model)
+
+        with (
+            patch("model_api.models.Model.create_model", return_value=model),
+            patch.object(ModelService, "get_model_variants", return_value=[model_variant]),
+            patch.object(
+                ModelService,
+                "get_model_binary_files",
+                return_value=(True, (tmp_path / "model.xml", tmp_path / "model.bin")),
+            ),
+            patch("app.services.inference.inference_server.needs_float32_input", return_value=True),
+            patch("app.services.inference.inference_server.create_core"),
+            patch("app.services.inference.inference_server._FP32OpenvinoAdapter") as mock_fp32_adapter,
+        ):
+            model_loaded = inference_server.set_inference_model(
+                project_id=project_id, model_id=model_id, device=device, ttl=60
+            )
+
+        assert model_loaded
+        assert inference_server._loaded_model is not None
+        assert inference_server._loaded_model.float32_input is True
+        mock_fp32_adapter.assert_called_once()
 
     def test_get_status_idle(self, tmp_path) -> None:
         inference_server = InferenceServer(data_dir=Path(tmp_path))
@@ -104,7 +150,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=model_id, model=model, device=device, load_timestamp=datetime.now()
+            id=model_id, model=model, device=device, load_timestamp=datetime.now(), float32_input=False
         )
 
         status = inference_server.get_status()
@@ -123,7 +169,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now()
+            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now(), float32_input=False
         )
 
         inference_server.stop()
@@ -154,7 +200,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now()
+            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now(), float32_input=False
         )
 
         with patch("app.services.inference.inference_server.convert_prediction") as mock_convert_prediction:
@@ -172,3 +218,28 @@ class TestInferenceServer:
         mock_convert_prediction.assert_called_once_with(
             labels=[label], frame_data=input.data, prediction=inference_result
         )
+
+    def test_infer_batch_fp32_scales_input(self, tmp_path) -> None:
+        """Images are scaled to float32/255 when the loaded model has float32_input=True."""
+        media_id = uuid4()
+
+        model = MagicMock(spec=Model)
+        inference_result = MagicMock()
+        model.infer_batch.return_value = [inference_result]
+
+        label = MagicMock(spec=Label)
+        raw_uint8 = np.full((20, 20, 3), 128, dtype=np.uint8)
+        input_item = BatchInferenceInput(media_id=media_id, frame_index=0, data=raw_uint8)
+
+        inference_server = InferenceServer(data_dir=Path(tmp_path))
+        inference_server._loaded_model = _LoadedModel(
+            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now(), float32_input=True
+        )
+
+        with patch("app.services.inference.inference_server.convert_prediction", return_value=[]):
+            inference_server.infer_batch(labels=[label], inputs=[input_item])
+
+        (passed_batch,) = model.infer_batch.call_args.args
+        assert len(passed_batch) == 1
+        np.testing.assert_array_almost_equal(passed_batch[0], raw_uint8.astype(np.float32) / 255.0)
+        assert passed_batch[0].dtype == np.float32

--- a/application/backend/tests/unit/services/inference/test_inference_server.py
+++ b/application/backend/tests/unit/services/inference/test_inference_server.py
@@ -9,14 +9,7 @@ import numpy as np
 import pytest
 from model_api.models import Model
 
-from app.models import (
-    BatchInferenceInput,
-    BatchInferenceMedia,
-    BatchInferencePrediction,
-    BatchInferenceResult,
-    DatasetItemAnnotation,
-    Label,
-)
+from app.models import BatchInferenceInput, DatasetItemAnnotation, Label
 from app.models.model_revision import ModelFormat, ModelPrecision, ModelVariant
 from app.services import ModelService
 from app.services.inference import InferenceModel, InferenceServer, InferenceState, InferenceStatus
@@ -48,9 +41,8 @@ class TestInferenceServer:
                 attribute="get_model_binary_files",
                 return_value=(True, (tmp_path / "model.xml", tmp_path / "model.bin")),
             ) as mock_get_model_binary_files,
-            patch("app.services.inference.inference_server.needs_float32_input", return_value=False) as mock_needs_fp32,
             patch("app.services.inference.inference_server.create_core") as mock_create_core,
-            patch("app.services.inference.inference_server.OpenvinoAdapter") as mock_ov_adapter,
+            patch("app.services.inference.inference_server.FP32OpenvinoAdapter") as mock_fp32_adapter,
         ):
             model_loaded = inference_server.set_inference_model(
                 project_id=project_id, model_id=model_id, device=device, ttl=60
@@ -62,21 +54,19 @@ class TestInferenceServer:
                 and inference_server._loaded_model.id == model_id
                 and inference_server._loaded_model.model == model
                 and inference_server._loaded_model.device == device
-                and inference_server._loaded_model.float32_input is False
             )
 
             mock_get_model_variants.assert_called_once_with(project_id=project_id, model_id=model_id)
             mock_get_model_binary_files.assert_called_once_with(
                 project_id=project_id, model_id=model_id, model_variant_id=model_variant_id
             )
-            mock_needs_fp32.assert_called_once_with(tmp_path / "model.xml")
-            mock_ov_adapter.assert_called_once_with(
+            mock_fp32_adapter.assert_called_once_with(
                 mock_create_core.return_value,
                 str(tmp_path / "model.xml"),
                 device=device,
                 max_num_requests=2,
             )
-            mock_create_model.assert_called_once_with(mock_ov_adapter.return_value)
+            mock_create_model.assert_called_once_with(mock_fp32_adapter.return_value)
 
     def test_set_inference_model_already_loaded(self, tmp_path) -> None:
         project_id = uuid4()
@@ -87,7 +77,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=model_id, model=model, device=device, load_timestamp=datetime.now(), float32_input=False
+            id=model_id, model=model, device=device, load_timestamp=datetime.now()
         )
 
         model_loaded = inference_server.set_inference_model(
@@ -98,41 +88,6 @@ class TestInferenceServer:
         assert inference_server._loaded_model.id == model_id
         assert inference_server._loaded_model.model == model
         assert inference_server._loaded_model.device == device
-
-    def test_set_inference_model_fp32(self, tmp_path) -> None:
-        """IR with 0-1 normalisation scale → float32_input=True and _FP32OpenvinoAdapter is used."""
-        project_id = uuid4()
-        model_id = uuid4()
-        model_variant_id = uuid4()
-        device = "AUTO"
-
-        model_variant = MagicMock(
-            spec=ModelVariant, id=model_variant_id, format=ModelFormat.OPENVINO, precision=ModelPrecision.FP16
-        )
-
-        inference_server = InferenceServer(data_dir=Path(tmp_path))
-        model = MagicMock(spec=Model)
-
-        with (
-            patch("model_api.models.Model.create_model", return_value=model),
-            patch.object(ModelService, "get_model_variants", return_value=[model_variant]),
-            patch.object(
-                ModelService,
-                "get_model_binary_files",
-                return_value=(True, (tmp_path / "model.xml", tmp_path / "model.bin")),
-            ),
-            patch("app.services.inference.inference_server.needs_float32_input", return_value=True),
-            patch("app.services.inference.inference_server.create_core"),
-            patch("app.services.inference.inference_server.FP32OpenvinoAdapter") as mock_fp32_adapter,
-        ):
-            model_loaded = inference_server.set_inference_model(
-                project_id=project_id, model_id=model_id, device=device, ttl=60
-            )
-
-        assert model_loaded
-        assert inference_server._loaded_model is not None
-        assert inference_server._loaded_model.float32_input is True
-        mock_fp32_adapter.assert_called_once()
 
     def test_get_status_idle(self, tmp_path) -> None:
         inference_server = InferenceServer(data_dir=Path(tmp_path))
@@ -150,7 +105,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=model_id, model=model, device=device, load_timestamp=datetime.now(), float32_input=False
+            id=model_id, model=model, device=device, load_timestamp=datetime.now()
         )
 
         status = inference_server.get_status()
@@ -169,7 +124,7 @@ class TestInferenceServer:
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now(), float32_input=False
+            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now()
         )
 
         inference_server.stop()
@@ -194,51 +149,21 @@ class TestInferenceServer:
         model.infer_batch.return_value = [inference_result]
 
         label = MagicMock(spec=Label)
-        input = BatchInferenceInput(media_id=media_id, frame_index=15, data=np.random.rand(20, 20, 3))
+        raw_uint8 = np.full((20, 20, 3), 128, dtype=np.uint8)
+        input = BatchInferenceInput(media_id=media_id, frame_index=15, data=raw_uint8)
 
         annotation = MagicMock(spec=DatasetItemAnnotation)
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now(), float32_input=False
+            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now()
         )
 
         with patch("app.services.inference.inference_server.convert_prediction") as mock_convert_prediction:
             mock_convert_prediction.return_value = [annotation]
-            result = inference_server.infer_batch(labels=[label], inputs=[input])
+            inference_server.infer_batch(labels=[label], inputs=[input])
 
-        assert result == BatchInferenceResult(
-            predictions=[
-                BatchInferencePrediction(
-                    media=BatchInferenceMedia(id=media_id, frame_index=15), prediction=[annotation]
-                )
-            ]
-        )
-        model.infer_batch.assert_called_once_with([input.data])
-        mock_convert_prediction.assert_called_once_with(
-            labels=[label], frame_data=input.data, prediction=inference_result
-        )
-
-    def test_infer_batch_fp32_scales_input(self, tmp_path) -> None:
-        """Images are scaled to float32/255 when the loaded model has float32_input=True."""
-        media_id = uuid4()
-
-        model = MagicMock(spec=Model)
-        inference_result = MagicMock()
-        model.infer_batch.return_value = [inference_result]
-
-        label = MagicMock(spec=Label)
-        raw_uint8 = np.full((20, 20, 3), 128, dtype=np.uint8)
-        input_item = BatchInferenceInput(media_id=media_id, frame_index=0, data=raw_uint8)
-
-        inference_server = InferenceServer(data_dir=Path(tmp_path))
-        inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device="AUTO", load_timestamp=datetime.now(), float32_input=True
-        )
-
-        with patch("app.services.inference.inference_server.convert_prediction", return_value=[]):
-            inference_server.infer_batch(labels=[label], inputs=[input_item])
-
+        # Images are always scaled to float32 [0, 1]
         (passed_batch,) = model.infer_batch.call_args.args
         assert len(passed_batch) == 1
         np.testing.assert_array_almost_equal(passed_batch[0], raw_uint8.astype(np.float32) / 255.0)

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -96,7 +96,7 @@ class TestActiveModelServiceUnit:
             )
 
     def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state, monkeypatch):
-        """Test loading the active inference model."""
+        """Test loading the active inference model (uint8-scale IR, float32_input=False)."""
         dummy_model = Mock(spec=Model)
 
         with (
@@ -104,11 +104,36 @@ class TestActiveModelServiceUnit:
             patch.object(
                 fxt_active_model_service,
                 "_get_model_file_path",
-                new=lambda project_id, model_id, variant_id, extension: f"model.{extension}",
+                new=lambda project_id, model_id, variant_id, extension: Path(f"model.{extension}"),
             ),
+            patch("app.services.active_model_service.needs_float32_input", return_value=False),
+            patch("app.services.active_model_service.create_core"),
+            patch("app.services.active_model_service.OpenvinoAdapter"),
         ):
             loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
             assert isinstance(loaded, LoadedModel)
             assert loaded.model_revision_id == fxt_model_activation_state.active_model_id
             assert loaded.model is dummy_model
             assert loaded.device == fxt_model_activation_state.device
+            assert loaded.float32_input is False
+
+    def test_get_loaded_inference_model_fp32(self, fxt_active_model_service, fxt_model_activation_state):
+        """IR with 0-1 normalisation scale → float32_input=True and _FP32OpenvinoAdapter is used."""
+        dummy_model = Mock(spec=Model)
+
+        with (
+            patch.object(Model, "create_model", return_value=dummy_model),
+            patch.object(
+                fxt_active_model_service,
+                "_get_model_file_path",
+                new=lambda project_id, model_id, variant_id, extension: Path(f"model.{extension}"),
+            ),
+            patch("app.services.active_model_service.needs_float32_input", return_value=True),
+            patch("app.services.active_model_service.create_core"),
+            patch("app.services.active_model_service._FP32OpenvinoAdapter") as mock_fp32_adapter,
+        ):
+            loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
+
+        assert isinstance(loaded, LoadedModel)
+        assert loaded.float32_input is True
+        mock_fp32_adapter.assert_called_once()

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -130,7 +130,7 @@ class TestActiveModelServiceUnit:
             ),
             patch("app.services.active_model_service.needs_float32_input", return_value=True),
             patch("app.services.active_model_service.create_core"),
-            patch("app.services.active_model_service._FP32OpenvinoAdapter") as mock_fp32_adapter,
+            patch("app.services.active_model_service.FP32OpenvinoAdapter") as mock_fp32_adapter,
         ):
             loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
 

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -96,7 +96,7 @@ class TestActiveModelServiceUnit:
             )
 
     def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state, monkeypatch):
-        """Test loading the active inference model (uint8-scale IR, float32_input=False)."""
+        """Test loading the active inference model."""
         dummy_model = Mock(spec=Model)
 
         with (
@@ -106,34 +106,11 @@ class TestActiveModelServiceUnit:
                 "_get_model_file_path",
                 new=lambda project_id, model_id, variant_id, extension: Path(f"model.{extension}"),
             ),
-            patch("app.services.active_model_service.needs_float32_input", return_value=False),
             patch("app.services.active_model_service.create_core"),
-            patch("app.services.active_model_service.OpenvinoAdapter"),
+            patch("app.services.active_model_service.FP32OpenvinoAdapter"),
         ):
             loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
             assert isinstance(loaded, LoadedModel)
             assert loaded.model_revision_id == fxt_model_activation_state.active_model_id
             assert loaded.model is dummy_model
             assert loaded.device == fxt_model_activation_state.device
-            assert loaded.float32_input is False
-
-    def test_get_loaded_inference_model_fp32(self, fxt_active_model_service, fxt_model_activation_state):
-        """IR with 0-1 normalisation scale → float32_input=True and _FP32OpenvinoAdapter is used."""
-        dummy_model = Mock(spec=Model)
-
-        with (
-            patch.object(Model, "create_model", return_value=dummy_model),
-            patch.object(
-                fxt_active_model_service,
-                "_get_model_file_path",
-                new=lambda project_id, model_id, variant_id, extension: Path(f"model.{extension}"),
-            ),
-            patch("app.services.active_model_service.needs_float32_input", return_value=True),
-            patch("app.services.active_model_service.create_core"),
-            patch("app.services.active_model_service.FP32OpenvinoAdapter") as mock_fp32_adapter,
-        ):
-            loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
-
-        assert isinstance(loaded, LoadedModel)
-        assert loaded.float32_input is True
-        mock_fp32_adapter.assert_called_once()

--- a/library/src/otx/backend/openvino/models/base.py
+++ b/library/src/otx/backend/openvino/models/base.py
@@ -55,8 +55,8 @@ class _FP32OpenvinoAdapter(OpenvinoAdapter):
     _UINT8_SCALE_THRESHOLD = 1.0
 
     def embed_preprocessing(self, *args, **kwargs) -> None:
-        mean = kwargs.get("mean") or (args[5] if len(args) > 5 else None)
-        scale = kwargs.get("scale") or (args[6] if len(args) > 6 else None)
+        mean = kwargs.get("mean")
+        scale = kwargs.get("scale")
         bad_mean = mean and any(v > self._UINT8_SCALE_THRESHOLD for v in mean)
         bad_scale = scale and any(v > self._UINT8_SCALE_THRESHOLD for v in scale)
         if bad_mean or bad_scale:

--- a/library/src/otx/backend/openvino/models/base.py
+++ b/library/src/otx/backend/openvino/models/base.py
@@ -66,7 +66,7 @@ class _FP32OpenvinoAdapter(OpenvinoAdapter):
     def embed_preprocessing(self, *args, **kwargs) -> None:
         mean = kwargs.get("mean") or (args[5] if len(args) > 5 else None)
         scale = kwargs.get("scale") or (args[6] if len(args) > 6 else None)
-        bad_mean  = mean  and any(v > self._UINT8_SCALE_THRESHOLD for v in mean)
+        bad_mean = mean and any(v > self._UINT8_SCALE_THRESHOLD for v in mean)
         bad_scale = scale and any(v > self._UINT8_SCALE_THRESHOLD for v in scale)
         if bad_mean or bad_scale:
             msg = (
@@ -79,6 +79,7 @@ class _FP32OpenvinoAdapter(OpenvinoAdapter):
             raise ValueError(msg)
         kwargs["dtype"] = float
         super().embed_preprocessing(*args, **kwargs)
+
 
 class OVModel:
     """Base class for the OpenVINO model.

--- a/library/src/otx/backend/openvino/models/base.py
+++ b/library/src/otx/backend/openvino/models/base.py
@@ -42,6 +42,44 @@ if TYPE_CHECKING:
 logger = logging.getLogger()
 
 
+class _FP32OpenvinoAdapter(OpenvinoAdapter):
+    """OpenvinoAdapter variant that forces float32 input tensors.
+
+    OTX models are trained with a ``scale_to_unit`` intensity transform that
+    converts images to float32 [0, 1] *before* the GPU Kornia ``Normalize``
+    step.  During OpenVINO inference the GPU Normalize is not executed, so the
+    raw [0, 1] float32 images are passed directly to ModelAPI.  The embedded
+    preprocessing in the IR must therefore receive float32 input, and its
+    stored ``mean_values`` / ``scale_values`` must be in the **0-1 scale**
+    (e.g. ``0.485 0.456 0.406``).
+
+    Guard: if the IR was exported with an older OTX version that stored
+    mean_values in the 0-255 scale (e.g. ``123.675``), applying those values
+    to [0, 1] inputs produces completely wrong normalisation.  A
+    ``ValueError`` is raised in that case so the problem is caught early
+    rather than silently producing bad predictions.
+    """
+
+    # Values above this threshold indicate uint8 (0-255) scale rather than 0-1 scale.
+    _UINT8_SCALE_THRESHOLD = 1.0
+
+    def embed_preprocessing(self, *args, **kwargs) -> None:
+        mean = kwargs.get("mean") or (args[5] if len(args) > 5 else None)
+        scale = kwargs.get("scale") or (args[6] if len(args) > 6 else None)
+        bad_mean  = mean  and any(v > self._UINT8_SCALE_THRESHOLD for v in mean)
+        bad_scale = scale and any(v > self._UINT8_SCALE_THRESHOLD for v in scale)
+        if bad_mean or bad_scale:
+            msg = (
+                f"IR mean_values {mean} / scale_values {scale} appear to be in "
+                "uint8 (0-255) scale, but _FP32OpenvinoAdapter expects float32 "
+                "[0, 1] inputs with values in 0-1 scale "
+                "(e.g. mean=0.485 0.456 0.406, std=0.229 0.224 0.225). "
+                "Re-export the model with the current OTX version."
+            )
+            raise ValueError(msg)
+        kwargs["dtype"] = float
+        super().embed_preprocessing(*args, **kwargs)
+
 class OVModel:
     """Base class for the OpenVINO model.
 
@@ -129,7 +167,7 @@ class OVModel:
         if self.use_throughput_mode:
             plugin_config["PERFORMANCE_HINT"] = "THROUGHPUT"
 
-        model_adapter = OpenvinoAdapter(
+        model_adapter = _FP32OpenvinoAdapter(
             ie,
             self.model_path,
             device=ov_device,

--- a/library/src/otx/backend/openvino/models/base.py
+++ b/library/src/otx/backend/openvino/models/base.py
@@ -30,6 +30,7 @@ from otx.types.task import OTXTaskType
 from .utils import get_default_num_async_infer_requests
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from model_api.models.result import Result
@@ -43,21 +44,11 @@ logger = logging.getLogger()
 
 
 class _FP32OpenvinoAdapter(OpenvinoAdapter):
-    """OpenvinoAdapter variant that forces float32 input tensors.
+    """OpenvinoAdapter that forces float32 input tensors.
 
-    OTX models are trained with a ``scale_to_unit`` intensity transform that
-    converts images to float32 [0, 1] *before* the GPU Kornia ``Normalize``
-    step.  During OpenVINO inference the GPU Normalize is not executed, so the
-    raw [0, 1] float32 images are passed directly to ModelAPI.  The embedded
-    preprocessing in the IR must therefore receive float32 input, and its
-    stored ``mean_values`` / ``scale_values`` must be in the **0-1 scale**
-    (e.g. ``0.485 0.456 0.406``).
-
-    Guard: if the IR was exported with an older OTX version that stored
-    mean_values in the 0-255 scale (e.g. ``123.675``), applying those values
-    to [0, 1] inputs produces completely wrong normalisation.  A
-    ``ValueError`` is raised in that case so the problem is caught early
-    rather than silently producing bad predictions.
+    Sets ``dtype=float`` so ModelAPI builds an f32 input tensor matching
+    the 0-1 normalisation scale used by new OTX exports.  Raises
+    ``ValueError`` if the IR still stores mean/scale in the 0-255 range.
     """
 
     # Values above this threshold indicate uint8 (0-255) scale rather than 0-1 scale.
@@ -78,7 +69,41 @@ class _FP32OpenvinoAdapter(OpenvinoAdapter):
             )
             raise ValueError(msg)
         kwargs["dtype"] = float
-        super().embed_preprocessing(*args, **kwargs)
+        _patch_pad_constant_type(super().embed_preprocessing, *args, **kwargs)
+
+
+def _patch_pad_constant_type(embed_fn: Callable, *args: object, **kwargs: object) -> None:
+    """Call ``embed_fn`` while monkey-patching ``opset.pad`` to fix pad-value dtype.
+
+    ModelAPI hardcodes pad constants as ``uint8``.  With f32 input this causes
+    a type-mismatch error, so we temporarily wrap ``opset.pad`` to insert a
+    ``Convert`` when the element types differ.
+    """
+    import model_api.adapters.utils as _mapi_utils
+
+    _opset = _mapi_utils.opset
+    _orig_pad = _opset.pad
+
+    def _pad_with_type_cast(
+        arg: openvino.Node,
+        pads_begin: openvino.Node,
+        pads_end: openvino.Node,
+        pad_mode: str,
+        arg_pad_value: openvino.Node | None = None,
+        name: str | None = None,
+    ) -> openvino.Node:
+        if arg_pad_value is not None:
+            data_et = arg.get_element_type()
+            pad_et = arg_pad_value.get_element_type()
+            if data_et != pad_et:
+                arg_pad_value = _opset.convert(arg_pad_value, data_et)
+        return _orig_pad(arg, pads_begin, pads_end, pad_mode, arg_pad_value, name)
+
+    _opset.pad = _pad_with_type_cast  # pyrefly: ignore[bad-assignment]
+    try:
+        embed_fn(*args, **kwargs)
+    finally:
+        _opset.pad = _orig_pad
 
 
 class OVModel:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

OTX now exports OpenVINO IR models with mean/std values in 0-1 scale (e.g. mean=0.485, std=0.229) instead of the old uint8 scale (e.g. mean=123.675, std=58.395).

The application inference server (InferenceServer, ActiveModelService, InferenceWorker) was unconditionally passing raw uint8 [0–255] images to ModelAPI with a default dtype=int (u8) IR input tensor, causing wildly incorrect normalization

This resulted in broken predictions for all models exported with the new OTX normalization format.

Solution
Added automatic IR format detection at model load time. The system inspects the embedded mean_values/scale_values from the IR <rt_info> and decides once — zero runtime overhead per frame.

resolves https://github.com/open-edge-platform/training_extensions/issues/5877

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
