### PR TITLE
Add benchmark instead of category on model card

### DIFF
--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -11,6 +11,7 @@ export type Model = components['schemas']['ModelView'];
 export type ModelVariant = components['schemas']['ModelVariantView'];
 export type ModelArchitecture = components['schemas']['ModelArchitectureView'];
 export type ModelArchitectureWithPerformanceCategory = ModelArchitecture & { performanceCategory?: string };
+export type BenchmarkMetrics = components['schemas']['BenchmarkMetrics'];
 export type ModelFormat = components['schemas']['ModelFormat'];
 export type RecommendedModelArchitectures = components['schemas']['TopPicks'];
 export type Evaluation = components['schemas']['EvaluationView'];

--- a/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
@@ -8,7 +8,7 @@ import { Flex } from '@geti/ui';
 import type { ModelArchitecture as ModelArchitectureType } from '../../../../constants/shared-types';
 import { SortModelArchitectures } from '../sort-model-architectures/sort-model-architectures.component';
 import { SORT_OPTIONS, SORTING_HANDLERS, SortingOptions } from '../sort-model-architectures/utils';
-import { ModelArchitecture } from './model-architecture.component';
+import { DetailedModelArchitecture } from './model-architecture.component';
 import { ModelArchitecturesListLayout } from './model-architectures-list-layout/model-architectures-list-layout.component';
 
 type AllModelArchitecturesProps = {
@@ -36,13 +36,12 @@ export const AllModelArchitectures = ({
                 ariaLabel={'ALL model architectures'}
             >
                 {sortedModelArchitectures.map((modelArchitecture) => (
-                    <ModelArchitecture
+                    <DetailedModelArchitecture
                         key={modelArchitecture.id}
                         activeModelArchitectureId={activeModelArchitectureId}
                         modelArchitecture={modelArchitecture}
                         selectedModelArchitectureId={selectedModelArchitectureId}
                         onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
-                        showBenchmarkStats
                     />
                 ))}
             </ModelArchitecturesListLayout>

--- a/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
@@ -42,6 +42,7 @@ export const AllModelArchitectures = ({
                         modelArchitecture={modelArchitecture}
                         selectedModelArchitectureId={selectedModelArchitectureId}
                         onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
+                        showBenchmarkStats
                     />
                 ))}
             </ModelArchitecturesListLayout>

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
@@ -37,14 +37,23 @@ const ModelArchitectureDivider = () => {
 };
 
 const ModelArchitectureParameters = () => {
-    const { modelArchitecture, showBenchmarkStats } = useModelArchitecture();
-    const accuracyMetric = showBenchmarkStats ? getAccuracyMetric(modelArchitecture) : undefined;
+    const { modelArchitecture } = useModelArchitecture();
 
     return (
         <ul className={classes.modelArchitectureParameters}>
             <li>Number of parameters: {modelArchitecture.stats.trainable_parameters} million</li>
             <li>License: Apache 2.0</li>
-            {showBenchmarkStats && <li>Gigaflops: {modelArchitecture.stats.gigaflops}</li>}
+        </ul>
+    );
+};
+
+const ModelArchitectureBenchmark = () => {
+    const { modelArchitecture } = useModelArchitecture();
+    const accuracyMetric = getAccuracyMetric(modelArchitecture);
+
+    return (
+        <ul className={classes.modelArchitectureParameters}>
+            <li>Gigaflops: {modelArchitecture.stats.gigaflops}</li>
             {accuracyMetric !== undefined && (
                 <li>
                     {accuracyMetric.label}: {accuracyMetric.value}%
@@ -53,6 +62,13 @@ const ModelArchitectureParameters = () => {
         </ul>
     );
 };
+
+const ModelArchitectureDetailedParameters = () => (
+    <>
+        <ModelArchitectureParameters />
+        <ModelArchitectureBenchmark />
+    </>
+);
 
 const ModelArchitectureName = () => {
     const { modelArchitecture, isSelected } = useModelArchitecture();
@@ -77,7 +93,6 @@ const ModelArchitectureName = () => {
 type ModelArchitectureContextProps = {
     isSelected: boolean;
     modelArchitecture: ModelArchitectureType;
-    showBenchmarkStats: boolean;
 };
 
 const ModelArchitectureContext = createContext<ModelArchitectureContextProps | null>(null);
@@ -97,7 +112,6 @@ type ModelArchitectureProps = {
     children: ReactNode;
     onSelect: () => void;
     modelArchitecture: ModelArchitectureType;
-    showBenchmarkStats?: boolean;
 };
 
 export const ModelArchitectureCard = ({
@@ -105,10 +119,9 @@ export const ModelArchitectureCard = ({
     children,
     onSelect,
     modelArchitecture,
-    showBenchmarkStats = false,
 }: ModelArchitectureProps) => {
     return (
-        <ModelArchitectureContext value={{ isSelected, modelArchitecture, showBenchmarkStats }}>
+        <ModelArchitectureContext value={{ isSelected, modelArchitecture }}>
             <div
                 className={clsx(classes.modelArchitectureContainer, {
                     [classes.modelArchitectureSelected]: isSelected,
@@ -123,6 +136,8 @@ export const ModelArchitectureCard = ({
 
 ModelArchitectureCard.Name = ModelArchitectureName;
 ModelArchitectureCard.Parameters = ModelArchitectureParameters;
+ModelArchitectureCard.Benchmark = ModelArchitectureBenchmark;
+ModelArchitectureCard.DetailedParameters = ModelArchitectureDetailedParameters;
 ModelArchitectureCard.Divider = ModelArchitectureDivider;
 ModelArchitectureCard.Description = ModelArchitectureDescription;
 ModelArchitectureCard.Active = ActiveModelArchitecture;

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
@@ -136,7 +136,6 @@ export const ModelArchitectureCard = ({
 
 ModelArchitectureCard.Name = ModelArchitectureName;
 ModelArchitectureCard.Parameters = ModelArchitectureParameters;
-ModelArchitectureCard.Benchmark = ModelArchitectureBenchmark;
 ModelArchitectureCard.DetailedParameters = ModelArchitectureDetailedParameters;
 ModelArchitectureCard.Divider = ModelArchitectureDivider;
 ModelArchitectureCard.Description = ModelArchitectureDescription;

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
@@ -7,12 +7,13 @@ import { Badge, Content, ContextualHelp, Divider, Flex, Heading, Radio, Text } f
 import { clsx } from 'clsx';
 
 import { type ModelArchitecture as ModelArchitectureType } from '../../../../../constants/shared-types';
+import { getAccuracyMetric } from '../utils';
 
-import styles from './model-architecture-card.module.scss';
+import classes from './model-architecture-card.module.scss';
 
 const ActiveModelArchitecture = () => {
     return (
-        <Badge variant={'info'} UNSAFE_className={styles.activeModelArchitecture}>
+        <Badge variant={'info'} UNSAFE_className={classes.activeModelArchitecture}>
             Active model
         </Badge>
     );
@@ -22,7 +23,7 @@ const ModelArchitectureDescription = () => {
     const { modelArchitecture, isSelected } = useModelArchitecture();
 
     return (
-        <ContextualHelp variant='info' UNSAFE_className={clsx({ [styles.description]: isSelected })}>
+        <ContextualHelp variant='info' UNSAFE_className={clsx({ [classes.description]: isSelected })}>
             <Heading>{modelArchitecture.name}</Heading>
             <Content>
                 <Text>{modelArchitecture.description}</Text>
@@ -36,12 +37,19 @@ const ModelArchitectureDivider = () => {
 };
 
 const ModelArchitectureParameters = () => {
-    const { modelArchitecture } = useModelArchitecture();
+    const { modelArchitecture, showBenchmarkStats } = useModelArchitecture();
+    const accuracyMetric = showBenchmarkStats ? getAccuracyMetric(modelArchitecture) : undefined;
 
     return (
-        <ul className={styles.modelArchitectureParameters}>
+        <ul className={classes.modelArchitectureParameters}>
             <li>Number of parameters: {modelArchitecture.stats.trainable_parameters} million</li>
             <li>License: Apache 2.0</li>
+            {showBenchmarkStats && <li>Gigaflops: {modelArchitecture.stats.gigaflops}</li>}
+            {accuracyMetric !== undefined && (
+                <li>
+                    {accuracyMetric.label}: {accuracyMetric.value}%
+                </li>
+            )}
         </ul>
     );
 };
@@ -55,8 +63,8 @@ const ModelArchitectureName = () => {
                 flex={1}
                 minWidth={0}
                 value={modelArchitecture.id}
-                UNSAFE_className={clsx(styles.modelArchitectureName, {
-                    [styles.modelArchitectureNameSelected]: isSelected,
+                UNSAFE_className={clsx(classes.modelArchitectureName, {
+                    [classes.modelArchitectureNameSelected]: isSelected,
                 })}
             >
                 {modelArchitecture.name}
@@ -69,6 +77,7 @@ const ModelArchitectureName = () => {
 type ModelArchitectureContextProps = {
     isSelected: boolean;
     modelArchitecture: ModelArchitectureType;
+    showBenchmarkStats: boolean;
 };
 
 const ModelArchitectureContext = createContext<ModelArchitectureContextProps | null>(null);
@@ -88,6 +97,7 @@ type ModelArchitectureProps = {
     children: ReactNode;
     onSelect: () => void;
     modelArchitecture: ModelArchitectureType;
+    showBenchmarkStats?: boolean;
 };
 
 export const ModelArchitectureCard = ({
@@ -95,12 +105,13 @@ export const ModelArchitectureCard = ({
     children,
     onSelect,
     modelArchitecture,
+    showBenchmarkStats = false,
 }: ModelArchitectureProps) => {
     return (
-        <ModelArchitectureContext value={{ isSelected, modelArchitecture }}>
+        <ModelArchitectureContext value={{ isSelected, modelArchitecture, showBenchmarkStats }}>
             <div
-                className={clsx(styles.modelArchitectureContainer, {
-                    [styles.modelArchitectureSelected]: isSelected,
+                className={clsx(classes.modelArchitectureContainer, {
+                    [classes.modelArchitectureSelected]: isSelected,
                 })}
                 onClick={onSelect}
             >

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
@@ -35,7 +35,7 @@ export const ModelArchitecture = ({
             <ModelArchitectureCard.Name />
             <ModelArchitectureCard.Parameters />
 
-            {(isActive || modelArchitecture.performanceCategory !== undefined) && (
+            {(isActive || (!showBenchmarkStats && modelArchitecture.performanceCategory !== undefined)) && (
                 <Flex gap={'size-100'} alignItems={'center'}>
                     {isActive && (
                         <View justifySelf={'start'}>

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
@@ -12,7 +12,6 @@ type ModelArchitectureProps = {
     modelArchitecture: ModelArchitectureWithPerformanceCategory;
     selectedModelArchitectureId: string | null;
     onSelectedModelArchitectureIdChange: (modelArchitectureId: string | null) => void;
-    showBenchmarkStats?: boolean;
 };
 
 export const ModelArchitecture = ({
@@ -20,7 +19,6 @@ export const ModelArchitecture = ({
     modelArchitecture,
     selectedModelArchitectureId,
     onSelectedModelArchitectureIdChange,
-    showBenchmarkStats = false,
 }: ModelArchitectureProps) => {
     const isSelected = modelArchitecture.id === selectedModelArchitectureId;
     const isActive = activeModelArchitectureId === modelArchitecture.id;
@@ -32,22 +30,49 @@ export const ModelArchitecture = ({
             onSelect={() => onSelectedModelArchitectureIdChange(modelArchitecture.id)}
         >
             <ModelArchitectureCard.Name />
-            {showBenchmarkStats ? <ModelArchitectureCard.DetailedParameters /> : <ModelArchitectureCard.Parameters />}
+            <ModelArchitectureCard.Parameters />
 
-            {(isActive || (!showBenchmarkStats && modelArchitecture.performanceCategory !== undefined)) && (
+            {(isActive || modelArchitecture.performanceCategory !== undefined) && (
                 <Flex gap={'size-100'} alignItems={'center'}>
                     {isActive && (
                         <View justifySelf={'start'}>
                             <ModelArchitectureCard.Active />
                         </View>
                     )}
-                    {!showBenchmarkStats && modelArchitecture.performanceCategory !== undefined && (
+                    {modelArchitecture.performanceCategory !== undefined && (
                         <PerformanceCategoryBadge
                             performanceCategory={modelArchitecture.performanceCategory}
                             color={'var(--spectrum-global-color-gray-100)'}
                         />
                     )}
                 </Flex>
+            )}
+        </ModelArchitectureCard>
+    );
+};
+
+export const DetailedModelArchitecture = ({
+    activeModelArchitectureId,
+    modelArchitecture,
+    selectedModelArchitectureId,
+    onSelectedModelArchitectureIdChange,
+}: ModelArchitectureProps) => {
+    const isSelected = modelArchitecture.id === selectedModelArchitectureId;
+    const isActive = activeModelArchitectureId === modelArchitecture.id;
+
+    return (
+        <ModelArchitectureCard
+            modelArchitecture={modelArchitecture}
+            isSelected={isSelected}
+            onSelect={() => onSelectedModelArchitectureIdChange(modelArchitecture.id)}
+        >
+            <ModelArchitectureCard.Name />
+            <ModelArchitectureCard.DetailedParameters />
+
+            {isActive && (
+                <View justifySelf={'start'}>
+                    <ModelArchitectureCard.Active />
+                </View>
             )}
         </ModelArchitectureCard>
     );

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
@@ -12,6 +12,7 @@ type ModelArchitectureProps = {
     modelArchitecture: ModelArchitectureWithPerformanceCategory;
     selectedModelArchitectureId: string | null;
     onSelectedModelArchitectureIdChange: (modelArchitectureId: string | null) => void;
+    showBenchmarkStats?: boolean;
 };
 
 export const ModelArchitecture = ({
@@ -19,6 +20,7 @@ export const ModelArchitecture = ({
     modelArchitecture,
     selectedModelArchitectureId,
     onSelectedModelArchitectureIdChange,
+    showBenchmarkStats = false,
 }: ModelArchitectureProps) => {
     const isSelected = modelArchitecture.id === selectedModelArchitectureId;
     const isActive = activeModelArchitectureId === modelArchitecture.id;
@@ -28,6 +30,7 @@ export const ModelArchitecture = ({
             modelArchitecture={modelArchitecture}
             isSelected={isSelected}
             onSelect={() => onSelectedModelArchitectureIdChange(modelArchitecture.id)}
+            showBenchmarkStats={showBenchmarkStats}
         >
             <ModelArchitectureCard.Name />
             <ModelArchitectureCard.Parameters />
@@ -39,7 +42,7 @@ export const ModelArchitecture = ({
                             <ModelArchitectureCard.Active />
                         </View>
                     )}
-                    {modelArchitecture.performanceCategory !== undefined && (
+                    {!showBenchmarkStats && modelArchitecture.performanceCategory !== undefined && (
                         <PerformanceCategoryBadge
                             performanceCategory={modelArchitecture.performanceCategory}
                             color={'var(--spectrum-global-color-gray-100)'}

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.component.tsx
@@ -30,10 +30,9 @@ export const ModelArchitecture = ({
             modelArchitecture={modelArchitecture}
             isSelected={isSelected}
             onSelect={() => onSelectedModelArchitectureIdChange(modelArchitecture.id)}
-            showBenchmarkStats={showBenchmarkStats}
         >
             <ModelArchitectureCard.Name />
-            <ModelArchitectureCard.Parameters />
+            {showBenchmarkStats ? <ModelArchitectureCard.DetailedParameters /> : <ModelArchitectureCard.Parameters />}
 
             {(isActive || (!showBenchmarkStats && modelArchitecture.performanceCategory !== undefined)) && (
                 <Flex gap={'size-100'} alignItems={'center'}>

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.test.tsx
@@ -10,7 +10,7 @@ import { getMockedModelArchitecture } from 'mocks/mock-model';
 import { render } from 'test-utils/render';
 
 import { ModelArchitectureWithPerformanceCategory } from '../../../../constants/shared-types';
-import { ModelArchitecture } from './model-architecture.component';
+import { DetailedModelArchitecture, ModelArchitecture } from './model-architecture.component';
 import { ModelArchitecturesListLayout } from './model-architectures-list-layout/model-architectures-list-layout.component';
 
 const renderModelArchitecture = ({
@@ -18,13 +18,11 @@ const renderModelArchitecture = ({
     selectedModelArchitectureId = null,
     onSelectedModelArchitectureIdChange = vi.fn(),
     modelArchitecture = getMockedModelArchitecture(),
-    showBenchmarkStats = false,
 }: {
     activeModelArchitectureId?: string;
     selectedModelArchitectureId?: string | null;
     onSelectedModelArchitectureIdChange?: ReturnType<typeof vi.fn>;
     modelArchitecture?: ModelArchitectureWithPerformanceCategory;
-    showBenchmarkStats?: boolean;
 } = {}) => {
     render(
         <ModelArchitecturesListLayout
@@ -37,7 +35,35 @@ const renderModelArchitecture = ({
                 modelArchitecture={modelArchitecture}
                 selectedModelArchitectureId={selectedModelArchitectureId}
                 onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
-                showBenchmarkStats={showBenchmarkStats}
+            />
+        </ModelArchitecturesListLayout>
+    );
+
+    return { modelArchitecture };
+};
+
+const renderDetailedModelArchitecture = ({
+    activeModelArchitectureId = undefined,
+    selectedModelArchitectureId = null,
+    onSelectedModelArchitectureIdChange = vi.fn(),
+    modelArchitecture = getMockedModelArchitecture(),
+}: {
+    activeModelArchitectureId?: string;
+    selectedModelArchitectureId?: string | null;
+    onSelectedModelArchitectureIdChange?: ReturnType<typeof vi.fn>;
+    modelArchitecture?: ModelArchitectureWithPerformanceCategory;
+} = {}) => {
+    render(
+        <ModelArchitecturesListLayout
+            selectedModelArchitectureId={selectedModelArchitectureId}
+            onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
+            ariaLabel={'Model architectures'}
+        >
+            <DetailedModelArchitecture
+                activeModelArchitectureId={activeModelArchitectureId}
+                modelArchitecture={modelArchitecture}
+                selectedModelArchitectureId={selectedModelArchitectureId}
+                onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
             />
         </ModelArchitecturesListLayout>
     );
@@ -155,20 +181,20 @@ describe('ModelArchitecture', () => {
         });
 
         it('shows gigaflops and mAP when using DetailedParameters', () => {
-            renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: true });
+            renderDetailedModelArchitecture({ modelArchitecture: detectionArchitecture });
 
             expect(screen.getByText(`Gigaflops: ${detectionArchitecture.stats.gigaflops}`)).toBeVisible();
             expect(screen.getByText('mAP: 55.3%')).toBeVisible();
         });
 
         it('hides the performance category badge when using DetailedParameters', () => {
-            renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: true });
+            renderDetailedModelArchitecture({ modelArchitecture: detectionArchitecture });
 
             expect(screen.queryByText('Speed')).not.toBeInTheDocument();
         });
 
         it('still shows the performance category badge when using Parameters only', () => {
-            renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: false });
+            renderModelArchitecture({ modelArchitecture: detectionArchitecture });
 
             expect(screen.getByText('Speed')).toBeVisible();
         });
@@ -188,7 +214,7 @@ describe('ModelArchitecture', () => {
                 },
             });
 
-            renderModelArchitecture({ modelArchitecture: classificationArchitecture, showBenchmarkStats: true });
+            renderDetailedModelArchitecture({ modelArchitecture: classificationArchitecture });
 
             expect(screen.getByText('Top-1 Acc: 76.2%')).toBeVisible();
         });

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.test.tsx
@@ -18,11 +18,13 @@ const renderModelArchitecture = ({
     selectedModelArchitectureId = null,
     onSelectedModelArchitectureIdChange = vi.fn(),
     modelArchitecture = getMockedModelArchitecture(),
+    showBenchmarkStats = false,
 }: {
     activeModelArchitectureId?: string;
     selectedModelArchitectureId?: string | null;
     onSelectedModelArchitectureIdChange?: ReturnType<typeof vi.fn>;
     modelArchitecture?: ModelArchitectureWithPerformanceCategory;
+    showBenchmarkStats?: boolean;
 } = {}) => {
     render(
         <ModelArchitecturesListLayout
@@ -35,6 +37,7 @@ const renderModelArchitecture = ({
                 modelArchitecture={modelArchitecture}
                 selectedModelArchitectureId={selectedModelArchitectureId}
                 onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
+                showBenchmarkStats={showBenchmarkStats}
             />
         </ModelArchitecturesListLayout>
     );
@@ -126,5 +129,68 @@ describe('ModelArchitecture', () => {
         renderModelArchitecture({ selectedModelArchitectureId: null });
 
         expect(screen.getByRole('radio', { name: 'Deim-DFine-L' })).not.toBeChecked();
+    });
+
+    describe('showBenchmarkStats', () => {
+        const detectionArchitecture = getMockedModelArchitecture({
+            task: 'detection',
+            stats: {
+                gigaflops: 91,
+                trainable_parameters: 31,
+                benchmark_metrics: {
+                    imagenet_top1_accuracy: null,
+                    imagenet_top5_accuracy: null,
+                    coco_map_50_95: 55.3,
+                    coco_map_50: null,
+                },
+            },
+            performanceCategory: 'speed',
+        });
+
+        it('does not show gigaflops or accuracy by default', () => {
+            renderModelArchitecture({ modelArchitecture: detectionArchitecture });
+
+            expect(screen.queryByText(/gigaflops/i)).not.toBeInTheDocument();
+            expect(screen.queryByText(/mAP/i)).not.toBeInTheDocument();
+        });
+
+        it('shows gigaflops and mAP when showBenchmarkStats is true', () => {
+            renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: true });
+
+            expect(screen.getByText(`Gigaflops: ${detectionArchitecture.stats.gigaflops}`)).toBeVisible();
+            expect(screen.getByText('mAP: 55.3%')).toBeVisible();
+        });
+
+        it('hides the performance category badge when showBenchmarkStats is true', () => {
+            renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: true });
+
+            expect(screen.queryByText('Speed')).not.toBeInTheDocument();
+        });
+
+        it('still shows the performance category badge when showBenchmarkStats is false', () => {
+            renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: false });
+
+            expect(screen.getByText('Speed')).toBeVisible();
+        });
+
+        it('shows Top-1 Acc for classification tasks', () => {
+            const classificationArchitecture = getMockedModelArchitecture({
+                task: 'classification',
+                stats: {
+                    gigaflops: 2,
+                    trainable_parameters: 5,
+                    benchmark_metrics: {
+                        imagenet_top1_accuracy: 76.2,
+                        imagenet_top5_accuracy: 95.3,
+                        coco_map_50_95: null,
+                        coco_map_50: null,
+                    },
+                },
+            });
+
+            renderModelArchitecture({ modelArchitecture: classificationArchitecture, showBenchmarkStats: true });
+
+            expect(screen.getByText('Top-1 Acc: 76.2%')).toBeVisible();
+        });
     });
 });

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.test.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture.test.tsx
@@ -131,7 +131,7 @@ describe('ModelArchitecture', () => {
         expect(screen.getByRole('radio', { name: 'Deim-DFine-L' })).not.toBeChecked();
     });
 
-    describe('showBenchmarkStats', () => {
+    describe('benchmark stats (DetailedParameters)', () => {
         const detectionArchitecture = getMockedModelArchitecture({
             task: 'detection',
             stats: {
@@ -147,33 +147,33 @@ describe('ModelArchitecture', () => {
             performanceCategory: 'speed',
         });
 
-        it('does not show gigaflops or accuracy by default', () => {
+        it('does not show gigaflops or accuracy when using Parameters (default)', () => {
             renderModelArchitecture({ modelArchitecture: detectionArchitecture });
 
             expect(screen.queryByText(/gigaflops/i)).not.toBeInTheDocument();
             expect(screen.queryByText(/mAP/i)).not.toBeInTheDocument();
         });
 
-        it('shows gigaflops and mAP when showBenchmarkStats is true', () => {
+        it('shows gigaflops and mAP when using DetailedParameters', () => {
             renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: true });
 
             expect(screen.getByText(`Gigaflops: ${detectionArchitecture.stats.gigaflops}`)).toBeVisible();
             expect(screen.getByText('mAP: 55.3%')).toBeVisible();
         });
 
-        it('hides the performance category badge when showBenchmarkStats is true', () => {
+        it('hides the performance category badge when using DetailedParameters', () => {
             renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: true });
 
             expect(screen.queryByText('Speed')).not.toBeInTheDocument();
         });
 
-        it('still shows the performance category badge when showBenchmarkStats is false', () => {
+        it('still shows the performance category badge when using Parameters only', () => {
             renderModelArchitecture({ modelArchitecture: detectionArchitecture, showBenchmarkStats: false });
 
             expect(screen.getByText('Speed')).toBeVisible();
         });
 
-        it('shows Top-1 Acc for classification tasks', () => {
+        it('shows Top-1 Acc for classification tasks when using DetailedParameters', () => {
             const classificationArchitecture = getMockedModelArchitecture({
                 task: 'classification',
                 stats: {

--- a/application/ui/src/features/models/train-model/model-architectures-list/utils.test.ts
+++ b/application/ui/src/features/models/train-model/model-architectures-list/utils.test.ts
@@ -190,7 +190,7 @@ describe('getAccuracyMetric', () => {
 
         const result = getAccuracyMetric(modelArchitecture);
 
-        expect(result).toEqual({ label: 'mAP', value: 72.1 });
+        expect(result).toEqual({ label: 'mAP50', value: 72.1 });
     });
 
     it('returns undefined when no accuracy metrics are available', () => {

--- a/application/ui/src/features/models/train-model/model-architectures-list/utils.test.ts
+++ b/application/ui/src/features/models/train-model/model-architectures-list/utils.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getMockedModelArchitecture } from '../../../../../mocks/mock-model';
-import { getRecommendedModelArchitecturesWithActiveArchitecture } from './utils';
+import { getAccuracyMetric, getRecommendedModelArchitecturesWithActiveArchitecture } from './utils';
 
 describe('getRecommendedModelArchitecturesWithActiveArchitecture', () => {
     it('returns recommended architectures when performanceCategory is defined', () => {
@@ -129,5 +129,87 @@ describe('getRecommendedModelArchitecturesWithActiveArchitecture', () => {
         expect(result[0].id).toBe('arch-1');
         expect(result[1].id).toBe('arch-2');
         expect(result[2].id).toBe('arch-3');
+    });
+});
+
+describe('getAccuracyMetric', () => {
+    it('returns Top-1 Acc for classification tasks', () => {
+        const modelArchitecture = getMockedModelArchitecture({
+            task: 'classification',
+            stats: {
+                gigaflops: 1,
+                trainable_parameters: 5,
+                benchmark_metrics: {
+                    imagenet_top1_accuracy: 76.2,
+                    imagenet_top5_accuracy: 95.3,
+                    coco_map_50_95: null,
+                    coco_map_50: null,
+                },
+            },
+        });
+
+        const result = getAccuracyMetric(modelArchitecture);
+
+        expect(result).toEqual({ label: 'Top-1 Acc', value: 76.2 });
+    });
+
+    it('returns mAP (50-95) for detection tasks', () => {
+        const modelArchitecture = getMockedModelArchitecture({
+            task: 'detection',
+            stats: {
+                gigaflops: 91,
+                trainable_parameters: 31,
+                benchmark_metrics: {
+                    imagenet_top1_accuracy: null,
+                    imagenet_top5_accuracy: null,
+                    coco_map_50_95: 55.3,
+                    coco_map_50: 72.1,
+                },
+            },
+        });
+
+        const result = getAccuracyMetric(modelArchitecture);
+
+        expect(result).toEqual({ label: 'mAP', value: 55.3 });
+    });
+
+    it('falls back to coco_map_50 when coco_map_50_95 is null', () => {
+        const modelArchitecture = getMockedModelArchitecture({
+            task: 'detection',
+            stats: {
+                gigaflops: 91,
+                trainable_parameters: 31,
+                benchmark_metrics: {
+                    imagenet_top1_accuracy: null,
+                    imagenet_top5_accuracy: null,
+                    coco_map_50_95: null,
+                    coco_map_50: 72.1,
+                },
+            },
+        });
+
+        const result = getAccuracyMetric(modelArchitecture);
+
+        expect(result).toEqual({ label: 'mAP', value: 72.1 });
+    });
+
+    it('returns undefined when no accuracy metrics are available', () => {
+        const modelArchitecture = getMockedModelArchitecture({
+            task: 'detection',
+            stats: {
+                gigaflops: 91,
+                trainable_parameters: 31,
+                benchmark_metrics: {
+                    imagenet_top1_accuracy: null,
+                    imagenet_top5_accuracy: null,
+                    coco_map_50_95: null,
+                    coco_map_50: null,
+                },
+            },
+        });
+
+        const result = getAccuracyMetric(modelArchitecture);
+
+        expect(result).toBeUndefined();
     });
 });

--- a/application/ui/src/features/models/train-model/model-architectures-list/utils.ts
+++ b/application/ui/src/features/models/train-model/model-architectures-list/utils.ts
@@ -1,6 +1,8 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { isNil } from 'lodash-es';
+
 import type { ModelArchitectureWithPerformanceCategory } from '../../../../constants/shared-types';
 import { getAccuracyMetricBasedOnTask } from '../sort-model-architectures/utils';
 
@@ -11,7 +13,7 @@ export const getAccuracyMetric = (
 ): AccuracyMetric | undefined => {
     const value = getAccuracyMetricBasedOnTask(modelArchitecture);
 
-    if (value === null || value === undefined) {
+    if (isNil(value)) {
         return undefined;
     }
 

--- a/application/ui/src/features/models/train-model/model-architectures-list/utils.ts
+++ b/application/ui/src/features/models/train-model/model-architectures-list/utils.ts
@@ -2,6 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ModelArchitectureWithPerformanceCategory } from '../../../../constants/shared-types';
+import { getAccuracyMetricBasedOnTask } from '../sort-model-architectures/utils';
+
+export type AccuracyMetric = { label: string; value: number };
+
+export const getAccuracyMetric = (
+    modelArchitecture: ModelArchitectureWithPerformanceCategory
+): AccuracyMetric | undefined => {
+    const value = getAccuracyMetricBasedOnTask(modelArchitecture);
+
+    if (value === null || value === undefined) {
+        return undefined;
+    }
+
+    const label = modelArchitecture.task === 'classification' ? 'Top-1 Acc' : 'mAP';
+
+    return { label, value };
+};
 
 const getRecommendedArchitectures = (modelArchitectures: ModelArchitectureWithPerformanceCategory[]) => {
     const recommended = modelArchitectures.filter(

--- a/application/ui/src/features/models/train-model/model-architectures-list/utils.ts
+++ b/application/ui/src/features/models/train-model/model-architectures-list/utils.ts
@@ -3,23 +3,32 @@
 
 import { isNil } from 'lodash-es';
 
-import type { ModelArchitectureWithPerformanceCategory } from '../../../../constants/shared-types';
-import { getAccuracyMetricBasedOnTask } from '../sort-model-architectures/utils';
+import type { BenchmarkMetrics, ModelArchitectureWithPerformanceCategory } from '../../../../constants/shared-types';
 
 export type AccuracyMetric = { label: string; value: number };
+
+type BenchmarkMetricKey = keyof BenchmarkMetrics;
+
+const ACCURACY_METRIC_LABELS: Partial<Record<BenchmarkMetricKey, string>> = {
+    imagenet_top1_accuracy: 'Top-1 Acc',
+    coco_map_50_95: 'mAP',
+    coco_map_50: 'mAP50',
+};
 
 export const getAccuracyMetric = (
     modelArchitecture: ModelArchitectureWithPerformanceCategory
 ): AccuracyMetric | undefined => {
-    const value = getAccuracyMetricBasedOnTask(modelArchitecture);
+    const benchmarkMetrics = modelArchitecture.stats.benchmark_metrics;
 
-    if (isNil(value)) {
-        return undefined;
+    for (const [key, label] of Object.entries(ACCURACY_METRIC_LABELS)) {
+        const value = benchmarkMetrics[key as BenchmarkMetricKey];
+
+        if (!isNil(value)) {
+            return { label, value };
+        }
     }
 
-    const label = modelArchitecture.task === 'classification' ? 'Top-1 Acc' : 'mAP';
-
-    return { label, value };
+    return undefined;
 };
 
 const getRecommendedArchitectures = (modelArchitectures: ModelArchitectureWithPerformanceCategory[]) => {

--- a/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
+++ b/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
@@ -20,7 +20,7 @@ type SortingHandler = (
     modelArchitectures: ModelArchitectureWithPerformanceCategory[]
 ) => ModelArchitectureWithPerformanceCategory[];
 
-export const getAccuracyMetricBasedOnTask = ({
+const getAccuracyMetricBasedOnTask = ({
     stats: { benchmark_metrics: benchmarkMetrics },
 }: ModelArchitectureWithPerformanceCategory) => {
     return benchmarkMetrics.imagenet_top1_accuracy ?? benchmarkMetrics.coco_map_50_95 ?? benchmarkMetrics.coco_map_50;

--- a/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
+++ b/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
@@ -20,7 +20,7 @@ type SortingHandler = (
     modelArchitectures: ModelArchitectureWithPerformanceCategory[]
 ) => ModelArchitectureWithPerformanceCategory[];
 
-const getAccuracyMetricBasedOnTask = ({
+export const getAccuracyMetricBasedOnTask = ({
     stats: { benchmark_metrics: benchmarkMetrics },
 }: ModelArchitectureWithPerformanceCategory) => {
     return benchmarkMetrics.imagenet_top1_accuracy ?? benchmarkMetrics.coco_map_50_95 ?? benchmarkMetrics.coco_map_50;


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* For AllModelView (not RecommendedView) show model benchmarks instead of performance category
* Closes the last point of https://github.com/open-edge-platform/training_extensions/issues/5903

<img width="1090" height="1003" alt="Screenshot 2026-04-14 at 13 17 17" src="https://github.com/user-attachments/assets/795add48-0001-401b-b45b-efad992a8d29" />
<img width="849" height="900" alt="Screenshot 2026-04-14 at 13 17 23" src="https://github.com/user-attachments/assets/e439252e-6c5f-468b-900d-76450f93b48b" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
