### PR TITLE
Fix reported number of total frames during dataset import

### DIFF
--- a/application/backend/app/services/staged_dataset_service.py
+++ b/application/backend/app/services/staged_dataset_service.py
@@ -85,7 +85,7 @@ def _get_dataset_metadata(dataset: Dataset) -> DatasetMetadata:
                 counts.num_annotated_images += annotation_count > 0
             case LazyVideoFrame():
                 video_path = str(media.video_path)
-                if video_path not in counts.video_paths and Path(video_path).exists():
+                if video_path not in counts.video_paths:
                     counts.num_frames += media.video_info.total_frames
                 counts.video_paths.add(video_path)
                 counts.num_annotations += annotation_count

--- a/application/backend/app/services/staged_dataset_service.py
+++ b/application/backend/app/services/staged_dataset_service.py
@@ -72,7 +72,7 @@ def _get_dataset_metadata(dataset: Dataset) -> DatasetMetadata:
 
     counts = _Counts()
     for item in dataset:
-        ann_type, count = _count_annotations(item)
+        ann_type, annotation_count = _count_annotations(item)
         if ann_type != AnnotationType.UNKNOWN:
             counts.annotation_type = ann_type
         target_media_attrs = ("media", "image", "image_path")
@@ -81,13 +81,15 @@ def _get_dataset_metadata(dataset: Dataset) -> DatasetMetadata:
         match media:
             case LazyImage() | str():
                 counts.num_images += 1
-                counts.num_annotations += count
-                counts.num_annotated_images += count > 0
+                counts.num_annotations += annotation_count
+                counts.num_annotated_images += annotation_count > 0
             case LazyVideoFrame():
-                counts.num_frames += 1
-                counts.video_paths.add(str(item.media.video_path))
-                counts.num_annotations += count
-                counts.num_annotated_frames += count > 0
+                video_path = str(media.video_path)
+                if video_path not in counts.video_paths and Path(video_path).exists():
+                    counts.num_frames += media.video_info.total_frames
+                counts.video_paths.add(video_path)
+                counts.num_annotations += annotation_count
+                counts.num_annotated_frames += annotation_count > 0
             case _:
                 raise ValueError(f"Unsupported media type: {type(media)}")
 

--- a/application/backend/tests/integration/services/test_staged_dataset_service.py
+++ b/application/backend/tests/integration/services/test_staged_dataset_service.py
@@ -5,6 +5,7 @@ import asyncio
 from pathlib import Path
 from uuid import UUID, uuid4
 
+import cv2
 import numpy as np
 import pytest
 from datumaro.experimental import Dataset, LazyImage, LazyVideoFrame, MediaInfo, export_dataset
@@ -20,6 +21,16 @@ from app.datumaro_converter import (
 from app.models import AnnotationType, DatasetFormat
 from app.models.dataset import DatasetMetadata
 from app.services import StagedDatasetService
+
+
+def _create_dummy_video(path: Path, num_frames: int = 20, width: int = 64, height: int = 64, fps: int = 10) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fourcc = cv2.VideoWriter.fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, fps, (width, height))
+    for _ in range(num_frames):
+        frame = np.random.randint(0, 255, (height, width, 3), dtype=np.uint8)
+        writer.write(frame)
+    writer.release()
 
 
 def _stage_dataset_archive(root: Path, file_name: str, content: bytes = b"data") -> tuple[UUID, Path]:
@@ -71,10 +82,12 @@ def _stage_multilabel_dataset(root: Path) -> tuple[UUID, Path]:
             user_reviewed=False,
         )
     )
+    video_path = root / "videos" / "video1.mp4"
+    _create_dummy_video(video_path, num_frames=20)
     dataset.append(
         MultilabelClassificationImportExportSample(
             id=str(uuid4()),
-            media=LazyVideoFrame(video_path=ds_dir / "videos/video1.mp4", frame_index=10),
+            media=LazyVideoFrame(video_path=video_path, frame_index=10),
             media_info=MediaInfo(width=200, height=200),
             label=np.array([]),
             subset=Subset.TRAINING,
@@ -225,7 +238,7 @@ class TestStagedDatasetServiceIntegration:
         assert geti_ds.filename == str(geti_path)
         assert geti_ds.metadata == DatasetMetadata(
             num_images=3,
-            num_frames=0,
+            num_frames=20,
             num_videos=1,
             annotation_type=AnnotationType.LABEL,
             num_annotations=3,
@@ -286,7 +299,7 @@ class TestStagedDatasetServiceIntegration:
         assert result.format == DatasetFormat.GETI
         assert result.metadata == DatasetMetadata(
             num_images=3,
-            num_frames=0,
+            num_frames=20,
             num_videos=1,
             annotation_type=AnnotationType.LABEL,
             num_annotations=3,

--- a/application/backend/tests/integration/services/test_staged_dataset_service.py
+++ b/application/backend/tests/integration/services/test_staged_dataset_service.py
@@ -225,7 +225,7 @@ class TestStagedDatasetServiceIntegration:
         assert geti_ds.filename == str(geti_path)
         assert geti_ds.metadata == DatasetMetadata(
             num_images=3,
-            num_frames=1,
+            num_frames=0,
             num_videos=1,
             annotation_type=AnnotationType.LABEL,
             num_annotations=3,
@@ -286,7 +286,7 @@ class TestStagedDatasetServiceIntegration:
         assert result.format == DatasetFormat.GETI
         assert result.metadata == DatasetMetadata(
             num_images=3,
-            num_frames=1,
+            num_frames=0,
             num_videos=1,
             annotation_type=AnnotationType.LABEL,
             num_annotations=3,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] `num_frames` is calculated based on `total_frames` from video metadata


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
