### PR TITLE
feat: Last used model takes precedences over active model

### DIFF
--- a/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
+++ b/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
@@ -34,10 +34,10 @@ const useSelectedModelId = (models: Model[]) => {
     const selectableModels = useMemo(() => getAllModelsWithOpenVINOVariants(models), [models]);
 
     const defaultSelectedId =
-        selectableModels.find((model) => model.modelId === activeModel?.model_variant_id)?.modelVariantId ??
+        selectableModels.find((model) => model.modelVariantId === activeModel?.model_variant_id)?.modelVariantId ??
         getLatestModel(models);
 
-    return useLocalStorage<string | null>(`${projectId}-active-model-id`, defaultSelectedId);
+    return useLocalStorage<string | null>(`${projectId}-model-variant-id`, defaultSelectedId);
 };
 
 export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) => {

--- a/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
+++ b/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
@@ -1,32 +1,51 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+import { createContext, ReactNode, useContext, useMemo } from 'react';
 
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { orderBy } from 'lodash-es';
+import { useLocalStorage } from 'usehooks-ts';
+
+import { Model } from '../../constants/shared-types';
 import { useGetActiveModel } from '../models/hooks/api/use-get-active-model.hook';
 import { useGetSuccessfulModels } from '../models/hooks/api/use-get-models.hook';
 import { getAllModelsWithOpenVINOVariants, SelectableModel } from '../models/utils';
 
 type PredictionsSetupContextProps = {
     selectableModels: SelectableModel[];
-    selectedModelId: string | undefined;
+    selectedModelId: string | null;
     selectedModel: SelectableModel | undefined;
-    changeSelectedModelId: (modelId: string | undefined) => void;
+    changeSelectedModelId: (modelId: string | null) => void;
 };
 
 const PredictionSetupContext = createContext<PredictionsSetupContextProps | null>(null);
 
-export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) => {
-    const { data: models } = useGetSuccessfulModels();
+const getLatestModel = (models: Model[]): string | null => {
+    const sortedModels = orderBy(models, (model) => model.training_info.end_time, 'desc');
+
+    return getAllModelsWithOpenVINOVariants(sortedModels).at(0)?.modelVariantId ?? null;
+};
+
+const useSelectedModelId = (models: Model[]) => {
+    const projectId = useProjectIdentifier();
     const activeModel = useGetActiveModel();
 
     const selectableModels = useMemo(() => getAllModelsWithOpenVINOVariants(models), [models]);
 
     const defaultSelectedId =
         selectableModels.find((model) => model.modelId === activeModel?.model_variant_id)?.modelVariantId ??
-        selectableModels.at(0)?.modelVariantId;
+        getLatestModel(models);
 
-    const [selectedModelId, setSelectedModelId] = useState<string | undefined>(defaultSelectedId);
+    return useLocalStorage<string | null>(`${projectId}-active-model-id`, defaultSelectedId);
+};
+
+export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) => {
+    const { data: models } = useGetSuccessfulModels();
+
+    const selectableModels = useMemo(() => getAllModelsWithOpenVINOVariants(models), [models]);
+
+    const [selectedModelId, setSelectedModelId] = useSelectedModelId(models);
 
     const selectedModel = selectableModels.find((model) => model.modelVariantId === selectedModelId);
 

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -946,4 +946,238 @@ test.describe('Annotator', () => {
             await expect(annotatorPage.getSelectedSubset()).toHaveText('Training');
         });
     });
