### PR TITLE
Allow GPU_SLOTS override for just run-image

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -68,7 +68,8 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("coturn_host", long="coturn-host", help="Coturn server listening host (default: server's public IP)")]
 [arg("coturn_port", long="coturn-port", help="Coturn server listening port (default: 443)")]
 [arg("stun_server", long="stun", help="STUN server URL to use for WebRTC")]
-run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="":
+[arg("gpu-slots", long="gpu-slots", help="Number of GPU slots available for model tuning (default: 1)")]
+run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s nullglob
@@ -212,6 +213,7 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-na
         --publish {{ port }}:{{ port }} \
         --env HOST={{ host }} \
         --env PORT={{ port }} \
+        --env GPU_SLOTS={{ gpu-slots }} \
         --env WEBRTC_ADVERTISE_IP="${HOST_IP}" \
         $COTURN_ENV \
         $STUN_ENV \


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Introduce additional arg `gpu-slots` for `just run-image`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
