### PR TITLE
fix:  Annotations are displayed before image is loaded

### DIFF
--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -3,6 +3,10 @@
 
 import { MouseEvent, useEffect, useRef } from 'react';
 
+import { Loading } from '@geti/ui';
+import { useIsFetching } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
 import { ZoomTransform } from '../../../components/zoom/zoom-transform';
 import type { Media } from '../../../constants/shared-types';
 import { useAnnotationActions } from '../../../shared/annotator/annotation-actions-provider.component';
@@ -13,6 +17,7 @@ import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
+import { loadImageQueryOptions } from '../hooks/use-load-image-query.hook';
 import { ToolManager } from '../tools/tool-manager.component';
 import { usePrefetchVideoFramesAnnotations } from '../video-player/api/use-video-frames-annotations';
 import {
@@ -160,11 +165,17 @@ type AnnotatorCanvasProps = {
 };
 
 export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: AnnotatorCanvasProps) => {
+    const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
+    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey });
 
+    const isLoadingMedia = isFetchingMedia > 0;
     const areToolsDisabled = isSceneBusy || isReadOnly;
-
     const size = { width: mediaItem.width, height: mediaItem.height };
+
+    if (isLoadingMedia) {
+        return <Loading size='M' />;
+    }
 
     return (
         <ZoomTransform target={size}>
@@ -174,7 +185,6 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
                 className={isReadOnly ? classes.readOnlyCanvas : undefined}
             >
                 <MediaImage image={image} mediaItem={mediaItem} />
-
                 <MediaAnnotations mediaItem={mediaItem} mode={mode} />
 
                 {!areToolsDisabled && <ToolManager />}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Closes #6260

Renders the loading component while the media item is being fetched.

<img width="1163" height="890" alt="image-annotations" src="https://github.com/user-attachments/assets/57beb3df-4b47-4990-b6b5-d0d7e009e5c4" />

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
