### PR TITLE
Fix segmentation dataset import with float coordinates

### DIFF
--- a/application/backend/app/datumaro_converter/utils/shape.py
+++ b/application/backend/app/datumaro_converter/utils/shape.py
@@ -13,6 +13,6 @@ class ShapeConverter:
         return [rectangle.x, rectangle.y, rectangle.x + rectangle.width, rectangle.y + rectangle.height]
 
     @staticmethod
-    def polygon_to_points(polygon: Polygon) -> list[list[int]]:
+    def polygon_to_points(polygon: Polygon) -> list[list[float]]:
         """Converts polygon to list of xy points."""
         return [[point.x, point.y] for point in polygon.points]

--- a/application/backend/app/models/shape.py
+++ b/application/backend/app/models/shape.py
@@ -6,8 +6,8 @@ from pydantic import BaseModel, Field
 
 
 class Point(BaseModel):
-    x: int = Field(..., description="Point x coordinate", ge=0)
-    y: int = Field(..., description="Point y coordinate", ge=0)
+    x: float = Field(..., description="Point x coordinate", ge=0)
+    y: float = Field(..., description="Point y coordinate", ge=0)
 
 
 class Rectangle(BaseModel):

--- a/application/backend/app/models/shape.py
+++ b/application/backend/app/models/shape.py
@@ -26,7 +26,9 @@ class Polygon(BaseModel):
     type: Literal["polygon"] = "polygon"
     points: list[Point] = Field(..., description="Polygon points")
 
-    model_config = {"json_schema_extra": {"example": {"type": "polygon", "points": [[10, 20], [20, 60], [30, 40]]}}}
+    model_config = {
+        "json_schema_extra": {"example": {"type": "polygon", "points": [[10.2, 20.2], [20.2, 60.6], [30.3, 40.4]]}}
+    }
 
 
 class FullImage(BaseModel):

--- a/application/backend/tests/unit/datumaro_converter/utils/test_shape.py
+++ b/application/backend/tests/unit/datumaro_converter/utils/test_shape.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import pytest
 
 from app.datumaro_converter.utils import ShapeConverter
 from app.models import Point, Polygon, Rectangle
@@ -16,4 +17,7 @@ def test_polygon_to_points() -> None:
         points=[Point(x=10.1, y=20.2), Point(x=20.2, y=30.3), Point(x=30.3, y=40.4), Point(x=40.4, y=50.5)]
     )
     result = ShapeConverter.polygon_to_points(polygon)
-    assert result == [[10.1, 20.2], [20.2, 30.3], [30.3, 40.4], [40.4, 50.5]]
+    expected = [[10.1, 20.2], [20.2, 30.3], [30.3, 40.4], [40.4, 50.5]]
+    assert len(result) == len(expected)
+    for actual_point, expected_point in zip(result, expected):
+        assert actual_point == pytest.approx(expected_point, abs=1e-6)

--- a/application/backend/tests/unit/datumaro_converter/utils/test_shape.py
+++ b/application/backend/tests/unit/datumaro_converter/utils/test_shape.py
@@ -12,6 +12,8 @@ def test_rectangle_to_bbox() -> None:
 
 
 def test_polygon_to_points() -> None:
-    polygon = Polygon(points=[Point(x=10, y=20), Point(x=20, y=30), Point(x=30, y=40), Point(x=40, y=50)])
+    polygon = Polygon(
+        points=[Point(x=10.1, y=20.2), Point(x=20.2, y=30.3), Point(x=30.3, y=40.4), Point(x=40.4, y=50.5)]
+    )
     result = ShapeConverter.polygon_to_points(polygon)
-    assert result == [[10, 20], [20, 30], [30, 40], [40, 50]]
+    assert result == [[10.1, 20.2], [20.2, 30.3], [30.3, 40.4], [40.4, 50.5]]

--- a/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
@@ -240,8 +240,8 @@ class TestSegmentationConversion:
         assert len(result) == 1
         assert isinstance(result[0].shape, Polygon)
         assert len(result[0].shape.points) == 3
-        assert result[0].shape.points[0].x == 10.2
-        assert result[0].shape.points[0].y == 20.5
+        assert result[0].shape.points[0].x == pytest.approx(10.2, abs=1e-6)
+        assert result[0].shape.points[0].y == pytest.approx(20.5, abs=1e-6)
         assert result[0].labels[0].id == fxt_project_labels[0].id
         assert result[0].confidences == pytest.approx([0.92], abs=1e-6)
 

--- a/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
@@ -231,7 +231,7 @@ class TestSegmentationConversion:
     def test_convert_segmentation_sample(self, fxt_converter, fxt_project_labels):
         """Test converting an instance segmentation sample."""
         labels = np.array([0])
-        polygons = np.array([[[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]])
+        polygons = np.array([[[10.2, 20.5], [30.6, 40.7], [50.1, 60.3]]])
         confidences = np.array([0.92])
         sample = InstanceSegmentationImportExportSample(label=labels, polygons=polygons, confidence=confidences)
 
@@ -240,8 +240,8 @@ class TestSegmentationConversion:
         assert len(result) == 1
         assert isinstance(result[0].shape, Polygon)
         assert len(result[0].shape.points) == 3
-        assert result[0].shape.points[0].x == 10.0
-        assert result[0].shape.points[0].y == 20.0
+        assert result[0].shape.points[0].x == 10.2
+        assert result[0].shape.points[0].y == 20.5
         assert result[0].labels[0].id == fxt_project_labels[0].id
         assert result[0].confidences == pytest.approx([0.92], abs=1e-6)
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Define (x, y) as float in Point class

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
