### PR TITLE
Make VideoService dep optional for MediaService

### DIFF
--- a/application/backend/app/lifecycle.py
+++ b/application/backend/app/lifecycle.py
@@ -51,7 +51,7 @@ from app.webrtc import SDPHandler, WebRTCManager, WebRTCSettings
 
 
 def setup_job_controller(
-    data_dir: Path, staged_datasets_dir: Path | None, max_parallel_jobs: int, video_service: VideoService
+    data_dir: Path, staged_datasets_dir: Path | None, max_parallel_jobs: int
 ) -> tuple[JobQueue, JobController]:
     """
     Initializes and configures the job queue and job controller for managing parallel job execution.
@@ -64,7 +64,6 @@ def setup_job_controller(
         data_dir: Path to the directory containing data required for job execution.
         staged_datasets_dir: Path to the directory for storing staged datasets.
         max_parallel_jobs (int): Maximum number of jobs that can run concurrently.
-        video_service: Video service instance
 
     Returns:
         tuple[JobQueue, JobController]: The job queue and the configured job controller.
@@ -76,7 +75,7 @@ def setup_job_controller(
     label_service = LabelService()
     dataset_service = DatasetService(
         label_service=label_service,
-        media_service=MediaService(data_dir=data_dir, video_service=video_service),
+        media_service=MediaService(data_dir=data_dir),
     )
     project_service = ProjectService(
         data_dir=data_dir,
@@ -139,7 +138,7 @@ def setup_job_controller(
             staged_datasets_dir=staged_datasets_dir,
             dataset_service=dataset_service,
             label_service=label_service,
-            media_service=MediaService(data_dir=data_dir, video_service=video_service),
+            media_service=MediaService(data_dir=data_dir),
             db_session_factory=get_db_session,
         ),
     )
@@ -151,7 +150,7 @@ def setup_job_controller(
             project_service=project_service,
             dataset_service=dataset_service,
             label_service=label_service,
-            media_service=MediaService(data_dir=data_dir, video_service=video_service),
+            media_service=MediaService(data_dir=data_dir),
             db_session_factory=get_db_session,
         ),
     )
@@ -227,7 +226,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         data_dir=settings.data_dir,
         staged_datasets_dir=settings.staged_datasets_dir,
         max_parallel_jobs=settings.gpu_slots,
-        video_service=video_service,
     )
     app.state.job_queue = job_queue
 

--- a/application/backend/app/lifecycle.py
+++ b/application/backend/app/lifecycle.py
@@ -200,7 +200,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     video_service = VideoService(cache_config=cache_config)
     app.state.video_service = video_service
 
-    data_collector = DataCollector(data_dir=settings.data_dir, event_bus=event_bus, video_service=video_service)
+    data_collector = DataCollector(data_dir=settings.data_dir, event_bus=event_bus)
     app.state.data_collector = data_collector
 
     inference_server = InferenceServer(data_dir=settings.data_dir)

--- a/application/backend/app/services/data_collect/data_collector.py
+++ b/application/backend/app/services/data_collect/data_collector.py
@@ -13,7 +13,6 @@ from app.models.media import ImageFormat
 from app.services.data_collect.prediction_converter import get_confidence_scores
 from app.services.event.event_bus import EventBus, EventType
 from app.services.media_service import ImageMetadata
-from app.services.video import VideoService
 from app.stream.stream_data import InferenceData
 
 
@@ -85,11 +84,10 @@ class ConfidenceThresholdPolicyChecker(PolicyChecker):
 
 
 class DataCollector:
-    def __init__(self, data_dir: Path, event_bus: EventBus, video_service: VideoService) -> None:
+    def __init__(self, data_dir: Path, event_bus: EventBus) -> None:
         self.should_collect_next_frame = False
         self.data_dir = data_dir
         self.event_bus = event_bus
-        self.video_service = video_service
         self.active_pipeline_data: tuple[Pipeline, Project] | None = None
         self.policy_checkers: list[PolicyChecker] = []
 
@@ -186,7 +184,7 @@ class DataCollector:
         frame_data = cv2.cvtColor(frame_data, cv2.COLOR_BGR2RGB)  # Convert BGR to RGB
         with get_db_session() as session:
             label_service = LabelService(db_session=session)
-            media_service = MediaService(data_dir=self.data_dir, video_service=self.video_service, db_session=session)
+            media_service = MediaService(data_dir=self.data_dir, db_session=session)
             dataset_service = DatasetService(
                 label_service=label_service, media_service=media_service, db_session=session
             )

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -83,7 +83,7 @@ class MediaService(BaseSessionManagedService):
             # FIXME: direct instance as a tmp workaround to avoid sending non-pickable objects between process
             #  boundaries in the current job execution implementation.
             #  Should be refactored with a proper DI in lifecycle.py.
-            return VideoService()
+            self._video_service = VideoService()
         return self._video_service
 
     @staticmethod

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -71,12 +71,20 @@ class MediaService(BaseSessionManagedService):
     def __init__(
         self,
         data_dir: Path,
-        video_service: VideoService,
+        video_service: VideoService | None = None,
         db_session: Session | None = None,
     ) -> None:
         super().__init__(db_session)
         self.projects_dir = data_dir / "projects"
         self._video_service = video_service
+
+    def _get_video_service(self) -> VideoService:
+        if self._video_service is None:
+            # FIXME: direct instance as a tmp workaround to avoid sending non-pickable objects between process
+            #  boundaries in the current job execution implementation.
+            #  Should be refactored with a proper DI in lifecycle.py.
+            return VideoService()
+        return self._video_service
 
     @staticmethod
     def _read_image_from_ndarray(data: np.ndarray) -> Image.Image:
@@ -173,7 +181,7 @@ class MediaService(BaseSessionManagedService):
                 f.write(chunk)
 
         try:
-            video_metadata = self._video_service.get_video_metadata(video_path=binary_path)
+            video_metadata = self._get_video_service().get_video_metadata(video_path=binary_path)
             media = MediaDB(
                 id=str(media_id),
                 project_id=str(project_id),
@@ -334,14 +342,16 @@ class MediaService(BaseSessionManagedService):
             Dictionary mapping frame index to numpy array (RGB format).
         """
         video_path = self.get_media_binary_path(project_id=project.id, media=video)
