### PR TITLE
Add support of INT8 model selection

### DIFF
--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -15,7 +15,11 @@ from app.api.schemas import PipelineMetricsView, PipelineView
 from app.api.validators import ProjectID
 from app.models import DataCollectionConfig, DataCollectionPolicyAdapter, PipelineStatus
 from app.services import PipelineMetricsService, PipelineService, SystemService
-from app.services.pipeline_service import DeviceInt8NotSupportedError, InvalidModelVariantError, OtherProjectActiveError
+from app.services.pipeline_service import (
+    DeviceInt8NotSupportedError,
+    IncompatibleModelVariantError,
+    OtherProjectActiveError,
+)
 
 router = APIRouter(prefix="/api/projects/{project_id}/pipeline", tags=["Pipelines"])
 
@@ -146,7 +150,7 @@ def update_pipeline(
         return PipelineView.model_validate(updated, from_attributes=True)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except InvalidModelVariantError as e:
+    except IncompatibleModelVariantError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except DeviceInt8NotSupportedError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))

--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -15,20 +15,32 @@ from app.api.schemas import PipelineMetricsView, PipelineView
 from app.api.validators import ProjectID
 from app.models import DataCollectionConfig, DataCollectionPolicyAdapter, PipelineStatus
 from app.services import PipelineMetricsService, PipelineService, SystemService
-from app.services.pipeline_service import OtherProjectActiveError
+from app.services.pipeline_service import DeviceInt8NotSupportedError, InvalidModelVariantError, OtherProjectActiveError
 
 router = APIRouter(prefix="/api/projects/{project_id}/pipeline", tags=["Pipelines"])
 
 UPDATE_PIPELINE_BODY_DESCRIPTION = """
 Partial pipeline configuration update. May contain any subset of fields including 'device', 'data_collection', 
-'source_id', 'sink_id', or 'model_id'. Fields not included in the request will remain unchanged.
+'source_id', 'sink_id', 'model_id', or 'model_variant_id'. Fields not included in the request will remain unchanged.
+
+When 'model_id' is provided without 'model_variant_id', the default FP16 OpenVINO variant is selected automatically.
+Only OpenVINO model variants can be used for inference. If an INT8 variant is selected, the server validates that the 
+inference device supports INT8.
 """
 UPDATE_PIPELINE_BODY_EXAMPLES = {
     "switch_model": Example(
         summary="Switch active model",
-        description="Change the active model of the pipeline",
+        description="Change the active model of the pipeline (defaults to FP16 OpenVINO variant)",
         value={
             "model_id": "c1feaabc-da2b-442e-9b3e-55c11c2c2ff3",
+        },
+    ),
+    "switch_model_variant": Example(
+        summary="Switch active model with specific variant",
+        description="Change the active model and select a specific model variant (must be OpenVINO format)",
+        value={
+            "model_id": "c1feaabc-da2b-442e-9b3e-55c11c2c2ff3",
+            "model_variant_id": "a2d3e4f5-1234-5678-9abc-def012345678",
         },
     ),
     "reconfigure": Example(
@@ -94,6 +106,9 @@ def get_pipeline(
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid request body or project ID"},
         status.HTTP_404_NOT_FOUND: {"description": "Project or pipeline not found"},
         status.HTTP_409_CONFLICT: {"description": "Pipeline cannot be enabled"},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "Invalid model variant (e.g., non-OpenVINO format or INT8 not supported on device)"
+        },
     },
 )
 def update_pipeline(
@@ -131,6 +146,10 @@ def update_pipeline(
         return PipelineView.model_validate(updated, from_attributes=True)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except InvalidModelVariantError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except DeviceInt8NotSupportedError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
     except OtherProjectActiveError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -68,6 +68,7 @@ class ActiveModelService:
                     for v in model_variants
                     if v.format == ModelFormat.OPENVINO and v.precision == ModelPrecision.FP16
                 )
+                logger.warning("No active model variant ID found, loaded fallback model %s", active_variant_id)
             pipeline_device = active_model_repo.get_active_pipeline_device()
             if pipeline_device is None:
                 raise RuntimeError("Active pipeline must have a device configured")

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -58,11 +58,16 @@ class ActiveModelService:
                 )
             model_rev_repo = ModelRevisionRepository(project_id=str(active_model.project_id), db=db)
             available_models = model_rev_repo.list_all(training_status=TrainingStatus.SUCCESSFUL)
-            model_variants_repo = ModelVariantRepository(db=db)
-            model_variants = model_variants_repo.list_by_model_revision(str(active_model.id))
-            active_variant_id = next(
-                v.id for v in model_variants if v.format == ModelFormat.OPENVINO and v.precision == ModelPrecision.FP16
-            )
+            # Use the variant configured in the pipeline, fall back to FP16 OpenVINO
+            active_variant_id = active_model_repo.get_active_model_variant_id()
+            if active_variant_id is None:
+                model_variants_repo = ModelVariantRepository(db=db)
+                model_variants = model_variants_repo.list_by_model_revision(str(active_model.id))
+                active_variant_id = next(
+                    v.id
+                    for v in model_variants
+                    if v.format == ModelFormat.OPENVINO and v.precision == ModelPrecision.FP16
+                )
             pipeline_device = active_model_repo.get_active_pipeline_device()
             if pipeline_device is None:
                 raise RuntimeError("Active pipeline must have a device configured")

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -173,7 +173,7 @@ class PipelineService(BaseSessionManagedService):
         if pipeline_db.model_variant_id is not None:
             # Explicit variant specified: validate it
             variant_db = model_variant_repo.get_by_id(pipeline_db.model_variant_id)