+
+    test.describe('Prediction mode model', () => {
+        const olderModel = getMockedModel({
+            id: 'older-model-id',
+            name: 'Older_Model (older)',
+            variants: [getMockedVariant({ id: 'older-variant-id', format: 'openvino', precision: 'fp32' })],
+            training_info: {
+                status: 'successful',
+                label_schema_revision: { labels: [{ id: 'label-1', name: 'cat' }] },
+                start_time: '2025-01-01T10:00:00.000000+00:00',
+                end_time: '2025-01-01T12:00:00.000000+00:00',
+                dataset_revision_id: 'dataset-1',
+            },
+        });
+
+        const newerModel = getMockedModel({
+            id: 'newer-model-id',
+            name: 'Newer_Model (newer)',
+            variants: [getMockedVariant({ id: 'newer-variant-id', format: 'openvino', precision: 'fp16' })],
+            training_info: {
+                status: 'successful',
+                label_schema_revision: { labels: [{ id: 'label-1', name: 'cat' }] },
+                start_time: '2025-02-01T10:00:00.000000+00:00',
+                end_time: '2025-02-01T12:00:00.000000+00:00',
+                dataset_revision_id: 'dataset-2',
+            },
+        });
+
+        const emptyPredictHandler = http.post('/api/projects/{project_id}/dataset/media/media:predict', async () => {
+            return HttpResponse.json({ predictions: [{ media: { id: 'item-1' }, prediction: [] }] });
+        });
+
+        test('shows no model selector when no models are available', async ({ page, annotatorPage, network }) => {
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([]);
+                }),
+                emptyPredictHandler
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('open prediction mode', async () => {
+                await annotatorPage.openPredictionMode();
+            });
+
+            await test.step('model selector is not visible when no models available', async () => {
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toBeHidden();
+            });
+        });
+
+        test('shows no model selector when models have no OpenVINO variants', async ({
+            page,
+            annotatorPage,
+            network,
+        }) => {
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([
+                        getMockedModel({
+                            id: 'pytorch-only-model',
+                            variants: [getMockedVariant({ id: 'pytorch-variant', format: 'pytorch' })],
+                        }),
+                    ]);
+                }),
+                emptyPredictHandler
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('open prediction mode', async () => {
+                await annotatorPage.openPredictionMode();
+            });
+
+            await test.step('model selector is not visible when no OpenVINO models available', async () => {
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toBeHidden();
+            });
+        });
+
+        test('selects latest model by training end time when no active model is set', async ({
+            page,
+            annotatorPage,
+            network,
+        }) => {
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([olderModel, newerModel]);
+                }),
+                emptyPredictHandler
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('open prediction mode', async () => {
+                await annotatorPage.openPredictionMode();
+            });
+
+            await test.step('the newer model is pre-selected in the picker', async () => {
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Newer_Model'
+                );
+            });
+        });
+
+        test('active model takes priority over default latest model selection', async ({
+            page,
+            annotatorPage,
+            network,
+        }) => {
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([olderModel, newerModel]);
+                }),
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json({
+                        project_id: mockedDetectionProject.id,
+                        status: 'idle',
+                        source: null,
+                        sink: null,
+                        // model_variant.id must equal the model's id to match active model resolution logic
+                        // @ts-expect-error We care only about mocking the active model resolution behavior
+                        model: olderModel,
+                        // @ts-expect-error model_revision_id is not included in getMockedVariant
+                        model_variant: getMockedVariant({ id: olderModel.id }),
+                        device: 'cpu',
+                    });
+                }),
+                emptyPredictHandler
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('open prediction mode', async () => {
+                await annotatorPage.openPredictionMode();
+            });
+
+            await test.step('the active model is pre-selected instead of the latest model', async () => {
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Older_Model'
+                );
+            });
+        });
+
+        test('changing model selection uses the newly selected model for predictions', async ({
+            page,
+            annotatorPage,
+            network,
+        }) => {
+            let capturedModelVariantId: string | undefined;
+
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([olderModel, newerModel]);
+                }),
+                http.post('/api/projects/{project_id}/dataset/media/media:predict', async ({ request }) => {
+                    const body = await request.json();
+                    capturedModelVariantId = (body as unknown as Record<string, string>).model_variant_id;
+
+                    return HttpResponse.json({ predictions: [{ media: { id: 'item-1' }, prediction: [] }] });
+                })
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('open prediction mode — newer model should be selected by default', async () => {
+                await annotatorPage.openPredictionMode();
+
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Newer_Model'
+                );
+            });
+
+            await test.step('select the older model from the picker', async () => {
+                const predictResponsePromise = page.waitForResponse((res) => res.url().includes('media:predict'));
+
+                await page.getByRole('button', { name: 'Select prediction model' }).click();
+                await page.getByRole('option', { name: /Older_Model/ }).click();
+
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Older_Model'
+                );
+
+                await predictResponsePromise;
+            });
+
+            await test.step('predictions are requested with the newly selected model variant', async () => {
+                expect(capturedModelVariantId).toBe(olderModel.variants[0].id);
+            });
+        });
+
+        test('last used model is used by default', async ({ page, annotatorPage, network }) => {
+            network.use(
+                http.get('/api/projects/{project_id}/models', async () => {
+                    return HttpResponse.json([olderModel, newerModel]);
+                }),
+                emptyPredictHandler
+            );
+
+            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
+
+            await test.step('open prediction mode — newer model is auto-selected by default', async () => {
+                await annotatorPage.openPredictionMode();
+
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Newer_Model'
+                );
+            });
+
+            await test.step('change selection to the older model', async () => {
+                const predictResponsePromise = page.waitForResponse((res) => res.url().includes('media:predict'));
+
+                await page.getByRole('button', { name: 'Select prediction model' }).click();
+                await page.getByRole('option', { name: /Older_Model/ }).click();
+
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Older_Model'
+                );
+
+                await predictResponsePromise;
+            });
+
+            await test.step('reload the page', async () => {
+                await page.reload();
+            });
+
+            await test.step('open prediction mode after reload — older model is still selected', async () => {
+                await annotatorPage.openPredictionMode();
+
+                await expect(page.getByRole('button', { name: 'Select prediction model' })).toContainText(
+                    'Older_Model'
+                );
+            });
+        });
+    });
 });

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -1065,11 +1065,10 @@ test.describe('Annotator', () => {
                         status: 'idle',
                         source: null,
                         sink: null,
-                        // model_variant.id must equal the model's id to match active model resolution logic
                         // @ts-expect-error We care only about mocking the active model resolution behavior
                         model: olderModel,
                         // @ts-expect-error model_revision_id is not included in getMockedVariant
-                        model_variant: getMockedVariant({ id: olderModel.id }),
+                        model_variant: getMockedVariant({ id: olderModel.variants[0].id }),
                         device: 'cpu',
                     });
                 }),


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Store model id in the local storage (there is no endpoint that could return the model used for the inference).
2. If there is no model in the local storage:
- use active model id;
- use latest model if active model id does not exist.

Fix: #6393 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
