### PR TITLE
fix: reset _export flag on all rfdetr sub-modules after export

### DIFF
--- a/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
+++ b/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
@@ -289,11 +289,21 @@ class RFDETRMixin:
 
     @staticmethod
     def _restore_forward_methods(module: torch.nn.Module) -> None:
-        """Undo ``module.export()`` forward monkey-patching on all sub-modules."""
+        """Undo ``module.export()`` forward monkey-patching on all sub-modules.
+
+        Some rfdetr sub-modules (e.g. ``TransformerDecoder``, ``MSDeformAttn``)
+        set ``_export = True`` in their ``export()`` method but do **not** swap
+        ``forward`` (i.e. they have no ``_forward_origin``).  They instead
+        branch on ``self._export`` inside their existing ``forward``.  We must
+        reset the flag on *every* module that carries it, not only those whose
+        ``forward`` was monkey-patched.
+        """
         for m in module.modules():
-            if getattr(m, "_export", False) and hasattr(m, "_forward_origin"):
+            if not getattr(m, "_export", False):
+                continue
+            if hasattr(m, "_forward_origin"):
                 m.forward = m._forward_origin  # noqa: SLF001  # pyrefly: ignore[bad-assignment]
-                m._export = False  # noqa: SLF001  # pyrefly: ignore[bad-argument-type]
+            m._export = False  # noqa: SLF001  # pyrefly: ignore[bad-argument-type]
 
     def export(
         self,

--- a/library/tests/unit/backend/lightning/models/instance_segmentation/test_rfdetr_inst.py
+++ b/library/tests/unit/backend/lightning/models/instance_segmentation/test_rfdetr_inst.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import torch
 
 from getitune.backend.lightning.models.base import DataInputParams
+from getitune.backend.lightning.models.common.rfdetr_mixin import RFDETRMixin
 from getitune.backend.lightning.models.instance_segmentation.rfdetr_inst import RFDETRInst
 from getitune.data.entity import PredictionBatch
 
@@ -155,6 +156,40 @@ class TestRFDETRInst:
         output = model.forward_for_tracing(torch.randn(1, 3, 312, 312))
         # Should return boxes, labels, scores, masks
         assert len(output) == 4
+
+    def test_predict_after_export_restore(self, fxt_instance_seg_batch) -> None:
+        """Inference must work after export() + _restore_forward_methods().
+
+        Regression test for a bug where ``TransformerDecoder._export`` was not
+        reset by ``_restore_forward_methods`` because the decoder has no
+        ``_forward_origin``.  The lingering flag made the decoder return a 3-D
+        tensor instead of 4-D, crashing the segmentation head's einsum.
+        """
+        model = RFDETRInst(
+            model_name="rfdetr_seg_n",
+            label_info=3,
+            data_input_params=DataInputParams((312, 312), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+        )
+        model = model.cpu()
+        model.eval()
+
+        fxt_instance_seg_batch.images = [
+            torch.randn(3, 312, 312),
+            torch.randn(3, 312, 312),
+        ]
+
+        # Simulate what RFDETRMixin.export() does: export then restore.
+        lwdetr = model.model.lwdetr  # pyrefly: ignore[missing-attribute]
+        lwdetr.export()  # pyrefly: ignore[missing-attribute]
+        RFDETRMixin._restore_forward_methods(lwdetr)  # pyrefly: ignore[bad-argument-type]
+
+        # Verify the decoder flag was cleared.
+        assert not lwdetr.transformer.decoder._export  # pyrefly: ignore[missing-attribute]
+
+        # Inference must succeed after the round-trip.
+        output = model(fxt_instance_seg_batch)
+        assert isinstance(output, PredictionBatch)
+        assert output.masks is not None
 
     def test_customize_inputs(self, fxt_instance_seg_batch) -> None:
         """Test input customization for RF-DETR format."""


### PR DESCRIPTION
_restore_forward_methods only cleared _export on modules with _forward_origin. Modules like TransformerDecoder and MSDeformAttn set _export=True but branch on the flag in their existing forward() without swapping it. The lingering flag caused the decoder to return a 3-D tensor instead of 4-D, crashing the segmentation head's einsum during inference after export.

Resolves #6320 

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
