### PR TITLE
Corrected uv-version parsing

### DIFF
--- a/application/backend/app/api/routers/dataset_ie.py
+++ b/application/backend/app/api/routers/dataset_ie.py
@@ -30,7 +30,7 @@ async def upload_archive(
     try:
         if not file.filename or not file.filename.endswith(".zip"):
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="Only zip files are allowed.",
             )
         staged_dataset = await staged_datasets_service.upload(
@@ -105,7 +105,7 @@ def download_archive(
 
     if not staged_dataset.compressed:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="Staged dataset is not in zip format ready for download.",
         )
 

--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -110,7 +110,7 @@ def get_pipeline(
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid request body or project ID"},
         status.HTTP_404_NOT_FOUND: {"description": "Project or pipeline not found"},
         status.HTTP_409_CONFLICT: {"description": "Pipeline cannot be enabled"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Invalid model variant (e.g., non-OpenVINO format or INT8 not supported on device)"
         },
     },
@@ -151,9 +151,9 @@ def update_pipeline(
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except IncompatibleModelVariantError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except DeviceInt8NotSupportedError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except OtherProjectActiveError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 

--- a/application/backend/tests/unit/api/routers/test_dataset_ie.py
+++ b/application/backend/tests/unit/api/routers/test_dataset_ie.py
@@ -60,7 +60,7 @@ class TestDatasetIEEndpoints:
 
         response = fxt_client.post("/api/staged_datasets", files=files)
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         fxt_staged_dataset_service.upload.assert_not_called()
 
     def test_list_datasets_success(
@@ -147,7 +147,7 @@ class TestDatasetIEEndpoints:
 
         response = fxt_client.get(f"/api/staged_datasets/{fxt_staged_dataset.id}/zip")
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         assert response.json()["detail"] == "Staged dataset is not in zip format ready for download."
 
     def test_delete_dataset_success(

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -220,7 +220,7 @@ class TestPipelineEndpoints:
             json={"model_id": str(uuid4()), "model_variant_id": str(uuid4())},
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         assert "OpenVINO" in response.json()["detail"]
 
     def test_update_pipeline_int8_not_supported(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
@@ -233,7 +233,7 @@ class TestPipelineEndpoints:
             json={"model_id": str(uuid4()), "model_variant_id": str(uuid4())},
         )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         assert "INT8" in response.json()["detail"]
 
     def test_get_pipeline_metrics_success(self, fxt_pipeline, fxt_pipeline_metrics_service, fxt_client):

--- a/application/recipes.justfile
+++ b/application/recipes.justfile
@@ -16,14 +16,14 @@ install-uv:
     set -euo pipefail
     REPO_ROOT=$(git rev-parse --show-toplevel)
     # Extract the version from required-version, stripping any PEP 440 specifier prefix and CR/LF
-    UV_VERSION=$(grep -A 3 '\[tool\.uv\]' "${REPO_ROOT}/application/backend/pyproject.toml" | grep 'required-version' | sed -E 's/.*=\s*"[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | tr -d '\r')
+    UV_VERSION=$(grep -A 3 '\[tool\.uv\]' "${REPO_ROOT}/application/backend/pyproject.toml" | grep 'required-version' | sed -E 's/.*=[[:space:]]*"[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | tr -d '\r')
     if [ -z "$UV_VERSION" ]; then
         echo "Error: could not parse uv version from pyproject.toml" >&2
         exit 1
     fi
     if command -v uv > /dev/null; then
         INSTALLED_VERSION=$(uv --version | awk '{print $2}' | tr -d '\r')
-        if [ "$INSTALLED_VERSION" = "$UV_VERSION" ] || [ "$(printf '%s\n%s\n' "$UV_VERSION" "$INSTALLED_VERSION" | sort -V | head -n1)" = "$UV_VERSION" ]; then
+        if [ "$INSTALLED_VERSION" = "$UV_VERSION" ]; then
             exit 0
         else
             echo "uv version mismatch: installed=${INSTALLED_VERSION}, required~=${UV_VERSION}. Reinstalling..."


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Problem: The sed regex used \s to match whitespace. While GNU sed (Linux) supports \s as a shorthand for whitespace, BSD sed (macOS) does not, it treats \s as a literal character s. This caused the regex to fail to match on macOS, so sed passed the entire line through unmodified instead of extracting just the version number.

Fix: Replaced \s with [[:space:]], which is a POSIX character class supported by both GNU sed (Linux/Windows) and BSD sed (macOS). This ensures the regex works consistently across all three platforms.

Also fixed an issue with deprecated HTTP status
<img width="1454" height="282" alt="image" src="https://github.com/user-attachments/assets/9b4d9976-831f-4832-8565-c074dfa5cd24" />


### How to test

`just run-server`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
