### PR TITLE
Security: Raw exception details returned to clients in WebRTC offer endpoint

### DIFF
--- a/application/backend/app/api/routers/webrtc.py
+++ b/application/backend/app/api/routers/webrtc.py
@@ -27,9 +27,12 @@ async def create_webrtc_offer(offer: Offer, webrtc_manager: Annotated[WebRTCMana
     """Create a WebRTC offer"""
     try:
         return await webrtc_manager.handle_offer(offer)
-    except Exception as e:
+    except Exception:
         logger.exception("Error processing WebRTC offer")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to process WebRTC offer",
+        )
 
 
 @router.post(


### PR DESCRIPTION
## Summary

Security: Raw exception details returned to clients in WebRTC offer endpoint

## Problem

**Severity**: `Medium` | **File**: `application/backend/app/api/routers/webrtc.py:L31`

The `/api/webrtc/offer` handler catches a broad `Exception` and returns `detail=str(e)` in the HTTP 500 response. This can expose internal error messages, stack-context clues, library/runtime details, or sensitive operational information to unauthenticated/low-privilege clients.

## Solution

Return a generic error message to clients (e.g., "Failed to process WebRTC offer") and keep detailed exception information only in server logs. Prefer catching specific expected exception types and mapping them to safe error responses.

## Changes

- `application/backend/app/api/routers/webrtc.py` (modified)