### PR TITLE
Automate project and squad assignment for new issues

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,24 +4,23 @@ on:
   issues:
     types: [opened, transferred]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   add-to-project:
     name: Add issue to org project and set Squad
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     steps:
       - name: Add issue to project
         id: add-project
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/open-edge-platform/projects/7
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
 
       - name: Set Squad field
         env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
           ITEM_ID: ${{ steps.add-project.outputs.itemId }}
           PROJECT_ID: ${{ vars.PROJECT_ID }}
           SQUAD_FIELD_ID: ${{ vars.SQUAD_FIELD_ID }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,6 +10,9 @@ jobs:
   add-to-project:
     name: Add issue to org project and set Squad
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    environment:
+      name: auto-add-new-issue-to-project
+      deployment: false
     steps:
       - name: Add issue to project
         id: add-project

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Add issue to project
         id: add-project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/open-edge-platform/projects/7
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,68 @@
+name: Add new issues to project
+
+on:
+  issues:
+    types: [opened, transferred]
+  # TEMP: manual dispatch for pre-merge testing. Remove before merging to main.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Existing issue number to process (manual test)
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    name: Add issue to org project and set Squad
+    runs-on: ubuntu-latest
+    steps:
+      # TEMP: resolves an existing issue's URL when run via workflow_dispatch.
+      - name: Resolve issue (manual runs)
+        if: github.event_name == 'workflow_dispatch'
+        id: manual
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          url=$(gh issue view "${{ inputs.issue_number }}" \
+            -R "${{ github.repository }}" --json url --jq .url)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Add issue to project
+        id: add-project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/open-edge-platform/projects/7
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          # Falls back to the issue from the event on normal runs.
+          issue-url: ${{ steps.manual.outputs.url || github.event.issue.html_url }}
+
+      - name: Set Squad field
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          ITEM_ID: ${{ steps.add-project.outputs.itemId }}
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          SQUAD_FIELD_ID: ${{ vars.SQUAD_FIELD_ID }}
+          SQUAD_OPTION_ID: ${{ vars.SQUAD_OPTION_ID }}
+        run: |
+          gh api graphql -f query='
+            mutation(
+              $project: ID!,
+              $item: ID!,
+              $field: ID!,
+              $option: String!
+            ) {
+              updateProjectV2ItemFieldValue(
+                input: {
+                  projectId: $project,
+                  itemId: $item,
+                  fieldId: $field,
+                  value: { singleSelectOptionId: $option }
+                }
+              ) { projectV2Item { id } }
+            }' \
+            -f project="$PROJECT_ID" \
+            -f item="$ITEM_ID" \
+            -f field="$SQUAD_FIELD_ID" \
+            -f option="$SQUAD_OPTION_ID"

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -3,12 +3,6 @@ name: Add new issues to project
 on:
   issues:
     types: [opened, transferred]
-  # TEMP: manual dispatch for pre-merge testing. Remove before merging to main.
-  workflow_dispatch:
-    inputs:
-      issue_number:
-        description: Existing issue number to process (manual test)
-        required: true
 
 permissions:
   contents: read
@@ -18,25 +12,12 @@ jobs:
     name: Add issue to org project and set Squad
     runs-on: ubuntu-latest
     steps:
-      # TEMP: resolves an existing issue's URL when run via workflow_dispatch.
-      - name: Resolve issue (manual runs)
-        if: github.event_name == 'workflow_dispatch'
-        id: manual
-        env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
-        run: |
-          url=$(gh issue view "${{ inputs.issue_number }}" \
-            -R "${{ github.repository }}" --json url --jq .url)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-
       - name: Add issue to project
         id: add-project
         uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/open-edge-platform/projects/7
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          # Falls back to the issue from the event on normal runs.
-          issue-url: ${{ steps.manual.outputs.url || github.event.issue.html_url }}
 
       - name: Set Squad field
         env:


### PR DESCRIPTION
### Summary

This workflow automatically adds new issues to the Geti project and assigns the geti tune squad. Tested the commands run in this workflow locally and works as expected. 

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
