### PR TITLE
Enable cuda in docker

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -181,9 +181,15 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-na
         volume_args+=(--volume "$vol")
     done
 
+    GPU_FLAG=""
+    if [[ "{{ accelerator }}" == "cuda" ]]; then
+        GPU_FLAG="--gpus all"
+    fi
+
     echo "Running docker container from image: ${IMAGE_NAME}"
     docker run \
         {{ docker-run-args }} \
+        $GPU_FLAG \
         --publish {{ webrtc-ports }}:{{ webrtc-ports }}/udp \
         --publish {{ port }}:{{ port }} \
         --env HOST={{ host }} \

--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -213,25 +213,6 @@ COPY --link --from=web-ui /home/application/ui/dist/ ${STATIC_FILES_DIR}
 ######################
 FROM runtime-base AS geti-cuda
 
-USER root
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update  \
-    && apt-get install -y --no-install-recommends wget=1.25.0-2 \
-    && wget -q https://developer.download.nvidia.com/compute/cuda/repos/debian13/x86_64/cuda-keyring_1.1-1_all.deb \
-    && dpkg -i cuda-keyring_1.1-1_all.deb \
-    && rm -rf cuda-keyring_1.1-1_all.deb \
-    && apt-get remove -y wget
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update \
-    && apt-get install -y --no-install-recommends \
-      nvidia-open=590.48.01-1
-
-USER ${USER_NAME}
-
 COPY --from=cuda-base --chown=${UID}:${UID} /application/backend/.venv /application/backend/.venv
 
 # App code + UI assets last – source-only changes only invalidate this layer


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Rely on host for nvidia drivers and pass `--gpus all` when `cuda` requested

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

1. Build and run image with `cuda`:

```bash

just build-image --accelerator="cuda"
just run-image --accelerator="cuda"
```

2. Check available training devices

```bash

curl localhost:7860/api/system/devices/training | jq
```

Cuda compatible graphics should be in response, e.g.:

```bash

[
  {
    "type": "cpu",
    "name": "CPU",
    "memory": null,
    "index": null
  },
  {
    "type": "cuda",
    "name": "NVIDIA A100-PCIE-40GB",
    "memory": 42404806656,
    "index": 0
  }
]
```

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
