### PR TITLE
feature: shows number of annotated frames

### DIFF
--- a/application/ui/src/components/media-item/media-item.module.scss
+++ b/application/ui/src/components/media-item/media-item.module.scss
@@ -2,7 +2,6 @@
     opacity: 0;
     position: absolute;
     line-height: 0px;
-    padding: var(--spectrum-global-dimension-size-150);
     border-radius: var(--spectrum-global-dimension-size-50);
 
     &:empty {

--- a/application/ui/src/components/media-item/media-item.module.scss
+++ b/application/ui/src/components/media-item/media-item.module.scss
@@ -40,7 +40,8 @@ div[class*='mediaItem']:is([data-hovered], [data-selected]) {
 }
 
 // When media actions menu is open, we don't want to hide the button that opens it
-div[class*='mediaItem']:has(button[aria-label='Media actions'][aria-expanded='true']) {
+div[class*='mediaItem']:has(button[aria-label='Media actions'][aria-expanded='true']),
+div[class*='mediaItem']:has(button[aria-label='Media information'][aria-expanded='true']) {
     .rightTopElement {
         opacity: 1;
     }

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -33,7 +33,11 @@ const VideoIndicator = ({ frameCount, annotatedFrameCount }: VideoIndicatorProps
         >
             {`${annotatedFrameCount} / ${frameCount} ${frameCount !== 1 ? 'frames' : 'frame'}`}
 
-            <ContextualHelp variant='info' UNSAFE_className={classes.videoIndicatorDetails}>
+            <ContextualHelp
+                variant='info'
+                UNSAFE_className={classes.videoIndicatorDetails}
+                aria-label='annotated frames'
+            >
                 <Content>
                     <Text>Total frames: {frameCount}</Text>
                     <br />

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { View } from '@geti/ui';
+import { Content, ContextualHelp, Flex, Text } from '@geti/ui';
 
 import type { Media, MediaVideo } from '../../constants/shared-types';
 import { isVideo } from '../../shared/media-item-utils';
@@ -23,9 +23,24 @@ type VideoIndicatorProps = {
 
 const VideoIndicator = ({ frameCount, annotatedFrameCount }: VideoIndicatorProps) => {
     return (
-        <View position={'absolute'} bottom={'size-50'} left={'size-50'} UNSAFE_className={classes.videoIndicator}>
+        <Flex
+            gap={'size-50'}
+            left={'size-50'}
+            bottom={'size-50'}
+            position={'absolute'}
+            alignItems={'center'}
+            UNSAFE_className={classes.videoIndicator}
+        >
             {`${annotatedFrameCount} / ${frameCount} ${frameCount !== 1 ? 'frames' : 'frame'}`}
-        </View>
+
+            <ContextualHelp variant='info' UNSAFE_className={classes.videoIndicatorDetails}>
+                <Content>
+                    <Text>Total frames: {frameCount}</Text>
+                    <br />
+                    <Text>Number of annotated frames: {annotatedFrameCount}</Text>
+                </Content>
+            </ContextualHelp>
+        </Flex>
     );
 };
 

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Content, ContextualHelp, Flex, Text } from '@geti/ui';
+import { Flex } from '@geti/ui';
 
 import type { Media, MediaVideo } from '../../constants/shared-types';
 import { formatDurationText } from '../../features/annotator/video-player/video-toolbar/time-utils';
@@ -18,12 +18,10 @@ type MediaThumbnailProps = {
 };
 
 type VideoIndicatorProps = {
-    frameCount: number;
     duration: number;
-    annotatedFrameCount: number;
 };
 
-const VideoIndicator = ({ frameCount, duration, annotatedFrameCount }: VideoIndicatorProps) => {
+const VideoIndicator = ({ duration }: VideoIndicatorProps) => {
     return (
         <Flex
             gap={'size-50'}
@@ -34,18 +32,6 @@ const VideoIndicator = ({ frameCount, duration, annotatedFrameCount }: VideoIndi
             UNSAFE_className={classes.videoIndicator}
         >
             {formatDurationText(duration)}
-
-            <ContextualHelp
-                variant='info'
-                UNSAFE_className={classes.videoIndicatorDetails}
-                aria-label='annotated frames'
-            >
-                <Content>
-                    <Text>Total frames: {frameCount}</Text>
-                    <br />
-                    <Text>Number of annotated frames: {annotatedFrameCount}</Text>
-                </Content>
-            </ContextualHelp>
         </Flex>
     );
 };
@@ -54,13 +40,7 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
     return (
         <div onDoubleClick={onDoubleClick} onClick={onClick} className={classes.imgContainer}>
             <img src={url} alt={alt} className={classes.img} />
-            {isVideo(item) && (
-                <VideoIndicator
-                    duration={item.duration}
-                    frameCount={item.frame_count}
-                    annotatedFrameCount={item.annotated_frame_count}
-                />
-            )}
+            {isVideo(item) && <VideoIndicator duration={item.duration} />}
         </div>
     );
 };

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -13,7 +13,7 @@ type MediaThumbnailProps = {
     onDoubleClick?: () => void;
     url: string;
     alt: string;
-    item: Pick<Media, 'type'> | Pick<MediaVideo, 'type' | 'frame_count'>;
+    item: Pick<Media, 'type'> | Pick<MediaVideo, 'type' | 'frame_count' | 'annotated_frame_count'>;
 };
 
 type VideoIndicatorProps = {

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -4,6 +4,7 @@
 import { Content, ContextualHelp, Flex, Text } from '@geti/ui';
 
 import type { Media, MediaVideo } from '../../constants/shared-types';
+import { formatDurationText } from '../../features/annotator/video-player/video-toolbar/time-utils';
 import { isVideo } from '../../shared/media-item-utils';
 
 import classes from './media-thumbnail.module.scss';
@@ -13,15 +14,16 @@ type MediaThumbnailProps = {
     onDoubleClick?: () => void;
     url: string;
     alt: string;
-    item: Pick<Media, 'type'> | Pick<MediaVideo, 'type' | 'frame_count' | 'annotated_frame_count'>;
+    item: Pick<Media, 'type'> | Pick<MediaVideo, 'type' | 'frame_count' | 'annotated_frame_count' | 'duration'>;
 };
 
 type VideoIndicatorProps = {
     frameCount: number;
+    duration: number;
     annotatedFrameCount: number;
 };
 
-const VideoIndicator = ({ frameCount, annotatedFrameCount }: VideoIndicatorProps) => {
+const VideoIndicator = ({ frameCount, duration, annotatedFrameCount }: VideoIndicatorProps) => {
     return (
         <Flex
             gap={'size-50'}
@@ -31,7 +33,7 @@ const VideoIndicator = ({ frameCount, annotatedFrameCount }: VideoIndicatorProps
             alignItems={'center'}
             UNSAFE_className={classes.videoIndicator}
         >
-            {`${annotatedFrameCount} / ${frameCount} ${frameCount !== 1 ? 'frames' : 'frame'}`}
+            {formatDurationText(duration)}
 
             <ContextualHelp
                 variant='info'
@@ -53,7 +55,11 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
         <div onDoubleClick={onDoubleClick} onClick={onClick} className={classes.imgContainer}>
             <img src={url} alt={alt} className={classes.img} />
             {isVideo(item) && (
-                <VideoIndicator frameCount={item.frame_count} annotatedFrameCount={item.annotated_frame_count} />
+                <VideoIndicator
+                    duration={item.duration}
+                    frameCount={item.frame_count}
+                    annotatedFrameCount={item.annotated_frame_count}
+                />
             )}
         </div>
     );

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -18,12 +18,13 @@ type MediaThumbnailProps = {
 
 type VideoIndicatorProps = {
     frameCount: number;
+    annotatedFrameCount: number;
 };
 
-const VideoIndicator = ({ frameCount }: VideoIndicatorProps) => {
+const VideoIndicator = ({ frameCount, annotatedFrameCount }: VideoIndicatorProps) => {
     return (
         <View position={'absolute'} bottom={'size-50'} left={'size-50'} UNSAFE_className={classes.videoIndicator}>
-            {frameCount} {frameCount !== 1 ? 'frames' : 'frame'}
+            {`${annotatedFrameCount} / ${frameCount} ${frameCount !== 1 ? 'frames' : 'frame'}`}
         </View>
     );
 };
@@ -32,7 +33,9 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
     return (
         <div onDoubleClick={onDoubleClick} onClick={onClick} className={classes.imgContainer}>
             <img src={url} alt={alt} className={classes.img} />
-            {isVideo(item) && <VideoIndicator frameCount={item.frame_count} />}
+            {isVideo(item) && (
+                <VideoIndicator frameCount={item.frame_count} annotatedFrameCount={item.annotated_frame_count} />
+            )}
         </div>
     );
 };

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
@@ -17,9 +17,20 @@
 }
 
 .videoIndicator {
-    font-size: var(--spectrum-global-dimension-font-size-50);
     color: var(--spectrum-global-color-gray-900);
-    background-color: var(--spectrum-global-color-gray-50);
     padding: var(--spectrum-global-dimension-size-50);
+    font-size: var(--spectrum-global-dimension-font-size-50);
     border-radius: var(--spectrum-alias-border-radius-regular);
+    background-color: var(--spectrum-global-color-gray-50);
+}
+
+.videoIndicatorDetails {
+    [class*='spectrum-Dialog-content'] {
+        margin: 0px !important;
+    }
+
+    [class*='spectrum-Dialog-grid'] {
+        --spectrum-dialog-padding-x: var(--spectrum-global-dimension-size-200) !important;
+        --spectrum-dialog-padding-y: var(--spectrum-global-dimension-size-200) !important;
+    }
 }

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
@@ -23,14 +23,3 @@
     border-radius: var(--spectrum-alias-border-radius-regular);
     background-color: var(--spectrum-global-color-gray-50);
 }
-
-.videoIndicatorDetails {
-    [class*='spectrum-Dialog-content'] {
-        margin: 0px !important;
-    }
-
-    [class*='spectrum-Dialog-grid'] {
-        --spectrum-dialog-padding-x: var(--spectrum-global-dimension-size-200) !important;
-        --spectrum-dialog-padding-y: var(--spectrum-global-dimension-size-200) !important;
-    }
-}

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
@@ -38,10 +38,10 @@ describe('MediaThumbnail', () => {
                 url='test-video.mp4'
                 alt='Test Image'
                 onClick={mockedClick}
-                item={{ type: 'video', frame_count: 3600, annotated_frame_count: 10 }}
+                item={{ type: 'video', frame_count: 3600, annotated_frame_count: 10, duration: 60 }}
             />
         );
 
-        expect(screen.getByText('10 / 3600 frames')).toBeInTheDocument();
+        expect(screen.getByText('00:01:00')).toBeInTheDocument();
     });
 });

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
@@ -38,10 +38,10 @@ describe('MediaThumbnail', () => {
                 url='test-video.mp4'
                 alt='Test Image'
                 onClick={mockedClick}
-                item={{ type: 'video', frame_count: 3600 }}
+                item={{ type: 'video', frame_count: 3600, annotated_frame_count: 10 }}
             />
         );
 
-        expect(screen.getByText('3600 frames')).toBeInTheDocument();
+        expect(screen.getByText('10 / 3600 frames')).toBeInTheDocument();
     });
 });

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -141,3 +141,5 @@ export type TrainingRequestPayload = components['schemas']['TrainingRequest'];
 export type TrainingConfigurationRequestPayload = {
     [key: string]: unknown;
 };
+
+export type Pagination = components['schemas']['Pagination'];

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -143,3 +143,4 @@ export type TrainingConfigurationRequestPayload = {
 };
 
 export type Pagination = components['schemas']['Pagination'];
+export type MediaWithPagination = components['schemas']['MediaWithPagination'];

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Checkbox, DialogContainer, Flex, Size, ViewModes } from '@geti/ui';
+import { Checkbox, DialogContainer, dimensionValue, Flex, Size, ViewModes } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isEmpty } from 'lodash-es';
 import { GridLayoutOptions } from 'react-aria-components';
