### PR TITLE
Fix DEIMv2 pretrained weight loading for decoder self-attention

### DIFF
--- a/library/src/getitune/backend/lightning/models/detection/deimv2.py
+++ b/library/src/getitune/backend/lightning/models/detection/deimv2.py
@@ -158,7 +158,7 @@ class DEIMV2(DEIMDFine):
         # Remap decoder self-attention keys: checkpoint uses nn.MultiheadAttention naming,
         # our decoder uses fused qkv_proj/out_proj. Scoped to decoder layers only.
         key_mapping: dict[str, str] = {}
-        for i in range(6):
+        for i in range(model.decoder.num_layers):
             prefix = f"decoder.decoder.layers.{i}."
             key_mapping[f"{prefix}self_attn.in_proj_"] = f"{prefix}qkv_proj."
             key_mapping[f"{prefix}self_attn.out_proj."] = f"{prefix}out_proj."

--- a/library/src/getitune/backend/lightning/models/detection/deimv2.py
+++ b/library/src/getitune/backend/lightning/models/detection/deimv2.py
@@ -155,7 +155,19 @@ class DEIMV2(DEIMDFine):
             input_size=self.data_input_params.input_size[0],
         )
         model.init_weights()
-        load_checkpoint(model, self._pretrained_weights[self.model_name], map_location="cpu")
+        # The DEIMTransformer decoder replaces nn.MultiheadAttention with a custom
+        # fused QKV self-attention implementation for memory efficiency. This changes
+        # parameter names: self_attn.in_proj_{weight,bias} -> qkv_proj.{weight,bias}
+        # and self_attn.out_proj.{weight,bias} -> out_proj.{weight,bias}.
+        # We scope the key mapping to decoder layers only to avoid accidentally
+        # remapping the encoder's nn.MultiheadAttention keys which already match.
+        key_mapping: dict[str, str] = {}
+        max_decoder_layers = 6  # covers all variants (s/m: 4, l: 4, x: 6)
+        for i in range(max_decoder_layers):
+            prefix = f"decoder.decoder.layers.{i}."
+            key_mapping[f"{prefix}self_attn.in_proj_"] = f"{prefix}qkv_proj."
+            key_mapping[f"{prefix}self_attn.out_proj."] = f"{prefix}out_proj."
+        load_checkpoint(model, self._pretrained_weights[self.model_name], map_location="cpu", key_mapping=key_mapping)
         return model
 
     @property

--- a/library/src/getitune/backend/lightning/models/detection/deimv2.py
+++ b/library/src/getitune/backend/lightning/models/detection/deimv2.py
@@ -158,7 +158,7 @@ class DEIMV2(DEIMDFine):
         # Remap decoder self-attention keys: checkpoint uses nn.MultiheadAttention naming,
         # our decoder uses fused qkv_proj/out_proj. Scoped to decoder layers only.
         key_mapping: dict[str, str] = {}
-        for i in range(model.decoder.num_layers):
+        for i in range(decoder.num_layers):
             prefix = f"decoder.decoder.layers.{i}."
             key_mapping[f"{prefix}self_attn.in_proj_"] = f"{prefix}qkv_proj."
             key_mapping[f"{prefix}self_attn.out_proj."] = f"{prefix}out_proj."

--- a/library/src/getitune/backend/lightning/models/detection/deimv2.py
+++ b/library/src/getitune/backend/lightning/models/detection/deimv2.py
@@ -155,15 +155,10 @@ class DEIMV2(DEIMDFine):
             input_size=self.data_input_params.input_size[0],
         )
         model.init_weights()
-        # The DEIMTransformer decoder replaces nn.MultiheadAttention with a custom
-        # fused QKV self-attention implementation for memory efficiency. This changes
-        # parameter names: self_attn.in_proj_{weight,bias} -> qkv_proj.{weight,bias}
-        # and self_attn.out_proj.{weight,bias} -> out_proj.{weight,bias}.
-        # We scope the key mapping to decoder layers only to avoid accidentally
-        # remapping the encoder's nn.MultiheadAttention keys which already match.
+        # Remap decoder self-attention keys: checkpoint uses nn.MultiheadAttention naming,
+        # our decoder uses fused qkv_proj/out_proj. Scoped to decoder layers only.
         key_mapping: dict[str, str] = {}
-        max_decoder_layers = 6  # covers all variants (s/m: 4, l: 4, x: 6)
-        for i in range(max_decoder_layers):
+        for i in range(6):
             prefix = f"decoder.decoder.layers.{i}."
             key_mapping[f"{prefix}self_attn.in_proj_"] = f"{prefix}qkv_proj."
             key_mapping[f"{prefix}self_attn.out_proj."] = f"{prefix}out_proj."

