### PR TITLE
fix: Display proper annotation status for video frame

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -29,7 +29,7 @@ type GalleryProps = {
     hasActiveFilter: boolean;
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
-    isUserReviewed: (mediaItemId: string) => boolean;
+    isMediaItemReviewedById: (mediaItemId: string) => boolean;
 };
 
 // DetailsView isn’t needed, so we’re forcing the cast to prevent TS from complaining about missing properties
@@ -44,7 +44,7 @@ type GalleryListProps = {
     viewMode: ViewModes;
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
-    isUserReviewed: (mediaItemId: string) => boolean;
+    isMediaItemReviewedById: (mediaItemId: string) => boolean;
     onSelectedMediaItemChange: (item: Media) => void;
 };
 
@@ -54,7 +54,7 @@ const GalleryList = ({
     isFetchingNextPage,
     fetchNextPage,
     onSelectedMediaItemChange,
-    isUserReviewed,
+    isMediaItemReviewedById,
 }: GalleryListProps) => {
     const projectId = useProjectIdentifier();
     const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
@@ -115,7 +115,7 @@ const GalleryList = ({
                             </Flex>
                         )}
                         bottomRightElement={() => (
-                            <AnnotationStatusIcon state={isUserReviewed(item.id) ? 'accepted' : undefined} />
+                            <AnnotationStatusIcon state={isMediaItemReviewedById(item.id) ? 'accepted' : undefined} />
                         )}
                     />
                 );
