### PR TITLE
Include timezone info in project creation date

### DIFF
--- a/application/backend/app/api/schemas/project.py
+++ b/application/backend/app/api/schemas/project.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Generic, TypeVar
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_serializer, model_validator
 
 from app.core.models import HasID, RequiresID
 from app.models import TaskType
@@ -89,6 +89,17 @@ class ProjectCreate(HasID, ProjectBase[TaskCreate]):
 class ProjectView(RequiresID, ProjectBase[TaskView]):
     active_pipeline: bool = Field(..., description="Whether the project has an active pipeline.")
     created_at: datetime = Field(..., description="Timestamp when the project was created.")
+
+    @field_serializer("created_at")
+    def serialize_created_at(self, v: datetime) -> str:
+        """Ensure created_at is always serialized with UTC timezone info.
+
+        The DB (SQLite) stores naive datetimes, so timezone info must be attached
+        here before the value is written to the JSON response.
+        """
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=UTC)
+        return v.isoformat()
 
     model_config = {
         "json_schema_extra": {

--- a/application/backend/tests/unit/api/routers/test_projects.py
+++ b/application/backend/tests/unit/api/routers/test_projects.py
@@ -82,6 +82,29 @@ class TestProjectEndpoints:
         assert response.status_code == status.HTTP_200_OK
         fxt_project_service.get_project_by_id.assert_called_once_with(fxt_project.id)
 
+    def test_get_project_created_at_has_timezone(self, fxt_project, fxt_project_service, fxt_client):
+        fxt_project_service.get_project_by_id.return_value = fxt_project
+
+        response = fxt_client.get(f"/api/projects/{str(fxt_project.id)}")
+
+        assert response.status_code == status.HTTP_200_OK
+        created_at_str = response.json()["created_at"]
+        parsed = datetime.fromisoformat(created_at_str)
+        assert parsed.tzinfo is not None, "created_at must include timezone info"
+
+    def test_get_project_naive_created_at_becomes_utc(self, fxt_project, fxt_project_service, fxt_client):
+        """Ensure a project with a naive created_at (as returned by SQLite) gets UTC timezone in the response."""
+        naive_project = fxt_project.model_copy(update={"created_at": datetime(2025, 6, 1, 12, 0, 0)})
+        fxt_project_service.get_project_by_id.return_value = naive_project
+
+        response = fxt_client.get(f"/api/projects/{str(fxt_project.id)}")
+
+        assert response.status_code == status.HTTP_200_OK
+        created_at_str = response.json()["created_at"]
+        parsed = datetime.fromisoformat(created_at_str)
+        assert parsed.tzinfo is not None, "created_at must include timezone info even when DB returns naive datetime"
+        assert parsed == datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
     @pytest.mark.parametrize("exclude_attrs", [{}, {"id"}])
     def test_create_project_success(self, exclude_attrs, fxt_project, fxt_project_service, fxt_client):
         fxt_project_service.create_project.return_value = fxt_project


### PR DESCRIPTION
### Summary

With this PR, the `/projects` endpoints will also return timezone info (UTC) in the response `created_at`, so that the UI can adjust the visualized datetime based on the local time settings.

### How to test

Check the response of `GET /projects`, both for new and existing projects

<img width="365" height="157" alt="image" src="https://github.com/user-attachments/assets/020a01dd-b0dd-465e-96ed-f86ac09e8583" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
