### PR TITLE
Extend DataInputParams with IntensityConfig fields for model export

### DIFF
--- a/library/src/otx/backend/native/engine.py
+++ b/library/src/otx/backend/native/engine.py
@@ -148,6 +148,18 @@ class OTXEngine(Engine):
                 params["mean"] = self._datamodule.input_mean
             if self._datamodule.input_std is not None:
                 params["std"] = self._datamodule.input_std
+            if hasattr(self._datamodule, "intensity_config"):
+                ic = self._datamodule.intensity_config
+                params["storage_dtype"] = ic.storage_dtype
+                params["intensity_mode"] = ic.mode
+                params["intensity_max_value"] = ic.max_value
+                params["window_center"] = ic.window_center
+                params["window_width"] = ic.window_width
+                params["percentile_low"] = ic.percentile_low
+                params["percentile_high"] = ic.percentile_high
+                params["scale_factor"] = ic.scale_factor
+                params["min_value"] = ic.min_value
+                params["repeat_channels"] = ic.repeat_channels
             get_model_args["data_input_params"] = params
 
             model = self._auto_configurator.get_model(**get_model_args)

--- a/library/src/otx/backend/native/engine.py
+++ b/library/src/otx/backend/native/engine.py
@@ -33,6 +33,7 @@ from otx.backend.native.callbacks.lr_monitor import SimpleLearningRateMonitor
 from otx.backend.native.models.base import OTXModel
 from otx.backend.native.tools import adapt_batch_size
 from otx.backend.native.utils.cache import TrainerArgumentsCache
+from otx.config.data import IntensityConfig
 from otx.config.device import DeviceConfig
 from otx.config.explain import ExplainConfig
 from otx.data.module import OTXDataModule
@@ -148,8 +149,8 @@ class OTXEngine(Engine):
                 params["mean"] = self._datamodule.input_mean
             if self._datamodule.input_std is not None:
                 params["std"] = self._datamodule.input_std
-            if hasattr(self._datamodule, "intensity_config"):
-                ic = self._datamodule.intensity_config
+            ic = getattr(self._datamodule, "intensity_config", None)
+            if isinstance(ic, IntensityConfig):
                 params["storage_dtype"] = ic.storage_dtype
                 params["intensity_mode"] = ic.mode
                 params["intensity_max_value"] = ic.max_value

--- a/library/src/otx/backend/native/exporter/base.py
+++ b/library/src/otx/backend/native/exporter/base.py
@@ -174,13 +174,27 @@ class OTXModelExporter:
         mean_str = " ".join(map(str, self.data_input_params.mean)) if self.data_input_params.mean else ""
         std_str = " ".join(map(str, self.data_input_params.std)) if self.data_input_params.std else ""
 
+        dip = self.data_input_params
         extra_data = {
             ("model_info", "mean_values"): mean_str.strip(),
             ("model_info", "scale_values"): std_str.strip(),
             ("model_info", "resize_type"): self.resize_mode,
             ("model_info", "pad_value"): str(self.pad_value),
             ("model_info", "reverse_input_channels"): str(self.swap_rgb),
+            ("model_info", "storage_dtype"): dip.storage_dtype,
+            ("model_info", "intensity_mode"): dip.intensity_mode,
+            ("model_info", "percentile_low"): str(dip.percentile_low),
+            ("model_info", "percentile_high"): str(dip.percentile_high),
+            ("model_info", "scale_factor"): str(dip.scale_factor),
+            ("model_info", "min_value"): str(dip.min_value),
+            ("model_info", "repeat_channels"): str(dip.repeat_channels),
         }
+        if dip.intensity_max_value is not None:
+            extra_data[("model_info", "intensity_max_value")] = str(dip.intensity_max_value)
+        if dip.window_center is not None:
+            extra_data[("model_info", "window_center")] = str(dip.window_center)
+        if dip.window_width is not None:
+            extra_data[("model_info", "window_width")] = str(dip.window_width)
         extra_data.update(metadata)
 
         return extra_data

