### PR TITLE
Memory grows every time pipeline is started

### DIFF
--- a/application/backend/app/models/model_activation.py
+++ b/application/backend/app/models/model_activation.py
@@ -15,7 +15,7 @@ class ModelActivationState(BaseModel):
         ..., description="ID of the model variant that is currently used for inference"
     )
     available_models: list[UUID] = Field(..., description="List of all available model IDs that can be activated")
-    device: DeviceInfo = Field(..., description="Device to use for inference (e.g., 'cpu', 'gpu')")
+    device: DeviceInfo = Field(..., description="Device information for inference")
 
     @field_validator("active_model_id")
     @classmethod

--- a/application/backend/app/models/model_activation.py
+++ b/application/backend/app/models/model_activation.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.models.system import DeviceInfo
+
 
 class ModelActivationState(BaseModel):
     project_id: UUID | None = Field(..., description="Project ID of the model that is currently used for inference")
@@ -13,7 +15,7 @@ class ModelActivationState(BaseModel):
         ..., description="ID of the model variant that is currently used for inference"
     )
     available_models: list[UUID] = Field(..., description="List of all available model IDs that can be activated")
-    device: str = Field(default="cpu", description="Device to use for inference (e.g., 'cpu', 'gpu')")
+    device: DeviceInfo = Field(..., description="Device to use for inference (e.g., 'cpu', 'gpu')")
 
     @field_validator("active_model_id")
     @classmethod
@@ -23,12 +25,3 @@ class ModelActivationState(BaseModel):
                 f"active_model_id '{v}' must be one of the available_models: {info.data['available_models']}"
             )
         return v
-
-    def to_json_dict(self) -> dict:
-        """Serialize the state to a JSON-compatible dictionary."""
-        return self.model_dump()
-
-    @classmethod
-    def from_json_dict(cls, data: dict) -> "ModelActivationState":
-        """Deserialize the state from a JSON-compatible dictionary."""
-        return cls.model_validate(data)

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -1,34 +1,20 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
 from uuid import UUID
 
 from loguru import logger
-from model_api.adapters import OpenvinoAdapter, create_core
-from model_api.models import Model
 
 from app.db.engine import get_db_session
 from app.models.model_activation import ModelActivationState
 from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
+from app.models.system import DeviceInfo, DeviceType
 from app.repositories import ModelRevisionRepository, ModelVariantRepository
 from app.repositories.active_model_repo import ActiveModelRepo
-from app.utils.ir_format import FP32OpenvinoAdapter
+from app.services.inference.model_loader import LoadedModelHandle, ModelLoader
 
 from .system_service import SystemService
-
-MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
-
-
-@dataclass(frozen=True)
-class LoadedModel:
-    model_revision_id: UUID
-    model_variant_id: UUID
-    model: Model
-    device: str
 
 
 class ActiveModelService:
@@ -41,11 +27,11 @@ class ActiveModelService:
     def __init__(self, data_dir: Path) -> None:
         self.projects_dir = data_dir / "projects"
         self._model_activation_state: ModelActivationState = self._load_state()
-        self._loaded_model: LoadedModel | None = None
+        self._loaded_model: LoadedModelHandle | None = None
 
     @staticmethod
     def _load_state() -> ModelActivationState:
-        """Load the state from the file if it exists, otherwise initialize an empty state"""
+        """Load the state from the DB if it exists, otherwise initialize an empty state"""
         with get_db_session() as db:
             active_model_repo = ActiveModelRepo(db=db)
             active_model = active_model_repo.get_active_revision()
@@ -55,7 +41,7 @@ class ActiveModelService:
                     active_model_id=None,
                     active_model_variant_id=None,
                     available_models=[],
-                    device="",
+                    device=DeviceInfo(type=DeviceType.CPU, name="cpu"),
                 )
             model_rev_repo = ModelRevisionRepository(project_id=str(active_model.project_id), db=db)
             available_models = model_rev_repo.list_all(training_status=TrainingStatus.SUCCESSFUL)
@@ -79,7 +65,7 @@ class ActiveModelService:
                 active_model_id=UUID(active_model.id),
                 active_model_variant_id=UUID(active_variant_id),
                 available_models=[UUID(m.id) for m in available_models],
-                device=geti_device.as_openvino,
+                device=geti_device,
             )
 
     def _get_model_file_path(self, project_id: UUID, model_id: UUID, variant_id: UUID, extension: str = "xml") -> Path:
@@ -88,7 +74,7 @@ class ActiveModelService:
             return file_path
         raise FileNotFoundError(f"Model file not found: {file_path}")
 
