### PR TITLE
chore: Improve annotator mode cues

### DIFF
--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
@@ -55,16 +55,33 @@ interface AnnotatorModesProps {
 
 export const AnnotatorModes = ({ mode, onModeChange, hasAnnotations, hasPredictions }: AnnotatorModesProps) => {
     const [dismissedCues, setDismissedCues] = useState<Set<AnnotatorMode>>(new Set());
+
     const shouldDisplayAnnotationCue = mode === 'prediction' && hasAnnotations && !dismissedCues.has('annotation');
     const shouldDisplayPredictionCue =
         mode === 'annotation' && !hasAnnotations && hasPredictions && !dismissedCues.has('prediction');
 
     const handleModeChange = (nextMode: AnnotatorMode) => {
-        const hasContent = nextMode === 'annotation' ? hasAnnotations : hasPredictions;
-
-        if (hasContent) {
-            setDismissedCues((prev) => new Set(prev).add(nextMode));
+        if (mode === nextMode) {
+            return;
         }
+
+        setDismissedCues((prev) => {
+            const next = new Set(prev);
+
+            // user is leaving the current mode — if it had content they've seen it
+            const currentHasContent = mode === 'annotation' ? hasAnnotations : hasPredictions;
+            if (currentHasContent) {
+                next.add(mode);
+            }
+
+            // user is switching to the next mode — if it has content they're about to see it
+            const nextHasContent = nextMode === 'annotation' ? hasAnnotations : hasPredictions;
+            if (nextHasContent) {
+                next.add(nextMode);
+            }
+
+            return next;
+        });
 
         onModeChange(nextMode);
     };

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
@@ -65,22 +65,22 @@ export const AnnotatorModes = ({ mode, onModeChange, hasAnnotations, hasPredicti
             return;
         }
 
-        setDismissedCues((prev) => {
-            const next = new Set(prev);
+        setDismissedCues((prevDismissedCues) => {
+            const nextDismissedCues = new Set(prevDismissedCues);
 
             // user is leaving the current mode — if it had content they've seen it
             const currentHasContent = mode === 'annotation' ? hasAnnotations : hasPredictions;
             if (currentHasContent) {
-                next.add(mode);
+                nextDismissedCues.add(mode);
             }
 
             // user is switching to the next mode — if it has content they're about to see it
             const nextHasContent = nextMode === 'annotation' ? hasAnnotations : hasPredictions;
             if (nextHasContent) {
-                next.add(nextMode);
+                nextDismissedCues.add(nextMode);
             }
 
-            return next;
+            return nextDismissedCues;
         });
 
         onModeChange(nextMode);

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.test.tsx
@@ -134,4 +134,49 @@ describe('AnnotatorModes', () => {
             expect(screen.queryByRole('status', { name: 'Prediction available' })).not.toBeInTheDocument();
         });
     });
+
+    describe('Pre-dismissed cues on mount', () => {
+        it('does not show annotation cue when starting in annotation mode with annotations, after switching to prediction', () => {
+            renderComponent({ mode: 'annotation', hasAnnotations: true, hasPredictions: false });
+
+            fireEvent.click(screen.getByRole('button', { name: 'Prediction' }));
+
+            expect(screen.queryByRole('status', { name: 'Annotation available' })).not.toBeInTheDocument();
+        });
+
+        it('does not show prediction cue when starting in prediction mode with predictions, after switching to annotation', () => {
+            renderComponent({ mode: 'prediction', hasPredictions: true, hasAnnotations: false });
+
+            fireEvent.click(screen.getByRole('button', { name: 'Annotation' }));
+
+            expect(screen.queryByRole('status', { name: 'Prediction available' })).not.toBeInTheDocument();
+        });
+
+        it('shows annotation cue when annotations appear after mount and user switches to prediction', () => {
+            const DynamicWrapper = () => {
+                const [hasAnnotations, setHasAnnotations] = useState(false);
+                const [mode, setMode] = useState<AnnotatorMode>('annotation');
+
+                return (
+                    <>
+                        <button onClick={() => setHasAnnotations(true)}>Add annotations</button>
+                        <AnnotatorModes
+                            mode={mode}
+                            onModeChange={setMode}
+                            hasAnnotations={hasAnnotations}
+                            hasPredictions={false}
+                        />
+                    </>
+                );
+            };
+
+            render(<DynamicWrapper />);
+
+            fireEvent.click(screen.getByRole('button', { name: 'Add annotations' }));
+
+            fireEvent.click(screen.getByRole('button', { name: 'Prediction' }));
+
+            expect(screen.getByRole('status', { name: 'Annotation available' })).toBeInTheDocument();
+        });
+    });
 });

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.test.tsx
@@ -151,32 +151,5 @@ describe('AnnotatorModes', () => {
 
             expect(screen.queryByRole('status', { name: 'Prediction available' })).not.toBeInTheDocument();
         });
-
-        it('shows annotation cue when annotations appear after mount and user switches to prediction', () => {
-            const DynamicWrapper = () => {
-                const [hasAnnotations, setHasAnnotations] = useState(false);
-                const [mode, setMode] = useState<AnnotatorMode>('annotation');
-
-                return (
-                    <>
-                        <button onClick={() => setHasAnnotations(true)}>Add annotations</button>
-                        <AnnotatorModes
-                            mode={mode}
-                            onModeChange={setMode}
-                            hasAnnotations={hasAnnotations}
-                            hasPredictions={false}
-                        />
-                    </>
-                );
-            };
-
-            render(<DynamicWrapper />);
-
-            fireEvent.click(screen.getByRole('button', { name: 'Add annotations' }));
-
-            fireEvent.click(screen.getByRole('button', { name: 'Prediction' }));
-
-            expect(screen.getByRole('status', { name: 'Annotation available' })).toBeInTheDocument();
-        });
     });
 });

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -553,6 +553,8 @@ test.describe('Annotator', () => {
             page,
             network,
         }) => {
+            // item-1: no annotations (404), has predictions
+            // item-2: has 1 annotation, has predictions
             const mediaItems = [
                 getMockedMediaImage({ id: 'item-1', name: 'item-1.jpg', width: 1920, height: 1080 }),
                 getMockedMediaImage({ id: 'item-2', name: 'item-2.jpg', width: 1920, height: 1080 }),
@@ -615,29 +617,39 @@ test.describe('Annotator', () => {
                 })
             );
 
-            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+            await test.step('item-1 (annotation mode): prediction cue visible because there are no annotations but predictions exist', async () => {
+                await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
 
-            await expect(page.getByLabel('Prediction available')).toBeVisible();
+                await expect(page.getByLabel('Prediction available')).toBeVisible();
+            });
 
-            await annotatorPage.openPredictionMode();
+            await test.step('item-1: switching annotation -> prediction dismisses prediction cue; switching back keeps it dismissed', async () => {
+                await annotatorPage.openPredictionMode();
 
-            await annotatorPage.openAnnotationMode();
+                await annotatorPage.openAnnotationMode();
 
-            await expect(page.getByLabel('Prediction available')).toBeHidden();
+                await expect(page.getByLabel('Prediction available')).toBeHidden();
+            });
 
-            await annotatorPage.openPredictionMode();
+            await test.step('navigate to item-2 (in prediction mode): annotation cue visible because there are annotations', async () => {
+                await annotatorPage.openPredictionMode();
+                await annotatorPage.selectMediaItem('item-2');
 
-            await annotatorPage.selectMediaItem('item-2');
+                await expect(page.getByLabel('Annotation available')).toBeVisible();
+            });
 
-            await expect(page.getByLabel('Annotation available')).toBeVisible();
+            await test.step('item-2: switching prediction -> annotation dismisses both cues simultaneously', async () => {
+                await annotatorPage.openAnnotationMode();
 
-            await annotatorPage.openAnnotationMode();
+                await expect(page.getByLabel('Prediction available')).toBeHidden();
+                await expect(page.getByLabel('Annotation available')).toBeHidden();
+            });
 
-            await expect(page.getByLabel('Prediction available')).toBeHidden();
+            await test.step('item-2: switching back to prediction mode keeps annotation cue hidden (already dismissed)', async () => {
+                await annotatorPage.openPredictionMode();
 
-            await annotatorPage.openPredictionMode();
-
-            await expect(page.getByLabel('Annotation available')).toBeHidden();
+                await expect(page.getByLabel('Annotation available')).toBeHidden();
+            });
         });
 
         test('Displays "No object" when media:predict returns empty predictions', async ({


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

When we're in the annotation mode and there is annotation (user sees that) and when we switch to prediction mode, user should not get any cue about available annotation. The same should happen to predictions.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
