### PR TITLE
feat: Allow user to disconnect source

### DIFF
--- a/application/ui/src/features/inference/sources/source-list/source-list.component.tsx
+++ b/application/ui/src/features/inference/sources/source-list/source-list.component.tsx
@@ -25,10 +25,11 @@ type SourcesListProps = {
 type SourceListItemProps = {
     source: SourceConfig;
     isConnected: boolean;
+    isPipelineRunning: boolean;
     onEditSource: (config: SourceConfig) => void;
 };
 
-const SourceListItem = ({ source, isConnected, onEditSource }: SourceListItemProps) => {
+const SourceListItem = ({ source, isConnected, onEditSource, isPipelineRunning }: SourceListItemProps) => {
     return (
         <Flex
             key={source.id}
@@ -56,6 +57,7 @@ const SourceListItem = ({ source, isConnected, onEditSource }: SourceListItemPro
                     name={source.name}
                     isConnected={isConnected}
                     onEdit={() => onEditSource(source)}
+                    isPipelineRunning={isPipelineRunning}
                 />
             </Flex>
         </Flex>
@@ -64,7 +66,8 @@ const SourceListItem = ({ source, isConnected, onEditSource }: SourceListItemPro
 
 export const SourcesList = ({ sources, onAddSource, onEditSource }: SourcesListProps) => {
     const pipeline = usePipeline();
-    const currentSourceId = pipeline.data?.source?.id;
+    const currentSourceId = pipeline.data.source?.id;
+    const isPipelineRunning = pipeline.data.status === 'running';
 
     return (
         <Flex
@@ -82,6 +85,7 @@ export const SourcesList = ({ sources, onAddSource, onEditSource }: SourcesListP
                     source={source}
                     isConnected={isEqual(currentSourceId, source.id)}
                     onEditSource={onEditSource}
+                    isPipelineRunning={isPipelineRunning}
                 />
             ))}
         </Flex>

--- a/application/ui/src/features/inference/sources/source-menu/source-menu.component.tsx
+++ b/application/ui/src/features/inference/sources/source-menu/source-menu.component.tsx
@@ -1,35 +1,83 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActionButton, Item, Key, Menu, MenuTrigger, toast } from '@geti/ui';
+import { useState } from 'react';
+
+import {
+    ActionButton,
+    Button,
+    ButtonGroup,
+    Content,
+    Dialog,
+    DialogContainer,
+    Divider,
+    Heading,
+    Item,
+    Key,
+    Menu,
+    MenuTrigger,
+    Text,
+    toast,
+} from '@geti/ui';
 import { MoreMenu } from '@geti/ui/icons';
+import { useDisablePipeline } from 'hooks/api/pipeline.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import { $api } from '../../../../api/client';
 
-export interface SourceMenuProps {
+type DisconnectSourceWarningDialogProps = {
+    onCancel: () => void;
+    onDisconnect: () => void;
+    name: string;
+    isPending: boolean;
+};
+
+const DisconnectSourceWarningDialog = ({
+    name,
+    onCancel,
+    isPending,
+    onDisconnect,
+}: DisconnectSourceWarningDialogProps) => {
+    return (
+        <Dialog>
+            <Heading>Disconnect {name}</Heading>
+            <Divider />
+            <Content>
+                <Text>
+                    Disconnecting this source will also disable the inference pipeline. Do you want to continue?
+                </Text>
+            </Content>
+            <ButtonGroup>
+                <Button variant={'secondary'} onPress={onCancel}>
+                    Cancel
+                </Button>
+                <Button variant={'accent'} onPress={onDisconnect} isDisabled={isPending}>
+                    Disconnect
+                </Button>
+            </ButtonGroup>
+        </Dialog>
+    );
+};
+
+const SOURCE_MENU_OPTIONS = {
+    CONNECT: 'connect',
+    DISCONNECT: 'disconnect',
+    REMOVE: 'remove',
+    EDIT: 'edit',
+};
+
+export type SourceMenuProps = {
     id: string;
     name: string;
     isConnected: boolean;
     onEdit: () => void;
-}
+    isPipelineRunning: boolean;
+};
 
-export const SourceMenu = ({ id, name, isConnected, onEdit }: SourceMenuProps) => {
+export const SourceMenu = ({ id, name, isConnected, onEdit, isPipelineRunning }: SourceMenuProps) => {
     const project_id = useProjectIdentifier();
-
-    const handleOnAction = (option: Key) => {
-        switch (option) {
-            case 'connect':
-                handleConnect();
-                break;
-            case 'remove':
-                handleDelete();
-                break;
-            default:
-                onEdit();
-                break;
-        }
-    };
+    const [isDisconnectConfirmationDialogVisible, setIsDisconnectConfirmationDialogVisible] = useState<boolean>(false);
+    const disablePipelineMutation = useDisablePipeline();
 
     const updatePipeline = $api.useMutation('patch', '/api/projects/{project_id}/pipeline', {
         meta: {
@@ -39,6 +87,34 @@ export const SourceMenu = ({ id, name, isConnected, onEdit }: SourceMenuProps) =
             ],
         },
     });
+
+    const removeSource = $api.useMutation('delete', '/api/sources/{source_id}', {
+        meta: {
+            invalidateQueries: [['get', '/api/sources']],
+        },
+    });
+
+    const handleOnAction = (option: Key) => {
+        switch (option) {
+            case SOURCE_MENU_OPTIONS.CONNECT:
+                handleConnect();
+                break;
+            case SOURCE_MENU_OPTIONS.DISCONNECT:
+                if (isPipelineRunning) {
+                    setIsDisconnectConfirmationDialogVisible(true);
+                    break;
+                }
+
+                handleDisconnect();
+                break;
+            case SOURCE_MENU_OPTIONS.REMOVE:
+                handleRemove();
+                break;
+            case SOURCE_MENU_OPTIONS.EDIT:
+                onEdit();
+                break;
+        }
+    };
 
     const handleConnect = () => {
         updatePipeline.mutate(
@@ -57,13 +133,56 @@ export const SourceMenu = ({ id, name, isConnected, onEdit }: SourceMenuProps) =
         );
     };
 
-    const removeSource = $api.useMutation('delete', '/api/sources/{source_id}', {
-        meta: {
-            invalidateQueries: [['get', '/api/sources']],
-        },
-    });
+    const handleDisconnect = () => {
+        updatePipeline.mutate(
+            {
+                params: { path: { project_id } },
+                body: { source_id: null },
+            },
+            {
+                onSuccess: () => {
+                    toast({
+                        type: 'success',
+                        message: `Successfully disconnected from "${name}".`,
+                    });
+                },
+            }
+        );
+    };
 
-    const handleDelete = () => {
+    const handleDisablePipelineAndDisconnect = () => {
+        disablePipelineMutation.mutate(
+            {
+                params: {
+                    path: {
+                        project_id,
+                    },
+                },
+            },
+            {
+                onSuccess: () => {
+                    updatePipeline.mutate(
+                        {
+                            params: { path: { project_id } },
+                            body: { source_id: null },
+                        },
+                        {
+                            onSuccess: () => {
+                                toast({
+                                    type: 'success',
+                                    message: `Successfully disabled pipeline and disconnected from "${name}".`,
+                                });
+
+                                setIsDisconnectConfirmationDialogVisible(false);
+                            },
+                        }
+                    );
+                },
+            }
+        );
+    };
+
+    const handleRemove = () => {
         removeSource.mutate(
             { params: { path: { source_id: id } } },
             {
@@ -78,15 +197,31 @@ export const SourceMenu = ({ id, name, isConnected, onEdit }: SourceMenuProps) =
     };
 
     return (
-        <MenuTrigger>
-            <ActionButton isQuiet aria-label='source menu'>
-                <MoreMenu />
-            </ActionButton>
-            <Menu onAction={handleOnAction} disabledKeys={isConnected ? ['connect', 'remove'] : []}>
-                <Item key='connect'>Connect</Item>
-                <Item key='edit'>Edit</Item>
-                <Item key='remove'>Remove</Item>
-            </Menu>
-        </MenuTrigger>
+        <>
+            <MenuTrigger>
+                <ActionButton isQuiet aria-label='source menu'>
+                    <MoreMenu />
+                </ActionButton>
+                <Menu onAction={handleOnAction} disabledKeys={isConnected ? [SOURCE_MENU_OPTIONS.REMOVE] : []}>
+                    {isConnected ? (
+                        <Item key={SOURCE_MENU_OPTIONS.DISCONNECT}>Disconnect</Item>
+                    ) : (
+                        <Item key={SOURCE_MENU_OPTIONS.CONNECT}>Connect</Item>
+                    )}
+                    <Item key={SOURCE_MENU_OPTIONS.EDIT}>Edit</Item>
+                    <Item key={SOURCE_MENU_OPTIONS.REMOVE}>Remove</Item>
+                </Menu>
+            </MenuTrigger>
+            <DialogContainer onDismiss={() => setIsDisconnectConfirmationDialogVisible(false)}>
+                {isDisconnectConfirmationDialogVisible && (
+                    <DisconnectSourceWarningDialog
+                        name={name}
+                        onDisconnect={handleDisablePipelineAndDisconnect}
+                        isPending={disablePipelineMutation.isPending || updatePipeline.isPending}
+                        onCancel={() => setIsDisconnectConfirmationDialogVisible(false)}
+                    />
+                )}
+            </DialogContainer>
+        </>
     );
 };

--- a/application/ui/src/features/inference/sources/source-menu/source-menu.component.tsx
+++ b/application/ui/src/features/inference/sources/source-menu/source-menu.component.tsx
@@ -102,10 +102,9 @@ export const SourceMenu = ({ id, name, isConnected, onEdit, isPipelineRunning }:
             case SOURCE_MENU_OPTIONS.DISCONNECT:
                 if (isPipelineRunning) {
                     setIsDisconnectConfirmationDialogVisible(true);
-                    break;
+                } else {
+                    handleDisconnect();
                 }
-
-                handleDisconnect();
                 break;
             case SOURCE_MENU_OPTIONS.REMOVE:
                 handleRemove();

--- a/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
+++ b/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
@@ -128,5 +128,102 @@ describe('SourceMenu', () => {
                 'An unexpected error occurred. Please try again.'
             );
         });
+
+        it('shows d when is disconnected', async () => {
+            renderApp({ name, isConnected: false });
+
+            await userEvent.click(screen.getByRole('button', { name: /source menu/i }));
+            expect(screen.getByRole('menuitem', { name: /Connect/i })).toBeVisible();
+        });
+    });
+
+    describe('disconnect', () => {
+        const name = 'test-name';
+
+        it('successfully disconnects source when pipeline is not running', async () => {
+            const pipelinePatchSpy = vi.fn();
+            const disablePipeline = vi.fn();
+
+            server.use(
+                http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
+                    const body = await request.json();
+
+                    pipelinePatchSpy(body);
+
+                    return HttpResponse.json({
+                        project_id: '',
+                        status: 'idle',
+                        device: 'images_folder',
+                    });
+                }),
+                http.post('/api/projects/{project_id}/pipeline:disable', async () => {
+                    disablePipeline();
+
+                    return HttpResponse.json(null, { status: 204 });
+                })
+            );
+
+            renderApp({ name, isConnected: true, isPipelineRunning: false });
+
+            await userEvent.click(screen.getByRole('button', { name: /source menu/i }));
+            await userEvent.click(screen.getByRole('menuitem', { name: /Disconnect/i }));
+
+            await expect(await screen.findByLabelText('toast')).toHaveTextContent(
+                `Successfully disconnected from "${name}"`
+            );
+
+            expect(disablePipeline).not.toHaveBeenCalled();
+            expect(pipelinePatchSpy).toHaveBeenCalledWith({ source_id: null });
+        });
+
+        it('successfully disconnects source when pipeline is running', async () => {
+            const pipelinePatchSpy = vi.fn();
+            const disablePipeline = vi.fn();
+
+            server.use(
+                http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
+                    const body = await request.json();
+
+                    pipelinePatchSpy(body);
+
+                    return HttpResponse.json({
+                        project_id: '',
+                        status: 'idle',
+                        device: 'images_folder',
+                    });
+                }),
+                http.post('/api/projects/{project_id}/pipeline:disable', async () => {
+                    disablePipeline();
+
+                    return HttpResponse.json(null, { status: 204 });
+                })
+            );
+
+            renderApp({ name, isConnected: true, isPipelineRunning: true });
+
+            await userEvent.click(screen.getByRole('button', { name: /source menu/i }));
+            await userEvent.click(screen.getByRole('menuitem', { name: /Disconnect/i }));
+
+            expect(screen.getByRole('heading', { name: `Disconnect ${name}` })).toBeVisible();
+
+            await userEvent.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+            await expect(await screen.findByLabelText('toast')).toHaveTextContent(
+                `Successfully disabled pipeline and disconnected from "${name}"`
+            );
+
+            expect(disablePipeline).toHaveBeenCalled();
+            expect(pipelinePatchSpy).toHaveBeenCalledWith({ source_id: null });
+            expect(disablePipeline.mock.invocationCallOrder[0]).toBeLessThan(
+                pipelinePatchSpy.mock.invocationCallOrder[0]
+            );
+        });
+
+        it('shows disconnect when is connected', async () => {
+            renderApp({ name, isConnected: true });
+
+            await userEvent.click(screen.getByRole('button', { name: /source menu/i }));
+            expect(screen.getByRole('menuitem', { name: /Disconnect/i })).toBeVisible();
+        });
     });
 });

