### PR TITLE
Bugfix: training job did not properly forward the intensity configuration when instantiating model

### DIFF
--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -386,6 +386,7 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
             input_size=cast(tuple[int, int], getitune_datamodule.input_size),
             mean=getitune_datamodule.input_mean if getitune_datamodule.input_mean is not None else (0.0, 0.0, 0.0),
             std=getitune_datamodule.input_std if getitune_datamodule.input_std is not None else (1.0, 1.0, 1.0),
+            intensity_config=getitune_datamodule.input_intensity_config,
         ).as_dict()
         model_parser = ArgumentParser()
         model_parser.add_subclass_arguments(LightningModel, "model", required=False, fail_untyped=False)

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -14,6 +14,7 @@ from datumaro.experimental import Dataset, LazyImage
 from datumaro.experimental.categories import LabelCategories
 from datumaro.experimental.fields import ImageInfo, Subset
 from getitune import TaskType as GetiTuneTaskType
+from getitune.config.data import IntensityConfig
 from getitune.metrics.accuracy import MultiClassClsMetricCallable, MultiLabelClsMetricCallable
 from getitune.metrics.mean_ap import MaskRLEMeanAPCallable, MeanAPCallable
 from getitune.metrics.types import MetricCallable
@@ -748,6 +749,13 @@ class TestGetiTuneTrainerTrainModel:
         mock_datamodule.input_size = (640, 640)
         mock_datamodule.input_mean = [0.485, 0.456, 0.406]
         mock_datamodule.input_std = [0.229, 0.224, 0.225]
+        mock_datamodule.input_intensity_config = IntensityConfig(
+            storage_dtype="uint16",
+            mode="range_scale",
+            min_value=500,
+            max_value=1200,
+            scale_factor=0.5,
+        )
         mock_datamodule.tile_config = None
 
         # Mock LightningModel


### PR DESCRIPTION
### Summary

This PR fixes a bug in the propagation of intensity configuration from the Geti server to the training backend.

### How to test

Train a model with custom intensity settings and verify that they're used at training time and also embedded in the exported OV model.

<img width="859" height="299" alt="image" src="https://github.com/user-attachments/assets/fab0cf3b-4afc-4a1a-ba69-7053933d9c9f" />

<img width="698" height="486" alt="image" src="https://github.com/user-attachments/assets/802a6ffa-7f54-4498-b21b-7460dd862ed1" />

_Note: dtype is incorrect due to another bug._

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
