### PR TITLE
BMG card not detected in Docker container: extra_render_args limited to first XPU

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -143,14 +143,12 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-na
     # For XPU acceleration, we need to pass through the appropriate render device and group permissions
     extra_render_args=()
     if [[ "{{ accelerator }}" == "xpu" ]]; then
-      RENDER_GID=$($PYTHON -c "import grp; print((grp.getgrnam('render').gr_gid) if any(g.gr_name == 'render' for g in grp.getgrall()) else '')")
-      RENDER_NODE=$($PYTHON -c "from pathlib import Path; print(render_nodes[0]) if (render_nodes := sorted(Path('/dev/dri').glob('renderD*'))) else ''")
-      if [[ -n "$RENDER_NODE" ]]; then
-        extra_render_args+=(--device "$RENDER_NODE")
-      fi
-      if [[ -n "$RENDER_GID" ]]; then
-        extra_render_args+=(--group-add "$RENDER_GID")
-      fi
+      RENDER_GID=$(getent group render | cut -d: -f3)
+      for node in /dev/dri/renderD*; do
+        vendor=$(cat /sys/class/drm/$(basename "$node")/device/vendor 2>/dev/null)
+        [[ "$vendor" == "0x8086" ]] && extra_render_args+=(--device "$node")
+      done
+      [[ -n "$RENDER_GID" ]] && extra_render_args+=(--group-add "$RENDER_GID")
     fi
 
     passthrough_devices_args=()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Populate `extra_render_args` with all available Intel DRI

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

On a BM with multiple Intel DRI run:

```bash
just build-image accelerator="xpu"
just run-image  accelerator="xpu"
curl localhost:7860/api/system/devices/training | jq
```

Response should contain all supported XPUs, e.g.:

```bash
devuser@geti-kr-gd-01:~$ curl localhost:7860/api/system/devices/training | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   228  100   228    0     0   256k      0 --:--:-- --:--:-- --:--:--  222k
[
  {
    "type": "cpu",
    "name": "CPU",
    "memory": null,
    "index": null
  },
  {
    "type": "xpu",
    "name": "Intel(R) Arc(TM) A770 Graphics",
    "memory": 16225243136,
    "index": 0
  },
  {
    "type": "xpu",
    "name": "Intel(R) Arc(TM) A770 Graphics",
    "memory": 16225243136,
    "index": 1
  }
]
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
