### PR TITLE
Evaluate OV and ONNX separately

### DIFF
--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -16,6 +16,7 @@ from datumaro.experimental.fields import Subset
 from getitune import TaskType
 from getitune.backend.lightning.engine import LightningEngine
 from getitune.backend.lightning.models.base import DataInputParams, LightningModel
+from getitune.backend.openvino.engine import OVEngine
 from getitune.config.data import SamplerConfig, SubsetConfig
 from getitune.data.dataset.base import VisionDataset
 from getitune.data.factory import TransformLibFactory
@@ -438,14 +439,73 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
         self,
         getitune_engine: LightningEngine,
         model_checkpoint_path: Path,
+        exported_model_paths: ExportedModels,
         task: Task,
+        model_revision_id: UUID,
+        created_variants: dict[ModelFormat, UUID],
+        dataset_revision_id: UUID,
+    ) -> None:
+        """Evaluate the trained model variants (PyTorch, OpenVINO, ONNX) on the testing set.
+
+        Each variant is evaluated using its own dedicated engine so that the recorded
+        metrics reflect the runtime that will actually serve it. Results are persisted
+        against the corresponding model variant id.
+        """
+        metric_callable = get_metric_by_task(task)
+
+        # PyTorch evaluation via the LightningEngine used for training
+        logger.info("Evaluating the PyTorch model...")
+        pytorch_metrics = getitune_engine.test(checkpoint=model_checkpoint_path, metric=metric_callable)
+        self._save_evaluation_result(
+            metrics=pytorch_metrics,
+            model_revision_id=model_revision_id,
+            model_variant_id=created_variants[ModelFormat.PYTORCH],
+            dataset_revision_id=dataset_revision_id,
+        )
+
+        # OpenVINO IR and ONNX evaluations both go through OVEngine, which now accepts
+        # either a .xml (OpenVINO IR) or a .onnx checkpoint.
+        ov_work_dir_base = Path(getitune_engine.work_dir)
+        datamodule = getitune_engine.datamodule
+
+        ov_xml_path = exported_model_paths.openvino_model_path.with_suffix(".xml")
+        logger.info("Evaluating the OpenVINO model...")
+        ov_engine = OVEngine(
+            model=ov_xml_path,
+            data=datamodule,
+            work_dir=ov_work_dir_base / "ov_eval",
+        )
+        ov_metrics = ov_engine.test(checkpoint=ov_xml_path, metric=metric_callable)
+        self._save_evaluation_result(
+            metrics=ov_metrics,
+            model_revision_id=model_revision_id,
+            model_variant_id=created_variants[ModelFormat.OPENVINO],
+            dataset_revision_id=dataset_revision_id,
+        )
+
+        onnx_path = exported_model_paths.onnx_model_path.with_suffix(".onnx")
+        logger.info("Evaluating the ONNX model...")
+        onnx_engine = OVEngine(
+            model=onnx_path,
+            data=datamodule,
+            work_dir=ov_work_dir_base / "onnx_eval",
+        )
+        onnx_metrics = onnx_engine.test(checkpoint=onnx_path, metric=metric_callable)
+        self._save_evaluation_result(
+            metrics=onnx_metrics,
+            model_revision_id=model_revision_id,
+            model_variant_id=created_variants[ModelFormat.ONNX],
+            dataset_revision_id=dataset_revision_id,
+        )
+
+    def _save_evaluation_result(
+        self,
+        metrics: dict,
         model_revision_id: UUID,
         model_variant_id: UUID,
         dataset_revision_id: UUID,
     ) -> None:
