### PR TITLE
fix: Float range parameter respects min and max parameter value

### DIFF
--- a/application/ui/src/features/models/train-model/advanced-settings/components/parameters.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/parameters.component.tsx
@@ -287,7 +287,11 @@ const ParameterField = ({ parameter, onChange, isDisabled }: ParameterFieldProps
         return (
             <RangeParameterField
                 value={parameter.value}
-                defaultValue={parameter.default_value}
+                // TODO: Replace these two lines with `max_value` and `min_value`
+                maxValue={parameter.default_value[1]}
+                minValue={parameter.default_value[0]}
+                //maxValue={parameter.max_value}
+                //minValue={parameter.min_value}
                 onChange={handleChange}
                 isDisabled={isDisabled}
                 name={parameter.name}

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
@@ -51,7 +51,6 @@ export const RangeParameterField = ({
     };
 
     const handleNumberChange = (start: number, end: number): void => {
-        // Prevent start and end from being equal
         setParameterValues({ start, end });
         onChange([start, end]);
     };

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
@@ -1,67 +1,59 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Flex, NumberField, RangeSlider, type RangeValue } from '@geti/ui';
+import { isEqual } from 'lodash-es';
 
 import { FloatConfigurableRangeParameter } from '../../../../../../constants/shared-types';
-import { getFloatingPointStep } from '../../utils';
+import { getStep } from '../utils';
 
 import classes from './range-parameter-field.module.scss';
 
+type RangeParameterValue = FloatConfigurableRangeParameter['value'];
+
 type RangeParameterFieldProps = {
-    onChange: (value: [number, number]) => void;
+    onChange: (value: RangeParameterValue) => void;
     isDisabled?: boolean;
     step?: number;
     name: string;
-    value: FloatConfigurableRangeParameter['value'];
-    defaultValue: FloatConfigurableRangeParameter['default_value'];
-};
-
-const getStep = ({ step, maxValue, minValue }: { step?: number; minValue: number; maxValue: number }): number => {
-    if (step !== undefined) {
-        return step;
-    }
-
-    return getFloatingPointStep(minValue, maxValue);
+    value: RangeParameterValue;
+    maxValue: number;
+    minValue: number;
 };
 
 export const RangeParameterField = ({
-    defaultValue,
     value,
     onChange,
     isDisabled,
     name,
     step,
+    minValue,
+    maxValue,
 }: RangeParameterFieldProps) => {
-    const [draftRange, setDraftRange] = useState<RangeValue<number> | null>(null);
-    const parameterValue = draftRange ?? { start: value[0], end: value[1] };
+    const [parameterValues, setParameterValues] = useState<RangeValue<number>>({ start: value[0], end: value[1] });
+    const prevValues = useRef<RangeParameterValue>(value);
 
-    const fieldStep = getStep({ step, maxValue: defaultValue[1], minValue: defaultValue[0] });
+    if (!isEqual(prevValues.current, value)) {
+        prevValues.current = value;
+        setParameterValues({ start: value[0], end: value[1] });
+    }
+
+    const fieldStep = getStep({ step, type: 'float', maxValue, minValue });
     const decimalPlaces = (fieldStep.toString().split('.')[1] || '').length;
 
     const handleRangeChangeEnd = (inputValue: RangeValue<number>): void => {
         const { start, end } = inputValue;
 
-        setDraftRange(null);
+        setParameterValues(inputValue);
         onChange([start, end]);
-    };
-
-    const handleRangeChange = (inputValue: RangeValue<number>): void => {
-        const { start, end } = inputValue;
-        // Prevent start and end from being equal
-        if (end - start >= fieldStep) {
-            setDraftRange({ start, end });
-        }
     };
 
     const handleNumberChange = (start: number, end: number): void => {
         // Prevent start and end from being equal
-        if (end - start >= fieldStep) {
-            setDraftRange(null);
-            onChange([start, end]);
-        }
+        setParameterValues({ start, end });
+        onChange([start, end]);
     };
 
     return (
@@ -69,20 +61,17 @@ export const RangeParameterField = ({
             <NumberField
                 isQuiet
                 step={fieldStep}
-                value={parameterValue.start}
-                minValue={defaultValue[0]}
-                maxValue={defaultValue[1]}
-                onChange={(start) => handleNumberChange(start, parameterValue.end)}
+                value={parameterValues.start}
+                minValue={minValue}
+                maxValue={parameterValues.end}
+                onChange={(start) => handleNumberChange(start, parameterValues.end)}
                 isDisabled={isDisabled}
                 aria-label={`Change ${name} start range value`}
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}
             />
             <RangeSlider
-                value={parameterValue}
-                minValue={defaultValue[0]}
-                maxValue={defaultValue[1]}
-                defaultValue={{ start: defaultValue[0], end: defaultValue[1] }}
-                onChange={handleRangeChange}
+                value={parameterValues}
+                onChange={setParameterValues}
                 onChangeEnd={handleRangeChangeEnd}
                 step={fieldStep}
                 flex={1}
@@ -93,10 +82,10 @@ export const RangeParameterField = ({
             <NumberField
                 isQuiet
                 step={fieldStep}
-                value={parameterValue.end}
-                minValue={defaultValue[0]}
-                maxValue={defaultValue[1]}
-                onChange={(end) => handleNumberChange(parameterValue.start, end)}
+                value={parameterValues.end}
+                minValue={parameterValues.start}
+                maxValue={maxValue}
+                onChange={(end) => handleNumberChange(parameterValues.start, end)}
                 isDisabled={isDisabled}
                 aria-label={`Change ${name} end range value`}
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.component.tsx
@@ -70,6 +70,8 @@ export const RangeParameterField = ({
                 formatOptions={{ maximumFractionDigits: decimalPlaces }}
             />
             <RangeSlider
+                minValue={minValue}
+                maxValue={maxValue}
                 value={parameterValues}
                 onChange={setParameterValues}
                 onChangeEnd={handleRangeChangeEnd}

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.test.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.test.tsx
@@ -1,14 +1,15 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { fireEvent, screen } from '@testing-library/react';
+import { useState } from 'react';
+
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test-utils/render';
 
 import { RangeParameterField } from './range-parameter-field.component';
 
 describe('RangeParameterField', () => {
-    const defaultValue: [number, number] = [0.5, 1.5];
     const name = 'Scaling ratio range';
     const onChange = vi.fn();
 
@@ -17,14 +18,22 @@ describe('RangeParameterField', () => {
     });
 
     const renderApp = ({
-        value = defaultValue,
+        value = [0.5, 1.5],
         isDisabled = false,
     }: {
         value?: [number, number];
         isDisabled?: boolean;
     }) => {
         return render(
-            <RangeParameterField value={value} onChange={onChange} name={name} isDisabled={isDisabled} step={0.001} />
+            <RangeParameterField
+                value={value}
+                onChange={onChange}
+                name={name}
+                isDisabled={isDisabled}
+                step={0.001}
+                minValue={0}
+                maxValue={2}
+            />
         );
     };
 
@@ -59,20 +68,20 @@ describe('RangeParameterField', () => {
         expect(onChange).toHaveBeenCalledWith([0.5, 1]);
     });
 
-    it('does not allow start and end to be equal', async () => {
+    it('allows start and end to be equal', async () => {
         renderApp({});
 
         const startField = screen.getByLabelText(`Change ${name} start range value`);
-        const endField = screen.getByLabelText(`Change ${name} end range value`);
         await userEvent.clear(startField);
         await userEvent.type(startField, '1');
         startField.blur();
+
+        const endField = screen.getByLabelText(`Change ${name} end range value`);
         await userEvent.clear(endField);
         await userEvent.type(endField, '1');
         endField.blur();
 
-        // onChange should not be called with [1, 1] because end value was not change to the same as start value
-        expect(onChange).toHaveBeenCalledWith([1, 1.5]);
+        expect(onChange).toHaveBeenCalledWith([1, 1]);
     });
 
     it('disables fields when isDisabled is true', () => {
@@ -82,15 +91,67 @@ describe('RangeParameterField', () => {
         expect(screen.getByLabelText(`Change ${name} end range value`)).toBeDisabled();
     });
 
-    it('does not allow range slider start and end to be equal', async () => {
-        renderApp({});
+    it('does not allow start value to exceed end value', async () => {
+        renderApp({ value: [0.5, 1.5] });
 
-        const handle = screen.getByRole('button', { name: 'Increase Change Scaling ratio range start range value' });
+        const startField = screen.getByLabelText(`Change ${name} start range value`);
+        await userEvent.clear(startField);
+        await userEvent.type(startField, '2');
+        startField.blur();
 
-        fireEvent.mouseDown(handle, { clientX: 0 });
-        fireEvent.mouseMove(handle, { clientX: 1000 }); // Move it far to the right
-        fireEvent.mouseUp(handle);
+        expect(onChange).toHaveBeenCalledWith([1.5, 1.5]);
+        expect(onChange).not.toHaveBeenCalledWith([2, 1.5]);
 
-        expect(onChange).not.toHaveBeenCalledWith([1.5, 1.5]);
+        await waitFor(() => {
+            expect(screen.getByLabelText(`Change ${name} start range value`)).toHaveValue('1.5');
+            expect(screen.getByLabelText(`Change ${name} end range value`)).toHaveValue('1.5');
+        });
+    });
+
+    it('does not allow end value to go below start value', async () => {
+        renderApp({ value: [0.5, 1.5] });
+
+        const endField = screen.getByLabelText(`Change ${name} end range value`);
+        await userEvent.clear(endField);
+        await userEvent.type(endField, '0');
+        endField.blur();
+
+        expect(onChange).toHaveBeenCalledWith([0.5, 0.5]);
+        expect(onChange).not.toHaveBeenCalledWith([0.5, 0]);
+
+        await waitFor(() => {
+            expect(screen.getByLabelText(`Change ${name} start range value`)).toHaveValue('0.5');
+            expect(screen.getByLabelText(`Change ${name} end range value`)).toHaveValue('0.5');
+        });
+    });
+
+    it('syncs internal state when value prop changes externally', () => {
+        const ControlledWrapper = () => {
+            const [value, setValue] = useState<[number, number]>([0.5, 1.5]);
+
+            return (
+                <>
+                    <button onClick={() => setValue([0.2, 1.8])}>Update value</button>
+                    <RangeParameterField
+                        value={value}
+                        onChange={onChange}
+                        name={name}
+                        step={0.001}
+                        minValue={0}
+                        maxValue={2}
+                    />
+                </>
+            );
+        };
+
+        render(<ControlledWrapper />);
+
+        expect(screen.getByLabelText(`Change ${name} start range value`)).toHaveValue('0.5');
+        expect(screen.getByLabelText(`Change ${name} end range value`)).toHaveValue('1.5');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Update value' }));
+
+        expect(screen.getByLabelText(`Change ${name} start range value`)).toHaveValue('0.2');
+        expect(screen.getByLabelText(`Change ${name} end range value`)).toHaveValue('1.8');
     });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.test.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/components/range-parameter-field/range-parameter-field.test.tsx
@@ -24,14 +24,7 @@ describe('RangeParameterField', () => {
         isDisabled?: boolean;
     }) => {
         return render(
-            <RangeParameterField
-                defaultValue={defaultValue}
-                value={value}
-                onChange={onChange}
-                name={name}
-                isDisabled={isDisabled}
-                step={0.001}
-            />
+            <RangeParameterField value={value} onChange={onChange} name={name} isDisabled={isDisabled} step={0.001} />
         );
     };
 

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -16,17 +16,6 @@ import type {
 } from '../../../../constants/shared-types';
 import { isParameter, isParameterGroup } from '../../model-listing/model-training-parameters/utils';
 
-const getDecimalPoints = (value: number): number => {
-    // When log10 returns 0 (log10(1) = 0) we need to return 1
-    return Math.abs(Math.ceil(Math.log10(value))) || 1;
-};
-
-export const getFloatingPointStep = (minValue: number, maxValue: number): number => {
-    const exponent = getDecimalPoints(maxValue - minValue);
-
-    return 1 / Math.pow(10, exponent + 3);
-};
-
 export const isBoolEnableParameter = (parameter: ConfigurableParameter) => {
     return parameter.value_type === 'bool' && parameter.key === 'enable';
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This fixes float range parameter boundaries. Previously (based on geti classic implementation) we used default values as boundaries but that is no longer the case. We want to use `max_value` and `min_value` provided by the server.

Server change will be made in https://github.com/open-edge-platform/training_extensions/issues/6094. Either in server PR or in the follow up to that PR we will need to uncomment the code that uses `max_value` and `min_value`.

Fix #6093 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
