### PR TITLE
Bugfix: training fails with KeyError 'precision'

### DIFF
--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -408,19 +408,17 @@ class OTXTrainer(Execution[TrainingJobParams]):
         callbacks_list = parser.instantiate_classes(parsed_callbacks_cfg).get("callbacks", [])
         callbacks_list.append(TrainingProgressCallback(self.update_progress, min_p=10, max_p=80))
 
-        # Determine the precision to use for training (default to fp32 if not specified in the configuration)
-        precision = training_config.get("precision", "32")
-        logger.info("Using precision '{}' for training", precision)
-
         # Start training
         logger.info("Starting the training loop (model_id={})", model_id)
-        train_kwargs = {"devices": [device.index]} if device.type is not DeviceType.CPU and device.index else {}
-        otx_engine.train(
-            max_epochs=training_config["max_epochs"],
-            precision=precision,
-            callbacks=callbacks_list,
-            **train_kwargs,  # pyrefly: ignore[bad-argument-type]
-        )
+        train_kwargs = {
+            "max_epochs": training_config["max_epochs"],
+            "callbacks": callbacks_list,
+        }
+        if device.type is not DeviceType.CPU and device.index:
+            train_kwargs["devices"] = [device.index]
+        if "precision" in training_config:
+            train_kwargs["precision"] = training_config["precision"]
+        otx_engine.train(**train_kwargs)  # pyrefly: ignore[bad-argument-type]
         trained_model_path = Path(otx_engine.work_dir) / "best_checkpoint.ckpt"
         logger.info("Model training completed. Trained model saved at {}", trained_model_path)
         return trained_model_path, otx_engine

--- a/application/backend/app/execution/training/otx_trainer.py
+++ b/application/backend/app/execution/training/otx_trainer.py
@@ -408,12 +408,16 @@ class OTXTrainer(Execution[TrainingJobParams]):
         callbacks_list = parser.instantiate_classes(parsed_callbacks_cfg).get("callbacks", [])
         callbacks_list.append(TrainingProgressCallback(self.update_progress, min_p=10, max_p=80))
 
+        # Determine the precision to use for training (default to fp32 if not specified in the configuration)
+        precision = training_config.get("precision", "32")
+        logger.info("Using precision '{}' for training", precision)
+
         # Start training
         logger.info("Starting the training loop (model_id={})", model_id)
         train_kwargs = {"devices": [device.index]} if device.type is not DeviceType.CPU and device.index else {}
         otx_engine.train(
             max_epochs=training_config["max_epochs"],
-            precision=training_config["precision"],
+            precision=precision,
             callbacks=callbacks_list,
             **train_kwargs,  # pyrefly: ignore[bad-argument-type]
         )

--- a/application/backend/tests/unit/execution/training/test_otx_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_otx_trainer.py
@@ -3,6 +3,7 @@
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, Mock, call, patch
 from uuid import uuid4
 
@@ -652,12 +653,14 @@ class TestOTXTrainerTrainModel:
         ],
         ids=["CPU", "XPU (Intel GPU)", "CUDA (NVIDIA GPU)"],
     )
+    @pytest.mark.parametrize("add_precision", [True, False])
     def test_train_model(
         self,
         fxt_otx_trainer: Callable[[], OTXTrainer],
         tmp_path: Path,
         geti_device: DeviceInfo,
         otx_device: str,
+        add_precision: bool,
     ):
         """Test successful model training."""
         # Arrange
@@ -685,7 +688,7 @@ class TestOTXTrainerTrainModel:
         weights_path.touch()
 
         # Create training configuration
-        training_config = {
+        training_config: dict[str, Any] = {
             "model": {
                 "class_path": "otx.backend.native.models.detection.yolox.YOLOXModel",
                 "init_args": {
@@ -693,7 +696,6 @@ class TestOTXTrainerTrainModel:
                 },
             },
             "max_epochs": 10,
-            "precision": "32",
             "callbacks": [
                 {
                     "class_path": "lightning.pytorch.callbacks.ModelCheckpoint",
@@ -704,6 +706,8 @@ class TestOTXTrainerTrainModel:
                 }
             ],
         }
+        if add_precision:
+            training_config["precision"] = "32"
 
         # Mock OTXDataModule
         mock_datamodule = Mock()
@@ -774,7 +778,10 @@ class TestOTXTrainerTrainModel:
         mock_otx_engine.train.assert_called_once()
         train_call_kwargs = mock_otx_engine.train.call_args.kwargs
         assert train_call_kwargs["max_epochs"] == 10
-        assert train_call_kwargs["precision"] == "32"
+        if add_precision:
+            assert train_call_kwargs["precision"] == "32"
+        else:
+            assert "precision" not in train_call_kwargs
         if geti_device.type == DeviceType.CPU or not geti_device.index:
             assert "devices" not in train_call_kwargs
         else:


### PR DESCRIPTION
### Summary

Fix a bug where training would fail due to missing key 'precision' in the training configuration. This key is injected in the training configuration in a very hacky way, based on the available hardware, and in some cases it might be missing (ref. [`configure_accelerator`](https://github.com/open-edge-platform/training_extensions/blob/develop/library/src/otx/backend/native/engine.py#L913)).

Fixes #6006 

### How to test

Build the Windows application and train a model.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