-    def get_loaded_inference_model(self, force_reload: bool = False) -> LoadedModel | None:
+    def get_loaded_inference_model(self, force_reload: bool = False) -> LoadedModelHandle | None:
         """
         Get the currently active model for inference.
 
@@ -115,8 +101,8 @@ class ActiveModelService:
         device = self._model_activation_state.device
         needs_reload = (
             self._loaded_model is None
-            or self._loaded_model.model_revision_id != active_model_id
-            or self._loaded_model.model_variant_id != active_variant_id
+            or self._loaded_model.model_id != active_model_id
+            or self._loaded_model.variant_id != active_variant_id
             or self._loaded_model.device != device
         )
         if needs_reload:
@@ -138,34 +124,18 @@ class ActiveModelService:
                     variant_id=active_variant_id,
                     extension="bin",
                 )
-                ie = create_core()
-                adapter = FP32OpenvinoAdapter(
-                    ie,
-                    str(model_xml_path),
-                    device=device,
-                    max_num_requests=int(MODELAPI_NSTREAMS),
+                self._loaded_model = ModelLoader.load(
+                    model_id=active_model_id, variant_id=active_variant_id, model_xml_path=model_xml_path, device=device
                 )
-                mapi_model = Model.create_model(adapter)
             except FileNotFoundError:
                 logger.exception("Failed to load model with ID '{}'", active_model_id)
                 return None
 
-            self._loaded_model = LoadedModel(
-                model_revision_id=self._model_activation_state.active_model_id,
-                model=mapi_model,
-                model_variant_id=active_variant_id,
-                device=device,
-            )
         return self._loaded_model
 
     def _unload_model(self) -> None:
         """Release the currently loaded model and free its resources."""
         if self._loaded_model is not None:
-            logger.debug("Unloading model '{}'", self._loaded_model.model_revision_id)
-            # Explicitly destroy OV native objects held by the adapter to release memory.
-            adapter = cast(OpenvinoAdapter, self._loaded_model.model.inference_adapter)
-            if hasattr(adapter, "async_queue"):
-                del adapter.async_queue
-            if hasattr(adapter, "compiled_model"):
-                del adapter.compiled_model
+            logger.debug("Unloading model '{}'", self._loaded_model.model_id)
+            ModelLoader.unload(self._loaded_model)
             self._loaded_model = None

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -4,10 +4,11 @@
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 from uuid import UUID
 
 from loguru import logger
-from model_api.adapters import create_core
+from model_api.adapters import OpenvinoAdapter, create_core
 from model_api.models import Model
 
 from app.db.engine import get_db_session
@@ -98,8 +99,8 @@ class ActiveModelService:
         Returns: Model for inference or None if no model is active, or if the model can't be loaded.
         """
         if force_reload:
+            self._unload_model()
             self._model_activation_state = self._load_state()
-            self._loaded_model = None
 
         if (
             self._model_activation_state.active_model_id is None
@@ -122,6 +123,7 @@ class ActiveModelService:
             logger.info(
                 "Loading model with ID '{}', variant '{}', on device '{}'", active_model_id, active_variant_id, device
             )
+            self._unload_model()
             try:
                 # Ensure all necessary model files exist before loading the model
                 model_xml_path = self._get_model_file_path(
@@ -155,3 +157,15 @@ class ActiveModelService:
                 device=device,
             )
         return self._loaded_model
+
+    def _unload_model(self) -> None:
+        """Release the currently loaded model and free its resources."""
+        if self._loaded_model is not None:
+            logger.debug("Unloading model '{}'", self._loaded_model.model_revision_id)
+            # Explicitly destroy OV native objects held by the adapter to release memory.
+            adapter = cast(OpenvinoAdapter, self._loaded_model.model.inference_adapter)
+            if hasattr(adapter, "async_queue"):
+                del adapter.async_queue
+            if hasattr(adapter, "compiled_model"):
+                del adapter.compiled_model
+            self._loaded_model = None

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -1,35 +1,21 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-import os
 import threading
-from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from uuid import UUID
 
 import numpy as np
 from loguru import logger
-from model_api.adapters import create_core
-from model_api.models import Model
 
 from app.db import get_db_session
 from app.models import BatchInferenceInput, BatchInferenceMedia, BatchInferencePrediction, BatchInferenceResult, Label
 from app.models.inference import InferenceModel, InferenceState, InferenceStatus
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.models.system import DeviceInfo
-from app.services import ResourceNotFoundError, ResourceType
+from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.data_collect.prediction_converter import convert_prediction
-from app.utils.ir_format import FP32OpenvinoAdapter
 
-MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
-
-
-@dataclass(frozen=True)
-class _LoadedModel:
-    id: UUID
-    model: Model
-    device: DeviceInfo
-    load_timestamp: datetime
+from .model_loader import LoadedModelHandle, ModelLoader
 
 
 class InferenceBusyError(Exception):
@@ -55,7 +41,7 @@ class InferenceServer:
 
     def __init__(self, data_dir: Path) -> None:
         self._data_dir = data_dir
-        self._loaded_model: _LoadedModel | None = None
+        self._loaded_model: LoadedModelHandle | None = None
         self._loading_model: bool = False
         self._lock = threading.Lock()
 
@@ -76,12 +62,12 @@ class InferenceServer:
         # Optimization: if the given model is already loaded on the given device, return immediately without acquiring
         # the lock
         loaded_model = self._loaded_model  # use a variable to avoid multiple unprotected reads of self._loaded_model
-        if loaded_model and loaded_model.id == model_id and loaded_model.device == device:
+        if loaded_model and loaded_model.model_id == model_id and loaded_model.device == device:
             return False  # same model and device, no need to reload
 
         self._lock.acquire()
         try:
-            if self._loaded_model and self._loaded_model.id == model_id and self._loaded_model.device == device:
+            if self._loaded_model and self._loaded_model.model_id == model_id and self._loaded_model.device == device:
                 return False  # same model and device, no need to reload
             self._loading_model = True
 
@@ -112,19 +98,10 @@ class InferenceServer:
                     )
                 model_xml_path, _ = paths
 
