### PR TITLE
feat: Show deleted weights badge when model's weights are deleted

### DIFF
--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.test.tsx
@@ -154,4 +154,35 @@ describe('ModelActions', () => {
         expect(renameItem).toHaveAttribute('aria-disabled', 'true');
         expect(deleteItem).not.toHaveAttribute('aria-disabled', 'true');
     });
+
+    describe('when model has deleted weights', () => {
+        const modelWithDeletedWeights = getMockedModel({
+            ...mockModel,
+            files_deleted: true,
+        });
+
+        it('disables "Delete weights", "View training logs", and "Set as active"', async () => {
+            render(<ModelActions model={modelWithDeletedWeights} />);
+
+            const menuButton = screen.getByRole('button', { name: 'Model actions' });
+            await userEvent.click(menuButton);
+
+            expect(screen.getByRole('menuitem', { name: 'Delete weights' })).toHaveAttribute('aria-disabled', 'true');
+            expect(screen.getByRole('menuitem', { name: 'View training logs' })).toHaveAttribute(
+                'aria-disabled',
+                'true'
+            );
+            expect(screen.getByRole('menuitem', { name: 'Set as active' })).toHaveAttribute('aria-disabled', 'true');
+        });
+
+        it('keeps "Rename" and "Delete model" enabled', async () => {
+            render(<ModelActions model={modelWithDeletedWeights} />);
+
+            const menuButton = screen.getByRole('button', { name: 'Model actions' });
+            await userEvent.click(menuButton);
+
+            expect(screen.getByRole('menuitem', { name: 'Rename' })).not.toHaveAttribute('aria-disabled', 'true');
+            expect(screen.getByRole('menuitem', { name: 'Delete model' })).not.toHaveAttribute('aria-disabled', 'true');
+        });
+    });
 });

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
@@ -47,7 +47,7 @@ export const ModelActions = ({ model }: ModelActionsProps) => {
     if (disableRenameAndActive) disabledKeys.push(MODEL_ACTIONS.ACTIVATE, MODEL_ACTIONS.RENAME);
     if (isTrainingModel(model)) disabledKeys.push(MODEL_ACTIONS.VIEW_LOGS);
     if (hasDeletedWeights(model))
-        disabledKeys.push(...[MODEL_ACTIONS.DELETE_WEIGHTS, MODEL_ACTIONS.VIEW_LOGS, MODEL_ACTIONS.ACTIVATE]);
+        disabledKeys.push(MODEL_ACTIONS.DELETE_WEIGHTS, MODEL_ACTIONS.VIEW_LOGS, MODEL_ACTIONS.ACTIVATE);
 
     const handleAction = (key: Key) => {
         if (key === MODEL_ACTIONS.ACTIVATE) {

--- a/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-actions/model-actions.component.tsx
@@ -12,7 +12,7 @@ import { usePatchPipeline } from '../../../../../hooks/api/pipeline.hook';
 import { useDeleteModel } from '../../../hooks/api/use-delete-model.hook';
 import { useRenameModel } from '../../../hooks/api/use-rename-model.hook';
 import { TrainingLogsDialog } from '../../../training-logs/training-logs-dialog.component';
-import { isFailedModel, isTrainingModel } from '../../utils/utils';
+import { hasDeletedWeights, isFailedModel, isTrainingModel } from '../../utils/utils';
 import { RenameModelDialog } from '../model-row/rename-model-dialog.component';
 
 const MODEL_ACTIONS = {
@@ -43,8 +43,11 @@ export const ModelActions = ({ model }: ModelActionsProps) => {
 
     const disableRenameAndActive = isFailedModel(model) || isTrainingModel(model);
     const disabledKeys = [];
+
     if (disableRenameAndActive) disabledKeys.push(MODEL_ACTIONS.ACTIVATE, MODEL_ACTIONS.RENAME);
     if (isTrainingModel(model)) disabledKeys.push(MODEL_ACTIONS.VIEW_LOGS);
+    if (hasDeletedWeights(model))
+        disabledKeys.push(...[MODEL_ACTIONS.DELETE_WEIGHTS, MODEL_ACTIONS.VIEW_LOGS, MODEL_ACTIONS.ACTIVATE]);
 
     const handleAction = (key: Key) => {
         if (key === MODEL_ACTIONS.ACTIVATE) {

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.test.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 import { screen, within } from '@testing-library/react';
@@ -133,6 +133,34 @@ describe('ModelRow', () => {
             );
 
             expect(screen.getByText('Failed')).toBeInTheDocument();
+        });
+
+        it('renders "Deleted weights" badge when model files_deleted is true', () => {
+            const deletedWeightsModel = getMockedModel({ files_deleted: true });
+
+            render(
+                <ModelRow
+                    model={deletedWeightsModel}
+                    datasetRevision={datasetRevision}
+                    groupBy={'dataset'}
+                    modelArchitecture={modelArchitecture}
+                />
+            );
+
+            expect(screen.getByText('Deleted weights')).toBeInTheDocument();
+        });
+
+        it('does not render "Deleted weights" badge when model files_deleted is false', () => {
+            render(
+                <ModelRow
+                    model={defaultModel}
+                    datasetRevision={datasetRevision}
+                    groupBy={'dataset'}
+                    modelArchitecture={modelArchitecture}
+                />
+            );
+
+            expect(screen.queryByText('Deleted weights')).not.toBeInTheDocument();
         });
     });
 

--- a/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/model-row/model-row.component.tsx
@@ -13,7 +13,7 @@ import { GRID_COLUMNS } from '../../constants';
 import { AccuracyIndicator } from '../../model-variants/accuracy-indicator.component';
 import { type GroupByMode } from '../../types';
 import { formatTrainingDateTime } from '../../utils/date-formatting';
-import { isFailedModel } from '../../utils/utils';
+import { hasDeletedWeights, isFailedModel } from '../../utils/utils';
 import { ActiveModelTag } from '../active-model-tag.component';
 import { ParentRevisionModel } from '../parent-revision-model.component';
 import { ArchitectureColumn } from './architecture-column.component';
@@ -34,6 +34,19 @@ type ModelRowProps = {
 
 const FailedModel = () => {
     return <Badge variant={'negative'}>Failed</Badge>;
+};
+
+const DeletedWeightsModel = () => {
+    return (
+        <Badge
+            variant={'yellow'}
+            UNSAFE_style={{
+                '--spectrum-yellow-background-color-default': `var(--brand-daisy)`,
+            }}
+        >
+            Deleted weights
+        </Badge>
+    );
 };
 
 export const ModelRow = ({
@@ -58,16 +71,12 @@ export const ModelRow = ({
     return (
         <Grid columns={GRID_COLUMNS} alignItems={'center'} width={'100%'} columnGap={'size-200'}>
             <Flex direction={'column'} gap={'size-50'}>
-                <Flex alignItems={'center'} gap={'size-100'}>
+                <Flex alignItems={'center'} gap={'size-100'} wrap>
                     <Text UNSAFE_className={classes.modelName} data-testid={'model-name'}>
                         {model.name ?? 'Unnamed Model'}
-                        {isFailedModel(model) && (
-                            <>
-                                {' '}
-                                <FailedModel />
-                            </>
-                        )}
                     </Text>
+                    {isFailedModel(model) && <FailedModel />}
+                    {hasDeletedWeights(model) && <DeletedWeightsModel />}
                     {model.id === activeModelId && <ActiveModelTag />}
                 </Flex>
                 <Text UNSAFE_className={classes.secondaryText}>

--- a/application/ui/src/features/models/model-listing/utils/utils.ts
+++ b/application/ui/src/features/models/model-listing/utils/utils.ts
@@ -17,3 +17,5 @@ export const isTrainingModel = (model: Pick<Model, 'training_info'>): boolean =>
 
 export const isSuccessfulModel = (model: Pick<Model, 'training_info'>): boolean =>
     model.training_info?.status === TRAINING_STATUS.Successful;
+
+export const hasDeletedWeights = (model: Pick<Model, 'files_deleted'>): boolean => model.files_deleted;


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Show badge.
2. Disable delete weights, set as active and view logs.

<img width="1250" height="383" alt="image" src="https://github.com/user-attachments/assets/2425b1f8-9a63-47dd-9411-23b8844b4dcb" />

Close #6323 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
