### PR TITLE
fix: hide annotation status for training datasets

### DIFF
--- a/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/bottom-toolbar/bottom-toolbar.component.tsx
@@ -23,6 +23,7 @@ type BottomToolbarProps = {
     onSubsetChange?: (key: Key | null) => void;
     hideHotkeys?: boolean;
     isReadOnlySubset: boolean;
+    hasAnnotationStatus?: boolean;
 };
 
 export const BottomToolbar = ({
@@ -32,6 +33,7 @@ export const BottomToolbar = ({
     subset,
     onSubsetChange,
     isReadOnlySubset,
+    hasAnnotationStatus = true,
 }: BottomToolbarProps) => {
     const fileName = `${mediaItem.name}.${mediaItem.format} (${mediaItem.width} x ${mediaItem.height} px)`;
 
@@ -48,14 +50,16 @@ export const BottomToolbar = ({
                     <Toolbar.Section>
                         <Flex gap={'size-100'} alignItems={'center'} height={'100%'}>
                             <Text UNSAFE_className={classes.filename}>{fileName}</Text>
-                            <Tag
-                                className={clsx({
-                                    [classes.accepted]: isUserReviewed,
-                                    [classes.forReview]: !isUserReviewed,
-                                })}
-                                prefix={isUserReviewed ? <Accept /> : <Search />}
-                                text={isUserReviewed ? 'Accepted' : 'For Review'}
-                            />
+                            {hasAnnotationStatus && (
+                                <Tag
+                                    className={clsx({
+                                        [classes.accepted]: isUserReviewed,
+                                        [classes.forReview]: !isUserReviewed,
+                                    })}
+                                    prefix={isUserReviewed ? <Accept /> : <Search />}
+                                    text={isUserReviewed ? 'Accepted' : 'For Review'}
+                                />
+                            )}
 
                             {isReadOnlySubset ? (
                                 <Tag withDot={false} text={capitalize(subset)} id={'selected-subset-badge'} />

--- a/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/read-only-annotator.component.tsx
@@ -21,6 +21,7 @@ type ReadOnlyAnnotatorProps = {
     image: ImageData;
     onClose: () => void;
     subset: DatasetSubset;
+    hasAnnotationStatus?: boolean;
 };
 
 /**
@@ -34,7 +35,14 @@ type ReadOnlyAnnotatorProps = {
  * Note: This component renders into the parent grid layout from MediaPreview.
  * It uses the same gridArea structure as the normal annotator but with fewer elements.
  */
-export const ReadOnlyAnnotator = ({ mode, image, mediaItem, onClose, subset }: ReadOnlyAnnotatorProps) => {
+export const ReadOnlyAnnotator = ({
+    mode,
+    image,
+    mediaItem,
+    subset,
+    hasAnnotationStatus = true,
+    onClose,
+}: ReadOnlyAnnotatorProps) => {
     return (
         <>
             <View gridArea={'header'} UNSAFE_className={classes.toolbarContainer}>
@@ -65,7 +73,13 @@ export const ReadOnlyAnnotator = ({ mode, image, mediaItem, onClose, subset }: R
             )}
 
             <View gridArea={'bottom'}>
-                <BottomToolbar mediaItem={mediaItem} hideHotkeys subset={subset} isReadOnlySubset />
+                <BottomToolbar
+                    mediaItem={mediaItem}
+                    hideHotkeys
+                    subset={subset}
+                    isReadOnlySubset
+                    hasAnnotationStatus={hasAnnotationStatus}
+                />
             </View>
         </>
     );

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -75,6 +75,7 @@ const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
                             onClose={onClose}
                             mode={mode}
                             subset={item.subset}
+                            hasAnnotationStatus={false}
                         />
                     </AnnotatorProviders>
                 </Grid>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Closes #6179

<img width="1124" height="840" alt="image" src="https://github.com/user-attachments/assets/a948b201-a38f-412d-a0d1-ad447c88a242" />


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
