### PR TITLE
feat: Allow a disconnected sink

### DIFF
--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -81,6 +81,14 @@ UPDATE_PIPELINE_BODY_EXAMPLES = {
         description="Change the device used for model inference (e.g., 'cpu', 'xpu', 'xpu-1')",
         value={"device": "xpu"},
     ),
+    "disconnect_sink": Example(
+        summary="Disconnect sink",
+        description=(
+            "Clear the configured sink. Predictions will only be routed to the WebRTC visualization "
+            "stream and not forwarded to any external sink."
+        ),
+        value={"sink_id": None},
+    ),
 }
 
 

--- a/application/backend/app/models/pipeline.py
+++ b/application/backend/app/models/pipeline.py
@@ -49,7 +49,9 @@ class Pipeline(BaseEntity):
         device: The device used for model inference (e.g., 'cpu', 'xpu', 'cuda', 'xpu-1', etc.).
 
     Raises:
-        ValueError: If attempting to set status to RUNNING when source, sink, or model is not configured.
+        ValueError: If attempting to set status to RUNNING when source or model is not configured.
+            A sink is not required: when no sink is configured, inference output is only routed to the
+            WebRTC visualization stream and not forwarded to any external sink.
     """
 
     project_id: UUID
@@ -81,8 +83,8 @@ class Pipeline(BaseEntity):
 
     @model_validator(mode="after")
     def validate_running_status(self) -> "Pipeline":
-        if self.status == PipelineStatus.RUNNING and any(
-            x is None for x in (self.source_id, self.sink_id, self.model_id)
-        ):
-            raise ValueError("Pipeline cannot be in 'running' state when source, sink, or model is not configured.")
+        # A sink is intentionally NOT required to enable a pipeline. When no sink is configured, predictions are still
+        # routed to the WebRTC visualization stream, skipping external sinks (folder, MQTT, ROS, webhook, ...)
+        if self.status == PipelineStatus.RUNNING and any(x is None for x in (self.source_id, self.model_id)):
+            raise ValueError("Pipeline cannot be in 'running' state when source or model is not configured.")
         return self

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -216,15 +216,16 @@ class PipelineService(BaseSessionManagedService):
             )
         if pipeline.status == PipelineStatus.RUNNING and updated.status == PipelineStatus.RUNNING:
             # If the pipeline source_id or sink_id is being updated while running
-            if pipeline.source.id != updated.source.id:  # type: ignore[union-attr] # source is always there for running pipeline
+            if pipeline.source_id != updated.source_id:
                 self._event_bus.emit_event(EventType.SOURCE_CHANGED)
-            if pipeline.sink_id != updated.sink_id:  # type: ignore[union-attr] # sink is always there for running pipeline
+            if pipeline.sink_id != updated.sink_id:
+                # Sink may be None (disconnected): in that case predictions are only routed to WebRTC.
                 self._event_bus.emit_event(EventType.SINK_CHANGED)
             if pipeline.data_collection != updated.data_collection:
                 self._event_bus.emit_event(EventType.PIPELINE_DATASET_COLLECTION_POLICIES_CHANGED)
             if pipeline.device != updated.device:
                 self._event_bus.emit_event(EventType.INFERENCE_DEVICE_CHANGED)
-            if pipeline.model_id != updated.model_revision.id or pipeline.model_variant_id != updated.model_variant_id:  # type: ignore[union-attr] # model_revision is always there for running pipeline
+            if pipeline.model_id != updated.model_id or pipeline.model_variant_id != updated.model_variant_id:
                 self._event_bus.emit_event(EventType.MODEL_CHANGED)
         elif pipeline.status != updated.status:
             # If the pipeline is being activated or stopped

--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -68,11 +68,6 @@ class DispatchingWorker(BaseThreadWorker):
 
     def run_loop(self) -> None:
         while not self.should_stop():
-            if self._sink.sink_type == SinkType.DISCONNECTED:
-                logger.debug("No sink available... retrying in 1 second")
-                self.stop_aware_sleep(1)
-                continue
-
             # Read from the queue
             try:
                 stream_data: StreamData = self._pred_queue.get(timeout=1)
@@ -91,13 +86,16 @@ class DispatchingWorker(BaseThreadWorker):
 
             image_with_visualization = inference_data.visualized_prediction
             prediction = inference_data.prediction
-            # Postprocess and dispatch results
-            for destination in self._destinations:
-                destination.dispatch(
-                    original_image=stream_data.frame_data,
-                    image_with_visualization=image_with_visualization,
-                    predictions=prediction,
-                )
+
+            # Postprocess and dispatch results to external sinks (folder, MQTT, ROS, webhook, ...).
+            # Skipped when no sink is configured; WebRTC and data collection still run below.
+            if self._sink.sink_type != SinkType.DISCONNECTED:
+                for destination in self._destinations:
+                    destination.dispatch(
+                        original_image=stream_data.frame_data,
+                        image_with_visualization=image_with_visualization,
+                        predictions=prediction,
+                    )
 
             # Dispatch to WebRTC stream
             self._rtc_stream_broadcaster.broadcast(image_with_visualization)

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -488,9 +488,13 @@ class TestPipelineServiceIntegration:
         else:
             assert not db_updated.is_running
 
-    @pytest.mark.parametrize("config", ["sink", "source", "model_revision"])
+    @pytest.mark.parametrize("config", ["source", "model_revision"])
     def test_enable_misconfigured_pipeline(self, config, fxt_project_with_pipeline, fxt_pipeline_service, db_session):
-        """Test enabling a misconfigured pipeline raises error."""
+        """Test enabling a misconfigured pipeline raises error.
+
+        Note: a sink is intentionally NOT required to enable a pipeline. When no sink is configured,
+        predictions are still routed to the WebRTC visualization stream.
+        """
         _, db_pipeline = fxt_project_with_pipeline(is_running=False)
         setattr(db_pipeline, config, None)  # Misconfigure the pipeline
         db_session.flush()
@@ -499,6 +503,19 @@ class TestPipelineServiceIntegration:
             fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"status": PipelineStatus.RUNNING})
 
         assert not db_session.get(PipelineDB, db_pipeline.project_id).is_running
+
+    def test_enable_pipeline_without_sink(self, fxt_project_with_pipeline, fxt_pipeline_service, db_session):
+        """A pipeline can be enabled even when no sink is configured."""
+        _, db_pipeline = fxt_project_with_pipeline(is_running=False)
+        db_pipeline.sink = None
+        db_pipeline.sink_id = None
+        db_session.flush()
+
+        updated = fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"status": PipelineStatus.RUNNING})
+
+        assert updated.status == PipelineStatus.RUNNING
+        assert updated.sink_id is None
+        assert db_session.get(PipelineDB, db_pipeline.project_id).is_running
 
     def test_reconfigure_non_existent_pipeline(self, fxt_pipeline_service):
         """Test updating a non-existent pipeline raises error."""

--- a/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.component.tsx
+++ b/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.component.tsx
@@ -5,9 +5,9 @@ import { Key } from 'react';
 
 import { ActionButton, Item, Menu, MenuTrigger, toast } from '@geti/ui';
 import { MoreMenu } from '@geti/ui/icons';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../../../api/client';
-import { useProjectIdentifier } from '../../../../../hooks/use-project-identifier.hook';
 
 const SINK_MENU_OPTIONS = {
     CONNECT: 'connect',
@@ -86,7 +86,20 @@ export const SinkMenu = ({ id, name, isConnected, onEdit }: SinkMenuProps) => {
     };
 
     const handleDisconnect = () => {
-        //
+        updatePipeline.mutate(
+            {
+                params: { path: { project_id } },
+                body: { sink_id: null },
+            },
+            {
+                onSuccess: () => {
+                    toast({
+                        type: 'success',
+                        message: `Successfully disconnected from "${name}"`,
+                    });
+                },
+            }
+        );
     };
 
     return (

--- a/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.component.tsx
+++ b/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.component.tsx
@@ -9,12 +9,19 @@ import { MoreMenu } from '@geti/ui/icons';
 import { $api } from '../../../../../api/client';
 import { useProjectIdentifier } from '../../../../../hooks/use-project-identifier.hook';
 
-export interface SinkMenuProps {
+const SINK_MENU_OPTIONS = {
+    CONNECT: 'connect',
+    DISCONNECT: 'disconnect',
+    REMOVE: 'remove',
+    EDIT: 'edit',
+};
+
+export type SinkMenuProps = {
     id: string;
     name: string;
     isConnected: boolean;
     onEdit: () => void;
-}
+};
 
 export const SinkMenu = ({ id, name, isConnected, onEdit }: SinkMenuProps) => {
     const project_id = useProjectIdentifier();
@@ -32,13 +39,16 @@ export const SinkMenu = ({ id, name, isConnected, onEdit }: SinkMenuProps) => {
 
     const handleOnAction = (option: Key) => {
         switch (option) {
-            case 'connect':
+            case SINK_MENU_OPTIONS.CONNECT:
                 handleConnect();
                 break;
-            case 'remove':
-                handleDelete();
+            case SINK_MENU_OPTIONS.DISCONNECT:
+                handleDisconnect();
                 break;
-            default:
+            case SINK_MENU_OPTIONS.REMOVE:
+                handleRemove();
+                break;
+            case SINK_MENU_OPTIONS.EDIT:
                 onEdit();
                 break;
         }
@@ -61,7 +71,7 @@ export const SinkMenu = ({ id, name, isConnected, onEdit }: SinkMenuProps) => {
         );
     };
 
-    const handleDelete = () => {
+    const handleRemove = () => {
         removeSink.mutate(
             { params: { path: { sink_id: id } } },
             {
@@ -75,15 +85,23 @@ export const SinkMenu = ({ id, name, isConnected, onEdit }: SinkMenuProps) => {
         );
     };
 
+    const handleDisconnect = () => {
+        //
+    };
+
     return (
         <MenuTrigger>
             <ActionButton isQuiet aria-label='sink menu'>
                 <MoreMenu />
             </ActionButton>
-            <Menu onAction={handleOnAction} disabledKeys={isConnected ? ['connect', 'remove'] : []}>
-                <Item key='connect'>Connect</Item>
-                <Item key='edit'>Edit</Item>
-                <Item key='remove'>Remove</Item>
+            <Menu onAction={handleOnAction} disabledKeys={isConnected ? [SINK_MENU_OPTIONS.REMOVE] : []}>
+                {isConnected ? (
+                    <Item key={SINK_MENU_OPTIONS.DISCONNECT}>Disconnect</Item>
+                ) : (
+                    <Item key={SINK_MENU_OPTIONS.CONNECT}>Connect</Item>
+                )}
+                <Item key={SINK_MENU_OPTIONS.EDIT}>Edit</Item>
+                <Item key={SINK_MENU_OPTIONS.REMOVE}>Remove</Item>
             </Menu>
         </MenuTrigger>
     );

--- a/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.test.tsx
+++ b/application/ui/src/features/inference/sinks/sink-list/sink-menu/sink-menu.test.tsx
@@ -116,12 +116,56 @@ describe('SinkMenu', () => {
             );
         });
 
-        it('disabled when sink is connected', async () => {
+        it('shows connect when sink is disconnected', async () => {
+            renderApp({ name, isConnected: false });
+
+            await userEvent.click(screen.getByRole('button', { name: /sink menu/i }));
+
+            expect(screen.getByRole('menuitem', { name: /Connect/i })).toBeVisible();
+        });
+    });
+
+    describe('disconnect', () => {
+        const name = 'test-name';
+
+        it('successfully disconnects', async () => {
+            const pipelinePatchSpy = vi.fn();
+
+            server.use(
+                http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
+                    const body = await request.json();
+
+                    pipelinePatchSpy(body);
+
+                    return HttpResponse.json(
+                        {
+                            project_id: '',
+                            status: 'idle',
+                            device: 'images_folder',
+                        },
+                        { status: 200 }
+                    );
+                })
+            );
+
+            renderApp({ name, isConnected: true });
+
+            await userEvent.click(screen.getByRole('button', { name: /sink menu/i }));
+            await userEvent.click(screen.getByRole('menuitem', { name: /Disconnect/i }));
+
+            expect(await screen.findByLabelText('toast')).toHaveTextContent(`Successfully disconnected from "${name}"`);
+
+            expect(pipelinePatchSpy).toHaveBeenCalledWith({
+                sink_id: null,
+            });
+        });
+
+        it('shows disconnect when sink is connected', async () => {
             renderApp({ name: 'test-name', isConnected: true });
 
             await userEvent.click(screen.getByRole('button', { name: /sink menu/i }));
 
-            expect(screen.getByRole('menuitem', { name: /Connect/i })).toHaveAttribute('aria-disabled', 'true');
+            expect(screen.getByRole('menuitem', { name: /Disconnect/i })).toBeVisible();
         });
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

The user may now enable the pipeline with a disconnected sink.
The predictions will still be sent to the stream for visualisation, but not stored anywhere.

Close #6337

### How to test

Disconnect the sink, then enable the pipeline.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
