### PR TITLE
Normalize 16-bit images when displaying them

### DIFF
--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -346,7 +346,12 @@ def get_media_binary(
     binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media.id)
 
     # Normalize high bit depth images on the fly for display; cheap mode-check first
-    if not raw and needs_display_normalization(binary_path):
+    if (
+        not raw
+        and media.type == MediaType.IMAGE
+        and isinstance(media.format, ImageFormat)
+        and needs_display_normalization(binary_path)
+    ):
         png_bytes = normalize_image_to_png_bytes(binary_path)
         return write_bytes_to_response(bytes=BytesIO(png_bytes), filename=f"{media.name}.png", media_type="image/png")
 

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
 import os
 from datetime import datetime
+from io import BytesIO
 from typing import Annotated
 from uuid import UUID
 
@@ -18,7 +20,7 @@ from app.api.dependencies import (
     get_project,
     get_system_service,
 )
-from app.api.io_utils import write_file_to_response, write_image_to_response
+from app.api.io_utils import write_bytes_to_response, write_file_to_response, write_image_to_response
 from app.api.schemas.media import (
     AnnotatedVideoFrame,
     BulkDeleteMedia,
@@ -38,6 +40,7 @@ from app.services.dataset_service import AnnotationValidationError, SubsetAlread
 from app.services.inference import InferenceBusyError
 from app.services.media_prediction_service import BinaryNotFoundError, VideoRangeError
 from app.services.media_service import ImageMetadata, InvalidImageError, MediaFilters
+from app.utils.images import needs_display_normalization, normalize_image_to_png_bytes
 
 router = APIRouter(prefix="/api/projects/{project_id}/dataset/media", tags=["Media"])
 
@@ -331,6 +334,7 @@ def get_media_binary(
     project: Annotated[Project, Depends(get_project)],
     media: Annotated[Media | NotAnnotatedVideoFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
+    raw: Annotated[bool, Query(description="Return the original file without normalization")] = False,
 ) -> StreamingResponse | FileResponse:
     """Get media binary content"""
     if isinstance(media, NotAnnotatedVideoFrame):
@@ -340,6 +344,12 @@ def get_media_binary(
         )
 
     binary_path = media_service.get_media_binary_path_by_id(project_id=project.id, media_id=media.id)
+
+    # Normalize high bit depth images on the fly for display; cheap mode-check first
+    if not raw and needs_display_normalization(binary_path):
+        png_bytes = normalize_image_to_png_bytes(binary_path)
+        return write_bytes_to_response(bytes=BytesIO(png_bytes), filename=f"{media.name}.png", media_type="image/png")
+
     filename = f"{media.name}.{media.format.value.lower()}"
 
     return write_file_to_response(path=binary_path, filename=filename)

--- a/application/backend/app/utils/images.py
+++ b/application/backend/app/utils/images.py
@@ -1,7 +1,11 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
 import numpy as np
 from PIL import Image
+
+_HIGH_BIT_DEPTH_MODES = ("I;16", "I;16B", "I;16L", "I;16S", "I;16BS", "I", "F")
 
 
 def crop_to_thumbnail(image: Image.Image, target_height: int, target_width: int) -> Image.Image:
@@ -40,25 +44,83 @@ def crop_to_thumbnail(image: Image.Image, target_height: int, target_width: int)
     return resized_image.crop((x1, y1, x2, y2))
 
 
+def is_high_bit_depth_image(image: Image.Image) -> bool:
+    """Check if a PIL image is in a high bit depth mode (16-bit, 32-bit int, or float)."""
+    return image.mode in _HIGH_BIT_DEPTH_MODES
+
+
+def normalize_high_bit_depth_image(image: Image.Image) -> Image.Image:
+    """Normalize a high bit depth image to 8-bit RGB using min-max scaling.
+
+    This maps the actual pixel value range to [0, 255], making narrow-range
+    images (e.g. 16-bit values in [500-1000]) visible instead of appearing black.
+
+    Args:
+        image: A PIL Image in a high bit depth mode (16-bit, 32-bit int, or float).
+
+    Returns:
+        An 8-bit RGB PIL Image with normalized pixel values.
+    """
+    arr = np.array(image, dtype=np.float64)
+    lo, hi = arr.min(), arr.max()
+    if hi > lo:
+        arr = (arr - lo) / (hi - lo) * 255.0
+    else:
+        arr = np.zeros_like(arr)
+    return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
+
+
 def convert_to_jpeg_compatible(image: Image.Image) -> Image.Image:
     """Convert an image to a JPEG-compatible mode (RGB, L, or CMYK).
 
-    16-bit modes (I;16, I) require explicit normalization: PIL's built-in
+    High bit depth modes (I;16, I, F) require explicit normalization: PIL's built-in
     RGB conversion only preserves the most-significant byte, clipping the
     lower half of the dynamic range and producing washed-out thumbnails.
     We normalize the full value range to [0, 255] before converting to L.
     """
     if image.mode in ("RGB", "L", "CMYK"):
         return image
-    if image.mode in ("I;16", "I;16B", "I;16L", "I;16S", "I;16BS", "I"):
-        # Normalize the 16-bit (or 32-bit signed int) range to 8-bit
-        image = image.convert("I")
-        arr = np.array(image, dtype=np.float32)
-        lo, hi = arr.min(), arr.max()
-        if hi > lo:
-            arr = (arr - lo) / (hi - lo) * 255.0
-        else:
-            arr = np.zeros_like(arr)
-        return Image.fromarray(arr.astype(np.uint8), mode="L").convert("RGB")
-    # All other non-JPEG-compatible modes (RGBA, P, F, …)
+    if is_high_bit_depth_image(image):
+        return normalize_high_bit_depth_image(image)
+    # All other non-JPEG-compatible modes (RGBA, P, …)
     return image.convert("RGB")
+
+
+def needs_display_normalization(image_path: Path) -> bool:
+    """Return True if the image at the given path requires normalization for display.
+
+    Opens the image with deferred decoding (no pixel data read) and checks the mode.
+    This is cheap enough to call on every request for candidate formats (TIF, PNG).
+
+    Args:
+        image_path: Path to the image file on disk.
+
+    Returns:
+        True if the image is high bit depth and should be normalized before display.
+    """
+    with Image.open(image_path) as img:
+        return is_high_bit_depth_image(img)
+
+
+def normalize_image_to_png_bytes(image_path: Path) -> bytes:
+    """Normalize a high bit depth image to 8-bit PNG bytes on the fly.
+
+    Opens the image at the given path, applies min-max normalization to map the
+    full pixel value range to [0, 255], and returns the result encoded as PNG bytes.
+
+    This function always performs normalization. Call :func:`needs_display_normalization`
+    first to guard against unnecessary work for standard 8-bit images.
+
+    Args:
+        image_path: Path to the image file on disk.
+
+    Returns:
+        PNG-encoded bytes of the normalized 8-bit image.
+    """
+    from io import BytesIO
+
+    with Image.open(image_path) as img:
+        normalized_img = normalize_high_bit_depth_image(img)
+        buffer = BytesIO()
+        normalized_img.save(buffer, format="PNG")
+        return buffer.getvalue()

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, PropertyMock, call
+from unittest.mock import ANY, MagicMock, PropertyMock, call, patch
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
@@ -606,7 +606,10 @@ class TestMediaEndpoints:
             with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
                 temp_file_path = Path(tmp_file.name)
                 fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
-                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/binary")
+                # needs_display_normalization is tested separately; mock it out so that
+                # arbitrary (possibly non-image) temp files don't cause PIL errors here.
+                with patch("app.api.routers.media.needs_display_normalization", return_value=False):
+                    response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/binary")
 
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
@@ -617,6 +620,73 @@ class TestMediaEndpoints:
         fxt_media_service.get_media_binary_path_by_id.assert_called_once_with(
             project_id=fxt_get_project.id, media_id=media.id
         )
+
+    @pytest.mark.parametrize(
+        "image_format, suffix",
+        [
+            (ImageFormat.TIF, ".tif"),
+            (ImageFormat.PNG, ".png"),
+        ],
+    )
+    def test_get_media_binary_normalizes_high_bit_depth(
+        self, fxt_get_project, fxt_media_service, fxt_client, image_format, suffix
+    ):
+        """High bit depth images are normalized to 8-bit PNG on the fly, regardless of format."""
+        import numpy as np
+
+        media = MagicMock(spec=Image, id=uuid4(), format=image_format, type=MediaType.IMAGE)
+        type(media).name = PropertyMock(return_value="test_16bit")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        temp_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
+                temp_file_path = Path(tmp_file.name)
+                img = PILImage.fromarray(np.ones((10, 10), dtype="uint16") * 1000, mode="I;16")
+                img.save(temp_file_path)
+                fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
+                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/binary")
+        finally:
+            if temp_file_path and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "image/png" in response.headers.get("content-type", "")
+
+    @pytest.mark.parametrize(
+        "image_format, suffix",
+        [
+            (ImageFormat.TIF, ".tif"),
+            (ImageFormat.PNG, ".png"),
+        ],
+    )
+    def test_get_media_binary_raw_skips_normalization(
+        self, fxt_get_project, fxt_media_service, fxt_client, image_format, suffix
+    ):
+        """When raw=true, the normalization function is never called regardless of format."""
+        import numpy as np
+
+        media = MagicMock(spec=Image, id=uuid4(), format=image_format, type=MediaType.IMAGE)
+        type(media).name = PropertyMock(return_value="test_16bit")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        temp_file_path = None
+        try:
+            with (
+                tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file,
+                patch("app.api.routers.media.normalize_image_to_png_bytes") as mock_normalize_image,
+            ):
+                temp_file_path = Path(tmp_file.name)
+                img = PILImage.fromarray(np.ones((10, 10), dtype="uint16") * 1000, mode="I;16")
+                img.save(temp_file_path)
+                fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
+                response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media.id)}/binary?raw=true")
+        finally:
+            if temp_file_path and os.path.exists(temp_file_path):
+                os.unlink(temp_file_path)
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_normalize_image.assert_not_called()
 
     def test_get_video_frame_binary_on_the_fly_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
         video_id = uuid4()
