### PR TITLE
Update optimizer to AdamW for rtmdet_inst_tiny

### DIFF
--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -81,8 +81,8 @@ hyperparameters:
         sharpness: 0.5
         probability: 0.5
   training:
-    learning_rate: 0.001
-    weight_decay: 0.0001
+    learning_rate: 0.004
+    weight_decay: 0.01
     scheduler:
       factor: 0.1
       patience: 9

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -81,7 +81,7 @@ hyperparameters:
         sharpness: 0.5
         probability: 0.5
   training:
-    learning_rate: 0.004
+    learning_rate: 0.0007
     weight_decay: 0.01
     scheduler:
       factor: 0.1

--- a/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -8,7 +8,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: 0.004
+        lr: 0.0007
         weight_decay: 0.01
         betas: [0.9, 0.999]
 

--- a/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
+++ b/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny.yaml
@@ -6,11 +6,11 @@ model:
     model_name: rtmdet_inst_tiny
 
     optimizer:
-      class_path: torch.optim.SGD
+      class_path: torch.optim.AdamW
       init_args:
-        lr: 0.001
-        momentum: 0.9
-        weight_decay: 0.0001
+        lr: 0.004
+        weight_decay: 0.01
+        betas: [0.9, 0.999]
 
     scheduler:
       class_path: getitune.backend.lightning.schedulers.LinearWarmupSchedulerCallable
@@ -62,7 +62,7 @@ overrides:
       - 640
 
     train_subset:
-      batch_size: 4
+      batch_size: 8
       num_workers: 8
       augmentations_cpu:
         - class_path: getitune.data.augmentation.transforms.CachedMosaic

--- a/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -8,7 +8,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: 0.004
+        lr: 0.0007
         weight_decay: 0.01
         betas: [0.9, 0.999]
 

--- a/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -5,12 +5,14 @@ model:
     label_info: 80
     model_name: rtmdet_inst_tiny
 
+    # See rtmdet_inst_tiny.yaml — RTMDet-Inst reference uses AdamW, not
+    # SGD. The previous SGD/lr=1e-3 setup was severely under-fitting.
     optimizer:
-      class_path: torch.optim.SGD
+      class_path: torch.optim.AdamW
       init_args:
-        lr: 0.001
-        momentum: 0.9
-        weight_decay: 0.0001
+        lr: 0.004
+        weight_decay: 0.01
+        betas: [0.9, 0.999]
 
     scheduler:
       class_path: getitune.backend.lightning.schedulers.LinearWarmupSchedulerCallable
@@ -70,7 +72,7 @@ overrides:
       enable_adaptive_tiling: true
 
     train_subset:
-      batch_size: 4
+      batch_size: 8
       num_workers: 8
       augmentations_cpu:
         - class_path: getitune.data.augmentation.transforms.Resize

--- a/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
+++ b/library/src/getitune/recipe/instance_segmentation/rtmdet_inst_tiny_tile.yaml
@@ -5,8 +5,6 @@ model:
     label_info: 80
     model_name: rtmdet_inst_tiny
 
-    # See rtmdet_inst_tiny.yaml — RTMDet-Inst reference uses AdamW, not
-    # SGD. The previous SGD/lr=1e-3 setup was severely under-fitting.
     optimizer:
       class_path: torch.optim.AdamW
       init_args:


### PR DESCRIPTION
### Summary
The RTMdet recipe was implemented with the SGD optimizer, however, this does not match with the default setup described in the [paper](https://ar5iv.labs.arxiv.org/html/2212.07784) where they use AdamW. 

I have ran a few benchmarks using the WGISD dataset and the map50 improved significantly when using AdamW. The bottom result in the screenshot is with SGD optimizer, other results are using AdamW. 
<img width="722" height="191" alt="image" src="https://github.com/user-attachments/assets/34745d7e-d199-4716-9f4f-b787a131f2fc" />


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