-            if variant_db is None:
+            if variant_db is None or variant_db.files_deleted:
                 raise ResourceNotFoundError(resource_type=ResourceType.MODEL, resource_id=pipeline_db.model_variant_id)
             if variant_db.model_revision_id != model_revision_id:
                 raise IncompatibleModelVariantError(
@@ -194,7 +194,7 @@ class PipelineService(BaseSessionManagedService):
                 format=ModelFormat.OPENVINO,
                 precision=ModelPrecision.FP16,
             )
-            if default_variant is None:
+            if default_variant is None or default_variant.files_deleted:
                 raise IncompatibleModelVariantError(
                     f"No FP16 OpenVINO variant found for model revision '{model_revision_id}'. "
                     f"Please specify a model_variant_id explicitly."

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -35,8 +35,8 @@ class OtherProjectActiveError(Exception):
         )
 
 
-class InvalidModelVariantError(ValueError):
-    """Exception raised when a model variant is invalid for pipeline inference (e.g., not OpenVINO format)."""
+class IncompatibleModelVariantError(ValueError):
+    """Exception raised when a model variant is incompatible for pipeline inference (e.g., not OpenVINO format)."""
 
 
 class DeviceInt8NotSupportedError(Exception):
@@ -152,7 +152,7 @@ class PipelineService(BaseSessionManagedService):
         Raises:
             ResourceNotFoundError: If the model revision or variant is not found.
             ValueError: If the model revision is not successfully trained.
