### PR TITLE
feat(training advanced settings): Add dependency logic to augmentation parameters

### DIFF
--- a/application/ui/src/features/models/model-listing/model-training-parameters/model-training-parameters.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-parameters/model-training-parameters.component.tsx
@@ -7,7 +7,7 @@ import { Grid, Text } from '@geti/ui';
 
 import { TrainingConfigurationParameter } from '../../../../constants/shared-types';
 import { useGetModelTrainingConfiguration } from '../../hooks/api/use-get-model-training-configuration.hook';
-import { filterDependentParameters } from '../../train-model/advanced-settings/training/learning-parameters/utils';
+import { filterDependentParameters } from '../../train-model/advanced-settings/utils';
 import { Box } from '../components/box/box.component';
 import { findGroupByKey, flattenParameters } from './utils';
 

--- a/application/ui/src/features/models/model-listing/model-training-parameters/utils.ts
+++ b/application/ui/src/features/models/model-listing/model-training-parameters/utils.ts
@@ -13,8 +13,10 @@ export const isParameterGroup = (
     return parameter.type === 'parameter_group';
 };
 
-export const isParameter = (parameter: TrainingConfigurationParameter): parameter is ConfigurableParameter => {
-    return parameter.type === 'parameter';
+export const isParameter = (
+    parameter: TrainingConfigurationParameter | undefined
+): parameter is ConfigurableParameter => {
+    return parameter?.type === 'parameter';
 };
 
 export const findGroupByKey = (

--- a/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
@@ -71,7 +71,7 @@ export const NumberParameterField = ({
     const formatOptions = type === 'float' ? { maximumFractionDigits: Math.abs(Math.log10(fieldStep)) } : undefined;
 
     const handleValueChange = (inputValue: number): void => {
-        setDraftValue(null);
+        setDraftValue(inputValue);
         onChange(inputValue);
     };
 

--- a/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
@@ -6,17 +6,7 @@ import { useRef, useState } from 'react';
 import { Flex, NumberField, Slider } from '@geti/ui';
 
 import { NumberConfigurableParameter } from '../../../../../constants/shared-types';
-
-const getDecimalPoints = (value: number): number => {
-    // When log10 returns 0 (log10(1) = 0) we need to return 1
-    return Math.abs(Math.ceil(Math.log10(value))) || 1;
-};
-
-const getFloatingPointStep = (minValue: number, maxValue: number): number => {
-    const exponent = getDecimalPoints(maxValue - minValue);
-
-    return 1 / Math.pow(10, exponent + 3);
-};
+import { getStep } from './utils';
 
 type NumberGroupParamsProps = {
     name: string;
@@ -27,35 +17,6 @@ type NumberGroupParamsProps = {
     maxValue: number | null;
     value: number;
     type: NumberConfigurableParameter['value_type'];
-};
-
-const DEFAULT_INT_STEP = 1;
-const DEFAULT_FLOAT_STEP = 0.1;
-
-export const getStep = ({
-    step,
-    maxValue,
-    minValue,
-    type,
-}: {
-    step?: number;
-    minValue: number | null;
-    maxValue: number | null;
-    type: NumberConfigurableParameter['value_type'];
-}): number => {
-    if (step !== undefined) {
-        return step;
-    }
-
-    if (type === 'int') {
-        return DEFAULT_INT_STEP;
-    }
-
-    if (maxValue === null || minValue === null) {
-        return DEFAULT_FLOAT_STEP;
-    }
-
-    return getFloatingPointStep(minValue, maxValue);
 };
 
 export const NumberParameterField = ({

--- a/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/number-parameter-field.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Flex, NumberField, Slider } from '@geti/ui';
 
@@ -47,8 +47,12 @@ export const getStep = ({
         return step;
     }
 
+    if (type === 'int') {
+        return DEFAULT_INT_STEP;
+    }
+
     if (maxValue === null || minValue === null) {
-        return type === 'int' ? DEFAULT_INT_STEP : DEFAULT_FLOAT_STEP;
+        return DEFAULT_FLOAT_STEP;
     }
 
     return getFloatingPointStep(minValue, maxValue);
@@ -64,14 +68,19 @@ export const NumberParameterField = ({
     name,
     step,
 }: NumberGroupParamsProps) => {
-    const [draftValue, setDraftValue] = useState<number | null>(null);
-    const parameterValue = draftValue ?? value;
+    const [parameterValue, setParameterValue] = useState<number>(value);
+    const previousValueRef = useRef<number>(value);
+
+    if (previousValueRef.current !== value) {
+        previousValueRef.current = value;
+        setParameterValue(value);
+    }
 
     const fieldStep = getStep({ step, type, maxValue, minValue });
     const formatOptions = type === 'float' ? { maximumFractionDigits: Math.abs(Math.log10(fieldStep)) } : undefined;
 
     const handleValueChange = (inputValue: number): void => {
-        setDraftValue(inputValue);
+        setParameterValue(inputValue);
         onChange(inputValue);
     };
 
@@ -96,8 +105,8 @@ export const NumberParameterField = ({
                 value={parameterValue}
                 minValue={minValue}
                 maxValue={maxValue}
-                onChange={setDraftValue}
-                onChangeEnd={handleValueChange}
+                onChange={setParameterValue}
+                onChangeEnd={onChange}
                 step={fieldStep}
                 isFilled
                 flex={1}

--- a/application/ui/src/features/models/train-model/advanced-settings/components/parameters.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/parameters.component.tsx
@@ -387,7 +387,7 @@ export const ParametersEnableGroup = ({
     return (
         <ParametersContainer
             key={parameters.key}
-            rowGap={configurableParameters.length > 0 ? 'size-150' : 'size-0'}
+            rowGap={configurableParameters.length > 0 ? 'size-100' : 'size-0'}
             isReadOnly={isReadOnly}
             id={createTestId(parentGroupKeys, parameters.key)}
         >

--- a/application/ui/src/features/models/train-model/advanced-settings/components/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/utils.test.ts
@@ -1,0 +1,68 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { getStep } from './utils';
+
+describe('getStep', () => {
+    it('returns the provided step value for float type', () => {
+        expect(getStep({ step: 0.5, minValue: 0.0, maxValue: 1.0, type: 'float' })).toBe(0.5);
+    });
+
+    describe('when step is undefined and type is int', () => {
+        it('returns the default int step of 1', () => {
+            expect(getStep({ minValue: 0, maxValue: 100, type: 'int' })).toBe(1);
+        });
+
+        it('returns the default int step of 1 when minValue and maxValue are null', () => {
+            expect(getStep({ minValue: null, maxValue: null, type: 'int' })).toBe(1);
+        });
+
+        it('returns the default int step of 1 when only minValue is null', () => {
+            expect(getStep({ minValue: null, maxValue: 100, type: 'int' })).toBe(1);
+        });
+
+        it('returns the default int step of 1 when only maxValue is null', () => {
+            expect(getStep({ minValue: 0, maxValue: null, type: 'int' })).toBe(1);
+        });
+    });
+
+    describe('when step is undefined, type is float, and minValue or maxValue is null', () => {
+        it('returns the default float step of 0.1 when maxValue is null', () => {
+            expect(getStep({ minValue: 0.0, maxValue: null, type: 'float' })).toBe(0.1);
+        });
+
+        it('returns the default float step of 0.1 when minValue is null', () => {
+            expect(getStep({ minValue: null, maxValue: 1.0, type: 'float' })).toBe(0.1);
+        });
+
+        it('returns the default float step of 0.1 when both are null', () => {
+            expect(getStep({ minValue: null, maxValue: null, type: 'float' })).toBe(0.1);
+        });
+    });
+
+    describe('when step is undefined, type is float, and both minValue and maxValue are provided', () => {
+        it('computes a fine-grained step for a range of 1 (0.0 to 1.0)', () => {
+            // range = 1.0 - 0.0 = 1, log10(1) = 0, ceil(|0|) = 0, but || 1 yields exponent = 1
+            // step = 1 / 10^(1+3) = 1 / 10000 = 0.0001
+            expect(getStep({ minValue: 0.0, maxValue: 1.0, type: 'float' })).toBeCloseTo(0.0001);
+        });
+
+        it('computes a fine-grained step for a range of 0.1 (0.0 to 0.1)', () => {
+            // range = 0.1, log10(0.1) = -1, ceil(|-1|) = 1, exponent = 1
+            // step = 1 / 10^(1+3) = 1 / 10000 = 0.0001
+            expect(getStep({ minValue: 0.0, maxValue: 0.1, type: 'float' })).toBeCloseTo(0.0001);
+        });
+
+        it('computes a fine-grained step for a negative minValue range (-1.0 to 1.0)', () => {
+            // range = 1.0 - (-1.0) = 2, log10(2) ≈ 0.301, ceil(|0.301|) = 1, exponent = 1
+            // step = 1 / 10^(1+3) = 1 / 10000 = 0.0001
+            expect(getStep({ minValue: -1.0, maxValue: 1.0, type: 'float' })).toBeCloseTo(0.0001);
+        });
+
+        it('computes a fine-grained step when min equals max (range of 0)', () => {
+            // range = 5.0 - 5.0 = 0, log10(0) = -Infinity, ceil(|-Infinity|) = Infinity
+            // 1 / 10^(Infinity+3) = 0
+            expect(getStep({ minValue: 5.0, maxValue: 5.0, type: 'float' })).toBe(0);
+        });
+    });
+});

--- a/application/ui/src/features/models/train-model/advanced-settings/components/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/utils.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { NumberConfigurableParameter } from '../../../../../constants/shared-types';
+
+const DEFAULT_INT_STEP = 1;
+const DEFAULT_FLOAT_STEP = 0.1;
+
+const getDecimalPoints = (value: number): number => {
+    // When log10 returns 0 (log10(1) = 0) we need to return 1
+    return Math.abs(Math.ceil(Math.log10(value))) || 1;
+};
+
+const getFloatingPointStep = (minValue: number, maxValue: number): number => {
+    const exponent = getDecimalPoints(maxValue - minValue);
+
+    return 1 / Math.pow(10, exponent + 3);
+};
+
+export const getStep = ({
+    step,
+    maxValue,
+    minValue,
+    type,
+}: {
+    step?: number;
+    minValue: number | null;
+    maxValue: number | null;
+    type: NumberConfigurableParameter['value_type'];
+}): number => {
+    if (step !== undefined) {
+        return step;
+    }
+
+    if (type === 'int') {
+        return DEFAULT_INT_STEP;
+    }
+
+    if (maxValue === null || minValue === null) {
+        return DEFAULT_FLOAT_STEP;
+    }
+
+    return getFloatingPointStep(minValue, maxValue);
+};

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation-parameters-list.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation-parameters-list.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Dispatch, SetStateAction, useDeferredValue } from 'react';
+import { Dispatch, SetStateAction, useMemo } from 'react';
 
 import { ConfigurableParameter, type TrainingConfiguration } from '../../../../../../constants/shared-types';
 import { Parameters } from '../../components/parameters.component';
@@ -41,10 +41,9 @@ export const DataAugmentationParametersList = ({
         });
     };
 
-    const augmentationParameters = useDeferredValue(
-        filterDependentParameters(dataAugmentationParameters.parameters),
-        dataAugmentationParameters.parameters
-    );
+    const augmentationParameters = useMemo(() => {
+        return filterDependentParameters(dataAugmentationParameters.parameters);
+    }, [dataAugmentationParameters.parameters]);
 
     return <Parameters parameters={augmentationParameters} onChange={handleAugmentationParameterChange} />;
 };

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation-parameters-list.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation-parameters-list.component.tsx
@@ -1,15 +1,15 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useDeferredValue } from 'react';
 
 import { ConfigurableParameter, type TrainingConfiguration } from '../../../../../../constants/shared-types';
-import { ParametersGroup } from '../../components/parameters.component';
-import { deepReplaceParameters } from '../../utils';
-import { DataAugmentationConfigurableParameters } from './utils';
+import { Parameters } from '../../components/parameters.component';
+import { deepReplaceParameters, filterDependentParameters } from '../../utils';
+import { DataAugmentationConfigurationParameters } from './utils';
 
 type DataAugmentationParametersListProps = {
-    dataAugmentationParameters: DataAugmentationConfigurableParameters;
+    dataAugmentationParameters: DataAugmentationConfigurationParameters;
     onTrainingConfigurationChange: Dispatch<SetStateAction<TrainingConfiguration | undefined>>;
 };
 
@@ -21,7 +21,7 @@ const changeDataAugmentationParameters = (
     const parameters: TrainingConfiguration['parameters'] = deepReplaceParameters(
         trainingConfiguration.parameters,
         [newParameter],
-        ['dataset_preparation', ...parameterGroupKeys]
+        ['dataset_preparation', 'augmentation', ...parameterGroupKeys]
     );
 
     return {
@@ -41,7 +41,10 @@ export const DataAugmentationParametersList = ({
         });
     };
 
-    return (
-        <ParametersGroup parametersGroup={dataAugmentationParameters} onChange={handleAugmentationParameterChange} />
+    const augmentationParameters = useDeferredValue(
+        filterDependentParameters(dataAugmentationParameters.parameters),
+        dataAugmentationParameters.parameters
     );
+
+    return <Parameters parameters={augmentationParameters} onChange={handleAugmentationParameterChange} />;
 };

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation.component.tsx
@@ -6,10 +6,10 @@ import { Dispatch, SetStateAction } from 'react';
 import { type TrainingConfiguration } from '../../../../../../constants/shared-types';
 import { Accordion } from '../../components/accordion/accordion.component';
 import { DataAugmentationParametersList } from './data-augmentation-parameters-list.component';
-import { DataAugmentationConfigurableParameters, isDataAugmentationEnabled } from './utils';
+import { DataAugmentationConfigurationParameters, isDataAugmentationEnabled } from './utils';
 
 type DataAugmentationProps = {
-    dataAugmentationParameters: DataAugmentationConfigurableParameters;
+    dataAugmentationParameters: DataAugmentationConfigurationParameters;
     onTrainingConfigurationChange: Dispatch<SetStateAction<TrainingConfiguration | undefined>>;
 };
 

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation.test.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation.test.tsx
@@ -12,13 +12,10 @@ import {
 import { render } from 'test-utils/render';
 
 import { TrainingConfiguration } from '../../../../../../constants/shared-types';
+import { isParameter, isParameterGroup } from '../../../../model-listing/model-training-parameters/utils';
 import { isBoolEnableParameter, isBoolParameter } from '../../utils';
 import { DataAugmentation } from './data-augmentation.component';
-import {
-    DataAugmentationConfigurableParameters,
-    DataAugmentationConfigurationParameters,
-    getDataAugmentationParameters,
-} from './utils';
+import { DataAugmentationConfigurationParameters, getDataAugmentationParameters } from './utils';
 
 const getToggleEnableParameter = (name: string) => {
     return screen.getByRole('switch', { name: `Toggle ${name}` });
@@ -37,9 +34,19 @@ describe('DataAugmentation', () => {
         key: 'augmentation',
         name: 'Augmentation',
         parameters: [
+            getMockedConfigurationParameter({
+                key: 'deim_framework',
+                value_type: 'bool',
+                name: 'DEIM framework',
+                depends_on: null,
+                value: false,
+            }),
             getMockedConfigurationParameterGroup({
                 key: 'center_crop',
                 name: 'Center crop',
+                depends_on: {
+                    deim_framework: [false, null],
+                },
                 parameters: [
                     getMockedConfigurationParameter({
                         key: 'enable',
@@ -64,6 +71,9 @@ describe('DataAugmentation', () => {
             getMockedConfigurationParameterGroup({
                 key: 'random_affine',
                 name: 'Random affine',
+                depends_on: {
+                    deim_framework: [false, null],
+                },
                 parameters: [
                     getMockedConfigurationParameter({
                         key: 'enable',
@@ -116,9 +126,9 @@ describe('DataAugmentation', () => {
                 ],
             }),
         ],
-    }) as DataAugmentationConfigurableParameters;
+    });
 
-    const App = (props: { dataAugmentationParameters: DataAugmentationConfigurableParameters }) => {
+    const App = (props: { dataAugmentationParameters: DataAugmentationConfigurationParameters }) => {
         const [trainingConfiguration, setTrainingConfiguration] = useState<TrainingConfiguration | undefined>({
             parameters: [
                 getMockedConfigurationParameterGroup({
@@ -166,21 +176,23 @@ describe('DataAugmentation', () => {
         render(<App dataAugmentationParameters={dataAugmentationParameters} />);
 
         dataAugmentationParameters.parameters.forEach((parametersGroup) => {
-            const enableParameter = parametersGroup.parameters[0];
-            expect(getToggleEnableParameter(enableParameter.name)).toBeChecked();
+            if (isParameterGroup(parametersGroup)) {
+                const enableParameter = parametersGroup.parameters[0];
+                expect(getToggleEnableParameter(enableParameter.name)).toBeChecked();
 
-            const restOfParameters = parametersGroup.parameters.slice(1);
+                const restOfParameters = parametersGroup.parameters.slice(1);
 
-            restOfParameters.forEach((parameter) => {
-                expect(getParameter(parameter.name)).toBeEnabled();
-            });
+                restOfParameters.forEach((parameter) => {
+                    expect(getParameter(parameter.name)).toBeEnabled();
+                });
 
-            toggleParameter(enableParameter.name);
-            expect(getToggleEnableParameter(enableParameter.name)).not.toBeChecked();
+                toggleParameter(enableParameter.name);
+                expect(getToggleEnableParameter(enableParameter.name)).not.toBeChecked();
 
-            restOfParameters.forEach((parameter) => {
-                expect(getParameter(parameter.name)).toBeDisabled();
-            });
+                restOfParameters.forEach((parameter) => {
+                    expect(getParameter(parameter.name)).toBeDisabled();
+                });
+            }
         });
     });
 
@@ -188,37 +200,57 @@ describe('DataAugmentation', () => {
         render(<App dataAugmentationParameters={dataAugmentationParameters} />);
 
         for (const parametersGroup of dataAugmentationParameters.parameters) {
-            for (const parameter of parametersGroup.parameters) {
-                if (isBoolEnableParameter(parameter)) {
-                    expect(getToggleEnableParameter(parameter.name)).toBeChecked();
+            if (isParameterGroup(parametersGroup)) {
+                for (const parameter of parametersGroup.parameters) {
+                    if (!isParameter(parameter)) return;
 
-                    toggleParameter(parameter.name);
+                    if (isBoolEnableParameter(parameter)) {
+                        expect(getToggleEnableParameter(parameter.name)).toBeChecked();
 
-                    expect(getToggleEnableParameter(parameter.name)).not.toBeChecked();
+                        toggleParameter(parameter.name);
 
-                    await userEvent.click(screen.getByRole('button', { name: `Reset ${parametersGroup.name}` }));
-                    expect(getToggleEnableParameter(parameter.name)).toBeChecked();
-                } else if (isBoolParameter(parameter)) {
-                    expect(getToggleEnableParameter(parameter.name)).toBeChecked();
+                        expect(getToggleEnableParameter(parameter.name)).not.toBeChecked();
 
-                    toggleParameter(parameter.name);
+                        await userEvent.click(screen.getByRole('button', { name: `Reset ${parametersGroup.name}` }));
+                        expect(getToggleEnableParameter(parameter.name)).toBeChecked();
+                    } else if (isBoolParameter(parameter)) {
+                        expect(getToggleEnableParameter(parameter.name)).toBeChecked();
 
-                    expect(getToggleEnableParameter(parameter.name)).not.toBeChecked();
+                        toggleParameter(parameter.name);
 
-                    await userEvent.click(screen.getByRole('button', { name: `Reset ${parameter.name}` }));
-                    expect(getToggleEnableParameter(parameter.name)).toBeChecked();
-                } else {
-                    expect(getParameter(parameter.name)).toHaveValue(parameter.value.toString());
+                        expect(getToggleEnableParameter(parameter.name)).not.toBeChecked();
 
-                    await userEvent.click(screen.getByRole('button', { name: `Increase Change ${parameter.name}` }));
+                        await userEvent.click(screen.getByRole('button', { name: `Reset ${parameter.name}` }));
+                        expect(getToggleEnableParameter(parameter.name)).toBeChecked();
+                    } else {
+                        expect(getParameter(parameter.name)).toHaveValue(parameter.value.toString());
 
-                    expect(getParameter(parameter.name)).toHaveValue((Number(parameter.value) + 0.1).toString());
+                        await userEvent.click(
+                            screen.getByRole('button', { name: `Increase Change ${parameter.name}` })
+                        );
 
-                    await userEvent.click(screen.getByRole('button', { name: `Reset ${parameter.name}` }));
+                        expect(getParameter(parameter.name)).toHaveValue((Number(parameter.value) + 0.1).toString());
 
-                    expect(getParameter(parameter.name)).toHaveValue(parameter.default_value.toString());
+                        await userEvent.click(screen.getByRole('button', { name: `Reset ${parameter.name}` }));
+
+                        expect(getParameter(parameter.name)).toHaveValue(parameter.default_value.toString());
+                    }
                 }
             }
         }
+    });
+
+    it('hides all dependent parameters when "DEIM framework" parameter is enabled', () => {
+        render(<App dataAugmentationParameters={dataAugmentationParameters} />);
+
+        expect(getToggleEnableParameter('DEIM framework')).not.toBeChecked();
+        expect(screen.getByTestId('center_crop')).toBeVisible();
+        expect(screen.getByTestId('random_affine')).toBeVisible();
+
+        toggleParameter('DEIM framework');
+
+        expect(getToggleEnableParameter('DEIM framework')).toBeChecked();
+        expect(screen.queryByTestId('center_crop')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('random_affine')).not.toBeInTheDocument();
     });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation.test.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/data-augmentation.test.tsx
@@ -202,7 +202,7 @@ describe('DataAugmentation', () => {
         for (const parametersGroup of dataAugmentationParameters.parameters) {
             if (isParameterGroup(parametersGroup)) {
                 for (const parameter of parametersGroup.parameters) {
-                    if (!isParameter(parameter)) return;
+                    if (!isParameter(parameter)) continue;
 
                     if (isBoolEnableParameter(parameter)) {
                         expect(getToggleEnableParameter(parameter.name)).toBeChecked();

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.test.ts
@@ -6,11 +6,7 @@ import {
     getMockedConfigurationParameterGroup,
 } from 'mocks/mock-training-configuration';
 
-import {
-    DataAugmentationConfigurableParameters,
-    DataAugmentationConfigurationParameters,
-    isDataAugmentationEnabled,
-} from './utils';
+import { DataAugmentationConfigurationParameters, isDataAugmentationEnabled } from './utils';
 
 const buildAugmentationGroup = (enableValue: boolean) => {
     return getMockedConfigurationParameterGroup({
@@ -30,7 +26,7 @@ const buildAugmentationGroupWithoutEnable = () => {
 const buildDataAugmentationConfigurableParameters = (groups: DataAugmentationConfigurationParameters[]) => {
     return getMockedConfigurationParameterGroup({
         parameters: groups,
-    }) as DataAugmentationConfigurableParameters;
+    }) as DataAugmentationConfigurationParameters;
 };
 
 describe('isDataAugmentationEnabled', () => {
@@ -91,5 +87,29 @@ describe('isDataAugmentationEnabled', () => {
 
         const params = buildDataAugmentationConfigurableParameters([groupWithNonEnableBool]);
         expect(isDataAugmentationEnabled(params)).toBe(false);
+    });
+
+    it('returns true when deim_framework parameter is set to true', () => {
+        const groupWithDeimFramework = getMockedConfigurationParameterGroup({
+            parameters: [
+                getMockedConfigurationParameter({ value_type: 'bool', key: 'deim_framework', value: true }),
+                getMockedConfigurationParameter({ value_type: 'float', key: 'probability', value: 0.5 }),
+                buildAugmentationGroup(true),
+            ],
+        });
+
+        expect(isDataAugmentationEnabled(groupWithDeimFramework)).toBe(true);
+    });
+
+    it('returns true when deim_framework parameter is set to false and at least one enable parameter is true', () => {
+        const groupWithDeimFramework = getMockedConfigurationParameterGroup({
+            parameters: [
+                getMockedConfigurationParameter({ value_type: 'bool', key: 'deim_framework', value: false }),
+                getMockedConfigurationParameter({ value_type: 'float', key: 'probability', value: 0.5 }),
+                buildAugmentationGroup(true),
+            ],
+        });
+
+        expect(isDataAugmentationEnabled(groupWithDeimFramework)).toBe(true);
     });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.test.ts
@@ -112,4 +112,16 @@ describe('isDataAugmentationEnabled', () => {
 
         expect(isDataAugmentationEnabled(groupWithDeimFramework)).toBe(true);
     });
+
+    it('returns false when deim_framework parameter is set to false and at least one enable parameter is false', () => {
+        const groupWithDeimFramework = getMockedConfigurationParameterGroup({
+            parameters: [
+                getMockedConfigurationParameter({ value_type: 'bool', key: 'deim_framework', value: false }),
+                getMockedConfigurationParameter({ value_type: 'float', key: 'probability', value: 0.5 }),
+                buildAugmentationGroup(false),
+            ],
+        });
+
+        expect(isDataAugmentationEnabled(groupWithDeimFramework)).toBe(false);
+    });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.test.ts
@@ -14,19 +14,19 @@ const buildAugmentationGroup = (enableValue: boolean) => {
             getMockedConfigurationParameter({ value_type: 'bool', key: 'enable', value: enableValue }),
             getMockedConfigurationParameter({ value_type: 'float', key: 'probability', value: 0.5 }),
         ],
-    }) as DataAugmentationConfigurationParameters;
+    });
 };
 
 const buildAugmentationGroupWithoutEnable = () => {
     return getMockedConfigurationParameterGroup({
         parameters: [getMockedConfigurationParameter({ value_type: 'float', key: 'probability', value: 0.5 })],
-    }) as DataAugmentationConfigurationParameters;
+    });
 };
 
 const buildDataAugmentationConfigurableParameters = (groups: DataAugmentationConfigurationParameters[]) => {
     return getMockedConfigurationParameterGroup({
         parameters: groups,
-    }) as DataAugmentationConfigurationParameters;
+    });
 };
 
 describe('isDataAugmentationEnabled', () => {

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.ts
@@ -1,11 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    ConfigurableParameter,
-    ConfigurableParameterGroup,
-    TrainingConfiguration,
-} from '../../../../../../constants/shared-types';
+import { ConfigurableParameterGroup, TrainingConfiguration } from '../../../../../../constants/shared-types';
 import {
     findGroupByKey,
     isParameter,
@@ -13,17 +9,9 @@ import {
 } from '../../../../model-listing/model-training-parameters/utils';
 import { isBoolEnableParameter } from '../../utils';
 
-export type DataAugmentationConfigurationParameters = Omit<ConfigurableParameterGroup, 'parameters'> & {
-    parameters: ConfigurableParameter[];
-};
+export type DataAugmentationConfigurationParameters = ConfigurableParameterGroup;
 
-export type DataAugmentationConfigurableParameters = Omit<ConfigurableParameterGroup, 'parameters'> & {
-    parameters: DataAugmentationConfigurationParameters[];
-};
-
-export const getDataAugmentationParameters = (
-    trainingConfiguration: TrainingConfiguration
-): DataAugmentationConfigurableParameters | undefined => {
+export const getDataAugmentationParameters = (trainingConfiguration: TrainingConfiguration) => {
     const datasetPreparation = findGroupByKey(trainingConfiguration.parameters, 'dataset_preparation')?.parameters;
     const dataAugmentation = findGroupByKey(datasetPreparation, 'augmentation');
 
@@ -31,17 +19,33 @@ export const getDataAugmentationParameters = (
 
     return {
         ...dataAugmentation,
-        parameters: dataAugmentation.parameters
-            .filter((parameter) => parameter.key !== 'tiling')
-            .filter(isParameterGroup)
-            .map((parameter) => ({
-                ...parameter,
-                parameters: parameter.parameters.filter(isParameter),
-            })),
+        parameters: dataAugmentation.parameters.filter((parameter) => parameter.key !== 'tiling'),
     };
 };
 
-export const isDataAugmentationEnabled = (dataAugmentationParameters: DataAugmentationConfigurableParameters) =>
-    dataAugmentationParameters.parameters
-        .map((group) => group.parameters.find(isBoolEnableParameter))
-        .some((parameter) => parameter?.value === true);
+const getDeimFrameworkParameter = (parameters: ConfigurableParameterGroup['parameters']) => {
+    return parameters.find((parameter) => isParameter(parameter) && parameter.key === 'deim_framework');
+};
+
+export const isDataAugmentationEnabled = (dataAugmentationParameters: DataAugmentationConfigurationParameters) => {
+    const deimParameter = getDeimFrameworkParameter(dataAugmentationParameters.parameters);
+
+    if (isParameter(deimParameter) && deimParameter.value === true) {
+        return true;
+    }
+
+    return dataAugmentationParameters.parameters
+        .map((group) => {
+            if (isParameterGroup(group)) {
+                const enableParameter = group.parameters.find(
+                    (parameter) => isParameter(parameter) && isBoolEnableParameter(parameter)
+                );
+
+                return enableParameter;
+            }
+
+            return undefined;
+        })
+        .filter(Boolean)
+        .some((parameter) => isParameter(parameter));
+};

--- a/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/data-management/data-augmentation/utils.ts
@@ -47,5 +47,5 @@ export const isDataAugmentationEnabled = (dataAugmentationParameters: DataAugmen
             return undefined;
         })
         .filter(Boolean)
-        .some((parameter) => isParameter(parameter));
+        .some((parameter) => isParameter(parameter) && parameter.value === true);
 };

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/learning-parameters-list.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/learning-parameters-list.component.tsx
@@ -8,9 +8,9 @@ import { partition } from 'lodash-es';
 
 import { ConfigurableParameter, TrainingConfiguration } from '../../../../../../constants/shared-types';
 import { Parameters } from '../../components/parameters.component';
-import { deepReplaceParameters } from '../../utils';
+import { deepReplaceParameters, filterDependentParameters } from '../../utils';
 import { InputSizeParameters } from './input-size-parameters.component';
-import { filterDependentParameters, isInputSizeParameter, LearningConfigurationGroup } from './utils';
+import { isInputSizeParameter, LearningConfigurationGroup } from './utils';
 
 const changeLearningParameters = (
     trainingConfiguration: TrainingConfiguration,

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/learning-parameters.test.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/learning-parameters.test.tsx
@@ -8,7 +8,7 @@ import { render } from 'test-utils/render';
 import { describe } from 'vitest';
 
 import { NumberConfigurableParameter, TrainingConfiguration } from '../../../../../../constants/shared-types';
-import { getStep } from '../../components/number-parameter-field.component';
+import { getStep } from '../../components/utils';
 import { isBoolEnableParameterGroup, isNumberParameter } from '../../utils';
 import { LearningParameters } from './learning-parameters.component';
 import { learningParameters } from './mocks';

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.test.ts
@@ -7,14 +7,7 @@ import {
 } from 'mocks/mock-training-configuration';
 
 import { TrainingConfigurationParameter } from '../../../../../../constants/shared-types';
-import { isParameter, isParameterGroup } from '../../../../model-listing/model-training-parameters/utils';
-import { learningParameters } from './mocks';
-import {
-    filterDependentParameters,
-    isInputSizeHeightParameter,
-    isInputSizeWidthParameter,
-    LearningConfigurationGroup,
-} from './utils';
+import { isInputSizeHeightParameter, isInputSizeWidthParameter } from './utils';
 
 const buildEnumNumberParameter = (key: string): TrainingConfigurationParameter =>
     getMockedConfigurationParameter({ value_type: 'int', key, allowed_values: [320, 416, 512, 640] });
@@ -88,76 +81,5 @@ describe('isInputSizeHeightParameter', () => {
         const group = getMockedConfigurationParameterGroup({ key: 'input_size_height' });
 
         expect(isInputSizeHeightParameter(group)).toBe(false);
-    });
-});
-
-describe('filterDependentParameters', () => {
-    it('keeps independent parameters in their original order', () => {
-        const result = filterDependentParameters(learningParameters.parameters);
-        const keys = result.filter(isParameter).map((p) => p.key);
-
-        expect(keys).toContain('max_epochs');
-        expect(keys).toContain('batch_size');
-        expect(keys.indexOf('max_epochs')).toBeLessThan(keys.indexOf('batch_size'));
-    });
-
-    it('places dependent parameters immediately after the parameter they depend on', () => {
-        const schedulerGroup = learningParameters.parameters.find(
-            (p) => isParameterGroup(p) && p.key === 'scheduler'
-        ) as LearningConfigurationGroup;
-        const result = filterDependentParameters(schedulerGroup.parameters);
-        const keys = result.filter(isParameter).map((p) => p.key);
-
-        const typeIndex = keys.indexOf('type');
-        const factorIndex = keys.indexOf('factor');
-        const patienceIndex = keys.indexOf('patience');
-
-        // 'factor' and 'patience' depend on 'type' === 'reduce_lr_on_plateau' (which is the current value)
-        // so they should immediately follow 'type'
-        expect(factorIndex).toBe(typeIndex + 1);
-        expect(patienceIndex).toBe(typeIndex + 2);
-    });
-
-    it('excludes dependent parameters whose condition does not match the current value', () => {
-        const schedulerGroup = learningParameters.parameters.find(
-            (p) => isParameterGroup(p) && p.key === 'scheduler'
-        ) as LearningConfigurationGroup;
-        const result = filterDependentParameters(schedulerGroup.parameters);
-        const keys = result.filter(isParameter).map((p) => p.key);
-
-        // 'min_lr' depends on type === 'cosine_annealing', but type === 'reduce_lr_on_plateau'
-        expect(keys).not.toContain('min_lr');
-    });
-
-    it('preserves parameter groups in the output', () => {
-        const result = filterDependentParameters(learningParameters.parameters);
-        const groupKeys = result.filter(isParameterGroup).map((p) => p.key);
-
-        expect(groupKeys).toContain('early_stopping');
-        expect(groupKeys).toContain('scheduler');
-        expect(groupKeys).toContain('gradient_accumulation');
-        expect(groupKeys).toContain('gradient_clip');
-    });
-
-    it('returns an empty array when given an empty array', () => {
-        expect(filterDependentParameters([])).toEqual([]);
-    });
-
-    it('returns a single independent parameter unchanged', () => {
-        const param = getMockedConfigurationParameter({ value_type: 'int', key: 'solo', depends_on: null });
-        const result = filterDependentParameters([param]);
-
-        expect(result).toEqual([param]);
-    });
-
-    it('does not include standalone dependent parameters that have no matching parent', () => {
-        const dependent = getMockedConfigurationParameter({
-            value_type: 'float',
-            key: 'orphan',
-            depends_on: { some_key: 'some_value' },
-        });
-        const result = filterDependentParameters([dependent]);
-
-        expect(result).toEqual([]);
     });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/utils.ts
@@ -7,14 +7,9 @@ import {
     TrainingConfiguration,
     TrainingConfigurationParameter,
 } from '../../../../../../constants/shared-types';
-import {
-    findGroupByKey,
-    isParameter,
-    isParameterGroup,
-} from '../../../../model-listing/model-training-parameters/utils';
+import { findGroupByKey, isParameter } from '../../../../model-listing/model-training-parameters/utils';
 import { isEnumNumberParameter } from '../../utils';
 
-export type LearningConfigurationParameters = TrainingConfigurationParameter;
 export type LearningConfigurationGroup = ConfigurableParameterGroup;
 
 export const getLearningParameters = (
@@ -43,35 +38,3 @@ export const getInputSizeWidthParameter = (
 export const getInputSizeHeightParameter = (
     parameters: TrainingConfigurationParameter[]
 ): NumberEnumConfigurableParameter | undefined => parameters.find(isInputSizeHeightParameter);
-
-export const filterDependentParameters = (
-    parameters: LearningConfigurationParameters[]
-): LearningConfigurationParameters[] => {
-    return parameters
-        .reduce<LearningConfigurationParameters[][]>((acc, curr) => {
-            if (isParameter(curr) && curr.depends_on == null) {
-                const parametersDependingOnCurr = parameters.filter((parameter) => {
-                    return (
-                        isParameter(parameter) &&
-                        parameter.depends_on != null &&
-                        parameter.depends_on[curr.key] === curr.value
-                    );
-                });
-
-                return [...acc, [curr, ...parametersDependingOnCurr]];
-            }
-
-            if (isParameter(curr) && curr.depends_on != null) {
-                return acc;
-            }
-
-            if (isParameterGroup(curr)) {
-                const groupedParameters = filterDependentParameters(curr.parameters);
-
-                return [...acc, [{ ...curr, parameters: groupedParameters }]];
-            }
-
-            return [...acc, [curr]];
-        }, [])
-        .flatMap((group) => group);
-};

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.test.ts
@@ -11,9 +11,10 @@ import {
     ConfigurableParameterGroup,
     TrainingConfigurationParameter,
 } from '../../../../constants/shared-types';
-import { isParameterGroup } from '../../model-listing/model-training-parameters/utils';
+import { isParameter, isParameterGroup } from '../../model-listing/model-training-parameters/utils';
 import { learningParameters } from './training/learning-parameters/mocks';
-import { deepReplaceParameters } from './utils';
+import { LearningConfigurationGroup } from './training/learning-parameters/utils';
+import { deepReplaceParameters, filterDependentParameters } from './utils';
 
 const getParam = (params: ConfigurableParameter[], key: string): ConfigurableParameter | undefined =>
     params.find((p) => p.key === key) as ConfigurableParameter | undefined;
@@ -307,5 +308,76 @@ describe('deepReplaceParameters', () => {
             const replaced = getParam(result as ConfigurableParameter[], 'weight_decay');
             expect(replaced?.value).toBe(0.001);
         });
+    });
+});
+
+describe('filterDependentParameters', () => {
+    it('keeps independent parameters in their original order', () => {
+        const result = filterDependentParameters(learningParameters.parameters);
+        const keys = result.filter(isParameter).map((p) => p.key);
+
+        expect(keys).toContain('max_epochs');
+        expect(keys).toContain('batch_size');
+        expect(keys.indexOf('max_epochs')).toBeLessThan(keys.indexOf('batch_size'));
+    });
+
+    it('places dependent parameters immediately after the parameter they depend on', () => {
+        const schedulerGroup = learningParameters.parameters.find(
+            (p) => isParameterGroup(p) && p.key === 'scheduler'
+        ) as LearningConfigurationGroup;
+        const result = filterDependentParameters(schedulerGroup.parameters);
+        const keys = result.filter(isParameter).map((p) => p.key);
+
+        const typeIndex = keys.indexOf('type');
+        const factorIndex = keys.indexOf('factor');
+        const patienceIndex = keys.indexOf('patience');
+
+        // 'factor' and 'patience' depend on 'type' === 'reduce_lr_on_plateau' (which is the current value)
+        // so they should immediately follow 'type'
+        expect(factorIndex).toBe(typeIndex + 1);
+        expect(patienceIndex).toBe(typeIndex + 2);
+    });
+
+    it('excludes dependent parameters whose condition does not match the current value', () => {
+        const schedulerGroup = learningParameters.parameters.find(
+            (p) => isParameterGroup(p) && p.key === 'scheduler'
+        ) as LearningConfigurationGroup;
+        const result = filterDependentParameters(schedulerGroup.parameters);
+        const keys = result.filter(isParameter).map((p) => p.key);
+
+        // 'min_lr' depends on type === 'cosine_annealing', but type === 'reduce_lr_on_plateau'
+        expect(keys).not.toContain('min_lr');
+    });
+
+    it('preserves parameter groups in the output', () => {
+        const result = filterDependentParameters(learningParameters.parameters);
+        const groupKeys = result.filter(isParameterGroup).map((p) => p.key);
+
+        expect(groupKeys).toContain('early_stopping');
+        expect(groupKeys).toContain('scheduler');
+        expect(groupKeys).toContain('gradient_accumulation');
+        expect(groupKeys).toContain('gradient_clip');
+    });
+
+    it('returns an empty array when given an empty array', () => {
+        expect(filterDependentParameters([])).toEqual([]);
+    });
+
+    it('returns a single independent parameter unchanged', () => {
+        const param = getMockedConfigurationParameter({ value_type: 'int', key: 'solo', depends_on: null });
+        const result = filterDependentParameters([param]);
+
+        expect(result).toEqual([param]);
+    });
+
+    it('does not include standalone dependent parameters that have no matching parent', () => {
+        const dependent = getMockedConfigurationParameter({
+            value_type: 'float',
+            key: 'orphan',
+            depends_on: { some_key: 'some_value' },
+        });
+        const result = filterDependentParameters([dependent]);
+
+        expect(result).toEqual([]);
     });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -117,3 +117,44 @@ export const isBoolEnableParameterGroup = (
         isBoolEnableParameter(parameter.parameters[0])
     );
 };
+
+export const filterDependentParameters = (
+    parameters: TrainingConfigurationParameter[]
+): TrainingConfigurationParameter[] => {
+    return parameters
+        .reduce<TrainingConfigurationParameter[][]>((acc, curr) => {
+            if (isParameter(curr) && curr.depends_on == null) {
+                const parametersDependingOnCurr = parameters.filter((parameter) => {
+                    if (parameter.depends_on == null) return false;
+
+                    const dependsOnValue = parameter.depends_on[curr.key];
+
+                    if (Array.isArray(dependsOnValue)) {
+                        return dependsOnValue.includes(curr.value);
+                    }
+
+                    return dependsOnValue === curr.value;
+                });
+
+                acc.push([curr, ...parametersDependingOnCurr]);
+                return acc;
+            }
+
+            if (curr.depends_on != null) {
+                return acc;
+            }
+
+            if (isParameterGroup(curr)) {
+                const groupedParameters = filterDependentParameters(curr.parameters);
+
+                acc.push([{ ...curr, parameters: groupedParameters }]);
+
+                return acc;
+            }
+
+            acc.push([curr]);
+
+            return acc;
+        }, [])
+        .flatMap((group) => group);
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR adds dependency logic to augmentation parameters. To achieve that I had to update `filterDependentParameters`. Moreover, when deim parameter is enabled, augmentation tag should display "Yes", informing that parameter was enabled.
Besides that I found bug in the `NumberParameterField`, value was flickering because of setting value to be `null` and `step` was decimal value for `int` field. These issues are fixed as well.


<img width="677" height="265" alt="image" src="https://github.com/user-attachments/assets/cd3e94a2-dd24-4e46-bab1-ff146ed5aed8" />
<img width="666" height="383" alt="image" src="https://github.com/user-attachments/assets/24d0d435-6b6a-4bfb-b713-687cddb7010e" />

Close #5968 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
