### PR TITLE
Allow running geti tune on different ports

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -58,7 +58,7 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("tag", long="tag", short="t")]
 [arg("host", long="host", short="h", help="Host address to bind the server to")]
 [arg("port", long="port", short="p", help="Host port to publish (forwarded to the container's internal port)")]
-[arg("container-port", long="container-port", help="Container-internal port the server listens on (defaults to the value of --port)")]
+[arg("container-port", long="container-port", help="Container-internal port the server listens on")]
 [arg("container-name", long="name", short="n", help="Custom name for the container (defaults to geti-<accelerator>)")]
 [arg("detach", long="detach", short="d", value="true", help="Run the container in detached mode")]
 [arg("remove", long="remove", value="true", help="Automatically remove the container after it exits")]
@@ -71,7 +71,7 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("coturn_port", long="coturn-port", help="Coturn server listening port (default: 443)")]
 [arg("stun_server", long="stun", help="STUN server URL to use for WebRTC")]
 [arg("gpu-slots", long="gpu-slots", help="Number of GPU slots available for model tuning (default: 1)")]
-run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
+run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s nullglob
@@ -83,12 +83,6 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-po
         CONTAINER_NAME="{{ application-name }}-{{ accelerator }}"
     fi
 
-    # Resolve container-internal port (defaults to host port for backwards compatibility)
-    if [[ -n "{{ container-port }}" ]]; then
-        CONTAINER_PORT="{{ container-port }}"
-    else
-        CONTAINER_PORT="{{ port }}"
-    fi
 
     if ! docker image inspect "${IMAGE_NAME}" > /dev/null 2>&1; then
         echo "Error: Docker image '${IMAGE_NAME}' not found." >&2
@@ -219,9 +213,9 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-po
         {{ docker-run-args }} \
         $GPU_FLAG \
         --publish {{ webrtc-ports }}:{{ webrtc-ports }}/udp \
-        --publish {{ port }}:${CONTAINER_PORT} \
+        --publish {{ port }}:{{ container-port }} \
         --env HOST={{ host }} \
-        --env PORT=${CONTAINER_PORT} \
+        --env PORT={{ container-port }} \
         --env GPU_SLOTS={{ gpu-slots }} \
         --env WEBRTC_ADVERTISE_IP="${HOST_IP}" \
         $COTURN_ENV \
@@ -229,10 +223,10 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-po
         --sysctl net.ipv4.ip_local_port_range="{{ replace(webrtc-ports, '-', ' ') }}" \
         --volume {{ data-volume }}:/application/data/ \
         --volume {{ logs-volume }}:/application/logs/ \
-        "${volume_args[@]}" \
+        ${volume_args[@]+"${volume_args[@]}"} \
         $WSL_LIB_FLAG \
-        "${passthrough_devices_args[@]}" \
-        "${extra_render_args[@]}" \
+        ${passthrough_devices_args[@]+"${passthrough_devices_args[@]}"} \
+        ${extra_render_args[@]+"${extra_render_args[@]}"} \
         $SHM_SIZE_FLAG \
         --name "${CONTAINER_NAME}" \
         $DETACH_FLAG \

--- a/application/Justfile
+++ b/application/Justfile
@@ -57,7 +57,8 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("accelerator", long="accelerator", short="a", pattern="cpu|xpu|cuda")]
 [arg("tag", long="tag", short="t")]
 [arg("host", long="host", short="h", help="Host address to bind the server to")]
-[arg("port", long="port", short="p", help="Port number to bind the server to")]
+[arg("port", long="port", short="p", help="Host port to publish (forwarded to the container's internal port)")]
+[arg("container-port", long="container-port", help="Container-internal port the server listens on (defaults to the value of --port)")]
 [arg("container-name", long="name", short="n", help="Custom name for the container (defaults to geti-<accelerator>)")]
 [arg("detach", long="detach", short="d", value="true", help="Run the container in detached mode")]
 [arg("remove", long="remove", value="true", help="Automatically remove the container after it exits")]
@@ -70,7 +71,7 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("coturn_port", long="coturn-port", help="Coturn server listening port (default: 443)")]
 [arg("stun_server", long="stun", help="STUN server URL to use for WebRTC")]
 [arg("gpu-slots", long="gpu-slots", help="Number of GPU slots available for model tuning (default: 1)")]
-run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
+run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s nullglob
@@ -80,6 +81,13 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-na
         CONTAINER_NAME="{{ container-name }}"
     else
         CONTAINER_NAME="{{ application-name }}-{{ accelerator }}"
+    fi
+
+    # Resolve container-internal port (defaults to host port for backwards compatibility)
+    if [[ -n "{{ container-port }}" ]]; then
+        CONTAINER_PORT="{{ container-port }}"
+    else
+        CONTAINER_PORT="{{ port }}"
     fi
 
     if ! docker image inspect "${IMAGE_NAME}" > /dev/null 2>&1; then
@@ -211,9 +219,9 @@ run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-na
         {{ docker-run-args }} \
         $GPU_FLAG \
         --publish {{ webrtc-ports }}:{{ webrtc-ports }}/udp \
-        --publish {{ port }}:{{ port }} \
+        --publish {{ port }}:${CONTAINER_PORT} \
         --env HOST={{ host }} \
-        --env PORT={{ port }} \
+        --env PORT=${CONTAINER_PORT} \
         --env GPU_SLOTS={{ gpu-slots }} \
         --env WEBRTC_ADVERTISE_IP="${HOST_IP}" \
         $COTURN_ENV \

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -111,8 +111,18 @@ class Settings(BaseSettings):
 
     @property
     def cors_allowed_origins(self) -> list[str]:
-        """Parsed list of allowed CORS origins."""
-        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+        """Parsed list of allowed CORS origins.
+
+        Always includes localhost / 127.0.0.1 entries for the configured server port,
+        so that browser requests from a forwarded / non-default port are accepted.
+        """
+        origins = [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+        for host in ("localhost", "127.0.0.1"):
+            for scheme in ("http", "https"):
+                entry = f"{scheme}://{host}:{self.port}"
+                if entry not in origins:
+                    origins.append(entry)
+        return origins
 
     @model_validator(mode="after")
     def set_default_dirs(self) -> "Settings":


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Allow running geti tune on other ports than 7860

Resolves #6247 

<img width="1150" height="497" alt="image" src="https://github.com/user-attachments/assets/d372872a-1d98-4df1-bc74-d26f9364a311" />


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