@@ -631,13 +701,15 @@ class TestMediaEndpoints:
 
         temp_file_path = None
         try:
-            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
+            with (
+                tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file,
+                patch("app.api.routers.media.needs_display_normalization", return_value=False),
+            ):
                 temp_file_path = Path(tmp_file.name)
                 fxt_media_service.get_media_binary_path_by_id.return_value = temp_file_path
                 response = fxt_client.get(
                     f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/binary?frame_index=10"
                 )
-
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
                 os.unlink(temp_file_path)

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -695,7 +695,7 @@ class TestMediaEndpoints:
         media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
         fxt_media_service.get_media_by_id.return_value = media
 
-        video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG)
+        video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG, type=MediaType.VIDEO_FRAME)
         type(video_frame).name = PropertyMock(return_value="test_10")
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
 

--- a/application/backend/tests/unit/utils/test_images.py
+++ b/application/backend/tests/unit/utils/test_images.py
@@ -1,0 +1,217 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+from io import BytesIO
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image as PILImage
+
+from app.utils.images import (
+    convert_to_jpeg_compatible,
+    crop_to_thumbnail,
+    is_high_bit_depth_image,
+    needs_display_normalization,
+    normalize_high_bit_depth_image,
+    normalize_image_to_png_bytes,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_image_in_mode(mode: str) -> PILImage.Image:
+    """Return a small PIL image in the requested mode.
+
+    Modes that PIL can only produce by loading from a file (e.g. "I;16") are
+    constructed via an in-memory TIFF round-trip.
+    """
+    if mode == "I":
+        return PILImage.fromarray(np.zeros((4, 4), dtype=np.int32), mode="I")
+    if mode == "F":
+        return PILImage.fromarray(np.zeros((4, 4), dtype=np.float32), mode="F")
+    # "I;16" and variants: round-trip through an in-memory TIFF
+    buf = io.BytesIO()
+    PILImage.fromarray(np.zeros((4, 4), dtype=np.uint16), mode="I;16").save(buf, format="TIFF")
+    buf.seek(0)
+    img = PILImage.open(buf)
+    img.load()
+    return img
+
+
+def _save_tmp(image: PILImage.Image, tmp_path: Path, filename: str) -> Path:
+    path = tmp_path / filename
+    image.save(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# is_high_bit_depth_image
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["I", "F"])
+def test_is_high_bit_depth_image(mode: str) -> None:
+    assert is_high_bit_depth_image(_make_image_in_mode(mode)) is True
+
+
+def test_is_high_bit_depth_image_16bit_tiff(tmp_path: Path) -> None:
+    """I;16 mode is only exposed after loading a real TIFF file."""
+    path = _save_tmp(PILImage.fromarray(np.zeros((4, 4), dtype=np.uint16), mode="I;16"), tmp_path, "t.tif")
+    with PILImage.open(path) as img:
+        assert is_high_bit_depth_image(img) is True
+
+
+@pytest.mark.parametrize("mode", ["RGB", "L", "RGBA", "P", "CMYK"])
+def test_is_high_bit_depth_image_standard_modes(mode: str) -> None:
+    assert is_high_bit_depth_image(PILImage.new(mode, (4, 4))) is False
+
+
+# ---------------------------------------------------------------------------
+# needs_display_normalization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "image, filename, expected",
+    [
+        pytest.param(
+            PILImage.fromarray(np.ones((8, 8), dtype=np.uint16) * 1000, mode="I;16"),
+            "img.tif",
+            True,
+            id="16bit_tiff",
+        ),
+        pytest.param(
+            PILImage.fromarray(np.ones((8, 8), dtype=np.float32) * 0.5, mode="F"),
+            "img_float.tif",
+            True,
+            id="32bit_float_tiff",
+        ),
+        pytest.param(
+            PILImage.new("RGB", (8, 8), color=(128, 64, 32)),
+            "img.png",
+            False,
+            id="8bit_rgb_png",
+        ),
+        pytest.param(
+            PILImage.new("RGB", (8, 8), color=(10, 20, 30)),
+            "img.jpg",
+            False,
+            id="8bit_jpeg",
+        ),
+    ],
+)
+def test_needs_display_normalization(image: PILImage.Image, filename: str, expected: bool, tmp_path: Path) -> None:
+    path = _save_tmp(image, tmp_path, filename)
+    assert needs_display_normalization(path) is expected
+
+
+# ---------------------------------------------------------------------------
+# normalize_high_bit_depth_image
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "image",
+    [
+        pytest.param(PILImage.fromarray(np.ones((8, 8), dtype=np.uint16) * 1000, mode="I;16"), id="16bit_int"),
+        pytest.param(
+            PILImage.fromarray(np.linspace(0.0, 1.0, 64, dtype=np.float32).reshape(8, 8), mode="F"), id="32bit_float"
+        ),
+    ],
+)
+def test_normalize_high_bit_depth_image(image: PILImage.Image) -> None:
+    result = normalize_high_bit_depth_image(image)
+    assert result.mode == "RGB"
+    assert result.size == image.size
+
+
+def test_normalize_high_bit_depth_image_uniform_becomes_black() -> None:
+    """A uniform image (lo == hi) must produce all-zero output, not divide-by-zero."""
+    img = PILImage.fromarray(np.full((4, 4), fill_value=500, dtype=np.uint16), mode="I;16")
+    assert np.array(normalize_high_bit_depth_image(img)).max() == 0
+
+
+def test_normalize_high_bit_depth_image_maps_full_range() -> None:
+    """Min pixel maps to 0 and max pixel maps to 255 after normalization."""
+    arr = np.array([[500, 1000]], dtype=np.int32)
+    result = normalize_high_bit_depth_image(PILImage.fromarray(arr, mode="I")).convert("L")
+    pixels = np.array(result)
+    assert pixels.min() == 0
+    assert pixels.max() == 255
+
+
+# ---------------------------------------------------------------------------
+# normalize_image_to_png_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_image_to_png_bytes(tmp_path: Path) -> None:
+    path = _save_tmp(PILImage.fromarray(np.ones((8, 8), dtype=np.uint16) * 1000, mode="I;16"), tmp_path, "t.tif")
+    result = normalize_image_to_png_bytes(path)
+    assert isinstance(result, bytes) and len(result) > 0
+    reloaded = PILImage.open(BytesIO(result))
+    assert reloaded.format == "PNG"
+    assert reloaded.mode == "RGB"
+
+
+def test_normalize_image_to_png_bytes_narrow_range(tmp_path: Path) -> None:
+    """Values in a narrow range (e.g. [500, 1000]) must span the full [0, 255] output."""
+    arr = np.array([[500, 1000]], dtype=np.int32)
+    path = _save_tmp(PILImage.fromarray(arr, mode="I"), tmp_path, "t.tif")
+    pixels = np.array(PILImage.open(BytesIO(normalize_image_to_png_bytes(path))).convert("L"))
+    assert pixels.min() == 0
+    assert pixels.max() == 255
+
+
+# ---------------------------------------------------------------------------
+# convert_to_jpeg_compatible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["RGB", "L", "CMYK"])
+def test_convert_to_jpeg_compatible_already_compatible(mode: str) -> None:
+    img = PILImage.new(mode, (4, 4))
+    assert convert_to_jpeg_compatible(img) is img
+
+
+@pytest.mark.parametrize(
+    "mode, expected_mode",
+    [
+        pytest.param("RGBA", "RGB", id="rgba_to_rgb"),
+        pytest.param("P", "RGB", id="palette_to_rgb"),
+    ],
+)
+def test_convert_to_jpeg_compatible_non_jpeg_modes(mode: str, expected_mode: str) -> None:
+    assert convert_to_jpeg_compatible(PILImage.new(mode, (4, 4))).mode == expected_mode
+
+
+def test_convert_to_jpeg_compatible_high_bit_depth() -> None:
+    """High bit depth images are normalized to RGB, not just cast."""
+    img = PILImage.fromarray(np.full((4, 4), fill_value=1000, dtype=np.uint16), mode="I;16")
+    result = convert_to_jpeg_compatible(img)
+    assert result.mode == "RGB"
+    # Uniform value → all zeros after min-max normalization
+    assert np.array(result).max() == 0
+
+
+# ---------------------------------------------------------------------------
+# crop_to_thumbnail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src_size, target_h, target_w",
+    [
+        pytest.param((200, 100), 50, 50, id="landscape_to_square"),
+        pytest.param((100, 200), 50, 50, id="portrait_to_square"),
+        pytest.param((10, 10), 64, 64, id="upscale_small_image"),
+        pytest.param((128, 128), 32, 64, id="asymmetric_target"),
+    ],
+)
+def test_crop_to_thumbnail(src_size: tuple[int, int], target_h: int, target_w: int) -> None:
+    result = crop_to_thumbnail(PILImage.new("RGB", src_size), target_height=target_h, target_width=target_w)
+    assert result.size == (target_w, target_h)

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -10,7 +10,7 @@ import { MediaItem } from '../../../components/media-item/media-item.component';
 import { MediaThumbnail } from '../../../components/media-thumbnail/media-thumbnail.component';
 import { VirtualizerGridLayout } from '../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import type { Media } from '../../../constants/shared-types';
