### PR TITLE
fix: A few fixes in models screen

### DIFF
--- a/application/ui/src/features/models/model-listing/components/group-headers/architecture-group-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/group-headers/architecture-group-header.component.tsx
@@ -2,11 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { dimensionValue, Flex, Heading, Text } from '@geti/ui';
-import { capitalize } from 'lodash-es';
 
-import { ReactComponent as ThumbsUp } from '../../../../../assets/icons/thumbs-up.svg';
 import { type ModelArchitectureWithPerformanceCategory } from '../../../../../constants/shared-types';
-import { ModelBadge } from '../model-row/model-badge.component';
+import { PerformanceCategoryBadge } from '../model-row/performance-category-badge.component';
 
 type ArchitectureGroupHeaderProps = {
     architecture: ModelArchitectureWithPerformanceCategory | undefined;
@@ -24,12 +22,12 @@ export const ArchitectureGroupHeader = ({ architecture }: ArchitectureGroupHeade
                 {architecture.name}
             </Heading>
 
-            <Flex alignItems={'center'} gap={'size-100'}>
-                <ModelBadge>
-                    <ThumbsUp />
-                    <Text>{capitalize(architecture.performanceCategory)}</Text>
-                </ModelBadge>
-            </Flex>
+            {architecture.performanceCategory !== undefined && (
+                <PerformanceCategoryBadge
+                    id={'architecture-name'}
+                    performanceCategory={architecture.performanceCategory}
+                />
+            )}
         </Flex>
     );
 };

