### PR TITLE
:bugfix: Prevent SAM lockup when deselecting a label

### DIFF
--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -9,7 +9,6 @@ import { useGetDatasetMediaItems } from 'hooks/use-get-dataset-media-items.hook'
 
 import selectionCursor from '../../../../assets/icons/selection.svg?url';
 import { useZoom } from '../../../../components/zoom/zoom.provider';
-import type { Label } from '../../../../constants/shared-types';
 import type { Annotation, RegionOfInterest, Shape } from '../../../../shared/types';
 import { useNextMediaItem } from '../../../dataset/media-preview/utils';
 import { AnnotationShape } from '../../annotations/annotation-shape/annotation-shape.component';
@@ -57,7 +56,6 @@ const PreviewAnnotations = ({ previewAnnotations, image }: PreviewAnnotationsPro
 
 export const SegmentAnythingTool = () => {
     const [previewShapes, setPreviewShapes] = useState<Shape[]>([]);
-    const [acceptedShapes, setAcceptedShapes] = useState<Shape[] | null>(null);
     const ref = useRef<SVGSVGElement>(null);
 
     const zoom = useZoom();
@@ -76,10 +74,6 @@ export const SegmentAnythingTool = () => {
     const clampPoint = clampPointBetweenImage(image);
 
     const handleMouseMove = (event: PointerEvent<SVGSVGElement>) => {
-        if (acceptedShapes !== null) {
-            return;
-        }
-
         if (!canvasRef.current) {
             return;
         }
@@ -91,11 +85,6 @@ export const SegmentAnythingTool = () => {
         cancellableThrottledDecodingQueryFn.call([{ ...point, positive: true }]).then((shapes) => {
             setPreviewShapes(shapes.map((shape) => removeOffLimitPoints(shape, roi)));
         });
-    };
-
-    const handleAddAnnotations = (shapes: Shape[], label: Label) => {
-        addAndSelectAnnotations(shapes, [label]);
-        setPreviewShapes([]);
     };
 
     const handlePointerDown = (event: PointerEvent<SVGSVGElement>) => {
@@ -111,13 +100,8 @@ export const SegmentAnythingTool = () => {
             return;
         }
 
-        if (selectedLabel == null) {
-            setAcceptedShapes(previewShapes);
-
-            return;
-        }
-
-        handleAddAnnotations(previewShapes, selectedLabel);
+        addAndSelectAnnotations(previewShapes, selectedLabel ? [selectedLabel] : []);
+        setPreviewShapes([]);
     };
 
     const handlePointerLeave = () => {
@@ -125,7 +109,7 @@ export const SegmentAnythingTool = () => {
         setPreviewShapes([]);
     };
 
-    const previewAnnotations = (acceptedShapes ?? previewShapes).map((shape, idx): Annotation => {
+    const previewAnnotations = previewShapes.map((shape, idx): Annotation => {
         return {
             shape,
             labels: selectedLabel ? [selectedLabel] : [],

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -100,6 +100,7 @@ export const SegmentAnythingTool = () => {
             return;
         }
 
+        cancellableThrottledDecodingQueryFn.cancel();
         addAndSelectAnnotations(previewShapes, selectedLabel ? [selectedLabel] : []);
         setPreviewShapes([]);
     };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Get rid of accepted shapes


Explanation --- The flow we had before was:
1) User clicks, adding a shape
2) User selects a label
3) Annotation is added

The bug is that, the user has a label selected before doing 1), so when he clicked on the label, it DESELECTED IT, which means there was no label selected, which caused a stuck state. To avoid this and other bugs related with a weird state, we now add the annotation directly. This has 2 benefits: one less click since the user will most likely have a label selected, and secondly, allow for quickly add as many annotations as the user wants. He/she can then go to Select tool and assign all the necessary labels


Fixes https://github.com/open-edge-platform/training_extensions/issues/5832

![rec](https://github.com/user-attachments/assets/b86d66e6-4859-4930-9a9e-bc5d129821a9)



### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
