### PR TITLE
fix: Prediction loading and buffering

### DIFF
--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -14,6 +14,7 @@ import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
 import { ToolManager } from '../tools/tool-manager.component';
+import { usePrefetchVideoFramesAnnotations } from '../video-player/api/use-video-frames-annotations';
 import {
     PREDICTION_CHUNK_SIZE,
     PREDICTION_FRAME_SKIP,
@@ -79,6 +80,21 @@ const ImageAnnotations = ({ mediaItem }: ImageAnnotationsProps) => {
     );
 };
 
+const PrefetchAnnotations = () => {
+    const { videoFrame, step } = useVideoPlayer();
+
+    const nextFrameRangeIndexes = getVideoFrameRangeIndexes({
+        frames: videoFrame.frame_count - 1,
+        frameSkip: step,
+        frameNumber: videoFrame.frame_number,
+    });
+
+    usePrefetchVideoFramesAnnotations({ frameNumber: videoFrame.frame_number, frameSkip: step });
+    usePrefetchVideoFramesAnnotations({ frameNumber: nextFrameRangeIndexes.endFrameIndex + 1, frameSkip: step });
+
+    return null;
+};
+
 const PrefetchPredictions = () => {
     const { videoFrame } = useVideoPlayer();
     const nextFrameRangeIndexes = getVideoFrameRangeIndexes({
@@ -111,7 +127,12 @@ const MediaAnnotations = ({ mediaItem, mode }: MediaAnnotationsProps) => {
 
     if (isVideoFrame(mediaItem) && videoPlayerContext?.videoControls?.isPlaying) {
         if (mode === 'annotation') {
-            return <VideoAnnotations />;
+            return (
+                <>
+                    <VideoAnnotations />
+                    <PrefetchAnnotations />
+                </>
+            );
         } else if (mode === 'prediction') {
             return (
                 <>
@@ -126,6 +147,7 @@ const MediaAnnotations = ({ mediaItem, mode }: MediaAnnotationsProps) => {
         <>
             <ImageAnnotations mediaItem={mediaItem} />
             {isVideoFrame(mediaItem) && mode === 'prediction' && <PrefetchPredictions />}
+            {isVideoFrame(mediaItem) && mode === 'annotation' && <PrefetchAnnotations />}
         </>
     );
 };

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -1,12 +1,16 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { queryOptions, useQuery } from '@tanstack/react-query';
+import { queryOptions, useIsFetching, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { fetchClient } from '../../../api/client';
 import { PredictionDTO, PredictionVideoRangePayload } from '../../../constants/shared-types';
 import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
+
+const MEDIA_PREDICTIONS_QUERY_KEY_PREFIX = (projectId: string, mediaId: string) => {
+    return [projectId, 'media-predictions', mediaId];
+};
 
 export const mediaPredictionsQueryOptions = ({
     projectId,
@@ -20,7 +24,7 @@ export const mediaPredictionsQueryOptions = ({
     range?: PredictionVideoRangePayload | null;
 }) =>
     queryOptions({
-        queryKey: [projectId, 'media-predictions', mediaId, modelId, range],
+        queryKey: [...MEDIA_PREDICTIONS_QUERY_KEY_PREFIX(projectId, mediaId), modelId, range],
         queryFn: async () => {
             if (modelId === undefined) return [];
 
@@ -70,4 +74,16 @@ export const useMediaPredictions = ({
     const projectId = useProjectIdentifier();
 
     return useQuery(mediaPredictionsQueryOptions({ projectId, modelId, mediaId, range }));
+};
+
+export const useIsLoadingAnyPredictions = (mediaId: string) => {
+    const projectId = useProjectIdentifier();
+
+    const queryKey = MEDIA_PREDICTIONS_QUERY_KEY_PREFIX(projectId, mediaId);
+
+    return (
+        useIsFetching({
+            queryKey,
+        }) > 0
+    );
 };

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -76,14 +76,12 @@ export const useMediaPredictions = ({
     return useQuery(mediaPredictionsQueryOptions({ projectId, modelId, mediaId, range }));
 };
 
-export const useIsLoadingAnyPredictions = (mediaId: string) => {
+export const useIsFetchingAnyPredictions = (mediaId: string) => {
     const projectId = useProjectIdentifier();
 
     const queryKey = MEDIA_PREDICTIONS_QUERY_KEY_PREFIX(projectId, mediaId);
 
-    return (
-        useIsFetching({
-            queryKey,
-        }) > 0
-    );
+    const numberOfFetchingPredictions = useIsFetching({ queryKey });
+
+    return numberOfFetchingPredictions > 0;
 };

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-annotations.ts
@@ -1,12 +1,53 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { usePrefetchQuery, useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../../api/client';
 import { AnnotatedVideoFrame } from '../../../../constants/shared-types';
 import { useVideoPlayer } from '../video-player-provider.component';
 import { getVideoFrameRangeIndexes } from './utils';
+
+const useGetVideoFramesAnnotationsQueryOptions = ({
+    frameNumber,
+    frameSkip,
+}: {
+    frameSkip: number;
+    frameNumber: number;
+}) => {
+    const projectId = useProjectIdentifier();
+    const { videoFrame } = useVideoPlayer();
+
+    const frames = videoFrame.frame_count - 1;
+
+    const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({ frames, frameSkip, frameNumber });
+
+    return $api.queryOptions('get', '/api/projects/{project_id}/dataset/media/{media_id}/frames', {
+        params: {
+            path: {
+                project_id: projectId,
+                media_id: videoFrame.id,
+            },
+            query: {
+                frame_index_from: startFrameIndex,
+                frame_index_to: endFrameIndex,
+            },
+        },
+    });
+};
+
+export const usePrefetchVideoFramesAnnotations = ({
+    frameNumber,
+    frameSkip,
+}: {
+    frameNumber: number;
+    frameSkip: number;
+}) => {
+    const queryOptions = useGetVideoFramesAnnotationsQueryOptions({ frameNumber, frameSkip });
+
+    return usePrefetchQuery(queryOptions);
+};
 
 export const useVideoFramesAnnotations = <T>({
     frameNumber,
@@ -17,33 +58,16 @@ export const useVideoFramesAnnotations = <T>({
     frameSkip: number;
     selector: (data: AnnotatedVideoFrame[]) => T;
 }) => {
-    const projectId = useProjectIdentifier();
-    const { videoFrame } = useVideoPlayer();
+    const queryOptions = useGetVideoFramesAnnotationsQueryOptions({
+        frameSkip,
+        frameNumber,
+    });
 
-    const frames = videoFrame.frame_count - 1;
-
-    const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({ frames, frameSkip, frameNumber });
-
-    return $api.useQuery(
-        'get',
-        '/api/projects/{project_id}/dataset/media/{media_id}/frames',
-        {
-            params: {
-                path: {
-                    project_id: projectId,
-                    media_id: videoFrame.id,
-                },
-                query: {
-                    frame_index_from: startFrameIndex,
-                    frame_index_to: endFrameIndex,
-                },
-            },
-        },
-        {
-            select: selector,
-            // We invalidate cache manually when the user annotates a frame, so we can set an infinite stale time to
-            // avoid unnecessary refetches
-            staleTime: Infinity,
-        }
-    );
+    return useQuery({
+        ...queryOptions,
+        select: selector,
+        // We invalidate cache manually when the user annotates a frame, so we can set an infinite stale time to
+        // avoid unnecessary refetches
+        staleTime: Infinity,
+    });
 };

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
@@ -5,7 +5,7 @@ import { ActionButton, Flex } from '@geti/ui';
 import { Pause, Play, SoundOff, SoundOn, StepBackward, StepForward } from '@geti/ui/icons';
 
 import { AnnotatorMode } from '../../../../shared/annotator/annotator-mode';
-import { useIsLoadingAnyPredictions } from '../../api/use-media-predictions';
+import { useIsFetchingAnyPredictions } from '../../api/use-media-predictions';
 import { useVideoPlayer } from '../video-player-provider.component';
 
 type VideoControlsProps = {
@@ -17,7 +17,7 @@ export const VideoControls = ({ mode }: VideoControlsProps) => {
     const { isPlaying, play, pause, previousFrame, nextFrame, canSelectPreviousFrame, canSelectNextFrame } =
         videoControls;
 
-    const isLoadingPredictions = useIsLoadingAnyPredictions(videoFrame.id) && mode === 'prediction';
+    const isLoadingPredictions = useIsFetchingAnyPredictions(videoFrame.id) && mode === 'prediction';
 
     return (
         <Flex alignItems={'center'} gap={'size-100'}>

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
@@ -4,12 +4,20 @@
 import { ActionButton, Flex } from '@geti/ui';
 import { Pause, Play, SoundOff, SoundOn, StepBackward, StepForward } from '@geti/ui/icons';
 
+import { AnnotatorMode } from '../../../../shared/annotator/annotator-mode';
+import { useIsLoadingAnyPredictions } from '../../api/use-media-predictions';
 import { useVideoPlayer } from '../video-player-provider.component';
 
-export const VideoControls = () => {
-    const { isMuted, toggleMute, videoControls } = useVideoPlayer();
+type VideoControlsProps = {
+    mode: AnnotatorMode;
+};
+
+export const VideoControls = ({ mode }: VideoControlsProps) => {
+    const { isMuted, toggleMute, videoControls, videoFrame } = useVideoPlayer();
     const { isPlaying, play, pause, previousFrame, nextFrame, canSelectPreviousFrame, canSelectNextFrame } =
         videoControls;
+
+    const isLoadingPredictions = useIsLoadingAnyPredictions(videoFrame.id) && mode === 'prediction';
 
     return (
         <Flex alignItems={'center'} gap={'size-100'}>
@@ -27,7 +35,7 @@ export const VideoControls = () => {
                         <Pause />
                     </ActionButton>
                 ) : (
-                    <ActionButton isQuiet aria-label={'Play video'} onPress={play}>
+                    <ActionButton isQuiet aria-label={'Play video'} onPress={play} isDisabled={isLoadingPredictions}>
                         <Play />
                     </ActionButton>
                 )}

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.component.tsx
@@ -43,7 +43,7 @@ export const VideoToolbar = ({ mode }: VideoToolbarProps) => {
                         <Flex alignItems={'center'} gap={'size-200'}>
                             {isExpanded && <Text>Frames</Text>}
 
-                            <VideoControls />
+                            <VideoControls mode={mode} />
                             <VideoDuration videoFrame={videoFrame} />
 
                             {isExpanded && (

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { Key, Loading, View } from '@geti/ui';
 
@@ -11,16 +11,13 @@ import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
 import { useIsLoadingAnyPredictions } from '../../annotator/api/use-media-predictions';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
-import {
-    useVideoPlayerContext,
-    VideoPlayerProvider,
-} from '../../annotator/video-player/video-player-provider.component';
+import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { PrimaryToolbar } from './primary-toolbar/primary-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
-import { useNextMediaPrefetch } from './utils';
+import { useNextMediaPrefetch, usePlayPauseVideoBySystem } from './utils';
 
 const DATASET_SUBSETS: DatasetSubset[] = ['unassigned', 'training', 'validation', 'testing'];
 
@@ -57,32 +54,6 @@ const useSubset = (subset: DatasetSubset, mediaItem: Media) => {
         changeCurrentSubset: changeSubset,
         isReadOnlySubset: pendingSubset === subset && subset !== 'unassigned',
     };
-};
-
-const usePlayPauseVideoBySystem = (isLoadingPredictions: boolean) => {
-    const isPausedBySystem = useRef<boolean>(false);
-    const context = useVideoPlayerContext();
-
-    const playRef = useRef(context?.videoControls.play);
-    const pauseRef = useRef(context?.videoControls.pause);
-
-    useEffect(() => {
-        playRef.current = context?.videoControls.play;
-    }, [context?.videoControls.play]);
-
-    useEffect(() => {
-        pauseRef.current = context?.videoControls.pause;
-    }, [context?.videoControls.pause]);
-
-    useEffect(() => {
-        if (isLoadingPredictions && context?.videoControls.isPlaying) {
-            isPausedBySystem.current = true;
-            pauseRef.current?.();
-        } else if (!isLoadingPredictions && isPausedBySystem.current) {
-            isPausedBySystem.current = false;
-            playRef.current?.();
-        }
-    }, [isLoadingPredictions, context?.videoControls.isPlaying]);
 };
 
 type AnnotatorProps = {

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -104,6 +104,7 @@ const Annotator = ({
                     onModeChange={onChangeAnnotatorMode}
                     onSelectNextMediaItem={selectNextMediaItem}
                     subset={currentSubset}
+                    isSubsetChanged={currentSubset !== subset}
                 />
             </View>
 

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -1,16 +1,20 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { Key, View } from '@geti/ui';
+import { Key, Loading, View } from '@geti/ui';
 
 import type { DatasetSubset, Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
+import { useIsLoadingAnyPredictions } from '../../annotator/api/use-media-predictions';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
-import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
+import {
+    useVideoPlayerContext,
+    VideoPlayerProvider,
+} from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { PrimaryToolbar } from './primary-toolbar/primary-toolbar.component';
@@ -55,6 +59,32 @@ const useSubset = (subset: DatasetSubset, mediaItem: Media) => {
     };
 };
 
+const usePlayPauseVideoBySystem = (isLoadingPredictions: boolean) => {
+    const isPausedBySystem = useRef<boolean>(false);
+    const context = useVideoPlayerContext();
+
+    const playRef = useRef(context?.videoControls.play);
+    const pauseRef = useRef(context?.videoControls.pause);
+
+    useEffect(() => {
+        playRef.current = context?.videoControls.play;
+    }, [context?.videoControls.play]);
+
+    useEffect(() => {
+        pauseRef.current = context?.videoControls.pause;
+    }, [context?.videoControls.pause]);
+
+    useEffect(() => {
+        if (isLoadingPredictions && context?.videoControls.isPlaying) {
+            isPausedBySystem.current = true;
+            pauseRef.current?.();
+        } else if (!isLoadingPredictions && isPausedBySystem.current) {
+            isPausedBySystem.current = false;
+            playRef.current?.();
+        }
+    }, [isLoadingPredictions, context?.videoControls.isPlaying]);
+};
+
 type AnnotatorProps = {
     image: ImageData;
     mediaItem: Media;
@@ -78,8 +108,14 @@ const Annotator = ({
     onSelectedMediaItem,
     onChangeAnnotatorMode,
 }: AnnotatorProps) => {
+    const isAnnotationMode = mode === 'annotation';
+    const isPredictionMode = mode === 'prediction';
+
     const { nextMediaItem } = useNextMediaPrefetch(mediaItem, items);
     const { currentSubset, changeCurrentSubset, isReadOnlySubset } = useSubset(subset, mediaItem);
+    const isLoadingPredictions = useIsLoadingAnyPredictions(mediaItem.id) && isPredictionMode;
+
+    usePlayPauseVideoBySystem(isLoadingPredictions);
 
     const selectNextMediaItem = async () => {
         if (nextMediaItem === undefined) {
@@ -88,9 +124,6 @@ const Annotator = ({
 
         onSelectedMediaItem(nextMediaItem);
     };
-
-    const isAnnotationMode = mode === 'annotation';
-    const isPredictionMode = mode === 'prediction';
 
     return (
         <>
@@ -105,6 +138,7 @@ const Annotator = ({
                     onSelectNextMediaItem={selectNextMediaItem}
                     subset={currentSubset}
                     isSubsetChanged={currentSubset !== subset}
+                    isLoadingPredictions={isLoadingPredictions}
                 />
             </View>
 
@@ -130,7 +164,8 @@ const Annotator = ({
                 />
             </View>
 
-            <View gridArea={'canvas'} overflow={'hidden'}>
+            <View gridArea={'canvas'} overflow={'hidden'} position={'relative'}>
+                {isLoadingPredictions && <Loading mode={'overlay'} />}
                 <AnnotatorCanvasSettings>
                     <AnnotatorCanvas mediaItem={mediaItem} image={image} mode={mode} isReadOnly={isPredictionMode} />
                 </AnnotatorCanvasSettings>

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -9,7 +9,7 @@ import type { DatasetSubset, Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { useIsLoadingAnyPredictions } from '../../annotator/api/use-media-predictions';
+import { useIsFetchingAnyPredictions } from '../../annotator/api/use-media-predictions';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
@@ -84,7 +84,7 @@ const Annotator = ({
 
     const { nextMediaItem } = useNextMediaPrefetch(mediaItem, items);
     const { currentSubset, changeCurrentSubset, isReadOnlySubset } = useSubset(subset, mediaItem);
-    const isLoadingPredictions = useIsLoadingAnyPredictions(mediaItem.id) && isPredictionMode;
+    const isLoadingPredictions = useIsFetchingAnyPredictions(mediaItem.id) && isPredictionMode;
 
     usePlayPauseVideoBySystem(isLoadingPredictions);
 
@@ -108,7 +108,7 @@ const Annotator = ({
                     onModeChange={onChangeAnnotatorMode}
                     onSelectNextMediaItem={selectNextMediaItem}
                     subset={currentSubset}
-                    isSubsetChanged={currentSubset !== subset}
+                    hasSubsetChanged={currentSubset !== subset}
                     isLoadingPredictions={isLoadingPredictions}
                 />
             </View>

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/prediction-model-selector.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/prediction-model-selector.component.tsx
@@ -6,7 +6,11 @@ import { isEmpty } from 'lodash-es';
 
 import { usePredictionSetup } from '../../../../annotator/predictions-setup-provider.component';
 
-export const PredictionModelSelector = () => {
+type PredictionModelSelectorProps = {
+    isDisabled: boolean;
+};
+
+export const PredictionModelSelector = ({ isDisabled }: PredictionModelSelectorProps) => {
     const { models, selectedModelId, changeSelectedModelId } = usePredictionSetup();
 
     if (isEmpty(models)) {
@@ -19,6 +23,7 @@ export const PredictionModelSelector = () => {
             aria-label={'Select prediction model'}
             items={models}
             selectedKey={selectedModelId}
+            isDisabled={isDisabled}
             onSelectionChange={(key) => key !== null && changeSelectedModelId(String(key))}
         >
             {(item) => <Item key={item.id}>{item.name}</Item>}

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/predictions-buttons.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/predictions-buttons.component.tsx
@@ -46,10 +46,7 @@ export const PredictionButtons = ({ onSubmit, onModeChange, isDisabled }: Predic
                 <Text>Confirm prediction</Text>
             </ActionButton>
 
-            <EditPredictionButton
-                onEditPrediction={handleEditPrediction}
-                isDisabled={isEmpty(annotations) || isDisabled}
-            />
+            <EditPredictionButton onEditPrediction={handleEditPrediction} isDisabled={isDisabled} />
         </>
     );
 };

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/predictions-buttons.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/predictions-buttons.component.tsx
@@ -3,7 +3,6 @@
 
 import { ActionButton, Icon, Text } from '@geti/ui';
 import { Checkmark, Edit } from '@geti/ui/icons';
-import { isEmpty } from 'lodash-es';
 
 import { useAnnotationActions } from '../../../../../shared/annotator/annotation-actions-provider.component';
 import type { AnnotatorMode } from '../../../../../shared/annotator/annotator-mode';

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 import { ActionButton, Button, ButtonGroup, Divider, Flex, Icon, Text } from '@geti/ui';
@@ -9,6 +9,7 @@ import type { DatasetSubset, Media } from '../../../../constants/shared-types';
 import { useAnnotationActions } from '../../../../shared/annotator/annotation-actions-provider.component';
 import type { AnnotatorMode } from '../../../../shared/annotator/annotator-mode';
 import { Labels } from '../../../annotator/labels/labels.component';
+import { useVideoPlayerContext } from '../../../annotator/video-player/video-player-provider.component';
 import { isClassificationTask, isMultiLabelClassificationTask } from '../../../project/task-type-guards';
 import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-item.component';
 import { Toolbar } from '../toolbar-container/toolbar-container.component';
@@ -47,7 +48,8 @@ type SecondaryToolbarProps = {
     onModeChange: (mode: AnnotatorMode) => void;
     onSelectNextMediaItem: () => void;
     subset: DatasetSubset;
-    isSubsetChanged?: boolean;
+    isSubsetChanged: boolean;
+    isLoadingPredictions: boolean;
 };
 
 export const SecondaryToolbar = ({
@@ -60,8 +62,11 @@ export const SecondaryToolbar = ({
     onSelectNextMediaItem,
     subset,
     isSubsetChanged = false,
+    isLoadingPredictions = false,
 }: SecondaryToolbarProps) => {
     const { data: selectedProject } = useProject();
+    const videoPlayerContext = useVideoPlayerContext();
+    const isPlaying = videoPlayerContext?.videoControls?.isPlaying ?? false;
 
     const { canSubmit, isSaving, submitAnnotations } = useAnnotationActions();
 
@@ -84,7 +89,7 @@ export const SecondaryToolbar = ({
     const isAnnotationMode = mode === 'annotation';
 
     // If annotations are not changed but subset has changed we want to allow user to submit
-    const isSubmitDisabled = !((canSubmit || isSubsetChanged) && !isSaving);
+    const isSubmitDisabled = (!canSubmit && !isSubsetChanged) || isSaving || isLoadingPredictions;
 
     return (
         <Flex
@@ -98,7 +103,7 @@ export const SecondaryToolbar = ({
                 <Toolbar.Section>
                     <Flex alignItems={'center'} gap={'size-200'}>
                         <AnnotatorModes mode={mode} onModeChange={onModeChange} />
-                        {isPredictionMode && <PredictionModelSelector />}
+                        {isPredictionMode && <PredictionModelSelector isDisabled={isLoadingPredictions || isPlaying} />}
                     </Flex>
                 </Toolbar.Section>
             </Toolbar.Container>

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -48,7 +48,7 @@ type SecondaryToolbarProps = {
     onModeChange: (mode: AnnotatorMode) => void;
     onSelectNextMediaItem: () => void;
     subset: DatasetSubset;
-    isSubsetChanged: boolean;
+    hasSubsetChanged: boolean;
     isLoadingPredictions: boolean;
 };
 
@@ -61,7 +61,7 @@ export const SecondaryToolbar = ({
     onModeChange,
     onSelectNextMediaItem,
     subset,
-    isSubsetChanged = false,
+    hasSubsetChanged = false,
     isLoadingPredictions = false,
 }: SecondaryToolbarProps) => {
     const { data: selectedProject } = useProject();
@@ -89,7 +89,7 @@ export const SecondaryToolbar = ({
     const isAnnotationMode = mode === 'annotation';
 
     // If annotations are not changed but subset has changed we want to allow user to submit
-    const isSubmitDisabled = (!canSubmit && !isSubsetChanged) || isSaving || isLoadingPredictions;
+    const isSubmitDisabled = (!canSubmit && !hasSubsetChanged) || isSaving || isLoadingPredictions;
 
     return (
         <Flex

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -47,6 +47,7 @@ type SecondaryToolbarProps = {
     onModeChange: (mode: AnnotatorMode) => void;
     onSelectNextMediaItem: () => void;
     subset: DatasetSubset;
+    isSubsetChanged?: boolean;
 };
 
 export const SecondaryToolbar = ({
@@ -58,6 +59,7 @@ export const SecondaryToolbar = ({
     onModeChange,
     onSelectNextMediaItem,
     subset,
+    isSubsetChanged = false,
 }: SecondaryToolbarProps) => {
     const { data: selectedProject } = useProject();
 
@@ -82,7 +84,7 @@ export const SecondaryToolbar = ({
     const isAnnotationMode = mode === 'annotation';
 
     // If annotations are not changed but subset has changed we want to allow user to submit
-    const isSubmitDisabled = !((canSubmit || subset !== 'unassigned') && !isSaving);
+    const isSubmitDisabled = !((canSubmit || isSubsetChanged) && !isSaving);
 
     return (
         <Flex

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -7,7 +7,22 @@ import { getMockedMediaImage, getMockedVideoFrame, getMultipleMockedMediaImage }
 import { renderHook } from 'test-utils/render';
 
 import type { AnnotationDTO } from '../../../constants/shared-types';
-import { getInitialAnnotations, getNextMediaItem, useAnnotatorMode } from './utils';
+import { useVideoPlayerContext } from '../../annotator/video-player/video-player-provider.component';
+import { getInitialAnnotations, getNextMediaItem, useAnnotatorMode, usePlayPauseVideoBySystem } from './utils';
+
+vi.mock('../../annotator/video-player/video-player-provider.component', () => ({
+    useVideoPlayerContext: vi.fn(),
+}));
+
+const mockUseVideoPlayerContext = vi.mocked(useVideoPlayerContext);
+
+const createVideoPlayerContext = (isPlaying: boolean) => {
+    const play = vi.fn().mockResolvedValue(undefined);
+    const pause = vi.fn();
+    return {
+        videoControls: { isPlaying, play, pause },
+    };
+};
 
 describe('getInitialAnnotations', () => {
     const mockAnnotations: AnnotationDTO[] = [
@@ -167,5 +182,74 @@ describe('useAnnotatorMode', () => {
         });
 
         expect(result.current[0]).toBe('annotation');
+    });
+});
+
+describe('usePlayPauseVideoBySystem', () => {
+    beforeEach(() => {
+        mockUseVideoPlayerContext.mockReturnValue(null);
+    });
+
+    it('does not call play or pause when not loading and video is not playing', () => {
+        const context = createVideoPlayerContext(false);
+        mockUseVideoPlayerContext.mockReturnValue(context as never);
+
+        renderHook(() => usePlayPauseVideoBySystem(false));
+
+        expect(context.videoControls.play).not.toHaveBeenCalled();
+        expect(context.videoControls.pause).not.toHaveBeenCalled();
+    });
+
+    it('calls pause when isLoadingPredictions becomes true and video is playing', () => {
+        const context = createVideoPlayerContext(true);
+        mockUseVideoPlayerContext.mockReturnValue(context as never);
+
+        renderHook(() => usePlayPauseVideoBySystem(true));
+
+        expect(context.videoControls.pause).toHaveBeenCalledTimes(1);
+        expect(context.videoControls.play).not.toHaveBeenCalled();
+    });
+
+    it('calls play when isLoadingPredictions becomes false after system paused the video', () => {
+        const context = createVideoPlayerContext(true);
+        mockUseVideoPlayerContext.mockReturnValue(context as never);
+
+        let isLoading = true;
+        const { rerender } = renderHook(() => usePlayPauseVideoBySystem(isLoading));
+
+        expect(context.videoControls.pause).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            isLoading = false;
+            rerender();
+        });
+
+        expect(context.videoControls.play).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call play when isLoadingPredictions becomes false but video was paused by user', () => {
+        const context = createVideoPlayerContext(false);
+        mockUseVideoPlayerContext.mockReturnValue(context as never);
+
+        let isLoading = true;
+        const { rerender } = renderHook(() => usePlayPauseVideoBySystem(isLoading));
+
+        expect(context.videoControls.pause).not.toHaveBeenCalled();
+
+        act(() => {
+            isLoading = false;
+            rerender();
+        });
+
+        expect(context.videoControls.play).not.toHaveBeenCalled();
+    });
+
+    it('does not call pause when video is not playing and isLoadingPredictions becomes true', () => {
+        const context = createVideoPlayerContext(false);
+        mockUseVideoPlayerContext.mockReturnValue(context as never);
+
+        renderHook(() => usePlayPauseVideoBySystem(true));
+
+        expect(context.videoControls.pause).not.toHaveBeenCalled();
     });
 });

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
@@ -118,4 +118,30 @@ export const useAnnotatorMode = ({
     }, [hasAnnotations, hasPredictions, setMode]);
 
     return [mode, setMode] as const;
+};
+
+export const usePlayPauseVideoBySystem = (isLoadingPredictions: boolean) => {
+    const isPausedBySystem = useRef<boolean>(false);
+    const context = useVideoPlayerContext();
+
+    const playRef = useRef(context?.videoControls.play);
+    const pauseRef = useRef(context?.videoControls.pause);
+
+    useEffect(() => {
+        playRef.current = context?.videoControls.play;
+    }, [context?.videoControls.play]);
+
+    useEffect(() => {
+        pauseRef.current = context?.videoControls.pause;
+    }, [context?.videoControls.pause]);
+
+    useEffect(() => {
+        if (isLoadingPredictions && context?.videoControls.isPlaying) {
+            isPausedBySystem.current = true;
+            pauseRef.current?.();
+        } else if (!isLoadingPredictions && isPausedBySystem.current) {
+            isPausedBySystem.current = false;
+            playRef.current?.();
+        }
+    }, [isLoadingPredictions, context?.videoControls.isPlaying]);
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Add loading overlay while waiting for predictions to be returned from the server.
2. Play/pause video automatically while we're waiting for the predictions.
3. Fix disable state of the submit button.
4. Disabled models picker when video is playing or predictions are loading.
5. Prefetch annotations.

Fix #6184 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
