### PR TITLE
chore: Add toast notification that download process has started

### DIFF
--- a/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
+++ b/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
@@ -3,7 +3,7 @@
 
 import { Key } from 'react';
 
-import { ActionButton, DialogContainer, Item, Menu, MenuTrigger } from '@geti/ui';
+import { ActionButton, DialogContainer, Item, Menu, MenuTrigger, toast } from '@geti/ui';
 import { MoreMenu } from '@geti/ui/icons';
 
 import { downloadFile } from '../../../../shared/util';
@@ -30,6 +30,7 @@ export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName, onAnn
     const handleAction = (key: Key) => {
         if (key === MEDIA_ACTIONS.DOWNLOAD) {
             downloadFile(mediaUrl, mediaFileName);
+            toast({ type: 'info', message: `Downloading ${mediaFileName} started` });
         } else if (key === MEDIA_ACTIONS.DELETE) {
             openDeleteDialog();
         } else if (key === MEDIA_ACTIONS.ANNOTATE) {

--- a/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
+++ b/application/ui/src/features/dataset/gallery/media-item-actions/media-item-actions.component.tsx
@@ -30,7 +30,7 @@ export const MediaItemActions = ({ id, onDeleted, mediaUrl, mediaFileName, onAnn
     const handleAction = (key: Key) => {
         if (key === MEDIA_ACTIONS.DOWNLOAD) {
             downloadFile(mediaUrl, mediaFileName);
-            toast({ type: 'info', message: `Downloading ${mediaFileName} started` });
+            toast({ type: 'info', message: `${mediaFileName} download has started` });
         } else if (key === MEDIA_ACTIONS.DELETE) {
             openDeleteDialog();
         } else if (key === MEDIA_ACTIONS.ANNOTATE) {

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
@@ -33,7 +33,7 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
         const url = `${API_BASE_URL}/api/staged_datasets/${job.metadata.dataset_id}/zip`;
 
         downloadFile(url, `dataset_${job.metadata.dataset_id}.zip`);
-        toast({ type: 'info', message: `Downloading ${datasetName} dataset started` });
+        toast({ type: 'info', message: 'Dataset download started' });
     };
 
     return (

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Divider, Flex, Text, View } from '@geti/ui';
+import { Button, Divider, Flex, Text, toast, View } from '@geti/ui';
 import { useDeleteStagedDataset, useStagedDataset } from 'hooks/api/staged-dataset.hook';
 import { isNil } from 'lodash-es';
 
@@ -33,6 +33,7 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
         const url = `${API_BASE_URL}/api/staged_datasets/${job.metadata.dataset_id}/zip`;
 
         downloadFile(url, `dataset_${job.metadata.dataset_id}.zip`);
+        toast({ type: 'info', message: `Downloading ${datasetName} dataset started` });
     };
 
     return (

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
@@ -103,7 +103,7 @@ export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => 
         const url = `${API_BASE_URL}/api/projects/${projectId}/models/${model.id}/variants/${modelVariantId}/binary`;
         downloadFile(url);
 
-        toast({ type: 'info', message: 'Downloading model started' });
+        toast({ type: 'info', message: 'Model download started' });
     };
 
     return (

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
@@ -100,10 +100,10 @@ export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => 
         : undefined;
 
     const handleDownloadModel = (modelVariantId: string) => {
-        toast({ type: 'info', message: 'Model download started...please wait.' });
-
         const url = `${API_BASE_URL}/api/projects/${projectId}/models/${model.id}/variants/${modelVariantId}/binary`;
         downloadFile(url);
+
+        toast({ type: 'info', message: 'Downloading model started' });
     };
 
     return (

--- a/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
+++ b/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
@@ -60,7 +60,7 @@ const downloadModelLogsFile = async (projectId: string, modelId: string) => {
 
     const url = URL.createObjectURL(data);
     downloadFile(url, `training-logs-${modelId}.log`);
-    toast({ type: 'info', message: 'Downloading training logs started' });
+    toast({ type: 'info', message: 'Training logs download started' });
 };
 
 export const useDownloadModelLogs = (modelId: string) => {

--- a/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
+++ b/application/ui/src/features/models/training-logs/hooks/use-model-logs.hook.ts
@@ -60,6 +60,7 @@ const downloadModelLogsFile = async (projectId: string, modelId: string) => {
 
     const url = URL.createObjectURL(data);
     downloadFile(url, `training-logs-${modelId}.log`);
+    toast({ type: 'info', message: 'Downloading training logs started' });
 };
 
 export const useDownloadModelLogs = (modelId: string) => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

To mitigate the missing UX for tauri application (there is no download manager like in the browser) we display the notification that downloading has started (agreed on the squad level). 

Fix #6276 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
