### PR TITLE
API URL issues when accessing UI

### DIFF
--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -24,7 +24,7 @@
         "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
         "lint:fix": "eslint --fix \"./src/**/*.ts*\"",
         "preinstall": "npm run clone-geti-ui-packages",
-        "preview": "rsbuild preview",
+        "preview": "npm run build && rsbuild preview",
         "test:unit": "vitest --config vitest.config.ts",
         "test:unit:watch": "vitest --config vitest.config.ts --reporter=verbose --watch",
         "test:unit:coverage": "vitest --coverage",

--- a/application/ui/src/shared/media-url.utils.test.ts
+++ b/application/ui/src/shared/media-url.utils.test.ts
@@ -1,44 +1,43 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// `API_BASE_URL` is read at module load time, so each scenario uses
-// `vi.doMock` + `vi.resetModules` to re-import the module under test with a
-// different value. This covers:
-//   - Dev/preview: absolute base (e.g. `http://localhost:7860`)
-//   - Docker:      empty base (UI served by FastAPI on the same origin)
+import {
+    getDatasetRevisionThumbnailUrl,
+    getMediaBinaryUrl,
+    getProjectThumbnailUrl,
+    getThumbnailUrl,
+    getVideoFrameBinaryUrl,
+    getVideoFrameThumbnailUrl,
+} from './media-url.utils';
 
-afterEach(() => {
-    vi.resetModules();
-    vi.doUnmock('../api/client');
-});
+const mocks = vi.hoisted(() => ({ apiBaseUrl: '' }));
 
