### PR TITLE
Video frames grouping during extraction

### DIFF
--- a/application/backend/app/services/media_prediction_service.py
+++ b/application/backend/app/services/media_prediction_service.py
@@ -185,25 +185,26 @@ class MediaPredictionService(BaseSessionManagedService):
         batch_inference_result: BatchInferenceResult,
         model_id: UUID,
     ) -> None:
+        prediction_map: dict[tuple[UUID, int | None], BatchInferencePrediction] = {
+            (pred.media.id, pred.media.frame_index): pred for pred in batch_inference_result.predictions
+        }
+        input_map: dict[tuple[UUID, int | None], BatchInferenceInput] = {
+            (inp.media_id, inp.frame_index): inp for inp in inputs
+        }
+
         for media in loaded_media.single_media:
-            prediction = next(pred for pred in batch_inference_result.predictions if pred.media.id == media.id)
+            prediction = prediction_map[(media.id, None)]
             self._create_or_update_dataset_item(project=project, media=media, prediction=prediction, model_id=model_id)
 
         for frame in loaded_media.video_frames:
-            prediction = next(
-                pred
-                for pred in batch_inference_result.predictions
-                if pred.media.id == frame.video_id and pred.media.frame_index == frame.frame_index
-            )
+            prediction = prediction_map[(frame.video_id, frame.frame_index)]
             logger.debug("Prediction is {}, frame is {}", prediction, frame)
             if isinstance(frame, VideoFrame):
                 self._create_or_update_dataset_item(
                     project=project, media=frame, prediction=prediction, model_id=model_id
                 )
             else:
-                input_data = next(
-                    inp for inp in inputs if inp.media_id == frame.video.id and inp.frame_index == frame.frame_index
-                )
+                input_data = input_map[(frame.video_id, frame.frame_index)]
                 frame_image = PILImage.fromarray(input_data.data)
                 video_frame = self._media_service.save_video_frame(
                     project=project, video=frame.video, frame_index=frame.frame_index, frame_image=frame_image

--- a/application/backend/app/services/media_prediction_service.py
+++ b/application/backend/app/services/media_prediction_service.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from collections import defaultdict
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -104,29 +105,43 @@ class MediaPredictionService(BaseSessionManagedService):
                 )
         return LoadedMedia(single_media=single_media, video_frames=video_frames)
 
-    def _convert_to_inference_input(
-        self, project: Project, loaded_media: LoadedMedia
-    ) -> tuple[list[BatchInferenceInput], dict[NotAnnotatedVideoFrame, PILImage.Image]]:
+    def _convert_to_inference_input(self, project: Project, loaded_media: LoadedMedia) -> list[BatchInferenceInput]:
         inputs: list[BatchInferenceInput] = []
-        frame_images: dict[NotAnnotatedVideoFrame, PILImage.Image] = {}
+
+        # Process single media (images and already-saved video frames)
         for single_media in loaded_media.single_media:
             data = self._load_media_binary(project_id=project.id, media=single_media)
             inputs.append(BatchInferenceInput(media_id=single_media.id, data=data))
+
+        # Process video frames: group by video to extract all frames per video in a single pass
+        annotated_by_video: dict[UUID, list[VideoFrame]] = defaultdict(list)
+        not_annotated_by_video: dict[UUID, list[NotAnnotatedVideoFrame]] = defaultdict(list)
         for video_frame in loaded_media.video_frames:
             if isinstance(video_frame, VideoFrame):
-                binary_data = self._load_media_binary(project_id=project.id, media=video_frame)
+                annotated_by_video[video_frame.video_id].append(video_frame)
             else:
