### PR TITLE
Add tiff support for annotator

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -5,7 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "@geti/ui",
+            "name": "@geti/app-ui",
             "version": "1.0.0",
             "hasInstallScript": true,
             "workspaces": [
@@ -34,6 +34,7 @@
                 "react-router-dom": "~6.30.1",
                 "recharts": "~3.7.0",
                 "static-path": "~0.0.4",
+                "utif": "^3.1.0",
                 "uuid": "~11.1.0"
             },
             "devDependencies": {
@@ -57,6 +58,7 @@
                 "@types/node": "~24.0.15",
                 "@types/react": "~19.1.10",
                 "@types/react-dom": "~19.1.7",
+                "@types/utif": "^3.0.6",
                 "@types/uuid": "~10.0.0",
                 "@typescript-eslint/eslint-plugin": "~8.31.1",
                 "@vitejs/plugin-react": "~4.7.0",
@@ -9134,6 +9136,16 @@
             "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
+        "node_modules/@types/utif": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/utif/-/utif-3.0.6.tgz",
+            "integrity": "sha512-4XHDJkLHoUeLA2P/VOd6dpDJpSTpV84tN9EyHojZrW22jtUR0VrdLwVRUAw+oI3g72vSzOo+YQOzfwcW6WYHLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/uuid": {
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -14930,6 +14942,12 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -17876,6 +17894,15 @@
             },
             "peerDependencies": {
                 "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
+            }
+        },
+        "node_modules/utif": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/utif/-/utif-3.1.0.tgz",
+            "integrity": "sha512-WEo4D/xOvFW53K5f5QTaTbbiORcm2/pCL9P6qmJnup+17eYfKaEhDeX9PeQkuyEoIxlbGklDuGl8xwuXYMrrXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "pako": "^1.0.5"
             }
         },
         "node_modules/utility-types": {

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -54,6 +54,7 @@
         "react-router-dom": "~6.30.1",
         "recharts": "~3.7.0",
         "static-path": "~0.0.4",
+        "utif": "^3.1.0",
         "uuid": "~11.1.0"
     },
     "devDependencies": {
@@ -77,6 +78,7 @@
         "@types/node": "~24.0.15",
         "@types/react": "~19.1.10",
         "@types/react-dom": "~19.1.7",
+        "@types/utif": "^3.0.6",
         "@types/uuid": "~10.0.0",
         "@typescript-eslint/eslint-plugin": "~8.31.1",
         "@vitejs/plugin-react": "~4.7.0",

--- a/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
+++ b/application/ui/src/features/annotator/hooks/use-load-image-query.hook.ts
@@ -7,6 +7,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { Media } from '../../../constants/shared-types';
 import { isVideoFrame } from '../../../shared/media-item-utils';
 import { getMediaBinaryUrl, getVideoFrameBinaryUrl } from '../../../shared/media-url.utils';
+import { getImageDataFromTiffUrl, isTiffFormat } from '../../../shared/media-utils';
 import { getImageData, loadImage } from '../tools/utils';
 
 export const loadImageQueryOptions = (projectId: string, media: Media) =>
@@ -18,6 +19,10 @@ export const loadImageQueryOptions = (projectId: string, media: Media) =>
             const url = isVideoFrame(media)
                 ? getVideoFrameBinaryUrl(projectId, media.id, media.frame_number)
                 : getMediaBinaryUrl(projectId, media.id);
+
+            if (isTiffFormat(media)) {
+                return getImageDataFromTiffUrl(url);
+            }
 
             const image = await loadImage(url);
 

--- a/application/ui/src/setup-tests.ts
+++ b/application/ui/src/setup-tests.ts
@@ -81,7 +81,9 @@ class ImageDataMock {
     }
 }
 
