### PR TITLE
Perform inference only for key frames & copy predictions for the rest

### DIFF
--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -103,7 +103,7 @@ def get_inference_model_ttl(request: Request) -> int:
     return request.app.state.settings.inference_model_ttl
 
 
-def get_inference_keyframe_stride(request: Request) -> int | None:
+def get_inference_keyframe_stride(request: Request) -> int:
     """Provides the inference frame skip from settings."""
     return request.app.state.settings.inference_keyframe_stride
 
@@ -225,7 +225,7 @@ def get_media_prediction_service(
     media_service: Annotated[MediaService, Depends(get_media_service)],
     inference_server: Annotated[InferenceServer, Depends(get_inference_server)],
     inference_model_ttl: Annotated[int, Depends(get_inference_model_ttl)],
-    inference_keyframe_stride: Annotated[int | None, Depends(get_inference_keyframe_stride)],
+    inference_keyframe_stride: Annotated[int, Depends(get_inference_keyframe_stride)],
     db: Annotated[Session, Depends(get_db)],
 ) -> MediaPredictionService:
     """Provides a MediaPredictionService instance."""

--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -103,6 +103,11 @@ def get_inference_model_ttl(request: Request) -> int:
     return request.app.state.settings.inference_model_ttl
 
 
+def get_inference_frame_skip(request: Request) -> int | None:
+    """Provides the inference frame skip from settings."""
+    return request.app.state.settings.inference_frame_skip
+
+
 def get_event_bus(request: Request) -> EventBus:
     """Provides an EventBus instance."""
     return request.app.state.event_bus
@@ -220,6 +225,7 @@ def get_media_prediction_service(
     media_service: Annotated[MediaService, Depends(get_media_service)],
     inference_server: Annotated[InferenceServer, Depends(get_inference_server)],
     inference_model_ttl: Annotated[int, Depends(get_inference_model_ttl)],
+    inference_frame_skip: Annotated[int, Depends(get_inference_frame_skip)],
     db: Annotated[Session, Depends(get_db)],
 ) -> MediaPredictionService:
     """Provides a MediaPredictionService instance."""
@@ -228,6 +234,7 @@ def get_media_prediction_service(
         media_service=media_service,
         inference_server=inference_server,
         inference_model_ttl=inference_model_ttl,
+        inference_frame_skip=inference_frame_skip,
         db_session=db,
     )
 

--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -225,7 +225,7 @@ def get_media_prediction_service(
     media_service: Annotated[MediaService, Depends(get_media_service)],
     inference_server: Annotated[InferenceServer, Depends(get_inference_server)],
     inference_model_ttl: Annotated[int, Depends(get_inference_model_ttl)],
-    inference_frame_skip: Annotated[int, Depends(get_inference_frame_skip)],
+    inference_frame_skip: Annotated[int | None, Depends(get_inference_frame_skip)],
     db: Annotated[Session, Depends(get_db)],
 ) -> MediaPredictionService:
     """Provides a MediaPredictionService instance."""

--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -103,9 +103,9 @@ def get_inference_model_ttl(request: Request) -> int:
     return request.app.state.settings.inference_model_ttl
 
 
-def get_inference_frame_skip(request: Request) -> int | None:
+def get_inference_keyframe_stride(request: Request) -> int | None:
     """Provides the inference frame skip from settings."""
-    return request.app.state.settings.inference_frame_skip
+    return request.app.state.settings.inference_keyframe_stride
 
 
 def get_event_bus(request: Request) -> EventBus:
@@ -225,7 +225,7 @@ def get_media_prediction_service(
     media_service: Annotated[MediaService, Depends(get_media_service)],
     inference_server: Annotated[InferenceServer, Depends(get_inference_server)],
     inference_model_ttl: Annotated[int, Depends(get_inference_model_ttl)],
-    inference_frame_skip: Annotated[int | None, Depends(get_inference_frame_skip)],
+    inference_keyframe_stride: Annotated[int | None, Depends(get_inference_keyframe_stride)],
     db: Annotated[Session, Depends(get_db)],
 ) -> MediaPredictionService:
     """Provides a MediaPredictionService instance."""
@@ -234,7 +234,7 @@ def get_media_prediction_service(
         media_service=media_service,
         inference_server=inference_server,
         inference_model_ttl=inference_model_ttl,
-        inference_frame_skip=inference_frame_skip,
+        inference_keyframe_stride=inference_keyframe_stride,
         db_session=db,
     )
 

