### PR TITLE
Upgrade Model API to 0.4.1

### DIFF
--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -1004,7 +1004,7 @@ requires-dist = [
     { name = "onnxconverter-common", specifier = "==1.16.0" },
     { name = "onnxscript", specifier = "==0.6.2" },
     { name = "openvino", specifier = "~=2026.1.0" },
-    { name = "openvino-model-api", git = "https://github.com/open-edge-platform/model_api.git" },
+    { name = "openvino-model-api", specifier = "==0.4.1" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = "==0.12.0" },
     { name = "pytorchcv", specifier = "==0.0.74" },
     { name = "pyyaml", specifier = "==6.0.3" },
@@ -2290,13 +2290,17 @@ wheels = [
 
 [[package]]
 name = "openvino-model-api"
-version = "0.4.0.0"
-source = { git = "https://github.com/open-edge-platform/model_api.git#3be26b34fccd66c95ea374c284f6a1d162ae59f0" }
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "opencv-python-headless", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "openvino", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
     { name = "pillow", marker = "(extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-cuda') or (extra == 'extra-4-geti-cpu' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cpu' and extra == 'extra-8-getitune-cpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-4-geti-xpu') or (extra == 'extra-4-geti-cuda' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-4-geti-xpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-cuda') or (extra == 'extra-8-getitune-cpu' and extra == 'extra-8-getitune-xpu') or (extra == 'extra-8-getitune-cuda' and extra == 'extra-8-getitune-xpu')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/63/5c4fcf0b46d7158eec3f33cae95263de4602da2e35237e0586e1de9f2776/openvino_model_api-0.4.1.tar.gz", hash = "sha256:b5ac69982f9b5fdd025c2feaa76eab807dda5a99acc1f7ae45960ff8f3c32692", size = 516385, upload-time = "2026-04-09T11:54:55.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/53/b894dd4cbf2787d3c4d7851c1ce6cb58a8b764adea2a84e6f05191711280/openvino_model_api-0.4.1-py3-none-any.whl", hash = "sha256:210f4ae13a361a3968726a5cca7c7e8c1a8c4c067abb16b91c98a400076dd083", size = 135028, upload-time = "2026-04-09T11:54:54.621Z" },
 ]
 
 [[package]]

--- a/library/pyproject.toml
+++ b/library/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pytorchcv==0.0.74",
     "timm==1.0.3",
     "openvino~=2026.1.0",
-    "openvino-model-api @ git+https://github.com/open-edge-platform/model_api.git",
+    "openvino-model-api==0.4.1",
     "onnx==1.21.0",
     "onnxconverter-common==1.16.0",
     "onnxscript==0.6.2",

--- a/library/uv.lock
+++ b/library/uv.lock
@@ -1355,7 +1355,7 @@ requires-dist = [
     { name = "onnxconverter-common", specifier = "==1.16.0" },
     { name = "onnxscript", specifier = "==0.6.2" },
     { name = "openvino", specifier = "~=2026.1.0" },
-    { name = "openvino-model-api", git = "https://github.com/open-edge-platform/model_api.git" },
+    { name = "openvino-model-api", specifier = "==0.4.1" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = "==0.12.0" },
     { name = "pytorchcv", specifier = "==0.0.74" },
     { name = "pyyaml", specifier = "==6.0.3" },
@@ -3396,13 +3396,17 @@ wheels = [
 
 [[package]]
 name = "openvino-model-api"
-version = "0.4.0.0"
-source = { git = "https://github.com/open-edge-platform/model_api.git#3be26b34fccd66c95ea374c284f6a1d162ae59f0" }
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "opencv-python-headless" },
     { name = "openvino" },
     { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/63/5c4fcf0b46d7158eec3f33cae95263de4602da2e35237e0586e1de9f2776/openvino_model_api-0.4.1.tar.gz", hash = "sha256:b5ac69982f9b5fdd025c2feaa76eab807dda5a99acc1f7ae45960ff8f3c32692", size = 516385, upload-time = "2026-04-09T11:54:55.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/53/b894dd4cbf2787d3c4d7851c1ce6cb58a8b764adea2a84e6f05191711280/openvino_model_api-0.4.1-py3-none-any.whl", hash = "sha256:210f4ae13a361a3968726a5cca7c7e8c1a8c4c067abb16b91c98a400076dd083", size = 135028, upload-time = "2026-04-09T11:54:54.621Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

This PR upgrades `openvino-model-api` to the public 0.4.1 release. Notable, this MAPI version adds support for [NMS](https://open-edge-platform.github.io/model_api/latest/guides/nms-enablement.html) post-processing, so that this operation doesn't have to be embedded in the OV graph (this operation is not supported by all devices).

Resolves #6142 

### How to test

Train a few models in Geti and verify their predictions.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