-global.ImageData = ImageDataMock as unknown as typeof ImageData;
+if (typeof global.ImageData === 'undefined') {
+    global.ImageData = ImageDataMock as unknown as typeof ImageData;
+}
 
 const createLocalStorageMock = () => {
     let store: Record<string, string> = {};

--- a/application/ui/src/setup-tests.ts
+++ b/application/ui/src/setup-tests.ts
@@ -69,6 +69,20 @@ class IntersectionObserverMock {
 
 global.IntersectionObserver = IntersectionObserverMock as unknown as typeof IntersectionObserver;
 
+class ImageDataMock {
+    data: Uint8ClampedArray;
+    width: number;
+    height: number;
+
+    constructor(data: Uint8ClampedArray, width: number, height?: number) {
+        this.data = data;
+        this.width = width;
+        this.height = height ?? 1;
+    }
+}
+
+global.ImageData = ImageDataMock as unknown as typeof ImageData;
+
 const createLocalStorageMock = () => {
     let store: Record<string, string> = {};
 

--- a/application/ui/src/shared/media-utils.test.ts
+++ b/application/ui/src/shared/media-utils.test.ts
@@ -16,6 +16,7 @@ vi.mock('utif', () => ({
 
 afterEach(() => {
     vi.resetAllMocks();
+    vi.restoreAllMocks();
 });
 
 const TIFF_BINARY_URL = '/api/projects/test-project/dataset/media/test-media/binary';

--- a/application/ui/src/shared/media-utils.test.ts
+++ b/application/ui/src/shared/media-utils.test.ts
@@ -1,0 +1,90 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { HttpResponse } from 'msw';
+import * as UTIF from 'utif';
+
+import { http } from '../api/utils';
+import { server } from '../msw-node-setup';
+import { getImageDataFromTiffUrl, isTiffFormat } from './media-utils';
+
+vi.mock('utif', () => ({
+    decode: vi.fn(),
+    decodeImage: vi.fn(),
+    toRGBA8: vi.fn(),
+}));
+
+afterEach(() => {
+    vi.resetAllMocks();
+});
+
+const TIFF_BINARY_URL = '/api/projects/test-project/dataset/media/test-media/binary';
+
+describe('isTiffFormat', () => {
+    it.each(['tif', 'tiff', 'TIF', 'TIFF'])('returns true for format "%s"', (format) => {
+        expect(isTiffFormat({ format })).toBe(true);
+    });
+
+    it.each(['jpg', 'jpeg', 'png', 'webp', 'bmp'])('returns false for format "%s"', (format) => {
+        expect(isTiffFormat({ format })).toBe(false);
+    });
+
+    it('returns false when format is undefined', () => {
+        expect(isTiffFormat({})).toBe(false);
+    });
+});
+
+describe('getImageDataFromTiffUrl', () => {
+    it('returns decoded ImageData for a valid TIFF', async () => {
+        const fakeBuffer = new ArrayBuffer(8);
+        const fakeRgba = new Uint8Array([255, 0, 0, 255]);
+        const fakeTiff = { width: 1, height: 1, data: new Uint8Array(fakeBuffer) };
+
+        server.use(
+            http.get(
+                '/api/projects/{project_id}/dataset/media/{media_id}/binary',
+                () => new HttpResponse(fakeBuffer, { headers: { 'Content-Type': 'image/tiff' } })
+            )
+        );
+        vi.mocked(UTIF.decode).mockReturnValue([fakeTiff]);
+        vi.mocked(UTIF.toRGBA8).mockReturnValue(fakeRgba);
+
+        const result = await getImageDataFromTiffUrl(TIFF_BINARY_URL);
+
+        expect(UTIF.decode).toHaveBeenCalledWith(expect.any(ArrayBuffer));
+        expect(UTIF.decodeImage).toHaveBeenCalledWith(expect.any(ArrayBuffer), fakeTiff);
+        expect(result).toBeInstanceOf(ImageData);
+        expect(result.width).toBe(1);
+        expect(result.height).toBe(1);
+    });
+
+    it('returns 1x1 fallback when decode returns no IFDs', async () => {
+        server.use(
+            http.get(
+                '/api/projects/{project_id}/dataset/media/{media_id}/binary',
+                () => new HttpResponse(new ArrayBuffer(0))
+            )
+        );
+        vi.mocked(UTIF.decode).mockReturnValue([]);
+
+        const result = await getImageDataFromTiffUrl(TIFF_BINARY_URL);
+
+        expect(result.width).toBe(1);
+        expect(result.height).toBe(1);
+    });
+
+    it('returns 1x1 fallback and logs error when fetch fails', async () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        server.use(
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/binary', () => {
+                throw new Error('network error');
+            })
+        );
+
+        const result = await getImageDataFromTiffUrl(TIFF_BINARY_URL);
+
+        expect(result.width).toBe(1);
+        expect(result.height).toBe(1);
+        expect(consoleSpy).toHaveBeenCalledWith('Failed to decode TIFF image:', expect.any(Error));
+    });
+});

--- a/application/ui/src/shared/media-utils.ts
+++ b/application/ui/src/shared/media-utils.ts
@@ -1,0 +1,32 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import * as UTIF from 'utif';
+
+const TIFF_FORMATS = ['tif', 'tiff'];
+
+export const isTiffFormat = (media: { format?: string }): boolean => {
+    return TIFF_FORMATS.includes(String(media.format).toLowerCase());
+};
+
+export const getImageDataFromTiffUrl = async (url: string): Promise<ImageData> => {
+    try {
+        const response = await fetch(url);
+        const buffer = await response.arrayBuffer();
+        const ifds = UTIF.decode(buffer);
+
+        if (ifds.length === 0) {
+            return new ImageData(1, 1);
+        }
+
+        const tiff = ifds[0];
+        UTIF.decodeImage(buffer, tiff);
+        const rgba = UTIF.toRGBA8(tiff);
+
+        return new ImageData(new Uint8ClampedArray(rgba), tiff.width, tiff.height);
+    } catch (error) {
+        console.error('Failed to decode TIFF image:', error);
+
+        return new ImageData(1, 1);
+    }
+};

--- a/application/ui/src/shared/media-utils.ts
+++ b/application/ui/src/shared/media-utils.ts
@@ -12,6 +12,13 @@ export const isTiffFormat = (media: { format?: string }): boolean => {
 export const getImageDataFromTiffUrl = async (url: string): Promise<ImageData> => {
     try {
         const response = await fetch(url);
+
+        if (!response.ok) {
+            throw new Error(
+                `Failed to fetch TIFF image from "${url}". HTTP status ${response.status} ${response.statusText}`
+            );
+        }
+
         const buffer = await response.arrayBuffer();
         const ifds = UTIF.decode(buffer);
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Uploading .tif/.tiff already works out of the box since backend is ready and returns a jpeg thumbnail
* What was missing was the rendering part, which https://github.com/photopea/UTIF.js help us to do, just like in classic

Closes https://github.com/open-edge-platform/training_extensions/issues/5615

<img width="1254" height="1151" alt="Screenshot 2026-03-27 at 07 26 17" src="https://github.com/user-attachments/assets/60346624-32d2-4489-8e75-70edb2032f5f" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
