### PR TITLE
Instance segmentation bugfixes 

### DIFF
--- a/library/src/getitune/backend/lightning/models/detection/detectors/rfdetr.py
+++ b/library/src/getitune/backend/lightning/models/detection/detectors/rfdetr.py
@@ -149,15 +149,22 @@ class RFDETRDetector(BaseModule):
         self,
         batch_inputs: Tensor,
         num_select: int = 300,
-    ) -> tuple[Tensor, Tensor, Tensor, Tensor] | tuple[Tensor, Tensor, Tensor]:
+        merge_scores: bool = False,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor] | tuple[Tensor, Tensor, Tensor] | tuple[Tensor, Tensor]:
         """Export function for model tracing with mask support.
 
         Args:
             batch_inputs: Input images tensor.
             num_select: Number of top predictions to select.
-
+            merge_scores: If True, concatenate ``scores`` as the last column of
+                ``boxes``
         Returns:
-            Tuple of (boxes, labels, scores, masks) tensors.
+            When ``merge_scores`` is ``False`` (default):
+                - With masks:    ``(boxes, labels, scores, masks)``
+                - Without masks: ``(boxes, labels, scores)``
+            When ``merge_scores`` is ``True``:
+                - With masks:    ``(boxes_with_scores, labels, masks)``
+                - Without masks: ``(boxes_with_scores, labels)``
         """
         outputs = self.lwdetr(batch_inputs)
         # outputs may be dict or tuple in export mode
@@ -193,6 +200,12 @@ class RFDETRDetector(BaseModule):
             )
             # Apply sigmoid to get mask probabilities
             masks = torch.sigmoid(masks)
+            if merge_scores:
+                boxes_with_scores = torch.cat([boxes, scores.unsqueeze(-1)], dim=-1)
+                return boxes_with_scores, labels, masks
             return boxes, labels, scores, masks
 
+        if merge_scores:
+            boxes_with_scores = torch.cat([boxes, scores.unsqueeze(-1)], dim=-1)
+            return boxes_with_scores, labels
         return boxes, labels, scores

--- a/library/src/getitune/backend/lightning/models/detection/necks/fpn.py
+++ b/library/src/getitune/backend/lightning/models/detection/necks/fpn.py
@@ -237,18 +237,8 @@ class FPN:
             "add_extra_convs": "on_output",
             "relu_before_extra_convs": True,
         },
-        "maskrcnn_efficientnet_b2b": {
-            "in_channels": [24, 48, 120, 352],
-            "out_channels": 80,
-            "num_outs": 5,
-            "upsample_cfg": {"scale_factor": 2.0, "mode": "nearest"},
-        },
-        "maskrcnn_swin_tiny": {
-            "in_channels": [96, 192, 384, 768],
-            "out_channels": 256,
-            "num_outs": 5,
-            "upsample_cfg": {"scale_factor": 2.0, "mode": "nearest"},
-        },
+        "maskrcnn_efficientnet_b2b": {"in_channels": [24, 48, 120, 352], "out_channels": 80, "num_outs": 5},
+        "maskrcnn_swin_tiny": {"in_channels": [96, 192, 384, 768], "out_channels": 256, "num_outs": 5},
     }
 
     def __new__(cls, model_name: str) -> FPNModule:

--- a/library/src/getitune/backend/lightning/models/detection/necks/fpn.py
+++ b/library/src/getitune/backend/lightning/models/detection/necks/fpn.py
@@ -237,8 +237,18 @@ class FPN:
             "add_extra_convs": "on_output",
             "relu_before_extra_convs": True,
         },
-        "maskrcnn_efficientnet_b2b": {"in_channels": [24, 48, 120, 352], "out_channels": 80, "num_outs": 5},
-        "maskrcnn_swin_tiny": {"in_channels": [96, 192, 384, 768], "out_channels": 256, "num_outs": 5},
+        "maskrcnn_efficientnet_b2b": {
+            "in_channels": [24, 48, 120, 352],
+            "out_channels": 80,
+            "num_outs": 5,
+            "upsample_cfg": {"scale_factor": 2.0, "mode": "nearest"},
+        },
+        "maskrcnn_swin_tiny": {
+            "in_channels": [96, 192, 384, 768],
+            "out_channels": 256,
+            "num_outs": 5,
+            "upsample_cfg": {"scale_factor": 2.0, "mode": "nearest"},
+        },
     }
 
     def __new__(cls, model_name: str) -> FPNModule:

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn.py
@@ -352,7 +352,7 @@ class MaskRCNN(LightningInstanceSegModel):
                 "autograd_inlining": False,
                 "dynamo": False,
             },
