### PR TITLE
Include number of annotated frames for a video in media listing

### DIFF
--- a/application/backend/app/api/schemas/media.py
+++ b/application/backend/app/api/schemas/media.py
@@ -81,6 +81,7 @@ class VideoView(BaseRequiredIDNameModel):
     size: int
     fps: float
     frame_count: int
+    annotated_frame_count: int
     source_id: UUID | None = None
     duration: float
 
@@ -95,6 +96,7 @@ class VideoView(BaseRequiredIDNameModel):
                 "height": 720,
                 "fps": 25.0,
                 "frame_count": 100,
+                "annotated_frame_count": 25,
                 "duration": 4.0,
                 "size": 2211840,
                 "source_id": "c1feaabc-da2b-442e-9b3e-55c11c2c2ff3",

--- a/application/backend/app/models/media.py
+++ b/application/backend/app/models/media.py
@@ -97,6 +97,7 @@ class Video(BaseMedia):
     type: Literal[MediaType.VIDEO]
     fps: float
     frame_count: int
+    annotated_frame_count: int = 0
 
     @computed_field
     @property

--- a/application/backend/app/repositories/media_repo.py
+++ b/application/backend/app/repositories/media_repo.py
@@ -149,3 +149,16 @@ class MediaRepository:
             )
         )
         return [(dataset_item, media) for (dataset_item, media) in self.db.execute(stmt).all()]
+
+    def count_annotated_video_frames_by_video_id(self, video_id: str) -> int:
+        stmt = (
+            select(func.count(MediaDB.id))
+            .select_from(MediaDB)
+            .join(DatasetItemDB, DatasetItemDB.id == MediaDB.id)
+            .where(
+                MediaDB.project_id == self.project_id,
+                MediaDB.video_id == video_id,
+                DatasetItemDB.annotation_data.is_not(None),
+            )
+        )
+        return self.db.scalar(stmt) or 0

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -252,7 +252,13 @@ class MediaService(BaseSessionManagedService):
         db_media = repo.get_by_id(str(media_id))
         if not db_media:
             raise ResourceNotFoundError(ResourceType.MEDIA, str(media_id))
-        return MediaAdapter.validate_python(db_media)
+        return (
+            Video.model_validate(db_media).model_copy(
+                update={"annotated_frame_count": repo.count_annotated_video_frames_by_video_id(db_media.id)}
+            )
+            if db_media.type == MediaType.VIDEO
+            else MediaAdapter.validate_python(db_media)
+        )
 
     def get_media_by_ids(self, project_id: UUID, media_ids: list[UUID]) -> list[Media]:
         """Get a media list by its IDs"""

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -227,18 +227,23 @@ class MediaService(BaseSessionManagedService):
             filters = MediaFilters()
         repo = MediaRepository(project_id=str(project_id), db=self.db_session)
         label_ids_str = [str(label_id) for label_id in filters.label_ids] if filters.label_ids else None
+        media_dbs = repo.list_items(
+            limit=filters.limit,
+            offset=filters.offset,
+            start_date=filters.start_date,
+            end_date=filters.end_date,
+            annotation_status=filters.annotation_status,
+            label_ids=label_ids_str,
+            subset=filters.subset,
+            exclude_types=exclude_types,
+        )
         return [
-            MediaAdapter.validate_python(db)
-            for db in repo.list_items(
-                limit=filters.limit,
-                offset=filters.offset,
-                start_date=filters.start_date,
-                end_date=filters.end_date,
-                annotation_status=filters.annotation_status,
-                label_ids=label_ids_str,
-                subset=filters.subset,
-                exclude_types=exclude_types,
+            Video.model_validate(media_db).model_copy(
+                update={"annotated_frame_count": repo.count_annotated_video_frames_by_video_id(media_db.id)}
             )
+            if media_db.type == MediaType.VIDEO
+            else MediaAdapter.validate_python(media_db)
+            for media_db in media_dbs
         ]
 
     def get_media_by_id(self, project_id: UUID, media_id: UUID) -> Media:

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -862,7 +862,7 @@ class TestMediaServiceIntegration:
         fxt_project_with_media: tuple[Project, list[MediaDB]],
         db_session: Session,
     ) -> None:
-        """Test listing media."""
+        """Test listing media with video that have annotated frame."""
         project, db_media_list = fxt_project_with_media
 
         db_video_frame = next(db_media for db_media in db_media_list if db_media.type == MediaType.VIDEO_FRAME)
@@ -912,6 +912,32 @@ class TestMediaServiceIntegration:
         fetched_media = fxt_media_service.get_media_by_id(project_id=project.id, media_id=UUID(db_media_list[0].id))
 
         assert str(fetched_media.id) == db_media_list[0].id and fetched_media.name == db_media_list[0].name
