### PR TITLE
Empty prediction

### DIFF
--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -6,6 +6,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { fetchClient } from '../../../api/client';
 import { PredictionVideoRangePayload } from '../../../constants/shared-types';
+import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
 
 export const mediaPredictionsQueryOptions = ({
     projectId,
@@ -34,7 +35,25 @@ export const mediaPredictionsQueryOptions = ({
             });
 
             if (response.error) return [];
-            return response.data?.predictions ?? [];
+
+            const predictions = response.data?.predictions ?? [];
+
+            return predictions.map((predictionItem) => {
+                if (predictionItem.prediction.length === 0) {
+                    return {
+                        ...predictionItem,
+                        prediction: [
+                            {
+                                shape: { type: 'full_image' },
+                                labels: [{ id: EMPTY_LABEL_ID }],
+                                confidences: null,
+                            },
+                        ],
+                    };
+                }
+
+                return predictionItem;
+            });
         },
         enabled: modelId !== undefined,
     });

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -5,7 +5,7 @@ import { queryOptions, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { fetchClient } from '../../../api/client';
-import { PredictionVideoRangePayload } from '../../../constants/shared-types';
+import { PredictionDTO, PredictionVideoRangePayload } from '../../../constants/shared-types';
 import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
 
 export const mediaPredictionsQueryOptions = ({
@@ -39,15 +39,15 @@ export const mediaPredictionsQueryOptions = ({
             const predictions = response.data?.predictions ?? [];
 
             return predictions.map((predictionItem) => {
-                if (predictionItem.prediction.length === 0) {
+                if ((predictionItem.prediction ?? []).length === 0) {
                     return {
                         ...predictionItem,
                         prediction: [
                             {
                                 shape: { type: 'full_image' },
                                 labels: [{ id: EMPTY_LABEL_ID }],
-                                confidences: null,
-                            },
+                                confidences: [1],
+                            } satisfies PredictionDTO,
                         ],
                     };
                 }

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -611,6 +611,42 @@ test.describe('Annotator', () => {
             await expect(annotatorPage.getAnnotatorMode('prediction')).toHaveAttribute('aria-pressed', 'false');
         });
 
+        test('Displays "No object" when media:predict returns empty predictions', async ({
+            page,
+            annotatorPage,
+            network,
+        }) => {
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([getMockedModel()]);
+                }),
+                http.get('/api/projects/{project_id}/dataset/media/{media_id}/annotations', async () => {
+                    return HttpResponse.json(
+                        {
+                            // @ts-expect-error We care only about mocking detail
+                            detail: 'Media has not been annotated yet',
+                        },
+                        { status: 404 }
+                    );
+                }),
+                http.post('/api/projects/{project_id}/dataset/media/media:predict', async () => {
+                    return HttpResponse.json({
+                        predictions: [
+                            {
+                                media: { id: '123' },
+                                prediction: [],
+                            },
+                        ],
+                    });
+                })
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await expect(annotatorPage.getAnnotatorMode('prediction')).toHaveAttribute('aria-pressed', 'true');
+            await expect(page.getByLabel('label No object background')).toHaveCount(1);
+        });
+
         test('Automatically switches to prediction mode only when there are no annotations and there are predictions', async ({
             annotatorPage,
             network,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Display "empty" prediction when media's `prediction` array is empty (same behavior as with annotations)

<img width="2466" height="982" alt="Screenshot 2026-04-14 at 10 18 52" src="https://github.com/user-attachments/assets/9ef8818d-0d22-4ac6-9642-e0e35eb7bfc4" />


* Closes https://github.com/open-edge-platform/training_extensions/issues/6097

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
