### PR TITLE
fix: Don't display preview annotations from previous media on the next one

### DIFF
--- a/application/ui/mocks/mock-annotation.ts
+++ b/application/ui/mocks/mock-annotation.ts
@@ -4,15 +4,14 @@
 import type { Annotation, Shape } from '../src/shared/types';
 import { getMockedLabel } from './mock-labels';
 
-export const getMockedShape = (shape: Partial<Shape> = {}): Shape => {
-    return {
-        ...shape,
-        type: 'rectangle',
-        x: 10,
-        y: 20,
-        width: 100,
-        height: 50,
-    };
+const SHAPE_DEFAULTS = {
+    rectangle: { type: 'rectangle', x: 10, y: 20, width: 100, height: 50 },
+    polygon: { type: 'polygon', points: [] },
+    full_image: { type: 'full_image' },
+};
+
+export const getMockedShape = (shape: Partial<Shape> & Pick<Shape, 'type'> = { type: 'rectangle' }): Shape => {
+    return { ...SHAPE_DEFAULTS[shape.type], ...shape } as Shape;
 };
 
 export const getMockedAnnotation = (annotation?: Partial<Annotation>): Annotation => {

--- a/application/ui/mocks/mock-annotation.ts
+++ b/application/ui/mocks/mock-annotation.ts
@@ -1,19 +1,24 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Annotation } from '../src/shared/types';
+import type { Annotation, Shape } from '../src/shared/types';
 import { getMockedLabel } from './mock-labels';
+
+export const getMockedShape = (shape: Partial<Shape> = {}): Shape => {
+    return {
+        ...shape,
+        type: 'rectangle',
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 50,
+    };
+};
 
 export const getMockedAnnotation = (annotation?: Partial<Annotation>): Annotation => {
     return {
         id: 'annotation-1',
-        shape: {
-            type: 'rectangle',
-            x: 10,
-            y: 20,
-            width: 100,
-            height: 50,
-        },
+        shape: getMockedShape(),
         labels: [getMockedLabel()],
         ...annotation,
     };

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -82,9 +82,14 @@ export const SegmentAnythingTool = () => {
             getRelativePoint(canvasRef.current, { x: event.clientX, y: event.clientY }, zoom.scale)
         );
 
-        cancellableThrottledDecodingQueryFn.call([{ ...point, positive: true }]).then((shapes) => {
-            setPreviewShapes(shapes.map((shape) => removeOffLimitPoints(shape, roi)));
-        });
+        cancellableThrottledDecodingQueryFn
+            .call([{ ...point, positive: true }])
+            .then((shapes) => {
+                setPreviewShapes(shapes.map((shape) => removeOffLimitPoints(shape, roi)));
+            })
+            .catch(() => {
+                return [];
+            });
     };
 
     const handlePointerDown = (event: PointerEvent<SVGSVGElement>) => {

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.test.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.test.ts
@@ -1,0 +1,164 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { act } from '@testing-library/react';
+import { getMockedShape } from 'mocks/mock-annotation';
+import { renderHook } from 'test-utils/render';
+
+import { Shape } from '../../../../shared/types';
+import { InteractiveAnnotationPoint } from './segment-anything.interface';
+import { useWithCancel } from './use-with-cancel';
+
+const getMockedInteractivePoint = (x: number, y: number, positive = true): InteractiveAnnotationPoint => ({
+    x,
+    y,
+    positive,
+});
+
+const makeControllableFn = () => {
+    const resolvers: Array<(shapes: Shape[]) => void> = [];
+
+    const fn = vi.fn(
+        (_points: InteractiveAnnotationPoint[]) =>
+            new Promise<Shape[]>((res) => {
+                resolvers.push(res);
+            })
+    );
+
+    return {
+        fn,
+        resolveCall: (index: number, shapes: Shape[] = [getMockedShape()]) => resolvers[index]?.(shapes),
+    };
+};
+
+describe('useWithCancel', () => {
+    it('returns the resolved value when fn resolves normally', async () => {
+        const shapes = [getMockedShape()];
+        const fn = vi.fn().mockResolvedValue(shapes);
+
+        const { result } = renderHook(() => useWithCancel(fn));
+
+        let returnedShapes: Shape[] | null = null;
+        await act(async () => {
+            returnedShapes = await result.current.call([getMockedInteractivePoint(1, 2)]);
+        });
+
+        expect(returnedShapes).toBe(shapes);
+    });
+
+    it('passes the correct arguments to fn', async () => {
+        const points = [getMockedInteractivePoint(3, 4, false), getMockedInteractivePoint(7, 8)];
+        const fn = vi.fn().mockResolvedValue([]);
+
+        const { result } = renderHook(() => useWithCancel(fn));
+
+        await act(async () => {
+            await result.current.call(points);
+        });
+
+        expect(fn).toHaveBeenCalledWith(points);
+    });
+
+    it('rejects with AbortError when cancel() is called while fn is in-flight', async () => {
+        const controlled = makeControllableFn();
+        const { result } = renderHook(() => useWithCancel(controlled.fn));
+
+        let callPromise: Promise<Shape[]> | null = null;
+
+        act(() => {
+            callPromise = result.current.call([getMockedInteractivePoint(1, 2)]);
+        });
+
+        // Cancel while fn is still pending.
+        act(() => {
+            result.current.cancel();
+        });
+
+        // Now let fn finish — the AbortError should be thrown despite fn resolving.
+        act(() => {
+            controlled.resolveCall(0);
+        });
+
+        await expect(callPromise).rejects.toMatchObject({ name: 'AbortError', message: 'Request aborted' });
+    });
+
+    it('rejects the first call with AbortError when a second call is made', async () => {
+        const controlled = makeControllableFn();
+        const { result } = renderHook(() => useWithCancel(controlled.fn));
+
+        let firstCallPromise: Promise<Shape[]> | null = null;
+        let secondCallPromise: Promise<Shape[]> | null = null;
+
+        act(() => {
+            firstCallPromise = result.current.call([getMockedInteractivePoint(0, 0)]);
+        });
+
+        // Trigger a second call — this should abort the first.
+        act(() => {
+            secondCallPromise = result.current.call([getMockedInteractivePoint(1, 1)]);
+        });
+
+        const secondCallShapes = [getMockedShape()];
+
+        // Resolve both fn invocations so both call promises can settle.
+        act(() => {
+            controlled.resolveCall(0);
+            controlled.resolveCall(1, secondCallShapes);
+        });
+
+        await expect(firstCallPromise).rejects.toMatchObject({ name: 'AbortError', message: 'Request aborted' });
+
+        // The second call should resolve normally.
+        const secondResult = await secondCallPromise;
+        expect(secondResult).toEqual(secondCallShapes);
+    });
+
+    it('does not throw when cancel() is called before any call', () => {
+        const fn = vi.fn().mockResolvedValue([]);
+        const { result } = renderHook(() => useWithCancel(fn));
+
+        expect(() => {
+            result.current.cancel();
+        }).not.toThrow();
+    });
+
+    it('rejects an in-flight call with AbortError when the component unmounts', async () => {
+        const controlled = makeControllableFn();
+        const { result, unmount } = renderHook(() => useWithCancel(controlled.fn));
+
+        let callPromise: Promise<Shape[]> | null = null;
+        act(() => {
+            callPromise = result.current.call([getMockedInteractivePoint(5, 5)]);
+        });
+
+        // Unmount triggers the useEffect cleanup which calls cancel().
+        act(() => {
+            unmount();
+        });
+
+        // Resolve fn after unmount — the AbortError should still be thrown.
+        act(() => {
+            controlled.resolveCall(0);
+        });
+
+        await expect(callPromise).rejects.toMatchObject({ name: 'AbortError', message: 'Request aborted' });
+    });
+
+    it('works normally after a previous cancel()', async () => {
+        const shapes = [getMockedShape()];
+        const fn = vi.fn().mockResolvedValue(shapes);
+
+        const { result } = renderHook(() => useWithCancel(fn));
+
+        act(() => {
+            result.current.cancel();
+        });
+
+        let returnedShapes: Shape[] | null = null;
+        await act(async () => {
+            returnedShapes = await result.current.call([getMockedInteractivePoint(2, 3)]);
+        });
+
+        expect(returnedShapes).toBe(shapes);
+    });
+});

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.ts
@@ -16,8 +16,8 @@ export const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Prom
 
             // Create a new controller for THIS call and capture its signal in a local
             // variable BEFORE awaiting anything. Any future cancel() call will replace
-            // abortController.current, but `signal` here is a closed-over reference to
-            // the controller for THIS specific invocation and will correctly reflect
+            // abortController.current, but `controller.signal` here is a closed-over reference to
+            // the abortController for THIS specific invocation and will correctly reflect
             // whether it was aborted — even after the ref has been replaced.
             const controller = new AbortController();
             abortController.current = controller;

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-with-cancel.ts
@@ -14,11 +14,17 @@ export const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Prom
             // Cancel any ongoing request
             abortController.current?.abort();
 
-            abortController.current = new AbortController();
+            // Create a new controller for THIS call and capture its signal in a local
+            // variable BEFORE awaiting anything. Any future cancel() call will replace
+            // abortController.current, but `signal` here is a closed-over reference to
+            // the controller for THIS specific invocation and will correctly reflect
+            // whether it was aborted — even after the ref has been replaced.
+            const controller = new AbortController();
+            abortController.current = controller;
 
             const result = await fn(...args);
 
-            if (abortController.current?.signal.aborted) {
+            if (controller.signal.aborted) {
                 throw new DOMException('Request aborted', 'AbortError');
             }
 
@@ -30,7 +36,7 @@ export const useWithCancel = (fn: (points: InteractiveAnnotationPoint[]) => Prom
     const cancel = useCallback(() => {
         abortController.current?.abort();
         abortController.current = null;
-    }, [abortController]);
+    }, []);
 
     useEffect(() => {
         return () => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was caused by incorrect `AbortController` instance inside the main function (race conditions/closures).
This PR fixes that and adds unit tests.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
