### PR TITLE
Fix all or no annotations should have confidence bug

### DIFF
--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -412,7 +412,7 @@ class OTXTrainer(Execution[TrainingJobParams]):
         logger.info("Starting the training loop (model_id={})", model_id)
         train_kwargs = {"devices": [device.index]} if device.type is not DeviceType.CPU and device.index else {}
         otx_engine.train(
-            max_epochs=training_config["max_epochs"],
+            max_epochs=1,  # training_config["max_epochs"],
             precision=training_config["precision"],
             callbacks=callbacks_list,
             **train_kwargs,  # pyrefly: ignore[bad-argument-type]

--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -412,7 +412,7 @@ class OTXTrainer(Execution[TrainingJobParams]):
         logger.info("Starting the training loop (model_id={})", model_id)
         train_kwargs = {"devices": [device.index]} if device.type is not DeviceType.CPU and device.index else {}
         otx_engine.train(
-            max_epochs=1,  # training_config["max_epochs"],
+            max_epochs=training_config["max_epochs"],
             precision=training_config["precision"],
             callbacks=callbacks_list,
             **train_kwargs,  # pyrefly: ignore[bad-argument-type]

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from collections import Counter
 from datetime import UTC, datetime
-from typing import Any, NamedTuple, cast
+from typing import Any, cast
 
 from sqlalchemy import CursorResult, Select, delete, func, select, update
 from sqlalchemy.dialects.sqlite import insert
@@ -12,12 +12,6 @@ from app.db.schema import DatasetItemDB, DatasetItemLabelDB, MediaDB
 from app.models import DatasetItemSubset
 
 from .filters import _apply_annotation_status_filter, _apply_subset_filter
-
-
-class UpdateDatasetItemAnnotation(NamedTuple):
-    annotation_data: list
-    user_reviewed: bool
-    prediction_model_id: str | None
 
 
 class DatasetItemRepository:
@@ -126,14 +120,9 @@ class DatasetItemRepository:
 
     def set_annotation_data(
         self, obj_id: str, annotation_data: list, user_reviewed: bool, prediction_model_id: str | None
-    ) -> UpdateDatasetItemAnnotation | None:
+    ) -> bool:
         stmt = (
             update(DatasetItemDB)
-            .returning(
-                DatasetItemDB.annotation_data,
-                DatasetItemDB.user_reviewed,
-                DatasetItemDB.prediction_model_id,
-            )
             .where(
                 DatasetItemDB.project_id == self.project_id,
                 DatasetItemDB.id == obj_id,
@@ -145,9 +134,8 @@ class DatasetItemRepository:
                 updated_at=datetime.now(UTC),
             )
         )
-        result = self.db.execute(stmt)
-        row = result.mappings().first()
-        return UpdateDatasetItemAnnotation(**row) if row else None  # pyrefly: ignore[missing-argument,bad-unpacking]
+        result = cast(CursorResult, self.db.execute(stmt))
+        return result.rowcount > 0
 
     def delete_annotation_data(self, obj_id: str) -> bool:
         stmt = (

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -299,7 +299,7 @@ class DatasetService(BaseSessionManagedService):
         """
         labels = self._label_service.list_all(project_id=project.id)
         media = self._media_service.get_media_by_id(project_id=project.id, media_id=dataset_item_id)
-        DatasetService._cleanup_and_validate_annotations(
+        annotations = DatasetService._cleanup_and_validate_annotations(
             annotations=annotations, task=project.task, labels=labels, media=media, user_reviewed=user_reviewed
         )
 

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -278,6 +278,11 @@ class DatasetService(BaseSessionManagedService):
         Returns:
             The updated dataset item.
         """
+        if user_reviewed:
+            # if user reviewed, user has accepted all predictions and/or added new annotations,
+            # so confidence scores are no longer meaningful
+            annotations = [annotation.model_copy(update={"confidences": None}) for annotation in annotations]
+
         labels = self._label_service.list_all(project_id=project.id)
         DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
         DatasetService._validate_annotations(annotations=annotations, task=project.task)

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -97,9 +97,9 @@ class DatasetService(BaseSessionManagedService):
 
         if annotations is not None:
             labels = self._label_service.list_all(project_id=project_id)
-            DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
-            DatasetService._validate_annotations(annotations=annotations, task=task)
-            DatasetService._validate_annotations_coordinates(annotations=annotations, media=media)
+            annotations = DatasetService._cleanup_and_validate_annotations(
+                annotations=annotations, task=task, labels=labels, media=media, user_reviewed=user_reviewed
+            )
 
             dataset_item.annotation_data = [annotation.model_dump(mode="json") for annotation in annotations]
 
@@ -199,6 +199,25 @@ class DatasetService(BaseSessionManagedService):
         return DatasetItem.model_validate(db_dataset_item)
 
     @staticmethod
+    def _cleanup_and_validate_annotations(
+        annotations: list[DatasetItemAnnotation],
+        task: Task,
+        labels: list[Label],
+        media: Media,
+        user_reviewed: bool,
+    ) -> list[DatasetItemAnnotation]:
+        if user_reviewed:
+            # if user reviewed, user has accepted all predictions and/or added new annotations,
+            # so confidence scores are no longer meaningful
+            annotations = [annotation.model_copy(update={"confidences": None}) for annotation in annotations]
+
+        DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
+        DatasetService._validate_annotation_shapes(annotations=annotations, task=task)
+        DatasetService._validate_annotations_coordinates(annotations=annotations, media=media)
+
+        return annotations
+
+    @staticmethod
     def _validate_annotations_labels(annotations: list[DatasetItemAnnotation], labels: Sequence[Label]) -> None:
         for annotation in annotations:
             for annotation_label in annotation.labels:
@@ -207,7 +226,7 @@ class DatasetService(BaseSessionManagedService):
                     raise AnnotationValidationError(f"Label {str(annotation_label.id)} is not found in the project.")
 
     @staticmethod
-    def _validate_annotations(annotations: list[DatasetItemAnnotation], task: Task) -> None:  # noqa: C901, PLR0912
+    def _validate_annotation_shapes(annotations: list[DatasetItemAnnotation], task: Task) -> None:  # noqa: C901, PLR0912
         match task.task_type:
             case TaskType.CLASSIFICATION:
                 if len(annotations) == 0:
@@ -278,28 +297,19 @@ class DatasetService(BaseSessionManagedService):
         Returns:
             The updated dataset item.
         """
-        if user_reviewed:
-            # if user reviewed, user has accepted all predictions and/or added new annotations,
-            # so confidence scores are no longer meaningful
-            annotations = [annotation.model_copy(update={"confidences": None}) for annotation in annotations]
-
         labels = self._label_service.list_all(project_id=project.id)
-        DatasetService._validate_annotations_labels(annotations=annotations, labels=labels)
-        DatasetService._validate_annotations(annotations=annotations, task=project.task)
+        media = self._media_service.get_media_by_id(project_id=project.id, media_id=dataset_item_id)
+        DatasetService._cleanup_and_validate_annotations(
+            annotations=annotations, task=project.task, labels=labels, media=media, user_reviewed=user_reviewed
+        )
 
         repo = DatasetItemRepository(project_id=str(project.id), db=self.db_session)
-        self.get_dataset_item_by_id(project_id=project.id, dataset_item_id=dataset_item_id)
-        media = self._media_service.get_media_by_id(project_id=project.id, media_id=dataset_item_id)
-
-        DatasetService._validate_annotations_coordinates(annotations=annotations, media=media)
-
-        result = repo.set_annotation_data(
+        if not repo.set_annotation_data(
             obj_id=str(dataset_item_id),
             annotation_data=[annotation.model_dump(mode="json") for annotation in annotations],
             user_reviewed=user_reviewed,
             prediction_model_id=str(prediction_model_id) if prediction_model_id is not None else None,
-        )
-        if not result:
+        ):
             raise ResourceNotFoundError(ResourceType.DATASET_ITEM, str(dataset_item_id))
 
         repo.set_labels(

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -908,24 +908,39 @@ class TestDatasetServiceIntegration:
         fxt_project_with_pipeline: tuple[Project, Pipeline],
         fxt_project_with_dataset_items: tuple[Project, list[DatasetItemDB]],
         fxt_annotations: Callable[[UUID], list[DatasetItemAnnotation]],
+        db_session: Session,
     ):
         """Test setting a dataset item annotation for a non-existent dataset item."""
         _, pipeline = fxt_project_with_pipeline
         project, db_dataset_items = fxt_project_with_dataset_items
-        non_existent_id = uuid4()
         annotations = fxt_annotations(project.task.labels[0].id)
+
+        # Create a media record with no corresponding dataset item so the media
+        # lookup succeeds but the dataset item update fails.
+        orphan_media = MediaDB(
+            type="image",
+            name="orphan",
+            format="jpg",
+            size=1024,
+            width=1024,
+            height=768,
+            project_id=str(project.id),
+        )
+        db_session.add(orphan_media)
+        db_session.flush()
+        orphan_media_id = UUID(orphan_media.id)
 
         with pytest.raises(ResourceNotFoundError) as excinfo:
             fxt_dataset_service.set_dataset_item_annotations(
                 project=project,
-                dataset_item_id=non_existent_id,
+                dataset_item_id=orphan_media_id,
                 annotations=annotations,
                 user_reviewed=True,
                 prediction_model_id=pipeline.model_id,
             )
 
         assert excinfo.value.resource_type == ResourceType.DATASET_ITEM
-        assert excinfo.value.resource_id == str(non_existent_id)
+        assert excinfo.value.resource_id == str(orphan_media_id)
 
     def test_delete_dataset_item_annotations(
         self,

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -372,9 +372,11 @@ class TestDatasetServiceUnit:
         ]
 
         with (
-            patch.object(DatasetService, "_validate_annotations_labels") as mock_validate_labels,
-            patch.object(DatasetService, "_validate_annotations") as mock_validate_annotations,
-            patch.object(DatasetService, "_validate_annotations_coordinates") as mock_validate_coordinates,
+            patch.object(
+                DatasetService,
+                "_cleanup_and_validate_annotations",
+                side_effect=lambda annotations, **kwargs: annotations,
+            ) as mock_cleanup_and_validate,
             patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
             patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,
             patch.object(DatasetItemRepository, "set_labels") as mock_repo_set_labels,
@@ -387,9 +389,7 @@ class TestDatasetServiceUnit:
                 prediction_model_id=None,
             )
 
-        mock_validate_labels.assert_called_once()
-        mock_validate_annotations.assert_called_once()
-        mock_validate_coordinates.assert_called_once()
+        mock_cleanup_and_validate.assert_called_once()
         mock_repo_set_annotation_data.assert_called_once_with(
             obj_id=str(dataset_item_id),
             annotation_data=[
@@ -429,7 +429,7 @@ class TestDatasetServiceUnit:
 
         with (
             patch.object(DatasetService, "_validate_annotations_labels"),
-            patch.object(DatasetService, "_validate_annotations"),
+            patch.object(DatasetService, "_validate_annotation_shapes"),
             patch.object(DatasetService, "_validate_annotations_coordinates"),
             patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
             patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,
@@ -463,7 +463,7 @@ class TestDatasetServiceUnit:
 
         with (
             patch.object(DatasetService, "_validate_annotations_labels"),
-            patch.object(DatasetService, "_validate_annotations"),
+            patch.object(DatasetService, "_validate_annotation_shapes"),
             patch.object(DatasetService, "_validate_annotations_coordinates"),
             patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
             patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -403,3 +403,75 @@ class TestDatasetServiceUnit:
             label_ids={str(label_id)},
         )
         assert result == dataset_item
+
+    def test_set_annotations_user_reviewed_strips_confidences(self, fxt_dataset_service, fxt_detection_project) -> None:
+        """When user submits annotations (user_reviewed=True), confidences must be stripped."""
+        dataset_service = fxt_dataset_service
+        dataset_item_id = uuid4()
+        dataset_item = MagicMock(spec=DatasetItem)
+        label_id = uuid4()
+        annotations = [
+            DatasetItemAnnotation(
+                labels=[LabelReference(id=label_id)],
+                shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
+                confidences=[0.95],
+            ),
+            DatasetItemAnnotation(
+                labels=[LabelReference(id=label_id)],
+                shape=Rectangle(type="rectangle", x=20, y=20, width=30, height=30),
+                confidences=None,
+            ),
+        ]
+
+        with (
+            patch.object(DatasetService, "_validate_annotations_labels"),
+            patch.object(DatasetService, "_validate_annotations"),
+            patch.object(DatasetService, "_validate_annotations_coordinates"),
+            patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
+            patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,
+            patch.object(DatasetItemRepository, "set_labels"),
+        ):
+            dataset_service.set_dataset_item_annotations(
+                project=fxt_detection_project,
+                dataset_item_id=dataset_item_id,
+                annotations=annotations,
+                user_reviewed=True,
+                prediction_model_id=None,
+            )
+
+        saved_annotation_data = mock_repo_set_annotation_data.call_args.kwargs["annotation_data"]
+        assert all(ann["confidences"] is None for ann in saved_annotation_data)
+
+    def test_set_annotations_prediction_preserves_confidences(self, fxt_dataset_service, fxt_detection_project) -> None:
+        """When predictions are stored (user_reviewed=False), confidences must be preserved."""
+        dataset_service = fxt_dataset_service
+        dataset_item_id = uuid4()
+        dataset_item = MagicMock(spec=DatasetItem)
+        label_id = uuid4()
+        model_id = uuid4()
+        annotations = [
+            DatasetItemAnnotation(
+                labels=[LabelReference(id=label_id)],
+                shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
+                confidences=[0.95],
+            ),
+        ]
+
+        with (
+            patch.object(DatasetService, "_validate_annotations_labels"),
+            patch.object(DatasetService, "_validate_annotations"),
+            patch.object(DatasetService, "_validate_annotations_coordinates"),
+            patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
+            patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,
+            patch.object(DatasetItemRepository, "set_labels"),
+        ):
+            dataset_service.set_dataset_item_annotations(
+                project=fxt_detection_project,
+                dataset_item_id=dataset_item_id,
+                annotations=annotations,
+                user_reviewed=False,
+                prediction_model_id=model_id,
+            )
+
+        saved_annotation_data = mock_repo_set_annotation_data.call_args.kwargs["annotation_data"]
+        assert saved_annotation_data[0]["confidences"] == [0.95]

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -167,11 +167,13 @@ class TestDatasetServiceUnit:
             )
         ]
         # Should not raise any exception since multilabel classification allows multiple labels
-        DatasetService._validate_annotations(annotations=annotations, task=fxt_multilabel_classification_project.task)
+        DatasetService._validate_annotation_shapes(
+            annotations=annotations, task=fxt_multilabel_classification_project.task
+        )
 
     def test_validate_annotations_multilabel_classification_empty(self, fxt_multilabel_classification_project) -> None:
         # Should not raise any exception since multilabel classification allows the empty label
-        DatasetService._validate_annotations(annotations=[], task=fxt_multilabel_classification_project.task)
+        DatasetService._validate_annotation_shapes(annotations=[], task=fxt_multilabel_classification_project.task)
 
     def test_validate_annotations_multilabel_classification_multi_annotations(
         self, fxt_multilabel_classification_project
@@ -189,7 +191,7 @@ class TestDatasetServiceUnit:
         # Should raise an exception since multilabel classification does not allow multiple annotations
         # (only one 'full_image' shape, possibly with multiple labels, is allowed)
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(
+            DatasetService._validate_annotation_shapes(
                 annotations=annotations, task=fxt_multilabel_classification_project.task
             )
 
@@ -211,7 +213,7 @@ class TestDatasetServiceUnit:
         ]
         # Should raise an exception since classification only allows 'full_image' shape
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(
+            DatasetService._validate_annotation_shapes(
                 annotations=annotations, task=fxt_multilabel_classification_project.task
             )
 
@@ -223,12 +225,14 @@ class TestDatasetServiceUnit:
             )
         ]
         # Should not raise any exception since the annotation is valid for multiclass classification
-        DatasetService._validate_annotations(annotations=annotations, task=fxt_multiclass_classification_project.task)
+        DatasetService._validate_annotation_shapes(
+            annotations=annotations, task=fxt_multiclass_classification_project.task
+        )
 
     def test_validate_annotations_multiclass_classification_empty(self, fxt_multiclass_classification_project) -> None:
         # Should raise an exception since multiclass classification requires exactly one label (empty label not allowed)
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=[], task=fxt_multiclass_classification_project.task)
+            DatasetService._validate_annotation_shapes(annotations=[], task=fxt_multiclass_classification_project.task)
 
     def test_validate_annotations_multiclass_classification_multiple_labels(
         self, fxt_multiclass_classification_project
@@ -241,7 +245,7 @@ class TestDatasetServiceUnit:
         ]
         # Should raise an exception since multiclass classification does not allow multiple labels
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(
+            DatasetService._validate_annotation_shapes(
                 annotations=annotations, task=fxt_multiclass_classification_project.task
             )
 
@@ -257,11 +261,11 @@ class TestDatasetServiceUnit:
             ),
         ]
         # Should not raise any exception since the annotations are valid for detection task
-        DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
+        DatasetService._validate_annotation_shapes(annotations=annotations, task=fxt_detection_project.task)
 
     def test_validate_annotations_detection_empty(self, fxt_detection_project) -> None:
         # Should not raise any exception since detection task allows the empty label
-        DatasetService._validate_annotations(annotations=[], task=fxt_detection_project.task)
+        DatasetService._validate_annotation_shapes(annotations=[], task=fxt_detection_project.task)
 
     @pytest.mark.parametrize(
         "shape",
@@ -283,7 +287,7 @@ class TestDatasetServiceUnit:
         ]
         # Should raise an exception since detection task only allows 'rectangle' shape
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
+            DatasetService._validate_annotation_shapes(annotations=annotations, task=fxt_detection_project.task)
 
     def test_validate_annotations_detection_wrong_shape_multiple_labels(self, fxt_detection_project) -> None:
         annotations = [
@@ -298,7 +302,7 @@ class TestDatasetServiceUnit:
         ]
         # Should raise an exception since detection task does not allow multiple labels on the same shape
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, task=fxt_detection_project.task)
+            DatasetService._validate_annotation_shapes(annotations=annotations, task=fxt_detection_project.task)
 
     def test_validate_annotations_segmentation(self, fxt_segmentation_project) -> None:
         annotations = [
@@ -312,11 +316,11 @@ class TestDatasetServiceUnit:
             ),
         ]
         # Should not raise any exception since the annotations are valid for segmentation task
-        DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
+        DatasetService._validate_annotation_shapes(annotations=annotations, task=fxt_segmentation_project.task)
 
     def test_validate_annotations_segmentation_empty(self, fxt_segmentation_project) -> None:
         # Should not raise any exception since segmentation task allows the empty label
-        DatasetService._validate_annotations(annotations=[], task=fxt_segmentation_project.task)
+        DatasetService._validate_annotation_shapes(annotations=[], task=fxt_segmentation_project.task)
 
     @pytest.mark.parametrize(
         "shape",
@@ -338,7 +342,7 @@ class TestDatasetServiceUnit:
         ]
         # Should raise an exception since segmentation task only allows 'polygon' shape
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
+            DatasetService._validate_annotation_shapes(annotations=annotations, task=fxt_segmentation_project.task)
 
     def test_validate_annotations_segmentation_wrong_shape_multiple_labels(self, fxt_segmentation_project) -> None:
         annotations = [
@@ -353,7 +357,7 @@ class TestDatasetServiceUnit:
         ]
         # Should raise an exception since segmentation task does not allow multiple labels on the same shape
         with pytest.raises(AnnotationValidationError):
-            DatasetService._validate_annotations(annotations=annotations, task=fxt_segmentation_project.task)
+            DatasetService._validate_annotation_shapes(annotations=annotations, task=fxt_segmentation_project.task)
 
     def test_set_dataset_item_annotations(self, fxt_dataset_service, fxt_detection_project) -> None:
         dataset_service = fxt_dataset_service

--- a/application/backend/tests/unit/services/test_dataset_service.py
+++ b/application/backend/tests/unit/services/test_dataset_service.py
@@ -408,12 +408,16 @@ class TestDatasetServiceUnit:
         )
         assert result == dataset_item
 
-    def test_set_annotations_user_reviewed_strips_confidences(self, fxt_dataset_service, fxt_detection_project) -> None:
-        """When user submits annotations (user_reviewed=True), confidences must be stripped."""
+    @pytest.mark.parametrize("user_reviewed", [True, False])
+    def test_set_annotations_confidences_handling(
+        self, user_reviewed, fxt_dataset_service, fxt_detection_project
+    ) -> None:
+        """When user_reviewed=True confidences are stripped; when False they are preserved."""
         dataset_service = fxt_dataset_service
         dataset_item_id = uuid4()
         dataset_item = MagicMock(spec=DatasetItem)
         label_id = uuid4()
+        prediction_model_id = None if user_reviewed else uuid4()
         annotations = [
             DatasetItemAnnotation(
                 labels=[LabelReference(id=label_id)],
@@ -439,43 +443,13 @@ class TestDatasetServiceUnit:
                 project=fxt_detection_project,
                 dataset_item_id=dataset_item_id,
                 annotations=annotations,
-                user_reviewed=True,
-                prediction_model_id=None,
+                user_reviewed=user_reviewed,
+                prediction_model_id=prediction_model_id,
             )
 
         saved_annotation_data = mock_repo_set_annotation_data.call_args.kwargs["annotation_data"]
-        assert all(ann["confidences"] is None for ann in saved_annotation_data)
-
-    def test_set_annotations_prediction_preserves_confidences(self, fxt_dataset_service, fxt_detection_project) -> None:
-        """When predictions are stored (user_reviewed=False), confidences must be preserved."""
-        dataset_service = fxt_dataset_service
-        dataset_item_id = uuid4()
-        dataset_item = MagicMock(spec=DatasetItem)
-        label_id = uuid4()
-        model_id = uuid4()
-        annotations = [
-            DatasetItemAnnotation(
-                labels=[LabelReference(id=label_id)],
-                shape=Rectangle(type="rectangle", x=0, y=0, width=10, height=10),
-                confidences=[0.95],
-            ),
-        ]
-
-        with (
-            patch.object(DatasetService, "_validate_annotations_labels"),
-            patch.object(DatasetService, "_validate_annotation_shapes"),
-            patch.object(DatasetService, "_validate_annotations_coordinates"),
-            patch.object(DatasetService, "get_dataset_item_by_id", return_value=dataset_item),
-            patch.object(DatasetItemRepository, "set_annotation_data") as mock_repo_set_annotation_data,
-            patch.object(DatasetItemRepository, "set_labels"),
-        ):
-            dataset_service.set_dataset_item_annotations(
-                project=fxt_detection_project,
-                dataset_item_id=dataset_item_id,
-                annotations=annotations,
-                user_reviewed=False,
-                prediction_model_id=model_id,
-            )
-
-        saved_annotation_data = mock_repo_set_annotation_data.call_args.kwargs["annotation_data"]
-        assert saved_annotation_data[0]["confidences"] == [0.95]
+        if user_reviewed:
+            assert all(ann["confidences"] is None for ann in saved_annotation_data)
+        else:
+            assert saved_annotation_data[0]["confidences"] == [0.95]
+            assert saved_annotation_data[1]["confidences"] is None


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

This bug removes any confidence from annotations if a user reviewed the annotation. This resolves a bug where training would fail on dataset items that contain a mixture of annotation with and without confidence scores.

Resolves #5975

### How to test

Tests have been updated and added to cover new code.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