-                frame_image = self._media_service.get_frame_binary(
-                    project=project, video=video_frame.video, frame_index=video_frame.frame_index
-                )
-                frame_images[video_frame] = frame_image
-                binary_data = np.asarray(frame_image)
-            inputs.append(
-                BatchInferenceInput(
-                    media_id=video_frame.video_id, data=binary_data, frame_index=video_frame.frame_index
-                )
+                not_annotated_by_video[video_frame.video.id].append(video_frame)
+
+        # Load annotated video frames (already saved as images on disk)
+        for _video_id, frames in annotated_by_video.items():
+            for vf in frames:
+                binary_data = self._load_media_binary(project_id=project.id, media=vf)
+                inputs.append(BatchInferenceInput(media_id=vf.video_id, data=binary_data, frame_index=vf.frame_index))
+
+        # Batch-extract not-annotated video frames: one video open/close per video
+        for video_id, frames in not_annotated_by_video.items():
+            video = frames[0].video
+            frame_indexes = [f.frame_index for f in frames]
+            extracted = self._media_service.get_frame_binaries(
+                project=project, video=video, frame_indexes=frame_indexes
             )
-        return inputs, frame_images
+            for na_frame in frames:
+                binary_data = extracted[na_frame.frame_index]
+                inputs.append(
+                    BatchInferenceInput(media_id=na_frame.video.id, data=binary_data, frame_index=na_frame.frame_index)
+                )
+
+        return inputs
 
     def _create_or_update_dataset_item(
         self,
@@ -166,7 +181,7 @@ class MediaPredictionService(BaseSessionManagedService):
         self,
         project: Project,
         loaded_media: LoadedMedia,
-        frame_images: dict[NotAnnotatedVideoFrame, PILImage.Image],
+        inputs: list[BatchInferenceInput],
         batch_inference_result: BatchInferenceResult,
         model_id: UUID,
     ) -> None:
@@ -186,7 +201,10 @@ class MediaPredictionService(BaseSessionManagedService):
                     project=project, media=frame, prediction=prediction, model_id=model_id
                 )
             else:
-                frame_image = frame_images[frame]
+                input_data = next(
+                    inp for inp in inputs if inp.media_id == frame.video.id and inp.frame_index == frame.frame_index
+                )
+                frame_image = PILImage.fromarray(input_data.data)
                 video_frame = self._media_service.save_video_frame(
                     project=project, video=frame.video, frame_index=frame.frame_index, frame_image=frame_image
                 )
@@ -227,7 +245,7 @@ class MediaPredictionService(BaseSessionManagedService):
             "Loaded {} media and {} video frames", len(loaded_media.single_media), len(loaded_media.video_frames)
         )
 
-        inputs, frame_images = self._convert_to_inference_input(project=project, loaded_media=loaded_media)
+        inputs = self._convert_to_inference_input(project=project, loaded_media=loaded_media)
 
         labels = self._label_service.list_all(project_id=project.id)
 
@@ -241,7 +259,7 @@ class MediaPredictionService(BaseSessionManagedService):
             self._create_dataset_items(
                 project=project,
                 loaded_media=loaded_media,
-                frame_images=frame_images,
+                inputs=inputs,
                 batch_inference_result=batch_inference_result,
                 model_id=request.model_id,
             )

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -19,7 +19,7 @@ from app.db.schema import MediaDB
 from app.models import DatasetItem, DatasetItemAnnotationStatus, Media, MediaType, Project, Video, VideoFrame
 from app.models.media import ImageFormat, MediaAdapter, VideoFormat
 from app.repositories import MediaRepository
-from app.services.video import extract_video_frame, get_video_metadata
+from app.services.video import extract_video_frame, extract_video_frames, get_video_metadata
 from app.utils.images import convert_to_jpeg_compatible, crop_to_thumbnail
 
 from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
@@ -314,6 +314,21 @@ class MediaService(BaseSessionManagedService):
     def get_frame_binary(self, project: Project, video: Video, frame_index: int) -> Image.Image:
         video_path = self.get_media_binary_path(project_id=project.id, media=video)
         return self._get_frame_binary_from_video_file(video_path=video_path, frame_index=frame_index)
+
+    def get_frame_binaries(self, project: Project, video: Video, frame_indexes: list[int]) -> dict[int, np.ndarray]:
+        """
+        Extract multiple frames from a video in a single pass.
+
+        Args:
+            project: Project containing the video.
+            video: Video to extract frames from.
+            frame_indexes: List of frame indexes to extract.
+
+        Returns:
+            Dictionary mapping frame index to numpy array (RGB format).
+        """
+        video_path = self.get_media_binary_path(project_id=project.id, media=video)
+        return extract_video_frames(video_path=video_path, frame_indexes=frame_indexes)
 
     def get_frame_thumbnail(self, project: Project, video: Video, frame_index: int) -> Image.Image:
         video_frame = self.get_frame_binary(project=project, video=video, frame_index=frame_index)

