### PR TITLE
fix: Open media with missing thumbnail

### DIFF
--- a/application/ui/src/components/media-item/media-item.component.tsx
+++ b/application/ui/src/components/media-item/media-item.component.tsx
@@ -27,7 +27,7 @@ export const MediaItem = ({
     bottomRightElement,
 }: MediaItemProps) => {
     return (
-        <View width={'100%'} UNSAFE_className={className}>
+        <View height={'100%'} width={'100%'} UNSAFE_className={className}>
             {contentElement()}
 
             {isFunction(topLeftElement) && (

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
@@ -1,7 +1,8 @@
 .imgContainer {
+    height: 100%;
     overflow: hidden;
-    text-align: center;
     position: relative;
+    text-align: center;
 }
 
 .img {

--- a/application/ui/src/features/annotator/labels/labels-editor/labels-editor-popover.component.tsx
+++ b/application/ui/src/features/annotator/labels/labels-editor/labels-editor-popover.component.tsx
@@ -21,13 +21,10 @@ type LabelEditorPopoverProps = {
 const LabelEditorPopover = ({ triggerRef, state, children }: LabelEditorPopoverProps) => {
     return (
         <Popover
-            hideArrow
             triggerRef={triggerRef}
             state={state}
             placement={'bottom end'}
-            UNSAFE_style={{
-                transform: 'translateY(10%)',
-            }}
+            UNSAFE_style={{ transform: 'translateY(2%)' }}
         >
             {children}
         </Popover>

--- a/application/ui/src/features/project/list/project-list.module.scss
+++ b/application/ui/src/features/project/list/project-list.module.scss
@@ -86,7 +86,7 @@
 }
 
 .labelList {
-    @include lineClamp.clamp(3);
+    @include lineClamp.clamp(2);
 }
 
 .projectCreationDate {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
closes #5528

Updates the media container to use all available vertical space, making it easier to open the annotator when the thumbnail fails. It also reduces the number of clamped lines so the content doesn’t overflow.

| Before  | After |
| ------------- | ------------- |
| <img width="1243" height="618" alt="Screenshot 2026-04-20 at 11 24 18" src="https://github.com/user-attachments/assets/019ea2cf-dfef-4228-a83e-274e74359dde" /> | <img width="1243" height="614" alt="Screenshot 2026-04-20 at 11 23 48" src="https://github.com/user-attachments/assets/be8ba3c2-a78d-4d0d-9caf-67f1ff6b160a" /> |


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
