### PR TITLE
Fix #6004: D_FINE_L (and other) training fails with "Input size shoul...

### DIFF
--- a/library/src/otx/backend/native/models/base.py
+++ b/library/src/otx/backend/native/models/base.py
@@ -1004,11 +1004,22 @@ class OTXModel(LightningModule):
             data_input_params.input_size[0] % self.input_size_multiplier != 0
             or data_input_params.input_size[1] % self.input_size_multiplier != 0
         ):
-            msg = (
-                f"Input size should be a multiple of {self.input_size_multiplier}, "
-                f"but got {data_input_params.input_size} instead."
+            m = self.input_size_multiplier
+            rounded = (
+                round(data_input_params.input_size[0] / m) * m,
+                round(data_input_params.input_size[1] / m) * m,
             )
-            raise ValueError(msg)
+            logger.warning(
+                "Input size %s is not a multiple of %d. Rounding to %s.",
+                data_input_params.input_size,
+                m,
+                rounded,
+            )
+            data_input_params = DataInputParams(
+                input_size=rounded,
+                mean=data_input_params.mean,
+                std=data_input_params.std,
+            )
 
         return data_input_params
 

--- a/library/tests/unit/backend/native/models/test_base.py
+++ b/library/tests/unit/backend/native/models/test_base.py
@@ -32,10 +32,20 @@ class MockNNModule(torch.nn.Module):
 
 
 class TestOTXModel:
-    def test_init(self, monkeypatch):
+    def test_init(self, monkeypatch, mocker):
         monkeypatch.setattr(OTXModel, "input_size_multiplier", 10, raising=False)
-        with pytest.raises(ValueError, match="Input size should be a multiple"):
-            OTXModel(label_info=2, data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)))
+        with mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(2)):
+            model = OTXModel(label_info=2, data_input_params=DataInputParams((224, 224), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)))
+        # Input size (224, 224) rounded to nearest multiple of 10 -> (220, 220)
+        assert model.data_input_params.input_size == (220, 220)
+
+    def test_init_non_multiple_input_size_is_rounded(self, monkeypatch, mocker):
+        """Non-multiple-of-32 input sizes (e.g. from arbitrary user images) are rounded, not rejected."""
+        monkeypatch.setattr(OTXModel, "input_size_multiplier", 32, raising=False)
+        with mocker.patch.object(OTXModel, "_create_model", return_value=MockNNModule(1)):
+            model = OTXModel(label_info=1, data_input_params=DataInputParams((2297, 2297), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)))
+        # 2297 / 32 = 71.78... -> round to 72 -> 72 * 32 = 2304
+        assert model.data_input_params.input_size == (2304, 2304)
 
     def test_training_step_none_loss(self, mocker: MockerFixture) -> None:
         mock_trainer = mocker.create_autospec(spec=Trainer)


### PR DESCRIPTION
Closes #6004

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

When a user uploads images whose dimensions are not a multiple of the model's `input_size_multiplier` (e.g. 2297×2297 with D-FINE/DEIM models that require multiples of 32), `OTXModel.__init__` in `library/src/otx/backend/native/models/base.py` previously raised a hard `ValueError`, aborting training entirely.

This PR changes that behaviour: instead of raising, the code now rounds each dimension to the nearest multiple of `input_size_multiplier` and emits a `logger.warning`. A new `DataInputParams` instance is constructed with the rounded size, preserving `mean` and `std` unchanged.

Resolves #6004.

**Changed files:**
- `library/src/otx/backend/native/models/base.py` (`OTXModel._validate_input_size`, lines ~1004–1025): replaced `raise ValueError` with `round(dim / m) * m` rounding and a warning log.
- `library/tests/unit/backend/native/models/test_base.py`: updated `test_init` to assert rounding behaviour (224→220 with multiplier 10) and added `test_init_non_multiple_input_size_is_rounded` to cover the exact reported case (2297→2304 with multiplier 32).

### How to test

**Automated:** The two unit tests cover the rounding logic directly:
- `TestOTXModel::test_init` — verifies (224, 224) rounds to (220, 220) with `input_size_multiplier=10`.
- `TestOTXModel::test_init_non_multiple_input_size_is_rounded` — verifies (2297, 2297) rounds to (2304, 2304) with `input_size_multiplier=32` (the exact failure case from the issue).

**Manual:** Create a detection project, upload images with non-power-of-32 dimensions (e.g. 2297×2297), annotate, and launch D_FINE_L training. Training should proceed past model initialisation and a warning like `Input size (2297, 2297) is not a multiple of 32. Rounding to (2304, 2304).` should appear in the logs instead of a traceback.

### Checklist

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*