### PR TITLE
fix: Currently running container takes the full width

### DIFF
--- a/application/ui/src/features/models/model-listing/current-model-running/current-model-running.component.tsx
+++ b/application/ui/src/features/models/model-listing/current-model-running/current-model-running.component.tsx
@@ -33,6 +33,7 @@ export const CurrentModelRunning = ({ groupBy, datasetRevisions }: CurrentModelR
 
     return (
         <Flex
+            width={'100%'}
             gap={'size-200'}
             direction={'column'}
             UNSAFE_style={{ padding: 'var(--spectrum-global-dimension-size-300)' }}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

I was not able to reproduce the issue. Based on the video recording attached to the issue I saw that jumping effect was caused by job status when that was changing its message.
If you can please check if u can reproduce that issue.
I expect adding `width: 100%` should fix the issue.

Fix #6064 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
