### PR TITLE
Bugfix: training config update failing due to broken serialization

### DIFF
--- a/application/backend/app/execution/common/geti_config_converter.py
+++ b/application/backend/app/execution/common/geti_config_converter.py
@@ -814,6 +814,8 @@ class GetiConfigConverter:
             intensity_config["scale_factor"] = intensity_mapping.get("scale_factor", 1.0)
             intensity_config["min_value"] = intensity_mapping.get("clip_min_value", 0.0)
             intensity_config["max_value"] = intensity_mapping.get("clip_max_value", 255.0)
+        else:
+            raise ValueError(f"Unsupported intensity mapping mode: {mode}")
 
         # Apply to all subsets
         for subset_key in ("train_subset", "val_subset", "test_subset"):

--- a/application/backend/app/models/training_configuration/dataset_preparation.py
+++ b/application/backend/app/models/training_configuration/dataset_preparation.py
@@ -115,8 +115,10 @@ class IntensityMapping(BaseModel):
 
     @field_serializer("mode")
     @staticmethod
-    def serialize_mode(value: IntensityMappingMode) -> str:
+    def serialize_mode(value: IntensityMappingMode | str) -> str:
         """Serialize mode as the lowercase enum key name expected by the training library."""
+        if not isinstance(value, IntensityMappingMode):
+            value = IntensityMappingMode(value)
         return value.name.lower()
 
 


### PR DESCRIPTION
### Summary

The `serialize_mode` method of `IntensityMapping` would throw an error because on PATCH it receives as input a string ("Unit interval scaling") instead of an enum object (`IntensityMappingMode.SCALE_TO_UNIT`). Update the logic to make it robust to both enums and strings.

<img width="368" height="101" alt="image" src="https://github.com/user-attachments/assets/953904b3-870d-4222-841a-7be529bafa53" />

### How to test

1. Open a project
2. Train a model with a custom configuration
3. Verify that no error occurs, and the Geti config converter receives the right values

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
