### PR TITLE
fix: Round frame number properly

### DIFF
--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -44,7 +44,8 @@ const convertMediaItem = (mediaItem: Media, frameNumber: number): Media => {
         return {
             ...mediaItem,
             type: 'video_frame',
-            frame_stride: mediaItem.fps,
+            fps: Math.round(mediaItem.fps),
+            frame_stride: Math.round(mediaItem.fps),
             frame_number: frameNumber,
         };
     }

--- a/application/ui/src/features/annotator/video-player/use-video-controls.ts
+++ b/application/ui/src/features/annotator/video-player/use-video-controls.ts
@@ -76,7 +76,10 @@ export const useVideoControls = ({
         setIsPlaying(false);
         videoRef.current.pause();
 
-        goto(currentFrameNumber);
+        const maxNearestFrame = Math.floor((videoFrame.frame_count - 1) / step) * step;
+        const nearestFrame = Math.min(maxNearestFrame, roundFrameNumber(currentFrameNumber, step));
+
+        goto(nearestFrame);
     };
 
     const nextFrame = () => {

--- a/application/ui/src/features/annotator/video-player/use-video-controls.ts
+++ b/application/ui/src/features/annotator/video-player/use-video-controls.ts
@@ -17,6 +17,8 @@ export type VideoControls = {
     canPlay?: boolean;
 };
 
+const roundFrameNumber = (frameNumber: number, step: number) => Math.round(Math.round(frameNumber / step) * step);
+
 export const useVideoControls = ({
     step,
     videoRef,
@@ -35,11 +37,10 @@ export const useVideoControls = ({
     const totalFrames = videoFrame?.frame_count ?? 1;
     const currentFrameNumber = videoFrame?.frame_number ?? 0;
 
-    const round = (x: number) => Math.round(x / step) * step;
-    const previousVideoFrameNumber = round(currentFrameNumber - step);
+    const previousVideoFrameNumber = roundFrameNumber(currentFrameNumber - step, step);
     const canSelectPreviousFrame = previousVideoFrameNumber >= 0;
 
-    const nextVideoFrameNumber = round(currentFrameNumber + step);
+    const nextVideoFrameNumber = roundFrameNumber(currentFrameNumber + step, step);
     const canSelectNextFrame = nextVideoFrameNumber < totalFrames;
 
     const selectFrame = (frameNumber: number) => {
@@ -75,10 +76,7 @@ export const useVideoControls = ({
         setIsPlaying(false);
         videoRef.current.pause();
 
-        const maxNearestFrame = Math.floor((videoFrame.frame_count - 1) / step) * step;
-        const nearestFrame = Math.min(maxNearestFrame, Math.round(currentFrameNumber / step) * step);
-
-        goto(nearestFrame);
+        goto(currentFrameNumber);
     };
 
     const nextFrame = () => {
@@ -122,7 +120,7 @@ export const useVideoControls = ({
         }
 
         videoRef.current.currentTime = (frameNumber + 1) / videoFrame.fps;
-        const nearest = Math.min(Math.round(frameNumber / step) * step, totalFrames - 1);
+        const nearest = Math.min(roundFrameNumber(frameNumber, step), totalFrames - 1);
 
         selectFrame(nearest);
     };

--- a/application/ui/src/features/annotator/video-player/use-video-controls.ts
+++ b/application/ui/src/features/annotator/video-player/use-video-controls.ts
@@ -17,7 +17,7 @@ export type VideoControls = {
     canPlay?: boolean;
 };
 
-const roundFrameNumber = (frameNumber: number, step: number) => Math.round(Math.round(frameNumber / step) * step);
+const roundFrameNumber = (frameNumber: number, step: number) => Math.round(frameNumber / step) * step;
 
 export const useVideoControls = ({
     step,
@@ -119,7 +119,6 @@ export const useVideoControls = ({
             setIsPlaying(false);
         }
 
-        videoRef.current.currentTime = (frameNumber + 1) / videoFrame.fps;
         const nearest = Math.min(roundFrameNumber(frameNumber, step), totalFrames - 1);
 
         selectFrame(nearest);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that `fps` is not the integer but `float`. In this case it was `29.992017030335283` instead of `30` which caused not rounded frame indexes, which caused the issue while trying to create annotations (frame number must be integer).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
