### PR TITLE
Move unit tests to overflow runner

### DIFF
--- a/.github/workflows/lib-lint-and-test.yaml
+++ b/.github/workflows/lib-lint-and-test.yaml
@@ -69,7 +69,7 @@ jobs:
         run: just lint
 
   unit-tests:
-    runs-on: [self-hosted, linux, x64, dev, dmount]
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     permissions:
       contents: read
       # The id-token permission is required by Codecov to use OIDC


### PR DESCRIPTION
This PR reduces the load on the self hosted runner. Unit tests do not depend on a GPU and can be run on the overflow runner instead.


<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