-const loadHelpers = async (apiBaseUrl: string) => {
-    vi.doMock('../api/client', () => ({ API_BASE_URL: apiBaseUrl }));
-    return import('./media-url.utils');
-};
+vi.mock('../api/client', () => ({
+    get API_BASE_URL() {
+        return mocks.apiBaseUrl;
+    },
+}));
 
 describe.each([
     { name: 'absolute base (dev/preview)', base: 'http://localhost:7860', prefix: 'http://localhost:7860' },
     { name: 'absolute base with trailing slash', base: 'http://localhost:7860/', prefix: 'http://localhost:7860' },
     { name: 'empty base (Docker, same origin)', base: '', prefix: '' },
 ])('media-url helpers with $name', ({ base, prefix }) => {
-    it('does not throw when constructing URLs', async () => {
-        await expect(loadHelpers(base)).resolves.toBeDefined();
+    beforeEach(() => {
+        mocks.apiBaseUrl = base;
     });
 
-    it('builds the expected URLs', async () => {
-        const helpers = await loadHelpers(base);
-
-        expect(helpers.getProjectThumbnailUrl('p1')).toBe(`${prefix}/api/projects/p1/thumbnail`);
-        expect(helpers.getThumbnailUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/thumbnail`);
-        expect(helpers.getMediaBinaryUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/binary`);
-        expect(helpers.getDatasetRevisionThumbnailUrl('p1', 'r1', 'm1')).toBe(
+    it('builds the expected URLs', () => {
+        expect(getProjectThumbnailUrl('p1')).toBe(`${prefix}/api/projects/p1/thumbnail`);
+        expect(getThumbnailUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/thumbnail`);
+        expect(getMediaBinaryUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/binary`);
+        expect(getDatasetRevisionThumbnailUrl('p1', 'r1', 'm1')).toBe(
             `${prefix}/api/projects/p1/dataset_revisions/r1/items/m1/thumbnail`
         );
-        expect(helpers.getVideoFrameBinaryUrl('p1', 'm1', 7)).toBe(
+        expect(getVideoFrameBinaryUrl('p1', 'm1', 7)).toBe(
             `${prefix}/api/projects/p1/dataset/media/m1/binary?frame_index=7`
         );
-        expect(helpers.getVideoFrameThumbnailUrl('p1', 'm1', 7)).toBe(
+        expect(getVideoFrameThumbnailUrl('p1', 'm1', 7)).toBe(
             `${prefix}/api/projects/p1/dataset/media/m1/thumbnail?frame_index=7`
         );
     });

--- a/application/ui/src/shared/media-url.utils.test.ts
+++ b/application/ui/src/shared/media-url.utils.test.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// `API_BASE_URL` is read at module load time, so each scenario uses
+// `vi.doMock` + `vi.resetModules` to re-import the module under test with a
+// different value. This covers:
+//   - Dev/preview: absolute base (e.g. `http://localhost:7860`)
+//   - Docker:      empty base (UI served by FastAPI on the same origin)
+
+afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../api/client');
+});
+
+const loadHelpers = async (apiBaseUrl: string) => {
+    vi.doMock('../api/client', () => ({ API_BASE_URL: apiBaseUrl }));
+    return import('./media-url.utils');
+};
+
+describe.each([
+    { name: 'absolute base (dev/preview)', base: 'http://localhost:7860', prefix: 'http://localhost:7860' },
+    { name: 'empty base (Docker, same origin)', base: '', prefix: '' },
+])('media-url helpers with $name', ({ base, prefix }) => {
+    it('does not throw when constructing URLs', async () => {
+        await expect(loadHelpers(base)).resolves.toBeDefined();
+    });
+
+    it('builds the expected URLs', async () => {
+        const helpers = await loadHelpers(base);
+
+        expect(helpers.getProjectThumbnailUrl('p1')).toBe(`${prefix}/api/projects/p1/thumbnail`);
+        expect(helpers.getThumbnailUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/thumbnail`);
+        expect(helpers.getMediaBinaryUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/binary`);
+        expect(helpers.getDatasetRevisionThumbnailUrl('p1', 'r1', 'm1')).toBe(
+            `${prefix}/api/projects/p1/dataset_revisions/r1/items/m1/thumbnail`
+        );
+        expect(helpers.getVideoFrameBinaryUrl('p1', 'm1', 7)).toBe(
+            `${prefix}/api/projects/p1/dataset/media/m1/binary?frame_index=7`
+        );
+        expect(helpers.getVideoFrameThumbnailUrl('p1', 'm1', 7)).toBe(
+            `${prefix}/api/projects/p1/dataset/media/m1/thumbnail?frame_index=7`
+        );
+    });
+});

--- a/application/ui/src/shared/media-url.utils.test.ts
+++ b/application/ui/src/shared/media-url.utils.test.ts
@@ -19,6 +19,7 @@ const loadHelpers = async (apiBaseUrl: string) => {
 
 describe.each([
     { name: 'absolute base (dev/preview)', base: 'http://localhost:7860', prefix: 'http://localhost:7860' },
+    { name: 'absolute base with trailing slash', base: 'http://localhost:7860/', prefix: 'http://localhost:7860' },
     { name: 'empty base (Docker, same origin)', base: '', prefix: '' },
 ])('media-url helpers with $name', ({ base, prefix }) => {
     it('does not throw when constructing URLs', async () => {

--- a/application/ui/src/shared/media-url.utils.ts
+++ b/application/ui/src/shared/media-url.utils.ts
@@ -3,39 +3,27 @@
 
 import { API_BASE_URL } from '../api/client';
 
-export const getProjectThumbnailUrl = (projectId: string) =>
-    new URL(`api/projects/${projectId}/thumbnail`, API_BASE_URL).toString();
+// Use plain string concatenation instead of `new URL(path, base)`. The latter
+// requires an absolute base, but `API_BASE_URL` is an empty string when the UI
+// is served from the same origin as the backend (the default in Docker).
+const apiPath = (path: string) => `${API_BASE_URL}/api/${path}`;
 
-const getMediaBaseUrl = (projectId: string, itemId: string) =>
-    new URL(`api/projects/${projectId}/dataset/media/${itemId}`, API_BASE_URL).toString();
+export const getProjectThumbnailUrl = (projectId: string) => apiPath(`projects/${projectId}/thumbnail`);
+
+const getMediaBaseUrl = (projectId: string, itemId: string) => apiPath(`projects/${projectId}/dataset/media/${itemId}`);
 
 const getDatasetRevisionItemBaseUrl = (projectId: string, datasetRevisionId: string, itemId: string) =>
-    new URL(`api/projects/${projectId}/dataset_revisions/${datasetRevisionId}/items/${itemId}`, API_BASE_URL);
+    apiPath(`projects/${projectId}/dataset_revisions/${datasetRevisionId}/items/${itemId}`);
 
-export const getThumbnailUrl = (projectId: string, itemId: string) => {
-    return new URL('thumbnail', `${getMediaBaseUrl(projectId, itemId)}/`).toString();
-};
+export const getThumbnailUrl = (projectId: string, itemId: string) => `${getMediaBaseUrl(projectId, itemId)}/thumbnail`;
 
-export const getMediaBinaryUrl = (projectId: string, itemId: string) => {
-    return new URL('binary', `${getMediaBaseUrl(projectId, itemId)}/`).toString();
-};
+export const getMediaBinaryUrl = (projectId: string, itemId: string) => `${getMediaBaseUrl(projectId, itemId)}/binary`;
 
-export const getDatasetRevisionThumbnailUrl = (projectId: string, datasetRevisionId: string, itemId: string) => {
-    return new URL('thumbnail', `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/`).toString();
-};
+export const getDatasetRevisionThumbnailUrl = (projectId: string, datasetRevisionId: string, itemId: string) =>
+    `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/thumbnail`;
 
-export const getVideoFrameBinaryUrl = (projectId: string, itemId: string, frameNumber: number) => {
-    const url = new URL(getMediaBinaryUrl(projectId, itemId));
+export const getVideoFrameBinaryUrl = (projectId: string, itemId: string, frameNumber: number) =>
+    `${getMediaBinaryUrl(projectId, itemId)}?frame_index=${frameNumber}`;
 
-    url.searchParams.set('frame_index', frameNumber.toString());
-
-    return url.toString();
-};
-
-export const getVideoFrameThumbnailUrl = (projectId: string, itemId: string, frameNumber: number) => {
-    const url = new URL('thumbnail', `${getMediaBaseUrl(projectId, itemId)}/`);
-
-    url.searchParams.set('frame_index', frameNumber.toString());
-
-    return url.toString();
-};
+export const getVideoFrameThumbnailUrl = (projectId: string, itemId: string, frameNumber: number) =>
+    `${getMediaBaseUrl(projectId, itemId)}/thumbnail?frame_index=${frameNumber}`;

--- a/application/ui/src/shared/media-url.utils.ts
+++ b/application/ui/src/shared/media-url.utils.ts
@@ -6,7 +6,8 @@ import { API_BASE_URL } from '../api/client';
 // Use plain string concatenation instead of `new URL(path, base)`. The latter
 // requires an absolute base, but `API_BASE_URL` is an empty string when the UI
 // is served from the same origin as the backend (the default in Docker).
-const apiPath = (path: string) => `${API_BASE_URL}/api/${path}`;
+const normalizedBase = API_BASE_URL.replace(/\/$/, '');
+const apiPath = (path: string) => `${normalizedBase}/api/${path}`;
 
 export const getProjectThumbnailUrl = (projectId: string) => apiPath(`projects/${projectId}/thumbnail`);
 

--- a/application/ui/src/shared/media-url.utils.ts
+++ b/application/ui/src/shared/media-url.utils.ts
@@ -6,8 +6,7 @@ import { API_BASE_URL } from '../api/client';
 // Use plain string concatenation instead of `new URL(path, base)`. The latter
 // requires an absolute base, but `API_BASE_URL` is an empty string when the UI
 // is served from the same origin as the backend (the default in Docker).
-const normalizedBase = API_BASE_URL.replace(/\/$/, '');
-const apiPath = (path: string) => `${normalizedBase}/api/${path}`;
+const apiPath = (path: string) => `${API_BASE_URL.replace(/\/$/, '')}/api/${path}`;
 
 export const getProjectThumbnailUrl = (projectId: string) => apiPath(`projects/${projectId}/thumbnail`);
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Use plain string concatenation instead of `new URL(path, base)`. The latter requires an absolute base, but `API_BASE_URL` is an empty string when the UI is served from the same origin as the backend (the default in Docker). Which will cause [this](https://github.com/open-edge-platform/training_extensions/issues/5906#issuecomment-4311206760)

* Closes https://github.com/open-edge-platform/training_extensions/issues/5906

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
