### PR TITLE
Add number of images with no object to dataset statistics

### DIFF
--- a/application/backend/app/api/schemas/dataset.py
+++ b/application/backend/app/api/schemas/dataset.py
@@ -92,7 +92,7 @@ class MediaCountsView(BaseModel):
 
 
 class InstancesPerLabelView(BaseModel):
-    label_id: UUID = Field(..., description="Unique identifier of label")
+    label_id: UUID | None = Field(..., description="Unique identifier of label")
     instances: int = Field(0, description="Number of annotation instances with this label in dataset")
 
     model_config = {

--- a/application/backend/app/models/dataset.py
+++ b/application/backend/app/models/dataset.py
@@ -52,15 +52,16 @@ class MediaCounts(BaseEntity):
 
 
 class InstancesPerLabel(BaseEntity):
-    label_id: UUID
+    label_id: UUID | None
     instances: int = 0
 
     @model_validator(mode="before")
     @classmethod
     def populate_instances_per_label(cls, data: object) -> object:
         if isinstance(data, dict):
+            label_id = data.get("label_id")
             return {
-                "label_id": UUID(str(data.get("label_id"))),
+                "label_id": UUID(str(label_id)) if label_id is not None else None,
                 "instances": data.get("instances", 0),
             }
         return data

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -279,32 +279,29 @@ class DatasetItemRepository:
         annotated_video_count = self.db.execute(annotated_video_stmt).scalar()
         annotated_counts["annotated_videos"] = annotated_video_count or 0
 
-        # Total instances:
+        # Total instances and instances_per_label
         annotated_dataset_items_stmt = select(DatasetItemDB.annotation_data).where(
             DatasetItemDB.project_id == self.project_id,
             DatasetItemDB.annotation_data.isnot(None),
             DatasetItemDB.user_reviewed,
         )
-        annotated_counts["instances"] = sum(
-            len(item.annotation_data)
-            for item in self.db.execute(annotated_dataset_items_stmt)
-            if item.annotation_data is not None
-        )
+        total_instances = 0
+        labels_counts: Counter[str] = Counter()
+        no_object_count = 0
+        for item in self.db.execute(annotated_dataset_items_stmt):
+            if not item.annotation_data:
+                no_object_count += 1
+            else:
+                total_instances += len(item.annotation_data)
+                for annotation in item.annotation_data:
+                    for label in annotation["labels"]:
+                        labels_counts[label["id"]] += 1
 
-        # instances_per_label
-        labels_counts = Counter(
-            label["id"]
-            for item in self.db.execute(annotated_dataset_items_stmt)
-            if item.annotation_data is not None
-            for annotation in item.annotation_data
-            for label in annotation["labels"]
-        )
-        no_object_count = sum(1 for item in self.db.execute(annotated_dataset_items_stmt) if not item.annotation_data)
-
+        annotated_counts["instances"] = total_instances
         annotated_counts["instances_per_label"] = [
             {"label_id": label_id, "instances": count} for label_id, count in labels_counts.items()
         ]
-        annotated_counts["instances_per_label"].append({"label_id": None, "instances": no_object_count})
+        annotated_counts["instances_per_label"].append({"label_id": None, "instances": no_object_count})  # type: ignore[dict-item]
 
         statistics.update(annotated_counts)
 

--- a/application/backend/app/repositories/dataset_item_repo.py
+++ b/application/backend/app/repositories/dataset_item_repo.py
@@ -292,10 +292,6 @@ class DatasetItemRepository:
         )
 
         # instances_per_label
-        annotated_dataset_items_stmt = select(DatasetItemDB.annotation_data).where(
-            DatasetItemDB.project_id == self.project_id, DatasetItemDB.annotation_data.isnot(None)
-        )
-
         labels_counts = Counter(
             label["id"]
             for item in self.db.execute(annotated_dataset_items_stmt)
@@ -303,9 +299,12 @@ class DatasetItemRepository:
             for annotation in item.annotation_data
             for label in annotation["labels"]
         )
+        no_object_count = sum(1 for item in self.db.execute(annotated_dataset_items_stmt) if not item.annotation_data)
+
         annotated_counts["instances_per_label"] = [
             {"label_id": label_id, "instances": count} for label_id, count in labels_counts.items()
         ]
+        annotated_counts["instances_per_label"].append({"label_id": None, "instances": no_object_count})
 
         statistics.update(annotated_counts)
 

--- a/application/backend/tests/integration/services/test_dataset_service.py
+++ b/application/backend/tests/integration/services/test_dataset_service.py
@@ -541,6 +541,23 @@ def fxt_project_with_rich_dataset_items(fxt_project_with_pipeline, db_session) -
     db_media_items.append(annotated_image)
     db_dataset_items.append(item_annotated_image)
 
