### PR TITLE
fix: Go back navigates either to the previous page or to the projects page as fallback

### DIFF
--- a/application/ui/src/features/project/create/create-project-form.test.tsx
+++ b/application/ui/src/features/project/create/create-project-form.test.tsx
@@ -8,6 +8,7 @@ import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
 import { http } from '../../../api/utils';
+import { paths } from '../../../constants/paths';
 import { Project } from '../../../constants/shared-types';
 import { server } from '../../../msw-node-setup';
 import { CreateProjectForm } from './create-project-form';
@@ -258,12 +259,45 @@ describe('CreateProjectForm', () => {
     });
 
     describe('navigation', () => {
-        test('navigates back when "Go Back" button is clicked', () => {
-            renderCreateProjectForm();
+        const mockReferrer = (value: string) => {
+            Object.defineProperty(document, 'referrer', { get: () => value, configurable: true });
+        };
 
+        afterEach(() => {
+            Object.defineProperty(document, 'referrer', { get: () => '', configurable: true });
+        });
+
+        it('navigates to previous page when referrer is from the same origin', () => {
+            mockReferrer('http://localhost/projects');
+            vi.stubGlobal('location', { ...window.location, origin: 'http://localhost' });
+
+            renderCreateProjectForm();
             clickGoBack();
 
             expect(mockNavigate).toHaveBeenCalledWith(-1);
+
+            vi.unstubAllGlobals();
+        });
+
+        it('navigates to projects page when there is no referrer', () => {
+            mockReferrer('');
+
+            renderCreateProjectForm();
+            clickGoBack();
+
+            expect(mockNavigate).toHaveBeenCalledWith(paths.project.index({}));
+        });
+
+        it('navigates to projects page when referrer is from a different origin', () => {
+            mockReferrer('https://external-site.com/page');
+            vi.stubGlobal('location', { ...window.location, origin: 'http://localhost' });
+
+            renderCreateProjectForm();
+            clickGoBack();
+
+            expect(mockNavigate).toHaveBeenCalledWith(paths.project.index({}));
+
+            vi.unstubAllGlobals();
         });
     });
 });

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -143,7 +143,16 @@ export const CreateProjectForm = ({ projects }: CreateProjectFormProps) => {
             <Flex direction={'column'} alignItems={'center'} UNSAFE_className={classes.buttonGroup} gap={'size-300'}>
                 <Divider size={'S'} width={'100%'} />
                 <ButtonGroup>
-                    <Button variant={'secondary'} onPress={() => navigate(-1)}>
+                    <Button
+                        variant={'secondary'}
+                        onPress={() => {
+                            const isExternalReferrer =
+                                document.referrer === '' ||
+                                new URL(document.referrer).origin !== window.location.origin;
+
+                            isExternalReferrer ? navigate(paths.project.index({})) : navigate(-1);
+                        }}
+                    >
                         Go back
                     </Button>
                     <Button type={'submit'} variant='accent' isDisabled={isCreateProjectDisabled}>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

If the create project page is opened using the geti app (e.g. clicked create project), then when "Go back" is clicked we navigate back. When user is on google.com and opens create project page directly (using bookmark or whatever) we navigate to the projects page as a fallback.

Fix #6255 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