--- a/application/backend/app/services/inference/__init__.py
+++ b/application/backend/app/services/inference/__init__.py
@@ -1,19 +1,9 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from .inference_server import (
-    BatchInferenceInput,
-    BatchInferenceResult,
-    InferenceBusyError,
-    InferenceModel,
-    InferenceServer,
-    InferenceState,
-    InferenceStatus,
-)
+from .inference_server import InferenceBusyError, InferenceModel, InferenceServer, InferenceState, InferenceStatus
 
 __all__ = [
-    "BatchInferenceInput",
-    "BatchInferenceResult",
     "InferenceBusyError",
     "InferenceModel",
     "InferenceServer",

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -136,7 +136,7 @@ class InferenceServer:
             inputs: List of inputs
 
         Returns:
-            Prediction results for inputs
+            Dictionary mapping (media_id, frame_index) tuples to lists of DatasetItemAnnotation predictions.
         """
         if self._loaded_model is None:
             raise RuntimeError("No model loaded for inference")

--- a/application/backend/app/services/inference/inference_server.py
+++ b/application/backend/app/services/inference/inference_server.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from loguru import logger
 
 from app.db import get_db_session
-from app.models import BatchInferenceInput, BatchInferenceMedia, BatchInferencePrediction, BatchInferenceResult, Label
+from app.models import BatchInferenceInput, DatasetItemAnnotation, Label
 from app.models.inference import InferenceModel, InferenceState, InferenceStatus
 from app.models.model_revision import ModelFormat, ModelPrecision
 from app.models.system import DeviceInfo
@@ -123,7 +123,9 @@ class InferenceServer:
             ),
         )
 
-    def infer_batch(self, labels: list[Label], inputs: list[BatchInferenceInput]) -> BatchInferenceResult:
+    def infer_batch(
+        self, labels: list[Label], inputs: list[BatchInferenceInput]
+    ) -> dict[tuple[UUID, int | None], list[DatasetItemAnnotation]]:
         """
         Perform batch inference on the provided inputs using the currently loaded model.
         It processes each input, runs inference, and converts the raw predictions into a structured
@@ -150,17 +152,12 @@ class InferenceServer:
         finally:
             self._lock.release()
 
-        result = BatchInferenceResult(predictions=[])
-        for idx, input in enumerate(inputs):
-            result.predictions.append(
-                BatchInferencePrediction(
-                    media=BatchInferenceMedia(id=input.media_id, frame_index=input.frame_index),
-                    prediction=convert_prediction(
-                        labels=labels, frame_data=input_data[idx], prediction=inference_result[idx]
-                    ),
-                )
+        return {
+            (input.media_id, input.frame_index): convert_prediction(
+                labels=labels, frame_data=input_data[idx], prediction=inference_result[idx]
             )
-        return result
+            for idx, input in enumerate(inputs)
+        }
 
     def stop(self) -> None:
         """

--- a/application/backend/app/services/media_prediction_service.py
+++ b/application/backend/app/services/media_prediction_service.py
@@ -59,14 +59,14 @@ class MediaPredictionService(BaseSessionManagedService):
         inference_server: InferenceServer,
         inference_model_ttl: int,
         db_session: Session | None = None,
-        inference_frame_skip: int | None = None,
+        inference_keyframe_stride: int | None = None,
     ) -> None:
         super().__init__(db_session)
         self._label_service = label_service
         self._media_service = media_service
         self._inference_server = inference_server
         self._inference_model_ttl = inference_model_ttl
-        self._inference_frame_skip = inference_frame_skip
+        self._inference_keyframe_stride = inference_keyframe_stride
 
     def _load_media_binary(self, project_id: UUID, media: Media) -> np.ndarray:
         binary_path = self._media_service.get_media_binary_path(project_id=project_id, media=media)
@@ -76,8 +76,8 @@ class MediaPredictionService(BaseSessionManagedService):
         return cv2.cvtColor(binary_data, cv2.COLOR_BGR2RGB)
 
     @staticmethod
-    def _is_frame_index_to_infer(index: int, frame_indexes: list[int], inference_frame_skip: int) -> bool:
-        return index == 0 or index == len(frame_indexes) - 1 or index % inference_frame_skip == 0
+    def _is_frame_index_to_infer(index: int, frame_indexes: list[int], inference_keyframe_stride: int) -> bool:
+        return index == 0 or index == len(frame_indexes) - 1 or index % inference_keyframe_stride == 0
 
     def _load_frame_range(self, project: Project, video: Video, video_range: VideoRange) -> list[Frame]:
         video_frames: list[Frame] = []
@@ -90,9 +90,9 @@ class MediaPredictionService(BaseSessionManagedService):
             annotated_frame = next((frame for frame in annotated_frames if frame.frame_index == frame_index), None)
             skip = (
                 not MediaPredictionService._is_frame_index_to_infer(
-                    index=idx, frame_indexes=frame_indexes, inference_frame_skip=self._inference_frame_skip
+                    index=idx, frame_indexes=frame_indexes, inference_keyframe_stride=self._inference_keyframe_stride
                 )
-                if self._inference_frame_skip is not None
+                if self._inference_keyframe_stride is not None
                 else False
             )
             video_frames.append(Frame(frame_index=frame_index, annotated_frame=annotated_frame, skip=skip))

--- a/application/backend/app/services/media_prediction_service.py
+++ b/application/backend/app/services/media_prediction_service.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import bisect
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -157,6 +158,18 @@ class MediaPredictionService(BaseSessionManagedService):
 
         return inputs
 
+    @staticmethod
+    def _find_nearest_keyframe_index(frame_index: int, keyframe_indexes: list[int]) -> int:
+        """Find the nearest keyframe index for a given frame index using bisect."""
+        pos = bisect.bisect_left(keyframe_indexes, frame_index)
+        if pos == 0:
+            return keyframe_indexes[0]
+        if pos == len(keyframe_indexes):
+            return keyframe_indexes[-1]
+        before = keyframe_indexes[pos - 1]
+        after = keyframe_indexes[pos]
+        return before if (frame_index - before) <= (after - frame_index) else after
+
     def _convert_result(
         self, loaded_media: LoadedMedia, inference_result: dict[tuple[UUID, int | None], list[DatasetItemAnnotation]]
     ) -> BatchInferenceResult:
@@ -167,19 +180,22 @@ class MediaPredictionService(BaseSessionManagedService):
                     media=BatchInferenceMedia(id=single_media.id), prediction=inference_result[(single_media.id, None)]
                 )
             )
-        previous_prediction: list[DatasetItemAnnotation] | None = None
         for video in loaded_media.video_frames:
             frames = loaded_media.video_frames[video]
+            # Collect keyframe predictions (frames that were inferred)
+            keyframe_predictions: dict[int, list[DatasetItemAnnotation]] = {
+                frame.frame_index: inference_result[(video.id, frame.frame_index)] for frame in frames if not frame.skip
+            }
+
+            # Sorted keyframe indexes for nearest-keyframe lookup
+            keyframe_indexes = sorted(keyframe_predictions.keys())
+
             for frame in frames:
                 if not frame.skip:
-                    prediction = inference_result[(video.id, frame.frame_index)]
-                    previous_prediction = prediction
+                    prediction = keyframe_predictions[frame.frame_index]
                 else:
-                    # For skipped frames, we copy-paste previous inference prediction
-                    if previous_prediction is None:
-                        # Shouldn't be the case because we always pass the first frame to the inference
-                        raise RuntimeError("No prediction found")
-                    prediction = previous_prediction
+                    nearest = self._find_nearest_keyframe_index(frame.frame_index, keyframe_indexes)
+                    prediction = keyframe_predictions[nearest]
                 predictions.append(
                     BatchInferencePrediction(
                         media=BatchInferenceMedia(id=video.id, frame_index=frame.frame_index), prediction=prediction

--- a/application/backend/app/services/media_prediction_service.py
+++ b/application/backend/app/services/media_prediction_service.py
@@ -58,8 +58,8 @@ class MediaPredictionService(BaseSessionManagedService):
         media_service: MediaService,
         inference_server: InferenceServer,
         inference_model_ttl: int,
+        inference_keyframe_stride: int,
         db_session: Session | None = None,
-        inference_keyframe_stride: int | None = None,
     ) -> None:
         super().__init__(db_session)
         self._label_service = label_service
@@ -92,7 +92,7 @@ class MediaPredictionService(BaseSessionManagedService):
                 not MediaPredictionService._is_frame_index_to_infer(
                     index=idx, frame_indexes=frame_indexes, inference_keyframe_stride=self._inference_keyframe_stride
                 )
-                if self._inference_keyframe_stride is not None
+                if self._inference_keyframe_stride > 1
                 else False
             )
             video_frames.append(Frame(frame_index=frame_index, annotated_frame=annotated_frame, skip=skip))

--- a/application/backend/app/services/media_prediction_service.py
+++ b/application/backend/app/services/media_prediction_service.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from collections import defaultdict
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -9,14 +8,30 @@ import numpy as np
 from loguru import logger
 from sqlalchemy.orm import Session
 
-from app.models import BatchInferenceInput, BatchInferenceResult, Image, Project, VideoFrame
-from app.models.media import Media, MediaListPredictionRequest, MediaType, NotAnnotatedVideoFrame, Video, VideoRange
+from app.models import (
+    BatchInferenceInput,
+    BatchInferenceMedia,
+    BatchInferencePrediction,
+    BatchInferenceResult,
+    DatasetItemAnnotation,
+    Image,
+    Project,
+    VideoFrame,
+)
+from app.models.media import Media, MediaListPredictionRequest, MediaType, Video, VideoRange
 from app.models.system import DeviceInfo
 
 from .base import BaseSessionManagedService, ResourceError, ResourceNotFoundError, ResourceType
 from .inference import InferenceServer
 from .label_service import LabelService
 from .media_service import MediaService
+
+
+@dataclass(frozen=True)
+class Frame:
+    frame_index: int
+    skip: bool
+    annotated_frame: VideoFrame | None = None
 
 
 class VideoRangeError(ResourceError):
@@ -32,7 +47,7 @@ class BinaryNotFoundError(Exception):
 @dataclass(frozen=True)
 class LoadedMedia:
     single_media: list[Image | VideoFrame]
-    video_frames: list[VideoFrame | NotAnnotatedVideoFrame]
+    video_frames: dict[Video, list[Frame]]
 
 
 class MediaPredictionService(BaseSessionManagedService):
@@ -43,12 +58,14 @@ class MediaPredictionService(BaseSessionManagedService):
         inference_server: InferenceServer,
         inference_model_ttl: int,
         db_session: Session | None = None,
+        inference_frame_skip: int | None = None,
     ) -> None:
         super().__init__(db_session)
         self._label_service = label_service
         self._media_service = media_service
         self._inference_server = inference_server
         self._inference_model_ttl = inference_model_ttl
+        self._inference_frame_skip = inference_frame_skip
 
     def _load_media_binary(self, project_id: UUID, media: Media) -> np.ndarray:
         binary_path = self._media_service.get_media_binary_path(project_id=project_id, media=media)
@@ -57,27 +74,32 @@ class MediaPredictionService(BaseSessionManagedService):
             raise BinaryNotFoundError(f"Media {str(media.id)} binary cannot be found")
         return cv2.cvtColor(binary_data, cv2.COLOR_BGR2RGB)
 
-    def _load_frame_range(
-        self, project: Project, video: Video, video_range: VideoRange
-    ) -> list[VideoFrame | NotAnnotatedVideoFrame]:
-        video_frames: list[VideoFrame | NotAnnotatedVideoFrame] = []
+    @staticmethod
+    def _is_frame_index_to_infer(index: int, frame_indexes: list[int], inference_frame_skip: int) -> bool:
+        return index == 0 or index == len(frame_indexes) - 1 or index % inference_frame_skip == 0
+
+    def _load_frame_range(self, project: Project, video: Video, video_range: VideoRange) -> list[Frame]:
+        video_frames: list[Frame] = []
 
         frame_indexes = list(range(video_range.start_frame, video_range.end_frame + 1, video_range.stride))
         annotated_frames = self._media_service.search_video_frames_by_video_id_and_indexes(
             project=project, video_id=video.id, frame_indexes=frame_indexes
         )
-        for frame_index in frame_indexes:
+        for idx, frame_index in enumerate(frame_indexes):
             annotated_frame = next((frame for frame in annotated_frames if frame.frame_index == frame_index), None)
-            if annotated_frame is not None:
-                video_frames.append(annotated_frame)
-            else:
-                video_frame = NotAnnotatedVideoFrame(video=video, frame_index=frame_index)
-                video_frames.append(video_frame)
+            skip = (
+                not MediaPredictionService._is_frame_index_to_infer(
+                    index=idx, frame_indexes=frame_indexes, inference_frame_skip=self._inference_frame_skip
+                )
+                if self._inference_frame_skip is not None
+                else False
+            )
+            video_frames.append(Frame(frame_index=frame_index, annotated_frame=annotated_frame, skip=skip))
         return video_frames
 
     def _load_media(self, project: Project, request: MediaListPredictionRequest) -> LoadedMedia:
         single_media: list[Image | VideoFrame] = []
-        video_frames: list[VideoFrame | NotAnnotatedVideoFrame] = []
+        video_frames: dict[Video, list[Frame]] = {}
 
         media_ids: list[UUID] = [media_request.media_id for media_request in request.media]
         media_list = self._media_service.get_media_by_ids(project_id=project.id, media_ids=media_ids)
@@ -96,8 +118,8 @@ class MediaPredictionService(BaseSessionManagedService):
             else:
                 if media.type != MediaType.VIDEO:
                     raise VideoRangeError(str(media_request.media_id), "Frame range can be specified only for videos.")
-                video_frames.extend(
-                    self._load_frame_range(project=project, video=media, video_range=media_request.range)
+                video_frames[media] = self._load_frame_range(
+                    project=project, video=media, video_range=media_request.range
                 )
         return LoadedMedia(single_media=single_media, video_frames=video_frames)
 
@@ -109,35 +131,62 @@ class MediaPredictionService(BaseSessionManagedService):
             data = self._load_media_binary(project_id=project.id, media=single_media)
             inputs.append(BatchInferenceInput(media_id=single_media.id, data=data))
 
-        # Process video frames: group by video to extract all frames per video in a single pass
-        annotated_by_video: dict[UUID, list[VideoFrame]] = defaultdict(list)
-        not_annotated_by_video: dict[UUID, list[NotAnnotatedVideoFrame]] = defaultdict(list)
-        for video_frame in loaded_media.video_frames:
-            if isinstance(video_frame, VideoFrame):
-                annotated_by_video[video_frame.video_id].append(video_frame)
-            else:
-                not_annotated_by_video[video_frame.video.id].append(video_frame)
+        for video in loaded_media.video_frames:
+            frames = loaded_media.video_frames[video]
+            annotated_frames: list[Frame] = [
+                frame for frame in frames if frame.annotated_frame is not None and not frame.skip
+            ]
+            for frame in annotated_frames:
+                binary_data = self._load_media_binary(
+                    project_id=project.id,
+                    media=frame.annotated_frame,  # pyrefly: ignore[bad-argument-type]
+                )
+                inputs.append(BatchInferenceInput(media_id=video.id, data=binary_data, frame_index=frame.frame_index))
 
-        # Load annotated video frames (already saved as images on disk)
-        for _video_id, frames in annotated_by_video.items():
-            for vf in frames:
-                binary_data = self._load_media_binary(project_id=project.id, media=vf)
-                inputs.append(BatchInferenceInput(media_id=vf.video_id, data=binary_data, frame_index=vf.frame_index))
-
-        # Batch-extract not-annotated video frames: one video open/close per video
-        for video_id, frames in not_annotated_by_video.items():
-            video = frames[0].video
-            frame_indexes = [f.frame_index for f in frames]
+            not_annotated_frames: list[Frame] = [
+                frame for frame in frames if frame.annotated_frame is None and not frame.skip
+            ]
+            # Batch-extract not-annotated video frames: one video open/close per video
+            frame_indexes = [f.frame_index for f in not_annotated_frames]
             extracted = self._media_service.get_frame_binaries(
                 project=project, video=video, frame_indexes=frame_indexes
             )
-            for na_frame in frames:
-                binary_data = extracted[na_frame.frame_index]
-                inputs.append(
-                    BatchInferenceInput(media_id=na_frame.video.id, data=binary_data, frame_index=na_frame.frame_index)
-                )
+            for frame in not_annotated_frames:
+                binary_data = extracted[frame.frame_index]
+                inputs.append(BatchInferenceInput(media_id=video.id, data=binary_data, frame_index=frame.frame_index))
 
         return inputs
+
+    def _convert_result(
+        self, loaded_media: LoadedMedia, inference_result: dict[tuple[UUID, int | None], list[DatasetItemAnnotation]]
+    ) -> BatchInferenceResult:
+        predictions: list[BatchInferencePrediction] = []
+        for single_media in loaded_media.single_media:
+            predictions.append(
+                BatchInferencePrediction(
+                    media=BatchInferenceMedia(id=single_media.id), prediction=inference_result[(single_media.id, None)]
+                )
+            )
+        previous_prediction: list[DatasetItemAnnotation] | None = None
+        for video in loaded_media.video_frames:
+            frames = loaded_media.video_frames[video]
+            for frame in frames:
+                if not frame.skip:
+                    prediction = inference_result[(video.id, frame.frame_index)]
+                    previous_prediction = prediction
+                else:
+                    # For skipped frames, we copy-paste previous inference prediction
+                    if previous_prediction is None:
+                        # Shouldn't be the case because we always pass the first frame to the inference
+                        raise RuntimeError("No prediction found")
+                    prediction = previous_prediction
+                predictions.append(
+                    BatchInferencePrediction(
+                        media=BatchInferenceMedia(id=video.id, frame_index=frame.frame_index), prediction=prediction
+                    )
+                )
+
+        return BatchInferenceResult(predictions=predictions)
 
     def predict_media(
         self,
@@ -172,4 +221,5 @@ class MediaPredictionService(BaseSessionManagedService):
         self._inference_server.set_inference_model(
             project_id=project.id, model_id=request.model_id, device=device, ttl=self._inference_model_ttl
         )
-        return self._inference_server.infer_batch(labels=labels, inputs=inputs)
+        result = self._inference_server.infer_batch(labels=labels, inputs=inputs)
+        return self._convert_result(loaded_media=loaded_media, inference_result=result)

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -85,11 +85,15 @@ class Settings(BaseSettings):
         alias="INFERENCE_MODEL_TTL",
         description="Time to live for a model loaded for inference, before unloading",
     )
-    inference_keyframe_stride: int | None = Field(
+    inference_keyframe_stride: int = Field(
         default=5,
         alias="INFERENCE_KEYFRAME_STRIDE",
-        description="Stride for video frame inference; only frames where frame_index % stride == 0 are processed. "
-        "First and last frames are always processed.",
+        description=(
+            "This stride value controls which video frames are considered 'key frames' and therefore "
+            "sent to the model for inference, while predictions for other frames are interpolated based "
+            "on key frames. Key frames satisfy the condition frame_index % stride == 0. "
+            "Additionally, the first and last frames are also considered key frames."
+        ),
         gt=0,
     )
 

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -89,6 +89,7 @@ class Settings(BaseSettings):
         default=None,
         alias="INFERENCE_FRAME_SKIP",
         description="Number of frames to skip between inferences for video processing",
+        gt=0,
     )
 
     # Video

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -85,6 +85,11 @@ class Settings(BaseSettings):
         alias="INFERENCE_MODEL_TTL",
         description="Time to live for a model loaded for inference, before unloading",
     )
+    inference_frame_skip: int | None = Field(
+        default=None,
+        alias="INFERENCE_FRAME_SKIP",
+        description="Number of frames to skip between inferences for video processing",
+    )
 
     # Video
     video_cache_ttl: float = Field(

--- a/application/backend/app/settings.py
+++ b/application/backend/app/settings.py
@@ -85,10 +85,11 @@ class Settings(BaseSettings):
         alias="INFERENCE_MODEL_TTL",
         description="Time to live for a model loaded for inference, before unloading",
     )
-    inference_frame_skip: int | None = Field(
-        default=None,
-        alias="INFERENCE_FRAME_SKIP",
-        description="Number of frames to skip between inferences for video processing",
+    inference_keyframe_stride: int | None = Field(
+        default=5,
+        alias="INFERENCE_KEYFRAME_STRIDE",
+        description="Stride for video frame inference; only frames where frame_index % stride == 0 are processed. "
+        "First and last frames are always processed.",
         gt=0,
     )
 

--- a/application/backend/tests/unit/services/inference/test_inference_server.py
+++ b/application/backend/tests/unit/services/inference/test_inference_server.py
@@ -229,9 +229,11 @@ class TestInferenceServer:
 
         with patch("app.services.inference.inference_server.convert_prediction") as mock_convert_prediction:
             mock_convert_prediction.return_value = [annotation]
-            inference_server.infer_batch(labels=[label], inputs=[input])
+            result = inference_server.infer_batch(labels=[label], inputs=[input])
 
         (passed_batch,) = model.infer_batch.call_args.args
         assert len(passed_batch) == 1
         np.testing.assert_array_equal(passed_batch[0], raw_uint8)
         assert passed_batch[0].dtype == np.uint8
+
+        assert result == {(media_id, 15): [annotation]}

--- a/application/backend/tests/unit/services/test_media_prediction_service.py
+++ b/application/backend/tests/unit/services/test_media_prediction_service.py
@@ -7,20 +7,27 @@ import numpy as np
 import pytest
 from sqlalchemy.orm import Session
 
-from app.models import BatchInferenceResult, Project, Task, Video
+from app.models import (
+    BatchInferenceMedia,
+    BatchInferencePrediction,
+    BatchInferenceResult,
+    DatasetItemAnnotation,
+    Project,
+    Task,
+    Video,
+)
 from app.models.media import (
     Image,
     MediaListPredictionRequest,
     MediaPredictionRequest,
     MediaType,
-    NotAnnotatedVideoFrame,
     VideoFrame,
     VideoRange,
 )
 from app.models.system import DeviceInfo, DeviceType
 from app.services import DatasetService, LabelService, MediaPredictionService, MediaService, ResourceNotFoundError
 from app.services.inference import InferenceServer
-from app.services.media_prediction_service import LoadedMedia
+from app.services.media_prediction_service import Frame, LoadedMedia
 
 
 class TestMediaPredictionServiceUnit:
@@ -44,14 +51,35 @@ class TestMediaPredictionServiceUnit:
 
     @pytest.fixture
     def fxt_media_prediction_service(self, fxt_label_service, fxt_media_service, fxt_inference_server):
-        db_session = MagicMock(spec=Session)
-        return MediaPredictionService(
-            label_service=fxt_label_service,
-            media_service=fxt_media_service,
-            inference_server=fxt_inference_server,
-            inference_model_ttl=10,
-            db_session=db_session,
+        def _create_media_prediction_service(inference_frame_skip: int | None = None):
+            db_session = MagicMock(spec=Session)
+            return MediaPredictionService(
+                label_service=fxt_label_service,
+                media_service=fxt_media_service,
+                inference_server=fxt_inference_server,
+                inference_model_ttl=10,
+                inference_frame_skip=inference_frame_skip,
+                db_session=db_session,
+            )
+
+        return _create_media_prediction_service
+
+    @pytest.mark.parametrize(
+        "index, frame_indexes, inference_frame_skip, expected_result",
+        [
+            (0, [0, 1, 2, 3, 4, 5], 2, True),
+            (1, [0, 1, 2, 3, 4, 5], 2, False),
+            (2, [0, 1, 2, 3, 4, 5], 2, True),
+            (3, [0, 1, 2, 3, 4, 5], 2, False),
+            (4, [0, 1, 2, 3, 4, 5], 2, True),
+            (5, [0, 1, 2, 3, 4, 5], 2, True),
+        ],
+    )
+    def test_is_frame_index_to_infer(self, index, frame_indexes, inference_frame_skip, expected_result):
+        result = MediaPredictionService._is_frame_index_to_infer(
+            index=index, frame_indexes=frame_indexes, inference_frame_skip=inference_frame_skip
         )
+        assert result == expected_result
 
     def test_load_frame_range(self, fxt_media_prediction_service, fxt_media_service):
         project = MagicMock(spec=Project)
@@ -61,7 +89,8 @@ class TestMediaPredictionServiceUnit:
         video_frame = MagicMock(spec=VideoFrame, video_id=video.id, frame_index=0)
         fxt_media_service.search_video_frames_by_video_id_and_indexes.return_value = [video_frame]
 
-        result = fxt_media_prediction_service._load_frame_range(
+        media_prediction_service = fxt_media_prediction_service()
+        result = media_prediction_service._load_frame_range(
             project=project, video=video, video_range=VideoRange(start_frame=0, end_frame=2, stride=1)
         )
 
@@ -70,9 +99,35 @@ class TestMediaPredictionServiceUnit:
             project=project, video_id=video.id, frame_indexes=[0, 1, 2]
         )
         assert result == [
-            video_frame,
-            NotAnnotatedVideoFrame(video=video, frame_index=1),
-            NotAnnotatedVideoFrame(video=video, frame_index=2),
+            Frame(frame_index=0, annotated_frame=video_frame, skip=False),
+            Frame(frame_index=1, skip=False),
+            Frame(frame_index=2, skip=False),
+        ]
+
+    def test_load_frame_range_skip(self, fxt_media_prediction_service, fxt_media_service):
+        project = MagicMock(spec=Project)
+        video = MagicMock(spec=Video, id=uuid4())
+
+        # One frame is already annotated
+        video_frame = MagicMock(spec=VideoFrame, video_id=video.id, frame_index=0)
+        fxt_media_service.search_video_frames_by_video_id_and_indexes.return_value = [video_frame]
+
+        media_prediction_service = fxt_media_prediction_service(2)
+        result = media_prediction_service._load_frame_range(
+            project=project, video=video, video_range=VideoRange(start_frame=0, end_frame=5, stride=1)
+        )
+
+        # Assert that one annotated and one unannotated frame is returned
+        fxt_media_service.search_video_frames_by_video_id_and_indexes.assert_called_once_with(
+            project=project, video_id=video.id, frame_indexes=[0, 1, 2, 3, 4, 5]
+        )
+        assert result == [
+            Frame(frame_index=0, annotated_frame=video_frame, skip=False),
+            Frame(frame_index=1, skip=True),
+            Frame(frame_index=2, skip=False),
+            Frame(frame_index=3, skip=True),
+            Frame(frame_index=4, skip=False),
+            Frame(frame_index=5, skip=False),
         ]
 
     def test_load_media(self, fxt_media_prediction_service, fxt_media_service):
@@ -86,12 +141,17 @@ class TestMediaPredictionServiceUnit:
         video_range = VideoRange(start_frame=0, end_frame=1, stride=1)
         fxt_media_service.get_media_by_ids.return_value = [image, video]
 
+        media_prediction_service = fxt_media_prediction_service()
         with patch.object(
-            fxt_media_prediction_service,
+            media_prediction_service,
             "_load_frame_range",
-            return_value=[NotAnnotatedVideoFrame(video=video, frame_index=0)],
+            return_value=[
+                Frame(frame_index=0, skip=False),
+                Frame(frame_index=1, skip=True),
+                Frame(frame_index=2, skip=False),
+            ],
         ) as mock_load_frame_range:
-            result = fxt_media_prediction_service._load_media(
+            result = media_prediction_service._load_media(
                 project=project,
                 request=MediaListPredictionRequest(
                     model_id=model_id,
@@ -109,7 +169,13 @@ class TestMediaPredictionServiceUnit:
         mock_load_frame_range.assert_called_once_with(project=project, video=video, video_range=video_range)
         assert result == LoadedMedia(
             single_media=[image],
-            video_frames=[NotAnnotatedVideoFrame(video=video, frame_index=0)],
+            video_frames={
+                video: [
+                    Frame(frame_index=0, skip=False),
+                    Frame(frame_index=1, skip=True),
+                    Frame(frame_index=2, skip=False),
+                ]
+            },
         )
 
     def test_load_media_not_found(self, fxt_media_prediction_service, fxt_media_service):
@@ -119,8 +185,9 @@ class TestMediaPredictionServiceUnit:
 
         fxt_media_service.get_media_by_ids.return_value = []
 
+        media_prediction_service = fxt_media_prediction_service()
         with pytest.raises(ResourceNotFoundError):
-            fxt_media_prediction_service._load_media(
+            media_prediction_service._load_media(
                 project=project,
                 request=MediaListPredictionRequest(
                     model_id=model_id,
@@ -141,19 +208,29 @@ class TestMediaPredictionServiceUnit:
         video = MagicMock(spec=Video, id=video_id, type=MediaType.VIDEO)
         video_frame = MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, video_id=video_id, frame_index=0)
 
-        not_annotated_video_frame = NotAnnotatedVideoFrame(video=video, frame_index=1)
         not_annotated_video_frame_binary = np.random.randint(0, 255, (768, 1024, 3), dtype=np.uint8)
 
         loaded_media = LoadedMedia(
             single_media=[image],
-            video_frames=[video_frame, not_annotated_video_frame],
+            video_frames={
+                video: [
+                    Frame(frame_index=0, annotated_frame=video_frame, skip=False),
+                    Frame(frame_index=1, skip=False),
+                    Frame(frame_index=2, skip=True),
+                    Frame(frame_index=3, skip=False),
+                ]
+            },
         )
 
-        fxt_media_service.get_frame_binaries.return_value = {1: not_annotated_video_frame_binary}
+        fxt_media_service.get_frame_binaries.return_value = {
+            1: not_annotated_video_frame_binary,
+            3: not_annotated_video_frame_binary,
+        }
 
-        with patch.object(fxt_media_prediction_service, "_load_media_binary") as mock_load_media_binary:
+        media_prediction_service = fxt_media_prediction_service()
+        with patch.object(media_prediction_service, "_load_media_binary") as mock_load_media_binary:
             mock_load_media_binary.side_effect = [np.random.rand(100, 100, 3), np.random.rand(100, 100, 3)]
-            result_inputs = fxt_media_prediction_service._convert_to_inference_input(
+            result_inputs = media_prediction_service._convert_to_inference_input(
                 project=project,
                 loaded_media=loaded_media,
             )
@@ -164,34 +241,87 @@ class TestMediaPredictionServiceUnit:
                 call(project_id=project.id, media=video_frame),
             ]
         )
-        fxt_media_service.get_frame_binaries.assert_called_once_with(project=project, video=video, frame_indexes=[1])
-        assert len(result_inputs) == 3
-        na_frame_input = next(inp for inp in result_inputs if inp.media_id == video_id and inp.frame_index == 1)
+        fxt_media_service.get_frame_binaries.assert_called_once_with(project=project, video=video, frame_indexes=[1, 3])
+        assert len(result_inputs) == 4
+        na_frame_input = next(
+            inp
+            for inp in result_inputs
+            if inp.media_id == video_id and (inp.frame_index == 1 or (inp.frame_index == 3))
+        )
         np.testing.assert_array_equal(na_frame_input.data, not_annotated_video_frame_binary)
+
+    def test_convert_result(self, fxt_media_prediction_service):
+        image_id = uuid4()
+        video_id = uuid4()
+        image = MagicMock(spec=Image, id=image_id, type=MediaType.IMAGE)
+        video = MagicMock(spec=Video, id=video_id, type=MediaType.VIDEO)
+        video_frame = MagicMock(spec=VideoFrame, type=MediaType.VIDEO_FRAME, video_id=video_id, frame_index=0)
+
+        image_annotation = MagicMock(spec=DatasetItemAnnotation)
+        video_frame_annotation = MagicMock(spec=DatasetItemAnnotation)
+
+        loaded_media = LoadedMedia(
+            single_media=[image],
+            video_frames={
+                video: [
+                    Frame(frame_index=0, annotated_frame=video_frame, skip=False),
+                    Frame(frame_index=1, skip=False),
+                    Frame(frame_index=2, skip=True),
+                    Frame(frame_index=3, skip=False),
+                ]
+            },
+        )
+        inference_result = {
+            (image_id, None): [image_annotation],
+            (video_id, 0): [],
+            (video_id, 1): [video_frame_annotation],
+            (video_id, 3): [],
+        }
+
+        media_prediction_service = fxt_media_prediction_service()
+        result = media_prediction_service._convert_result(loaded_media=loaded_media, inference_result=inference_result)
+        assert result == BatchInferenceResult(
+            predictions=[
+                BatchInferencePrediction(media=BatchInferenceMedia(id=image_id), prediction=[image_annotation]),
+                BatchInferencePrediction(media=BatchInferenceMedia(id=video_id, frame_index=0), prediction=[]),
+                BatchInferencePrediction(
+                    media=BatchInferenceMedia(id=video_id, frame_index=1), prediction=[video_frame_annotation]
+                ),
+                BatchInferencePrediction(
+                    media=BatchInferenceMedia(id=video_id, frame_index=2), prediction=[video_frame_annotation]
+                ),
+                BatchInferencePrediction(media=BatchInferenceMedia(id=video_id, frame_index=3), prediction=[]),
+            ]
+        )
 
     def test_predict_media(self, fxt_media_prediction_service, fxt_label_service, fxt_inference_server):
         model_id = uuid4()
         task = MagicMock(spec=Task)
         project = MagicMock(spec=Project, id=uuid4(), task=task)
 
-        loaded_media = LoadedMedia(single_media=[], video_frames=[])
+        loaded_media = LoadedMedia(single_media=[], video_frames={})
         inputs = MagicMock(spec=list)
         labels = MagicMock(spec=list)
         batch_inference_result = MagicMock(spec=BatchInferenceResult)
+        infer_batch_result = {}
 
         fxt_label_service.list_all.return_value = labels
-        fxt_inference_server.infer_batch.return_value = batch_inference_result
+        fxt_inference_server.infer_batch.return_value = infer_batch_result
 
         request = MediaListPredictionRequest(model_id=model_id, media=[], device="AUTO")
         device = DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
 
+        media_prediction_service = fxt_media_prediction_service()
         with (
-            patch.object(fxt_media_prediction_service, "_load_media", return_value=loaded_media) as mock_load_media,
+            patch.object(media_prediction_service, "_load_media", return_value=loaded_media) as mock_load_media,
             patch.object(
-                fxt_media_prediction_service, "_convert_to_inference_input", return_value=inputs
+                media_prediction_service, "_convert_to_inference_input", return_value=inputs
             ) as mock_convert_to_inference_input,
+            patch.object(
+                media_prediction_service, "_convert_result", return_value=batch_inference_result
+            ) as mock_convert_result,
         ):
-            result = fxt_media_prediction_service.predict_media(project=project, request=request, device=device)
+            result = media_prediction_service.predict_media(project=project, request=request, device=device)
 
         mock_load_media.assert_called_once_with(project=project, request=request)
         mock_convert_to_inference_input.assert_called_once_with(project=project, loaded_media=loaded_media)
@@ -200,4 +330,5 @@ class TestMediaPredictionServiceUnit:
             project_id=project.id, model_id=model_id, device=device, ttl=10
         )
         fxt_inference_server.infer_batch.assert_called_once_with(labels=labels, inputs=inputs)
+        mock_convert_result.assert_called_once_with(loaded_media=loaded_media, inference_result=infer_batch_result)
         assert result == batch_inference_result

--- a/application/backend/tests/unit/services/test_media_prediction_service.py
+++ b/application/backend/tests/unit/services/test_media_prediction_service.py
@@ -51,7 +51,7 @@ class TestMediaPredictionServiceUnit:
 
     @pytest.fixture
     def fxt_media_prediction_service(self, fxt_label_service, fxt_media_service, fxt_inference_server):
-        def _create_media_prediction_service(inference_keyframe_stride: int | None = None):
+        def _create_media_prediction_service(inference_keyframe_stride: int = 1):
             db_session = MagicMock(spec=Session)
             return MediaPredictionService(
                 label_service=fxt_label_service,

--- a/application/backend/tests/unit/services/test_media_prediction_service.py
+++ b/application/backend/tests/unit/services/test_media_prediction_service.py
@@ -51,21 +51,21 @@ class TestMediaPredictionServiceUnit:
 
     @pytest.fixture
     def fxt_media_prediction_service(self, fxt_label_service, fxt_media_service, fxt_inference_server):
-        def _create_media_prediction_service(inference_frame_skip: int | None = None):
+        def _create_media_prediction_service(inference_keyframe_stride: int | None = None):
             db_session = MagicMock(spec=Session)
             return MediaPredictionService(
                 label_service=fxt_label_service,
                 media_service=fxt_media_service,
                 inference_server=fxt_inference_server,
                 inference_model_ttl=10,
-                inference_frame_skip=inference_frame_skip,
+                inference_keyframe_stride=inference_keyframe_stride,
                 db_session=db_session,
             )
 
         return _create_media_prediction_service
 
     @pytest.mark.parametrize(
-        "index, frame_indexes, inference_frame_skip, expected_result",
+        "index, frame_indexes, inference_keyframe_stride, expected_result",
         [
             (0, [0, 1, 2, 3, 4, 5], 2, True),
             (1, [0, 1, 2, 3, 4, 5], 2, False),
@@ -75,9 +75,9 @@ class TestMediaPredictionServiceUnit:
             (5, [0, 1, 2, 3, 4, 5], 2, True),
         ],
     )
-    def test_is_frame_index_to_infer(self, index, frame_indexes, inference_frame_skip, expected_result):
+    def test_is_frame_index_to_infer(self, index, frame_indexes, inference_keyframe_stride, expected_result):
         result = MediaPredictionService._is_frame_index_to_infer(
-            index=index, frame_indexes=frame_indexes, inference_frame_skip=inference_frame_skip
+            index=index, frame_indexes=frame_indexes, inference_keyframe_stride=inference_keyframe_stride
         )
         assert result == expected_result
 

--- a/application/backend/tests/unit/services/test_media_prediction_service.py
+++ b/application/backend/tests/unit/services/test_media_prediction_service.py
@@ -332,3 +332,23 @@ class TestMediaPredictionServiceUnit:
         fxt_inference_server.infer_batch.assert_called_once_with(labels=labels, inputs=inputs)
         mock_convert_result.assert_called_once_with(loaded_media=loaded_media, inference_result=infer_batch_result)
         assert result == batch_inference_result
+
+    @pytest.mark.parametrize(
+        "frame_index, keyframe_indexes, expected",
+        [
+            (0, [0, 5, 10, 15, 20], 0),
+            (2, [0, 5, 10, 15, 20], 0),
+            (3, [0, 5, 10, 15, 20], 5),
+            (5, [0, 5, 10, 15, 20], 5),
+            (7, [0, 5, 10, 15, 20], 5),
+            (8, [0, 5, 10, 15, 20], 10),
+            (14, [0, 5, 10, 15, 20], 15),
+            (20, [0, 5, 10, 15, 20], 20),
+            (0, [0], 0),
+            (5, [0, 10], 0),  # equidistant, picks the earlier one (<=)
+            (100, [0, 10, 20], 20),
+        ],
+    )
+    def test_find_nearest_keyframe_index(self, frame_index, keyframe_indexes, expected):
+        result = MediaPredictionService._find_nearest_keyframe_index(frame_index, keyframe_indexes)
+        assert result == expected


### PR DESCRIPTION
Perform real inference only for each N-th frame (controlled by INFERENCE_FRAME_SKIP) and copy predictions for the rest.
This will allow to balance between the predictions accuracy and inference performance which is crucial for real-time video predictions.
Resolves #6218