+    # Image (annotated with no objects - empty annotations)
+    no_object_image = MediaDB(
+        id=str(uuid4()),
+        type="image",
+        name="no_object_img",
+        format="jpg",
+        **default_media_values,
+    )
+    item_no_object_image = DatasetItemDB(
+        id=str(no_object_image.id),
+        **default_item_values,
+        annotation_data=[],
+        user_reviewed=True,
+    )
+    db_media_items.append(no_object_image)
+    db_dataset_items.append(item_no_object_image)
+
     # Video (annotated frames)
     annotated_video = MediaDB(
         id=str(uuid4()),
@@ -1510,21 +1527,25 @@ class TestDatasetServiceIntegration:
         statistics = fxt_dataset_service.get_dataset_statistics(project_id=project.id)
 
         # Media counts
-        assert statistics.media_counts.images == 2
+        assert statistics.media_counts.images == 3
         assert statistics.media_counts.videos == 2
         assert statistics.media_counts.video_frames == 35
 
         # Annotation counts
-        assert statistics.annotations_counts.annotated_images == 1
+        assert statistics.annotations_counts.annotated_images == 2
         assert statistics.annotations_counts.annotated_videos == 1
         assert statistics.annotations_counts.annotated_video_frames == 2
 
         # Instances counts
         assert statistics.annotations_counts.instances == 5
-        assert len(statistics.annotations_counts.instances_per_label) == 2
-        label_counts = {str(lbl.label_id): lbl.instances for lbl in statistics.annotations_counts.instances_per_label}
+        assert len(statistics.annotations_counts.instances_per_label) == 3
+        label_counts = {
+            str(lbl.label_id) if lbl.label_id is not None else None: lbl.instances
+            for lbl in statistics.annotations_counts.instances_per_label
+        }
         assert label_counts[str(project.task.labels[0].id)] == 3
         assert label_counts[str(project.task.labels[1].id)] == 2
+        assert label_counts[None] == 1
 
     def test_get_dataset_statistics_no_annotations(
         self,
@@ -1571,7 +1592,9 @@ class TestDatasetServiceIntegration:
         assert statistics.media_counts.video_frames == 0
         assert statistics.annotations_counts.annotated_images == 0
         assert statistics.annotations_counts.instances == 0
-        assert statistics.annotations_counts.instances_per_label == []
+        assert len(statistics.annotations_counts.instances_per_label) == 1
+        assert statistics.annotations_counts.instances_per_label[0].label_id is None
+        assert statistics.annotations_counts.instances_per_label[0].instances == 0
 
     def test_get_dataset_statistics_mixed_annotated_and_unannotated(
         self,
@@ -1646,6 +1669,10 @@ class TestDatasetServiceIntegration:
         assert statistics.media_counts.images == 2
         assert statistics.annotations_counts.annotated_images == 1
         assert statistics.annotations_counts.instances == 1
-        assert len(statistics.annotations_counts.instances_per_label) == 1
-        assert str(statistics.annotations_counts.instances_per_label[0].label_id) == label_id
-        assert statistics.annotations_counts.instances_per_label[0].instances == 1
+        assert len(statistics.annotations_counts.instances_per_label) == 2
+        label_counts = {
+            str(lbl.label_id) if lbl.label_id is not None else None: lbl.instances
+            for lbl in statistics.annotations_counts.instances_per_label
+        }
+        assert label_counts[label_id] == 1
+        assert label_counts[None] == 0

--- a/application/backend/tests/unit/api/routers/test_datasets.py
+++ b/application/backend/tests/unit/api/routers/test_datasets.py
@@ -247,6 +247,7 @@ class TestDatasetItemEndpoints:
             "instances_per_label": [
                 {"label_id": "11111111-1111-1111-1111-111111111111", "instances": 5},
                 {"label_id": "22222222-2222-2222-2222-222222222222", "instances": 2},
+                {"label_id": None, "instances": 3},
             ],
         }
         # Patch the service to return a DatasetStatistics model with the correct fields
@@ -269,6 +270,7 @@ class TestDatasetItemEndpoints:
                 "instances_per_label": [
                     {"label_id": "11111111-1111-1111-1111-111111111111", "instances": 5},
                     {"label_id": "22222222-2222-2222-2222-222222222222", "instances": 2},
+                    {"label_id": None, "instances": 3},
                 ],
             },
         }

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.component.tsx
@@ -15,12 +15,12 @@ import {
     YAxis,
 } from 'recharts';
 
-import { useProjectLabelsWithEmptyLabel } from '../../../../../shared/annotator/labels';
+import { isEmptyLabel, useProjectLabelsWithEmptyLabel } from '../../../../../shared/annotator/labels';
 
 type DatasetLabelsChartProps = {
     totalItems: number;
     instancesPerLabel: {
-        label_id: string;
+        label_id: string | null;
         instances: number;
     }[];
 };
