### PR TITLE
ci: enable stale branch deletion (dry-run: false)

### DIFF
--- a/.github/workflows/remove-stale-branches.yaml
+++ b/.github/workflows/remove-stale-branches.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: fpicalausa/remove-stale-branches@7c4f2afe88a36c0f9114cd958380979b9d7323fb # v2.4.0
         with:
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'true' }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
           days-before-branch-stale: 90
           days-before-branch-delete: 7
           operations-per-run: 10


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
This PR switches off `dry-run` parameter in the `remove-stale-branches` workflow.  
Related Issue - #5936
Previous pr - #5962

### How to test
Dry-run verified in https://github.com/open-edge-platform/training_extensions/actions/runs/23850859047/job/69530290111. 


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)

cc @AlexanderBarabanov 