@@ -91,6 +91,7 @@ const GalleryList = ({
                                 height={'size-200'}
                                 alignItems={'center'}
                                 justifyContent={'center'}
+                                UNSAFE_style={{ margin: dimensionValue('size-150') }}
                             >
                                 <Checkbox
                                     aria-label={`Select media item ${item.name}`}

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -19,6 +19,7 @@ import { DatasetDropZone } from './drop-zone.component';
 import { EmptyDataset } from './empty-dataset.component';
 import { useSelectDatasetItem } from './hooks/use-select-dataset-item.hook';
 import { MediaItemActions } from './media-item-actions/media-item-actions.component';
+import { MediaItemContextualHelp } from './media-item-contextual-help/media-item-contextual-help.component';
 import { useUploadFiles } from './use-upload-files';
 
 type GalleryProps = {
@@ -101,13 +102,17 @@ const GalleryList = ({
                             </Flex>
                         )}
                         topRightElement={() => (
-                            <MediaItemActions
-                                id={item.id}
-                                onDeleted={toggleSelectedKeys}
-                                mediaUrl={fullMediaUrl}
-                                mediaFileName={mediaFileName}
-                                onAnnotate={() => onSelectedMediaItemChange(item)}
-                            />
+                            <Flex alignItems={'center'} gap={'size-50'}>
+                                <MediaItemContextualHelp item={item} />
+
+                                <MediaItemActions
+                                    id={item.id}
+                                    onDeleted={toggleSelectedKeys}
+                                    mediaUrl={fullMediaUrl}
+                                    mediaFileName={mediaFileName}
+                                    onAnnotate={() => onSelectedMediaItemChange(item)}
+                                />
+                            </Flex>
                         )}
                         bottomRightElement={() => (
                             <AnnotationStatusIcon state={isUserReviewed(item.id) ? 'accepted' : undefined} />

--- a/application/ui/src/features/dataset/gallery/media-item-contextual-help/media-item-contextual-help.component.tsx
+++ b/application/ui/src/features/dataset/gallery/media-item-contextual-help/media-item-contextual-help.component.tsx
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Content, ContextualHelp, Divider, Text } from '@geti/ui';
+
+import { Media, MediaVideo } from '../../../../constants/shared-types';
+import { isVideo } from '../../../../shared/media-item-utils';
+
+import classes from './media-item-contextual-help.module.scss';
+
+type MediaItemContextualHelpProps = {
+    item: Pick<Media, 'type'> | Pick<MediaVideo, 'type' | 'frame_count' | 'annotated_frame_count' | 'duration'>;
+};
+
+export const MediaItemContextualHelp = ({ item }: MediaItemContextualHelpProps) => {
+    if (!isVideo(item)) {
+        return null;
+    }
+
+    return (
+        <>
+            <ContextualHelp
+                variant='info'
+                UNSAFE_className={classes.videoIndicatorDetails}
+                aria-label='Media information'
+            >
+                <Content>
+                    <Text>Number of annotated frames: {item.annotated_frame_count}</Text>
+                    <br />
+                    <Text>Total frames: {item.frame_count}</Text>
+                </Content>
+            </ContextualHelp>
+
+            <Divider orientation={'vertical'} size={'S'} />
+        </>
+    );
+};

--- a/application/ui/src/features/dataset/gallery/media-item-contextual-help/media-item-contextual-help.module.scss
+++ b/application/ui/src/features/dataset/gallery/media-item-contextual-help/media-item-contextual-help.module.scss
@@ -1,0 +1,10 @@
+.videoIndicatorDetails {
+    [class*='spectrum-Dialog-content'] {
+        margin: 0px !important;
+    }
+
+    [class*='spectrum-Dialog-grid'] {
+        --spectrum-dialog-padding-x: var(--spectrum-global-dimension-size-200) !important;
+        --spectrum-dialog-padding-y: var(--spectrum-global-dimension-size-200) !important;
+    }
+}

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -4,7 +4,7 @@
 import { useMemo } from 'react';
 
 import { $api } from '../api/client';
-import type { DatasetItemAnnotationStatus, DatasetSubset } from '../constants/shared-types';
+import type { DatasetItemAnnotationStatus, DatasetSubset, Pagination } from '../constants/shared-types';
 import { useProjectIdentifier } from './use-project-identifier.hook';
 
 const DATASET_ITEMS_LIMIT = 20;
@@ -46,11 +46,7 @@ export const useGetDatasetItems = ({ subset, annotationStatus }: UseGetDatasetIt
         },
         {
             pageParamName: 'offset',
-            getNextPageParam: ({
-                pagination,
-            }: {
-                pagination: { offset: number; limit: number; count: number; total: number };
-            }) => {
+            getNextPageParam: ({ pagination }: { pagination: Pagination }) => {
                 const total = pagination.offset + pagination.count;
 
                 if (total >= pagination.total) {

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../api/client';
-import { DatasetItemAnnotationStatus, DatasetSubset, Media, MediaDTO } from '../constants/shared-types';
+import { DatasetItemAnnotationStatus, DatasetSubset, Media, MediaDTO, Pagination } from '../constants/shared-types';
 
 const DATASET_ITEMS_LIMIT = 20;
 
@@ -62,11 +62,7 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
         { params: { query, path: { project_id } } },
         {
             pageParamName: 'offset',
-            getNextPageParam: ({
-                pagination,
-            }: {
-                pagination: { offset: number; limit: number; count: number; total: number };
-            }) => {
+            getNextPageParam: ({ pagination }: { pagination: Pagination }) => {
                 const total = pagination.offset + pagination.count;
 
                 if (total >= pagination.total) {

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -59,12 +59,7 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = $api.useInfiniteQuery(
         'get',
         '/api/projects/{project_id}/dataset/media',
-        {
-            params: {
-                query,
-                path: { project_id },
-            },
-        },
+        { params: { query, path: { project_id } } },
         {
             pageParamName: 'offset',
             getNextPageParam: ({

--- a/application/ui/src/hooks/use-get-dataset-revision-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-revision-items.hook.ts
@@ -4,7 +4,7 @@
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../api/client';
-import type { DatasetRevisionItem, DatasetSubset } from '../constants/shared-types';
+import type { DatasetRevisionItem, DatasetSubset, Pagination } from '../constants/shared-types';
 
 const DATASET_ITEMS_LIMIT = 20;
 
@@ -31,11 +31,7 @@ export const useGetDatasetRevisionItems = ({ datasetRevisionId, subset }: UseGet
         },
         {
             pageParamName: 'offset',
-            getNextPageParam: ({
-                pagination,
-            }: {
-                pagination: { offset: number; limit: number; count: number; total: number };
-            }) => {
+            getNextPageParam: ({ pagination }: { pagination: Pagination }) => {
                 const total = pagination.offset + pagination.count;
 
                 if (total >= pagination.total) {

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -75,10 +75,9 @@ export const AnnotationActionsProvider = ({
                 [
                     'get',
                     '/api/projects/{project_id}/dataset/media/{media_id}/frames',
-                    {
-                        params: { path: { project_id: projectId, media_id: mediaItem.id } },
-                    },
+                    { params: { path: { project_id: projectId, media_id: mediaItem.id } } },
                 ],
+                ['get', '/api/projects/{project_id}/dataset/media', { params: { path: { project_id: projectId } } }],
             ],
         },
     });

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -3,6 +3,7 @@
 
 import { createContext, ReactNode, useContext, useMemo, useRef } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isEqual } from 'lodash-es';
 import { v4 as uuid } from 'uuid';
@@ -16,6 +17,7 @@ import type { Annotation, Shape } from '../types';
 import { mapLocalAnnotationsToServer, mapServerAnnotationsToLocal } from './annotation-mappers';
 import type { AnnotatorMode } from './annotator-mode';
 import { EMPTY_LABEL_ID, useProjectLabelsWithEmptyLabel } from './labels';
+import { incrementCachedAnnotatedFrameCount } from './util';
 
 type AnnotationsContextValue = {
     annotations: Annotation[];
@@ -58,6 +60,7 @@ export const AnnotationActionsProvider = ({
     isReadOnly = false,
 }: AnnotationActionsProviderProps) => {
     const projectId = useProjectIdentifier();
+    const queryClient = useQueryClient();
     const saveMutation = $api.useMutation('post', '/api/projects/{project_id}/dataset/media/{media_id}/annotations', {
         meta: {
             invalidateQueries: [
@@ -77,7 +80,6 @@ export const AnnotationActionsProvider = ({
                     '/api/projects/{project_id}/dataset/media/{media_id}/frames',
                     { params: { path: { project_id: projectId, media_id: mediaItem.id } } },
                 ],
-                ['get', '/api/projects/{project_id}/dataset/media', { params: { path: { project_id: projectId } } }],
             ],
         },
     });
@@ -166,6 +168,10 @@ export const AnnotationActionsProvider = ({
             params: { path: { media_id: mediaItem.id, project_id: projectId }, query },
             body: { annotations: annotationsDTO, subset: subset ?? undefined },
         });
+
+        if (isVideoFrame(mediaItem)) {
+            incrementCachedAnnotatedFrameCount(queryClient, mediaItem);
+        }
 
         undoRedoActions.reset(mapServerAnnotationsToLocal(annotationsDTO, projectLabels));
     };

--- a/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotation-actions-provider.component.tsx
@@ -164,14 +164,16 @@ export const AnnotationActionsProvider = ({
               }
             : undefined;
 
-        await saveMutation.mutateAsync({
-            params: { path: { media_id: mediaItem.id, project_id: projectId }, query },
-            body: { annotations: annotationsDTO, subset: subset ?? undefined },
-        });
-
-        if (isVideoFrame(mediaItem)) {
-            incrementCachedAnnotatedFrameCount(queryClient, mediaItem);
-        }
+        await saveMutation
+            .mutateAsync({
+                params: { path: { media_id: mediaItem.id, project_id: projectId }, query },
+                body: { annotations: annotationsDTO, subset: subset ?? undefined },
+            })
+            .then(() => {
+                if (isVideoFrame(mediaItem)) {
+                    incrementCachedAnnotatedFrameCount(queryClient, mediaItem);
+                }
+            });
 
         undoRedoActions.reset(mapServerAnnotationsToLocal(annotationsDTO, projectLabels));
     };

--- a/application/ui/src/shared/annotator/util.test.ts
+++ b/application/ui/src/shared/annotator/util.test.ts
@@ -46,7 +46,9 @@ describe('incrementCachedAnnotatedFrameCount', () => {
         incrementCachedAnnotatedFrameCount(queryClient, video);
 
         const data = getMediaQueryData(queryClient);
-        expect(data?.pages[0].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 6 }));
+        expect(data?.pages[0].items[0]).toEqual(
+            expect.objectContaining({ annotated_frame_count: video.annotated_frame_count + 1 })
+        );
     });
 
     it('does not modify non-matching videos', () => {
@@ -61,7 +63,10 @@ describe('incrementCachedAnnotatedFrameCount', () => {
         incrementCachedAnnotatedFrameCount(queryClient, targetVideo);
 
         const data = getMediaQueryData(queryClient);
-        expect(data?.pages[0].items[1]).toEqual(expect.objectContaining({ annotated_frame_count: 10 }));
+        expect(data?.pages[0].items).toEqual([
+            expect.objectContaining({ annotated_frame_count: targetVideo.annotated_frame_count + 1 }),
+            expect.objectContaining({ annotated_frame_count: otherVideo.annotated_frame_count }),
+        ]);
     });
 
     it('does not modify image items', () => {
@@ -74,7 +79,7 @@ describe('incrementCachedAnnotatedFrameCount', () => {
         incrementCachedAnnotatedFrameCount(queryClient, { ...image, type: 'image' });
 
         const data = getMediaQueryData(queryClient);
-        expect(data?.pages[0].items[0]).toEqual(image);
+        expect(data?.pages[0].items[0]).toEqual(expect.objectContaining({ id: image.id }));
     });
 
     it('handles multiple pages', () => {
@@ -90,6 +95,7 @@ describe('incrementCachedAnnotatedFrameCount', () => {
         incrementCachedAnnotatedFrameCount(queryClient, video2);
 
         const data = getMediaQueryData(queryClient);
+
         expect(data?.pages[0].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 2 }));
         expect(data?.pages[1].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 8 }));
     });

--- a/application/ui/src/shared/annotator/util.test.ts
+++ b/application/ui/src/shared/annotator/util.test.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { InfiniteData, QueryClient } from '@tanstack/react-query';
+
+import { getMockedMediaImage, getMockedVideo } from '../../../mocks/mock-media';
+import { SchemaMediaWithPagination } from '../../api/openapi-spec';
+import { Pagination } from '../../constants/shared-types';
+import { incrementCachedAnnotatedFrameCount } from './util';
+
+const createQueryClient = () => new QueryClient();
+
+const getMockedPagination = (overrides: Partial<Pagination>) => ({
+    total: 1,
+    offset: 0,
+    limit: 0,
+    count: 0,
+    ...overrides,
+});
+
+const MEDIA_QUERY_KEY = ['get', '/api/projects/{project_id}/dataset/media'] as const;
+
+const setMediaQueryData = (queryClient: QueryClient, pages: SchemaMediaWithPagination[]) => {
+    queryClient.setQueryData<InfiniteData<SchemaMediaWithPagination>>(MEDIA_QUERY_KEY, {
+        pages,
+        pageParams: pages.map((_, i) => i),
+    });
+};
+
+const getMediaQueryData = (queryClient: QueryClient) => {
+    return queryClient.getQueryData<InfiniteData<SchemaMediaWithPagination>>(MEDIA_QUERY_KEY);
+};
+
+describe('incrementCachedAnnotatedFrameCount', () => {
+    it('increments annotated_frame_count for the matching video', () => {
+        const queryClient = createQueryClient();
+        const video = getMockedVideo({ id: 'video-1', annotated_frame_count: 5 });
+
+        setMediaQueryData(queryClient, [
+            {
+                items: [video],
+                pagination: getMockedPagination({ total: 1 }),
+            },
+        ]);
+
+        incrementCachedAnnotatedFrameCount(queryClient, video);
+
+        const data = getMediaQueryData(queryClient);
+        expect(data?.pages[0].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 6 }));
+    });
+
+    it('does not modify non-matching videos', () => {
+        const queryClient = createQueryClient();
+        const targetVideo = getMockedVideo({ id: 'video-1', annotated_frame_count: 5 });
+        const otherVideo = getMockedVideo({ id: 'video-2', annotated_frame_count: 10 });
+
+        setMediaQueryData(queryClient, [
+            { items: [targetVideo, otherVideo], pagination: getMockedPagination({ total: 2 }) },
+        ]);
+
+        incrementCachedAnnotatedFrameCount(queryClient, targetVideo);
+
+        const data = getMediaQueryData(queryClient);
+        expect(data?.pages[0].items[1]).toEqual(expect.objectContaining({ annotated_frame_count: 10 }));
+    });
+
+    it('does not modify image items', () => {
+        const queryClient = createQueryClient();
+        const image = getMockedMediaImage({ id: 'image-1' });
+        const video = getMockedVideo({ id: 'video-1', annotated_frame_count: 3 });
+
+        setMediaQueryData(queryClient, [{ items: [image, video], pagination: getMockedPagination({ total: 2 }) }]);
+
+        incrementCachedAnnotatedFrameCount(queryClient, { ...image, type: 'image' });
+
+        const data = getMediaQueryData(queryClient);
+        expect(data?.pages[0].items[0]).toEqual(image);
+    });
+
+    it('handles multiple pages', () => {
+        const queryClient = createQueryClient();
+        const video1 = getMockedVideo({ id: 'video-1', annotated_frame_count: 2 });
+        const video2 = getMockedVideo({ id: 'video-2', annotated_frame_count: 7 });
+
+        setMediaQueryData(queryClient, [
+            { items: [video1], pagination: getMockedPagination({ total: 2 }) },
+            { items: [video2], pagination: getMockedPagination({ total: 2 }) },
+        ]);
+
+        incrementCachedAnnotatedFrameCount(queryClient, video2);
+
+        const data = getMediaQueryData(queryClient);
+        expect(data?.pages[0].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 2 }));
+        expect(data?.pages[1].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 8 }));
+    });
+});

--- a/application/ui/src/shared/annotator/util.test.ts
+++ b/application/ui/src/shared/annotator/util.test.ts
@@ -4,8 +4,7 @@
 import { InfiniteData, QueryClient } from '@tanstack/react-query';
 
 import { getMockedMediaImage, getMockedVideo } from '../../../mocks/mock-media';
-import { SchemaMediaWithPagination } from '../../api/openapi-spec';
-import { Pagination } from '../../constants/shared-types';
+import { MediaWithPagination, Pagination } from '../../constants/shared-types';
 import { incrementCachedAnnotatedFrameCount } from './util';
 
 const createQueryClient = () => new QueryClient();
@@ -20,15 +19,15 @@ const getMockedPagination = (overrides: Partial<Pagination>) => ({
 
 const MEDIA_QUERY_KEY = ['get', '/api/projects/{project_id}/dataset/media'] as const;
 
-const setMediaQueryData = (queryClient: QueryClient, pages: SchemaMediaWithPagination[]) => {
-    queryClient.setQueryData<InfiniteData<SchemaMediaWithPagination>>(MEDIA_QUERY_KEY, {
+const setMediaQueryData = (queryClient: QueryClient, pages: MediaWithPagination[]) => {
+    queryClient.setQueryData<InfiniteData<MediaWithPagination>>(MEDIA_QUERY_KEY, {
         pages,
         pageParams: pages.map((_, i) => i),
     });
 };
 
 const getMediaQueryData = (queryClient: QueryClient) => {
-    return queryClient.getQueryData<InfiniteData<SchemaMediaWithPagination>>(MEDIA_QUERY_KEY);
+    return queryClient.getQueryData<InfiniteData<MediaWithPagination>>(MEDIA_QUERY_KEY);
 };
 
 describe('incrementCachedAnnotatedFrameCount', () => {
@@ -96,7 +95,11 @@ describe('incrementCachedAnnotatedFrameCount', () => {
 
         const data = getMediaQueryData(queryClient);
 
-        expect(data?.pages[0].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 2 }));
-        expect(data?.pages[1].items[0]).toEqual(expect.objectContaining({ annotated_frame_count: 8 }));
+        expect(data?.pages[0].items[0]).toEqual(
+            expect.objectContaining({ annotated_frame_count: video1.annotated_frame_count })
+        );
+        expect(data?.pages[1].items[0]).toEqual(
+            expect.objectContaining({ annotated_frame_count: video2.annotated_frame_count + 1 })
+        );
     });
 });

--- a/application/ui/src/shared/annotator/util.ts
+++ b/application/ui/src/shared/annotator/util.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { InfiniteData, QueryClient } from '@tanstack/react-query';
+
+import { SchemaMediaWithPagination } from '../../api/openapi-spec';
+import { Media } from '../../constants/shared-types';
+import { isVideo } from '../media-item-utils';
+
+/* const updateAnnotatedFrameCount = (mediaItem: Media) => (item: MediaDTO) => {
+    return isVideo(item) && item.id === mediaItem.id
+        ? { ...item, annotated_frame_count: item.annotated_frame_count + 1 }
+        : item;
+}; */
+
+export const incrementCachedAnnotatedFrameCount = (queryClient: QueryClient, mediaItem: Media) => {
+    queryClient.setQueriesData<InfiniteData<SchemaMediaWithPagination>>(
+        { queryKey: ['get', '/api/projects/{project_id}/dataset/media'] },
+        (oldData) => {
+            if (!oldData?.pages) return oldData;
+
+            return {
+                ...oldData,
+                pages: oldData.pages.map((page) => ({
+                    ...page,
+                    items: page.items.map((item) =>
+                        isVideo(item) && item.id === mediaItem.id
+                            ? { ...item, annotated_frame_count: item.annotated_frame_count + 1 }
+                            : item
+                    ),
+                })),
+            };
+        }
+    );
+};

--- a/application/ui/src/shared/annotator/util.ts
+++ b/application/ui/src/shared/annotator/util.ts
@@ -3,12 +3,11 @@
 
 import { InfiniteData, QueryClient } from '@tanstack/react-query';
 
-import { SchemaMediaWithPagination } from '../../api/openapi-spec';
-import { Media } from '../../constants/shared-types';
+import { Media, MediaWithPagination } from '../../constants/shared-types';
 import { isVideo } from '../media-item-utils';
 
 export const incrementCachedAnnotatedFrameCount = (queryClient: QueryClient, mediaItem: Media) => {
-    queryClient.setQueriesData<InfiniteData<SchemaMediaWithPagination>>(
+    queryClient.setQueriesData<InfiniteData<MediaWithPagination>>(
         { queryKey: ['get', '/api/projects/{project_id}/dataset/media'] },
         (oldData) => {
             if (!oldData?.pages) return oldData;

--- a/application/ui/src/shared/annotator/util.ts
+++ b/application/ui/src/shared/annotator/util.ts
@@ -7,12 +7,6 @@ import { SchemaMediaWithPagination } from '../../api/openapi-spec';
 import { Media } from '../../constants/shared-types';
 import { isVideo } from '../media-item-utils';
 
-/* const updateAnnotatedFrameCount = (mediaItem: Media) => (item: MediaDTO) => {
-    return isVideo(item) && item.id === mediaItem.id
-        ? { ...item, annotated_frame_count: item.annotated_frame_count + 1 }
-        : item;
-}; */
-
 export const incrementCachedAnnotatedFrameCount = (queryClient: QueryClient, mediaItem: Media) => {
     queryClient.setQueriesData<InfiniteData<SchemaMediaWithPagination>>(
         { queryKey: ['get', '/api/projects/{project_id}/dataset/media'] },


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

#5903 `Dataset - for videos, the review status icon on the thumbnail should display the number of annotated frames out of the total (e.g. "44 / 350").`

| Gallery  | Sidebar |
| ------------- | ------------- |
| <img width="1112" height="907" alt="image" src="https://github.com/user-attachments/assets/60298cc6-8095-44b4-b478-019b40e56460" /> | <img width="1109" height="908" alt="image" src="https://github.com/user-attachments/assets/fcea8227-a4a8-41c7-b97f-23f0a7994269" /> |






<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