--- a/library/src/otx/backend/native/models/base.py
+++ b/library/src/otx/backend/native/models/base.py
@@ -986,6 +986,9 @@ class OTXModel(LightningModule):
         if isinstance(preprocessing_params, dict):
             # Merge with model defaults for any missing keys so callers can pass
             # a partial dict (e.g. only input_size) without knowing mean/std upfront.
+            # Fall back to DataInputParams field defaults when model has no defaults.
+            fallback = DataInputParams(input_size=(0, 0), mean=(0.0, 0.0, 0.0), std=(1.0, 1.0, 1.0))
+            default = default or fallback
             data_input_params = DataInputParams(
                 input_size=preprocessing_params.get("input_size") or default.input_size,
                 mean=preprocessing_params.get("mean") or default.mean,

--- a/library/src/otx/backend/native/models/base.py
+++ b/library/src/otx/backend/native/models/base.py
@@ -68,10 +68,34 @@ class DataInputParams:
     input_size: tuple[int, int]
     mean: tuple[float, float, float]
     std: tuple[float, float, float]
+    storage_dtype: str = "uint8"
+    intensity_mode: str = "scale_to_unit"
+    intensity_max_value: float | None = None
+    window_center: float | None = None
+    window_width: float | None = None
+    percentile_low: float = 1.0
+    percentile_high: float = 99.0
+    scale_factor: float = 1.0
+    min_value: float = 0.0
+    repeat_channels: int = 0
 
     def as_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
-        return {"input_size": self.input_size, "mean": self.mean, "std": self.std}
+        return {
+            "input_size": self.input_size,
+            "mean": self.mean,
+            "std": self.std,
+            "storage_dtype": self.storage_dtype,
+            "intensity_mode": self.intensity_mode,
+            "intensity_max_value": self.intensity_max_value,
+            "window_center": self.window_center,
+            "window_width": self.window_width,
+            "percentile_low": self.percentile_low,
+            "percentile_high": self.percentile_high,
+            "scale_factor": self.scale_factor,
+            "min_value": self.min_value,
+            "repeat_channels": self.repeat_channels,
+        }
 
     def as_ncwh(self, batch_size: int = 1) -> tuple[int, int, int, int]:
         """Convert input_size to NCWH format."""
@@ -966,6 +990,16 @@ class OTXModel(LightningModule):
                 input_size=preprocessing_params.get("input_size") or default.input_size,
                 mean=preprocessing_params.get("mean") or default.mean,
                 std=preprocessing_params.get("std") or default.std,
+                storage_dtype=preprocessing_params.get("storage_dtype", default.storage_dtype),
+                intensity_mode=preprocessing_params.get("intensity_mode", default.intensity_mode),
+                intensity_max_value=preprocessing_params.get("intensity_max_value", default.intensity_max_value),
+                window_center=preprocessing_params.get("window_center", default.window_center),
+                window_width=preprocessing_params.get("window_width", default.window_width),
+                percentile_low=preprocessing_params.get("percentile_low", default.percentile_low),
+                percentile_high=preprocessing_params.get("percentile_high", default.percentile_high),
+                scale_factor=preprocessing_params.get("scale_factor", default.scale_factor),
+                min_value=preprocessing_params.get("min_value", default.min_value),
+                repeat_channels=preprocessing_params.get("repeat_channels", default.repeat_channels),
             )
         elif isinstance(preprocessing_params, DataInputParams):
             data_input_params = preprocessing_params

--- a/library/src/otx/cli/cli.py
+++ b/library/src/otx/cli/cli.py
@@ -19,6 +19,7 @@ from otx.cli.utils import absolute_path
 from otx.cli.utils.help_formatter import CustomHelpFormatter
 from otx.cli.utils.jsonargparse import get_short_docstring, patch_update_configs
 from otx.cli.utils.workspace import Workspace
+from otx.config.data import IntensityConfig
 from otx.types.task import OTXTaskType
 
 if TYPE_CHECKING:
