### PR TITLE
fix: Unselect annotation when new annotation is being drawn

### DIFF
--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.test.tsx
@@ -14,6 +14,7 @@ import {
     AnnotationVisibilityProvider,
     useAnnotationVisibility,
 } from '../../../shared/annotator/annotation-visibility-provider.component';
+import { AnnotatorProvider } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { Annotation } from '../../../shared/types';
@@ -86,19 +87,21 @@ const renderWithAnnotation = async (
     render(
         <svg>
             <ZoomProvider>
-                <ToolProvider>
-                    <AnnotationVisibilityProvider>
-                        <CanvasSettingsProvider>
-                            <AnnotatorLabelsProvider>
-                                <AnnotationContext.Provider value={annotation}>
-                                    <EditableAnnotation>
-                                        <Child />
-                                    </EditableAnnotation>
-                                </AnnotationContext.Provider>
-                            </AnnotatorLabelsProvider>
-                        </CanvasSettingsProvider>
-                    </AnnotationVisibilityProvider>
-                </ToolProvider>
+                <AnnotatorProvider>
+                    <ToolProvider>
+                        <AnnotationVisibilityProvider>
+                            <CanvasSettingsProvider>
+                                <AnnotatorLabelsProvider>
+                                    <AnnotationContext.Provider value={annotation}>
+                                        <EditableAnnotation>
+                                            <Child />
+                                        </EditableAnnotation>
+                                    </AnnotationContext.Provider>
+                                </AnnotatorLabelsProvider>
+                            </CanvasSettingsProvider>
+                        </AnnotationVisibilityProvider>
+                    </ToolProvider>
+                </AnnotatorProvider>
             </ZoomProvider>
         </svg>
     );

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.test.tsx
@@ -15,6 +15,7 @@ import {
     useAnnotationVisibility,
 } from '../../../shared/annotator/annotation-visibility-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
+import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { Annotation } from '../../../shared/types';
 import { CanvasSettingsProvider } from '../../dataset/media-preview/primary-toolbar/settings/canvas-settings-provider.component';
 import { AnnotatorLabelsProvider } from '../annotator-labels-provider.component';
@@ -85,17 +86,19 @@ const renderWithAnnotation = async (
     render(
         <svg>
             <ZoomProvider>
-                <AnnotationVisibilityProvider>
-                    <CanvasSettingsProvider>
-                        <AnnotatorLabelsProvider>
-                            <AnnotationContext.Provider value={annotation}>
-                                <EditableAnnotation>
-                                    <Child />
-                                </EditableAnnotation>
-                            </AnnotationContext.Provider>
-                        </AnnotatorLabelsProvider>
-                    </CanvasSettingsProvider>
-                </AnnotationVisibilityProvider>
+                <ToolProvider>
+                    <AnnotationVisibilityProvider>
+                        <CanvasSettingsProvider>
+                            <AnnotatorLabelsProvider>
+                                <AnnotationContext.Provider value={annotation}>
+                                    <EditableAnnotation>
+                                        <Child />
+                                    </EditableAnnotation>
+                                </AnnotationContext.Provider>
+                            </AnnotatorLabelsProvider>
+                        </CanvasSettingsProvider>
+                    </AnnotationVisibilityProvider>
+                </ToolProvider>
             </ZoomProvider>
         </svg>
     );

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -1,11 +1,14 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode } from 'react';
+import { ReactNode, RefObject, useRef } from 'react';
+
+import { useEventListener } from 'hooks/event-listener.hook';
 
 import { useZoom } from '../../../components/zoom/zoom.provider';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
+import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { EditBoundingBox } from '../tools/edit-bounding-box/edit-bounding-box.component';
 import { EditPolygon } from '../tools/edit-polygon/edit-polygon.component';
 import { useAnnotation } from './annotation-context';
@@ -15,29 +18,79 @@ interface EditAnnotationProps {
     children: ReactNode;
 }
 
+const useUnselectAnnotationOnOutsideClick = (ref: RefObject<SVGGElement | null>) => {
+    const { selectedAnnotations, setSelectedAnnotations } = useSelectedAnnotations();
+    const { activeTool } = useTool();
+
+    const canvas = document.querySelector("[aria-label='Annotator canvas']");
+
+    useEventListener(
+        'pointerdown',
+        (event) => {
+            if (ref.current == null) {
+                return;
+            }
+
+            if (event.ctrlKey) {
+                return;
+            }
+
+            if (activeTool === 'selection' && event.shiftKey) {
+                return;
+            }
+
+            if (selectedAnnotations.size === 0) {
+                return;
+            }
+
+            if (ref.current.contains(event.target as Node)) {
+                return;
+            }
+
+            setSelectedAnnotations(new Set());
+        },
+        canvas
+    );
+};
+
+const UnselectAnnotationOnOutsideClick = ({ ref }: { ref: RefObject<SVGGElement | null> }) => {
+    useUnselectAnnotationOnOutsideClick(ref);
+
+    return null;
+};
+
 export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
     const { scale } = useZoom();
     const annotation = useAnnotation();
     const { selectedAnnotations } = useSelectedAnnotations();
     const { isVisible } = useAnnotationVisibility();
+    const ref = useRef<SVGGElement>(null);
 
     const isSelected = selectedAnnotations.has(annotation.id);
     const shouldDisplayEditAnchors = isVisible && isSelected && selectedAnnotations.size === 1;
 
     if (shouldDisplayEditAnchors) {
         if (isPolygon(annotation)) {
-            return <EditPolygon annotation={annotation} zoom={scale} />;
+            return (
+                <g ref={ref}>
+                    <EditPolygon annotation={annotation} zoom={scale} />
+                    <UnselectAnnotationOnOutsideClick ref={ref} />
+                </g>
+            );
         }
 
         if (isRectangle(annotation)) {
             const { shape } = annotation;
 
             return (
-                <EditBoundingBox
-                    key={`box-${shape.x}-${shape.y}-${shape.width}-${shape.height}`}
-                    annotation={annotation}
-                    zoom={scale}
-                />
+                <g ref={ref}>
+                    <EditBoundingBox
+                        key={`box-${shape.x}-${shape.y}-${shape.width}-${shape.height}`}
+                        annotation={annotation}
+                        zoom={scale}
+                    />
+                    <UnselectAnnotationOnOutsideClick ref={ref} />
+                </g>
             );
         }
     }

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -7,6 +7,7 @@ import { useEventListener } from 'hooks/event-listener.hook';
 
 import { useZoom } from '../../../components/zoom/zoom.provider';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
+import { useAnnotator } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { EditBoundingBox } from '../tools/edit-bounding-box/edit-bounding-box.component';
@@ -21,8 +22,7 @@ interface EditAnnotationProps {
 const useUnselectAnnotationOnOutsideClick = (ref: RefObject<SVGGElement | null>) => {
     const { selectedAnnotations, setSelectedAnnotations } = useSelectedAnnotations();
     const { activeTool } = useTool();
-
-    const canvas = document.querySelector("[aria-label='Annotator canvas']");
+    const { canvasRef } = useAnnotator();
 
     useEventListener(
         'pointerdown',
@@ -49,7 +49,7 @@ const useUnselectAnnotationOnOutsideClick = (ref: RefObject<SVGGElement | null>)
 
             setSelectedAnnotations(new Set());
         },
-        canvas
+        canvasRef
     );
 };
 

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -183,6 +183,7 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
                 style={{ position: 'relative', height: '100%', width: '100%' }}
                 onContextMenu={(event: MouseEvent): void => event.preventDefault()}
                 className={isReadOnly ? classes.readOnlyCanvas : undefined}
+                aria-label={'Annotator canvas'}
             >
                 <MediaImage image={image} mediaItem={mediaItem} />
                 <MediaAnnotations mediaItem={mediaItem} mode={mode} />

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -12,6 +12,7 @@ import type { Media } from '../../../constants/shared-types';
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
 import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
+import { useAnnotator } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
@@ -167,6 +168,7 @@ type AnnotatorCanvasProps = {
 export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: AnnotatorCanvasProps) => {
     const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
+    const { canvasRef } = useAnnotator();
     const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey });
 
     const isLoadingMedia = isFetchingMedia > 0;
