### PR TITLE
Add EpochSummary callback for per-epoch training metrics logging

### DIFF
--- a/library/src/getitune/backend/lightning/callbacks/__init__.py
+++ b/library/src/getitune/backend/lightning/callbacks/__init__.py
@@ -4,7 +4,8 @@
 """Module for getitune custom callbacks."""
 
 from .batchsize_finder import BatchSizeFinder
+from .epoch_summary import EpochSummary
 from .gpu_augmentation import GPUAugmentationCallback
 from .lr_monitor import SimpleLearningRateMonitor
 
-__all__ = ["BatchSizeFinder", "GPUAugmentationCallback", "SimpleLearningRateMonitor"]
+__all__ = ["BatchSizeFinder", "EpochSummary", "GPUAugmentationCallback", "SimpleLearningRateMonitor"]

--- a/library/src/getitune/backend/lightning/callbacks/epoch_summary.py
+++ b/library/src/getitune/backend/lightning/callbacks/epoch_summary.py
@@ -101,7 +101,7 @@ class EpochSummary(Callback):
 
         # Always show the epoch counter even when no whitelisted metric is
         # present (e.g. very first epoch with only train metrics flushed).
-        epoch = trainer.current_epoch
+        epoch = trainer.current_epoch + 1  # Epochs are 0 indexed, add one to clearly log current epoch
         max_epochs = trainer.max_epochs
         header = f"epoch {epoch:>3}/{max_epochs}" if max_epochs else f"epoch {epoch:>3}"
 

--- a/library/src/getitune/backend/lightning/callbacks/epoch_summary.py
+++ b/library/src/getitune/backend/lightning/callbacks/epoch_summary.py
@@ -103,7 +103,7 @@ class EpochSummary(Callback):
         # present (e.g. very first epoch with only train metrics flushed).
         epoch = trainer.current_epoch + 1  # Epochs are 0 indexed, add one to clearly log current epoch
         max_epochs = trainer.max_epochs
-        header = f"epoch {epoch:>3}/{max_epochs}" if max_epochs else f"epoch {epoch:>3}"
+        header = f"epoch {epoch:>3}/{max_epochs}" if max_epochs is not None else f"epoch {epoch:>3}"
 
         if parts:
             logger.info("%s | %s", header, "  ".join(parts))

