### PR TITLE
Bug fixes for project creation & layout updates

### DIFF
--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -116,13 +116,13 @@ export const ProjectsListPanel = () => {
                     </Flex>
                 </Header>
 
+                <Divider size={'S'} marginY={'size-200'} />
+
                 <Content>
-                    <Divider size={'S'} marginY={'size-200'} />
-
                     <ProjectsList projects={data} />
-
-                    <Divider size={'S'} marginY={'size-200'} />
                 </Content>
+
+                <Divider size={'S'} marginY={'size-200'} />
 
                 <ButtonGroup UNSAFE_className={classes.panelButtons}>
                     <AddProjectButton />

--- a/application/ui/src/components/project-panel/projects-list.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list.component.tsx
@@ -4,15 +4,13 @@
 import { Project } from '../../constants/shared-types';
 import { ProjectListItem } from './project-list-item/project-list-item.component';
 
-import classes from './projects-list.module.scss';
-
 type ProjectListProps = {
     projects: Project[];
 };
 
 export const ProjectsList = ({ projects }: ProjectListProps) => {
     return (
-        <ul className={classes.projectList}>
+        <ul>
             {projects.map((project) => (
                 <ProjectListItem key={project.id} project={project} />
             ))}

--- a/application/ui/src/components/project-panel/projects-list.module.scss
+++ b/application/ui/src/components/project-panel/projects-list.module.scss
@@ -1,7 +1,7 @@
 @use '../../shared/styles/line-clamp' as lineClamp;
 
 .panelButtons {
-    padding-block-start: 0;
+    padding: var(--spectrum-global-dimension-size-125);
 }
 
 .addProjectButton {
@@ -15,15 +15,9 @@
 
 .dialog {
     & div[class*='spectrum-Dialog-grid'] {
-        --spectrum-dialog-padding-x: 0px;
-        --spectrum-dialog-padding-y: var(--spectrum-global-dimension-size-250);
+        --spectrum-dialog-padding-x: 0;
+        --spectrum-dialog-padding-y: 0;
     }
-}
-
-.projectList {
-    list-style: none;
-    padding-inline-start: 0;
-    overflow: auto;
 }
 
 .projectName {

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-active-job.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-active-job.component.tsx
@@ -33,7 +33,7 @@ export const ExportActiveJob = ({ job, datasetName }: ExportActiveJobProps) => {
                     <CancelJobConfirmation jobId={job.job_id} onRemove={handleRemove} />
                 </Flex>
 
-                <Text>Dataset is being processed in order to export it</Text>
+                <Text>Processing dataset for export</Text>
 
                 <Divider size='S' marginY='size-150' />
 

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Flex, Text, View } from '@geti/ui';
+import { Button, Divider, Flex, Text, View } from '@geti/ui';
 import { useDeleteStagedDataset, useStagedDataset } from 'hooks/api/staged-dataset.hook';
 import { isNil } from 'lodash-es';
 
@@ -67,7 +67,9 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
                 </Flex>
             </Flex>
 
-            <Text>Dataset is ready to download</Text>
+            <Divider size={'S'} marginY={'size-150'} />
+
+            <Text>Dataset is ready for download</Text>
         </View>
     );
 };

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { dimensionValue, Divider, Flex, Grid, Text } from '@geti/ui';
+import { Badge, dimensionValue, Divider, Flex, Grid, Text } from '@geti/ui';
 import { isEmpty, isNil } from 'lodash-es';
 
 import { ExportDatasetMetadata } from '../../../../../../constants/shared-types';
@@ -26,11 +26,19 @@ export const ExportJobDetails = ({ datasetName, metadata }: ExportJobDetailsProp
     const labelsList = isEmpty(selectedLabels) ? projectLabelsNames : selectedLabels;
 
     return (
-        <Flex direction='column' UNSAFE_style={{ fontWeight: 500, fontSize: dimensionValue('size-200') }}>
-            <Text>Export {isNil(datasetName) ? 'dataset' : datasetName}</Text>
+        <Flex direction={'column'}>
+            <Text UNSAFE_style={{ fontWeight: 500, fontSize: dimensionValue('size-225') }}>
+                Export {isNil(datasetName) ? 'dataset' : datasetName}
+            </Text>
 
-            <Grid gap='size-125' columns={['auto', '1px', 'auto', '1px', '1fr']}>
+            <Grid
+                marginTop={'size-200'}
+                alignItems={'center'}
+                gap='size-125'
+                columns={['auto', '1px', 'auto', '1px', '1fr']}
+            >
                 <Text>
+                    Format:{' '}
                     <Text
                         UNSAFE_style={{
                             textTransform: isGetiFormat(metadata.export_format) ? 'capitalize' : 'uppercase',
@@ -38,18 +46,24 @@ export const ExportJobDetails = ({ datasetName, metadata }: ExportJobDetailsProp
                     >
                         {metadata.export_format}
                     </Text>{' '}
-                    format
                 </Text>
 
                 <Divider orientation='vertical' size='S' />
 
-                <Text>{metadata.filters.include_unannotated ? 'All media' : 'Only media with annotations'}</Text>
+                <Text>Media: {metadata.filters.include_unannotated ? 'All media' : 'Only media with annotations'}</Text>
 
                 <Divider orientation='vertical' size='S' />
 
-                <Text UNSAFE_style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
-                    With labels: {labelsList.join(', ')}
-                </Text>
+                <Flex alignItems={'center'} gap={'size-100'} minWidth={0}>
+                    <Text>Labels:</Text>
+                    <Flex gap={'size-75'} wrap UNSAFE_style={{ minWidth: 0, overflow: 'hidden' }}>
+                        {labelsList.map((label) => (
+                            <Badge variant={'neutral'} key={label}>
+                                {label}
+                            </Badge>
+                        ))}
+                    </Flex>
+                </Flex>
             </Grid>
         </Flex>
     );

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Badge, dimensionValue, Divider, Flex, Grid, Text } from '@geti/ui';
+import { dimensionValue, Divider, Flex, Grid, Text } from '@geti/ui';
 import { isEmpty, isNil } from 'lodash-es';
 
 import { ExportDatasetMetadata } from '../../../../../../constants/shared-types';
@@ -54,16 +54,9 @@ export const ExportJobDetails = ({ datasetName, metadata }: ExportJobDetailsProp
 
                 <Divider orientation='vertical' size='S' />
 
-                <Flex alignItems={'center'} gap={'size-100'} minWidth={0}>
-                    <Text>Labels:</Text>
-                    <Flex gap={'size-75'} wrap UNSAFE_style={{ minWidth: 0, overflow: 'hidden' }}>
-                        {labelsList.map((label) => (
-                            <Badge variant={'neutral'} key={label}>
-                                {label}
-                            </Badge>
-                        ))}
-                    </Flex>
-                </Flex>
+                <Text UNSAFE_style={{ overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}>
+                    Labels: {labelsList.join(', ')}
+                </Text>
             </Grid>
         </Flex>
     );

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.test.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.test.tsx
@@ -48,7 +48,10 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText(/With labels: label 1, label 2, label 3/)).toBeVisible();
+        expect(await screen.findByText('Labels:')).toBeVisible();
+        expect(screen.getByText('label 1')).toBeVisible();
+        expect(screen.getByText('label 2')).toBeVisible();
+        expect(screen.getByText('label 3')).toBeVisible();
     });
 
     it('displays selected labels when specific labels are filtered', async () => {
@@ -64,7 +67,10 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText(/With labels: label 1, label 2/)).toBeVisible();
+        expect(await screen.findByText('Labels:')).toBeVisible();
+        expect(screen.getByText('label 1')).toBeVisible();
+        expect(screen.getByText('label 2')).toBeVisible();
+        expect(screen.queryByText('label 3')).not.toBeInTheDocument();
     });
 
     it('filters out labels that are not in the project', async () => {
@@ -80,8 +86,8 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText(/With labels: label 1/)).toBeVisible();
-        expect(screen.queryByText(/NonExistentLabel/)).not.toBeInTheDocument();
+        expect(await screen.findByText('label 1')).toBeVisible();
+        expect(screen.queryByText('NonExistentLabel')).not.toBeInTheDocument();
     });
 
     it('displays "Only media with annotations" when include_unannotated is false', async () => {
@@ -94,7 +100,7 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText('Only media with annotations')).toBeVisible();
+        expect(await screen.findByText(/Only media with annotations/)).toBeVisible();
     });
 
     it('does not display "Only media with annotations" when include_unannotated is true', async () => {
@@ -109,6 +115,6 @@ describe('ExportJobDetails', () => {
 
         await screen.findByText('COCO');
 
-        expect(await screen.findByText('All media')).toBeVisible();
+        expect(await screen.findByText(/All media/)).toBeVisible();
     });
 });

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.test.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-details/export-details.test.tsx
@@ -48,10 +48,7 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText('Labels:')).toBeVisible();
-        expect(screen.getByText('label 1')).toBeVisible();
-        expect(screen.getByText('label 2')).toBeVisible();
-        expect(screen.getByText('label 3')).toBeVisible();
+        expect(await screen.findByText(/Labels:\s*label 1, label 2, label 3/)).toBeVisible();
     });
 
     it('displays selected labels when specific labels are filtered', async () => {
@@ -67,10 +64,8 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText('Labels:')).toBeVisible();
-        expect(screen.getByText('label 1')).toBeVisible();
-        expect(screen.getByText('label 2')).toBeVisible();
-        expect(screen.queryByText('label 3')).not.toBeInTheDocument();
+        expect(await screen.findByText(/Labels:\s*label 1, label 2$/)).toBeVisible();
+        expect(screen.queryByText(/label 3/)).not.toBeInTheDocument();
     });
 
     it('filters out labels that are not in the project', async () => {
@@ -86,8 +81,8 @@ describe('ExportJobDetails', () => {
 
         renderApp(metadata);
 
-        expect(await screen.findByText('label 1')).toBeVisible();
-        expect(screen.queryByText('NonExistentLabel')).not.toBeInTheDocument();
+        expect(await screen.findByText(/Labels:\s*label 1$/)).toBeVisible();
+        expect(screen.queryByText(/NonExistentLabel/)).not.toBeInTheDocument();
     });
 
     it('displays "Only media with annotations" when include_unannotated is false', async () => {

--- a/application/ui/src/features/models/model-listing/model-training-parameters/model-training.module.scss
+++ b/application/ui/src/features/models/model-listing/model-training-parameters/model-training.module.scss
@@ -1,4 +1,5 @@
 .scrollableContent {
     max-height: var(--spectrum-global-dimension-size-5000);
+    height: 100%;
     overflow-y: auto;
 }

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -37,10 +37,14 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
     const navigate = useNavigate();
     const createProjectMutation = useCreateProject();
 
-    const validationErrorMessage = validateProjectName(
-        name,
-        projects.map((project) => project.name)
-    );
+    const isSubmitting = createProjectMutation.isPending || createProjectMutation.isSuccess;
+
+    const validationErrorMessage = isSubmitting
+        ? undefined
+        : validateProjectName(
+              name,
+              projects.map((project) => project.name)
+          );
 
     const isSingleLabelClassification = isClassificationTask(selectedTask) && classificationTaskType === 'single-label';
     const needsMinimumNumberOfLabels = isSingleLabelClassification && labels.length < 2;

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -50,6 +50,7 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
     const needsMinimumNumberOfLabels = isSingleLabelClassification && labels.length < 2;
 
     const isCreateProjectDisabled =
+        isSubmitting ||
         selectedTask === null ||
         validationErrorMessage !== undefined ||
         labels.length === 0 ||

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
@@ -10,6 +10,7 @@ import { useStagedDatasetSuspense } from 'hooks/api/staged-dataset.hook';
 import { useImportDatasetAsNewProject } from 'hooks/storage/use-import-dataset-as-new-project.hook';
 
 import { TaskType } from '../../../../../constants/shared-types';
+import { generateUniqueProjectName } from '../../../create/utils';
 import { useImportDatasetDialog } from '../../../providers/import-dataset-dialog-provider.component';
 import { validateProjectName } from '../../../validator';
 import { getRecommendedTaskType, TASK_SELECTION_FORM_ID } from './util';
@@ -24,8 +25,10 @@ const useFormConfig = (stagedDatasetId: string, defaultTaskType: TaskType | unde
     const { getImportEntry, updateImportEntry } = useImportDatasetAsNewProject();
     const importEntry = getImportEntry(stagedDatasetId);
 
+    const uniqueProjectName = generateUniqueProjectName(projects.map((project) => project.name));
+
     const initialFormState = {
-        name: importEntry?.project?.name ?? `Project #${projects.length + 1}`,
+        name: importEntry?.project?.name ?? uniqueProjectName,
         task_type: importEntry?.project?.task_type ?? defaultTaskType,
     };
 

--- a/application/ui/tests/datasets/export-dataset.spec.ts
+++ b/application/ui/tests/datasets/export-dataset.spec.ts
@@ -119,9 +119,9 @@ test.describe('Export dataset', () => {
 
         await test.step('Verify export job progress', async () => {
             await expect(dialog).toBeHidden();
-            await expect(page.getByText('Labels:')).toBeVisible();
+            await expect(page.getByText(/Labels:/)).toBeVisible();
             for (const label of projectLabels) {
-                await expect(page.getByText(label.name, { exact: true })).toBeVisible();
+                await expect(page.getByText(label.name)).toBeVisible();
             }
             await expect(page.getByText(String(exportingJob.message))).toBeVisible();
         });

--- a/application/ui/tests/datasets/export-dataset.spec.ts
+++ b/application/ui/tests/datasets/export-dataset.spec.ts
@@ -127,7 +127,7 @@ test.describe('Export dataset', () => {
         });
 
         await test.step('Verify export job completes and download dataset', async () => {
-            await page.waitForSelector(`text="Dataset is ready to download"`);
+            await page.waitForSelector(`text="Dataset is ready for download"`);
 
             const downloadButton = page.getByRole('button', { name: /download dataset/i });
             await expect(downloadButton).toBeVisible();
@@ -144,7 +144,7 @@ test.describe('Export dataset', () => {
             const closeButton = page.getByRole('button', { name: /close export dataset status/i });
             await closeButton.click();
 
-            await expect(page.getByText('Dataset is ready to download')).toBeHidden();
+            await expect(page.getByText('Dataset is ready for download')).toBeHidden();
             await expect.poll(() => deletedStagedDatasetId).toBe(STAGED_DATASET_ID);
         });
     });

--- a/application/ui/tests/datasets/export-dataset.spec.ts
+++ b/application/ui/tests/datasets/export-dataset.spec.ts
@@ -119,9 +119,10 @@ test.describe('Export dataset', () => {
 
         await test.step('Verify export job progress', async () => {
             await expect(dialog).toBeHidden();
-            await expect(
-                page.getByText(`With labels: ${projectLabels.map((label) => label.name).join(', ')}`)
-            ).toBeVisible();
+            await expect(page.getByText('Labels:')).toBeVisible();
+            for (const label of projectLabels) {
+                await expect(page.getByText(label.name, { exact: true })).toBeVisible();
+            }
             await expect(page.getByText(String(exportingJob.message))).toBeVisible();
         });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Closes https://github.com/open-edge-platform/training_extensions/issues/6189
* Closes https://github.com/open-edge-platform/training_extensions/issues/6190
* Solves an issue with validation when creating a project. `useCreateProject` invalidates /api/projects so when we create a project, even with an unique name, the error "Project with name X already exists" flashed for a second
* Improve export job details layout
* Model training parameters "boxes" should now have all the same height regardless of the number of params

<img width="1051" height="893" alt="Screenshot 2026-04-21 at 11 13 58" src="https://github.com/user-attachments/assets/78f4c2c0-d3c2-4203-864c-733d4a6937f5" />
<img width="1461" height="305" alt="Screenshot 2026-04-21 at 11 36 27" src="https://github.com/user-attachments/assets/a3bd41cc-2ac8-4f9f-81af-f7d643e25a22" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