-            InvalidModelVariantError: If the variant is not OpenVINO or cannot be resolved.
+            IncompatibleModelVariantError: If the variant is not OpenVINO or cannot be resolved.
             DeviceInt8NotSupportedError: If the device does not support INT8 inference.
         """
         model_revision_id: str = pipeline_db.model_revision_id  # type: ignore[union-attr]
@@ -176,12 +176,12 @@ class PipelineService(BaseSessionManagedService):
             if variant_db is None:
                 raise ResourceNotFoundError(resource_type=ResourceType.MODEL, resource_id=pipeline_db.model_variant_id)
             if variant_db.model_revision_id != model_revision_id:
-                raise InvalidModelVariantError(
+                raise IncompatibleModelVariantError(
                     f"Model variant '{pipeline_db.model_variant_id}' does not belong to "
                     f"model revision '{model_revision_id}'."
                 )
             if variant_db.format != ModelFormat.OPENVINO:
-                raise InvalidModelVariantError(
+                raise IncompatibleModelVariantError(
                     f"Only OpenVINO model variants can be used for inference. "
                     f"The selected variant has format '{variant_db.format}'."
                 )
@@ -195,7 +195,7 @@ class PipelineService(BaseSessionManagedService):
                 precision=ModelPrecision.FP16,
             )
             if default_variant is None:
-                raise InvalidModelVariantError(
+                raise IncompatibleModelVariantError(
                     f"No FP16 OpenVINO variant found for model revision '{model_revision_id}'. "
                     f"Please specify a model_variant_id explicitly."
                 )

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -8,9 +8,10 @@ from sqlalchemy.orm import Session
 
 from app.db.schema import PipelineDB
 from app.models import Pipeline, PipelineStatus
-from app.models.model_revision import TrainingStatus
+from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
 from app.repositories import PipelineRepository
 from app.repositories.model_revision_repo import ModelRevisionRepository
+from app.repositories.model_variant_repo import ModelVariantRepository
 from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.event.event_bus import EventBus, EventType
 from app.services.parent_process_guard import parent_process_only
@@ -31,6 +32,20 @@ class OtherProjectActiveError(Exception):
             f"Attempted to enable a pipeline in project with ID {requested_project_id}, while a pipeline is still "
             f"enabled in another project with ID {active_project_id}. Please first disable pipeline in project with "
             f"ID {active_project_id}"
+        )
+
+
+class InvalidModelVariantError(ValueError):
+    """Exception raised when a model variant is invalid for pipeline inference (e.g., not OpenVINO format)."""
+
+
+class DeviceInt8NotSupportedError(Exception):
+    """Exception raised when INT8 inference is requested on a device that does not support it."""
+
+    def __init__(self, device: str):
+        super().__init__(
+            f"INT8 inference is not supported on device '{device}'. "
+            f"Please select a non-quantized (FP16/FP32) model variant or use a device that supports INT8."
         )
 
 
@@ -112,23 +127,79 @@ class PipelineService(BaseSessionManagedService):
                     requested_project_id=to_update_db.project_id, active_project_id=active_pipeline_db.project_id
                 )
         if to_update_db.model_revision_id is not None:
-            # Only successfully trained models can be part of a pipeline
-            model_revision_repo = ModelRevisionRepository(project_id=to_update_db.project_id, db=self.db_session)
-            model_revision_db = model_revision_repo.get_by_id(to_update_db.model_revision_id)
-            if model_revision_db is None:
-                raise ResourceNotFoundError(
-                    resource_type=ResourceType.MODEL, resource_id=to_update_db.model_revision_id
-                )
-            if model_revision_db.training_status != TrainingStatus.SUCCESSFUL:
-                raise ValueError(
-                    f"Provided model id ({to_update_db.model_revision_id}) points to a model that was not successfully "
-                    f"trained (status is {model_revision_db.training_status})."
-                )
+            self._validate_model_and_resolve_variant(to_update_db)
 
         pipeline_db = pipeline_repo.update(to_update_db)
         updated = Pipeline.model_validate(pipeline_db)
         self.__emit_event(pipeline, updated)
         return updated
+
+    def _validate_model_and_resolve_variant(self, pipeline_db: PipelineDB) -> None:
+        """Validate the model revision and resolve/validate the model variant for inference.
+
+        Ensures that:
+        - The model revision exists and was successfully trained.
+        - If a model_variant_id is provided, it belongs to the revision, is in OpenVINO format,
+          and the device supports INT8 when the variant is quantized.
+        - If no model_variant_id is provided, defaults to the FP16 OpenVINO variant.
+
+        The pipeline_db.model_variant_id field may be mutated in-place when the default variant
+        is resolved.
+
+        Args:
+            pipeline_db: The PipelineDB instance whose model_revision_id and model_variant_id to validate.
+
+        Raises:
+            ResourceNotFoundError: If the model revision or variant is not found.
+            ValueError: If the model revision is not successfully trained.
+            InvalidModelVariantError: If the variant is not OpenVINO or cannot be resolved.
+            DeviceInt8NotSupportedError: If the device does not support INT8 inference.
+        """
+        model_revision_id: str = pipeline_db.model_revision_id  # type: ignore[union-attr]
+
+        # Only successfully trained models can be part of a pipeline
+        model_revision_repo = ModelRevisionRepository(project_id=pipeline_db.project_id, db=self.db_session)
+        model_revision_db = model_revision_repo.get_by_id(model_revision_id)
+        if model_revision_db is None:
+            raise ResourceNotFoundError(resource_type=ResourceType.MODEL, resource_id=model_revision_id)
+        if model_revision_db.training_status != TrainingStatus.SUCCESSFUL:
+            raise ValueError(
+                f"Provided model id ({model_revision_id}) points to a model that was not successfully "
+                f"trained (status is {model_revision_db.training_status})."
+            )
+
+        # Validate and resolve model_variant_id
+        model_variant_repo = ModelVariantRepository(db=self.db_session)
+        if pipeline_db.model_variant_id is not None:
+            # Explicit variant specified: validate it
+            variant_db = model_variant_repo.get_by_id(pipeline_db.model_variant_id)
+            if variant_db is None:
+                raise ResourceNotFoundError(resource_type=ResourceType.MODEL, resource_id=pipeline_db.model_variant_id)
+            if variant_db.model_revision_id != model_revision_id:
+                raise InvalidModelVariantError(
+                    f"Model variant '{pipeline_db.model_variant_id}' does not belong to "
+                    f"model revision '{model_revision_id}'."
+                )
+            if variant_db.format != ModelFormat.OPENVINO:
+                raise InvalidModelVariantError(
+                    f"Only OpenVINO model variants can be used for inference. "
+                    f"The selected variant has format '{variant_db.format}'."
+                )
+            if variant_db.precision == ModelPrecision.INT8:
+                self._validate_int8_support(pipeline_db.device)
+        else:
+            # No variant specified: default to FP16 OpenVINO variant
+            default_variant = model_variant_repo.get_by_revision_and_format_and_precision(
+                model_revision_id=model_revision_id,
+                format=ModelFormat.OPENVINO,
+                precision=ModelPrecision.FP16,
+            )
+            if default_variant is None:
+                raise InvalidModelVariantError(
+                    f"No FP16 OpenVINO variant found for model revision '{model_revision_id}'. "
+                    f"Please specify a model_variant_id explicitly."
+                )
+            pipeline_db.model_variant_id = default_variant.id
 
     def __emit_event(self, pipeline: Pipeline, updated: Pipeline) -> None:
         if self._event_bus is None:
@@ -151,3 +222,18 @@ class PipelineService(BaseSessionManagedService):
         elif pipeline.status != updated.status:
             # If the pipeline is being activated or stopped
             self._event_bus.emit_event(EventType.PIPELINE_STATUS_CHANGED)
+
+    def _validate_int8_support(self, device: str) -> None:
+        """Validate that the device supports INT8 inference.
+
+        Args:
+            device: Device string (e.g., 'cpu', 'xpu', 'xpu-1').
+
+        Raises:
+            DeviceInt8NotSupportedError: If the device does not support INT8 inference.
+        """
+        if self._system_service is None:
+            raise ValueError("System service is required to validate INT8 support.")
+        device_info = self._system_service.get_device_info(device)
+        if not self._system_service.supports_int8(device_info):
+            raise DeviceInt8NotSupportedError(device)

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -224,7 +224,7 @@ class PipelineService(BaseSessionManagedService):
                 self._event_bus.emit_event(EventType.PIPELINE_DATASET_COLLECTION_POLICIES_CHANGED)
             if pipeline.device != updated.device:
                 self._event_bus.emit_event(EventType.INFERENCE_DEVICE_CHANGED)
-            if pipeline.model_id != updated.model_revision.id:  # type: ignore[union-attr] # model_revision is always there for running pipeline
+            if pipeline.model_id != updated.model_revision.id or pipeline.model_variant_id != updated.model_variant_id:  # type: ignore[union-attr] # model_revision is always there for running pipeline
                 self._event_bus.emit_event(EventType.MODEL_CHANGED)
         elif pipeline.status != updated.status:
             # If the pipeline is being activated or stopped

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -105,6 +105,13 @@ class PipelineService(BaseSessionManagedService):
         """Update an existing pipeline."""
         pipeline = self.get_pipeline_by_id(project_id)
         base = pipeline.model_dump()
+
+        # When model_id changes without an explicit model_variant_id, any existing model_variant_id should be cleared
+        # before merging dicts so that _validate_model_and_resolve_variant can default to the FP16 OpenVINO variant.
+        new_model_id = partial_config.get("model_id") or partial_config.get("model_revision_id")
+        if new_model_id is not None and "model_variant_id" not in partial_config:
+            base["model_variant_id"] = None
+
         to_update = type(pipeline).model_validate({**base, **partial_config})
         pipeline_repo = PipelineRepository(self.db_session)
         to_update_db = PipelineDB(

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -230,7 +230,11 @@ class SystemService:
             capabilities = core.get_property(device_name=ov_device, property="OPTIMIZATION_CAPABILITIES")
             return "INT8" in capabilities
         except Exception:
-            logger.warning("Failed to query INT8 support for device '{}'. Assuming not supported.", device_info.type)
+            logger.exception(
+                "Failed to query INT8 support for device '{}' (OpenVINO device '{}'). Assuming not supported.",
+                device_info,
+                device_info.as_openvino,
+            )
             return False
 
     @staticmethod

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -205,6 +205,35 @@ class SystemService:
         return DeviceType(device_type.lower()), device_index
 
     @staticmethod
+    def supports_int8(device_info: DeviceInfo) -> bool:
+        """
+        Check if the given device supports INT8 inference using OpenVINO.
+
+        For CPU devices, INT8 is always supported.
+        For GPU devices, the check is done via OpenVINO's OPTIMIZATION_CAPABILITIES property.
+
+        Args:
+            device_info: The device to check.
+
+        Returns:
+            bool: True if the device supports INT8 inference, False otherwise.
+        """
+        if device_info.type == DeviceType.CPU:
+            return True
+        if device_info.type == DeviceType.CUDA:
+            return False
+        try:
+            from model_api.adapters import create_core
+
+            core = create_core()
+            ov_device = device_info.as_openvino
+            capabilities = core.get_property(device_name=ov_device, property="OPTIMIZATION_CAPABILITIES")
+            return "INT8" in capabilities
+        except Exception:
+            logger.warning("Failed to query INT8 support for device '{}'. Assuming not supported.", device_info.type)
+            return False
+
+    @staticmethod
     def get_camera_devices() -> list[CameraInfo]:
         """
         Get available camera devices.

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -11,8 +11,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app.db.schema import Base, LabelDB, ModelRevisionDB, ProjectDB, SinkDB, SourceDB
+from app.db.schema import Base, LabelDB, ModelRevisionDB, ModelVariantDB, ProjectDB, SinkDB, SourceDB
 from app.models import OutputFormat, SinkType, SourceType, TaskType, TrainingStatus
