### PR TITLE
chore(ci): re-enable daily workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,8 +52,9 @@ jobs:
         device: [cpu, xpu, cuda]
     permissions:
       contents: read
-      packages: write
-      pull-requests: write
+      packages: write # Push Docker images to GHCR
+      pull-requests: write # Post image size comments on PRs
+      id-token: write # Use OIDC token to sign images
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -99,12 +100,41 @@ jobs:
           # cache export to avoid 403 errors from GHCR.
           cache-write: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
 
-      - name: Smoke-test docker image
-        if: github.event_name == 'pull_request'
+      - name: Resolve primary image tag for signing
+        if: github.event_name != 'pull_request'
+        id: primary-tag
         env:
-          IMAGE: ${{ steps.docker_build.outputs.image-name }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Use the first tag as the signing reference.
+          # The sign-image action resolves the digest from this tag via crane.
+          TAG="$(echo "$TAGS" | head -n1)"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request'
+        uses: open-edge-platform/geti-ci/actions/sign-image@6fe3ccd4f702a56614487b4aa3a414c4fe5221bf
+        with:
+          image-uri: ${{ steps.primary-tag.outputs.tag }}
+
+      - name: Pull image for smoke test
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE: ${{ steps.meta.outputs.tags }}
+        run: |
+          # Extract first tag from the list
+          FIRST_TAG=$(echo "${IMAGE}" | head -n1)
+          echo "Pulling ${FIRST_TAG} for smoke test..."
+          docker pull "${FIRST_TAG}"
+
+      - name: Smoke-test docker image
+        env:
+          # For PRs use local image, for other events use first pushed tag
+          IMAGE_SOURCE: ${{ github.event_name == 'pull_request' && steps.docker_build.outputs.image-name || steps.meta.outputs.tags }}
           DEVICE: ${{ matrix.device }}
         run: |
+          # Extract first tag if IMAGE_SOURCE contains multiple lines
+          IMAGE=$(echo "${IMAGE_SOURCE}" | head -n1)
           CONTAINER_NAME="geti-healthcheck-${DEVICE}"
 
           echo "Starting container from ${IMAGE} ..."

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,7 +13,9 @@ jobs:
     uses: ./.github/workflows/build.yaml
     permissions:
       contents: read
-      pull-requests: write # to comment PR with coverage report
+      packages: write # to push Docker images to GHCR
+      pull-requests: write # required by nested job
+      id-token: write # required for signing container images
 
   backend-lint-and-test:
     name: Daily backend lint and test
@@ -33,7 +35,7 @@ jobs:
     uses: ./.github/workflows/ui-lint-and-test.yaml
     permissions:
       contents: read
-      pull-requests: write # to comment PR with coverage report
+      pull-requests: write # required by nested job
 
   check-existing-issue:
     name: Check for existing failure issue

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -132,15 +132,6 @@ jobs:
             -p 7860:7860 \
             "$IMAGE_NAME"
 
-          # Cleanup container on exit
-          cleanup() {
-              echo "--- Container logs ---"
-              docker logs "$CONTAINER_NAME" || true
-              echo "--- Stopping container ---"
-              docker stop "$CONTAINER_NAME" || true
-          }
-          trap cleanup EXIT
-
           TEST_URL="localhost:7860"
           # Wait for container to be ready (max 60 seconds)
           echo "Waiting for container to be ready..."


### PR DESCRIPTION
### Summary

This PR re-enable daily workflow with signed container image publication (will be available with `develop` tag) and fix minor issue in security workflow (container stopped before testing ended).

### How to test

Was tested in a fork
- daily / successful run https://github.com/AlexanderBarabanov/training_extensions/actions/runs/23850438329
- daily with failure https://github.com/AlexanderBarabanov/training_extensions/actions/runs/23846704915
- issue example that will be opened in case of failure https://github.com/AlexanderBarabanov/training_extensions/issues/3
- security workflow run https://github.com/AlexanderBarabanov/training_extensions/actions/runs/23854425979

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
