### PR TITLE
fix: Display proper message for number of images and videos

### DIFF
--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -28,7 +28,7 @@ import { AssignLabel } from './assign-label.component';
 import { DatasetStatistics } from './dataset-statistics/dataset-statistics.component';
 import { FilterByStatus, type FilterByStatusKey } from './filter-by-status/filter-by-status.component';
 import { MediaUpload } from './media-upload.component';
-import { toggleMultipleSelection } from './util';
+import { getNumberOfImagesAndVideosMessage, toggleMultipleSelection } from './util';
 
 type ToolbarProps = {
     items: Media[];
@@ -58,7 +58,9 @@ export const Toolbar = ({ items, viewMode, setViewMode, onFilter }: ToolbarProps
 
     const totalSelectedElements = selectedMediaItems?.size ?? 0;
     const hasSelectedElements = totalSelectedElements > 0;
-    const message = hasSelectedElements ? `${totalSelectedElements} selected` : `${items.length} images`;
+    const message = hasSelectedElements
+        ? `${totalSelectedElements} selected`
+        : getNumberOfImagesAndVideosMessage(items);
 
     const handleToggleManyItemSelection = () => {
         const images = items.map((item) => String(item.id));

--- a/application/ui/src/features/dataset/gallery/toolbar/util.test.ts
+++ b/application/ui/src/features/dataset/gallery/toolbar/util.test.ts
@@ -1,7 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { toggleMultipleSelection } from './util';
+import { getMockedMediaImage, getMockedVideo } from 'mocks/mock-media';
+
+import { getNumberOfImagesAndVideosMessage, toggleMultipleSelection } from './util';
 
 describe('toggleMultipleSelection', () => {
     const items = ['a', 'b', 'c'];
@@ -29,5 +31,52 @@ describe('toggleMultipleSelection', () => {
     it('should select all items if more than one but not all items are selected', () => {
         const result = toggleMultipleSelection(items)(new Set(['a', 'b']));
         expect(result).toEqual(new Set(items));
+    });
+});
+
+describe('getNumberOfImagesAndVideosMessage', () => {
+    it('returns empty string for an empty array', () => {
+        expect(getNumberOfImagesAndVideosMessage([])).toBe('');
+    });
+
+    it('returns "1 image" for a single image', () => {
+        expect(getNumberOfImagesAndVideosMessage([getMockedMediaImage()])).toBe('1 image');
+    });
+
+    it('returns plural "images" for multiple images', () => {
+        const images = [
+            getMockedMediaImage({ id: '1' }),
+            getMockedMediaImage({ id: '2' }),
+            getMockedMediaImage({ id: '3' }),
+        ];
+        expect(getNumberOfImagesAndVideosMessage(images)).toBe('3 images');
+    });
+
+    it('returns "1 video" for a single video', () => {
+        expect(getNumberOfImagesAndVideosMessage([getMockedVideo()])).toBe('1 video');
+    });
+
+    it('returns plural "videos" for multiple videos', () => {
+        const videos = [getMockedVideo({ id: 'v1' }), getMockedVideo({ id: 'v2' }), getMockedVideo({ id: 'v3' })];
+        expect(getNumberOfImagesAndVideosMessage(videos)).toBe('3 videos');
+    });
+
+    it('returns combined message for a mix of images and videos', () => {
+        const media = [
+            getMockedMediaImage({ id: 'img1' }),
+            getMockedMediaImage({ id: 'img2' }),
+            getMockedVideo({ id: 'v1' }),
+            getMockedVideo({ id: 'v2' }),
+        ];
+        expect(getNumberOfImagesAndVideosMessage(media)).toBe('2 images, 2 videos');
+    });
+
+    it('uses singular "video" (no trailing "s") when exactly 1 video appears in a mixed array', () => {
+        const media = [
+            getMockedMediaImage({ id: 'img1' }),
+            getMockedMediaImage({ id: 'img2' }),
+            getMockedVideo({ id: 'v1' }),
+        ];
+        expect(getNumberOfImagesAndVideosMessage(media)).toBe('2 images, 1 video');
     });
 });

--- a/application/ui/src/features/dataset/gallery/toolbar/util.ts
+++ b/application/ui/src/features/dataset/gallery/toolbar/util.ts
@@ -3,6 +3,9 @@
 
 import { Key, Selection } from '@geti/ui';
 
+import { Media } from '../../../../constants/shared-types';
+import { isVideo } from '../../../../shared/media-item-utils';
+
 export const toggleMultipleSelection =
     (items: Key[]) =>
     (selectedItems: Selection): Selection => {
@@ -19,3 +22,25 @@ export const toggleMultipleSelection =
 
         return new Set();
     };
+
+export const getNumberOfImagesAndVideosMessage = (mediaItems: Media[]) => {
+    const numberOfVideos = mediaItems.filter(isVideo).length;
+    const numberOfImages = mediaItems.length - numberOfVideos;
+
+    const imagesMessage = `${numberOfImages} image${numberOfImages === 1 ? '' : 's'}`;
+    const videosMessage = `${numberOfVideos} video${numberOfVideos == 1 ? '' : 's'}`;
+
+    if (numberOfImages > 0 && numberOfVideos > 0) {
+        return `${imagesMessage}, ${videosMessage}`;
+    }
+
+    if (numberOfImages > 0) {
+        return imagesMessage;
+    }
+
+    if (numberOfVideos > 0) {
+        return videosMessage;
+    }
+
+    return '';
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

We always displays the number of images, no matter if there are images or videos. This PR fixes that.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
