### PR TITLE
fix: Task type

### DIFF
--- a/application/ui/src/components/import-card-status/staged-import-dataset/staged-import-dataset.component.tsx
+++ b/application/ui/src/components/import-card-status/staged-import-dataset/staged-import-dataset.component.tsx
@@ -55,7 +55,7 @@ export const StagedImportDataset = ({
                 </>
             }
             bottomIcon={<InfoOutline width={16} height={16} />}
-            bottomLeftMessage={message}
+            bottomIconMessage={message}
         />
     );
 };

--- a/application/ui/src/components/job-status-card/job-status-card.component.tsx
+++ b/application/ui/src/components/job-status-card/job-status-card.component.tsx
@@ -11,7 +11,8 @@ type JobStatusCardProps = {
     title: string;
     message?: string;
     bottomIcon?: ReactNode;
-    bottomLeftMessage: ReactNode;
+    bottomLeftMessage?: ReactNode;
+    bottomIconMessage?: ReactNode;
     bottomRightMessage?: string;
     actionButtons: ReactNode;
 };
@@ -20,6 +21,7 @@ export const JobStatusCard = ({
     title,
     message,
     actionButtons,
+    bottomIconMessage,
     bottomLeftMessage,
     bottomRightMessage,
     bottomIcon = null,
@@ -47,7 +49,10 @@ export const JobStatusCard = ({
 
             <Flex justifyContent='space-between'>
                 <Flex gap={'size-100'} direction={'column'}>
-                    {bottomIcon}
+                    <Flex gap={'size-100'} alignItems={'center'}>
+                        {bottomIcon}
+                        {isNonEmptyString(bottomIconMessage) ? <Text>{bottomIconMessage}</Text> : bottomIconMessage}
+                    </Flex>
 
                     {isNonEmptyString(bottomLeftMessage) ? <Text>{bottomLeftMessage}</Text> : bottomLeftMessage}
                 </Flex>

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
@@ -19,7 +19,17 @@ type ImportTaskSelectionProps = {
     stagedDatasetId: string;
 };
 
-const useFormConfig = (stagedDatasetId: string, defaultTaskType: TaskType | undefined) => {
+const TASK_LABELS: Record<TaskType, string> = {
+    detection: 'Object detection',
+    classification: 'Classification',
+    instance_segmentation: 'Instance segmentation',
+};
+
+const useFormConfig = (
+    stagedDatasetId: string,
+    defaultTaskType: TaskType | undefined,
+    allowedTaskTypes: TaskType[]
+) => {
     const { data: projects } = useProjects();
     const { setCurrentStep } = useImportDatasetDialog();
     const { getImportEntry, updateImportEntry } = useImportDatasetAsNewProject();
@@ -27,9 +37,12 @@ const useFormConfig = (stagedDatasetId: string, defaultTaskType: TaskType | unde
 
     const uniqueProjectName = generateUniqueProjectName(projects.map((project) => project.name));
 
+    const taskType = importEntry?.project?.task_type;
+    const finalTaskType = taskType && allowedTaskTypes.includes(taskType) ? taskType : defaultTaskType;
+
     const initialFormState = {
         name: importEntry?.project?.name ?? uniqueProjectName,
-        task_type: importEntry?.project?.task_type ?? defaultTaskType,
+        task_type: finalTaskType,
     };
 
     return useActionState<{ name: string; task_type: TaskType | undefined }, FormData>(async (_prevState, formData) => {
@@ -53,13 +66,18 @@ export const ImportTaskSelection = ({ stagedDatasetId }: ImportTaskSelectionProp
     const allowedTaskTypes = getAllowedTaskTypes(annotationType);
     const defaultTaskType = isGetiFormat ? getRecommendedTaskType(annotationType) : undefined;
 
-    const [formState, submitAction] = useFormConfig(stagedDatasetId, defaultTaskType);
+    const [formState, submitAction] = useFormConfig(stagedDatasetId, defaultTaskType, allowedTaskTypes);
     const [name, setName] = useState(formState.name);
 
     const validationErrorMessage = validateProjectName(
         name.trim(),
         projects.map((project) => project.name)
     );
+
+    const items = allowedTaskTypes.map((taskType) => ({
+        key: taskType,
+        label: defaultTaskType === taskType ? `${TASK_LABELS[taskType]} (Recommended)` : TASK_LABELS[taskType],
+    }));
 
     return (
         <View backgroundColor={'gray-75'} margin={'size-300'} padding={'size-300'}>
@@ -79,6 +97,7 @@ export const ImportTaskSelection = ({ stagedDatasetId }: ImportTaskSelectionProp
 
                 <Picker
                     isRequired
+                    items={items}
                     name={'task_type'}
                     label={'Task type'}
                     aria-label={'Task type'}
@@ -86,23 +105,7 @@ export const ImportTaskSelection = ({ stagedDatasetId }: ImportTaskSelectionProp
                     placeholder='Select task'
                     defaultSelectedKey={formState.task_type}
                 >
-                    {allowedTaskTypes.includes('detection') ? (
-                        <Item key={'detection'}>
-                            {defaultTaskType === 'detection' ? 'Object detection (Recommended)' : 'Object detection'}
-                        </Item>
-                    ) : null}
-                    {allowedTaskTypes.includes('classification') ? (
-                        <Item key={'classification'}>
-                            {defaultTaskType === 'classification' ? 'Classification (Recommended)' : 'Classification'}
-                        </Item>
-                    ) : null}
-                    {allowedTaskTypes.includes('instance_segmentation') ? (
-                        <Item key={'instance_segmentation'}>
-                            {defaultTaskType === 'instance_segmentation'
-                                ? 'Instance segmentation (Recommended)'
-                                : 'Instance segmentation'}
-                        </Item>
-                    ) : null}
+                    {(item) => <Item>{item.label}</Item>}
                 </Picker>
 
                 <Flex gap='size-100' alignItems={'center'}>

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
@@ -13,7 +13,7 @@ import { TaskType } from '../../../../../constants/shared-types';
 import { generateUniqueProjectName } from '../../../create/utils';
 import { useImportDatasetDialog } from '../../../providers/import-dataset-dialog-provider.component';
 import { validateProjectName } from '../../../validator';
-import { getRecommendedTaskType, TASK_SELECTION_FORM_ID } from './util';
+import { getAllowedTaskTypes, getRecommendedTaskType, TASK_SELECTION_FORM_ID } from './util';
 
 type ImportTaskSelectionProps = {
     stagedDatasetId: string;
@@ -48,8 +48,10 @@ export const ImportTaskSelection = ({ stagedDatasetId }: ImportTaskSelectionProp
     const { data: projects } = useProjects();
     const { data: stagedDataset } = useStagedDatasetSuspense(stagedDatasetId);
 
+    const annotationType = stagedDataset?.metadata?.annotation_type;
     const isGetiFormat = stagedDataset.format === 'geti';
-    const defaultTaskType = isGetiFormat ? getRecommendedTaskType(stagedDataset?.metadata?.annotation_type) : undefined;
+    const allowedTaskTypes = getAllowedTaskTypes(annotationType);
+    const defaultTaskType = isGetiFormat ? getRecommendedTaskType(annotationType) : undefined;
 
     const [formState, submitAction] = useFormConfig(stagedDatasetId, defaultTaskType);
     const [name, setName] = useState(formState.name);
@@ -81,20 +83,26 @@ export const ImportTaskSelection = ({ stagedDatasetId }: ImportTaskSelectionProp
                     label={'Task type'}
                     aria-label={'Task type'}
                     marginBottom={'size-150'}
-                    placeholder='select an option...'
+                    placeholder='Select task'
                     defaultSelectedKey={formState.task_type}
                 >
-                    <Item key={'detection'}>
-                        {defaultTaskType === 'detection' ? 'Object detection (Recommended)' : 'Object detection'}
-                    </Item>
-                    <Item key={'classification'}>
-                        {defaultTaskType === 'classification' ? 'Classification (Recommended)' : 'Classification'}
-                    </Item>
-                    <Item key={'instance_segmentation'}>
-                        {defaultTaskType === 'instance_segmentation'
-                            ? 'Instance segmentation (Recommended)'
-                            : 'Instance segmentation'}
-                    </Item>
+                    {allowedTaskTypes.includes('detection') ? (
+                        <Item key={'detection'}>
+                            {defaultTaskType === 'detection' ? 'Object detection (Recommended)' : 'Object detection'}
+                        </Item>
+                    ) : null}
+                    {allowedTaskTypes.includes('classification') ? (
+                        <Item key={'classification'}>
+                            {defaultTaskType === 'classification' ? 'Classification (Recommended)' : 'Classification'}
+                        </Item>
+                    ) : null}
+                    {allowedTaskTypes.includes('instance_segmentation') ? (
+                        <Item key={'instance_segmentation'}>
+                            {defaultTaskType === 'instance_segmentation'
+                                ? 'Instance segmentation (Recommended)'
+                                : 'Instance segmentation'}
+                        </Item>
+                    ) : null}
                 </Picker>
 
                 <Flex gap='size-100' alignItems={'center'}>

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.test.tsx
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.test.tsx
@@ -88,7 +88,7 @@ describe('ImportTaskSelection', () => {
         const listButton = await screen.findByRole('button', { name: /Task type/i });
         expect(listButton).toBeVisible();
 
-        userEvent.click(listButton);
+        await userEvent.click(listButton);
         const container = await screen.findByRole('listbox');
 
         expect(within(container).getByText('Object detection (Recommended)')).toBeVisible();
@@ -102,7 +102,7 @@ describe('ImportTaskSelection', () => {
         const listButton = await screen.findByRole('button', { name: /Task type/i });
         expect(listButton).toBeVisible();
 
-        userEvent.click(listButton);
+        await userEvent.click(listButton);
         const container = await screen.findByRole('listbox');
 
         expect(within(container).getByText('Object detection')).toBeVisible();
@@ -116,7 +116,7 @@ describe('ImportTaskSelection', () => {
         const listButton = await screen.findByRole('button', { name: /Task type/i });
         expect(listButton).toBeVisible();
 
-        userEvent.click(listButton);
+        await userEvent.click(listButton);
         const container = await screen.findByRole('listbox');
 
         expect(within(container).getByText('Classification (Recommended)')).toBeVisible();

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.test.tsx
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
@@ -82,36 +82,52 @@ describe('ImportTaskSelection', () => {
         render(<ImportTaskSelection stagedDatasetId={mockedStagedDatasetId} />);
     };
 
-    it('shows only Object detection as recommended for bounding box annotations in geti format', async () => {
+    it('shows all three task type options for bounding_box annotations', async () => {
         renderApp({ format: 'geti', taskType: 'detection', annotationType: 'bounding_box' });
 
-        expect(await screen.findByRole('button', { name: /Task type/i })).toHaveTextContent(
-            'Object detection (Recommended)'
-        );
+        const listButton = await screen.findByRole('button', { name: /Task type/i });
+        expect(listButton).toBeVisible();
+
+        userEvent.click(listButton);
+        const container = await screen.findByRole('listbox');
+
+        expect(within(container).getByText('Object detection (Recommended)')).toBeVisible();
+        expect(within(container).getByText('Classification')).toBeVisible();
+        expect(within(container).getByText('Instance segmentation')).toBeVisible();
     });
 
-    it('shows only Instance segmentation as recommended for polygon annotations in geti format', async () => {
+    it('shows all three task type options for polygon annotations', async () => {
         renderApp({ format: 'geti', taskType: 'instance_segmentation', annotationType: 'polygon' });
 
-        expect(await screen.findByRole('button', { name: /Task type/i })).toHaveTextContent(
-            'Instance segmentation (Recommended)'
-        );
-        expect(screen.getByText('Object detection')).toBeVisible();
-        expect(screen.getByText('Classification')).toBeVisible();
+        const listButton = await screen.findByRole('button', { name: /Task type/i });
+        expect(listButton).toBeVisible();
+
+        userEvent.click(listButton);
+        const container = await screen.findByRole('listbox');
+
+        expect(within(container).getByText('Object detection')).toBeVisible();
+        expect(within(container).getByText('Classification')).toBeVisible();
+        expect(within(container).getByText('Instance segmentation (Recommended)')).toBeVisible();
     });
 
-    it('shows only Classification as recommended for label annotations in geti format', async () => {
+    it('shows only Classification option for label annotations', async () => {
         renderApp({ format: 'geti', taskType: 'classification', annotationType: 'label' });
 
-        expect(await screen.findByRole('button', { name: /Task type/i })).toHaveTextContent(
-            'Classification (Recommended)'
-        );
+        const listButton = await screen.findByRole('button', { name: /Task type/i });
+        expect(listButton).toBeVisible();
+
+        userEvent.click(listButton);
+        const container = await screen.findByRole('listbox');
+
+        expect(within(container).getByText('Classification (Recommended)')).toBeVisible();
+        expect(within(container).queryByText('Object detection')).not.toBeInTheDocument();
+        expect(within(container).queryByText('Instance segmentation')).not.toBeInTheDocument();
     });
 
     it('does not show recommended task types for non-geti format', async () => {
         renderApp({ format: 'coco', annotationType: 'bounding_box' });
 
-        expect(await screen.findByRole('button', { name: /Task type/i })).toHaveTextContent(/Select an option.../i);
+        expect(await screen.findByRole('button', { name: /Task type/i })).toHaveTextContent(/Select task/i);
     });
 
     it('shows an error when the project name already exists', async () => {

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/util.ts
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/util.ts
@@ -5,6 +5,14 @@ import { AnnotationType, TaskType } from '../../../../../constants/shared-types'
 
 export const TASK_SELECTION_FORM_ID = 'task-selection-form';
 
+export const getAllowedTaskTypes = (annotationType: AnnotationType | undefined): TaskType[] => {
+    if (annotationType === 'label') {
+        return ['classification'];
+    }
+
+    return ['classification', 'detection', 'instance_segmentation'];
+};
+
 export const getRecommendedTaskType = (annotationType: AnnotationType | undefined): TaskType | undefined => {
     switch (annotationType) {
         case 'bounding_box':


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

This PR filters the tasks based on the dataset files’ annotation_type. If the type is unknown, all task types remain visible.
Closes #6246

| Label  | Polygon | Bounding box | Unknowm |
| ------------- | ------------- | ------------- |  ------------- |
| <img width="861" height="763" alt="image" src="https://github.com/user-attachments/assets/ff76816c-f24d-46d9-bcff-c44430d543b4" /> | <img width="860" height="762" alt="image" src="https://github.com/user-attachments/assets/d47ae05c-20cd-44f7-b286-5c797ae153ae" /> | <img width="858" height="760" alt="image" src="https://github.com/user-attachments/assets/4f56f30d-2c2a-4535-a4d7-0a5cde52be27" /> | <img width="858" height="761" alt="image" src="https://github.com/user-attachments/assets/5d5a8e00-0122-4d7e-b617-6f031031bfcc" /> |



<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