+from app.models.model_revision import ModelFormat, ModelPrecision
 from app.services import MetricsService, ResourceType
 from app.services.event.event_bus import EventBus
 
@@ -62,6 +63,20 @@ def fxt_db_models() -> list[ModelRevisionDB]:
             training_configuration={},
             label_schema_revision={},
         ),
+    ]
+
+
+@pytest.fixture
+def fxt_db_model_variants(fxt_db_models) -> list[ModelVariantDB]:
+    """Fixture to create FP16 OpenVINO model variants for each model revision."""
+    return [
+        ModelVariantDB(
+            id=str(uuid4()),
+            model_revision_id=model.id,
+            format=ModelFormat.OPENVINO,
+            precision=ModelPrecision.FP16,
+        )
+        for model in fxt_db_models
     ]
 
 

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -3,17 +3,23 @@
 
 from collections.abc import Callable
 from enum import StrEnum
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 
-from app.db.schema import PipelineDB, ProjectDB
+from app.db.schema import ModelVariantDB, PipelineDB, ProjectDB
 from app.models import DataCollectionConfig, PipelineStatus
 from app.models.data_collection_policy import FixedRateDataCollectionPolicy
-from app.models.model_revision import TrainingStatus
+from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
+from app.models.system import DeviceInfo, DeviceType
 from app.services import PipelineService, ResourceNotFoundError, ResourceType, SystemService
 from app.services.event.event_bus import EventType
-from app.services.pipeline_service import OtherProjectActiveError
+from app.services.pipeline_service import (
+    DeviceInt8NotSupportedError,
+    IncompatibleModelVariantError,
+    OtherProjectActiveError,
+)
 from tests.integration.project_factory import ProjectTestDataFactory
 
 
@@ -36,9 +42,9 @@ def fxt_pipeline_service(fxt_event_bus, db_session, fxt_system_service) -> Pipel
 
 @pytest.fixture
 def fxt_project_with_pipeline(
-    fxt_db_projects, fxt_db_sinks, fxt_db_sources, fxt_db_models, db_session
+    fxt_db_projects, fxt_db_sinks, fxt_db_sources, fxt_db_models, fxt_db_model_variants, db_session
 ) -> Callable[[bool, int, list[dict] | None, str], tuple[ProjectDB, PipelineDB]]:
