### PR TITLE
Report correct docker image size in comments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -152,7 +152,23 @@ jobs:
         env:
           IMAGE: ${{ steps.docker_build.outputs.image-name }}
         run: |
-          SIZE_BYTES=$(docker image inspect "${IMAGE}" --format='{{.Size}}')
+          # docker image inspect .Size may undercount with the docker buildx
+          # driver because it only reports the diff/top-layer size.  Summing
+          # all layer sizes via `docker history` gives the true uncompressed
+          # on-disk total.
+          SIZE_BYTES=$(docker history "${IMAGE}" --format '{{.Size}}' \
+            | awk '
+                /[0-9]+(\.[0-9]+)?[kKmMgG]?[bB]/ {
+                  n = $1+0; unit = $1;
+                  gsub(/[0-9.]+/, "", unit);
+                  unit = toupper(unit);
+                  if (unit == "KB") n *= 1024;
+                  else if (unit == "MB") n *= 1024*1024;
+                  else if (unit == "GB") n *= 1024*1024*1024;
+                  total += n
+                }
+                END { printf "%d", total }
+              ')
           SIZE_MB=$(awk "BEGIN {printf \"%.1f\", ${SIZE_BYTES} / 1024 / 1024}")
           SIZE_GB=$(awk "BEGIN {printf \"%.2f\", ${SIZE_BYTES} / 1024 / 1024 / 1024}")
           echo "bytes=${SIZE_BYTES}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR updates the docker image comment command so that the correct image size is reported. 

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