-                ie = create_core()
-                adapter = FP32OpenvinoAdapter(
-                    ie,
-                    str(model_xml_path),
-                    device=device.as_openvino,
-                    max_num_requests=int(MODELAPI_NSTREAMS),
-                )
-                model = Model.create_model(adapter)
-                self._loaded_model = _LoadedModel(
-                    id=model_id,
-                    model=model,
-                    device=device,
-                    load_timestamp=datetime.now(),
+                if self._loaded_model is not None:
+                    ModelLoader.unload(self._loaded_model)
+                self._loaded_model = ModelLoader.load(
+                    model_id=model_id, variant_id=model_variant.id, model_xml_path=model_xml_path, device=device
                 )
                 return True
         finally:
@@ -146,9 +123,9 @@ class InferenceServer:
         return InferenceState(
             status=InferenceStatus.ACTIVE,
             model=InferenceModel(
-                model_id=loaded_model.id,
+                model_id=loaded_model.model_id,
                 device=loaded_model.device,
-                load_timestamp=loaded_model.load_timestamp,
+                load_timestamp=loaded_model.loaded_at,
             ),
         )
 
@@ -197,4 +174,6 @@ class InferenceServer:
         """
         # TODO: model unload & active inference cancellation
         with self._lock:
-            self._loaded_model = None
+            if self._loaded_model is not None:
+                ModelLoader.unload(self._loaded_model)
+                self._loaded_model = None

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -59,12 +59,6 @@ class InferenceServer:
         Returns:
             True, if the model has been loaded, False if model has not been changed.
         """
-        # Optimization: if the given model is already loaded on the given device, return immediately without acquiring
-        # the lock
-        loaded_model = self._loaded_model  # use a variable to avoid multiple unprotected reads of self._loaded_model
-        if loaded_model and loaded_model.model_id == model_id and loaded_model.device == device:
-            return False  # same model and device, no need to reload
-
         self._lock.acquire()
         try:
             if self._loaded_model and self._loaded_model.model_id == model_id and self._loaded_model.device == device:
@@ -100,6 +94,7 @@ class InferenceServer:
 
                 if self._loaded_model is not None:
                     ModelLoader.unload(self._loaded_model)
+                    self._loaded_model = None
                 self._loaded_model = ModelLoader.load(
                     model_id=model_id, variant_id=model_variant.id, model_xml_path=model_xml_path, device=device
                 )

--- a/application/backend/app/services/inference/model_loader.py
+++ b/application/backend/app/services/inference/model_loader.py
@@ -17,7 +17,7 @@ from model_api.models import Model
 from app.models.system import DeviceInfo
 from app.utils.ir_format import FP32OpenvinoAdapter
 
-MODELAPI_NSTREAMS = int(os.getenv("MODELAPI_NSTREAMS", "2"))
+MODELAPI_NSTREAMS = os.getenv("MODELAPI_NSTREAMS", "2")
 
 
 @dataclass(frozen=True)
@@ -59,7 +59,7 @@ class ModelLoader:
             ie,
             str(model_xml_path),
             device=device.as_openvino,
-            max_num_requests=MODELAPI_NSTREAMS,
+            max_num_requests=int(MODELAPI_NSTREAMS),
         )
         model = Model.create_model(adapter)
         return LoadedModelHandle(

--- a/application/backend/app/services/inference/model_loader.py
+++ b/application/backend/app/services/inference/model_loader.py
@@ -1,0 +1,89 @@
+# app/services/inference/model_loader.py
+
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+from loguru import logger
+from model_api.adapters import OpenvinoAdapter, create_core
+from model_api.models import Model
+
+from app.models.system import DeviceInfo
+from app.utils.ir_format import FP32OpenvinoAdapter
+
+MODELAPI_NSTREAMS = int(os.getenv("MODELAPI_NSTREAMS", "2"))
+
+
+@dataclass(frozen=True)
+class LoadedModelHandle:
+    """Holds a loaded Model API model together with the identifiers used to load it."""
+
+    model_id: UUID
+    variant_id: UUID
+    device: DeviceInfo
+    model: Model
+    loaded_at: datetime
+
+
+class ModelLoader:
+    """
+    Responsible for loading and unloading OpenVINO models via Model API.
+
+    This is a low-level utility shared by higher-level services (e.g. ActiveModelService, InferenceServer).
+    It owns the lifecycle of the native OpenVINO objects and ensures they are properly released on unload.
+    """
+
+    @staticmethod
+    def load(model_id: UUID, variant_id: UUID, model_xml_path: Path, device: DeviceInfo) -> LoadedModelHandle:
+        """
+        Load a model from an OpenVINO IR file onto the given device.
+
+        Args:
+            model_id: The identifier of the model to load.
+            variant_id: The identifier of the variant to load the model from.
+            model_xml_path: Path to the .xml model file (the .bin must be alongside it).
+            device: The device to load the model on.
+
+        Returns:
+            A LoadedModelHandle containing the ready-to-use Model API model.
+        """
+        logger.debug("Loading model '{}' on device '{}'", model_xml_path, device)
+        ie = create_core()
+        adapter = FP32OpenvinoAdapter(
+            ie,
+            str(model_xml_path),
+            device=device.as_openvino,
+            max_num_requests=MODELAPI_NSTREAMS,
+        )
+        model = Model.create_model(adapter)
+        return LoadedModelHandle(
+            model_id=model_id,
+            variant_id=variant_id,
+            device=device,
+            model=model,
+            loaded_at=datetime.now(),
+        )
+
+    @staticmethod
+    def unload(handle: LoadedModelHandle) -> None:
+        """
+        Release all native OpenVINO resources held by the model.
+
+        Explicitly deletes the compiled model and async queue from the adapter so that OpenVINO frees GPU/CPU memory
+        immediately rather than waiting for the Python GC.
+
+        Args:
+            handle: The handle returned by a previous call to `load`.
+        """
+        logger.debug("Unloading model '{}'", handle.model_id)
+        adapter = cast(OpenvinoAdapter, handle.model.inference_adapter)
+        if hasattr(adapter, "async_queue"):
+            del adapter.async_queue
+        if hasattr(adapter, "compiled_model"):
+            del adapter.compiled_model

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -16,7 +16,7 @@ from model_api.models import Model
 from model_api.models.result import Result
 
 from app.services import ActiveModelService, MetricsService
-from app.services.active_model_service import LoadedModel
+from app.services.inference.model_loader import LoadedModelHandle
 from app.settings import Settings, get_settings
 from app.stream.stream_data import InferenceData, StreamData
 from app.utils import Visualizer
@@ -97,7 +97,7 @@ class InferenceWorker(BaseProcessWorker):
         self._settings: Settings | None = None
         self._metrics_service: MetricsService | None = None
         self._model_service: ActiveModelService | None = None
-        self._loaded_model: LoadedModel | None = None
+        self._loaded_model: LoadedModelHandle | None = None
         self._last_model_obj_id = 0  # track the id of the Model object to install the callback only once
 
         # The reorder buffer ensures that frames are broadcast in order, even if inference results are produced
@@ -154,7 +154,7 @@ class InferenceWorker(BaseProcessWorker):
         self._last_model_obj_id = obj_id
         logger.debug("Installed inference callback for model object with id '{}'", self._last_model_obj_id)
 
-    def _refresh_loaded_model(self) -> LoadedModel | None:
+    def _refresh_loaded_model(self) -> LoadedModelHandle | None:
         """
         Get (or reload) the active model. If reloads are requested repeatedly,
         clear the event until the latest model is loaded.
@@ -200,7 +200,7 @@ class InferenceWorker(BaseProcessWorker):
                         rgb_frame,
                         user_data={
                             "stream_data": item,
-                            "model_id": self._loaded_model.model_revision_id,
+                            "model_id": self._loaded_model.model_id,
                             "inference_start_time": inference_start_time,
                         },
                     )

--- a/application/backend/tests/unit/services/inference/test_inference_server.py
+++ b/application/backend/tests/unit/services/inference/test_inference_server.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, Mock, patch
 from uuid import uuid4
 
 import numpy as np
@@ -14,7 +14,7 @@ from app.models.model_revision import ModelFormat, ModelPrecision, ModelVariant
 from app.models.system import DeviceInfo, DeviceType
 from app.services import ModelService
 from app.services.inference import InferenceModel, InferenceServer, InferenceState, InferenceStatus
-from app.services.inference.inference_server import _LoadedModel
+from app.services.inference.model_loader import LoadedModelHandle
 
 
 class TestInferenceServer:
@@ -24,16 +24,18 @@ class TestInferenceServer:
         model_variant_id = uuid4()
         device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
 
-        model_variant = MagicMock(
+        model_variant = Mock(
             spec=ModelVariant, id=model_variant_id, format=ModelFormat.OPENVINO, precision=ModelPrecision.FP16
         )
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
 
-        model = MagicMock(spec=Model)
+        model = Mock(spec=Model)
+        model_handle = LoadedModelHandle(
+            model_id=model_id, variant_id=uuid4(), model=model, device=device, loaded_at=datetime.now()
+        )
 
         with (
-            patch("model_api.models.Model.create_model", return_value=model) as mock_create_model,
             patch.object(
                 target=ModelService, attribute="get_model_variants", return_value=[model_variant]
             ) as mock_get_model_variants,
@@ -42,8 +44,7 @@ class TestInferenceServer:
                 attribute="get_model_binary_files",
                 return_value=(True, (tmp_path / "model.xml", tmp_path / "model.bin")),
             ) as mock_get_model_binary_files,
-            patch("app.services.inference.inference_server.create_core") as mock_create_core,
-            patch("app.services.inference.inference_server.FP32OpenvinoAdapter") as mock_fp32_adapter,
+            patch("app.services.inference.model_loader.ModelLoader.load", return_value=model_handle) as mock_load_model,
         ):
             model_loaded = inference_server.set_inference_model(
                 project_id=project_id, model_id=model_id, device=device, ttl=60
@@ -52,7 +53,7 @@ class TestInferenceServer:
             assert model_loaded
             assert (
                 inference_server._loaded_model is not None
-                and inference_server._loaded_model.id == model_id
+                and inference_server._loaded_model.model_id == model_id
                 and inference_server._loaded_model.model == model
                 and inference_server._loaded_model.device == device
             )
@@ -61,34 +62,95 @@ class TestInferenceServer:
             mock_get_model_binary_files.assert_called_once_with(
                 project_id=project_id, model_id=model_id, model_variant_id=model_variant_id
             )
-            mock_fp32_adapter.assert_called_once_with(
-                mock_create_core.return_value,
-                str(tmp_path / "model.xml"),
-                device=device.as_openvino,
-                max_num_requests=2,
+            mock_load_model.assert_called_once_with(
+                model_id=model_id,
+                variant_id=model_variant_id,
+                model_xml_path=tmp_path / "model.xml",
+                device=device,
             )
-            mock_create_model.assert_called_once_with(mock_fp32_adapter.return_value)
 
-    def test_set_inference_model_already_loaded(self, tmp_path) -> None:
+    def test_set_inference_same_model_already_loaded(self, tmp_path) -> None:
+        """Tests that inference server doesn't try to load the model again if it is already loaded."""
         project_id = uuid4()
         model_id = uuid4()
         device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
 
-        model = MagicMock(spec=Model)
+        model = Mock(spec=Model)
+        model_handle = LoadedModelHandle(
+            model_id=model_id, variant_id=uuid4(), model=model, device=device, loaded_at=datetime.now()
+        )
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
-        inference_server._loaded_model = _LoadedModel(
-            id=model_id, model=model, device=device, load_timestamp=datetime.now()
+        inference_server._loaded_model = model_handle
+
+        with patch(
+            "app.services.inference.model_loader.ModelLoader.load", return_value=model_handle
+        ) as mock_load_model:
+            model_loaded = inference_server.set_inference_model(
+                project_id=project_id, model_id=model_id, device=device, ttl=60
+            )
+
+            mock_load_model.assert_not_called()
+            assert not model_loaded
+            assert inference_server._loaded_model.model_id == model_id
+            assert inference_server._loaded_model.model == model
+            assert inference_server._loaded_model.device == device
+
+    def test_set_inference_different_model_already_loaded(self, tmp_path) -> None:
+        """Tests that inference server first unloads the old model before loading the new one."""
+        project_id = uuid4()
+        model_id, new_model_id = uuid4(), uuid4()
+        new_model_variant_id = uuid4()
+        device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
+
+        model_variant = Mock(
+            spec=ModelVariant, id=new_model_variant_id, format=ModelFormat.OPENVINO, precision=ModelPrecision.FP16
         )
 
-        model_loaded = inference_server.set_inference_model(
-            project_id=project_id, model_id=model_id, device=device, ttl=60
+        model = Mock(spec=Model)
+        model_handle = LoadedModelHandle(
+            model_id=model_id, variant_id=uuid4(), model=model, device=device, loaded_at=datetime.now()
+        )
+        new_model_handle = LoadedModelHandle(
+            model_id=new_model_id, variant_id=new_model_variant_id, model=model, device=device, loaded_at=datetime.now()
         )
 
-        assert not model_loaded
-        assert inference_server._loaded_model.id == model_id
-        assert inference_server._loaded_model.model == model
-        assert inference_server._loaded_model.device == device
+        inference_server = InferenceServer(data_dir=Path(tmp_path))
+        inference_server._loaded_model = model_handle
+
+        with (
+            patch.object(
+                target=ModelService, attribute="get_model_variants", return_value=[model_variant]
+            ) as mock_get_model_variants,
+            patch.object(
+                target=ModelService,
+                attribute="get_model_binary_files",
+                return_value=(True, (tmp_path / "model.xml", tmp_path / "model.bin")),
+            ) as mock_get_model_binary_files,
+            patch(
+                "app.services.inference.model_loader.ModelLoader.load", return_value=new_model_handle
+            ) as mock_load_model,
+            patch("app.services.inference.model_loader.ModelLoader.unload") as mock_unload_model,
+        ):
+            model_loaded = inference_server.set_inference_model(
+                project_id=project_id, model_id=new_model_id, device=device, ttl=60
+            )
+
+            mock_get_model_variants.assert_called_once_with(project_id=project_id, model_id=new_model_id)
+            mock_get_model_binary_files.assert_called_once_with(
+                project_id=project_id, model_id=new_model_id, model_variant_id=new_model_variant_id
+            )
+            mock_unload_model.assert_called_once_with(model_handle)
+            mock_load_model.assert_called_once_with(
+                model_id=new_model_id,
+                variant_id=new_model_variant_id,
+                model_xml_path=tmp_path / "model.xml",
+                device=device,
+            )
+            assert model_loaded
+            assert inference_server._loaded_model.model_id == new_model_id
+            assert inference_server._loaded_model.model == model
+            assert inference_server._loaded_model.device == new_model_handle.device
 
     def test_get_status_idle(self, tmp_path) -> None:
         inference_server = InferenceServer(data_dir=Path(tmp_path))
@@ -102,11 +164,11 @@ class TestInferenceServer:
         model_id = uuid4()
         device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
 
-        model = MagicMock(spec=Model)
+        model = Mock(spec=Model)
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
-        inference_server._loaded_model = _LoadedModel(
-            id=model_id, model=model, device=device, load_timestamp=datetime.now()
+        inference_server._loaded_model = LoadedModelHandle(
+            model_id=model_id, variant_id=uuid4(), model=model, device=device, loaded_at=datetime.now()
         )
 
         status = inference_server.get_status()
@@ -122,20 +184,23 @@ class TestInferenceServer:
 
     def test_stop(self, tmp_path) -> None:
         device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
-        model = MagicMock(spec=Model)
-
-        inference_server = InferenceServer(data_dir=Path(tmp_path))
-        inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device=device, load_timestamp=datetime.now()
+        model = Mock(spec=Model)
+        model_handle = LoadedModelHandle(
+            model_id=uuid4(), variant_id=uuid4(), model=model, device=device, loaded_at=datetime.now()
         )
 
-        inference_server.stop()
+        inference_server = InferenceServer(data_dir=Path(tmp_path))
+        inference_server._loaded_model = model_handle
 
-        assert inference_server._loaded_model is None
+        with patch("app.services.inference.model_loader.ModelLoader.unload") as mock_unload_model:
+            inference_server.stop()
+
+            mock_unload_model.assert_called_once_with(model_handle)
+            assert inference_server._loaded_model is None
 
     def test_infer_batch_not_loaded(self, tmp_path) -> None:
-        label = MagicMock(spec=Label)
-        input = MagicMock(spec=BatchInferenceInput)
+        label = Mock(spec=Label)
+        input = Mock(spec=BatchInferenceInput)
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
         inference_server._loaded_model = None
@@ -147,19 +212,19 @@ class TestInferenceServer:
         device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
         media_id = uuid4()
 
-        model = MagicMock(spec=Model)
-        inference_result = MagicMock()
+        model = Mock(spec=Model)
+        inference_result = Mock()
         model.infer_batch.return_value = [inference_result]
 
-        label = MagicMock(spec=Label)
+        label = Mock(spec=Label)
         raw_uint8 = np.full((20, 20, 3), 128, dtype=np.uint8)
         input = BatchInferenceInput(media_id=media_id, frame_index=15, data=raw_uint8)
 
-        annotation = MagicMock(spec=DatasetItemAnnotation)
+        annotation = Mock(spec=DatasetItemAnnotation)
 
         inference_server = InferenceServer(data_dir=Path(tmp_path))
-        inference_server._loaded_model = _LoadedModel(
-            id=uuid4(), model=model, device=device, load_timestamp=datetime.now()
+        inference_server._loaded_model = LoadedModelHandle(
+            model_id=uuid4(), variant_id=uuid4(), model=model, device=device, loaded_at=datetime.now()
         )
 
         with patch("app.services.inference.inference_server.convert_prediction") as mock_convert_prediction:

--- a/application/backend/tests/unit/services/inference/test_model_loader.py
+++ b/application/backend/tests/unit/services/inference/test_model_loader.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+import pytest
+from model_api.adapters import OpenvinoAdapter
+from model_api.models import Model
+
+from app.models.system import DeviceInfo, DeviceType
+from app.services.inference.model_loader import MODELAPI_NSTREAMS, LoadedModelHandle, ModelLoader
+
+
+@pytest.fixture
+def fxt_device_cpu() -> DeviceInfo:
+    return DeviceInfo(type=DeviceType.CPU, name="cpu")
+
+
+@pytest.fixture
+def fxt_loaded_handle(fxt_device_cpu: DeviceInfo) -> LoadedModelHandle:
+    fake_model = Mock(spec=Model)
+    fake_model.inference_adapter = Mock(spec=OpenvinoAdapter)
+    return LoadedModelHandle(
+        model_id=uuid4(),
+        variant_id=uuid4(),
+        device=fxt_device_cpu,
+        model=fake_model,
+        loaded_at=datetime.now(),
+    )
+
+
+class TestModelLoader:
+    def test_load_returns_handle_with_correct_ids(self, fxt_device_cpu: DeviceInfo, tmp_path: Path) -> None:
+        """load() should return a LoadedModelHandle whose IDs match what was passed in."""
+        model_id = uuid4()
+        variant_id = uuid4()
+        fake_model = Mock(spec=Model)
+        fake_adapter = Mock(spec=OpenvinoAdapter)
+
+        with (
+            patch("app.services.inference.model_loader.create_core") as mock_create_core,
+            patch(
+                "app.services.inference.model_loader.FP32OpenvinoAdapter", return_value=fake_adapter
+            ) as mock_adapter_cls,
+            patch(
+                "app.services.inference.model_loader.Model.create_model", return_value=fake_model
+            ) as mock_create_model,
+        ):
+            handle = ModelLoader.load(
+                model_id=model_id,
+                variant_id=variant_id,
+                model_xml_path=tmp_path / "model.xml",
+                device=fxt_device_cpu,
+            )
+
+            mock_adapter_cls.assert_called_once_with(
+                mock_create_core.return_value,
+                str(tmp_path / "model.xml"),
+                device="CPU",
+                max_num_requests=MODELAPI_NSTREAMS,
+            )
+            mock_create_model.assert_called_once_with(fake_adapter)
+
+        assert handle.model_id == model_id
+        assert handle.variant_id == variant_id
+        assert handle.device == fxt_device_cpu
+        assert handle.model is fake_model
+        assert isinstance(handle.loaded_at, datetime)
+
+    def test_unload_deletes_async_queue_and_compiled_model(self, fxt_loaded_handle: LoadedModelHandle) -> None:
+        """unload() should delete both async_queue and compiled_model from the adapter."""
+        adapter = cast(OpenvinoAdapter, fxt_loaded_handle.model.inference_adapter)
+        adapter.async_queue = Mock()
+        adapter.compiled_model = Mock()
+
+        ModelLoader.unload(fxt_loaded_handle)
+
+        assert not hasattr(adapter, "async_queue")
+        assert not hasattr(adapter, "compiled_model")

--- a/application/backend/tests/unit/services/inference/test_model_loader.py
+++ b/application/backend/tests/unit/services/inference/test_model_loader.py
@@ -61,7 +61,7 @@ class TestModelLoader:
                 mock_create_core.return_value,
                 str(tmp_path / "model.xml"),
                 device="CPU",
-                max_num_requests=MODELAPI_NSTREAMS,
+                max_num_requests=int(MODELAPI_NSTREAMS),
             )
             mock_create_model.assert_called_once_with(fake_adapter)
 

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -2,16 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 import tempfile
 from collections.abc import Iterator
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from model_api.models import Model
 
 from app.models.model_activation import ModelActivationState
+from app.models.system import DeviceInfo, DeviceType
 from app.services import ActiveModelService
-from app.services.active_model_service import LoadedModel
+from app.services.inference.model_loader import LoadedModelHandle
 
 
 @pytest.fixture
@@ -27,7 +29,7 @@ def fxt_model_activation_state() -> ModelActivationState:
         active_model_id=active_model_id,
         active_model_variant_id=active_variant_id,
         available_models=available_models,
-        device="CPU",
+        device=DeviceInfo(type=DeviceType.CPU, name="cpu"),
     )
 
 
@@ -81,22 +83,52 @@ class TestActiveModelServiceUnit:
                 extension=extension,
             )
 
-    def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state, monkeypatch):
+    def test_get_loaded_inference_model(self, fxt_active_model_service, fxt_model_activation_state):
         """Test loading the active inference model."""
-        dummy_model = Mock(spec=Model)
 
         with (
-            patch.object(Model, "create_model", return_value=dummy_model),
             patch.object(
                 fxt_active_model_service,
                 "_get_model_file_path",
                 new=lambda project_id, model_id, variant_id, extension: Path(f"model.{extension}"),
             ),
-            patch("app.services.active_model_service.create_core"),
-            patch("app.services.active_model_service.FP32OpenvinoAdapter"),
+            patch("app.services.inference.model_loader.ModelLoader.load") as mock_load_model,
         ):
-            loaded = fxt_active_model_service.get_loaded_inference_model(force_reload=True)
-            assert isinstance(loaded, LoadedModel)
-            assert loaded.model_revision_id == fxt_model_activation_state.active_model_id
-            assert loaded.model is dummy_model
-            assert loaded.device == fxt_model_activation_state.device
+            fxt_active_model_service.get_loaded_inference_model(force_reload=True)
+
+            mock_load_model.assert_called_once_with(
+                model_id=fxt_model_activation_state.active_model_id,
+                variant_id=fxt_model_activation_state.active_model_variant_id,
+                model_xml_path=Path("model.xml"),
+                device=fxt_model_activation_state.device,
+            )
+
+    def test_force_reload_triggers_unload(self, fxt_active_model_service, tmp_path):
+        """
+        When force_reload=True is called on a service that already holds a loaded model, model unload must be invoked.
+        """
+        # Build a fake adapter with the OV native attributes we expect to be cleaned up
+        fake_adapter = Mock()
+        fake_adapter.async_queue = Mock()
+        fake_adapter.compiled_model = Mock()
+
+        fake_model = Mock(spec=Model)
+        fake_model.inference_adapter = fake_adapter
+
+        # Inject a pre-loaded model into the service as if inference already ran
+        fxt_active_model_service._loaded_model = LoadedModelHandle(
+            model_id=uuid4(),
+            variant_id=uuid4(),
+            model=fake_model,
+            device=DeviceInfo(type=DeviceType.CPU, name="cpu"),
+            loaded_at=datetime.now(),
+        )
+
+        with (
+            patch("app.services.inference.model_loader.ModelLoader.load") as mock_load_model,
+            patch("app.services.inference.model_loader.ModelLoader.unload") as mock_unload_model,
+            patch.object(fxt_active_model_service, "_get_model_file_path", return_value=tmp_path / "model.xml"),
+        ):
+            fxt_active_model_service.get_loaded_inference_model(force_reload=True)
+            mock_unload_model.assert_called_once()
+            mock_load_model.assert_called_once()


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Centralize model loading/unloading using model_api in a single class
- [x] Update `ActiveModelService` and `InferenceServer` to use the new class

### How to test

2 scenarios:

1. Enable/disable any inference pipeline
2. Try Prediction mode on any video in the project with at least 2 models - switch between those models 
 
Observe memory consumption - it shouldn't grow after each action

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