-        """Evaluate the trained model on the testing set"""
-        logger.info("Evaluating the model on the testing set...")
-        metrics = getitune_engine.test(checkpoint=model_checkpoint_path, metric=get_metric_by_task(task))
+        """Persist a single EvaluationResult tagged with the given model variant id."""
         with self._db_session_factory() as db:
             self._model_service.set_db_session(db)
             self._model_service.save_evaluation_result(
@@ -620,9 +680,10 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
             self.evaluate_model(
                 getitune_engine=getitune_engine,
                 model_checkpoint_path=trained_model_path,
+                exported_model_paths=exported_model_paths,
                 task=task,
                 model_revision_id=params.model_id,
-                model_variant_id=created_variants[ModelFormat.PYTORCH],
+                created_variants=created_variants,
                 dataset_revision_id=dataset_info.revision_id,
             )
 

--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -103,6 +103,21 @@ class ExportedModels:
     onnx_model_path: Path
 
 
+@dataclass(frozen=True)
+class ModelVariantDescriptor:
+    """Describes a single trained/exported model variant to be evaluated and stored.
+
+    Attributes:
+        id: The UUID of the variant record in the database.
+        path: Path to the variant's main file (.ckpt for PyTorch, .xml for OpenVINO IR, .onnx for ONNX).
+        format: The format of the variant.
+    """
+
+    id: UUID
+    path: Path
+    format: ModelFormat
+
+
 class GetiTuneTrainer(Execution[TrainingJobParams]):
     """getitune-specific trainer implementation."""
 
@@ -438,65 +453,52 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
     def evaluate_model(
         self,
         getitune_engine: LightningEngine,
-        model_checkpoint_path: Path,
-        exported_model_paths: ExportedModels,
         task: Task,
         model_revision_id: UUID,
-        created_variants: dict[ModelFormat, UUID],
+        model_variants: list[ModelVariantDescriptor],
         dataset_revision_id: UUID,
     ) -> None:
-        """Evaluate the trained model variants (PyTorch, OpenVINO, ONNX) on the testing set.
+        """Evaluate the trained model variants on the testing set.
 
         Each variant is evaluated using its own dedicated engine so that the recorded
         metrics reflect the runtime that will actually serve it. Results are persisted
         against the corresponding model variant id.
+
+        - PyTorch (.ckpt) variants are evaluated with the LightningEngine used for training.
+        - OpenVINO (.xml) and ONNX (.onnx) variants are evaluated with OVEngine, which
+          natively supports both checkpoint types.
         """
         metric_callable = get_metric_by_task(task)
-
-        # PyTorch evaluation via the LightningEngine used for training
-        logger.info("Evaluating the PyTorch model...")
-        pytorch_metrics = getitune_engine.test(checkpoint=model_checkpoint_path, metric=metric_callable)
-        self._save_evaluation_result(
-            metrics=pytorch_metrics,
-            model_revision_id=model_revision_id,
-            model_variant_id=created_variants[ModelFormat.PYTORCH],
-            dataset_revision_id=dataset_revision_id,
-        )
-
-        # OpenVINO IR and ONNX evaluations both go through OVEngine, which now accepts
-        # either a .xml (OpenVINO IR) or a .onnx checkpoint.
         ov_work_dir_base = Path(getitune_engine.work_dir)
         datamodule = getitune_engine.datamodule
 
-        ov_xml_path = exported_model_paths.openvino_model_path.with_suffix(".xml")
-        logger.info("Evaluating the OpenVINO model...")
-        ov_engine = OVEngine(
-            model=ov_xml_path,
-            data=datamodule,
-            work_dir=ov_work_dir_base / "ov_eval",
-        )
-        ov_metrics = ov_engine.test(checkpoint=ov_xml_path, metric=metric_callable)
-        self._save_evaluation_result(
-            metrics=ov_metrics,
-            model_revision_id=model_revision_id,
-            model_variant_id=created_variants[ModelFormat.OPENVINO],
-            dataset_revision_id=dataset_revision_id,
-        )
+        for variant in model_variants:
+            logger.info("Evaluating the {} model...", variant.format.value)
+            match variant.format:
+                case ModelFormat.PYTORCH:
+                    engine = getitune_engine
+                case ModelFormat.OPENVINO:
+                    engine = OVEngine(
+                        model=variant.path,
+                        data=datamodule,
+                        work_dir=ov_work_dir_base / "ov_eval",
+                    )
+                case ModelFormat.ONNX:
+                    engine = OVEngine(
+                        model=variant.path,
+                        data=datamodule,
+                        work_dir=ov_work_dir_base / "onnx_eval",
+                    )
+                case _:
+                    raise ExecutionErr(f"Unsupported model variant format for evaluation: {variant.format}")
 
-        onnx_path = exported_model_paths.onnx_model_path.with_suffix(".onnx")
-        logger.info("Evaluating the ONNX model...")
-        onnx_engine = OVEngine(
-            model=onnx_path,
-            data=datamodule,
-            work_dir=ov_work_dir_base / "onnx_eval",
-        )
-        onnx_metrics = onnx_engine.test(checkpoint=onnx_path, metric=metric_callable)
-        self._save_evaluation_result(
-            metrics=onnx_metrics,
-            model_revision_id=model_revision_id,
-            model_variant_id=created_variants[ModelFormat.ONNX],
-            dataset_revision_id=dataset_revision_id,
-        )
+            metrics = engine.test(metric=metric_callable)
+            self._save_evaluation_result(
+                metrics=metrics,
+                model_revision_id=model_revision_id,
+                model_variant_id=variant.id,
+                dataset_revision_id=dataset_revision_id,
+            )
 
     def _save_evaluation_result(
         self,
@@ -676,14 +678,31 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
             # Create variant DB records first (no file I/O yet)
             created_variants = self.create_model_variants(model_revision_id=params.model_id)
 
+            # Build descriptors mapping each variant id to its source file path inside the workspace
+            model_variants = [
+                ModelVariantDescriptor(
+                    id=created_variants[ModelFormat.PYTORCH],
+                    path=trained_model_path,
+                    format=ModelFormat.PYTORCH,
+                ),
+                ModelVariantDescriptor(
+                    id=created_variants[ModelFormat.OPENVINO],
+                    path=exported_model_paths.openvino_model_path.with_suffix(".xml"),
+                    format=ModelFormat.OPENVINO,
+                ),
+                ModelVariantDescriptor(
+                    id=created_variants[ModelFormat.ONNX],
+                    path=exported_model_paths.onnx_model_path.with_suffix(".onnx"),
+                    format=ModelFormat.ONNX,
+                ),
+            ]
+
             # Evaluate while the workspace and checkpoint still exist
             self.evaluate_model(
                 getitune_engine=getitune_engine,
-                model_checkpoint_path=trained_model_path,
-                exported_model_paths=exported_model_paths,
                 task=task,
                 model_revision_id=params.model_id,
-                created_variants=created_variants,
+                model_variants=model_variants,
                 dataset_revision_id=dataset_info.revision_id,
             )
 

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -32,7 +32,13 @@ from app.datumaro_converter.domain.samples.training import (
 )
 from app.execution.base import ExecutionErr
 from app.execution.common.geti_config_converter import GetiConfigConverter
-from app.execution.training.getitune_trainer import DatasetInfo, ExportedModels, GetiTuneTrainer, TrainingDependencies
+from app.execution.training.getitune_trainer import (
+    DatasetInfo,
+    ExportedModels,
+    GetiTuneTrainer,
+    ModelVariantDescriptor,
+    TrainingDependencies,
+)
 from app.models import (
     DatasetItemAnnotationStatus,
     DatasetItemSubset,
@@ -1044,16 +1050,26 @@ class TestGetiTuneTrainerEvaluateModel:
         model_checkpoint_path.touch()
         ov_export_path = tmp_path / "exported_model"
         onnx_export_path = tmp_path / "exported_model"
-        exported_model_paths = ExportedModels(
-            openvino_model_path=ov_export_path,
-            onnx_model_path=onnx_export_path,
-        )
+        ov_xml_path = ov_export_path.with_suffix(".xml")
+        onnx_path = onnx_export_path.with_suffix(".onnx")
 
-        created_variants = {
-            ModelFormat.PYTORCH: pytorch_variant_id,
-            ModelFormat.OPENVINO: openvino_variant_id,
-            ModelFormat.ONNX: onnx_variant_id,
-        }
+        model_variants = [
+            ModelVariantDescriptor(
+                id=pytorch_variant_id,
+                path=model_checkpoint_path,
+                format=ModelFormat.PYTORCH,
+            ),
+            ModelVariantDescriptor(
+                id=openvino_variant_id,
+                path=ov_xml_path,
+                format=ModelFormat.OPENVINO,
+            ),
+            ModelVariantDescriptor(
+                id=onnx_variant_id,
+                path=onnx_path,
+                format=ModelFormat.ONNX,
+            ),
+        ]
 
         training_params = TrainingJobParams(
             device=DeviceInfo(type=DeviceType.XPU, name="Intel Arc B580", memory=12884901888, index=0),
@@ -1076,11 +1092,9 @@ class TestGetiTuneTrainerEvaluateModel:
         ) as mock_ov_engine_cls:
             getitune_trainer.evaluate_model(
                 getitune_engine=mock_getitune_engine,
-                model_checkpoint_path=model_checkpoint_path,
-                exported_model_paths=exported_model_paths,
                 task=training_params.task,
                 model_revision_id=model_id,
-                created_variants=created_variants,
+                model_variants=model_variants,
                 dataset_revision_id=dataset_revision_id,
             )
 
@@ -1089,8 +1103,6 @@ class TestGetiTuneTrainerEvaluateModel:
 
         # Assert: OVEngine instantiated twice (OV + ONNX) and tested with the right checkpoints
         assert mock_ov_engine_cls.call_count == 2
-        ov_xml_path = ov_export_path.with_suffix(".xml")
-        onnx_path = onnx_export_path.with_suffix(".onnx")
         mock_ov_engine_cls.assert_has_calls(
             calls=[
                 call(

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -1009,21 +1009,51 @@ class TestGetiTuneTrainerEvaluateModel:
         tmp_path: Path,
         fxt_model_service: Mock,
     ):
-        """Test successful model evaluation on the testing set."""
+        """Test successful evaluation of all three model variants (PyTorch, OV, ONNX)."""
         # Arrange
         getitune_trainer = fxt_getitune_trainer()
         project_id = uuid4()
         model_id = uuid4()
-        model_variant_id = uuid4()
+        pytorch_variant_id = uuid4()
+        openvino_variant_id = uuid4()
+        onnx_variant_id = uuid4()
         dataset_revision_id = uuid4()
-        mock_getitune_engine = Mock()
-        mock_getitune_engine.test.return_value = {
+
+        pytorch_metrics = {
             "test/accuracy": torch.tensor(0.85),
             "test/precision": torch.tensor(0.82),
             "test/recall": torch.tensor(0.88),
         }
+        ov_metrics = {
+            "test/accuracy": torch.tensor(0.84),
+            "test/precision": torch.tensor(0.81),
+            "test/recall": torch.tensor(0.87),
+        }
+        onnx_metrics = {
+            "test/accuracy": torch.tensor(0.83),
+            "test/precision": torch.tensor(0.80),
+            "test/recall": torch.tensor(0.86),
+        }
+
+        mock_getitune_engine = Mock()
+        mock_getitune_engine.test.return_value = pytorch_metrics
+        mock_getitune_engine.work_dir = tmp_path / "getitune-workspace"
+        mock_getitune_engine.datamodule = Mock()
+
         model_checkpoint_path = tmp_path / "best_checkpoint.ckpt"
         model_checkpoint_path.touch()
+        ov_export_path = tmp_path / "exported_model"
+        onnx_export_path = tmp_path / "exported_model"
+        exported_model_paths = ExportedModels(
+            openvino_model_path=ov_export_path,
+            onnx_model_path=onnx_export_path,
+        )
+
+        created_variants = {
+            ModelFormat.PYTORCH: pytorch_variant_id,
+            ModelFormat.OPENVINO: openvino_variant_id,
+            ModelFormat.ONNX: onnx_variant_id,
+        }
 
         training_params = TrainingJobParams(
             device=DeviceInfo(type=DeviceType.XPU, name="Intel Arc B580", memory=12884901888, index=0),
@@ -1034,31 +1064,70 @@ class TestGetiTuneTrainerEvaluateModel:
             job_id=uuid4(),
         )
 
+        mock_ov_engine = Mock()
+        mock_ov_engine.test.return_value = ov_metrics
+        mock_onnx_engine = Mock()
+        mock_onnx_engine.test.return_value = onnx_metrics
+
         # Act
-        getitune_trainer.evaluate_model(
-            getitune_engine=mock_getitune_engine,
-            model_checkpoint_path=model_checkpoint_path,
-            task=training_params.task,
-            model_revision_id=model_id,
-            model_variant_id=model_variant_id,
-            dataset_revision_id=dataset_revision_id,
-        )
+        with patch(
+            "app.execution.training.getitune_trainer.OVEngine",
+            side_effect=[mock_ov_engine, mock_onnx_engine],
+        ) as mock_ov_engine_cls:
+            getitune_trainer.evaluate_model(
+                getitune_engine=mock_getitune_engine,
+                model_checkpoint_path=model_checkpoint_path,
+                exported_model_paths=exported_model_paths,
+                task=training_params.task,
+                model_revision_id=model_id,
+                created_variants=created_variants,
+                dataset_revision_id=dataset_revision_id,
+            )
 
-        # Assert
+        # Assert: PyTorch evaluation via the LightningEngine
         mock_getitune_engine.test.assert_called_once_with(checkpoint=model_checkpoint_path, metric=metric_callable)
-        fxt_model_service.set_db_session.assert_called_once()
-        actual_call = fxt_model_service.save_evaluation_result.call_args[0][0]
 
-        assert actual_call.model_variant_id == model_variant_id
-        assert actual_call.dataset_revision_id == dataset_revision_id
-        assert actual_call.subset == DatasetItemSubset.TESTING
-        assert actual_call.metrics == pytest.approx(
-            {
-                "accuracy": 0.85,
-                "precision": 0.82,
-                "recall": 0.88,
-            },
-            rel=1e-6,
+        # Assert: OVEngine instantiated twice (OV + ONNX) and tested with the right checkpoints
+        assert mock_ov_engine_cls.call_count == 2
+        ov_xml_path = ov_export_path.with_suffix(".xml")
+        onnx_path = onnx_export_path.with_suffix(".onnx")
+        mock_ov_engine_cls.assert_has_calls(
+            calls=[
+                call(
+                    model=ov_xml_path,
+                    data=mock_getitune_engine.datamodule,
+                    work_dir=mock_getitune_engine.work_dir / "ov_eval",
+                ),
+                call(
+                    model=onnx_path,
+                    data=mock_getitune_engine.datamodule,
+                    work_dir=mock_getitune_engine.work_dir / "onnx_eval",
+                ),
+            ]
+        )
+        mock_ov_engine.test.assert_called_once_with(checkpoint=ov_xml_path, metric=metric_callable)
+        mock_onnx_engine.test.assert_called_once_with(checkpoint=onnx_path, metric=metric_callable)
+
+        # Assert: each variant's metrics are persisted with the matching variant id
+        save_calls = fxt_model_service.save_evaluation_result.call_args_list
+        assert len(save_calls) == 3
+
+        results_by_variant = {c.args[0].model_variant_id: c.args[0] for c in save_calls}
+        assert set(results_by_variant) == {pytorch_variant_id, openvino_variant_id, onnx_variant_id}
+
+        for result in results_by_variant.values():
+            assert result.model_revision_id == model_id
+            assert result.dataset_revision_id == dataset_revision_id
+            assert result.subset == DatasetItemSubset.TESTING
+
+        assert results_by_variant[pytorch_variant_id].metrics == pytest.approx(
+            {"accuracy": 0.85, "precision": 0.82, "recall": 0.88}, rel=1e-6
+        )
+        assert results_by_variant[openvino_variant_id].metrics == pytest.approx(
+            {"accuracy": 0.84, "precision": 0.81, "recall": 0.87}, rel=1e-6
+        )
+        assert results_by_variant[onnx_variant_id].metrics == pytest.approx(
+            {"accuracy": 0.83, "precision": 0.80, "recall": 0.86}, rel=1e-6
         )
 
 

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -1099,7 +1099,7 @@ class TestGetiTuneTrainerEvaluateModel:
             )
 
         # Assert: PyTorch evaluation via the LightningEngine
-        mock_getitune_engine.test.assert_called_once_with(checkpoint=model_checkpoint_path, metric=metric_callable)
+        mock_getitune_engine.test.assert_called_once_with(metric=metric_callable)
 
         # Assert: OVEngine instantiated twice (OV + ONNX) and tested with the right checkpoints
         assert mock_ov_engine_cls.call_count == 2
@@ -1117,8 +1117,8 @@ class TestGetiTuneTrainerEvaluateModel:
                 ),
             ]
         )
-        mock_ov_engine.test.assert_called_once_with(checkpoint=ov_xml_path, metric=metric_callable)
-        mock_onnx_engine.test.assert_called_once_with(checkpoint=onnx_path, metric=metric_callable)
+        mock_ov_engine.test.assert_called_once_with(metric=metric_callable)
+        mock_onnx_engine.test.assert_called_once_with(metric=metric_callable)
 
         # Assert: each variant's metrics are persisted with the matching variant id
         save_calls = fxt_model_service.save_evaluation_result.call_args_list


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Adds a separate evaluation for the OV, ONNX, and PyTorch models, using their own respective engines to better reflect their individual performance at runtime.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
