### PR TITLE
Properly save thumbnail for 16 bit PNG

### DIFF
--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -20,7 +20,7 @@ from app.models import DatasetItem, DatasetItemAnnotationStatus, Media, MediaTyp
 from app.models.media import ImageFormat, MediaAdapter, VideoFormat
 from app.repositories import MediaRepository
 from app.services.video import extract_video_frame, get_video_metadata
-from app.utils.images import crop_to_thumbnail
+from app.utils.images import convert_to_jpeg_compatible, crop_to_thumbnail
 
 from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
 
@@ -85,36 +85,12 @@ class MediaService(BaseSessionManagedService):
             raise InvalidImageError
 
     @staticmethod
-    def _to_jpeg_compatible(image: Image.Image) -> Image.Image:
-        """Convert an image to a JPEG-compatible mode (RGB, L, or CMYK).
-
-        16-bit modes (I;16, I) require explicit normalization: PIL's built-in
-        RGB conversion only preserves the most-significant byte, clipping the
-        lower half of the dynamic range and producing washed-out thumbnails.
-        We normalize the full value range to [0, 255] before converting to L.
-        """
-        if image.mode in ("RGB", "L", "CMYK"):
-            return image
-        if image.mode in ("I;16", "I;16B", "I;16L", "I;16S", "I;16BS", "I"):
-            # Normalize the 16-bit (or 32-bit signed int) range to 8-bit
-            image = image.convert("I")
-            arr = np.array(image, dtype=np.float32)
-            lo, hi = arr.min(), arr.max()
-            if hi > lo:
-                arr = (arr - lo) / (hi - lo) * 255.0
-            else:
-                arr = np.zeros_like(arr)
-            return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
-        # All other non-JPEG-compatible modes (RGBA, P, F, …)
-        return image.convert("RGB")
-
-    @staticmethod
     def _generate_and_save_thumbnail(image: Image.Image, path: Path) -> None:
         try:
             thumbnail_image = crop_to_thumbnail(
                 image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
             )
-            thumbnail_image = MediaService._to_jpeg_compatible(thumbnail_image)
+            thumbnail_image = convert_to_jpeg_compatible(thumbnail_image)
             thumbnail_image.save(path)
         except Exception:
             logger.exception("Failed to generate thumbnail image")
@@ -297,7 +273,7 @@ class MediaService(BaseSessionManagedService):
         thumbnail = crop_to_thumbnail(
             image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
         )
-        return MediaService._to_jpeg_compatible(thumbnail)
+        return convert_to_jpeg_compatible(thumbnail)
 
     def delete_media(self, project: Project, media_id: UUID) -> None:
         """Delete a media by its ID"""

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -90,7 +90,8 @@ class MediaService(BaseSessionManagedService):
             thumbnail_image = crop_to_thumbnail(
                 image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
             )
-            if thumbnail_image.mode in ("RGBA", "P"):
+            # Convert non-JPEG-compatible modes (e.g. RGBA, P, I;16) to RGB
+            if thumbnail_image.mode not in ("RGB", "L", "CMYK"):
                 thumbnail_image = thumbnail_image.convert("RGB")
             thumbnail_image.save(path)
         except Exception:

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -85,14 +85,36 @@ class MediaService(BaseSessionManagedService):
             raise InvalidImageError
 
     @staticmethod
+    def _to_jpeg_compatible(image: Image.Image) -> Image.Image:
+        """Convert an image to a JPEG-compatible mode (RGB, L, or CMYK).
+
+        16-bit modes (I;16, I) require explicit normalization: PIL's built-in
+        RGB conversion only preserves the most-significant byte, clipping the
+        lower half of the dynamic range and producing washed-out thumbnails.
+        We normalize the full value range to [0, 255] before converting to L.
+        """
+        if image.mode in ("RGB", "L", "CMYK"):
+            return image
+        if image.mode in ("I;16", "I;16B", "I;16L", "I;16S", "I;16BS", "I"):
+            # Normalize the 16-bit (or 32-bit signed int) range to 8-bit
+            image = image.convert("I")
+            arr = np.array(image, dtype=np.float32)
+            lo, hi = arr.min(), arr.max()
+            if hi > lo:
+                arr = (arr - lo) / (hi - lo) * 255.0
+            else:
+                arr = np.zeros_like(arr)
+            return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
+        # All other non-JPEG-compatible modes (RGBA, P, F, …)
+        return image.convert("RGB")
+
+    @staticmethod
     def _generate_and_save_thumbnail(image: Image.Image, path: Path) -> None:
         try:
             thumbnail_image = crop_to_thumbnail(
                 image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
             )
-            # Convert non-JPEG-compatible modes (e.g. RGBA, P, I;16) to RGB
-            if thumbnail_image.mode not in ("RGB", "L", "CMYK"):
-                thumbnail_image = thumbnail_image.convert("RGB")
+            thumbnail_image = MediaService._to_jpeg_compatible(thumbnail_image)
             thumbnail_image.save(path)
         except Exception:
             logger.exception("Failed to generate thumbnail image")
@@ -275,9 +297,7 @@ class MediaService(BaseSessionManagedService):
         thumbnail = crop_to_thumbnail(
             image=image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
         )