-        return self._video_service.extract_video_frames(video_path=video_path, frame_indexes=frame_indexes)
+        return self._get_video_service().extract_video_frames(video_path=video_path, frame_indexes=frame_indexes)
 
     def get_frame_thumbnail(self, project: Project, video: Video, frame_index: int) -> Image.Image:
         video_frame = self.get_frame_binary(project=project, video=video, frame_index=frame_index)
         return MediaService._crop_image_to_thumbnail(video_frame)
 
     def _get_frame_binary_from_video_file(self, video_path: Path, frame_index: int) -> Image.Image:
-        video_frame_numpy = self._video_service.extract_video_frame(video_path=video_path, frame_index=frame_index)
+        video_frame_numpy = self._get_video_service().extract_video_frame(
+            video_path=video_path, frame_index=frame_index
+        )
         return MediaService._read_image_from_ndarray(video_frame_numpy)
 
     def save_video_frame(

--- a/application/backend/tests/unit/services/data_collect/test_data_collector.py
+++ b/application/backend/tests/unit/services/data_collect/test_data_collector.py
@@ -18,7 +18,6 @@ from app.services.data_collect.data_collector import (
     FixedRatePolicyChecker,
 )
 from app.services.media_service import ImageMetadata
-from app.services.video import VideoService
 
 
 class TestFixedRatePolicyCheckerUnit:
@@ -94,15 +93,10 @@ class TestConfidenceThresholdDataCollectionPolicyUnit:
 
 
 @pytest.fixture
-def fxt_video_service() -> MagicMock:
-    return MagicMock(spec=VideoService)
-
-
-@pytest.fixture
-def fxt_data_collector(fxt_event_bus, fxt_video_service) -> DataCollector:
+def fxt_data_collector(fxt_event_bus) -> DataCollector:
     """Fixture to create a DataCollector instance with mocked dependencies."""
     with patch("app.services.data_collect.data_collector.DataCollector._load_pipeline"):
-        return DataCollector(Path("data"), fxt_event_bus, fxt_video_service)
+        return DataCollector(Path("data"), fxt_event_bus)
 
 
 class TestDataCollectorUnit:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

This resolves the issue with non-pickable object passed between process boundaries when running jobs dependent on `MediaService`.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
