### PR TITLE
fix: clear intensity_config for YOLOX-S/L/X to prevent wrong scaling metadata on export

### DIFF
--- a/library/src/getitune/backend/lightning/models/detection/yolox.py
+++ b/library/src/getitune/backend/lightning/models/detection/yolox.py
@@ -99,6 +99,14 @@ class YOLOX(LightningDetectionModel):
             tile_config=tile_config,
         )
 
+        # YOLOX-S/L/X pretrained weights expect [0, 255] float inputs.
+        # The training pipeline scales to [0, 1] then _customize_inputs rescales
+        # back to [0, 255], but the exported model graph does NOT include this
+        # rescaling. Therefore we must NOT export intensity_mode=scale_to_unit
+        # metadata, otherwise ModelAPI will incorrectly scale inputs to [0, 1].
+        if model_name in _RAW_UINT8_MODELS:
+            self.data_input_params.intensity_config = None
+
     def _create_model(self, num_classes: int | None = None) -> SingleStageDetector:
         num_classes = num_classes if num_classes is not None else self.num_classes
         train_cfg: dict[str, Any] = {"assigner": SimOTAAssigner(center_radius=2.5)}

--- a/library/src/getitune/backend/lightning/models/detection/yolox.py
+++ b/library/src/getitune/backend/lightning/models/detection/yolox.py
@@ -99,13 +99,19 @@ class YOLOX(LightningDetectionModel):
             tile_config=tile_config,
         )
 
-        # YOLOX-S/L/X pretrained weights expect [0, 255] float inputs.
-        # The training pipeline scales to [0, 1] then _customize_inputs rescales
-        # back to [0, 255], but the exported model graph does NOT include this
-        # rescaling. Therefore we must NOT export intensity_mode=scale_to_unit
-        # metadata, otherwise ModelAPI will incorrectly scale inputs to [0, 1].
+        # Raw uint8 models expect [0, 255] inputs; intensity scaling must not be exported.
         if model_name in _RAW_UINT8_MODELS:
-            self.data_input_params.intensity_config = None
+            if (
+                self.data_input_params.intensity_config is not None
+                and self.data_input_params.intensity_config.storage_dtype in ("uint16", "int16")
+            ):
+                msg = (
+                    f"YOLOX ({model_name}) does not support high-bit-depth inputs "
+                    f"(got storage_dtype='{self.data_input_params.intensity_config.storage_dtype}'). "
+                    "Use yolox_tiny or a model with normalization for 16-bit images."
+                )
+                raise ValueError(msg)
+            self.data_input_params = dataclasses.replace(self.data_input_params, intensity_config=None)
 
     def _create_model(self, num_classes: int | None = None) -> SingleStageDetector:
         num_classes = num_classes if num_classes is not None else self.num_classes

--- a/library/tests/unit/backend/lightning/models/detection/test_yolox.py
+++ b/library/tests/unit/backend/lightning/models/detection/test_yolox.py
@@ -111,3 +111,13 @@ class TestYOLOX:
         else:
             assert model.data_input_params.intensity_config is not None
             assert model.data_input_params.intensity_config.mode == "scale_to_unit"
+
+    @pytest.mark.parametrize("model_name", ["yolox_s", "yolox_l", "yolox_x"])
+    @pytest.mark.parametrize("storage_dtype", ["uint16", "int16"])
+    def test_raw_uint8_models_reject_high_bit_depth(self, model_name, storage_dtype):
+        from getitune.config.data import IntensityConfig
+
+        intensity_cfg = IntensityConfig(storage_dtype=storage_dtype, mode="scale_to_unit")
+        params = DataInputParams((320, 320), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0), intensity_config=intensity_cfg)
+        with pytest.raises(ValueError, match="does not support high-bit-depth"):
+            YOLOX(model_name=model_name, label_info=3, data_input_params=params)

--- a/library/tests/unit/backend/lightning/models/detection/test_yolox.py
+++ b/library/tests/unit/backend/lightning/models/detection/test_yolox.py
@@ -95,3 +95,19 @@ class TestYOLOX:
         assert dets.shape[0] == 1
         assert dets.shape[2] == 5
         assert labels.shape == dets.shape[:2]
+
+    @pytest.mark.parametrize(
+        ("model_name", "expect_cleared"),
+        [("yolox_s", True), ("yolox_l", True), ("yolox_x", True), ("yolox_tiny", False)],
+    )
+    def test_intensity_config_cleared_for_raw_uint8_models(self, model_name, expect_cleared):
+        from getitune.config.data import IntensityConfig
+
+        intensity_cfg = IntensityConfig(mode="scale_to_unit", max_value=255.0)
+        params = DataInputParams((320, 320), (0.0, 0.0, 0.0), (1.0, 1.0, 1.0), intensity_config=intensity_cfg)
+        model = YOLOX(model_name=model_name, label_info=3, data_input_params=params)
+        if expect_cleared:
+            assert model.data_input_params.intensity_config is None
+        else:
+            assert model.data_input_params.intensity_config is not None
+            assert model.data_input_params.intensity_config.mode == "scale_to_unit"


### PR DESCRIPTION
## Summary

- Fix incorrect intensity_mode=scale_to_unit metadata being exported for YOLOX-S/L/X models, which caused ModelAPI to incorrectly scale inputs to [0, 1] at inference time resulting in No object predictions.
- Clear intensity_config from data_input_params for raw uint8 YOLOX variants (S/L/X) during model initialization so the exporter does not embed wrong intensity metadata.
- YOLOX-tiny (which uses ImageNet normalization and expects [0, 1] inputs) is unaffected.

## Root Cause

YOLOX-S/L/X pretrained weights (MMDet) expect [0, 255] float inputs. The training pipeline scales images to [0, 1] via the CPU augmentation pipeline, then _customize_inputs rescales back to [0, 255]. However, forward_for_tracing (used for export) bypasses _customize_inputs, so the exported model graph expects raw [0, 255] inputs directly. The dataset-level IntensityConfig(mode=scale_to_unit) was being unconditionally propagated to the export metadata, telling ModelAPI to divide by 255 before feeding the model.


Resolves #6407