### PR TITLE
fix: Do not show warning when number of reviewed unassigned items is greater or equal to number of empty subsets

### DIFF
--- a/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.test.ts
+++ b/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.test.ts
@@ -102,7 +102,7 @@ describe('useTrainModelDisabledReason', () => {
             expect(result.current.reason).toBe(
                 'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
                     'This condition is currently not satisfiable, because the training, validation, and testing subsets are empty and ' +
-                    'there are 1 reviewed items ready to assign and ' +
+                    'there are 1 reviewed item ready to assign and ' +
                     '2 items that still need annotation before they can be assigned.'
             );
         });
@@ -122,7 +122,7 @@ describe('useTrainModelDisabledReason', () => {
             expect(result.current.reason).toBe(
                 'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
                     'This condition is currently not satisfiable, because the training and validation subsets are empty and ' +
-                    'there are 1 reviewed items ready to assign and 1 items that still need annotation before they can be assigned.'
+                    'there are 1 reviewed item ready to assign and 1 item that still need annotation before they can be assigned.'
             );
         });
 
@@ -142,6 +142,25 @@ describe('useTrainModelDisabledReason', () => {
                 'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
                     'This condition is currently not satisfiable, because the training and validation subsets are empty and ' +
                     'there are 3 items that still need annotation before they can be assigned.'
+            );
+        });
+
+        it('uses singular form for unannotated items when count is 1', () => {
+            mockDatasetItems({
+                total: 4,
+                training: 0,
+                testing: 1,
+                validation: 0,
+                reviewedUnassigned: 0,
+                unassigned: 1,
+            });
+
+            const { result } = renderHook(() => useTrainModelDisabledReason());
+
+            expect(result.current.reason).toBe(
+                'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
+                    'This condition is currently not satisfiable, because the training and validation subsets are empty and ' +
+                    'there is 1 item that still need annotation before they can be assigned.'
             );
         });
 