-    """Fixture to create a ProjectDB with an associated PipelineDB."""
+    """Fixture to create a ProjectDB with an associated PipelineDB, including model variants."""
 
     def _create_project_with_pipeline(
         is_running: bool, project_index: int = 0, data_policies: list[dict] | None = None, device: str = "cpu"
@@ -46,6 +52,7 @@ def fxt_project_with_pipeline(
         db_session.add_all(fxt_db_sources)
         db_session.add_all(fxt_db_sinks)
         db_session.flush()
+        # Build project with pipeline (without model_variant_id, since variants need models to exist first)
         project_db = (
             ProjectTestDataFactory(db_session)
             .with_project(fxt_db_projects[project_index])
@@ -60,6 +67,13 @@ def fxt_project_with_pipeline(
             .with_data_policies(data_policies if data_policies else [])
             .build()
         )
+        # Persist model variants (requires model revisions to already exist)
+        db_session.add_all(fxt_db_model_variants)
+        db_session.flush()
+        # Now set the model_variant_id FK on the pipeline
+        pipeline_db = db_session.get(PipelineDB, project_db.id)
+        pipeline_db.model_variant_id = fxt_db_model_variants[project_index].id
+        db_session.flush()
         return project_db, db_session.get(PipelineDB, project_db.id)
 
     return _create_project_with_pipeline
@@ -185,11 +199,12 @@ class TestPipelineServiceIntegration:
         model_attr,
         fxt_project_with_pipeline,
         fxt_db_models,
+        fxt_db_model_variants,
         fxt_pipeline_service,
         fxt_event_bus,
         db_session,
     ):
-        """Test updating a pipeline by ID."""
+        """Test switching the model on a pipeline defaults to the FP16 OpenVINO variant."""
         _, db_pipeline = fxt_project_with_pipeline(is_running=True)
 
         model_id = fxt_db_models[1].id
@@ -200,6 +215,215 @@ class TestPipelineServiceIntegration:
         db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
         assert str(updated.model_id) == model_id
         assert str(updated.model_id) == db_updated.model_revision_id
+        # Default FP16 OpenVINO variant should have been resolved
+        assert db_updated.model_variant_id == fxt_db_model_variants[1].id
+
+    def test_switch_model_with_explicit_variant(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_db_model_variants,
+        fxt_pipeline_service,
+        fxt_event_bus,
+        db_session,
+    ):
+        """Test switching model with an explicit model_variant_id selects that variant."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[1]
+        target_variant = fxt_db_model_variants[1]
+
+        updated = fxt_pipeline_service.update_pipeline(
+            db_pipeline.project_id,
+            {"model_id": target_model.id, "model_variant_id": target_variant.id},
+        )
+
+        fxt_event_bus.emit_event.assert_called_once_with(EventType.MODEL_CHANGED)
+        db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
+        assert str(updated.model_id) == target_model.id
+        assert db_updated.model_variant_id == target_variant.id
+
+    def test_switch_model_defaults_to_fp16_openvino_variant(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_db_model_variants,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """Test that switching model without specifying a variant defaults to the FP16 OpenVINO variant."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[1]
+
+        fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"model_id": target_model.id})
+
+        db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
+        assert db_updated.model_variant_id == fxt_db_model_variants[1].id
+
+    def test_switch_model_rejects_non_openvino_variant(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """Test that specifying a non-OpenVINO variant raises IncompatibleModelVariantError."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[1]
+        # Create a PyTorch variant for the target model
+        pytorch_variant = ModelVariantDB(
+            id=str(uuid4()),
+            model_revision_id=target_model.id,
+            format=ModelFormat.PYTORCH,
+            precision=ModelPrecision.FP32,
+        )
+        db_session.add(pytorch_variant)
+        db_session.flush()
+
+        with pytest.raises(IncompatibleModelVariantError, match="Only OpenVINO model variants"):
+            fxt_pipeline_service.update_pipeline(
+                db_pipeline.project_id,
+                {"model_id": target_model.id, "model_variant_id": pytorch_variant.id},
+            )
+
+    def test_switch_model_rejects_variant_from_wrong_revision(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_db_model_variants,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """
+        Test that specifying a variant belonging to a different model revision raises IncompatibleModelVariantError.
+        """
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[1]
+        # Use a variant from the first model (index 0), which doesn't belong to target_model
+        wrong_variant = fxt_db_model_variants[0]
+
+        with pytest.raises(IncompatibleModelVariantError, match="does not belong to"):
+            fxt_pipeline_service.update_pipeline(
+                db_pipeline.project_id,
+                {"model_id": target_model.id, "model_variant_id": wrong_variant.id},
+            )
+
+    def test_switch_model_raises_when_no_fp16_variant_exists(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_db_model_variants,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """Test that switching to a model with no FP16 OpenVINO variant raises IncompatibleModelVariantError."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[1]
+        # Delete the FP16 variant by marking its files as deleted
+        target_variant = fxt_db_model_variants[1]
+        target_variant.files_deleted = True
+        db_session.flush()
+
+        with pytest.raises(IncompatibleModelVariantError, match="No FP16 OpenVINO variant found"):
+            fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"model_id": target_model.id})
+
+    def test_switch_model_rejects_variant_not_found(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """Test that specifying a non-existent variant ID raises ResourceNotFoundError."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[1]
+        non_existent_variant_id = str(uuid4())
+
+        with pytest.raises(ResourceNotFoundError) as exc_info:
+            fxt_pipeline_service.update_pipeline(
+                db_pipeline.project_id,
+                {"model_id": target_model.id, "model_variant_id": non_existent_variant_id},
+            )
+        assert exc_info.value.resource_type == ResourceType.MODEL
+        assert exc_info.value.resource_id == non_existent_variant_id
+
+    def test_switch_model_int8_variant_raises_on_unsupported_device(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_pipeline_service,
+        fxt_system_service,
+        db_session,
+    ):
+        """
+        Test that selecting an INT8 variant on a device that doesn't support INT8 raises DeviceInt8NotSupportedError.
+        """
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[0]
+        # Create an INT8 OpenVINO variant
+        int8_variant = ModelVariantDB(
+            id=str(uuid4()),
+            model_revision_id=target_model.id,
+            format=ModelFormat.OPENVINO,
+            precision=ModelPrecision.INT8,
+        )
+        db_session.add(int8_variant)
+        db_session.flush()
+
+        # Mock the system service to report no INT8 support
+        fxt_system_service.get_device_info = MagicMock(
+            return_value=DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
+        )
+        fxt_system_service.supports_int8 = MagicMock(return_value=False)
+
+        with pytest.raises(DeviceInt8NotSupportedError):
+            fxt_pipeline_service.update_pipeline(
+                db_pipeline.project_id,
+                {"model_id": target_model.id, "model_variant_id": int8_variant.id},
+            )
+
+    def test_switch_model_int8_variant_succeeds_on_supported_device(
+        self,
+        fxt_project_with_pipeline,
+        fxt_db_models,
+        fxt_pipeline_service,
+        fxt_system_service,
+        fxt_event_bus,
+        db_session,
+    ):
+        """Test that selecting an INT8 variant on a device that supports INT8 succeeds."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=True)
+
+        target_model = fxt_db_models[0]
+        # Create an INT8 OpenVINO variant
+        int8_variant = ModelVariantDB(
+            id=str(uuid4()),
+            model_revision_id=target_model.id,
+            format=ModelFormat.OPENVINO,
+            precision=ModelPrecision.INT8,
+        )
+        db_session.add(int8_variant)
+        db_session.flush()
+
+        # Mock the system service to report INT8 support
+        fxt_system_service.get_device_info = MagicMock(
+            return_value=DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
+        )
+        fxt_system_service.supports_int8 = MagicMock(return_value=True)
+
+        fxt_pipeline_service.update_pipeline(
+            db_pipeline.project_id,
+            {"model_id": target_model.id, "model_variant_id": int8_variant.id},
+        )
+
+        db_updated = db_session.get(PipelineDB, db_pipeline.project_id)
+        assert db_updated.model_variant_id == int8_variant.id
 
     @pytest.mark.parametrize(
         "training_status",
@@ -293,18 +517,28 @@ class TestPipelineServiceIntegration:
         fxt_db_sinks,
         fxt_db_sources,
         fxt_db_models,
+        fxt_db_model_variants,
         db_session,
     ):
         """Test setting pipeline data collection config."""
         db_session.add_all([fxt_db_sinks[0], fxt_db_sources[0]])
         db_session.flush()
-        (
+        project_db = (
             ProjectTestDataFactory(db_session)
             .with_project(fxt_db_projects[0])
-            .with_pipeline(sink_id=fxt_db_sinks[0].id, source_id=fxt_db_sources[0].id, model_id=fxt_db_models[0].id)
+            .with_pipeline(
+                sink_id=fxt_db_sinks[0].id,
+                source_id=fxt_db_sources[0].id,
+                model_id=fxt_db_models[0].id,
+            )
             .with_models([fxt_db_models[0]])
             .build()
         )
+        db_session.add(fxt_db_model_variants[0])
+        db_session.flush()
+        pipeline_db = db_session.get(PipelineDB, project_db.id)
+        pipeline_db.model_variant_id = fxt_db_model_variants[0].id
+        db_session.flush()
 
         pipeline = fxt_pipeline_service.update_pipeline(
             project_id=fxt_project_id,
@@ -328,19 +562,29 @@ class TestPipelineServiceIntegration:
         fxt_db_sinks,
         fxt_db_sources,
         fxt_db_models,
+        fxt_db_model_variants,
         db_session,
     ):
         """Test resetting pipeline data collection config."""
         db_session.add_all([fxt_db_sinks[0], fxt_db_sources[0]])
         db_session.flush()
-        (
+        project_db = (
             ProjectTestDataFactory(db_session)
             .with_project(fxt_db_projects[0])
-            .with_pipeline(sink_id=fxt_db_sinks[0].id, source_id=fxt_db_sources[0].id, model_id=fxt_db_models[0].id)
+            .with_pipeline(
+                sink_id=fxt_db_sinks[0].id,
+                source_id=fxt_db_sources[0].id,
+                model_id=fxt_db_models[0].id,
+            )
             .with_models([fxt_db_models[0]])
             .with_data_policies([{"type": "fixed_rate", "enabled": True, "rate": 0.1}])
             .build()
         )
+        db_session.add(fxt_db_model_variants[0])
+        db_session.flush()
+        pipeline_db = db_session.get(PipelineDB, project_db.id)
+        pipeline_db.model_variant_id = fxt_db_model_variants[0].id
+        db_session.flush()
 
         pipeline = fxt_pipeline_service.update_pipeline(
             project_id=fxt_project_id, partial_config={"data_collection": DataCollectionConfig()}

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -14,7 +14,7 @@ from app.main import app
 from app.models import DataCollectionConfig, FixedRateDataCollectionPolicy, PipelineStatus
 from app.models.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
 from app.services import PipelineMetricsService, PipelineService, ResourceNotFoundError, ResourceType
-from app.services.pipeline_service import OtherProjectActiveError
+from app.services.pipeline_service import DeviceInt8NotSupportedError, InvalidModelVariantError, OtherProjectActiveError
 
 
 @pytest.fixture
@@ -186,6 +186,51 @@ class TestPipelineEndpoints:
         fxt_pipeline_service.update_pipeline.assert_called_once_with(
             fxt_pipeline.project_id, {"status": PipelineStatus.RUNNING}
         )
+
+    def test_update_pipeline_with_model_variant_id(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
+        """Test updating pipeline with an explicit model_variant_id."""
+        project_id = fxt_pipeline.project_id
+        model_id = str(uuid4())
+        variant_id = str(uuid4())
+        fxt_pipeline_service.update_pipeline.return_value = fxt_pipeline
+
+        response = fxt_client.patch(
+            f"/api/projects/{project_id}/pipeline",
+            json={"model_id": model_id, "model_variant_id": variant_id},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        fxt_pipeline_service.update_pipeline.assert_called_once_with(
+            project_id, {"model_id": model_id, "model_variant_id": variant_id}
+        )
+
+    def test_update_pipeline_invalid_model_variant(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
+        """Test that InvalidModelVariantError returns 422."""
+        project_id = fxt_pipeline.project_id
+        fxt_pipeline_service.update_pipeline.side_effect = InvalidModelVariantError(
+            "Only OpenVINO model variants can be used for inference."
+        )
+
+        response = fxt_client.patch(
+            f"/api/projects/{project_id}/pipeline",
+            json={"model_id": str(uuid4()), "model_variant_id": str(uuid4())},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "OpenVINO" in response.json()["detail"]
+
+    def test_update_pipeline_int8_not_supported(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
+        """Test that DeviceInt8NotSupportedError returns 422."""
+        project_id = fxt_pipeline.project_id
+        fxt_pipeline_service.update_pipeline.side_effect = DeviceInt8NotSupportedError("gpu")
+
+        response = fxt_client.patch(
+            f"/api/projects/{project_id}/pipeline",
+            json={"model_id": str(uuid4()), "model_variant_id": str(uuid4())},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "INT8" in response.json()["detail"]
 
     def test_get_pipeline_metrics_success(self, fxt_pipeline, fxt_pipeline_metrics_service, fxt_client):
         """Test successful retrieval of pipeline metrics with default time window."""

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -14,7 +14,11 @@ from app.main import app
 from app.models import DataCollectionConfig, FixedRateDataCollectionPolicy, PipelineStatus
 from app.models.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics, ThroughputMetrics, TimeWindow
 from app.services import PipelineMetricsService, PipelineService, ResourceNotFoundError, ResourceType
-from app.services.pipeline_service import DeviceInt8NotSupportedError, InvalidModelVariantError, OtherProjectActiveError
+from app.services.pipeline_service import (
+    DeviceInt8NotSupportedError,
+    IncompatibleModelVariantError,
+    OtherProjectActiveError,
+)
 
 
 @pytest.fixture
@@ -204,10 +208,10 @@ class TestPipelineEndpoints:
             project_id, {"model_id": model_id, "model_variant_id": variant_id}
         )
 
-    def test_update_pipeline_invalid_model_variant(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
-        """Test that InvalidModelVariantError returns 422."""
+    def test_update_pipeline_incompatible_model_variant(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
+        """Test that IncompatibleModelVariantError returns 422."""
         project_id = fxt_pipeline.project_id
-        fxt_pipeline_service.update_pipeline.side_effect = InvalidModelVariantError(
+        fxt_pipeline_service.update_pipeline.side_effect = IncompatibleModelVariantError(
             "Only OpenVINO model variants can be used for inference."
         )
 

--- a/application/ui/src/features/inference/aside/data-collection.component.test.tsx
+++ b/application/ui/src/features/inference/aside/data-collection.component.test.tsx
@@ -41,7 +41,11 @@ describe('DataCollection capture rate fields', () => {
             http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
                 pipelinePatchSpy(await request.json());
 
-                return HttpResponse.json({});
+                return HttpResponse.json({
+                    project_id: '',
+                    status: 'idle',
+                    device: 'images_folder',
+                });
             })
         );
 

--- a/application/ui/src/features/inference/header/active-model.component.test.tsx
+++ b/application/ui/src/features/inference/header/active-model.component.test.tsx
@@ -58,7 +58,11 @@ describe('ActiveModel', () => {
             http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
                 patchSpy(await request.json());
 
-                return HttpResponse.json({});
+                return HttpResponse.json({
+                    project_id: '',
+                    status: 'idle',
+                    device: 'images_folder',
+                });
             })
         );
 

--- a/application/ui/src/features/inference/header/inference-devices.test.tsx
+++ b/application/ui/src/features/inference/header/inference-devices.test.tsx
@@ -29,7 +29,14 @@ describe('InferenceDevices', () => {
             http.get('/api/projects/{project_id}/pipeline', () => HttpResponse.json(pipelineResponse)),
             http.patch('/api/projects/{project_id}/pipeline', () => {
                 pipelinePatchSpy();
-                return HttpResponse.json({}, { status });
+                return HttpResponse.json(
+                    {
+                        project_id: '',
+                        status: 'idle',
+                        device: 'images_folder',
+                    },
+                    { status }
+                );
             })
         );
 

--- a/application/ui/src/features/inference/sinks/hooks/use-sink-action.test.tsx
+++ b/application/ui/src/features/inference/sinks/hooks/use-sink-action.test.tsx
@@ -42,7 +42,13 @@ const renderApp = async ({
     server.use(
         http.post('/api/sinks', newSink),
         http.patch('/api/sinks/{sink_id}', updateSink),
-        http.patch('/api/projects/{project_id}/pipeline', () => HttpResponse.json({}))
+        http.patch('/api/projects/{project_id}/pipeline', () =>
+            HttpResponse.json({
+                project_id: '',
+                status: 'idle',
+                device: 'images_folder',
+            })
+        )
     );
 
     const { result } = renderHook(() => useSinkAction({ config: mockedConfig, isNewSink, bodyFormatter }));

--- a/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.test.tsx
+++ b/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.test.tsx
@@ -39,7 +39,14 @@ describe('SinkMenu', () => {
             server.use(
                 http.patch('/api/projects/{project_id}/pipeline', () => {
                     pipelinePatchSpy();
-                    return HttpResponse.json({}, { status: 200 });
+                    return HttpResponse.json(
+                        {
+                            project_id: '',
+                            status: 'idle',
+                            device: 'images_folder',
+                        },
+                        { status: 200 }
+                    );
                 }),
                 http.delete('/api/sinks/{sink_id}', () => HttpResponse.json(null, { status }))
             );
@@ -71,7 +78,18 @@ describe('SinkMenu', () => {
     describe('connect', () => {
         const name = 'test-name';
         const configRequests = (status = 200) => {
-            server.use(http.patch('/api/projects/{project_id}/pipeline', () => HttpResponse.json({}, { status })));
+            server.use(
+                http.patch('/api/projects/{project_id}/pipeline', () =>
+                    HttpResponse.json(
+                        {
+                            project_id: '',
+                            status: 'idle',
+                            device: 'images_folder',
+                        },
+                        { status }
+                    )
+                )
+            );
         };
 
         it('success', async () => {

--- a/application/ui/src/features/inference/sources/hooks/use-source-action.test.tsx
+++ b/application/ui/src/features/inference/sources/hooks/use-source-action.test.tsx
@@ -37,7 +37,13 @@ const renderApp = async ({
     server.use(
         http.post('/api/sources', newResource),
         http.patch('/api/sources/{source_id}', updateResource),
-        http.patch('/api/projects/{project_id}/pipeline', () => HttpResponse.json({}))
+        http.patch('/api/projects/{project_id}/pipeline', () =>
+            HttpResponse.json({
+                project_id: '',
+                status: 'idle',
+                device: 'images_folder',
+            })
+        )
     );
 
     const { result } = renderHook(() => useSourceAction({ config: mockedConfig, isNewSource, bodyFormatter }));

--- a/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
+++ b/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
@@ -39,7 +39,14 @@ describe('SourceMenu', () => {
             server.use(
                 http.patch('/api/projects/{project_id}/pipeline', () => {
                     pipelinePatchSpy();
-                    return HttpResponse.json({}, { status });
+                    return HttpResponse.json(
+                        {
+                            project_id: '',
+                            status: 'idle',
+                            device: 'images_folder',
+                        },
+                        { status }
+                    );
                 }),
                 http.delete('/api/sources/{source_id}', () => HttpResponse.json(null, { status: 204 }))
             );
@@ -73,7 +80,18 @@ describe('SourceMenu', () => {
     describe('connect', () => {
         const name = 'test-name';
         const configRequests = (status = 200) => {
-            server.use(http.patch('/api/projects/{project_id}/pipeline', () => HttpResponse.json({}, { status })));
+            server.use(
+                http.patch('/api/projects/{project_id}/pipeline', () =>
+                    HttpResponse.json(
+                        {
+                            project_id: '',
+                            status: 'idle',
+                            device: 'images_folder',
+                        },
+                        { status }
+                    )
+                )
+            );
         };
 
         it('success', async () => {

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -110,7 +110,11 @@ test('Inference', async ({ streamPage, page, network }) => {
 
         network.use(
             http.patch('/api/projects/{project_id}/pipeline', () => {
-                return HttpResponse.json({});
+                return HttpResponse.json({
+                    project_id: '',
+                    status: 'idle',
+                    device: 'images_folder',
+                });
             }),
             http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
                 return response(200).json(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds support for selecting an INT8 model.
The backend validates the model revision and variant, as they must adhere to 
- The model revision exists and was successfully trained.
- If a model_variant_id is provided, it belongs to the revision, is in OpenVINO format,
  and the device supports INT8 when the variant is quantized.
- If no model_variant_id is provided, defaults to the FP16 OpenVINO variant.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