@@ -131,7 +131,7 @@ export const Gallery = ({
     hasActiveFilter,
     isFetchingNextPage,
     fetchNextPage,
-    isUserReviewed,
+    isMediaItemReviewedById,
 }: GalleryProps) => {
     const { selectedMediaItem, onSelectedMediaItemChange } = useSelectDatasetItem();
 
@@ -145,7 +145,7 @@ export const Gallery = ({
                 items={items}
                 viewMode={viewMode}
                 fetchNextPage={fetchNextPage}
-                isUserReviewed={isUserReviewed}
+                isMediaItemReviewedById={isMediaItemReviewedById}
                 onSelectedMediaItemChange={onSelectedMediaItemChange}
                 isFetchingNextPage={isFetchingNextPage}
             />

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -36,7 +36,7 @@ type MediaPreviewContentProps = {
     onSelectedMediaItem: (item: Media) => void;
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
-    isUserReviewed: (mediaItemId: string) => boolean;
+    isMediaItemReviewedById: (mediaItemId: string) => boolean;
 };
 
 type MediaPreviewPanelsProps = {
@@ -47,7 +47,7 @@ type MediaPreviewPanelsProps = {
     onSelectedMediaItem: (item: Media) => void;
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
-    isUserReviewed: (mediaItemId: string) => boolean;
+    isMediaItemReviewedById: (mediaItemId: string) => boolean;
     isCurrentMediaReviewed: boolean;
     subset: DatasetSubset;
 };
@@ -61,7 +61,7 @@ const MediaPreviewPanels = ({
     onSelectedMediaItem,
     isFetchingNextPage,
     fetchNextPage,
-    isUserReviewed,
+    isMediaItemReviewedById,
     isCurrentMediaReviewed,
 }: MediaPreviewPanelsProps) => {
     const { mediaItem } = useSelectedMediaItem();
@@ -85,7 +85,7 @@ const MediaPreviewPanels = ({
                     mediaItem={mediaItem}
                     isFetchingNextPage={isFetchingNextPage}
                     fetchNextPage={fetchNextPage}
-                    isUserReviewed={isUserReviewed}
+                    isUserReviewed={isMediaItemReviewedById}
                     onSelectedMediaItem={handleMediaTransition}
                 />
             </View>
@@ -99,7 +99,7 @@ const MediaPreviewContent = ({
     onClose,
     isFetchingNextPage,
     fetchNextPage,
-    isUserReviewed,
+    isMediaItemReviewedById,
 }: MediaPreviewContentProps) => {
     const { mediaItem } = useSelectedMediaItem();
     const { selectedModelId } = usePredictionSetup();
@@ -143,7 +143,7 @@ const MediaPreviewContent = ({
                     onSelectedMediaItem={onSelectedMediaItem}
                     isFetchingNextPage={isFetchingNextPage}
                     fetchNextPage={fetchNextPage}
-                    isUserReviewed={isUserReviewed}
+                    isMediaItemReviewedById={isMediaItemReviewedById}
                     isCurrentMediaReviewed={isCurrentMediaReviewed}
                     subset={subset}
                 />
@@ -153,7 +153,7 @@ const MediaPreviewContent = ({
 };
 
 export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPreviewProps) => {
-    const { items, isFetchingNextPage, fetchNextPage, isUserReviewed } = useDatasetMediaWithReviewStatus({});
+    const { items, isFetchingNextPage, fetchNextPage, isMediaItemReviewedById } = useDatasetMediaWithReviewStatus({});
 
     return (
         <Dialog
@@ -185,7 +185,7 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                                 onSelectedMediaItem={onSelectedMediaItem}
                                 isFetchingNextPage={isFetchingNextPage}
                                 fetchNextPage={fetchNextPage}
-                                isUserReviewed={isUserReviewed}
+                                isMediaItemReviewedById={isMediaItemReviewedById}
                             />
                         </PredictionsSetupProvider>
                     </SelectedMediaItemProvider>

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -48,6 +48,7 @@ type MediaPreviewPanelsProps = {
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
     isUserReviewed: (mediaItemId: string) => boolean;
+    isCurrentMediaReviewed: boolean;
     subset: DatasetSubset;
 };
 
@@ -61,6 +62,7 @@ const MediaPreviewPanels = ({
     isFetchingNextPage,
     fetchNextPage,
     isUserReviewed,
+    isCurrentMediaReviewed,
 }: MediaPreviewPanelsProps) => {
     const { mediaItem } = useSelectedMediaItem();
     const handleMediaTransition = useAnnotatorMediaTransition({ onSelectedMediaItem });
@@ -72,7 +74,7 @@ const MediaPreviewPanels = ({
                 items={items}
                 subset={subset}
                 onClose={onClose}
-                isUserReviewed={isUserReviewed(mediaItem.id)}
+                isUserReviewed={isCurrentMediaReviewed}
                 changeAnnotatorMode={changeAnnotatorMode}
                 onSelectedMediaItem={handleMediaTransition}
             />
@@ -142,6 +144,7 @@ const MediaPreviewContent = ({
                     isFetchingNextPage={isFetchingNextPage}
                     fetchNextPage={fetchNextPage}
                     isUserReviewed={isUserReviewed}
+                    isCurrentMediaReviewed={isCurrentMediaReviewed}
                     subset={subset}
                 />
             </AnnotatorProviders>

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -23,7 +23,7 @@ export const useDatasetMediaWithReviewStatus = ({ annotationStatus }: UseDataset
         }
     };
 
-    const isUserReviewed = (mediaItemId: string) => {
+    const isMediaItemReviewedById = (mediaItemId: string) => {
         return datasetItemsResponse.reviewStatus.get(mediaItemId) ?? false;
     };
 
@@ -32,6 +32,6 @@ export const useDatasetMediaWithReviewStatus = ({ annotationStatus }: UseDataset
         isPending: mediaItemsResponse.isPending || datasetItemsResponse.isPending,
         isFetchingNextPage: mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
         fetchNextPage,
-        isUserReviewed,
+        isMediaItemReviewedById,
     };
 };

--- a/application/ui/src/routes/dataset/dataset.component.tsx
+++ b/application/ui/src/routes/dataset/dataset.component.tsx
@@ -16,9 +16,10 @@ import { ImportJobsList } from '../../features/dataset/import-export/import-jobs
 export const Dataset = () => {
     const [viewMode, setViewMode] = useViewMode('dataset-gallery-view-mode');
     const [filterStatus, setFilterStatus] = useState<DatasetItemAnnotationStatus | null>(null);
-    const { items, isPending, isFetchingNextPage, fetchNextPage, isUserReviewed } = useDatasetMediaWithReviewStatus({
-        annotationStatus: filterStatus ?? undefined,
-    });
+    const { items, isPending, isFetchingNextPage, fetchNextPage, isMediaItemReviewedById } =
+        useDatasetMediaWithReviewStatus({
+            annotationStatus: filterStatus ?? undefined,
+        });
 
     const handleFilterByStatusChange = (status: FilterByStatusKey) => {
         setFilterStatus(status === 'all' ? null : status);
@@ -51,7 +52,7 @@ export const Dataset = () => {
                     viewMode={viewMode}
                     isPending={isPending}
                     fetchNextPage={fetchNextPage}
-                    isUserReviewed={isUserReviewed}
+                    isMediaItemReviewedById={isMediaItemReviewedById}
                     hasActiveFilter={filterStatus !== null}
                     isFetchingNextPage={isFetchingNextPage}
                 />


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue is that for video frame we don't have the ID in the UI, in the server ID is only created when annotation for frame is created. Because of that reason we cannot use `isUserReviewed(media.id)` because for videos it checks if the whole video is annotated or no. We use `isUserReviewed` from `/annotations` endpoint that always sends annotation status for media item.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