-import { getMediaBinaryUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
+import { getMediaDownloadUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
 import { MediaPreview } from '../media-preview/media-preview.component';
 import { useSelectedData } from '../providers/selected-data-provider.component';
 import { AnnotationStatusIcon } from './annotation-state-icon.component';
@@ -73,7 +73,7 @@ const GalleryList = ({
             onSelectionChange={setSelectedKeys}
             contentItem={(item) => {
                 const mediaUrl = getThumbnailUrl(projectId, item.id);
-                const fullMediaUrl = getMediaBinaryUrl(projectId, item.id);
+                const downloadUrl = getMediaDownloadUrl(projectId, item.id);
                 const mediaFileName = `${item.name}.${item.format}`;
 
                 return (
@@ -108,7 +108,7 @@ const GalleryList = ({
                                 <MediaItemActions
                                     id={item.id}
                                     onDeleted={toggleSelectedKeys}
-                                    mediaUrl={fullMediaUrl}
+                                    mediaUrl={downloadUrl}
                                     mediaFileName={mediaFileName}
                                     onAnnotate={() => onSelectedMediaItemChange(item)}
                                 />

--- a/application/ui/src/shared/media-url.utils.test.ts
+++ b/application/ui/src/shared/media-url.utils.test.ts
@@ -4,6 +4,7 @@
 import {
     getDatasetRevisionThumbnailUrl,
     getMediaBinaryUrl,
+    getMediaDownloadUrl,
     getProjectThumbnailUrl,
     getThumbnailUrl,
     getVideoFrameBinaryUrl,
@@ -31,6 +32,7 @@ describe.each([
         expect(getProjectThumbnailUrl('p1')).toBe(`${prefix}/api/projects/p1/thumbnail`);
         expect(getThumbnailUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/thumbnail`);
         expect(getMediaBinaryUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/binary`);
+        expect(getMediaDownloadUrl('p1', 'm1')).toBe(`${prefix}/api/projects/p1/dataset/media/m1/binary?raw=true`);
         expect(getDatasetRevisionThumbnailUrl('p1', 'r1', 'm1')).toBe(
             `${prefix}/api/projects/p1/dataset_revisions/r1/items/m1/thumbnail`
         );

--- a/application/ui/src/shared/media-url.utils.ts
+++ b/application/ui/src/shared/media-url.utils.ts
@@ -19,6 +19,9 @@ export const getThumbnailUrl = (projectId: string, itemId: string) => `${getMedi
 
 export const getMediaBinaryUrl = (projectId: string, itemId: string) => `${getMediaBaseUrl(projectId, itemId)}/binary`;
 
+export const getMediaDownloadUrl = (projectId: string, itemId: string) =>
+    `${getMediaBaseUrl(projectId, itemId)}/binary?raw=true`;
+
 export const getDatasetRevisionThumbnailUrl = (projectId: string, datasetRevisionId: string, itemId: string) =>
     `${getDatasetRevisionItemBaseUrl(projectId, datasetRevisionId, itemId)}/thumbnail`;
 


### PR DESCRIPTION
### Summary

16-bit images often have pixel values in a narrow range (eg [500-1000]); if we display them by mapping the full [0-65535] range to [0-255] in a linear way, the result would be a flat image (eg almost fully black) that is practically unusable for visualization purposes.

This PR solves the problem server-side, applying normalization on `GET media/<id>/binary` response when the requested image is not a standard 8-bit one. Since that endpoint is also used for downloading images, in which case the original image should be returned (without any normalization), a new query parameter `raw: bool` is added to optionally disable the normalization (default `raw=False`).

Note: for simplicity, the normalization is applied per-image, not per-dataset, meaning that two different images of the same dataset may use different normalization values (for display). The downside is that, when comparing two images that have different intensity range, one cannot see the _absolute_ intensity values of the original pixels. This will be addressed in another release, as it requires a more sophisticate user interface to control the normalization options.

Resolves #6388 

### How to test

Upload 16-bit images and annotate them.

<img width="1288" height="836" alt="16-bit-viz" src="https://github.com/user-attachments/assets/692abf2d-af6f-44ac-beb6-49a03338cc6f" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
