### PR TITLE
Fix glob in run-image recipe

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -71,6 +71,7 @@ build-image accelerator="cpu" tag="latest": install-uv
 run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="":
     #!/usr/bin/env bash
     set -euo pipefail
+    shopt -s nullglob
 
     IMAGE_NAME="{{ application-name }}-{{ accelerator }}:{{ tag }}"
     if [[ -n "{{ container-name }}" ]]; then


### PR DESCRIPTION
### Summary

This PR fixes a small bug in the Just `run-image` recipe that caused it to crash when no devices exist in `dev/dri/` and `--accelerator="xpu"` is provided: the glob expression `/dev/dri/renderD*` would not expand because no file matches. Setting `nullglob` is safer and avoids the problem.

### How to test

Run `just run-image --accelerator="xpu" --remove --reload`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