@@ -329,8 +330,8 @@ class OTXCLI:
                 _dip["mean"] = self.datamodule.input_mean
             if self.datamodule.input_std is not None:
                 _dip["std"] = self.datamodule.input_std
-            if hasattr(self.datamodule, "intensity_config"):
-                ic = self.datamodule.intensity_config
+            ic = getattr(self.datamodule, "intensity_config", None)
+            if isinstance(ic, IntensityConfig):
                 _dip["storage_dtype"] = ic.storage_dtype
                 _dip["intensity_mode"] = ic.mode
                 _dip["intensity_max_value"] = ic.max_value

--- a/library/src/otx/cli/cli.py
+++ b/library/src/otx/cli/cli.py
@@ -329,6 +329,18 @@ class OTXCLI:
                 _dip["mean"] = self.datamodule.input_mean
             if self.datamodule.input_std is not None:
                 _dip["std"] = self.datamodule.input_std
+            if hasattr(self.datamodule, "intensity_config"):
+                ic = self.datamodule.intensity_config
+                _dip["storage_dtype"] = ic.storage_dtype
+                _dip["intensity_mode"] = ic.mode
+                _dip["intensity_max_value"] = ic.max_value
+                _dip["window_center"] = ic.window_center
+                _dip["window_width"] = ic.window_width
+                _dip["percentile_low"] = ic.percentile_low
+                _dip["percentile_high"] = ic.percentile_high
+                _dip["scale_factor"] = ic.scale_factor
+                _dip["min_value"] = ic.min_value
+                _dip["repeat_channels"] = ic.repeat_channels
             model_config.init_args["data_input_params"] = _dip
 
             # Instantiate the model and needed components

--- a/library/src/otx/data/module.py
+++ b/library/src/otx/data/module.py
@@ -129,6 +129,7 @@ class OTXDataModule(LightningDataModule):
             self.input_mean = None
             self.input_std = None
         self.input_size = input_size
+        self.intensity_config = self.train_subset.intensity
 
         self._setup_otx_dataset(dataset)
 
@@ -327,6 +328,8 @@ class OTXDataModule(LightningDataModule):
         else:
             instance.input_mean = None
             instance.input_std = None
+
+        instance.intensity_config = instance.train_subset.intensity
 
         # Save hyperparameters
         instance.save_hyperparameters(

--- a/library/tests/unit/backend/native/models/test_base.py
+++ b/library/tests/unit/backend/native/models/test_base.py
@@ -256,6 +256,16 @@ class TestDataInputParams:
             "input_size": (224, 224),
             "mean": (0.485, 0.456, 0.406),
             "std": (0.229, 0.224, 0.225),
+            "storage_dtype": "uint8",
+            "intensity_mode": "scale_to_unit",
+            "intensity_max_value": None,
+            "window_center": None,
+            "window_width": None,
+            "percentile_low": 1.0,
+            "percentile_high": 99.0,
+            "scale_factor": 1.0,
+            "min_value": 0.0,
+            "repeat_channels": 0,
         }
 
     def test_as_ncwh(self):


### PR DESCRIPTION
### Summary
- `library/src/otx/backend/native/models/base.py` - Added fields to `DataInputParams`. Updated `as_dict()` and the dict-merge in `_configure_preprocessing_params`.
- `library/src/otx/backend/native/exporter/base.py` - `_extend_model_metadata` now writes all intensity fields into the exported IR.
- `library/src/otx/data/module.py` - Exposed `intensity_config` from `train_subset.intensity` in both `__init__` and `from_otx_datasets`.
- `library/src/otx/backend/native/engine.py` - Read `intensity_config` from the datamodule and pass its fields into the `data_input_params` dict.
- `library/src/otx/cli/cli.py` - Same as engine, for the CLI path.
- `library/tests/unit/backend/native/models/test_base.py` - Updated `test_as_dict` to match the new fields.

Resolves #5952

### How to test
Export a model and verify new metadata keys appear in the IR (storage_dtype, intensity_mode, etc.) 
### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