+
+    def test_get_media_by_id_with_annotated_frame(
+        self,
+        fxt_media_service: MediaService,
+        fxt_project_with_media: tuple[Project, list[MediaDB]],
+        db_session: Session,
+    ) -> None:
+        """Test get video with annotated frame."""
+        project, db_media_list = fxt_project_with_media
+
+        db_video_frame = next(db_media for db_media in db_media_list if db_media.type == MediaType.VIDEO_FRAME)
+        db_dataset_item = DatasetItemDB(
+            id=db_video_frame.id,
+            project_id=str(project.id),
+            subset="unassigned",
+            annotation_data=[{"labels": [{"id": str(uuid4())}], "shape": {"type": "full_image"}}],
+        )
+        db_session.add(db_dataset_item)
+        db_session.flush()
+
+        db_video = next(db_media for db_media in db_media_list if db_media.type == MediaType.VIDEO)
+
+        media = fxt_media_service.get_media_by_id(project_id=project.id, media_id=UUID(db_video.id))
+
+        assert isinstance(media, Video)
+        assert media.annotated_frame_count == 1
 
     def test_get_media_by_id_not_found(
         self,

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -856,6 +856,31 @@ class TestMediaServiceIntegration:
             else len(media_list) == len(db_media_list)
         )
 
+    def test_list_media_with_annotated_frame(
+        self,
+        fxt_media_service: MediaService,
+        fxt_project_with_media: tuple[Project, list[MediaDB]],
+        db_session: Session,
+    ) -> None:
+        """Test listing media."""
+        project, db_media_list = fxt_project_with_media
+
+        db_video_frame = next(db_media for db_media in db_media_list if db_media.type == MediaType.VIDEO_FRAME)
+        db_dataset_item = DatasetItemDB(
+            id=db_video_frame.id,
+            project_id=str(project.id),
+            subset="unassigned",
+            annotation_data=[{"labels": [{"id": str(uuid4())}], "shape": {"type": "full_image"}}],
+        )
+        db_session.add(db_dataset_item)
+        db_session.flush()
+
+        media_list = fxt_media_service.list_media(project_id=project.id)
+
+        videos = [m for m in media_list if isinstance(m, Video)]
+        assert len(videos) == 1
+        assert videos[0].annotated_frame_count == 1
+
     @pytest.mark.parametrize(
         "exclude_types, count", [([MediaType.IMAGE], 2), ([MediaType.VIDEO], 4), ([MediaType.VIDEO_FRAME], 4)]
     )

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -72,6 +72,7 @@ def fxt_video_media():
         size=2048,
         fps=25,
         frame_count=1000,
+        annotated_frame_count=100,
         source_id=uuid4(),
     )
 
@@ -148,6 +149,7 @@ def test_convert_video_to_view(fxt_video_media) -> None:
         size=fxt_video_media.size,
         fps=fxt_video_media.fps,
         frame_count=fxt_video_media.frame_count,
+        annotated_frame_count=fxt_video_media.annotated_frame_count,
         source_id=fxt_video_media.source_id,
         duration=fxt_video_media.duration,
     )
@@ -260,6 +262,7 @@ class TestMediaEndpoints:
             "width": 1024,
             "fps": 25.0,
             "frame_count": 1000,
+            "annotated_frame_count": 100,
             "duration": 40,
         }
         fxt_media_service.create_video.assert_called_once_with(
@@ -510,6 +513,7 @@ class TestMediaEndpoints:
             "width": fxt_video_media.width,
             "fps": fxt_video_media.fps,
             "frame_count": fxt_video_media.frame_count,
+            "annotated_frame_count": fxt_video_media.annotated_frame_count,
             "duration": fxt_video_media.duration,
         }
         fxt_media_service.get_media_by_id.assert_called_once_with(

--- a/application/ui/mocks/mock-media.ts
+++ b/application/ui/mocks/mock-media.ts
@@ -25,6 +25,7 @@ export const getMockedVideo = (props: Partial<MediaVideo> = {}): MediaVideo => (
     name: 'video',
     format: 'mp4',
     frame_count: 400,
+    annotated_frame_count: 100,
     source_id: undefined,
     ...props,
 });
@@ -40,6 +41,7 @@ export const getMockedVideoFrame = (props: Partial<MediaVideoFrame> = {}): Media
     fps: 60,
     duration: 10,
     frame_count: 10,
+    annotated_frame_count: 5,
     frame_stride: 1,
     frame_number: 0,
     ...props,

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -23,6 +23,7 @@ const getMediaEntities = (items: MediaDTO[]): Media[] => {
             return {
                 duration: 0,
                 frame_count: 0,
+                annotated_frame_count: 0,
                 fps: 0,
                 frame_number: 0,
                 frame_stride: 0,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Add `annotated_frame_count` to `VideoView`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