--- a/library/src/getitune/backend/lightning/callbacks/epoch_summary.py
+++ b/library/src/getitune/backend/lightning/callbacks/epoch_summary.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-epoch summary logger.
+
+Lightning's ``RichProgressBar`` is configured with ``leave=False`` (see
+``configure_callbacks`` in ``backend/lightning/engine.py``), so the in-place
+progress display is cleared at the end of each epoch. This is desirable
+interactively, but means a captured log file (``nohup``, CI artifacts, ...)
+ends up with only the final epoch's snapshot.
+
+This callback emits a single, plain-text, line-buffered summary at the end of
+every validation epoch, so logs accumulate one entry per epoch with the
+metrics that matter (loss, monitored metric, LR). It is cheap, has no
+interactive effect (RichProgressBar runs on a different stream/transient
+region), and survives stdout redirection.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+from lightning import Callback
+
+if TYPE_CHECKING:
+    import lightning.pytorch as pl
+
+logger = logging.getLogger(__name__)
+
+
+def _scalar(value: object) -> float | None:
+    """Best-effort conversion of a Lightning callback metric to ``float``."""
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            return None
+        return float(value.detach().cpu().item())
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+class EpochSummary(Callback):
+    """Log a one-line summary of training/validation metrics per epoch.
+
+    The summary is emitted via the standard ``logging`` module at INFO level,
+    so it is captured by any handler the engine has configured (file logging,
+    stdout, etc.) and timestamps line up with the rest of the training log.
+
+    Args:
+        keys: Metric keys to include in the summary, looked up in
+            ``trainer.callback_metrics``. Missing keys are silently skipped so
+            this callback works for every task without per-task wiring.
+        decimals: Number of decimal digits used when formatting metric values.
+    """
+
+    # Ordered, task-agnostic shortlist. The first matching key per task is
+    # picked up; the others are skipped silently. New tasks can extend this
+    # list without breaking existing ones.
+    DEFAULT_KEYS: tuple[str, ...] = (
+        "train/total_loss",
+        "train/loss",
+        "val/PCK",
+        "val/accuracy",
+        "val/Dice",
+        "val/mIoU",
+        "val/map_50",
+        "val/map",
+        "val/f1-score",
+        "val/image_AUROC",
+        "lr",
+    )
+
+    def __init__(
+        self,
+        keys: tuple[str, ...] | list[str] | None = None,
+        decimals: int = 4,
+    ) -> None:
+        super().__init__()
+        self._keys = tuple(keys) if keys is not None else self.DEFAULT_KEYS
+        self._decimals = int(decimals)
+
+    def on_validation_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Emit the per-epoch summary after validation has finished."""
+        # Skip Lightning's sanity-check pass at the start of training; those
+        # metrics are noisy and would offset the displayed epoch counter.
+        if trainer.sanity_checking:
+            return
+
+        metrics = trainer.callback_metrics
+        parts: list[str] = []
+        for key in self._keys:
+            value = _scalar(metrics.get(key))
+            if value is None:
+                continue
+            parts.append(f"{key}={value:.{self._decimals}f}")
+
+        # Always show the epoch counter even when no whitelisted metric is
+        # present (e.g. very first epoch with only train metrics flushed).
+        epoch = trainer.current_epoch
+        max_epochs = trainer.max_epochs
+        header = f"epoch {epoch:>3}/{max_epochs}" if max_epochs else f"epoch {epoch:>3}"
+
+        if parts:
+            logger.info("%s | %s", header, "  ".join(parts))
+        else:
+            logger.info("%s | (no whitelisted metrics)", header)

--- a/library/src/getitune/backend/lightning/engine.py
+++ b/library/src/getitune/backend/lightning/engine.py
@@ -27,6 +27,7 @@ from lightning.pytorch.utilities.rank_zero import rank_zero_info
 
 from getitune.backend.lightning.callbacks.adaptive_train_scheduling import AdaptiveTrainScheduling
 from getitune.backend.lightning.callbacks.aug_scheduler import AugmentationSchedulerCallback
+from getitune.backend.lightning.callbacks.epoch_summary import EpochSummary
 from getitune.backend.lightning.callbacks.gpu_augmentation import GPUAugmentationCallback
 from getitune.backend.lightning.callbacks.gpu_mem_monitor import GPUMemMonitor
 from getitune.backend.lightning.callbacks.iteration_timer import IterationTimer
@@ -1049,6 +1050,11 @@ class LightningEngine(Engine):
             )
         if not has_callback(GPUMemMonitor):
             callbacks.append(GPUMemMonitor())
+        if not has_callback(EpochSummary):
+            # One-line per-epoch summary so captured logs (nohup, CI artifacts)
+            # contain a permanent record of progress, complementing the
+            # transient RichProgressBar display.
+            callbacks.append(EpochSummary())
 
         # Add GPU augmentation callback if GPU augmentations are configured
         if not has_callback(GPUAugmentationCallback):

--- a/library/src/getitune/backend/lightning/engine.py
+++ b/library/src/getitune/backend/lightning/engine.py
@@ -1051,9 +1051,6 @@ class LightningEngine(Engine):
         if not has_callback(GPUMemMonitor):
             callbacks.append(GPUMemMonitor())
         if not has_callback(EpochSummary):
-            # One-line per-epoch summary so captured logs (nohup, CI artifacts)
-            # contain a permanent record of progress, complementing the
-            # transient RichProgressBar display.
             callbacks.append(EpochSummary())
 
         # Add GPU augmentation callback if GPU augmentations are configured

--- a/library/tests/unit/backend/lightning/callbacks/test_epoch_summary.py
+++ b/library/tests/unit/backend/lightning/callbacks/test_epoch_summary.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``EpochSummary`` callback."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch.demos.boring_classes import BoringModel
+
+from getitune.backend.lightning.callbacks.epoch_summary import EpochSummary, _scalar
+
+_LOGGER = "getitune.backend.lightning.callbacks.epoch_summary"
+
+
+def _trainer(
+    metrics: dict[str, Any],
+    *,
+    sanity_checking: bool = False,
+    current_epoch: int = 0,
+    max_epochs: int | None = 200,
+) -> Trainer:
+    """Minimal trainer-shaped object the callback can consume.
+
+    Cast to ``Trainer`` to satisfy static checkers; the callback only reads a
+    handful of attributes so a ``SimpleNamespace`` is sufficient at runtime.
+    """
+    return cast(
+        "Trainer",
+        SimpleNamespace(
+            sanity_checking=sanity_checking,
+            current_epoch=current_epoch,
+            max_epochs=max_epochs,
+            callback_metrics=metrics,
+        ),
+    )
+
+
+_PL_MODULE = cast("LightningModule", None)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        (torch.tensor(0.5), 0.5),
+        (torch.tensor([1.0, 2.0]), None),  # multi-element tensors are skipped, not crashed on
+        (3.14, 3.14),
+        ("not-a-number", None),
+    ],
+)
+def test_scalar_conversion(value: Any, expected: float | None) -> None:  # noqa: ANN401
+    result = _scalar(value)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == pytest.approx(expected)
+
+
+def test_renders_known_metrics_in_declared_order(caplog: pytest.LogCaptureFixture) -> None:
+    """Whitelisted metrics render in ``DEFAULT_KEYS`` order with the configured precision.
+
+    Also verifies that non-whitelisted keys, multi-element tensors, and non-numeric values
+    are silently skipped so the callback works for every task without per-task wiring.
+    """
+    cb = EpochSummary()
+    trainer = _trainer(
+        {
+            "train/total_loss": torch.tensor(-0.5290),
+            "val/PCK": torch.tensor(0.0021),
+            "lr": torch.tensor(0.001),
+            "val/per_class": torch.tensor([0.1, 0.2]),  # not scalar -> skipped
+            "val/note": "warming-up",  # non-numeric -> skipped
+            "custom/metric": 1.0,  # not in whitelist -> skipped
+        },
+        current_epoch=3,
+    )
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        cb.on_validation_epoch_end(trainer, pl_module=_PL_MODULE)
+
+    assert len(caplog.records) == 1
+    msg = caplog.records[0].getMessage()
+    assert "epoch   3/200" in msg
+    assert "train/total_loss=-0.5290" in msg
+    assert "val/PCK=0.0021" in msg
+    assert "lr=0.0010" in msg
+    # Order follows DEFAULT_KEYS, not dict insertion order.
+    assert msg.index("train/total_loss") < msg.index("val/PCK") < msg.index("lr")
+    for skipped in ("val/per_class", "val/note", "custom/metric"):
+        assert skipped not in msg
+
+
+def test_skips_during_sanity_check(caplog: pytest.LogCaptureFixture) -> None:
+    """Lightning's pre-training sanity validation must not produce output."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        EpochSummary().on_validation_epoch_end(
+            _trainer({"val/PCK": torch.tensor(0.0)}, sanity_checking=True),
+            pl_module=_PL_MODULE,
+        )
+    assert caplog.records == []
+
+
+def test_emits_placeholder_when_no_known_metrics(caplog: pytest.LogCaptureFixture) -> None:
+    """Always emit a line so the log shows training is alive even before metrics flush."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        EpochSummary().on_validation_epoch_end(_trainer({}), pl_module=_PL_MODULE)
+    assert "(no whitelisted metrics)" in caplog.records[0].getMessage()
+
+
+def test_header_without_max_epochs(caplog: pytest.LogCaptureFixture) -> None:
+    """``max_epochs`` is optional in Lightning; header must still render cleanly."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        EpochSummary().on_validation_epoch_end(
+            _trainer({"val/accuracy": torch.tensor(0.5)}, current_epoch=12, max_epochs=None),
+            pl_module=_PL_MODULE,
+        )
+    msg = caplog.records[0].getMessage()
+    assert "epoch  12 |" in msg
+    assert "/None" not in msg
+
+
+def test_custom_keys_and_decimals(caplog: pytest.LogCaptureFixture) -> None:
+    """The metric whitelist and precision are configurable; defaults are not auto-merged."""
+    cb = EpochSummary(keys=("val/custom",), decimals=2)
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        cb.on_validation_epoch_end(
+            _trainer({"val/custom": torch.tensor(0.123456), "val/PCK": torch.tensor(0.99)}),
+            pl_module=_PL_MODULE,
+        )
+    msg = caplog.records[0].getMessage()
+    assert "val/custom=0.12" in msg
+    assert "val/PCK" not in msg
+
+
+def test_runs_inside_lightning_trainer(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+    """End-to-end: the callback fires exactly once per real validation epoch."""
+    trainer = Trainer(
+        default_root_dir=tmp_path,
+        max_epochs=2,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        num_sanity_val_steps=0,
+        callbacks=[EpochSummary()],
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        accelerator="cpu",
+    )
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        trainer.fit(BoringModel())
+
+    assert len(caplog.records) == 2
+    assert "epoch   0/2" in caplog.records[0].getMessage()
+    assert "epoch   1/2" in caplog.records[1].getMessage()

--- a/library/tests/unit/backend/lightning/callbacks/test_epoch_summary.py
+++ b/library/tests/unit/backend/lightning/callbacks/test_epoch_summary.py
@@ -87,7 +87,7 @@ def test_renders_known_metrics_in_declared_order(caplog: pytest.LogCaptureFixtur
 
     assert len(caplog.records) == 1
     msg = caplog.records[0].getMessage()
-    assert "epoch   3/200" in msg
+    assert "epoch   4/200" in msg
     assert "train/total_loss=-0.5290" in msg
     assert "val/PCK=0.0021" in msg
     assert "lr=0.0010" in msg
@@ -122,7 +122,7 @@ def test_header_without_max_epochs(caplog: pytest.LogCaptureFixture) -> None:
             pl_module=_PL_MODULE,
         )
     msg = caplog.records[0].getMessage()
-    assert "epoch  12 |" in msg
+    assert "epoch  13 |" in msg
     assert "/None" not in msg
 
 
@@ -158,5 +158,5 @@ def test_runs_inside_lightning_trainer(tmp_path, caplog: pytest.LogCaptureFixtur
         trainer.fit(BoringModel())
 
     assert len(caplog.records) == 2
-    assert "epoch   0/2" in caplog.records[0].getMessage()
-    assert "epoch   1/2" in caplog.records[1].getMessage()
+    assert "epoch   1/2" in caplog.records[0].getMessage()
+    assert "epoch   2/2" in caplog.records[1].getMessage()


### PR DESCRIPTION
This pull request introduces a new `EpochSummary` callback to the Lightning backend, which logs a concise summary of training and validation metrics at the end of each epoch. This summary is designed to provide a persistent, line-buffered record of training progress in log files, complementing the transient RichProgressBar display. The callback is automatically added to the engine if not already present and is thoroughly unit tested to ensure correct behavior.

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
