### PR TITLE
ci: Fix stale marker workflow

### DIFF
--- a/.github/workflows/stale_marker.yaml
+++ b/.github/workflows/stale_marker.yaml
@@ -9,12 +9,13 @@ jobs:
   stale:
     runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
     permissions:
+      actions: write # required to delete state cache by key
       issues: write
       pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          stale-issue-message: "This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          stale-issue-message: "This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days."
           stale-pr-message: "This PR is stale because it has been open 90 days with no activity."
           close-issue-message: "This issue was closed because it has been stalled for 30 days with no activity."
           close-pr-message: "This PR was closed because it has been stalled for 180 days with no activity."


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

State deletion failure in cache is suspected as causing action to skip issues and PRs. Adding required permission.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