@@ -183,7 +185,7 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
                 style={{ position: 'relative', height: '100%', width: '100%' }}
                 onContextMenu={(event: MouseEvent): void => event.preventDefault()}
                 className={isReadOnly ? classes.readOnlyCanvas : undefined}
-                aria-label={'Annotator canvas'}
+                ref={canvasRef}
             >
                 <MediaImage image={image} mediaItem={mediaItem} />
                 <MediaAnnotations mediaItem={mediaItem} mode={mode} />

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -92,7 +92,7 @@ export const SegmentAnythingTool = () => {
             });
     };
 
-    const handlePointerDown = (event: PointerEvent<SVGSVGElement>) => {
+    const handlePointerUp = (event: PointerEvent<SVGSVGElement>) => {
         if (!ref.current) {
             return;
         }
@@ -150,7 +150,7 @@ export const SegmentAnythingTool = () => {
             canvasRef={canvasRef}
             aria-label='SAM tool canvas'
             onPointerMove={handleMouseMove}
-            onPointerDown={handlePointerDown}
+            onPointerUp={handlePointerUp}
             onPointerLeave={handlePointerLeave}
             style={{ cursor: `url(${selectionCursor}) ${CURSOR_OFFSET}, auto` }}
         >

--- a/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator-providers.component.tsx
@@ -8,6 +8,7 @@ import type { AnnotationDTO, Media } from '../../../constants/shared-types';
 import { AnnotationActionsProvider } from '../../../shared/annotator/annotation-actions-provider.component';
 import { AnnotationVisibilityProvider } from '../../../shared/annotator/annotation-visibility-provider.component';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
+import { AnnotatorProvider } from '../../../shared/annotator/annotator-provider.component';
 import { SelectAnnotationProvider } from '../../../shared/annotator/select-annotation-provider.component';
 import { AnnotatorLabelsProvider } from '../../annotator/annotator-labels-provider.component';
 import { CanvasSettingsProvider } from './primary-toolbar/settings/canvas-settings-provider.component';
@@ -32,23 +33,25 @@ export const AnnotatorProviders = ({
     children,
 }: AnnotatorProvidersProps) => {
     return (
-        <ZoomProvider>
-            <AnnotationVisibilityProvider>
-                <CanvasSettingsProvider>
-                    <AnnotatorLabelsProvider>
-                        <AnnotationActionsProvider
-                            mediaItem={mediaItem}
-                            initialAnnotationsDTO={initialAnnotationsDTO}
-                            initialPredictionsDTO={initialPredictionsDTO}
-                            isUserReviewed={isUserReviewed}
-                            mode={mode}
-                            isReadOnly={isReadOnly}
-                        >
-                            <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
-                        </AnnotationActionsProvider>
-                    </AnnotatorLabelsProvider>
-                </CanvasSettingsProvider>
-            </AnnotationVisibilityProvider>
-        </ZoomProvider>
+        <AnnotatorProvider>
+            <ZoomProvider>
+                <AnnotationVisibilityProvider>
+                    <CanvasSettingsProvider>
+                        <AnnotatorLabelsProvider>
+                            <AnnotationActionsProvider
+                                mediaItem={mediaItem}
+                                initialAnnotationsDTO={initialAnnotationsDTO}
+                                initialPredictionsDTO={initialPredictionsDTO}
+                                isUserReviewed={isUserReviewed}
+                                mode={mode}
+                                isReadOnly={isReadOnly}
+                            >
+                                <SelectAnnotationProvider>{children}</SelectAnnotationProvider>
+                            </AnnotationActionsProvider>
+                        </AnnotatorLabelsProvider>
+                    </CanvasSettingsProvider>
+                </AnnotationVisibilityProvider>
+            </ZoomProvider>
+        </AnnotatorProvider>
     );
 };

--- a/application/ui/src/shared/annotator/annotator-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotator-provider.component.tsx
@@ -1,0 +1,30 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, ReactNode, RefObject, use, useRef } from 'react';
+
+type AnnotatorContextProps = {
+    canvasRef: RefObject<HTMLDivElement | null>;
+};
+
+export const AnnotatorContext = createContext<AnnotatorContextProps | null>(null);
+
+type AnnotatorProviderProps = {
+    children: ReactNode;
+};
+
+export const AnnotatorProvider = ({ children }: AnnotatorProviderProps) => {
+    const canvasRef = useRef<HTMLDivElement | null>(null);
+
+    return <AnnotatorContext value={{ canvasRef }}>{children}</AnnotatorContext>;
+};
+
+export const useAnnotator = () => {
+    const context = use(AnnotatorContext);
+
+    if (context === null) {
+        throw new Error('useAnnotator must be used as an AnnotatorProvider');
+    }
+
+    return context;
+};

--- a/application/ui/src/shared/annotator/annotator-provider.component.tsx
+++ b/application/ui/src/shared/annotator/annotator-provider.component.tsx
@@ -23,7 +23,7 @@ export const useAnnotator = () => {
     const context = use(AnnotatorContext);
 
     if (context === null) {
-        throw new Error('useAnnotator must be used as an AnnotatorProvider');
+        throw new Error('useAnnotator must be used within an AnnotatorProvider');
     }
 
     return context;

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect } from '@playwright/test';
@@ -688,6 +688,168 @@ test.describe('Annotator', () => {
 
             await expect(annotatorPage.getAnnotatorMode('prediction')).toHaveAttribute('aria-pressed', 'true');
             await expect(page.getByLabel('label No object background')).toHaveCount(1);
+        });
+    });
+
+    test.describe('Edit mode deselection', () => {
+        const mockedSegmentationProject = getMockedProject({
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            task: {
+                exclusive_labels: true,
+                task_type: 'instance_segmentation',
+                labels: [redLabel, blueLabel],
+            },
+        });
+
+        const smallPolygon = {
+            type: 'polygon' as const,
+            points: [
+                { x: 100, y: 100 },
+                { x: 250, y: 100 },
+                { x: 250, y: 250 },
+                { x: 100, y: 250 },
+            ],
+        };
+
+        const secondPolygon = {
+            type: 'polygon' as const,
+            points: [
+                { x: 400, y: 300 },
+                { x: 550, y: 300 },
+                { x: 550, y: 450 },
+                { x: 400, y: 450 },
+            ],
+        };
+
+        test('detection task — bounding box tool deselects annotation in edit mode', async ({
+            page,
+            boundingBoxTool,
+            annotatorPage,
+        }) => {
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('Draw first bounding box and verify it enters edit mode', async () => {
+                await boundingBoxTool.selectTool();
+                await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
+
+                // After drawing, the newly created annotation is automatically selected
+                // and should show edit anchors (edit mode)
+                await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+            });
+
+            await test.step('Draw second bounding box with bounding box tool', async () => {
+                await boundingBoxTool.selectTool();
+                await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 150, height: 150 });
+            });
+
+            await test.step('Second annotation is in edit mode, first is not', async () => {
+                // Only one annotation should be in edit mode (the newly drawn second one)
+                await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+                // Two annotation rects should exist in total
+                expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(2);
+            });
+        });
+
+        test('detection task — entering edit mode via selection tool then drawing deselects original', async ({
+            page,
+            boundingBoxTool,
+            annotatorPage,
+        }) => {
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('Draw first bounding box', async () => {
+                await boundingBoxTool.selectTool();
+                await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
+            });
+
+            await test.step('Enter edit mode via selection tool', async () => {
+                await page.getByRole('button', { name: 'selection tool' }).click();
+                await page.getByLabel('annotation rect').nth(1).click();
+
+                await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+            });
+
+            await test.step('Draw second bounding box', async () => {
+                await boundingBoxTool.selectTool();
+                await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 150, height: 150 });
+            });
+
+            await test.step('Second annotation is in edit mode, first is not', async () => {
+                await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+
+                expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(2);
+            });
+        });
+
+        test('instance segmentation task — polygon tool deselects annotation in edit mode', async ({
+            page,
+            polygonTool,
+            annotatorPage,
+            network,
+        }) => {
+            network.use(
+                http.get('/api/projects/{project_id}', () => {
+                    return HttpResponse.json(mockedSegmentationProject);
+                })
+            );
+
+            await annotatorPage.goto(mockedSegmentationProject.id, 'item-1');
+
+            await test.step('Draw first polygon and verify it enters edit mode', async () => {
+                await polygonTool.selectPolygonTool();
+                await polygonTool.drawPolygon(smallPolygon);
+
+                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+            });
+
+            await test.step('Draw second polygon with polygon tool', async () => {
+                await polygonTool.selectPolygonTool();
+                await polygonTool.drawPolygon(secondPolygon);
+            });
+
+            await test.step('Second annotation is in edit mode, first is not', async () => {
+                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+
+                expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
+            });
+        });
+
+        test('instance segmentation task — entering edit mode via selection tool then drawing deselects original', async ({
+            page,
+            polygonTool,
+            annotatorPage,
+            network,
+        }) => {
+            network.use(
+                http.get('/api/projects/{project_id}', () => {
+                    return HttpResponse.json(mockedSegmentationProject);
+                })
+            );
+
+            await annotatorPage.goto(mockedSegmentationProject.id, 'item-1');
+
+            await test.step('Draw first polygon', async () => {
+                await polygonTool.selectPolygonTool();
+                await polygonTool.drawPolygon(smallPolygon);
+            });
+
+            await test.step('Enter edit mode via selection tool', async () => {
+                await page.getByRole('button', { name: 'selection tool' }).click();
+                await page.getByLabel('annotation polygon').nth(1).click();
+
+                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+            });
+
+            await test.step('Draw second polygon', async () => {
+                await polygonTool.selectPolygonTool();
+                await polygonTool.drawPolygon(secondPolygon);
+            });
+
+            await test.step('Second annotation is in edit mode, first is not', async () => {
+                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+
+                expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
+            });
         });
     });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This PR fixes the issue that when new annotation is drawn, previously selected annotation gets unselected.
I reintroduced annotator canvas but I think it will be a nice place to put active tool and maybe annotator mode as well.
I just didn't want to use `document.querySelector(...)`.

Fix #6259 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