@@ -43,8 +43,12 @@ const ItemLabel = (props: LabelProps) => {
 export const DatasetLabelsChart = ({ totalItems, instancesPerLabel }: DatasetLabelsChartProps) => {
     const projectLabels = useProjectLabelsWithEmptyLabel();
 
+    const emptyLabelInstance = instancesPerLabel.find(({ label_id }) => label_id === null);
+
     const chartData = projectLabels.map((projectLabel) => {
-        const matchingInstances = instancesPerLabel.find(({ label_id }) => label_id === projectLabel.id);
+        const matchingInstances = isEmptyLabel(projectLabel.id)
+            ? emptyLabelInstance
+            : instancesPerLabel.find(({ label_id }) => label_id === projectLabel.id);
 
         return {
             label: projectLabel.name,

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.test.tsx
@@ -8,6 +8,7 @@ import { getMockedLabel } from 'mocks/mock-labels';
 import { render } from 'test-utils/render';
 import { vi } from 'vitest';
 
+import { useProjectLabelsWithEmptyLabel } from '../../../../../shared/annotator/labels';
 import { DatasetLabelsChart } from './dataset-labels-chart.component';
 
 vi.mock('recharts', async () => {
@@ -32,11 +33,19 @@ const mockLabels = [
     getMockedLabel({ id: 'label-10', name: 'Fish-10' }),
 ];
 
-vi.mock('../../../../../shared/annotator/labels', () => ({
-    useProjectLabelsWithEmptyLabel: vi.fn(() => mockLabels),
-}));
+vi.mock('../../../../../shared/annotator/labels', async () => {
+    const actual = await vi.importActual('../../../../../shared/annotator/labels');
+    return {
+        ...actual,
+        useProjectLabelsWithEmptyLabel: vi.fn(),
+    };
+});
 
 describe('DatasetLabelsChart', () => {
+    beforeEach(() => {
+        vi.mocked(useProjectLabelsWithEmptyLabel).mockReturnValue(mockLabels);
+    });
+
     it('renders all label names with multiple items', () => {
         const instancesPerLabel = mockLabels.map(({ id }) => ({ label_id: id, instances: 10 }));
         render(<DatasetLabelsChart totalItems={instancesPerLabel.length * 2} instancesPerLabel={instancesPerLabel} />);
@@ -44,5 +53,17 @@ describe('DatasetLabelsChart', () => {
         mockLabels.forEach(({ name }) => {
             expect(screen.getByText(name)).toBeVisible();
         });
+    });
+
+    it('maps null label_id to the empty label', async () => {
+        const emptyLabel = getMockedLabel({ id: 'empty-label', name: 'No object' });
+        const labelsWithEmpty = [...mockLabels, emptyLabel];
+
+        vi.mocked(useProjectLabelsWithEmptyLabel).mockReturnValue(labelsWithEmpty);
+
+        const instancesPerLabel = [{ label_id: null, instances: 3 }];
+        render(<DatasetLabelsChart totalItems={10} instancesPerLabel={instancesPerLabel} />);
+
+        expect(screen.getByText('No object')).toBeVisible();
     });
 });

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-statistics-content.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-statistics-content.component.tsx
@@ -18,7 +18,7 @@ const getAnnotationPercentage = (annotated: number, total: number): number => {
     return Math.min(100, Math.max(0, percentage));
 };
 
-const getMaxInstancesPerLabel = (instancesPerLabel: { label_id: string; instances: number }[]): number => {
+const getMaxInstancesPerLabel = (instancesPerLabel: { label_id: string | null; instances: number }[]): number => {
     if (isEmpty(instancesPerLabel)) {
         return 0;
     }

--- a/application/ui/src/shared/annotator/labels.ts
+++ b/application/ui/src/shared/annotator/labels.ts
@@ -12,6 +12,8 @@ export const EMPTY_LABEL_ID = 'empty-label';
 const NO_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No label', color: '#FFF' };
 const NO_OBJECT_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No object', color: '#FFF' };
 
+export const isEmptyLabel = (id: string): boolean => id === EMPTY_LABEL_ID;
+
 const getEmptyLabel = (taskType: TaskType, exclusiveLabels: boolean): Label | null => {
     if (isClassificationTask(taskType)) {
         const isMultiLabel = exclusiveLabels === false;


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add a value for number of media with no object/no label to the dataset statistics "instances_per_label" part, using `None` as the label id. 

Note that the UI needs to be updated to detect the None label id and properly display the result.

Resolves #6232 

### How to test

Tests have been updated

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
