### PR TITLE
Pass group of video (GID) to docker in Justfile

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -152,13 +152,30 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-na
     fi
 
     passthrough_devices_args=()
+    has_video_device=false
     for dev in {{ passthrough-devices }}; do
         if [[ -e "$dev" ]]; then
             passthrough_devices_args+=(--device "$dev":"$dev")
+            # Track if any video device is being passed through
+            if [[ "$dev" == /dev/video* ]]; then
+                has_video_device=true
+            fi
         else
             echo "Warning: device '$dev' not found, skipping." >&2
         fi
     done
+
+    # When a video device is passed through, add the host's video group so the
+    # container process can actually open /dev/videoN (the in-container 'video'
+    # group created in the Dockerfile may have a different GID than the host's).
+    if [[ "$has_video_device" == "true" ]]; then
+        VIDEO_GID=$(getent group video | cut -d: -f3)
+        if [[ -n "$VIDEO_GID" ]]; then
+            passthrough_devices_args+=(--group-add "$VIDEO_GID")
+        else
+            echo "Warning: could not resolve host 'video' group GID; camera access may fail." >&2
+        fi
+    fi
 
     SHM_SIZE_FLAG=""
     if [[ -n "{{ shm-size }}" ]]; then


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Pass group of video (GID) to docker in Justfile

Resolves #5434 

### How to test

Manually tested with
```
just build-image
just run-image --passtrough-devices /dev/video0
```
Created project, uploaded images, annotated, trained image (max epoch=1) and configured pipeline with webcam as source. Video stream was working properly, including inference.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
