### PR TITLE
Show picker only if the subset is unassigned

### DIFF
--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.test.tsx
@@ -9,13 +9,14 @@ import { render } from 'test-utils/render';
 
 import { http } from '../../../../api/utils';
 import { ZoomProvider } from '../../../../components/zoom/zoom.provider';
+import type { MediaImage } from '../../../../constants/shared-types';
 import { server } from '../../../../msw-node-setup';
 import { AnnotationVisibilityProvider } from '../../../../shared/annotator/annotation-visibility-provider.component';
 import { CanvasSettingsProvider } from '../primary-toolbar/settings/canvas-settings-provider.component';
 import { BottomToolbar } from './bottom-toolbar.component';
 
 type BottomToolbarProps = {
-    mediaItem: ReturnType<typeof getMockedMediaImage>;
+    mediaItem: MediaImage;
 };
 
 const renderBottomToolbar = ({ mediaItem }: BottomToolbarProps) => {
@@ -73,10 +74,38 @@ describe('BottomToolbar', () => {
         expect(screen.getByLabelText('For Review')).toBeInTheDocument();
     });
 
-    it('renders the subset picker with default placeholder', () => {
+    it('renders the subset picker with default placeholder', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/items/{dataset_item_id}', () => {
+                return HttpResponse.json(
+                    getMockedDatasetItem({ id: 'media-123', user_reviewed: false, subset: 'unassigned' }),
+                    {
+                        status: 200,
+                    }
+                );
+            })
+        );
+
         renderBottomToolbar({ mediaItem: mockMediaItem });
 
-        expect(screen.getByLabelText('Select subset')).toBeInTheDocument();
+        expect(await screen.findByLabelText('Select subset')).toBeInTheDocument();
+    });
+
+    it('renders the subset instead of picker when subset is assigned', async () => {
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/items/{dataset_item_id}', () => {
+                return HttpResponse.json(
+                    getMockedDatasetItem({ id: 'media-123', user_reviewed: false, subset: 'validation' }),
+                    {
+                        status: 200,
+                    }
+                );
+            })
+        );
+
+        renderBottomToolbar({ mediaItem: mockMediaItem });
+
+        expect(await screen.findByLabelText('Validation')).toBeInTheDocument();
     });
 
     it('calls patch mutation when subset is changed', async () => {
@@ -104,7 +133,7 @@ describe('BottomToolbar', () => {
 
         renderBottomToolbar({ mediaItem: mockMediaItem });
 
-        const pickerButton = screen.getByRole('button', { name: /select subset/i });
+        const pickerButton = await screen.findByRole('button', { name: /select subset/i });
         fireEvent.click(pickerButton);
 
         const validationOption = await screen.findByRole('option', { name: /Validation/i });

--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
@@ -5,6 +5,7 @@ import { Flex, Grid, Item, Key, Picker, Tag, Text } from '@geti/ui';
 import { Accept, Search } from '@geti/ui/icons';
 import { clsx } from 'clsx';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { capitalize } from 'lodash-es';
 
 import { $api } from '../../../../api/client';
 import { DatasetSubset, Media } from '../../../../constants/shared-types';
@@ -70,6 +71,8 @@ export const BottomToolbar = ({ mediaItem, hideHotkeys }: BottomToolbarProps) =>
 
     const { currentSubset, isUserReviewed, handleSubsetChange } = useSubsets(mediaItem.id);
 
+    const isUnassigned = currentSubset === 'unassigned';
+
     return (
         <Flex justifyContent={'end'}>
             <Toolbar.Container>
@@ -81,7 +84,7 @@ export const BottomToolbar = ({ mediaItem, hideHotkeys }: BottomToolbarProps) =>
                     )}
 
                     <Toolbar.Section>
-                        <Flex gap={'size-100'} alignItems={'center'}>
+                        <Flex gap={'size-100'} alignItems={'center'} height={'100%'}>
                             <Text UNSAFE_className={classes.filename}>{fileName}</Text>
                             <Tag
                                 className={clsx({
@@ -92,16 +95,20 @@ export const BottomToolbar = ({ mediaItem, hideHotkeys }: BottomToolbarProps) =>
                                 text={isUserReviewed ? 'Accepted' : 'For Review'}
                             />
 
-                            <Picker
-                                selectedKey={currentSubset === 'unassigned' ? null : currentSubset}
-                                placeholder={'Select subset'}
-                                aria-label={'Select subset'}
-                                onSelectionChange={handleSubsetChange}
-                            >
-                                <Item key={'validation'}>Validation</Item>
-                                <Item key={'testing'}>Testing</Item>
-                                <Item key={'training'}>Training</Item>
-                            </Picker>
+                            {isUnassigned ? (
+                                <Picker
+                                    selectedKey={null}
+                                    placeholder={'Select subset'}
+                                    aria-label={'Select subset'}
+                                    onSelectionChange={handleSubsetChange}
+                                >
+                                    <Item key={'validation'}>Validation</Item>
+                                    <Item key={'testing'}>Testing</Item>
+                                    <Item key={'training'}>Training</Item>
+                                </Picker>
+                            ) : (
+                                <Tag withDot={false} text={capitalize(String(currentSubset))} />
+                            )}
                         </Flex>
                     </Toolbar.Section>
 

--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
@@ -71,7 +71,7 @@ export const BottomToolbar = ({ mediaItem, hideHotkeys }: BottomToolbarProps) =>
 
     const { currentSubset, isUserReviewed, handleSubsetChange } = useSubsets(mediaItem.id);
 
-    const isUnassigned = currentSubset === 'unassigned';
+    const isUnassigned = currentSubset === 'unassigned' || currentSubset === null;
 
     return (
         <Flex justifyContent={'end'}>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Previously, the picker would also show, and if the user tried to assign to a different subset, the server will throw an error. Now, we just show a static subset, to not let the user change it. Not sure if it's the best solution but it's better than what we had, since it would throw an error 100% of the time (by design).

<img width="1022" height="637" alt="Screenshot 2026-03-25 at 09 02 15" src="https://github.com/user-attachments/assets/abdbd497-a070-46f8-a698-d0dfb7480797" />
<img width="794" height="495" alt="Screenshot 2026-03-25 at 09 02 20" src="https://github.com/user-attachments/assets/a2ff9a43-bb24-4948-9778-85aa8037366d" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
