### PR TITLE
[TODO] Add error handling for video stream and dispatcher initialization

### DIFF
--- a/application/backend/app/services/dispatch_service.py
+++ b/application/backend/app/services/dispatch_service.py
@@ -21,7 +21,6 @@ class DispatchService:
 
     @classmethod
     def _get_destination(cls, output_config: Sink) -> Dispatcher | None:
-        # TODO handle exceptions: if some output cannot be initialized, exclude it and raise a warning
         factory = cls._dispatcher_registry.get(output_config.sink_type)
         if factory is None:
             raise ValueError(f"Unrecognized sink type: {output_config.sink_type}")

--- a/application/backend/app/services/dispatch_service.py
+++ b/application/backend/app/services/dispatch_service.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from loguru import logger
+
 from collections.abc import Callable, Sequence
 
 from app.models import Sink, SinkType
@@ -23,9 +25,11 @@ class DispatchService:
         factory = cls._dispatcher_registry.get(output_config.sink_type)
         if factory is None:
             raise ValueError(f"Unrecognized sink type: {output_config.sink_type}")
-
-        return factory(output_config)
-
+        try:
+            return factory(output_config)
+        except Exception as e:
+            logger.warning(f"Failed to initialize dispatcher for {output_config.sink_type}: {e}")
+            return None
     @classmethod
     def get_destinations(cls, output_configs: Sequence[Sink]) -> list[Dispatcher]:
         """

--- a/application/backend/app/services/video_stream_service.py
+++ b/application/backend/app/services/video_stream_service.py
@@ -15,29 +15,32 @@ class VideoStreamService:
     @staticmethod
     def get_video_stream(input_config: Source) -> VideoStream | None:
         video_stream: VideoStream | None
-        # TODO handle exceptions: if stream cannot be initialized, fallback to disconnected state
-        match input_config.source_type:
-            case SourceType.DISCONNECTED:
-                video_stream = None
-            case SourceType.USB_CAMERA:
-                video_stream = USBCameraStream(
-                    device_id=input_config.config_data.device_id, codec=input_config.config_data.codec
-                )
-            case SourceType.IP_CAMERA:
-                video_stream = IPCameraStream(config=input_config)
-            case SourceType.VIDEO_FILE:
-                video_stream = VideoFileStream(input_config.config_data.video_path)
-            case SourceType.IMAGES_FOLDER:
-                video_stream = ImagesFolderStream(
-                    folder_path=input_config.config_data.images_folder_path,
-                    ignore_existing_images=input_config.config_data.ignore_existing_images,
-                )
-            case _:
-                raise ValueError(f"Unrecognized source type: {input_config.source_type}")
+        try:
+            match input_config.source_type:
+                case SourceType.DISCONNECTED:
+                    video_stream = None
+                case SourceType.USB_CAMERA:
+                    video_stream = USBCameraStream(
+                        device_id=input_config.config_data.device_id, codec=input_config.config_data.codec
+                    )
+                case SourceType.IP_CAMERA:
+                    video_stream = IPCameraStream(config=input_config)
+                case SourceType.VIDEO_FILE:
+                    video_stream = VideoFileStream(input_config.config_data.video_path)
+                case SourceType.IMAGES_FOLDER:
+                    video_stream = ImagesFolderStream(
+                        folder_path=input_config.config_data.images_folder_path,
+                        ignore_existing_images=input_config.config_data.ignore_existing_images,
+                    )
+                case _:
+                    raise ValueError(f"Unrecognized source type: {input_config.source_type}")
 
-        if video_stream is not None:
-            logger.info("Initialized video stream for source type: {}", input_config.source_type)
-        else:
-            logger.info("No video stream initialized")
+            if video_stream is not None:
+                logger.info("Initialized video stream for source type: {}", input_config.source_type)
+            else:
+                logger.info("No video stream initialized")
 
-        return video_stream
+            return video_stream
+        except Exception as e:
+            logger.warning(f"Failed to initialize video stream for source type {input_config.source_type}: {e}")
+            return None


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
 Added try/except blocks to the initialization methods for video streams and dispatchers to resolve pending TODO comments. This prevents the backend from crashing if a device or stream fails to initialize by logging a warning and safely returning None.
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->



<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
