### PR TITLE
Auto-detect classification project type from dataset schema

### DIFF
--- a/application/backend/app/api/routers/jobs.py
+++ b/application/backend/app/api/routers/jobs.py
@@ -113,7 +113,6 @@ async def submit_job(
                         staged_dataset_id=job_request.staged_dataset_id,
                         project_name=job_request.parameters.project.name,
                         task_type=job_request.parameters.project.task_type,
-                        exclusive_labels=job_request.parameters.project.exclusive_labels,
                         labels=job_request.parameters.filters.labels,
                         subsets=job_request.parameters.filters.subsets,
                         include_unannotated=job_request.parameters.filters.include_unannotated,

--- a/application/backend/app/api/schemas/jobs/dataset_import.py
+++ b/application/backend/app/api/schemas/jobs/dataset_import.py
@@ -76,11 +76,6 @@ class ImportDatasetToProjectRequest(BaseImportRequest, BaseJobRequest):
 class NewProjectParams(BaseModel):
     name: str = Field(..., description="Name to assign to the new project")
     task_type: TaskType = Field(..., description="Type of the project to create")
-    exclusive_labels: bool = Field(
-        False,
-        description="For classification projects: If True, multiple labels per item are allowed (multi-label); "
-        "if False, exactly one label per item is allowed (multi-class)",
-    )
 
     model_config = {
         "json_schema_extra": {
@@ -187,7 +182,6 @@ class ImportDatasetMetadata(BaseModel):
                 "project": NewProjectParams(
                     name=data.params.project_name,
                     task_type=data.params.task_type,
-                    exclusive_labels=data.params.exclusive_labels,
                 ),
             }
 

--- a/application/backend/app/execution/dataset_import/base_import.py
+++ b/application/backend/app/execution/dataset_import/base_import.py
@@ -34,7 +34,7 @@ class BaseDatasetImport(Execution[JobParamsT], ABC):
     """
     Base implementation for dataset import logic, inheriting from Execution.
 
-    This class provides protected helper methods (_prepare_dataset, _create_items)
+    This class provides protected helper methods (_import_dataset, _convert_dataset, _create_items)
     that can be orchestrated by concrete subclasses using the @step decorator.
     It does not define the @step orchestration itself.
 

--- a/application/backend/app/execution/dataset_import/base_import.py
+++ b/application/backend/app/execution/dataset_import/base_import.py
@@ -70,7 +70,7 @@ class BaseDatasetImport(Execution[JobParamsT], ABC):
             MultilabelClassificationImportExportSample,
         ],
         MultilabelClassificationImportExportSample: [],
-        MulticlassClassificationImportExportSample: [MultilabelClassificationImportExportSample],
+        MulticlassClassificationImportExportSample: [],
     }
 
     def __init__(
@@ -88,11 +88,13 @@ class BaseDatasetImport(Execution[JobParamsT], ABC):
         self._dataset_service = dataset_service
         self._db_session_factory = db_session_factory
 
-    def _prepare_dataset(self, staged_dataset_id: UUID, task: Task) -> Dataset:
+    def _import_dataset(self, staged_dataset_id: UUID) -> Dataset:
         staged_dataset_path = self._staged_datasets_dir / str(staged_dataset_id) / "dataset"
         if not staged_dataset_path.exists() or not staged_dataset_path.is_dir():
             raise ValueError(f"Staged dataset directory does not exist: {staged_dataset_path}")
-        dataset = import_dataset(str(staged_dataset_path))
+        return import_dataset(str(staged_dataset_path))
+
+    def _convert_dataset(self, dataset: Dataset, task: Task) -> Dataset:
         dataset_type = dataset.dtype
         target_type = self.__get_sample_by_task(task=task)
         if target_type != dataset_type:
@@ -142,7 +144,7 @@ class BaseDatasetImport(Execution[JobParamsT], ABC):
                     and item.label.size == 0
                 )
                 if not empty_label:
-                    annotations = converter.convert_sample(item)
+                    annotations = converter.convert_sample(item) or None
                     # non-native *ImportExportSample types are always treated as reviewed
                     user_reviewed = user_reviewed if user_reviewed is not None else True
                     # If there are no annotations (due to filtering), we consider the item as not reviewed.

--- a/application/backend/app/execution/dataset_import/import_as_new_project.py
+++ b/application/backend/app/execution/dataset_import/import_as_new_project.py
@@ -7,6 +7,7 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from uuid import uuid4
 
+import polars as pl
 from datumaro.experimental import Dataset
 from datumaro.experimental.fields import Subset
 from sqlalchemy.orm import Session
@@ -27,9 +28,10 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
     including project creation with labels, dataset preparation, and item import.
 
     The execution follows these steps:
-    1. Create a new project with the specified task type and labels
-    2. Load and filter the prepared dataset from the staged directory
-    3. Create media items and dataset items with annotations for each dataset entry
+    1. Load dataset from the staged directory
+    2. Create a new project with the specified task type and labels
+    3. Convert and filter the loaded dataset according to the project task and import parameters
+    4. Create media items and dataset items with annotations for each dataset entry
 
     Attributes:
         params_type: The parameter type for this execution (ImportDatasetAsNewProjectJobParams).
@@ -57,8 +59,12 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
         super().__init__(staged_datasets_dir, dataset_service, label_service, media_service, db_session_factory)
         self._project_service = project_service
 
-    @step("Create new project", 5)
-    def create_project(self, params: ImportDatasetAsNewProjectJobParams) -> Project:
+    @step("Import dataset", 5)
+    def import_dataset(self, params: ImportDatasetAsNewProjectJobParams) -> Dataset:
+        return self._import_dataset(staged_dataset_id=params.staged_dataset_id)
+
+    @step("Create new project", 10)
+    def create_project(self, params: ImportDatasetAsNewProjectJobParams, exclusive_labels: bool) -> Project:
         project_labels = (
             [
                 Label(
@@ -71,22 +77,36 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
             if params.labels
             else []
         )
-        task = Task(
-            task_type=params.task_type,
-            labels=project_labels,
-            exclusive_labels=params.exclusive_labels,
-        )
+        task = Task(task_type=params.task_type, labels=project_labels, exclusive_labels=exclusive_labels)
         with self._db_session_factory() as db_session:
             self._project_service.set_db_session(db_session)
             return self._project_service.create_project(project_id=uuid4(), name=params.project_name, task=task)
 
     @step("Prepare dataset", 15)
-    def prepare_dataset(self, params: ImportDatasetAsNewProjectJobParams, task: Task) -> Dataset:
-        dataset = self._prepare_dataset(staged_dataset_id=params.staged_dataset_id, task=task)
+    def prepare_dataset(self, dataset: Dataset, params: ImportDatasetAsNewProjectJobParams, task: Task) -> Dataset:
+        dataset = self._convert_dataset(dataset=dataset, task=task)
         if len(dataset) > 0 and params.subsets:
             dataset = dataset.filter_by_subset(subset=[Subset[subset.name] for subset in params.subsets])
         if len(dataset) > 0 and params.labels:
+            # Track items that were explicitly labeled as empty (i.e., reviewed but intentionally have no labels)
+            # BEFORE filtering. This is necessary because filter_by_labels with keep_empty_samples=True will also keep
+            # genuinely unannotated items, making them indistinguishable from items that originally had empty labels.
+            # After filtering, we reset user_reviewed=False for any newly-empty items (those that lost their labels
+            # due to filtering) while preserving user_reviewed=True for items that were already empty-labeled before
+            # the filter.
+            empty_label_supported = "user_reviewed" in dataset.df.columns and dataset.df["label"].dtype == pl.List
+            empty_labeled = set()
+            if empty_label_supported:
+                mask = (pl.col("label").list.len() == 0) & pl.col("user_reviewed")
+                empty_labeled = set(dataset.df.filter(mask)["id"].to_list())
             dataset = dataset.filter_by_labels(labels=params.labels, keep_empty_samples=params.include_unannotated)
+            if empty_label_supported:
+                dataset.df = dataset.df.with_columns(
+                    pl.when((pl.col("label").list.len() == 0) & (~pl.col("id").is_in(empty_labeled)))
+                    .then(False)
+                    .otherwise(pl.col("user_reviewed"))
+                    .alias("user_reviewed")
+                )
         return dataset
 
     @step("Import items from dataset to project", 100)
@@ -108,7 +128,15 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
         )
 
     def execute(self, params: ImportDatasetAsNewProjectJobParams) -> None:
-        project = self.create_project(params)
+        dataset = self.import_dataset(params=params)
+        multilabel = self._is_multilabel_dataset(dataset=dataset)
+        project = self.create_project(params=params, exclusive_labels=not multilabel)
         self.update_metadata({"project_id": project.id})
-        dataset = self.prepare_dataset(params=params, task=project.task)
+        dataset = self.prepare_dataset(dataset=dataset, params=params, task=project.task)
         self.create_items(dataset=dataset, project=project, include_unannotated=params.include_unannotated)
+
+    @staticmethod
+    def _is_multilabel_dataset(dataset: Dataset) -> bool:
+        if "label" in dataset.schema.attributes:
+            return getattr(dataset.schema.attributes["label"].field, "multi_label", False)
+        return False

--- a/application/backend/app/execution/dataset_import/import_to_project.py
+++ b/application/backend/app/execution/dataset_import/import_to_project.py
@@ -55,7 +55,8 @@ class ImportDatasetToProject(BaseDatasetImport[ImportDatasetToProjectJobParams])
 
     @step("Prepare dataset", 10)
     def prepare_dataset(self, staged_dataset_id: UUID, task: Task) -> Dataset:
-        return self._prepare_dataset(staged_dataset_id=staged_dataset_id, task=task)
+        dataset = self._import_dataset(staged_dataset_id=staged_dataset_id)
+        return self._convert_dataset(dataset=dataset, task=task)
 
     @step("Import items from dataset to project", 100)
     def create_items(self, dataset: Dataset, params: ImportDatasetToProjectJobParams) -> None:

--- a/application/backend/app/execution/dataset_import/sample_to_annotation.py
+++ b/application/backend/app/execution/dataset_import/sample_to_annotation.py
@@ -102,7 +102,7 @@ class DatumaroSampleToGetiAnnotationConverter:
         """
         match sample:
             case MulticlassClassificationImportExportSample(label=label, confidence=confidence):
-                return self.__convert_classification_sample(label, confidence)
+                return self.__convert_multiclass_sample(label, confidence)
             case MultilabelClassificationImportExportSample(label=labels, confidence=confidences):
                 return self.__convert_multilabel_sample(labels, confidences)
             case DetectionImportExportSample(label=labels, bboxes=bboxes, confidence=confidences):
@@ -112,9 +112,9 @@ class DatumaroSampleToGetiAnnotationConverter:
             case _:
                 raise ValueError(f"Unsupported sample type: {type(sample)}")
 
-    def __convert_classification_sample(
+    def __convert_multiclass_sample(
         self, label: int | None, confidence: float | None
-    ) -> list[DatasetItemAnnotation]:
+    ) -> list[DatasetItemAnnotation] | None:
         if (label_refs := self.__convert_labels_to_refs(label)) and label_refs[0] is not None:
             return [
                 DatasetItemAnnotation(
@@ -123,11 +123,11 @@ class DatumaroSampleToGetiAnnotationConverter:
                     confidences=[confidence] if confidence is not None else None,
                 )
             ]
-        return []
+        return None
 
     def __convert_multilabel_sample(
         self, labels: NDArrayInt | None, confidences: NDArrayFloat32 | None
-    ) -> list[DatasetItemAnnotation]:
+    ) -> list[DatasetItemAnnotation] | None:
         if label_refs := self.__convert_labels_to_refs(labels):
             return [
                 DatasetItemAnnotation(
@@ -136,7 +136,7 @@ class DatumaroSampleToGetiAnnotationConverter:
                     confidences=confidences,
                 )
             ]
-        return []
+        return None
 
     def __convert_detection_sample(
         self, labels: NDArrayInt | None, bboxes: NDArrayInt | None, confidences: NDArrayFloat32 | None

--- a/application/backend/app/models/jobs/import_dataset_as_new_project_job.py
+++ b/application/backend/app/models/jobs/import_dataset_as_new_project_job.py
@@ -14,7 +14,6 @@ class ImportDatasetAsNewProjectJobParams(JobParams):
     task_type: TaskType
     labels: list[str] | None
     subsets: list[DatasetItemSubset] | None
-    exclusive_labels: bool = False
     include_unannotated: bool = True
     project_id: UUID | None = None
 

--- a/application/backend/tests/bdd/utils/samples.py
+++ b/application/backend/tests/bdd/utils/samples.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import secrets
+from uuid import uuid4
 
 import numpy as np
 from datumaro.experimental import LazyImage, LazyVideoFrame, MediaInfo
@@ -31,7 +32,7 @@ class SampleFactory:
     ):
         """Return a fully constructed sample for the task's annotation type."""
         base = {
-            "id": None,
+            "id": str(uuid4()),
             "media": lazy_media,
             "media_info": media_info,
             "subset": Subset[subset.upper()],

--- a/application/backend/tests/unit/execution/dataset_import/test_base_import.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_base_import.py
@@ -103,9 +103,9 @@ def create_mock_video(output_path: Path, width: int = 10, height: int = 10, fps:
 
 
 class TestBaseDatasetImport:
-    def test_prepare_dataset_no_directory(self, fxt_dummy_import: DummyDatasetImport) -> None:
+    def test_import_dataset_no_directory(self, fxt_dummy_import: DummyDatasetImport) -> None:
         with pytest.raises(ValueError, match="Staged dataset directory does not exist"):
-            fxt_dummy_import._prepare_dataset(staged_dataset_id=uuid4(), task=Task(task_type=TaskType.CLASSIFICATION))
+            fxt_dummy_import._import_dataset(staged_dataset_id=uuid4())
 
     @pytest.mark.parametrize(
         "sample_type, target_type, task",
@@ -147,12 +147,12 @@ class TestBaseDatasetImport:
             ),
             (
                 MulticlassClassificationImportExportSample,
-                DetectionImportExportSample,
-                Task(exclusive_labels=True, task_type=TaskType.DETECTION),
+                MultilabelClassificationImportExportSample,
+                Task(task_type=TaskType.CLASSIFICATION),
             ),
         ],
     )
-    def test_prepare_dataset_error(
+    def test_convert_dataset_error(
         self,
         sample_type: type[BaseImportExportSample],
         target_type: type[BaseImportExportSample],
@@ -163,19 +163,18 @@ class TestBaseDatasetImport:
         dataset_id = uuid4()
         dataset_dir = fxt_staged_datasets_dir / str(dataset_id) / "dataset"
         dataset_dir.mkdir(parents=True)
-        expected_dataset = Mock(spec=Dataset)
-        expected_dataset.dtype = sample_type
+        dataset = Mock(spec=Dataset)
+        dataset.dtype = sample_type
         converted_dataset = Mock(spec=Dataset)
-        expected_dataset.convert_to_schema.return_value = converted_dataset
+        dataset.convert_to_schema.return_value = converted_dataset
 
         with (
             pytest.raises(
                 ValueError,
                 match=f"Dataset type {sample_type.__name__} conversion to {target_type.__name__} is not supported.",
             ),
-            patch("app.execution.dataset_import.base_import.import_dataset", return_value=expected_dataset),
         ):
-            fxt_dummy_import._prepare_dataset(staged_dataset_id=dataset_id, task=task)
+            fxt_dummy_import._convert_dataset(dataset=dataset, task=task)
 
     @pytest.mark.parametrize(
         "sample_type, task",
@@ -184,10 +183,9 @@ class TestBaseDatasetImport:
             (InstanceSegmentationImportExportSample, Task(task_type=TaskType.DETECTION)),
             (DetectionImportExportSample, Task(task_type=TaskType.CLASSIFICATION)),
             (DetectionImportExportSample, Task(task_type=TaskType.INSTANCE_SEGMENTATION)),
-            (MulticlassClassificationImportExportSample, Task(task_type=TaskType.CLASSIFICATION)),
         ],
     )
-    def test_prepare_dataset_success(
+    def test_convert_dataset_success(
         self,
         sample_type: type[BaseImportExportSample],
         task: Task,
@@ -197,18 +195,15 @@ class TestBaseDatasetImport:
         dataset_id = uuid4()
         dataset_dir = fxt_staged_datasets_dir / str(dataset_id) / "dataset"
         dataset_dir.mkdir(parents=True)
-        expected_dataset = Mock(spec=Dataset)
-        expected_dataset.dtype = sample_type
+        dataset = Mock(spec=Dataset)
+        dataset.dtype = sample_type
         converted_dataset = Mock(spec=Dataset)
-        expected_dataset.convert_to_schema.return_value = converted_dataset
+        dataset.convert_to_schema.return_value = converted_dataset
 
-        with patch(
-            "app.execution.dataset_import.base_import.import_dataset", return_value=expected_dataset
-        ) as mock_import:
-            result = fxt_dummy_import._prepare_dataset(staged_dataset_id=dataset_id, task=task)
+        result = fxt_dummy_import._convert_dataset(dataset=dataset, task=task)
 
-            mock_import.assert_called_once_with(str(dataset_dir))
-            assert result == converted_dataset
+        dataset.convert_to_schema.assert_called_once()
+        assert result == converted_dataset
 
     def test_create_items_images(
         self,

--- a/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
+import polars as pl
 import pytest
 from datumaro.experimental import Dataset
 from datumaro.experimental.categories import LabelCategories
@@ -47,7 +48,6 @@ def fxt_import_params() -> ImportDatasetAsNewProjectJobParams:
     return ImportDatasetAsNewProjectJobParams(
         project_name="New Project",
         task_type=TaskType.CLASSIFICATION,
-        exclusive_labels=False,
         staged_dataset_id=uuid4(),
         labels=["label1", "label2"],
         subsets=[],
@@ -68,33 +68,46 @@ class TestImportDatasetAsNewProject:
         project.id = uuid4()
         fxt_project_service.create_project.return_value = project
 
-        result = fxt_import.create_project(fxt_import_params)
+        result = fxt_import.create_project(params=fxt_import_params, exclusive_labels=False)
 
         fxt_project_service.create_project.assert_called_once()
         call_args = fxt_project_service.create_project.call_args
         assert call_args.kwargs["name"] == fxt_import_params.project_name
-        assert call_args.kwargs["task"].exclusive_labels == fxt_import_params.exclusive_labels
         assert call_args.kwargs["task"].task_type == fxt_import_params.task_type
         assert result == project
 
+    @pytest.mark.parametrize("include_unannotated", [True, False])
     def test_prepare_dataset(
-        self, fxt_import: ImportDatasetAsNewProject, fxt_import_params: ImportDatasetAsNewProjectJobParams
+        self,
+        include_unannotated: bool,
+        fxt_import: ImportDatasetAsNewProject,
+        fxt_import_params: ImportDatasetAsNewProjectJobParams,
     ) -> None:
+        fxt_import_params.include_unannotated = include_unannotated
         dataset = MagicMock(spec=Dataset)
-        dataset.__len__.return_value = 10
+        dataset.__len__.return_value = 3
         dataset.filter_by_subset.return_value = dataset
         dataset.filter_by_labels.return_value = dataset
+        dataset.df = pl.DataFrame(
+            {
+                "id": ["item1", "item2"],
+                "label": [["label1"], []],
+                "user_reviewed": [True, True],
+            }
+        )
         task = Task(task_type=fxt_import_params.task_type)
 
-        with patch.object(fxt_import, "_prepare_dataset", return_value=dataset) as mock_prepare:
-            result = fxt_import.prepare_dataset(params=fxt_import_params, task=task)
+        with patch.object(fxt_import, "_convert_dataset", return_value=dataset) as mock_convert:
+            result = fxt_import.prepare_dataset(dataset=dataset, params=fxt_import_params, task=task)
 
-            mock_prepare.assert_called_once_with(staged_dataset_id=fxt_import_params.staged_dataset_id, task=task)
+            mock_convert.assert_called_once_with(dataset=dataset, task=task)
             dataset.filter_by_subset.assert_not_called()
             dataset.filter_by_labels.assert_called_once_with(
-                labels=fxt_import_params.labels, keep_empty_samples=fxt_import_params.include_unannotated
+                labels=fxt_import_params.labels, keep_empty_samples=include_unannotated
             )
             assert result == dataset
+            # make sure that item with empty label kept reviewed
+            assert result.df["user_reviewed"].to_list() == [True, True]
 
     @pytest.mark.parametrize(
         "dataset_labels, project_labels, expected_mapping",
@@ -162,14 +175,18 @@ class TestImportDatasetAsNewProject:
         project.name = fxt_import_params.project_name
         project.task = Mock(spec=Task)
         with (
+            patch.object(fxt_import, "import_dataset", return_value=dataset) as mock_import_dataset,
+            patch.object(fxt_import, "_is_multilabel_dataset", return_value=False) as mock_multilabel_dataset,
             patch.object(fxt_import, "create_project", return_value=project) as mock_create_project,
-            patch.object(fxt_import, "prepare_dataset", return_value=dataset) as mock_prepare,
+            patch.object(fxt_import, "prepare_dataset", return_value=dataset) as mock_prepare_dataset,
             patch.object(fxt_import, "create_items") as mock_create,
         ):
             fxt_import.execute(fxt_import_params)
 
-            mock_create_project.assert_called_once_with(fxt_import_params)
-            mock_prepare.assert_called_once_with(params=fxt_import_params, task=project.task)
+            mock_import_dataset.assert_called_once_with(params=fxt_import_params)
+            mock_multilabel_dataset.assert_called_once_with(dataset=dataset)
+            mock_create_project.assert_called_once_with(params=fxt_import_params, exclusive_labels=True)
+            mock_prepare_dataset.assert_called_once_with(dataset=dataset, params=fxt_import_params, task=project.task)
             mock_create.assert_called_once_with(
                 dataset=dataset, project=project, include_unannotated=fxt_import_params.include_unannotated
             )

--- a/application/backend/tests/unit/execution/dataset_import/test_import_to_project.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_import_to_project.py
@@ -47,14 +47,16 @@ class TestImportDatasetToProject:
     ) -> None:
         dataset = Mock(spec=Dataset)
 
-        with patch.object(fxt_import, "_prepare_dataset", return_value=dataset) as mock_prepare:
+        with (
+            patch.object(fxt_import, "_import_dataset", return_value=dataset) as mock_import_dataset,
+            patch.object(fxt_import, "_convert_dataset", return_value=dataset) as mock_convert_dataset,
+        ):
             result = fxt_import.prepare_dataset(
                 staged_dataset_id=fxt_import_params.staged_dataset_id, task=fxt_import_params.task
             )
 
-            mock_prepare.assert_called_once_with(
-                staged_dataset_id=fxt_import_params.staged_dataset_id, task=fxt_import_params.task
-            )
+            mock_import_dataset.assert_called_once_with(staged_dataset_id=fxt_import_params.staged_dataset_id)
+            mock_convert_dataset.assert_called_once_with(dataset=dataset, task=fxt_import_params.task)
             assert result == dataset
 
     def test_create_items(
@@ -79,12 +81,12 @@ class TestImportDatasetToProject:
         dataset = Mock(spec=Dataset)
 
         with (
-            patch.object(fxt_import, "prepare_dataset", return_value=dataset) as mock_prepare,
+            patch.object(fxt_import, "prepare_dataset", return_value=dataset) as mock_prepare_dataset,
             patch.object(fxt_import, "create_items") as mock_create,
         ):
             fxt_import.execute(fxt_import_params)
 
-            mock_prepare.assert_called_once_with(
+            mock_prepare_dataset.assert_called_once_with(
                 staged_dataset_id=fxt_import_params.staged_dataset_id, task=fxt_import_params.task
             )
             mock_create.assert_called_once_with(dataset=dataset, params=fxt_import_params)

--- a/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
@@ -112,7 +112,7 @@ class TestClassificationConversion:
 
         result = fxt_converter.convert_sample(sample)
 
-        assert result == []
+        assert result is None
 
     def test_convert_classification_sample_with_label_mapping(
         self, fxt_project_labels_for_mapping, fxt_converter_with_mapping
@@ -134,7 +134,7 @@ class TestClassificationConversion:
         sample = MulticlassClassificationImportExportSample(label=2, confidence=0.9)
         result = converter.convert_sample(sample)
 
-        assert result == []  # Label should be filtered out and no annotations returned
+        assert result is None  # Label should be filtered out and no annotations returned
 
 
 class TestMultilabelConversion:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Remove `exclusive_labels` from project request
- [x] Detect classification task based on dataset metadata
- [x] Fix regression when unannotated become empty labeled
- [x] Fix bdd tests

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
