### PR TITLE
Added default no op sink folder

### DIFF
--- a/application/backend/app/services/sink_service.py
+++ b/application/backend/app/services/sink_service.py
@@ -6,9 +6,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.schema import SinkDB
-from app.models import OutputFormat, Sink, SinkAdapter, SinkType
+from app.models import DisconnectedSinkConfig, OutputFormat, Sink, SinkAdapter, SinkType
 from app.models.sink import SinkConfig
-from app.repositories import SinkRepository
+from app.repositories import PipelineRepository, SinkRepository
 from app.repositories.base import PrimaryKeyIntegrityError, UniqueConstraintIntegrityError
 
 from .base import (
@@ -20,6 +20,8 @@ from .base import (
 )
 from .event.event_bus import EventBus, EventType
 from .parent_process_guard import parent_process_only
+
+DISCONNECTED_SINK_ID = UUID("00000000-0000-0000-0000-000000000000")
 
 
 class SinkService:
@@ -82,16 +84,21 @@ class SinkService:
             raise ResourceWithNameAlreadyExistsError(ResourceType.SINK, new_name)  # type: ignore[arg-type]
 
     def get_by_id(self, sink_id: UUID) -> Sink:
+        if sink_id == DISCONNECTED_SINK_ID:
+            return DisconnectedSinkConfig()
         db_sink = SinkRepository(self._db_session).get_by_id(str(sink_id))
         if not db_sink:
             raise ResourceNotFoundError(ResourceType.SINK, str(sink_id))
         return SinkAdapter.validate_python(db_sink, from_attributes=True)
 
     def list_all(self) -> list[Sink]:
-        return [
+        sinks: list[Sink] = [
             SinkAdapter.validate_python(db_sink, from_attributes=True)
             for db_sink in SinkRepository(self._db_session).list_all()
         ]
+        # Always expose the built-in "disconnected" (black-hole) sink so that the UI can select it.
+        sinks.append(DisconnectedSinkConfig())
+        return sinks
 
     @parent_process_only
     def delete_sink(self, sink: Sink) -> None:
@@ -103,9 +110,18 @@ class SinkService:
             raise ResourceInUseError(ResourceType.SINK, str(sink.id))
 
     def get_active_sink(self) -> Sink | None:
+        active_sink_id = self.get_active_sink_id()
+        if active_sink_id is None:
+            return None
+        if active_sink_id == DISCONNECTED_SINK_ID:
+            return DisconnectedSinkConfig()
         db_sink = SinkRepository(self._db_session).get_active_sink()
         return SinkAdapter.validate_python(db_sink, from_attributes=True) if db_sink else None
 
     def get_active_sink_id(self) -> UUID | None:
-        id = SinkRepository(self._db_session).get_active_sink_id()
-        return UUID(id) if id else None
+        # Read the sink_id from the active pipeline directly so that the built-in disconnected sink
+        # (which is not stored in the sinks table) is also reported as "active" when selected.
+        active_pipeline = PipelineRepository(self._db_session).get_active_pipeline()
+        if active_pipeline is None or active_pipeline.sink_id is None:
+            return None
+        return UUID(active_pipeline.sink_id)

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -9,7 +9,7 @@ import numpy as np
 from loguru import logger
 
 from app.db import get_db_session
-from app.models import DisconnectedSinkConfig, Sink, SinkType
+from app.models import Sink, SinkType
 from app.services import DispatchService, SinkService
 from app.services.data_collect import DataCollector
 from app.services.dispatchers import Dispatcher
@@ -42,7 +42,7 @@ class DispatchingWorker(BaseThreadWorker):
 
         self._data_collector = data_collector
 
-        self._sink: Sink
+        self._sink: Sink | None
         self._destinations: list[Dispatcher] = []
 
         self._sink, self._destinations = self._load_sink()
@@ -55,11 +55,10 @@ class DispatchingWorker(BaseThreadWorker):
     def setup(self) -> None:
         pass
 
-    def _load_sink(self) -> tuple[Sink, list[Dispatcher]]:
+    def _load_sink(self) -> tuple[Sink | None, list[Dispatcher]]:
         with get_db_session() as db:
-            active_sink = SinkService(event_bus=self._event_bus, db_session=db).get_active_sink()
-        sink = active_sink if active_sink is not None else DisconnectedSinkConfig()
-        destinations = DispatchService.get_destinations(output_configs=[sink])
+            sink = SinkService(event_bus=self._event_bus, db_session=db).get_active_sink()
+        destinations = DispatchService.get_destinations(output_configs=[sink]) if sink is not None else []
         return sink, destinations
 
     def _reload_sink(self) -> None:
@@ -68,7 +67,8 @@ class DispatchingWorker(BaseThreadWorker):
 
     def run_loop(self) -> None:
         while not self.should_stop():
-            if self._sink.sink_type == SinkType.DISCONNECTED:
+            if self._sink is None:
+                # No sink configuration at all (e.g. no active pipeline): wait and retry.
                 logger.debug("No sink available... retrying in 1 second")
                 self.stop_aware_sleep(1)
                 continue
@@ -91,13 +91,17 @@ class DispatchingWorker(BaseThreadWorker):
 
             image_with_visualization = inference_data.visualized_prediction
             prediction = inference_data.prediction
-            # Postprocess and dispatch results
-            for destination in self._destinations:
-                destination.dispatch(
-                    original_image=stream_data.frame_data,
-                    image_with_visualization=image_with_visualization,
-                    predictions=prediction,
-                )
+
+            # Postprocess and dispatch results to external destinations.
+            # When the "disconnected" (black-hole) sink is selected, predictions are simply discarded:
+            # we still consume the queue so that WebRTC streaming and data collection keep working.
+            if self._sink.sink_type != SinkType.DISCONNECTED:
+                for destination in self._destinations:
+                    destination.dispatch(
+                        original_image=stream_data.frame_data,
+                        image_with_visualization=image_with_visualization,
+                        predictions=prediction,
+                    )
 
             # Dispatch to WebRTC stream
             self._rtc_stream_broadcaster.broadcast(image_with_visualization)

--- a/application/backend/tests/integration/services/test_sink_service.py
+++ b/application/backend/tests/integration/services/test_sink_service.py
@@ -131,10 +131,13 @@ class TestSinkServiceIntegration:
 
         db_sinks = fxt_sink_service.list_all()
 
-        assert len(db_sinks) == len(fxt_db_sinks)
-        for i, sink in enumerate(db_sinks):
+        # The built-in "disconnected" (black-hole) sink is always appended at the end.
+        assert len(db_sinks) == len(fxt_db_sinks) + 1
+        for i, sink in enumerate(db_sinks[:-1]):
             assert str(sink.id) == fxt_db_sinks[i].id
             assert sink.name == fxt_db_sinks[i].name
+        assert str(db_sinks[-1].id) == "00000000-0000-0000-0000-000000000000"
+        assert db_sinks[-1].sink_type.value == "disconnected"
 
     def test_get_sink(self, fxt_db_sinks, fxt_sink_service, db_session):
         """Test retrieving a sink by ID."""


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds a new default sink which is essentially a black hole.

No predictions are stored on disk, everything is essentially skipped but the pipeline keeps running.

<img width="558" height="280" alt="image" src="https://github.com/user-attachments/assets/721e71b5-a263-497a-b749-ca2341b10c2f" />


### How to test

Add the new sink to the pipeline, enable and run inference.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