--- a/application/backend/app/services/video/__init__.py
+++ b/application/backend/app/services/video/__init__.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from .video_service import extract_video_frame, get_video_metadata
+from .video_service import extract_video_frame, extract_video_frames, get_video_metadata
 
 __all__ = [
     "extract_video_frame",
+    "extract_video_frames",
     "get_video_metadata",
 ]

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -59,19 +59,46 @@ def extract_video_frame(
     Returns:
         Extracted video frame as numpy array (RGB format)
     """
+    frames = extract_video_frames(video_path=video_path, frame_indexes=[frame_index])
+    return frames[frame_index]
+
+
+def extract_video_frames(
+    video_path: Path,
+    frame_indexes: list[int],
+) -> dict[int, np.ndarray]:
+    """
+    Extracts multiple video frames in a single pass over the video file.
+    The video is opened once and frames are read in ascending index order for optimal sequential access.
+
+    Args:
+        video_path: Video binary file path
+        frame_indexes: List of frame indexes to extract
+
+    Returns:
+        Dictionary mapping frame index to the extracted frame as numpy array (RGB format)
+    """
+    if not frame_indexes:
+        return {}
+
     cap = cv2.VideoCapture(str(video_path))
     if not cap.isOpened():
         raise RuntimeError(f"Cannot open video: {video_path}")
 
+    frames: dict[int, np.ndarray] = {}
     try:
-        cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
-        # Read the frame at the requested position
-        read_success, frame = cap.read()
-        if not read_success:
-            raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
-        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        sorted_indexes = sorted(set(frame_indexes))
+        for frame_index in sorted_indexes:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+            read_success, frame = cap.read()
+            if not read_success:
+                raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
+            frames[frame_index] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        return frames
+    except RuntimeError:
+        raise
     except Exception as e:
-        logger.error(f"Failed extracting video frame {frame_index} from video {video_path}", exc_info=e)
-        raise RuntimeError("Error occurred while extracting video frame")
+        logger.error(f"Failed extracting video frames from video {video_path}", exc_info=e)
+        raise RuntimeError("Error occurred while extracting video frames")
     finally:
         cap.release()

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -88,12 +88,19 @@ def extract_video_frames(
     frames: dict[int, np.ndarray] = {}
     try:
         sorted_indexes = sorted(set(frame_indexes))
-        for frame_index in sorted_indexes:
-            cap.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+        first_index = sorted_indexes[0]
+        last_index = sorted_indexes[-1]
+        requested_indexes = set(sorted_indexes)
+        if not cap.set(cv2.CAP_PROP_POS_FRAMES, first_index):
+            raise RuntimeError(f"Cannot seek to frame at {first_index} index in video: {video_path}")
+        current_index = first_index
+        while current_index <= last_index:
             read_success, frame = cap.read()
             if not read_success:
-                raise RuntimeError(f"Cannot read frame at {frame_index} index from video: {video_path}")
-            frames[frame_index] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                raise RuntimeError(f"Cannot read frame at {current_index} index from video: {video_path}")
+            if current_index in requested_indexes:
+                frames[current_index] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            current_index += 1
         return frames
     except RuntimeError:
         raise

--- a/application/backend/app/services/video/video_service.py
+++ b/application/backend/app/services/video/video_service.py
@@ -15,6 +15,55 @@ class VideoMetadata(BaseModel):
     fps: float = Field(..., description="Video frames per second", ge=0)
 
 
+def _group_consecutive(sorted_indexes: list[int], gap: int = 8) -> list[list[int]]:
+    """Group sorted frame indexes into runs where neighbours are within *gap* frames.
+
+    Frames within a small gap are cheaper to decode sequentially than to seek
+    to individually, so they are kept in the same group.
+
+    Args:
+        sorted_indexes: Ascending, deduplicated frame indexes.
+        gap: Maximum distance between consecutive indexes in a single group.
+
+    Returns:
+        List of groups, each a list of ascending frame indexes.
+    """
+    if not sorted_indexes:
+        return []
+    groups: list[list[int]] = [[sorted_indexes[0]]]
+    for idx in sorted_indexes[1:]:
+        if idx - groups[-1][-1] <= gap:
+            groups[-1].append(idx)
+        else:
+            groups.append([idx])
+    return groups
+
+
+def _decode_group(cap: cv2.VideoCapture, group: list[int], result: dict[int, np.ndarray]) -> None:
+    """Seek once to the first index of *group* and decode forward, collecting all needed frames.
+
+    Args:
+        cap: Open OpenCV VideoCapture handle.
+        group: Ascending list of frame indexes to extract (must be non-empty).
+        result: Dictionary to populate with ``{frame_index: rgb_ndarray}``.
+    """
+    requested_indexes = set(group)
+    first_index = group[0]
+    last_index = group[-1]
+
+    if not cap.set(cv2.CAP_PROP_POS_FRAMES, first_index):
+        raise RuntimeError(f"Cannot seek to frame at {first_index} index")
+
+    current_index = first_index
+    while current_index <= last_index:
+        read_success, frame = cap.read()
+        if not read_success:
+            raise RuntimeError(f"Cannot read frame at {current_index} index")
+        if current_index in requested_indexes:
+            result[current_index] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        current_index += 1
+
+
 def get_video_metadata(video_path: Path) -> VideoMetadata:
     """
     Extracts a video metadata
@@ -80,6 +129,8 @@ def extract_video_frames(
     """
     if not frame_indexes:
         return {}
+    sorted_indexes = sorted(set(frame_indexes))
+    groups = _group_consecutive(sorted_indexes)
 
     cap = cv2.VideoCapture(str(video_path))
     if not cap.isOpened():
@@ -87,20 +138,8 @@ def extract_video_frames(
 
     frames: dict[int, np.ndarray] = {}
     try:
-        sorted_indexes = sorted(set(frame_indexes))
-        first_index = sorted_indexes[0]
-        last_index = sorted_indexes[-1]
-        requested_indexes = set(sorted_indexes)
-        if not cap.set(cv2.CAP_PROP_POS_FRAMES, first_index):
-            raise RuntimeError(f"Cannot seek to frame at {first_index} index in video: {video_path}")
-        current_index = first_index
-        while current_index <= last_index:
-            read_success, frame = cap.read()
-            if not read_success:
-                raise RuntimeError(f"Cannot read frame at {current_index} index from video: {video_path}")
-            if current_index in requested_indexes:
-                frames[current_index] = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            current_index += 1
+        for group in groups:
+            _decode_group(cap, group, frames)
         return frames
     except RuntimeError:
         raise

--- a/application/backend/tests/unit/services/test_media_prediction_service.py
+++ b/application/backend/tests/unit/services/test_media_prediction_service.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 from uuid import uuid4
 
 import numpy as np
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.models import (
+    BatchInferenceInput,
     BatchInferenceMedia,
     BatchInferencePrediction,
     BatchInferenceResult,
@@ -164,18 +165,18 @@ class TestMediaPredictionServiceUnit:
         video_frame = MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, video_id=video_id, frame_index=0)
 
         not_annotated_video_frame = NotAnnotatedVideoFrame(video=video, frame_index=1)
-        not_annotated_video_frame_binary = PILImage.new("RGB", (1024, 768))
+        not_annotated_video_frame_binary = np.random.randint(0, 255, (768, 1024, 3), dtype=np.uint8)
 
         loaded_media = LoadedMedia(
             single_media=[image],
             video_frames=[video_frame, not_annotated_video_frame],
         )
 
-        fxt_media_service.get_frame_binary.return_value = not_annotated_video_frame_binary
+        fxt_media_service.get_frame_binaries.return_value = {1: not_annotated_video_frame_binary}
 
         with patch.object(fxt_media_prediction_service, "_load_media_binary") as mock_load_media_binary:
             mock_load_media_binary.side_effect = [np.random.rand(100, 100, 3), np.random.rand(100, 100, 3)]
-            result_inputs, result_frame_images = fxt_media_prediction_service._convert_to_inference_input(
+            result_inputs = fxt_media_prediction_service._convert_to_inference_input(
                 project=project,
                 loaded_media=loaded_media,
             )
@@ -186,9 +187,10 @@ class TestMediaPredictionServiceUnit:
                 call(project_id=project.id, media=video_frame),
             ]
         )
-        fxt_media_service.get_frame_binary.assert_called_once_with(project=project, video=video, frame_index=1)
+        fxt_media_service.get_frame_binaries.assert_called_once_with(project=project, video=video, frame_indexes=[1])
         assert len(result_inputs) == 3
-        assert result_frame_images == {not_annotated_video_frame: not_annotated_video_frame_binary}
+        na_frame_input = next(inp for inp in result_inputs if inp.media_id == video_id and inp.frame_index == 1)
+        np.testing.assert_array_equal(na_frame_input.data, not_annotated_video_frame_binary)
 
     def test_create_or_update_dataset_item_not_found(self, fxt_media_prediction_service, fxt_dataset_service):
         model_id = uuid4()
@@ -281,13 +283,17 @@ class TestMediaPredictionServiceUnit:
         not_annotated_video_frame_image_annotation = MagicMock(spec=DatasetItemAnnotation)
 
         not_annotated_video_frame = NotAnnotatedVideoFrame(video=video, frame_index=1)
-        not_annotated_video_frame_binary = PILImage.new("RGB", (1024, 768))
+        not_annotated_video_frame_numpy = np.random.randint(0, 255, (768, 1024, 3), dtype=np.uint8)
 
         loaded_media = LoadedMedia(
             single_media=[image],
             video_frames=[video_frame, not_annotated_video_frame],
         )
-        frame_images = {not_annotated_video_frame: not_annotated_video_frame_binary}
+        inputs = [
+            BatchInferenceInput(media_id=image_id, data=np.random.rand(100, 100, 3)),
+            BatchInferenceInput(media_id=video_id, data=np.random.rand(100, 100, 3), frame_index=0),
+            BatchInferenceInput(media_id=video_id, data=not_annotated_video_frame_numpy, frame_index=1),
+        ]
         batch_inference_result = BatchInferenceResult(
             predictions=[
                 image_prediction,
@@ -307,7 +313,7 @@ class TestMediaPredictionServiceUnit:
             fxt_media_prediction_service._create_dataset_items(
                 project=project,
                 loaded_media=loaded_media,
-                frame_images=frame_images,
+                inputs=inputs,
                 batch_inference_result=batch_inference_result,
                 model_id=model_id,
             )
@@ -327,8 +333,11 @@ class TestMediaPredictionServiceUnit:
 
         # Assert that new frame is created together with new dataset item
         fxt_media_service.save_video_frame.assert_called_once_with(
-            project=project, video=video, frame_index=1, frame_image=not_annotated_video_frame_binary
+            project=project, video=video, frame_index=1, frame_image=ANY
         )
+        saved_frame_image = fxt_media_service.save_video_frame.call_args.kwargs["frame_image"]
+        assert isinstance(saved_frame_image, PILImage.Image)
+        np.testing.assert_array_equal(np.asarray(saved_frame_image), not_annotated_video_frame_numpy)
         fxt_dataset_service.create_dataset_item.assert_called_once_with(
             project_id=project.id,
             task=task,
@@ -348,7 +357,6 @@ class TestMediaPredictionServiceUnit:
 
         loaded_media = LoadedMedia(single_media=[], video_frames=[])
         inputs = MagicMock(spec=list)
-        frame_images = MagicMock(spec=dict)
         labels = MagicMock(spec=list)
         batch_inference_result = MagicMock(spec=BatchInferenceResult)
 
@@ -363,7 +371,7 @@ class TestMediaPredictionServiceUnit:
         with (
             patch.object(fxt_media_prediction_service, "_load_media", return_value=loaded_media) as mock_load_media,
             patch.object(
-                fxt_media_prediction_service, "_convert_to_inference_input", return_value=(inputs, frame_images)
+                fxt_media_prediction_service, "_convert_to_inference_input", return_value=inputs
             ) as mock_convert_to_inference_input,
             patch.object(fxt_media_prediction_service, "_create_dataset_items") as mock_create_dataset_items,
         ):
@@ -380,7 +388,7 @@ class TestMediaPredictionServiceUnit:
             mock_create_dataset_items.assert_called_once_with(
                 project=project,
                 loaded_media=loaded_media,
-                frame_images=frame_images,
+                inputs=inputs,
                 batch_inference_result=batch_inference_result,
                 model_id=request.model_id,
             )


### PR DESCRIPTION
Grouping frames by video for optimized extraction from the video file.
Additionally conversion to Pillow image is done only if saving as a dataset item is needed
Resolves #6215