### PR TITLE
feat(annotator mode): Automatically switch annotator modes

### DIFF
--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { Content, Dialog, Grid, View } from '@geti/ui';
 import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook';
@@ -22,7 +22,7 @@ import { useAnnotationsQuery } from './api/use-annotations-query';
 import { SIDEBAR_WIDTH } from './constants';
 import { SidebarItems } from './sidebar-items/sidebar-items.component';
 import { useAnnotatorMediaTransition } from './use-annotator-media-transition.hook';
-import { getInitialAnnotations } from './utils';
+import { getInitialAnnotations, useAnnotatorMode } from './utils';
 
 type MediaPreviewProps = {
     mediaItem: Media;
@@ -95,7 +95,6 @@ const MediaPreviewContent = ({
     isFetchingNextPage,
     fetchNextPage,
 }: MediaPreviewContentProps) => {
-    const [mode, setMode] = useState<AnnotatorMode>('annotation');
     const { mediaItem } = useSelectedMediaItem();
     const { selectedModelId } = usePredictionSetup();
 
@@ -117,6 +116,8 @@ const MediaPreviewContent = ({
     const initialPredictions = useMemo(() => {
         return predictionsData?.flatMap((predictionData) => predictionData.prediction) ?? [];
     }, [predictionsData]);
+
+    const [mode, setMode] = useAnnotatorMode({ predictions: initialPredictions, annotations: initialAnnotations });
 
     return (
         <ToolProvider mode={mode}>

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -138,7 +138,7 @@ describe('useAnnotatorMode', () => {
         expect(result.current[0]).toBe('annotation');
     });
 
-    it('sets mode to "prediction" when there are no annotations and are predictions', () => {
+    it('sets mode to "prediction" when there are no annotations and there are predictions', () => {
         const { result } = renderHook(() =>
             useAnnotatorMode({
                 predictions: [getMockedAnnotation({ id: '1' })],

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -1,10 +1,13 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { act, waitFor } from '@testing-library/react';
+import { getMockedAnnotation } from 'mocks/mock-annotation';
 import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage } from 'mocks/mock-media';
+import { renderHook } from 'test-utils/render';
 
 import type { AnnotationDTO } from '../../../constants/shared-types';
-import { getInitialAnnotations, getNextMediaItem } from './utils';
+import { getInitialAnnotations, getNextMediaItem, useAnnotatorMode } from './utils';
 
 describe('getInitialAnnotations', () => {
     const mockAnnotations: AnnotationDTO[] = [
@@ -98,6 +101,77 @@ describe('getNextMediaItem', () => {
             const frame = getMockedVideoFrame({ id: 'video-1', frame_number: 5, frame_count: 10 });
             const result = getNextMediaItem(frame, [frame], 3);
             expect(result).toEqual({ ...frame, frame_number: 6 });
+        });
+    });
+});
+
+describe('useAnnotatorMode', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('sets mode to "annotation" when there are no annotations and no predictions', () => {
+        const { result } = renderHook(() => useAnnotatorMode({ predictions: [], annotations: [] }));
+
+        expect(result.current[0]).toBe('annotation');
+    });
+
+    it('sets mode to "annotation" when there are annotations and predictions', () => {
+        const { result } = renderHook(() =>
+            useAnnotatorMode({
+                predictions: [getMockedAnnotation({ id: '1' })],
+                annotations: [getMockedAnnotation({ id: '2' })],
+            })
+        );
+
+        expect(result.current[0]).toBe('annotation');
+    });
+
+    it('sets mode to "annotation" when there are annotations and no predictions', () => {
+        const { result } = renderHook(() =>
+            useAnnotatorMode({
+                predictions: [],
+                annotations: [getMockedAnnotation({ id: '1' })],
+            })
+        );
+
+        expect(result.current[0]).toBe('annotation');
+    });
+
+    it('sets mode to "prediction" when there are no annotations and are predictions', () => {
+        const { result } = renderHook(() =>
+            useAnnotatorMode({
+                predictions: [getMockedAnnotation({ id: '1' })],
+                annotations: [],
+            })
+        );
+
+        expect(result.current[0]).toBe('prediction');
+    });
+
+    it('updates mode manually properly', async () => {
+        const { result } = renderHook(() => useAnnotatorMode({ predictions: [], annotations: [] }));
+
+        const [_, setMode] = result.current;
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe('annotation');
+        });
+
+        act(() => {
+            setMode('prediction');
+        });
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe('prediction');
+        });
+
+        act(() => {
+            setMode('annotation');
+        });
+
+        await waitFor(() => {
+            expect(result.current[0]).toBe('annotation');
         });
     });
 });

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, waitFor } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { getMockedAnnotation } from 'mocks/mock-annotation';
 import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage } from 'mocks/mock-media';
 import { renderHook } from 'test-utils/render';
@@ -154,24 +154,18 @@ describe('useAnnotatorMode', () => {
 
         const [_, setMode] = result.current;
 
-        await waitFor(() => {
-            expect(result.current[0]).toBe('annotation');
-        });
+        expect(result.current[0]).toBe('annotation');
 
         act(() => {
             setMode('prediction');
         });
 
-        await waitFor(() => {
-            expect(result.current[0]).toBe('prediction');
-        });
+        expect(result.current[0]).toBe('prediction');
 
         act(() => {
             setMode('annotation');
         });
 
-        await waitFor(() => {
-            expect(result.current[0]).toBe('annotation');
-        });
+        expect(result.current[0]).toBe('annotation');
     });
 });

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -1,13 +1,15 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { range } from 'lodash-es';
+import { isEmpty, range } from 'lodash-es';
+import { useLocalStorage } from 'usehooks-ts';
 
-import type { AnnotationDTO, Media } from '../../../constants/shared-types';
+import type { AnnotationDTO, Media, PredictionDTO } from '../../../constants/shared-types';
+import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { isVideoFrame } from '../../../shared/media-item-utils';
 import { loadImageQueryOptions } from '../../annotator/hooks/use-load-image-query.hook';
 import { useVideoPlayerContext } from '../../annotator/video-player/video-player-provider.component';
@@ -87,4 +89,31 @@ export const useNextMediaPrefetch = (currentMediaItem: Media, allMediaItems: Med
         nextImage: nextImageQuery.data,
         isNextImageReady: nextImageQuery.isSuccess,
     };
+};
+
+export const useAnnotatorMode = ({
+    annotations,
+    predictions,
+}: {
+    annotations: AnnotationDTO[];
+    predictions: PredictionDTO[];
+}) => {
+    const projectId = useProjectIdentifier();
+    const [mode, setMode] = useLocalStorage<AnnotatorMode>(`${projectId}-annotator-mode`, 'annotation');
+
+    const hasPredictions = !isEmpty(predictions);
+    const hasAnnotations = !isEmpty(annotations);
+
+    useEffect(() => {
+        if (hasAnnotations) {
+            setMode('annotation');
+            return;
+        }
+
+        if (hasPredictions) {
+            setMode('prediction');
+        }
+    }, [hasAnnotations, hasPredictions, setMode]);
+
+    return [mode, setMode] as const;
 };

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -99,10 +99,12 @@ export const useAnnotatorMode = ({
     predictions: PredictionDTO[];
 }) => {
     const projectId = useProjectIdentifier();
-    const [mode, setMode] = useLocalStorage<AnnotatorMode>(`${projectId}-annotator-mode`, 'annotation');
-
     const hasPredictions = !isEmpty(predictions);
     const hasAnnotations = !isEmpty(annotations);
+    const [mode, setMode] = useLocalStorage<AnnotatorMode>(
+        `${projectId}-annotator-mode`,
+        hasAnnotations || !hasPredictions ? 'annotation' : 'prediction'
+    );
 
     useEffect(() => {
         if (hasAnnotations) {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

When media has an annotation, we display the annotation mode.
When media has no annotation and has prediction, we display the prediction mode.

Close #5898

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
