### PR TITLE
feat(backend): System info endpoint, version dependant license acceptance

### DIFF
--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -36,7 +36,6 @@ from app.services.event.event_bus import EventBus
 from app.services.inference import InferenceServer
 from app.services.license_service import LicenseService
 from app.services.training_configuration_service import TrainingConfigurationService
-from app.settings import get_settings
 from app.webrtc.manager import WebRTCManager
 
 
@@ -267,9 +266,10 @@ def get_base_weights_service(data_dir: Annotated[Path, Depends(get_data_dir)]) -
 
 def get_license_service(
     data_dir: Annotated[Path, Depends(get_data_dir)],
+    request: Request,
 ) -> LicenseService:
     """Provides a LicenseService instance for tracking license consent."""
-    return LicenseService(data_dir=data_dir, app_version=get_settings().version)
+    return LicenseService(data_dir=data_dir, app_version=request.app.state.settings.version)
 
 
 def get_staged_dataset_service(

--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -36,6 +36,7 @@ from app.services.event.event_bus import EventBus
 from app.services.inference import InferenceServer
 from app.services.license_service import LicenseService
 from app.services.training_configuration_service import TrainingConfigurationService
+from app.settings import get_settings
 from app.webrtc.manager import WebRTCManager
 
 
@@ -264,9 +265,11 @@ def get_base_weights_service(data_dir: Annotated[Path, Depends(get_data_dir)]) -
     return BaseWeightsService(data_dir)
 
 
-def get_license_service(data_dir: Annotated[Path, Depends(get_data_dir)]) -> LicenseService:
+def get_license_service(
+    data_dir: Annotated[Path, Depends(get_data_dir)],
+) -> LicenseService:
     """Provides a LicenseService instance for tracking license consent."""
-    return LicenseService(data_dir=data_dir)
+    return LicenseService(data_dir=data_dir, app_version=get_settings().version)
 
 
 def get_staged_dataset_service(

--- a/application/backend/app/api/routers/system.py
+++ b/application/backend/app/api/routers/system.py
@@ -3,15 +3,41 @@
 
 """System API Endpoints"""
 
+import sys
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from loguru import logger
 
-from app.api.dependencies import get_system_service
-from app.api.schemas.system import CameraInfoView, DeviceInfoView
+from app.api.dependencies import get_license_service, get_system_service
+from app.api.schemas.system import CameraInfoView, DeviceInfoView, PlatformType, SystemInfoView
 from app.services import SystemService
+from app.services.license_service import LicenseService
 
 router = APIRouter(prefix="/api/system", tags=["System"])
+
+
+def _get_platform() -> PlatformType:
+    """Return the current operating system platform."""
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "macos"
+    return "linux"
+
+
+@router.get("/info")
+async def get_system_info(
+    license_service: Annotated[LicenseService, Depends(get_license_service)],
+) -> SystemInfoView:
+    """Returns system information including license status and platform."""
+    try:
+        license_accepted = license_service.is_accepted()
+    except OSError:
+        logger.warning("License acceptance check failed", exc_info=True)
+        license_accepted = False
+
+    return SystemInfoView(license_accepted=license_accepted, platform=_get_platform())
 
 
 @router.get("/devices/inference")

--- a/application/backend/app/api/routers/system.py
+++ b/application/backend/app/api/routers/system.py
@@ -22,9 +22,7 @@ def _get_platform() -> PlatformType:
         return "windows"
     if sys.platform == "darwin":
         return "macos"
-    if sys.platform.startswith("linux"):
-        return "linux"
-    raise RuntimeError(f"Unsupported platform: {sys.platform}")
+    return "linux"
 
 
 @router.get("/info")

--- a/application/backend/app/api/routers/system.py
+++ b/application/backend/app/api/routers/system.py
@@ -7,7 +7,6 @@ import sys
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from loguru import logger
 
 from app.api.dependencies import get_license_service, get_system_service
 from app.api.schemas.system import CameraInfoView, DeviceInfoView, PlatformType, SystemInfoView
@@ -23,7 +22,9 @@ def _get_platform() -> PlatformType:
         return "windows"
     if sys.platform == "darwin":
         return "macos"
-    return "linux"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    raise RuntimeError(f"Unsupported platform: {sys.platform}")
 
 
 @router.get("/info")
@@ -31,13 +32,7 @@ async def get_system_info(
     license_service: Annotated[LicenseService, Depends(get_license_service)],
 ) -> SystemInfoView:
     """Returns system information including license status and platform."""
-    try:
-        license_accepted = license_service.is_accepted()
-    except OSError:
-        logger.warning("License acceptance check failed", exc_info=True)
-        license_accepted = False
-
-    return SystemInfoView(license_accepted=license_accepted, platform=_get_platform())
+    return SystemInfoView(license_accepted=license_service.is_accepted(), platform=_get_platform())
 
 
 @router.get("/devices/inference")

--- a/application/backend/app/api/schemas/system.py
+++ b/application/backend/app/api/schemas/system.py
@@ -3,9 +3,28 @@
 
 """System schemas"""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 from app.models.system import DeviceType
+
+PlatformType = Literal["linux", "windows", "macos"]
+
+
+class SystemInfoView(BaseModel):
+    """System information including license status and platform."""
+
+    license_accepted: bool = Field(..., description="Whether the license has been accepted for the current version")
+    platform: PlatformType = Field(..., description="Operating system platform")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"license_accepted": True, "platform": "linux"},
+            ]
+        }
+    }
 
 
 class DeviceInfoView(BaseModel):