-        if thumbnail.mode not in ("RGB", "L", "CMYK"):
-            thumbnail = thumbnail.convert("RGB")
-        return thumbnail
+        return MediaService._to_jpeg_compatible(thumbnail)
 
     def delete_media(self, project: Project, media_id: UUID) -> None:
         """Delete a media by its ID"""

--- a/application/backend/app/utils/images.py
+++ b/application/backend/app/utils/images.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import numpy as np
 from PIL import Image
 
 
@@ -37,3 +38,27 @@ def crop_to_thumbnail(image: Image.Image, target_height: int, target_width: int)
     y1 = round(max(y1, 0))
     y2 = round(min(y2, resized_image.height))
     return resized_image.crop((x1, y1, x2, y2))
+
+
+def convert_to_jpeg_compatible(image: Image.Image) -> Image.Image:
+    """Convert an image to a JPEG-compatible mode (RGB, L, or CMYK).
+
+    16-bit modes (I;16, I) require explicit normalization: PIL's built-in
+    RGB conversion only preserves the most-significant byte, clipping the
+    lower half of the dynamic range and producing washed-out thumbnails.
+    We normalize the full value range to [0, 255] before converting to L.
+    """
+    if image.mode in ("RGB", "L", "CMYK"):
+        return image
+    if image.mode in ("I;16", "I;16B", "I;16L", "I;16S", "I;16BS", "I"):
+        # Normalize the 16-bit (or 32-bit signed int) range to 8-bit
+        image = image.convert("I")
+        arr = np.array(image, dtype=np.float32)
+        lo, hi = arr.min(), arr.max()
+        if hi > lo:
+            arr = (arr - lo) / (hi - lo) * 255.0
+        else:
+            arr = np.zeros_like(arr)
+        return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
+    # All other non-JPEG-compatible modes (RGBA, P, F, …)
+    return image.convert("RGB")

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -568,6 +568,40 @@ class TestMediaServiceIntegration:
         thumbnail_file_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}-thumb.jpg"
         assert os.path.exists(thumbnail_file_path)
 
+    def test_create_image_16bit_png_thumbnail(
+        self,
+        tmp_path: Path,
+        fxt_media_service: MediaService,
+        fxt_project_with_pipeline: tuple[Project, Pipeline],
+    ) -> None:
+        """Test that a thumbnail is generated correctly for a 16-bit PNG image (mode I;16)."""
+        # Create a 16-bit grayscale image using numpy and PIL
+        rng = np.random.default_rng(seed=0)
+        data_16bit = rng.integers(0, 65535, (512, 512), dtype=np.uint16)
+        image = PILImage.fromarray(data_16bit, mode="I;16")
+
+        # Ensure the image is recognised as 16-bit by PIL
+        assert image.mode == "I;16"
+
+        project, _ = fxt_project_with_pipeline
+
+        created_media = fxt_media_service.create_image(
+            ImageMetadata(
+                project_id=project.id,
+                name="test_16bit",
+                image_format=ImageFormat.PNG,
+                data=image,
+            )
+        )
+
+        # The thumbnail must exist and be a valid JPEG readable by PIL
+        thumbnail_file_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}-thumb.jpg"
+        assert os.path.exists(thumbnail_file_path), "Thumbnail file was not created for 16-bit PNG"
+
+        with PILImage.open(thumbnail_file_path) as thumb:
+            assert thumb.format == "JPEG"
+            assert thumb.mode == "RGB"
+
     @pytest.mark.parametrize("use_pipeline_source", [True, False])
     @pytest.mark.parametrize("format", VideoFormat)
     def test_create_video(

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -574,8 +574,13 @@ class TestMediaServiceIntegration:
         fxt_media_service: MediaService,
         fxt_project_with_pipeline: tuple[Project, Pipeline],
     ) -> None:
-        """Test that a thumbnail is generated correctly for a 16-bit PNG image (mode I;16)."""
-        # Create a 16-bit grayscale image using numpy and PIL
+        """Test that a thumbnail is generated correctly for a 16-bit PNG image (mode I;16).
+
+        Specifically, the full dynamic range of the 16-bit source must be
+        preserved through normalization — a naive PIL convert("RGB") only
+        keeps the most-significant byte, producing washed-out thumbnails.
+        """
+        # Create a 16-bit grayscale image that uses the full 0-65535 range
         rng = np.random.default_rng(seed=0)
         data_16bit = rng.integers(0, 65535, (512, 512), dtype=np.uint16)
         image = PILImage.fromarray(data_16bit, mode="I;16")
@@ -601,6 +606,14 @@ class TestMediaServiceIntegration:
         with PILImage.open(thumbnail_file_path) as thumb:
             assert thumb.format == "JPEG"
             assert thumb.mode == "RGB"
+
+            # The normalized thumbnail must use a wide tonal range.
+            # A naive MSB-only conversion collapses most pixels to black (max≈255,
+            # but the vast majority of values cluster near 0), while correct
+            # normalization spreads values across the full 0-255 range.
+            arr = np.array(thumb)
+            assert arr.min() < 10, "Shadow end of range missing — normalization likely clipped low values"
+            assert arr.max() > 245, "Highlight end of range missing — normalization likely clipped high values"
 
     @pytest.mark.parametrize("use_pipeline_source", [True, False])
     @pytest.mark.parametrize("format", VideoFormat)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
16bit PNG images requires a conversion to a JPG compatible mode before creating the thumbnails.

Resolves #5888 

### How to test
Added integration test 

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
