### PR TITLE
Import job stuck due to running training job

### DIFF
--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -101,7 +101,7 @@ class JobController:
         task.add_done_callback(lambda t: (self._tasks.discard(t)))
 
     async def _run_job(self, job: Job) -> None:
-        needs_capacity_permit = job.job_type in (JobType.TRAIN, JobType.QUANTIZE)
+        needs_capacity_permit = job.job_type == JobType.TRAIN
         permit_ctx = self._capacity.permit() if needs_capacity_permit else contextlib.nullcontext()
         async with permit_ctx:
             job_run = self._runner_factory.for_job(job)

--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -7,7 +7,7 @@ import threading
 
 from loguru import logger
 
-from app.core.jobs.models import Cancelled, Done, Failed, Job, Progress, Started
+from app.core.jobs.models import Cancelled, Done, Failed, Job, JobType, Progress, Started
 from app.core.run import Runner, RunnerFactory
 
 from .capacity import Capacity
@@ -101,7 +101,9 @@ class JobController:
         task.add_done_callback(lambda t: (self._tasks.discard(t)))
 
     async def _run_job(self, job: Job) -> None:
-        async with self._capacity.permit():
+        needs_capacity_permit = job.job_type in (JobType.TRAIN, JobType.QUANTIZE)
+        permit_ctx = self._capacity.permit() if needs_capacity_permit else contextlib.nullcontext()
+        async with permit_ctx:
             job_run = self._runner_factory.for_job(job)
             event_q: asyncio.Queue = asyncio.Queue()
 

--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -38,7 +38,7 @@ class JobController:
     Args:
         jobs_queue: Source of jobs to execute and cancellation state tracker
         runner_factory: Creates appropriate runner contexts for different job types
-        max_parallel_jobs: Maximum number of jobs that can execute simultaneously
+        max_parallel_jobs: Maximum number of capacity-managed jobs that can execute simultaneously
     """
 
     def __init__(self, jobs_queue: JobQueue, runner_factory: RunnerFactory, max_parallel_jobs: int) -> None:

--- a/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
+++ b/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
@@ -9,7 +9,7 @@ import pytest
 
 from app.core.jobs.control_plane import CancellationResult, JobController, JobQueue
 from app.core.jobs.exec import ThreadRunnerFactory
-from app.core.jobs.models import Job, JobParams, JobStatus
+from app.core.jobs.models import Job, JobParams, JobStatus, JobType
 from app.core.run import ExecutionContext, RunnableFactory
 
 from .mock_runnable import MockRunnable, RunnableBehaviour
@@ -188,7 +188,21 @@ class TestJobControlPlaneIntegration:
             await job_controller.stop()
 
     @pytest.mark.asyncio
-    async def test_capacity_management_limits_concurrency(self, fxt_runnable_factory, fxt_job):
+    @pytest.mark.parametrize(
+        "job_type, jobs_in_progress",
+        [
+            (JobType.TRAIN, 1),
+            (JobType.QUANTIZE, 1),
+            (JobType.STAGE_DATASET, 3),
+            (JobType.IMPORT_DATASET_AS_NEW_PROJECT, 3),
+            (JobType.PREPARE_DATASET_FOR_IMPORT, 3),
+            (JobType.EXPORT_DATASET, 3),
+            (JobType.IMPORT_DATASET_TO_PROJECT, 3),
+        ],
+    )
+    async def test_capacity_management_limits_concurrency(
+        self, job_type, jobs_in_progress, fxt_runnable_factory, fxt_job
+    ):
         """Test that capacity management properly limits concurrent execution."""
         job_queue = JobQueue()
         runner_factory = ThreadRunnerFactory(fxt_runnable_factory)
@@ -220,7 +234,7 @@ class TestJobControlPlaneIntegration:
         # Create multiple jobs
         jobs = []
         for i in range(3):
-            job = fxt_job()
+            job = fxt_job(job_type=job_type)
             jobs.append(job)
             await job_queue.submit(job)
 
@@ -234,8 +248,10 @@ class TestJobControlPlaneIntegration:
             for job in jobs:
                 await self._wait_for_job_status(job, JobStatus.DONE, timeout=5.0)
 
-            # Verify capacity was respected (max 1 concurrent)
-            assert max_concurrent == 1, f"Expected max 1 concurrent job, got {max_concurrent}"
+            # Verify capacity was respected
+            assert max_concurrent == jobs_in_progress, (
+                f"Expected max {jobs_in_progress} concurrent job, got {max_concurrent}"
+            )
 
             # All jobs should complete
             assert all(job.status == JobStatus.DONE for job in jobs)

--- a/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
+++ b/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
@@ -192,7 +192,7 @@ class TestJobControlPlaneIntegration:
         "job_type, expected_max_concurrent",
         [
             (JobType.TRAIN, 1),
-            (JobType.QUANTIZE, 1),
+            (JobType.QUANTIZE, 3),
             (JobType.STAGE_DATASET, 3),
             (JobType.IMPORT_DATASET_AS_NEW_PROJECT, 3),
             (JobType.PREPARE_DATASET_FOR_IMPORT, 3),

--- a/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
+++ b/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
@@ -189,7 +189,7 @@ class TestJobControlPlaneIntegration:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "job_type, jobs_in_progress",
+        "job_type, expected_max_concurrent",
         [
             (JobType.TRAIN, 1),
             (JobType.QUANTIZE, 1),
@@ -201,7 +201,7 @@ class TestJobControlPlaneIntegration:
         ],
     )
     async def test_capacity_management_limits_concurrency(
-        self, job_type, jobs_in_progress, fxt_runnable_factory, fxt_job
+        self, job_type, expected_max_concurrent, fxt_runnable_factory, fxt_job
     ):
         """Test that capacity management properly limits concurrent execution."""
         job_queue = JobQueue()
@@ -249,8 +249,8 @@ class TestJobControlPlaneIntegration:
                 await self._wait_for_job_status(job, JobStatus.DONE, timeout=5.0)
 
             # Verify capacity was respected
-            assert max_concurrent == jobs_in_progress, (
-                f"Expected max {jobs_in_progress} concurrent job, got {max_concurrent}"
+            assert max_concurrent == expected_max_concurrent, (
+                f"Expected max {expected_max_concurrent} concurrent job, got {max_concurrent}"
             )
 
             # All jobs should complete


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR removes capacity management for all job types except `TRAIN`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