--- a/application/ui/src/features/models/model-listing/components/header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/header.component.tsx
@@ -85,7 +85,11 @@ export const Header = () => {
                 >
                     <Item key='name'>Sort: Name</Item>
                     <Item key='trained'>Sort: Trained</Item>
-                    <Item key='architecture'>Sort: Architecture</Item>
+                    {groupBy === 'dataset' ? (
+                        <Item key='architecture'>Sort: Architecture</Item>
+                    ) : (
+                        <Item key='dataset'>Sort: Dataset</Item>
+                    )}
                     <Item key='size'>Sort: Size</Item>
                     <Item key='score'>Sort: Score</Item>
                 </Picker>

--- a/application/ui/src/features/models/model-listing/components/models-table-header.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/models-table-header.component.tsx
@@ -45,7 +45,7 @@ export const ModelsTableHeader = () => {
             <ColumnHeader label='Trained' isSorted={sortBy === 'trained'} />
             <ColumnHeader
                 label={groupBy === 'architecture' ? 'Dataset' : 'Architecture'}
-                isSorted={sortBy === 'architecture'}
+                isSorted={sortBy === 'architecture' || sortBy === 'dataset'}
             />
             <ColumnHeader label='Total size' isSorted={sortBy === 'size'} />
             <ColumnHeader label={performanceColumnName} isSorted={sortBy === 'score'} />

--- a/application/ui/src/features/models/model-listing/hooks/use-grouped-models.hook.ts
+++ b/application/ui/src/features/models/model-listing/hooks/use-grouped-models.hook.ts
@@ -43,7 +43,7 @@ export const useGroupedModels = (models: Model[] | undefined, options: UseGroupe
             : filterOutFailedModels(filteredByTraining);
         const filteredBySearch = filterBySearch(filteredByFailedModels, searchBy);
         const grouped = groupModels(filteredBySearch, groupBy, datasetRevisions);
-        const sorted = sortGroupedModels(grouped, sortBy);
+        const sorted = sortGroupedModels(grouped, sortBy, datasetRevisions);
         const pinned = pinModel(sorted, pinActive ? activeModel?.id : undefined);
 
         return removeEmpty(pinned);

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
@@ -3,10 +3,10 @@
 
 import { ActionButton, Cell, Column, Flex, Row, TableBody, TableHeader, TableView, toast } from '@geti/ui';
 import { DownloadIcon } from '@geti/ui/icons';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { API_BASE_URL } from '../../../../api/client';
 import type { Model, ModelFormat } from '../../../../constants/shared-types';
-import { useProjectIdentifier } from '../../../../hooks/use-project-identifier.hook';
 import { downloadFile, formatBytes } from '../../../../shared/util';
 import {
     getBaselineVariant,
@@ -21,6 +21,7 @@ type ModelVariantTableProps = {
     model: Model;
     format: ModelFormat;
 };
+
 export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => {
     const projectId = useProjectIdentifier();
     const allVariants = model.variants ?? [];
@@ -57,7 +58,7 @@ export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => 
                     const isBaselineVariant = variant.id === baselineVariant?.id;
 
                     return (
-                        <Row key={`${variant.format}-${variant.precision}`}>
+                        <Row key={variant.id}>
                             <Cell>{variant.precision.toUpperCase()}</Cell>
                             <Cell>
                                 <ValueWithDelta

--- a/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/quantization-dialog/quantization-dialog.component.tsx
@@ -47,6 +47,7 @@ type QuantizationDialogProps = {
     modelId: string;
     onClose: () => void;
 };
+
 export const QuantizationDialog = ({ modelId, onClose }: QuantizationDialogProps) => {
     const [accuracyDrop, setAccuracyDrop] = useState(DEFAULT_QUANTIZATION_PARAMETERS.accuracyDrop);
     const [hasNoMaxAccuracyDrop, setHasNoMaxAccuracyDrop] = useState(

--- a/application/ui/src/features/models/model-listing/provider/model-listing-provider.tsx
+++ b/application/ui/src/features/models/model-listing/provider/model-listing-provider.tsx
@@ -59,6 +59,11 @@ export const ModelListingProvider = ({ children }: ModelListingProviderProps) =>
     });
 
     const onGroupByChange = (mode: GroupByMode) => {
+        if (mode === 'dataset' && sortBy === 'dataset') {
+            setSortBy('architecture');
+        } else if (mode === 'architecture' && sortBy === 'architecture') {
+            setSortBy('dataset');
+        }
         setGroupBy(mode);
     };
 

--- a/application/ui/src/features/models/model-listing/types.ts
+++ b/application/ui/src/features/models/model-listing/types.ts
@@ -5,7 +5,7 @@ import type { Model } from '../../../constants/shared-types';
 
 export type GroupByMode = 'dataset' | 'architecture';
 
-export type SortBy = 'name' | 'trained' | 'architecture' | 'size' | 'score';
+export type SortBy = 'name' | 'trained' | 'architecture' | 'dataset' | 'size' | 'score';
 
 export type DatasetGroup = {
     id: string;

--- a/application/ui/src/features/models/model-listing/utils/model-transforms.ts
+++ b/application/ui/src/features/models/model-listing/utils/model-transforms.ts
@@ -27,8 +27,11 @@ export const groupModels = (
 ): GroupedModels[] =>
     mode === 'dataset' ? groupModelsByDataset(models, { datasetRevisions }) : groupModelsByArchitecture(models);
 
-export const sortGroupedModels = (groups: GroupedModels[], sortBy: SortBy): GroupedModels[] =>
-    groups.map((group) => ({ ...group, models: sortModels(group.models, sortBy) }));
+export const sortGroupedModels = (
+    groups: GroupedModels[],
+    sortBy: SortBy,
+    datasetRevisions: DatasetRevision[]
+): GroupedModels[] => groups.map((group) => ({ ...group, models: sortModels(group.models, sortBy, datasetRevisions) }));
 
 export const pinModel = (groups: GroupedModels[], modelId: string | undefined): GroupedModels[] => {
     if (!modelId) return groups;

--- a/application/ui/src/features/models/model-listing/utils/sorting.test.ts
+++ b/application/ui/src/features/models/model-listing/utils/sorting.test.ts
@@ -1,42 +1,277 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { getMockedDatasetRevision } from 'mocks/mock-dataset-revision';
 import { getMockedModel } from 'mocks/mock-model';
+import { getMockedVariant } from 'mocks/mock-model-variant';
 
 import { sortModels } from './sorting';
 
 describe('sortModels', () => {
-    it('should return empty array for empty models', () => {
-        const result = sortModels([], 'name');
+    describe('name', () => {
+        it('returns empty array for empty models', () => {
+            const result = sortModels([], 'name', []);
 
-        expect(result).toEqual([]);
+            expect(result).toEqual([]);
+        });
+
+        it('sorts models by name ascending', () => {
+            const models = [
+                getMockedModel({ id: 'charlie', name: 'Charlie' }),
+                getMockedModel({ id: 'alpha', name: 'Alpha' }),
+                getMockedModel({ id: 'bravo', name: 'Bravo' }),
+            ];
+
+            const sorted = sortModels(models, 'name', []);
+
+            expect(sorted[0].id).toBe('alpha');
+            expect(sorted[1].id).toBe('bravo');
+            expect(sorted[2].id).toBe('charlie');
+        });
+
+        it('sorts models by name case-insensitively', () => {
+            const models = [
+                getMockedModel({ id: 'upper', name: 'ZEBRA' }),
+                getMockedModel({ id: 'lower', name: 'apple' }),
+            ];
+
+            const sorted = sortModels(models, 'name', []);
+
+            expect(sorted[0].id).toBe('lower');
+            expect(sorted[1].id).toBe('upper');
+        });
     });
 
-    it('should sort models by name ascending', () => {
-        const models = [
-            getMockedModel({ id: 'charlie', name: 'Charlie' }),
-            getMockedModel({ id: 'alpha', name: 'Alpha' }),
-            getMockedModel({ id: 'bravo', name: 'Bravo' }),
-        ];
+    describe('architecture', () => {
+        it('sorts models by architecture ascending', () => {
+            const models = [
+                getMockedModel({ id: 'model-1', architecture: 'YOLOX' }),
+                getMockedModel({ id: 'model-2', architecture: 'MobileNet' }),
+                getMockedModel({ id: 'model-3', architecture: 'ResNet' }),
+            ];
 
-        const sorted = sortModels(models, 'name');
+            const sorted = sortModels(models, 'architecture', []);
 
-        expect(sorted[0].id).toBe('alpha');
-        expect(sorted[1].id).toBe('bravo');
-        expect(sorted[2].id).toBe('charlie');
+            expect(sorted[0].architecture).toBe('MobileNet');
+            expect(sorted[1].architecture).toBe('ResNet');
+            expect(sorted[2].architecture).toBe('YOLOX');
+        });
+
+        it('sorts models by architecture case-insensitively', () => {
+            const models = [
+                getMockedModel({ id: 'upper', architecture: 'YOLOX' }),
+                getMockedModel({ id: 'lower', architecture: 'alexnet' }),
+            ];
+
+            const sorted = sortModels(models, 'architecture', []);
+
+            expect(sorted[0].id).toBe('lower');
+            expect(sorted[1].id).toBe('upper');
+        });
     });
 
-    it('should sort models by architecture ascending', () => {
-        const models = [
-            getMockedModel({ id: 'model-1', name: 'Charlie', architecture: 'YOLOX' }),
-            getMockedModel({ id: 'model-2', name: 'Alpha', architecture: 'MobileNet' }),
-            getMockedModel({ id: 'model-3', name: 'Bravo', architecture: 'ResNet' }),
-        ];
+    describe('trained', () => {
+        it('sorts models by training end time descending (most recent first)', () => {
+            const models = [
+                getMockedModel({
+                    id: 'oldest',
+                    training_info: { status: 'successful', end_time: '2025-01-01T00:00:00Z' },
+                }),
+                getMockedModel({
+                    id: 'newest',
+                    training_info: { status: 'successful', end_time: '2025-03-01T00:00:00Z' },
+                }),
+                getMockedModel({
+                    id: 'middle',
+                    training_info: { status: 'successful', end_time: '2025-02-01T00:00:00Z' },
+                }),
+            ];
 
-        const sorted = sortModels(models, 'architecture');
+            const sorted = sortModels(models, 'trained', []);
 
-        expect(sorted[0].architecture).toBe('MobileNet');
-        expect(sorted[1].architecture).toBe('ResNet');
-        expect(sorted[2].architecture).toBe('YOLOX');
+            expect(sorted[0].id).toBe('newest');
+            expect(sorted[1].id).toBe('middle');
+            expect(sorted[2].id).toBe('oldest');
+        });
+
+        it('places models with no end_time last (value 0)', () => {
+            const models = [
+                getMockedModel({ id: 'no-date', training_info: { status: 'not_started', end_time: null } }),
+                getMockedModel({
+                    id: 'has-date',
+                    training_info: { status: 'successful', end_time: '2025-01-01T00:00:00Z' },
+                }),
+            ];
+
+            const sorted = sortModels(models, 'trained', []);
+
+            expect(sorted[0].id).toBe('has-date');
+            expect(sorted[1].id).toBe('no-date');
+        });
+
+        it('places models with invalid end_time last (value 0)', () => {
+            const models = [
+                getMockedModel({
+                    id: 'invalid-date',
+                    training_info: { status: 'not_started', end_time: 'not-a-date' },
+                }),
+                getMockedModel({
+                    id: 'valid-date',
+                    training_info: { status: 'successful', end_time: '2025-06-01T00:00:00Z' },
+                }),
+            ];
+
+            const sorted = sortModels(models, 'trained', []);
+
+            expect(sorted[0].id).toBe('valid-date');
+            expect(sorted[1].id).toBe('invalid-date');
+        });
+    });
+
+    describe('size', () => {
+        it('sorts models by size ascending', () => {
+            const models = [
+                getMockedModel({ id: 'large', size: 3000000 }),
+                getMockedModel({ id: 'small', size: 500000 }),
+                getMockedModel({ id: 'medium', size: 1500000 }),
+            ];
+
+            const sorted = sortModels(models, 'size', []);
+
+            expect(sorted[0].id).toBe('small');
+            expect(sorted[1].id).toBe('medium');
+            expect(sorted[2].id).toBe('large');
+        });
+    });
+
+    describe('score', () => {
+        const makeModelWithScore = (id: string, primaryValue: number) =>
+            getMockedModel({
+                id,
+                variants: [
+                    getMockedVariant({
+                        evaluations: [
+                            {
+                                dataset_revision_id: 'rev-1',
+                                subset: 'testing',
+                                metrics: [{ name: 'Accuracy', value: primaryValue, primary: true }],
+                            },
+                        ],
+                    }),
+                ],
+            });
+
+        it('sorts models by primary testing metric value ascending', () => {
+            const models = [
+                makeModelWithScore('high', 0.9),
+                makeModelWithScore('low', 0.5),
+                makeModelWithScore('mid', 0.7),
+            ];
+
+            const sorted = sortModels(models, 'score', []);
+
+            expect(sorted[0].id).toBe('low');
+            expect(sorted[1].id).toBe('mid');
+            expect(sorted[2].id).toBe('high');
+        });
+
+        it('places models with no testing metric first (value 0)', () => {
+            const models = [getMockedModel({ id: 'no-metric', variants: [] }), makeModelWithScore('has-metric', 0.8)];
+
+            const sorted = sortModels(models, 'score', []);
+
+            expect(sorted[0].id).toBe('no-metric');
+            expect(sorted[1].id).toBe('has-metric');
+        });
+    });
+
+    describe('dataset', () => {
+        it('sorts models by dataset revision name ascending', () => {
+            const revisions = [
+                getMockedDatasetRevision({ id: 'rev-a', name: 'Alpha Dataset' }),
+                getMockedDatasetRevision({ id: 'rev-c', name: 'Charlie Dataset' }),
+                getMockedDatasetRevision({ id: 'rev-b', name: 'Bravo Dataset' }),
+            ];
+            const models = [
+                getMockedModel({
+                    id: 'model-c',
+                    training_info: { status: 'successful', dataset_revision_id: 'rev-c' },
+                }),
+                getMockedModel({
+                    id: 'model-a',
+                    training_info: { status: 'successful', dataset_revision_id: 'rev-a' },
+                }),
+                getMockedModel({
+                    id: 'model-b',
+                    training_info: { status: 'successful', dataset_revision_id: 'rev-b' },
+                }),
+            ];
+
+            const sorted = sortModels(models, 'dataset', revisions);
+
+            expect(sorted[0].id).toBe('model-a');
+            expect(sorted[1].id).toBe('model-b');
+            expect(sorted[2].id).toBe('model-c');
+        });
+
+        it('places models with no dataset_revision_id last', () => {
+            const revisions = [getMockedDatasetRevision({ id: 'rev-1', name: 'Zebra Dataset' })];
+            const models = [
+                getMockedModel({
+                    id: 'has-dataset',
+                    training_info: { status: 'successful', dataset_revision_id: 'rev-1' },
+                }),
+                getMockedModel({
+                    id: 'no-dataset',
+                    training_info: { status: 'not_started', dataset_revision_id: null },
+                }),
+            ];
+
+            const sorted = sortModels(models, 'dataset', revisions);
+
+            expect(sorted[0].id).toBe('has-dataset');
+            expect(sorted[1].id).toBe('no-dataset');
+        });
+
+        it('places models with a dataset_revision_id not found in revisions last', () => {
+            const revisions = [getMockedDatasetRevision({ id: 'rev-known', name: 'Known Dataset' })];
+            const models = [
+                getMockedModel({
+                    id: 'known',
+                    training_info: { status: 'successful', dataset_revision_id: 'rev-known' },
+                }),
+                getMockedModel({
+                    id: 'unknown',
+                    training_info: { status: 'successful', dataset_revision_id: 'rev-unknown' },
+                }),
+            ];
+
+            const sorted = sortModels(models, 'dataset', revisions);
+
+            // 'rev-unknown' is not in the revisions map, so it sorts after 'Known Dataset'
+            expect(sorted[0].id).toBe('known');
+            expect(sorted[1].id).toBe('unknown');
+        });
+
+        it('returns empty array when given no models', () => {
+            const revisions = [getMockedDatasetRevision()];
+
+            expect(sortModels([], 'dataset', revisions)).toEqual([]);
+        });
+    });
+
+    describe('default (unknown sort)', () => {
+        it('returns the original models array and logs an error for an unknown sort option', () => {
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+            const models = [getMockedModel({ id: 'a' }), getMockedModel({ id: 'b' })];
+            // Cast to bypass TypeScript's exhaustive check — tests the runtime default branch
+            const result = sortModels(models, 'unknown' as never, []);
+
+            expect(result).toBe(models);
+            expect(errorSpy).toHaveBeenCalledWith('Unknown sort option: unknown');
+
+            errorSpy.mockRestore();
+        });
     });
 });

--- a/application/ui/src/features/models/model-listing/utils/sorting.ts
+++ b/application/ui/src/features/models/model-listing/utils/sorting.ts
@@ -34,14 +34,28 @@ export const sortModels = (models: Model[], sortBy: SortBy, datasetRevisions: Da
             );
             return orderBy(
                 models,
-                (model) => {
-                    if (model.training_info?.dataset_revision_id != null) {
-                        return datasetRevisionsMap.get(model.training_info.dataset_revision_id) ?? '';
-                    }
+                [
+                    // First we sort by models that have dataset revision so they are on the top.
+                    (model) => {
+                        const name =
+                            model.training_info?.dataset_revision_id != null
+                                ? datasetRevisionsMap.get(model.training_info.dataset_revision_id)
+                                : undefined;
 
-                    return '';
-                },
-                'asc'
+                        return name != null ? 0 : 1;
+                    },
+                    // Then we sort alphabetically by dataset name
+                    (model) => {
+                        if (model.training_info?.dataset_revision_id != null) {
+                            return (
+                                datasetRevisionsMap.get(model.training_info.dataset_revision_id)?.toLowerCase() ?? ''
+                            );
+                        }
+
+                        return '';
+                    },
+                ],
+                ['asc', 'asc']
             );
         default:
             console.error(`Unknown sort option: ${sortBy satisfies never}`);

--- a/application/ui/src/features/models/model-listing/utils/sorting.ts
+++ b/application/ui/src/features/models/model-listing/utils/sorting.ts
@@ -4,11 +4,11 @@
 import dayjs from 'dayjs';
 import { orderBy } from 'lodash-es';
 
-import type { Model } from '../../../../constants/shared-types';
+import type { DatasetRevision, Model } from '../../../../constants/shared-types';
 import { getTestingMetric } from '../components/model-row/utils';
 import type { SortBy } from '../types';
 
-export const sortModels = (models: Model[], sortBy: SortBy): Model[] => {
+export const sortModels = (models: Model[], sortBy: SortBy, datasetRevisions: DatasetRevision[]): Model[] => {
     switch (sortBy) {
         case 'name':
             return orderBy(models, (model) => model.name?.toLowerCase() ?? '', 'asc');
@@ -28,7 +28,23 @@ export const sortModels = (models: Model[], sortBy: SortBy): Model[] => {
             return orderBy(models, (model) => model.size ?? 0, 'asc');
         case 'score':
             return orderBy(models, (model) => getTestingMetric(model)?.value ?? 0, 'asc');
+        case 'dataset':
+            const datasetRevisionsMap = new Map(
+                datasetRevisions.map((datasetRevision) => [datasetRevision.id, datasetRevision.name])
+            );
+            return orderBy(
+                models,
+                (model) => {
+                    if (model.training_info?.dataset_revision_id != null) {
+                        return datasetRevisionsMap.get(model.training_info.dataset_revision_id) ?? '';
+                    }
+
+                    return '';
+                },
+                'asc'
+            );
         default:
+            console.error(`Unknown sort option: ${sortBy satisfies never}`);
             return models;
     }
 };

--- a/application/ui/src/hooks/api/jobs/jobs.hook.ts
+++ b/application/ui/src/hooks/api/jobs/jobs.hook.ts
@@ -1,6 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useRef } from 'react';
+
 import { useQueryClient } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
@@ -15,9 +17,13 @@ const TERMINAL_STATUSES: string[] = ['DONE', 'FAILED', 'CANCELLED'];
 const useStreamJobStatus = (jobId: string | undefined) => {
     const queryClient = useQueryClient();
     const projectId = useProjectIdentifier();
+    const modelIdRef = useRef<string | null>(null);
 
     const { close } = useSSE<Job>(jobId ? `/api/jobs/${jobId}/status` : undefined, {
         onMessage: (updatedJob) => {
+            if (isQuantizeJob(updatedJob)) {
+                modelIdRef.current = updatedJob.metadata.model.id;
+            }
             // Update the job in the cache optimistically to reflect real-time progress
             queryClient.setQueryData<Job[]>(['get', '/api/jobs'], (prevJobs) => {
                 if (!prevJobs) {
@@ -40,6 +46,23 @@ const useStreamJobStatus = (jobId: string | undefined) => {
                     { params: { path: { project_id: projectId } } },
                 ]),
             });
+
+            modelIdRef.current !== null &&
+                queryClient.invalidateQueries({
+                    queryKey: getQueryKey([
+                        'get',
+                        '/api/projects/{project_id}/models/{model_id}',
+                        {
+                            params: {
+                                path: {
+                                    project_id: projectId,
+                                    model_id: modelIdRef.current,
+                                },
+                            },
+                        },
+                    ]),
+                });
+            modelIdRef.current = null;
         },
     });
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Fix displaying more than one row of int 8 quantized model.
2. Refetch model with new variants when quantization job finishes.
3. In group by architecture display sorting by dataset, in group by dataset display sorting by architecture.
4. Don't display model performance badge when there is no performance.
5. Add more tests for model sorting.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