--- a/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.test.ts
+++ b/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.test.ts
@@ -89,31 +89,11 @@ describe('useTrainModelDisabledReason', () => {
 
         it('includes both reviewed and unannotated unassigned detail when both are present', () => {
             mockDatasetItems({
-                total: 5,
+                total: 4,
                 training: 0,
-                testing: 1,
-                validation: 1,
-                reviewedUnassigned: 2,
-                unassigned: 5,
-            });
-
-            const { result } = renderHook(() => useTrainModelDisabledReason());
-
-            expect(result.current.reason).toBe(
-                'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
-                    'This condition is currently not satisfiable, because the training subset is empty and ' +
-                    'there are 2 reviewed items ready to assign and ' +
-                    '3 items that still need annotation before they can be assigned.'
-            );
-        });
-
-        it('mentions only reviewed items when all unassigned items are reviewed', () => {
-            mockDatasetItems({
-                total: 5,
-                training: 0,
-                testing: 1,
-                validation: 1,
-                reviewedUnassigned: 3,
+                testing: 0,
+                validation: 0,
+                reviewedUnassigned: 1,
                 unassigned: 3,
             });
 
@@ -121,47 +101,78 @@ describe('useTrainModelDisabledReason', () => {
 
             expect(result.current.reason).toBe(
                 'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
-                    'This condition is currently not satisfiable, because the training subset is empty and ' +
-                    'there are 3 reviewed items left to assign.'
+                    'This condition is currently not satisfiable, because the training, validation, and testing subsets are empty and ' +
+                    'there are 1 reviewed items ready to assign and ' +
+                    '2 items that still need annotation before they can be assigned.'
+            );
+        });
+
+        it('mentions only reviewed items when all unassigned items are reviewed', () => {
+            mockDatasetItems({
+                total: 4,
+                training: 0,
+                testing: 1,
+                validation: 0,
+                reviewedUnassigned: 1,
+                unassigned: 2,
+            });
+
+            const { result } = renderHook(() => useTrainModelDisabledReason());
+
+            expect(result.current.reason).toBe(
+                'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
+                    'This condition is currently not satisfiable, because the training and validation subsets are empty and ' +
+                    'there are 1 reviewed items ready to assign and 1 items that still need annotation before they can be assigned.'
             );
         });
 
         it('mentions only unannotated items when no reviewed unassigned items exist', () => {
             mockDatasetItems({
-                total: 5,
+                total: 4,
                 training: 0,
                 testing: 1,
-                validation: 1,
+                validation: 0,
                 reviewedUnassigned: 0,
-                unassigned: 4,
+                unassigned: 3,
             });
 
             const { result } = renderHook(() => useTrainModelDisabledReason());
 
             expect(result.current.reason).toBe(
                 'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
-                    'This condition is currently not satisfiable, because the training subset is empty and ' +
-                    'there are 4 items that still need annotation before they can be assigned.'
+                    'This condition is currently not satisfiable, because the training and validation subsets are empty and ' +
+                    'there are 3 items that still need annotation before they can be assigned.'
             );
         });
 
-        it('mentions no unassigned items when both unassigned counts are 0', () => {
+        it('returns undefined reason when empty subsets count does not exceed reviewed unassigned items', () => {
+            mockDatasetItems({
+                total: 4,
+                training: 0,
+                testing: 1,
+                validation: 1,
+                reviewedUnassigned: 1,
+                unassigned: 1,
+            });
+
+            const { result } = renderHook(() => useTrainModelDisabledReason());
+
+            expect(result.current.reason).toBeUndefined();
+        });
+
+        it('returns undefined reason when two subsets are empty but enough reviewed unassigned items to cover both', () => {
             mockDatasetItems({
                 total: 5,
                 training: 0,
                 testing: 1,
-                validation: 1,
-                reviewedUnassigned: 0,
-                unassigned: 0,
+                validation: 0,
+                reviewedUnassigned: 2,
+                unassigned: 2,
             });
 
             const { result } = renderHook(() => useTrainModelDisabledReason());
 
-            expect(result.current.reason).toBe(
-                'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
-                    'This condition is currently not satisfiable, because the training subset is empty and ' +
-                    'there are no unassigned items available to redistribute.'
-            );
+            expect(result.current.reason).toBeUndefined();
         });
 
         it('uses plural form when two subsets are empty', () => {

--- a/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.ts
+++ b/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.ts
@@ -5,6 +5,10 @@ import { useGetDatasetItems } from 'hooks/use-get-dataset-items.hook';
 
 const MIN_NUMBER_OF_ANNOTATED_ITEMS = 3;
 const listFormatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+const pluralRules = new Intl.PluralRules('en');
+
+const pluralizeItems = (count: number) => (pluralRules.select(count) === 'one' ? 'item' : 'items');
+const conjugateToBe = (count: number) => (pluralRules.select(count) === 'one' ? 'is' : 'are');
 
 export const useTrainModelDisabledReason = () => {
     const { totalCount, isPending: isTotalPending } = useGetDatasetItems({ annotationStatus: 'reviewed' });
@@ -71,13 +75,19 @@ export const useTrainModelDisabledReason = () => {
 
     if (reviewedUnassignedSubsetSize > 0 && unannotatedUnassignedSize > 0) {
         assignmentDetail =
-            `there are ${reviewedUnassignedSubsetSize} reviewed items ready to assign and ` +
-            `${unannotatedUnassignedSize} items that still need annotation before they can be assigned`;
+            `there are ${reviewedUnassignedSubsetSize} reviewed ${pluralizeItems(reviewedUnassignedSubsetSize)} ready` +
+            ' to assign and ' +
+            `${unannotatedUnassignedSize} ${pluralizeItems(unannotatedUnassignedSize)} that still need annotation ` +
+            'before they can be assigned';
     } else if (reviewedUnassignedSubsetSize > 0) {
-        assignmentDetail = `there are ${reviewedUnassignedSubsetSize} reviewed items left to assign`;
+        assignmentDetail =
+            `there are ${reviewedUnassignedSubsetSize} reviewed ` +
+            `${pluralizeItems(reviewedUnassignedSubsetSize)} left to assign`;
     } else if (unannotatedUnassignedSize > 0) {
         assignmentDetail =
-            `there are ${unannotatedUnassignedSize} items that still need annotation before they ` + 'can be assigned';
+            `there ${conjugateToBe(unannotatedUnassignedSize)} ${unannotatedUnassignedSize} ` +
+            `${pluralizeItems(unannotatedUnassignedSize)} that still need annotation before they ` +
+            'can be assigned';
     } else {
         assignmentDetail = 'there are no unassigned items available to redistribute';
     }

--- a/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.ts
+++ b/application/ui/src/features/models/train-model/hooks/use-train-model-disabled-reason.ts
@@ -55,40 +55,37 @@ export const useTrainModelDisabledReason = () => {
 
     const emptySubsets = subsetSizes.filter(({ value }) => value === 0);
 
-    if (emptySubsets.length > 0) {
-        const emptySubsetNames = emptySubsets.map(({ name }) => name);
-        const emptySubsetText =
-            emptySubsetNames.length === 1
-                ? `${emptySubsetNames[0]} subset is`
-                : `${listFormatter.format(emptySubsetNames)} subsets are`;
+    if (emptySubsets.length === 0 || emptySubsets.length <= reviewedUnassignedSubsetSize) {
+        return { reason: undefined };
+    }
 
-        const unannotatedUnassignedSize = unassignedSubsetSize - reviewedUnassignedSubsetSize;
+    const emptySubsetNames = emptySubsets.map(({ name }) => name);
+    const emptySubsetText =
+        emptySubsetNames.length === 1
+            ? `${emptySubsetNames[0]} subset is`
+            : `${listFormatter.format(emptySubsetNames)} subsets are`;
 
-        let assignmentDetail: string;
+    const unannotatedUnassignedSize = unassignedSubsetSize - reviewedUnassignedSubsetSize;
 
-        if (reviewedUnassignedSubsetSize > 0 && unannotatedUnassignedSize > 0) {
-            assignmentDetail =
-                `there are ${reviewedUnassignedSubsetSize} reviewed items ready to assign and ` +
-                `${unannotatedUnassignedSize} items that still need annotation before they can be assigned`;
-        } else if (reviewedUnassignedSubsetSize > 0) {
-            assignmentDetail = `there are ${reviewedUnassignedSubsetSize} reviewed items left to assign`;
-        } else if (unannotatedUnassignedSize > 0) {
-            assignmentDetail =
-                `there are ${unannotatedUnassignedSize} items that still need annotation before they ` +
-                'can be assigned';
-        } else {
-            assignmentDetail = 'there are no unassigned items available to redistribute';
-        }
+    let assignmentDetail: string;
 
-        return {
-            reason:
-                'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
-                `This condition is currently not satisfiable, because the ${emptySubsetText} empty and ` +
-                `${assignmentDetail}.`,
-        };
+    if (reviewedUnassignedSubsetSize > 0 && unannotatedUnassignedSize > 0) {
+        assignmentDetail =
+            `there are ${reviewedUnassignedSubsetSize} reviewed items ready to assign and ` +
+            `${unannotatedUnassignedSize} items that still need annotation before they can be assigned`;
+    } else if (reviewedUnassignedSubsetSize > 0) {
+        assignmentDetail = `there are ${reviewedUnassignedSubsetSize} reviewed items left to assign`;
+    } else if (unannotatedUnassignedSize > 0) {
+        assignmentDetail =
+            `there are ${unannotatedUnassignedSize} items that still need annotation before they ` + 'can be assigned';
+    } else {
+        assignmentDetail = 'there are no unassigned items available to redistribute';
     }
 
     return {
-        reason: undefined,
+        reason:
+            'In order to train a model, each subset (training, validation, testing) needs at least one item. ' +
+            `This condition is currently not satisfiable, because the ${emptySubsetText} empty and ` +
+            `${assignmentDetail}.`,
     };
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

For instance, when there are two empty subsets and four reviewed, unassigned dataset items we should not show the warning because those dataset items can be automatically assign by the server. Tho when there are two empty subsets and only one reviewed, unassigned dataset item we should show the warning.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
