### PR TITLE
fix: Display augmentation parameters when dependent parameter does not exist

### DIFF
--- a/application/ui/src/features/models/train-model/advanced-settings/utils.test.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.test.ts
@@ -370,7 +370,7 @@ describe('filterDependentParameters', () => {
         expect(result).toEqual([param]);
     });
 
-    it('does not include standalone dependent parameters that have no matching parent', () => {
+    it('includes a dependent parameter when the dependency key does not exist in the parameters list', () => {
         const dependent = getMockedConfigurationParameter({
             value_type: 'float',
             key: 'orphan',
@@ -378,6 +378,38 @@ describe('filterDependentParameters', () => {
         });
         const result = filterDependentParameters([dependent]);
 
-        expect(result).toEqual([]);
+        expect(result).toEqual([dependent]);
+    });
+
+    it('excludes a dependent parameter when the dependency exists but values do not match', () => {
+        const parent = getMockedConfigurationParameter({
+            value_type: 'str',
+            key: 'parent_key',
+            value: 'actual_value',
+        });
+        const dependent = getMockedConfigurationParameter({
+            value_type: 'float',
+            key: 'child',
+            depends_on: { parent_key: 'expected_value' },
+        });
+        const result = filterDependentParameters([parent, dependent]);
+
+        expect(result).toEqual([parent]);
+    });
+
+    it('includes a dependent parameter when the dependency exists and values match', () => {
+        const parent = getMockedConfigurationParameter({
+            value_type: 'str',
+            key: 'parent_key',
+            value: 'matching_value',
+        });
+        const dependent = getMockedConfigurationParameter({
+            value_type: 'float',
+            key: 'child',
+            depends_on: { parent_key: 'matching_value' },
+        });
+        const result = filterDependentParameters([parent, dependent]);
+
+        expect(result).toEqual([parent, dependent]);
     });
 });

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -101,41 +101,39 @@ export const isBoolEnableParameterGroup = (
 export const filterDependentParameters = (
     parameters: TrainingConfigurationParameter[]
 ): TrainingConfigurationParameter[] => {
-    return parameters
-        .reduce<TrainingConfigurationParameter[][]>((acc, curr, _idx, parametersOnTheDepth) => {
-            if (curr.depends_on != null) {
-                const dependentParameter = parametersOnTheDepth.find(
-                    (parameter) => curr.depends_on != null && curr.depends_on[parameter.key] != null
-                );
+    return parameters.reduce<TrainingConfigurationParameter[]>((acc, curr, _idx, parametersOnTheDepth) => {
+        if (curr.depends_on != null) {
+            const dependentParameter = parametersOnTheDepth.find(
+                (parameter) => curr.depends_on != null && curr.depends_on[parameter.key] != null
+            );
 
-                if (dependentParameter === undefined || !isParameter(dependentParameter)) {
-                    acc.push([curr]);
-                    return acc;
-                }
-
-                const dependsOnValue = curr.depends_on[dependentParameter.key];
-                const shouldBeVisible = Array.isArray(dependsOnValue)
-                    ? dependsOnValue.includes(dependentParameter.value)
-                    : dependsOnValue === dependentParameter.value;
-
-                if (shouldBeVisible) {
-                    acc.push([curr]);
-                }
-
+            if (dependentParameter === undefined || !isParameter(dependentParameter)) {
+                acc.push(curr);
                 return acc;
             }
 
-            if (isParameterGroup(curr)) {
-                const groupedParameters = filterDependentParameters(curr.parameters);
+            const dependsOnValue = curr.depends_on[dependentParameter.key];
+            const shouldBeVisible = Array.isArray(dependsOnValue)
+                ? dependsOnValue.includes(dependentParameter.value)
+                : dependsOnValue === dependentParameter.value;
 
-                acc.push([{ ...curr, parameters: groupedParameters }]);
-
-                return acc;
+            if (shouldBeVisible) {
+                acc.push(curr);
             }
-
-            acc.push([curr]);
 
             return acc;
-        }, [])
-        .flatMap((group) => group);
+        }
+
+        if (isParameterGroup(curr)) {
+            const groupedParameters = filterDependentParameters(curr.parameters);
+
+            acc.push({ ...curr, parameters: groupedParameters });
+
+            return acc;
+        }
+
+        acc.push(curr);
+
+        return acc;
+    }, []);
 };

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -98,6 +98,24 @@ export const isBoolEnableParameterGroup = (
     );
 };
 
+
+/**
+ * Filters a list of training configuration parameters based on their `depends_on` conditions.
+ *
+ * For each parameter that declares a `depends_on` mapping, this function looks for the
+ * referenced parameter at the same depth. A parameter is included in the output only if:
+ * - It has no `depends_on` declaration, OR
+ * - Its dependency parameter cannot be found (or is a group, not a leaf parameter), OR
+ * - The dependency parameter's current value satisfies the condition specified in `depends_on`
+ *   (either an exact match or inclusion in an allowed-values array).
+ *
+ * Parameter groups without a `depends_on` are recursively processed so that their nested
+ * parameters are also filtered.
+ *
+ * @param parameters - The flat or nested list of {@link TrainingConfigurationParameter} objects to filter.
+ * @returns A new array containing only the parameters (and recursively filtered groups) that
+ *          satisfy their dependency conditions.
+ */
 export const filterDependentParameters = (
     parameters: TrainingConfigurationParameter[]
 ): TrainingConfigurationParameter[] => {

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -98,7 +98,6 @@ export const isBoolEnableParameterGroup = (
     );
 };
 
-
 /**
  * Filters a list of training configuration parameters based on their `depends_on` conditions.
  *

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -101,9 +101,9 @@ export const isBoolEnableParameterGroup = (
 export const filterDependentParameters = (
     parameters: TrainingConfigurationParameter[]
 ): TrainingConfigurationParameter[] => {
-    return parameters.reduce<TrainingConfigurationParameter[]>((acc, curr, _idx, parametersOnTheDepth) => {
+    return parameters.reduce<TrainingConfigurationParameter[]>((acc, curr, _idx, parametersOnTheSameDepth) => {
         if (curr.depends_on != null) {
-            const dependentParameter = parametersOnTheDepth.find(
+            const dependentParameter = parametersOnTheSameDepth.find(
                 (parameter) => curr.depends_on != null && curr.depends_on[parameter.key] != null
             );
 

--- a/application/ui/src/features/models/train-model/advanced-settings/utils.ts
+++ b/application/ui/src/features/models/train-model/advanced-settings/utils.ts
@@ -102,25 +102,26 @@ export const filterDependentParameters = (
     parameters: TrainingConfigurationParameter[]
 ): TrainingConfigurationParameter[] => {
     return parameters
-        .reduce<TrainingConfigurationParameter[][]>((acc, curr) => {
-            if (isParameter(curr) && curr.depends_on == null) {
-                const parametersDependingOnCurr = parameters.filter((parameter) => {
-                    if (parameter.depends_on == null) return false;
-
-                    const dependsOnValue = parameter.depends_on[curr.key];
-
-                    if (Array.isArray(dependsOnValue)) {
-                        return dependsOnValue.includes(curr.value);
-                    }
-
-                    return dependsOnValue === curr.value;
-                });
-
-                acc.push([curr, ...parametersDependingOnCurr]);
-                return acc;
-            }
-
+        .reduce<TrainingConfigurationParameter[][]>((acc, curr, _idx, parametersOnTheDepth) => {
             if (curr.depends_on != null) {
+                const dependentParameter = parametersOnTheDepth.find(
+                    (parameter) => curr.depends_on != null && curr.depends_on[parameter.key] != null
+                );
+
+                if (dependentParameter === undefined || !isParameter(dependentParameter)) {
+                    acc.push([curr]);
+                    return acc;
+                }
+
+                const dependsOnValue = curr.depends_on[dependentParameter.key];
+                const shouldBeVisible = Array.isArray(dependsOnValue)
+                    ? dependsOnValue.includes(dependentParameter.value)
+                    : dependsOnValue === dependentParameter.value;
+
+                if (shouldBeVisible) {
+                    acc.push([curr]);
+                }
+
                 return acc;
             }
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that implementation assumed that we always have dependent parameter. That was wrong assumption and this PR fixes that.

Fix #6132 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
