### PR TITLE
fix: Labels management panel should not close on color's change

### DIFF
--- a/application/ui/src/features/annotator/labels/labels-editor/labels-editor-popover.component.tsx
+++ b/application/ui/src/features/annotator/labels/labels-editor/labels-editor-popover.component.tsx
@@ -1,24 +1,38 @@
-// Copyright (C) 2026 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef, useState } from 'react';
+import { ComponentProps, ComponentRef, ReactNode, useRef, useState } from 'react';
 
-import {
-    ActionButton,
-    AlertDialog,
-    CustomPopover,
-    DialogContainer,
-    FocusableRefValue,
-    Text,
-    Tooltip,
-    TooltipTrigger,
-} from '@geti/ui';
+import { ActionButton, AlertDialog, DialogContainer, Popover, Text, Tooltip, TooltipTrigger } from '@geti/ui';
 import { Add, Edit } from '@geti/ui/icons';
 import { useOverlayTriggerState } from '@react-stately/overlays';
+import { OverlayTriggerState } from 'react-stately';
 
 import type { Label } from '../../../../constants/shared-types';
 import { useLabels } from '../use-labels.hook';
 import { LabelsEditor } from './labels-editor.component';
+
+type LabelEditorPopoverProps = {
+    state: OverlayTriggerState;
+    triggerRef: ComponentProps<typeof Popover>['triggerRef'];
+    children: ReactNode;
+};
+
+const LabelEditorPopover = ({ triggerRef, state, children }: LabelEditorPopoverProps) => {
+    return (
+        <Popover
+            hideArrow
+            triggerRef={triggerRef}
+            state={state}
+            placement={'bottom end'}
+            UNSAFE_style={{
+                transform: 'translateY(10%)',
+            }}
+        >
+            {children}
+        </Popover>
+    );
+};
 
 type LabelsEditorPopoverProps = {
     isClassification?: boolean;
@@ -33,7 +47,7 @@ export const LabelsEditorPopover = ({
 }: LabelsEditorPopoverProps) => {
     const { deleteLabel } = useLabels({ isClassification, isMultiLabel });
 
-    const triggerRef = useRef<FocusableRefValue<HTMLElement, HTMLButtonElement>>(null);
+    const triggerRef = useRef<ComponentRef<'svg'>>(null);
     const popoverState = useOverlayTriggerState({});
     const deleteDialogState = useOverlayTriggerState({});
     const [labelToDelete, setLabelToDelete] = useState<Label | null>(null);
@@ -62,30 +76,29 @@ export const LabelsEditorPopover = ({
         <>
             {hasLabels ? (
                 <TooltipTrigger>
-                    <ActionButton ref={triggerRef} isQuiet aria-label='Edit labels' onPress={popoverState.open}>
-                        <Edit />
+                    <ActionButton isQuiet aria-label='Edit labels' onPress={popoverState.open}>
+                        <Edit ref={triggerRef} />
                     </ActionButton>
                     <Tooltip>Edit labels</Tooltip>
                 </TooltipTrigger>
             ) : (
                 <TooltipTrigger>
-                    <ActionButton ref={triggerRef} isQuiet aria-label='Create label' onPress={popoverState.open}>
-                        <Add />
+                    <ActionButton isQuiet aria-label='Create label' onPress={popoverState.open}>
+                        <Add ref={triggerRef} />
                         <Text>Create label</Text>
                     </ActionButton>
                     <Tooltip>Create label</Tooltip>
                 </TooltipTrigger>
             )}
-            {popoverState.isOpen && (
-                <CustomPopover ref={triggerRef} state={popoverState} placement='bottom end'>
-                    <LabelsEditor
-                        isClassification={isClassification}
-                        isMultiLabel={isMultiLabel}
-                        onRequestDeleteLabel={handleRequestDeleteLabel}
-                        autoCreateNewLabel={!hasLabels}
-                    />
-                </CustomPopover>
-            )}
+
+            <LabelEditorPopover state={popoverState} triggerRef={triggerRef}>
+                <LabelsEditor
+                    isClassification={isClassification}
+                    isMultiLabel={isMultiLabel}
+                    onRequestDeleteLabel={handleRequestDeleteLabel}
+                    autoCreateNewLabel={!hasLabels}
+                />
+            </LabelEditorPopover>
 
             <DialogContainer onDismiss={handleCancelDeleteLabel}>
                 {deleteDialogState.isOpen && labelToDelete && (


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that `CustomPopover` uses `useOnClickOutside` that closed that dialog whenever mouse is released on color picker. Now we use popover from spectrum directly so that is save and works fine.

Fix #6162 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