-            output_names=["bboxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     @property

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn_tv.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn_tv.py
@@ -297,7 +297,7 @@ class MaskRCNNTV(LightningInstanceSegModel):
                 "autograd_inlining": False,
                 "dynamo": False,
             },
-            output_names=["bboxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def forward_for_tracing(self, inputs: Tensor) -> tuple[Tensor, ...]:
@@ -311,21 +311,10 @@ class MaskRCNNTV(LightningInstanceSegModel):
 
     @property
     def _optimization_config(self) -> dict[str, Any]:
-        """PTQ config for torchvision MaskRCNN.
-
-        The mask branch (``roi_heads.mask_roi_pool``) only receives input when
-        the box branch produces detections. During NNCF calibration on small
-        datasets it is possible for some scatter/slice nodes inside
-        ``mask_roi_pool`` to never see activations, which causes
-        ``nncf.InternalError: Statistics were not collected for the node
-        __module.model.roi_heads.mask_roi_pool/aten::scatter/Slice_3``.
-        Excluding the entire ``mask_roi_pool`` subgraph from quantization
-        keeps PTQ stable while leaving the heavier conv-dominated parts of
-        the model quantized.
-        """
+        """PTQ config for torchvision MaskRCNN."""
         return {
             "ignored_scope": {
-                "patterns": [".*mask_roi_pool.*"],
+                "patterns": [r".*mask_roi_pool.*aten::scatter.*"],
                 "validate": False,
             },
         }

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn_tv.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/maskrcnn_tv.py
@@ -309,6 +309,27 @@ class MaskRCNNTV(LightningInstanceSegModel):
         meta_info_list = [meta_info] * len(inputs)
         return self.model.export(inputs, meta_info_list, explain_mode=self.explain_mode)
 
+    @property
+    def _optimization_config(self) -> dict[str, Any]:
+        """PTQ config for torchvision MaskRCNN.
+
+        The mask branch (``roi_heads.mask_roi_pool``) only receives input when
+        the box branch produces detections. During NNCF calibration on small
+        datasets it is possible for some scatter/slice nodes inside
+        ``mask_roi_pool`` to never see activations, which causes
+        ``nncf.InternalError: Statistics were not collected for the node
+        __module.model.roi_heads.mask_roi_pool/aten::scatter/Slice_3``.
+        Excluding the entire ``mask_roi_pool`` subgraph from quantization
+        keeps PTQ stable while leaving the heavier conv-dominated parts of
+        the model quantized.
+        """
+        return {
+            "ignored_scope": {
+                "patterns": [".*mask_roi_pool.*"],
+                "validate": False,
+            },
+        }
+
 
 class RotatedMaskRCNNModelV2(RotatedPredictMixin, MaskRCNNTV):
     """Rotated MaskRCNN for Torchvision MaskRCNN model implementation."""

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, Literal
 
-import torch
 from rfdetr import (
     RFDETRSeg2XLarge,
     RFDETRSegLarge,
@@ -28,6 +27,7 @@ from getitune.config.data import TileConfig
 from getitune.metrics.fmeasure import MaskRLEMeanAPFMeasureCallable
 
 if TYPE_CHECKING:
+    import torch
     from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 
     from getitune.backend.lightning.schedulers import LRSchedulerListCallable
@@ -155,23 +155,8 @@ class RFDETRInst(RFDETRMixin, LightningInstanceSegModel):  # pyrefly: ignore[inc
         )
 
     def forward_for_tracing(self, inputs: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        """Forward pass used for export.
-
-        The OpenVINO ``MaskRCNN`` model_api wrapper (used by all instance
-        segmentation models) expects the exported ``boxes`` output to have a
-        last dimension of 5, i.e. batched shape ``(B, N, 5)``, where the 5th
-        value is the confidence score. The default RF-DETR export returns
-        ``(boxes, labels, scores, masks)`` with batched ``boxes`` shaped
-        ``(B, N, 4)``, which causes an ``IndexError`` in
-        ``model_api.models.instance_segmentation.postprocess`` when it reads
-        the score column from ``outputs["boxes"]``. We therefore concatenate
-        ``scores`` onto ``boxes`` here and drop the standalone ``scores``
-        output, mirroring the convention used by the MaskRCNN exporters.
-        """
-        outputs = self.model.export(inputs)  # pyrefly: ignore[not-callable]
-        boxes, labels, scores, masks = outputs
-        boxes_with_scores = torch.cat([boxes, scores.unsqueeze(-1)], dim=-1)
-        return boxes_with_scores, labels, masks
+        """Forward pass used for export."""
+        return self.model.export(inputs, merge_scores=True)  # pyrefly: ignore[not-callable]
 
     @property
     def _default_preprocessing_params(self) -> dict[str, DataInputParams]:  # type: ignore[override]

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
@@ -158,14 +158,15 @@ class RFDETRInst(RFDETRMixin, LightningInstanceSegModel):  # pyrefly: ignore[inc
         """Forward pass used for export.
 
         The OpenVINO ``MaskRCNN`` model_api wrapper (used by all instance
-        segmentation models) expects the ``boxes`` output to have shape
-        ``(N, 5)`` where the 5th column is the confidence score. The default
-        RF-DETR export returns ``(boxes, labels, scores, masks)`` with a
-        4-column ``boxes`` tensor, which causes an ``IndexError`` in
+        segmentation models) expects the exported ``boxes`` output to have a
+        last dimension of 5, i.e. batched shape ``(B, N, 5)``, where the 5th
+        value is the confidence score. The default RF-DETR export returns
+        ``(boxes, labels, scores, masks)`` with batched ``boxes`` shaped
+        ``(B, N, 4)``, which causes an ``IndexError`` in
         ``model_api.models.instance_segmentation.postprocess`` when it reads
-        ``outputs["boxes"][:, 4]``. We therefore concatenate ``scores`` onto
-        ``boxes`` here and drop the standalone ``scores`` output, mirroring
-        the convention used by the MaskRCNN exporters.
+        the score column from ``outputs["boxes"]``. We therefore concatenate
+        ``scores`` onto ``boxes`` here and drop the standalone ``scores``
+        output, mirroring the convention used by the MaskRCNN exporters.
         """
         outputs = self.model.export(inputs)  # pyrefly: ignore[not-callable]
         boxes, labels, scores, masks = outputs

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/rfdetr_inst.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar, Literal
 
+import torch
 from rfdetr import (
     RFDETRSeg2XLarge,
     RFDETRSegLarge,
@@ -145,13 +146,31 @@ class RFDETRInst(RFDETRMixin, LightningInstanceSegModel):  # pyrefly: ignore[inc
             via_onnx=False,
             onnx_export_configuration={
                 "input_names": ["images"],
-                "output_names": ["bboxes", "labels", "scores", "masks"],
+                "output_names": ["boxes", "labels", "masks"],
                 "dynamic_shapes": {"inputs": {0: Dim("batch")}},
                 "autograd_inlining": False,
                 "opset_version": 18,
             },
-            output_names=["bboxes", "labels", "scores", "masks"],
+            output_names=["boxes", "labels", "masks"],
         )
+
+    def forward_for_tracing(self, inputs: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        """Forward pass used for export.
+
+        The OpenVINO ``MaskRCNN`` model_api wrapper (used by all instance
+        segmentation models) expects the ``boxes`` output to have shape
+        ``(N, 5)`` where the 5th column is the confidence score. The default
+        RF-DETR export returns ``(boxes, labels, scores, masks)`` with a
+        4-column ``boxes`` tensor, which causes an ``IndexError`` in
+        ``model_api.models.instance_segmentation.postprocess`` when it reads
+        ``outputs["boxes"][:, 4]``. We therefore concatenate ``scores`` onto
+        ``boxes`` here and drop the standalone ``scores`` output, mirroring
+        the convention used by the MaskRCNN exporters.
+        """
+        outputs = self.model.export(inputs)  # pyrefly: ignore[not-callable]
+        boxes, labels, scores, masks = outputs
+        boxes_with_scores = torch.cat([boxes, scores.unsqueeze(-1)], dim=-1)
+        return boxes_with_scores, labels, masks
 
     @property
     def _default_preprocessing_params(self) -> dict[str, DataInputParams]:  # type: ignore[override]

--- a/library/src/getitune/backend/lightning/models/instance_segmentation/rtmdet_inst.py
+++ b/library/src/getitune/backend/lightning/models/instance_segmentation/rtmdet_inst.py
@@ -173,7 +173,7 @@ class RTMDetInst(LightningInstanceSegModel):
                 "dynamo": False,
             },
             # TODO(Eugene): Add XAI support for RTMDetInst
-            output_names=["bboxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
+            output_names=["boxes", "labels", "masks", "feature_vector", "saliency_map"] if self.explain_mode else None,
         )
 
     def forward_for_tracing(self, inputs: Tensor) -> tuple[Tensor, ...]:

--- a/library/src/getitune/data/augmentation/transforms.py
+++ b/library/src/getitune/data/augmentation/transforms.py
@@ -125,9 +125,16 @@ class Resize(tvt_v2.Transform):
         sample.image = sample.image.clamp(0, 1)
         # Apply padding if needed
         if pad_left > 0 or pad_top > 0 or pad_right > 0 or pad_bottom > 0:
-            fill_value: float | int | list[float] = (
-                list(self.pad_value) if isinstance(self.pad_value, tuple) else self.pad_value
-            )
+            # Normalise pad value to match the image's value range.
+            is_float_image = sample.image.is_floating_point()
+            if isinstance(self.pad_value, tuple):
+                fill_value: float | int | list[float] = [
+                    (v / 255.0 if is_float_image and v > 1.0 + 1e-5 else v) for v in self.pad_value
+                ]
+            else:
+                fill_value = (
+                    self.pad_value / 255.0 if is_float_image and self.pad_value > 1.0 + 1e-5 else self.pad_value
+                )
             sample.image = F.pad(
                 sample.image,
                 padding=[pad_left, pad_top, pad_right, pad_bottom],

--- a/library/tests/unit/backend/lightning/models/detection/detectors/test_rfdetr_detector.py
+++ b/library/tests/unit/backend/lightning/models/detection/detectors/test_rfdetr_detector.py
@@ -228,3 +228,39 @@ class TestRFDETRDetector:
         # In valid xyxy format: x1 <= x2 and y1 <= y2 for all boxes
         assert (boxes[:, :, 0] <= boxes[:, :, 2]).all()
         assert (boxes[:, :, 1] <= boxes[:, :, 3]).all()
+        # Default boxes are 4-column xyxy.
+        assert boxes.shape[-1] == 4
+
+    def test_export_merge_scores_with_masks(
+        self,
+        rfdetr_detector: RFDETRDetector,
+        images: torch.Tensor,
+    ) -> None:
+        """``merge_scores=True`` must concat scores into ``boxes`` and drop scores tensor.
+
+        This is the contract required by the OpenVINO ``MaskRCNN`` model_api
+        wrapper used by the instance-segmentation export path, which reads
+        ``outputs["boxes"][:, 4]`` for the confidence score.
+        """
+        rfdetr_detector.eval()
+        if hasattr(rfdetr_detector.lwdetr, "export"):
+            rfdetr_detector.lwdetr.export()  # pyrefly: ignore[not-callable]
+
+        result = rfdetr_detector.export(images, merge_scores=True)
+
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        boxes_with_scores, labels, masks = result
+        # Boxes must now carry the score in the 5th column.
+        assert boxes_with_scores.ndim == 3
+        assert boxes_with_scores.shape[0] == 2
+        assert boxes_with_scores.shape[-1] == 5
+        # Scores (last column) must be in [0, 1] (sigmoid of pred_logits).
+        last_col = boxes_with_scores[..., 4]
+        assert torch.all(last_col >= 0.0)
+        assert torch.all(last_col <= 1.0)
+        # xyxy validity on the first 4 columns.
+        assert (boxes_with_scores[..., 0] <= boxes_with_scores[..., 2]).all()
+        assert (boxes_with_scores[..., 1] <= boxes_with_scores[..., 3]).all()
+        assert labels.shape[:2] == boxes_with_scores.shape[:2]
+        assert masks.shape[:2] == boxes_with_scores.shape[:2]

--- a/library/tests/unit/backend/lightning/models/instance_segmentation/test_maskrcnn.py
+++ b/library/tests/unit/backend/lightning/models/instance_segmentation/test_maskrcnn.py
@@ -72,3 +72,40 @@ class TestMaskRCNN:
         # fxt_model.explain_mode = True  # noqa: ERA001
         # output = fxt_model.forward_for_tracing(torch.randn(1, 3, 32, 32))  # noqa: ERA001
         # assert len(output) == 5  # noqa: ERA001
+
+    def test_maskrcnn_tv_optimization_config_excludes_mask_roi_pool(self) -> None:
+        """``MaskRCNNTV`` PTQ config must exclude ``mask_roi_pool``.
+
+        NNCF calibration on small datasets can leave scatter/slice nodes inside
+        ``roi_heads.mask_roi_pool`` without statistics, raising
+        ``InternalError: Statistics were not collected for the node
+        __module.model.roi_heads.mask_roi_pool/aten::scatter/Slice_3``.
+        Excluding the subgraph from PTQ keeps quantization stable.
+        """
+        model = MaskRCNNTV(
+            label_info=3,
+            model_name="maskrcnn_resnet_50",
+            data_input_params=DataInputParams((640, 640), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+        )
+        cfg = model._optimization_config
+        assert "ignored_scope" in cfg
+        ignored = cfg["ignored_scope"]
+        assert "patterns" in ignored
+        assert any("mask_roi_pool" in p for p in ignored["patterns"])
+        assert ignored.get("validate") is False
+
+    @pytest.mark.parametrize("model_name", ["maskrcnn_efficientnet_b2b", "maskrcnn_swin_tiny"])
+    def test_maskrcnn_fpn_uses_static_scale_factor(self, model_name: str) -> None:
+        """Mask R-CNN FPNs must use ``scale_factor`` instead of dynamic ``size``.
+
+        With dynamic ``size`` the ``F.interpolate(mode='nearest')`` lowering
+        under ``torch.compile`` produces a Triton kernel whose ``XBLOCK``
+        exceeds the hardware maximum (``AssertionError: 'XBLOCK' too large.
+        Maximum: 4096``). Using a static ``scale_factor=2.0`` is mathematically
+        equivalent for these configs (inputs are divisible by 32) and keeps
+        the kernel size bounded.
+        """
+        from getitune.backend.lightning.models.detection.necks.fpn import FPN
+
+        cfg = FPN.FPN_CFG[model_name]
+        assert cfg.get("upsample_cfg") == {"scale_factor": 2.0, "mode": "nearest"}

--- a/library/tests/unit/backend/lightning/models/instance_segmentation/test_maskrcnn.py
+++ b/library/tests/unit/backend/lightning/models/instance_segmentation/test_maskrcnn.py
@@ -93,19 +93,3 @@ class TestMaskRCNN:
         assert "patterns" in ignored
         assert any("mask_roi_pool" in p for p in ignored["patterns"])
         assert ignored.get("validate") is False
-
-    @pytest.mark.parametrize("model_name", ["maskrcnn_efficientnet_b2b", "maskrcnn_swin_tiny"])
-    def test_maskrcnn_fpn_uses_static_scale_factor(self, model_name: str) -> None:
-        """Mask R-CNN FPNs must use ``scale_factor`` instead of dynamic ``size``.
-
-        With dynamic ``size`` the ``F.interpolate(mode='nearest')`` lowering
-        under ``torch.compile`` produces a Triton kernel whose ``XBLOCK``
-        exceeds the hardware maximum (``AssertionError: 'XBLOCK' too large.
-        Maximum: 4096``). Using a static ``scale_factor=2.0`` is mathematically
-        equivalent for these configs (inputs are divisible by 32) and keeps
-        the kernel size bounded.
-        """
-        from getitune.backend.lightning.models.detection.necks.fpn import FPN
-
-        cfg = FPN.FPN_CFG[model_name]
-        assert cfg.get("upsample_cfg") == {"scale_factor": 2.0, "mode": "nearest"}

--- a/library/tests/unit/backend/lightning/models/instance_segmentation/test_maskrcnn.py
+++ b/library/tests/unit/backend/lightning/models/instance_segmentation/test_maskrcnn.py
@@ -74,13 +74,14 @@ class TestMaskRCNN:
         # assert len(output) == 5  # noqa: ERA001
 
     def test_maskrcnn_tv_optimization_config_excludes_mask_roi_pool(self) -> None:
-        """``MaskRCNNTV`` PTQ config must exclude ``mask_roi_pool``.
+        """``MaskRCNNTV`` PTQ config must exclude the ``mask_roi_pool`` scatter subgraph.
 
         NNCF calibration on small datasets can leave scatter/slice nodes inside
         ``roi_heads.mask_roi_pool`` without statistics, raising
         ``InternalError: Statistics were not collected for the node
         __module.model.roi_heads.mask_roi_pool/aten::scatter/Slice_3``.
-        Excluding the subgraph from PTQ keeps quantization stable.
+        We narrow the ignored scope to the failing scatter subgraph only, so
+        the conv-dominated parts of the mask branch remain quantized.
         """
         model = MaskRCNNTV(
             label_info=3,
@@ -91,5 +92,6 @@ class TestMaskRCNN:
         assert "ignored_scope" in cfg
         ignored = cfg["ignored_scope"]
         assert "patterns" in ignored
-        assert any("mask_roi_pool" in p for p in ignored["patterns"])
+        patterns = ignored["patterns"]
+        assert any("mask_roi_pool" in p and "scatter" in p for p in patterns), patterns
         assert ignored.get("validate") is False

--- a/library/tests/unit/backend/lightning/models/instance_segmentation/test_rfdetr_inst.py
+++ b/library/tests/unit/backend/lightning/models/instance_segmentation/test_rfdetr_inst.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import torch
 
+from getitune.backend.lightning.exporter.native import LightningModelExporter
 from getitune.backend.lightning.models.base import DataInputParams
 from getitune.backend.lightning.models.instance_segmentation.rfdetr_inst import RFDETRInst
 from getitune.data.entity import PredictionBatch
@@ -153,8 +154,30 @@ class TestRFDETRInst:
 
         # Test export forward pass
         output = model.forward_for_tracing(torch.randn(1, 3, 312, 312))
-        # Should return boxes, labels, scores, masks
-        assert len(output) == 4
+        # Should return (boxes, labels, masks) where ``boxes`` has scores
+        # concatenated as the 5th column to match the OpenVINO ``MaskRCNN``
+        # model_api wrapper's expectation of ``boxes[:, 4]`` being the score.
+        assert len(output) == 3
+        boxes, labels, masks = output
+        assert boxes.ndim == 3
+        assert boxes.shape[-1] == 5  # x1, y1, x2, y2, score
+        assert labels.shape[:2] == boxes.shape[:2]
+        assert masks.shape[:2] == boxes.shape[:2]
+
+    def test_exporter_output_names(self) -> None:
+        """Exporter must publish ``boxes``/``labels``/``masks`` (no standalone ``scores``).
+
+        The OpenVINO ``MaskRCNN`` model_api wrapper used at test/optimize time
+        reads ``outputs["boxes"][:, 4]`` for the score; emitting a separate
+        ``scores`` output and a 4-column ``boxes`` tensor would raise
+        ``IndexError: index 4 is out of bounds for axis 1 with size 4``.
+        """
+        model = RFDETRInst(model_name="rfdetr_seg_n", label_info=3)
+        exporter = model._exporter
+        assert exporter.output_names == ["boxes", "labels", "masks"]
+        assert isinstance(exporter, LightningModelExporter)
+        onnx_cfg = exporter.onnx_export_configuration
+        assert onnx_cfg["output_names"] == ["boxes", "labels", "masks"]
 
     def test_customize_inputs(self, fxt_instance_seg_batch) -> None:
         """Test input customization for RF-DETR format."""

--- a/library/tests/unit/backend/lightning/models/instance_segmentation/test_rfdetr_inst.py
+++ b/library/tests/unit/backend/lightning/models/instance_segmentation/test_rfdetr_inst.py
@@ -165,17 +165,11 @@ class TestRFDETRInst:
         assert masks.shape[:2] == boxes.shape[:2]
 
     def test_exporter_output_names(self) -> None:
-        """Exporter must publish ``boxes``/``labels``/``masks`` (no standalone ``scores``).
-
-        The OpenVINO ``MaskRCNN`` model_api wrapper used at test/optimize time
-        reads ``outputs["boxes"][:, 4]`` for the score; emitting a separate
-        ``scores`` output and a 4-column ``boxes`` tensor would raise
-        ``IndexError: index 4 is out of bounds for axis 1 with size 4``.
-        """
+        """Exporter must publish ``boxes``/``labels``/``masks`` (no standalone ``scores``)."""
         model = RFDETRInst(model_name="rfdetr_seg_n", label_info=3)
         exporter = model._exporter
-        assert exporter.output_names == ["boxes", "labels", "masks"]
         assert isinstance(exporter, LightningModelExporter)
+        assert exporter.output_names == ["boxes", "labels", "masks"]
         onnx_cfg = exporter.onnx_export_configuration
         assert onnx_cfg["output_names"] == ["boxes", "labels", "masks"]
 

--- a/library/tests/unit/data/augmentation/test_resize.py
+++ b/library/tests/unit/data/augmentation/test_resize.py
@@ -242,6 +242,37 @@ class TestResize:
             top_row_mean = result.image[:, 0, :].float().mean()
             assert abs(top_row_mean - pad_value) < 1.0
 
+    def test_resize_pad_value_normalised_for_float_image(self, wide_image_entity: InstanceSegmentationSample) -> None:
+        """``pad_value`` expressed in 0-255 range must be rescaled for float images.
+
+        Recipes (e.g. RTMDet/YOLOX letterbox) configure ``pad_value: 114`` while
+        the runtime image tensor is float32 in ``[0, 1]``. Without rescaling, the
+        padded region would be filled with 114.0, completely dominating any
+        downstream ImageNet-style normalisation.
+        """
+        pad_value = 114
+        resize = Resize(
+            size=(128, 128),
+            keep_aspect_ratio=True,
+            resize_targets=False,
+            pad_value=pad_value,
+        )
+        entity = deepcopy(wide_image_entity)
+        # Mimic the production CPU pipeline which scales uint8 → float32 in [0, 1]
+        # before any geometric augmentation runs.
+        entity.image = tv_tensors.Image(entity.image.float().div(255.0))
+
+        result = resize(entity)
+
+        # Wide image (100x200) → resized to 128x64 → padded bottom-right.
+        # The bottom row should be entirely padding.
+        pad_bottom = result.img_info.pad_offset[3]
+        assert pad_bottom > 0
+        bottom_row_mean = result.image[:, -1, :].float().mean().item()
+        assert abs(bottom_row_mean - pad_value / 255.0) < 1e-3
+        # Padding must stay within the image's [0, 1] range.
+        assert result.image.max().item() <= 1.0 + 1e-5
+
     def test_resize_masks_binary_preserved(self, square_image_entity: InstanceSegmentationSample) -> None:
         """Test that mask binary values are preserved after resize."""
         resize = Resize(size=(64, 64), resize_targets=True, keep_aspect_ratio=True)


### PR DESCRIPTION
### Summary

**Fix rfdetr export problem** where model api output did not match the expected format resulting in an error: RuntimeError: IndexError: index 4 is out of bounds for axis 1 with size 4

**Fix nncf quantization error**: nncf.errors.InternalError: Statistics were not collected for the node __module.model.roi_heads.mask_roi_pool/aten::scatter/Slice_3

**Fix rtmdet_inst_tiny performance:**

A bug in getitune.data.augmentation.transforms.Resize interacting with the rtmdet_inst_tiny.yaml recipe.
The recipe (and its tiled sibling rtmdet_inst_tiny_tile.yaml) is the only place where Resize is configured with both keep_aspect_ratio: true (letterbox padding) and the YOLOX/RTMDet-style pad_value: 114.
In the production CPU pipeline, _IntensityAdapter runs before user augmentations and converts the uint8 image to float32 in [0, 1]. Resize.forward then resized the image (still in [0, 1]) and called:
sample.image = F.pad(sample.image, padding=..., fill=self.pad_value)  # 114
So every padded pixel was filled with literal 114.0 — ~250× larger than any real pixel. The subsequent kornia.augmentation.Normalize(mean=[0.485,...], std=[0.229,...]) mapped those to (114 − 0.485) / 0.229 ≈ 495, completely dominating the input distribution across the entire letterbox region (which is a large fraction of every non-square image).

Performance improved after these changes: 
<img width="1024" height="129" alt="image" src="https://github.com/user-attachments/assets/835e199e-23f5-44a5-ad35-3ee869c75fe4" />



<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