--- a/application/backend/app/main.py
+++ b/application/backend/app/main.py
@@ -23,16 +23,15 @@ import logging
 from collections.abc import Awaitable, Callable
 from os import getenv
 from pathlib import Path
-from typing import Annotated, cast
+from typing import cast
 
 import uvicorn
-from fastapi import Depends, FastAPI, Request, Response, status
+from fastapi import FastAPI, Request, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
-from app.api.dependencies import get_license_service
 from app.api.routers import (
     dataset_ie,
     dataset_revisions,
@@ -53,7 +52,6 @@ from app.api.routers import (
 from app.core.logging import InterceptHandler
 from app.lifecycle import lifespan
 from app.services.base import ResourceNotFoundError
-from app.services.license_service import LicenseService
 from app.settings import get_settings
 
 settings = get_settings()
@@ -111,17 +109,9 @@ async def get_webrtc_stream() -> FileResponse:
 
 
 @app.get("/health")
-async def health_check(
-    license_service: Annotated[LicenseService, Depends(get_license_service)],
-) -> dict[str, str | bool]:
+async def health_check() -> dict[str, str]:
     """Health check endpoint"""
-    try:
-        license_accepted = license_service.is_accepted()
-    except OSError:
-        logger.warning("License acceptance check failed during health check", exc_info=True)
-        return {"status": "degraded", "license_accepted": False}
-
-    return {"status": "ok", "license_accepted": license_accepted}
+    return {"status": "ok"}
 
 
 @app.middleware("http")

--- a/application/backend/app/services/license_service.py
+++ b/application/backend/app/services/license_service.py
@@ -23,9 +23,17 @@ class LicenseService:
 
     def is_accepted(self) -> bool:
         """Check whether the license has been accepted for the current app version."""
-        if not self._consent_file.exists():
+        try:
+            if not self._consent_file.exists():
+                return False
+            accepted_version = self._consent_file.read_text().strip()
+        except OSError as exc:
+            logger.warning(
+                "Failed to read license consent file {}: {}",
+                self._consent_file,
+                exc,
+            )
             return False
-        accepted_version = self._consent_file.read_text().strip()
         return accepted_version == self._app_version
 
     def accept(self) -> None:

--- a/application/backend/app/services/license_service.py
+++ b/application/backend/app/services/license_service.py
@@ -9,18 +9,26 @@ from loguru import logger
 
 
 class LicenseService:
-    """Service to track third-party license consent using a file-based marker."""
+    """Service to track third-party license consent using a version-aware file marker.
+
+    The marker file stores the application version for which the license was accepted.
+    When the app version changes (e.g., after an upgrade), the license must be re-accepted.
+    """
 
     CONSENT_FILENAME = ".license_accepted"
 
-    def __init__(self, data_dir: Path) -> None:
+    def __init__(self, data_dir: Path, app_version: str) -> None:
         self._consent_file = data_dir / self.CONSENT_FILENAME
+        self._app_version = app_version
 
     def is_accepted(self) -> bool:
-        """Check whether the license has been accepted."""
-        return self._consent_file.exists()
+        """Check whether the license has been accepted for the current app version."""
+        if not self._consent_file.exists():
+            return False
+        accepted_version = self._consent_file.read_text().strip()
+        return accepted_version == self._app_version
 
     def accept(self) -> None:
-        """Record that the user accepted the license terms."""
-        self._consent_file.touch()
-        logger.info("License accepted — consent recorded at {}", self._consent_file)
+        """Record that the user accepted the license terms for the current app version."""
+        self._consent_file.write_text(self._app_version)
+        logger.info("License accepted for version {} — recorded at {}", self._app_version, self._consent_file)

--- a/application/backend/tests/integration/services/test_license_service.py
+++ b/application/backend/tests/integration/services/test_license_service.py
@@ -7,39 +7,50 @@ import pytest
 
 from app.services.license_service import LicenseService
 
+APP_VERSION = "1.0.0"
+
 
 class TestLicenseService:
     """Tests for LicenseService"""
 
     @pytest.fixture
     def fxt_license_service(self, tmp_path: Path) -> LicenseService:
-        return LicenseService(data_dir=tmp_path)
+        return LicenseService(data_dir=tmp_path, app_version=APP_VERSION)
 
-    def test_is_accepted_returns_false_initially(self, fxt_license_service: LicenseService) -> None:
-        """License should not be accepted when no consent file exists."""
+    def test_accept_creates_file_with_version_and_is_idempotent(
+        self, fxt_license_service: LicenseService, tmp_path: Path
+    ) -> None:
+        """License starts not accepted; accept() creates a versioned marker file and is idempotent."""
         assert not fxt_license_service.is_accepted()
 
-    def test_accept_creates_consent_file(self, fxt_license_service: LicenseService, tmp_path: Path) -> None:
-        """Accepting the license should create the consent marker file."""
         fxt_license_service.accept()
 
         consent_file = tmp_path / LicenseService.CONSENT_FILENAME
         assert consent_file.exists()
+        assert consent_file.read_text() == APP_VERSION
+        assert fxt_license_service.is_accepted()
 
-    def test_is_accepted_returns_true_after_accept(self, fxt_license_service: LicenseService) -> None:
-        """License should be accepted after calling accept()."""
+        assert LicenseService(data_dir=tmp_path, app_version=APP_VERSION).is_accepted()
+
         fxt_license_service.accept()
         assert fxt_license_service.is_accepted()
 
-    def test_accept_is_idempotent(self, fxt_license_service: LicenseService) -> None:
-        """Calling accept() multiple times should not raise an error."""
-        fxt_license_service.accept()
-        fxt_license_service.accept()
-        assert fxt_license_service.is_accepted()
+    def test_version_mismatch_requires_re_acceptance(self, tmp_path: Path) -> None:
+        """License accepted for one version is not accepted for another; re-accepting overwrites."""
+        old_service = LicenseService(data_dir=tmp_path, app_version="0.9.0")
+        old_service.accept()
 
-    def test_is_accepted_returns_true_when_file_pre_exists(self, tmp_path: Path) -> None:
-        """License should be accepted when the consent file already exists on disk."""
+        new_service = LicenseService(data_dir=tmp_path, app_version="1.0.0")
+        assert not new_service.is_accepted()
+
+        new_service.accept()
+        consent_file = tmp_path / LicenseService.CONSENT_FILENAME
+        assert consent_file.read_text() == "1.0.0"
+        assert new_service.is_accepted()
+
+    def test_empty_marker_file_is_not_accepted(self, tmp_path: Path) -> None:
+        """An empty consent file (e.g. legacy pre-version marker) is treated as not accepted."""
         (tmp_path / LicenseService.CONSENT_FILENAME).touch()
 
-        service = LicenseService(data_dir=tmp_path)
-        assert service.is_accepted()
+        service = LicenseService(data_dir=tmp_path, app_version=APP_VERSION)
+        assert not service.is_accepted()

--- a/application/backend/tests/integration/services/test_license_service.py
+++ b/application/backend/tests/integration/services/test_license_service.py
@@ -40,12 +40,12 @@ class TestLicenseService:
         old_service = LicenseService(data_dir=tmp_path, app_version="0.9.0")
         old_service.accept()
 
-        new_service = LicenseService(data_dir=tmp_path, app_version="1.0.0")
+        new_service = LicenseService(data_dir=tmp_path, app_version=APP_VERSION)
         assert not new_service.is_accepted()
 
         new_service.accept()
         consent_file = tmp_path / LicenseService.CONSENT_FILENAME
-        assert consent_file.read_text() == "1.0.0"
+        assert consent_file.read_text() == APP_VERSION
         assert new_service.is_accepted()
 
     def test_empty_marker_file_is_not_accepted(self, tmp_path: Path) -> None:

--- a/application/backend/tests/unit/api/routers/test_health.py
+++ b/application/backend/tests/unit/api/routers/test_health.py
@@ -1,50 +1,14 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Generator
-from unittest.mock import Mock
-
-import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from app.api.dependencies import get_license_service
-from app.main import app
-from app.services.license_service import LicenseService
-
-
-@pytest.fixture
-def fxt_license_service() -> Generator[Mock]:
-    license_service = Mock(spec=LicenseService)
-    app.dependency_overrides[get_license_service] = lambda: license_service
-    yield license_service
-    app.dependency_overrides.pop(get_license_service, None)
-
 
 class TestHealthEndpoint:
-    def test_health_returns_license_not_accepted(self, fxt_license_service: Mock, fxt_client: TestClient) -> None:
-        """GET /health should report license_accepted=False before the license is accepted."""
-        fxt_license_service.is_accepted.return_value = False
-
+    def test_health_returns_ok(self, fxt_client: TestClient) -> None:
+        """GET /health should return status ok."""
         response = fxt_client.get("/health")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {"status": "ok", "license_accepted": False}
-
-    def test_health_returns_license_accepted(self, fxt_license_service: Mock, fxt_client: TestClient) -> None:
-        """GET /health should report license_accepted=True after the license is accepted."""
-        fxt_license_service.is_accepted.return_value = True
-
-        response = fxt_client.get("/health")
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {"status": "ok", "license_accepted": True}
-
-    def test_health_returns_degraded_on_os_error(self, fxt_license_service: Mock, fxt_client: TestClient) -> None:
-        """GET /health should report status=degraded and license_accepted=False when the consent file is unreadable."""
-        fxt_license_service.is_accepted.side_effect = OSError("Permission denied")
-
-        response = fxt_client.get("/health")
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {"status": "degraded", "license_accepted": False}
+        assert response.json() == {"status": "ok"}

--- a/application/backend/tests/unit/api/routers/test_system_info.py
+++ b/application/backend/tests/unit/api/routers/test_system_info.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Generator
+from unittest.mock import Mock
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_license_service
+from app.api.routers import system as system_router
+from app.main import app
+from app.services.license_service import LicenseService
+
+
+@pytest.fixture
+def fxt_license_service() -> Generator[Mock]:
+    license_service = Mock(spec=LicenseService)
+    app.dependency_overrides[get_license_service] = lambda: license_service
+    yield license_service
+    app.dependency_overrides.pop(get_license_service, None)
+
+
+class TestSystemInfoEndpoint:
+    def test_returns_license_status_and_platform(
+        self, fxt_license_service: Mock, fxt_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GET /api/system/info returns license_accepted and the current platform."""
+        fxt_license_service.is_accepted.return_value = False
+        monkeypatch.setattr(system_router, "_get_platform", lambda: "test_platform")
+
+        response = fxt_client.get("/api/system/info")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == {"license_accepted": False, "platform": "test_platform"}
+
+        fxt_license_service.is_accepted.return_value = True
+        response = fxt_client.get("/api/system/info")
+        assert response.json()["license_accepted"] is True
+
+    def test_returns_false_on_os_error(self, fxt_license_service: Mock, fxt_client: TestClient) -> None:
+        """GET /api/system/info should return license_accepted=False when the consent file is unreadable."""
+        fxt_license_service.is_accepted.side_effect = OSError("Permission denied")
+
+        response = fxt_client.get("/api/system/info")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["license_accepted"] is False
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "expected"),
+    [("win32", "windows"), ("darwin", "macos"), ("linux", "linux")],
+)
+def test_get_platform_maps_supported_platforms(
+    monkeypatch: pytest.MonkeyPatch, platform_name: str, expected: str
+) -> None:
+    monkeypatch.setattr(system_router.sys, "platform", platform_name)
+
+    assert system_router._get_platform() == expected

--- a/application/backend/tests/unit/api/routers/test_system_info.py
+++ b/application/backend/tests/unit/api/routers/test_system_info.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Generator
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from fastapi import status
@@ -22,32 +22,34 @@ def fxt_license_service() -> Generator[Mock, None, None]:
     app.dependency_overrides.pop(get_license_service, None)
 
 
+@pytest.mark.parametrize(
+    ("is_accepted", "expected_license_accepted"),
+    [(False, False), (True, True)],
+)
 class TestSystemInfoEndpoint:
     def test_returns_license_status_and_platform(
-        self, fxt_license_service: Mock, fxt_client: TestClient, monkeypatch: pytest.MonkeyPatch
+        self,
+        fxt_license_service: Mock,
+        fxt_client: TestClient,
+        is_accepted: bool,
+        expected_license_accepted: bool,
     ) -> None:
         """GET /api/system/info returns license_accepted and the current platform."""
-        fxt_license_service.is_accepted.return_value = False
-        monkeypatch.setattr(system_router, "_get_platform", lambda: "linux")
+        fxt_license_service.is_accepted.return_value = is_accepted
 
-        response = fxt_client.get("/api/system/info")
+        with patch.object(system_router, "_get_platform", return_value="linux"):
+            response = fxt_client.get("/api/system/info")
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data == {"license_accepted": False, "platform": "linux"}
-
-        fxt_license_service.is_accepted.return_value = True
-        response = fxt_client.get("/api/system/info")
-        assert response.json()["license_accepted"] is True
+        assert data["license_accepted"] == expected_license_accepted
+        assert data["platform"] == "linux"
 
 
 @pytest.mark.parametrize(
     ("platform_name", "expected"),
     [("win32", "windows"), ("darwin", "macos"), ("linux", "linux")],
 )
-def test_get_platform_maps_supported_platforms(
-    monkeypatch: pytest.MonkeyPatch, platform_name: str, expected: str
-) -> None:
-    monkeypatch.setattr(system_router.sys, "platform", platform_name)
-
-    assert system_router._get_platform() == expected
+def test_get_platform_maps_supported_platforms(platform_name: str, expected: str) -> None:
+    with patch.object(system_router.sys, "platform", new=platform_name):
+        assert system_router._get_platform() == expected

--- a/application/backend/tests/unit/api/routers/test_system_info.py
+++ b/application/backend/tests/unit/api/routers/test_system_info.py
@@ -22,11 +22,11 @@ def fxt_license_service() -> Generator[Mock, None, None]:
     app.dependency_overrides.pop(get_license_service, None)
 
 
-@pytest.mark.parametrize(
-    ("is_accepted", "expected_license_accepted"),
-    [(False, False), (True, True)],
-)
 class TestSystemInfoEndpoint:
+    @pytest.mark.parametrize(
+        ("is_accepted", "expected_license_accepted"),
+        [(False, False), (True, True)],
+    )
     def test_returns_license_status_and_platform(
         self,
         fxt_license_service: Mock,

--- a/application/backend/tests/unit/api/routers/test_system_info.py
+++ b/application/backend/tests/unit/api/routers/test_system_info.py
@@ -15,7 +15,7 @@ from app.services.license_service import LicenseService
 
 
 @pytest.fixture
-def fxt_license_service() -> Generator[Mock]:
+def fxt_license_service() -> Generator[Mock, None, None]:
     license_service = Mock(spec=LicenseService)
     app.dependency_overrides[get_license_service] = lambda: license_service
     yield license_service
@@ -39,15 +39,6 @@ class TestSystemInfoEndpoint:
         fxt_license_service.is_accepted.return_value = True
         response = fxt_client.get("/api/system/info")
         assert response.json()["license_accepted"] is True
-
-    def test_returns_false_on_os_error(self, fxt_license_service: Mock, fxt_client: TestClient) -> None:
-        """GET /api/system/info should return license_accepted=False when the consent file is unreadable."""
-        fxt_license_service.is_accepted.side_effect = OSError("Permission denied")
-
-        response = fxt_client.get("/api/system/info")
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()["license_accepted"] is False
 
 
 @pytest.mark.parametrize(

--- a/application/backend/tests/unit/api/routers/test_system_info.py
+++ b/application/backend/tests/unit/api/routers/test_system_info.py
@@ -28,13 +28,13 @@ class TestSystemInfoEndpoint:
     ) -> None:
         """GET /api/system/info returns license_accepted and the current platform."""
         fxt_license_service.is_accepted.return_value = False
-        monkeypatch.setattr(system_router, "_get_platform", lambda: "test_platform")
+        monkeypatch.setattr(system_router, "_get_platform", lambda: "linux")
 
         response = fxt_client.get("/api/system/info")
 
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data == {"license_accepted": False, "platform": "test_platform"}
+        assert data == {"license_accepted": False, "platform": "linux"}
 
         fxt_license_service.is_accepted.return_value = True
         response = fxt_client.get("/api/system/info")

--- a/application/backend/tests/unit/api/routers/test_system_info.py
+++ b/application/backend/tests/unit/api/routers/test_system_info.py
@@ -15,7 +15,7 @@ from app.services.license_service import LicenseService
 
 
 @pytest.fixture
-def fxt_license_service() -> Generator[Mock, None, None]:
+def fxt_license_service() -> Generator[Mock]:
     license_service = Mock(spec=LicenseService)
     app.dependency_overrides[get_license_service] = lambda: license_service
     yield license_service


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

A platform information field was added so that the required licences list can be filtered by the client later.
The app platform and license_accepted fields were migrated to a separate endpoint to avoid bloating the health endpoint. 
Licence acceptance was updated to be version-specific.
Part of the #6072 

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