--- a/library/tests/unit/backend/lightning/models/detection/test_deimv2.py
+++ b/library/tests/unit/backend/lightning/models/detection/test_deimv2.py
@@ -62,6 +62,27 @@ class TestDEIMV2:
         # Verify load_checkpoint was called (may be called multiple times for backbone and model)
         assert mock_load_checkpoint.call_count >= 1
 
+    @pytest.mark.parametrize("model_name", ["deimv2_s", "deimv2_m"])
+    @patch("getitune.backend.lightning.models.detection.deimv2.load_checkpoint")
+    def test_create_model_passes_decoder_key_mapping(self, mock_load_checkpoint: MagicMock, model_name: str) -> None:
+        """Test that _create_model passes decoder self-attention key_mapping to load_checkpoint."""
+        mock_load_checkpoint.return_value = None
+
+        model = DEIMV2(model_name=model_name, label_info=5)
+        created_model = model._create_model()
+
+        # The last load_checkpoint call is the full-model load (backbone load happens first)
+        final_call = mock_load_checkpoint.call_args
+        key_mapping = final_call.kwargs.get("key_mapping", {})
+
+        num_layers = created_model.decoder.num_layers
+        for i in range(num_layers):
+            prefix = f"decoder.decoder.layers.{i}."
+            assert f"{prefix}self_attn.in_proj_" in key_mapping
+            assert key_mapping[f"{prefix}self_attn.in_proj_"] == f"{prefix}qkv_proj."
+            assert f"{prefix}self_attn.out_proj." in key_mapping
+            assert key_mapping[f"{prefix}self_attn.out_proj."] == f"{prefix}out_proj."
+
     @patch("getitune.backend.lightning.models.detection.deimv2.load_checkpoint")
     def test_backbone_lr_mapping(self, mock_load_checkpoint: MagicMock) -> None:
         """Test that backbone learning rate mapping works correctly."""

--- a/library/tests/unit/backend/lightning/models/detection/test_deimv2.py
+++ b/library/tests/unit/backend/lightning/models/detection/test_deimv2.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -62,9 +63,11 @@ class TestDEIMV2:
         # Verify load_checkpoint was called (may be called multiple times for backbone and model)
         assert mock_load_checkpoint.call_count >= 1
 
-    @pytest.mark.parametrize("model_name", ["deimv2_s", "deimv2_m"])
+    @pytest.mark.parametrize("model_name", ["deimv2_s", "deimv2_m", "deimv2_l"])
     @patch("getitune.backend.lightning.models.detection.deimv2.load_checkpoint")
-    def test_create_model_passes_decoder_key_mapping(self, mock_load_checkpoint: MagicMock, model_name: str) -> None:
+    def test_create_model_passes_decoder_key_mapping(
+        self, mock_load_checkpoint: MagicMock, model_name: Literal["deimv2_s", "deimv2_m", "deimv2_l"]
+    ) -> None:
         """Test that _create_model passes decoder self-attention key_mapping to load_checkpoint."""
         mock_load_checkpoint.return_value = None
 
@@ -75,7 +78,7 @@ class TestDEIMV2:
         final_call = mock_load_checkpoint.call_args
         key_mapping = final_call.kwargs.get("key_mapping", {})
 
-        num_layers = created_model.decoder.num_layers
+        num_layers: int = created_model.decoder.num_layers  # type: ignore[assignment]
         for i in range(num_layers):
             prefix = f"decoder.decoder.layers.{i}."
             assert f"{prefix}self_attn.in_proj_" in key_mapping


### PR DESCRIPTION
The DEIMTransformer decoder uses a custom fused QKV self-attention (qkv_proj + out_proj) instead of nn.MultiheadAttention (self_attn.in_proj_*
+ self_attn.out_proj.*). Without key remapping, 16 decoder self-attention parameters (~6% of model params) were silently skipped during pretrained weight loading (strict=False), leaving decoder attention randomly initialized and causing poor accuracy on all DEIMv2 variants (s/m).

Add scoped key_mapping to translate checkpoint keys to the model's naming convention, restricted to decoder.decoder.layers.* to avoid accidentally remapping the encoder's nn.MultiheadAttention keys which already match.

It improves metrics as expected:
<img width="319" height="120" alt="image" src="https://github.com/user-attachments/assets/24c31e82-bd0c-4bc6-8d0d-93e7cceef70e" />

DFINE-S for reference: 0.4415

Resolves #6297 

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