--- a/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
+++ b/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
@@ -129,7 +129,7 @@ describe('SourceMenu', () => {
             );
         });
 
-        it('shows d when is disconnected', async () => {
+        it('shows connected when is disconnected', async () => {
             renderApp({ name, isConnected: false });
 
             await userEvent.click(screen.getByRole('button', { name: /source menu/i }));

--- a/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
+++ b/application/ui/src/features/inference/sources/source-menu/source-menu.test.tsx
@@ -16,8 +16,17 @@ describe('SourceMenu', () => {
         name = 'name test',
         isConnected = false,
         onEdit = vi.fn(),
+        isPipelineRunning = false,
     }: Partial<SourceMenuProps>) => {
-        render(<SourceMenu id={id} name={name} isConnected={isConnected} onEdit={onEdit} />);
+        render(
+            <SourceMenu
+                id={id}
+                name={name}
+                isConnected={isConnected}
+                onEdit={onEdit}
+                isPipelineRunning={isPipelineRunning}
+            />
+        );
     };
 
     it('edit', async () => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. When pipeline is running and user disconnects the source, we need to disable the pipeline first and then disconnect the source.
2. When pipeline is not running, we just disconnect the source.

<img width="1690" height="1286" alt="image" src="https://github.com/user-attachments/assets/7ff83dfa-fee6-4960-abbc-3ef08a2d3429" />
<img width="537" height="277" alt="image" src="https://github.com/user-attachments/assets/4c4af55c-7f22-4fd6-80e7-51110b67c81a" />


Close #6342 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
