### PR TITLE
chore: remove empty export datasets

### DIFF
--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
@@ -3,13 +3,12 @@
 
 import { Button, Divider, Flex, Text, toast, View } from '@geti/ui';
 import { useDeleteStagedDataset, useStagedDataset } from 'hooks/api/staged-dataset.hook';
-import { isJobDone } from 'hooks/api/util';
 import { isNil } from 'lodash-es';
 
 import { API_BASE_URL } from '../../../../../../api/client';
 import { ExportDatasetJob } from '../../../../../../constants/shared-types';
 import { useExportDataset } from '../../../../../../hooks/storage/use-export-dataset.hook';
-import { downloadFile, isNonEmptyString } from '../../../../../../shared/util';
+import { downloadFile } from '../../../../../../shared/util';
 import { ExportJobDetails } from '../export-details/export-details.component';
 
 type ExportCompletedJobProps = {
@@ -21,20 +20,19 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
     const { removeLsExportId } = useExportDataset();
     const stageDatasetResponse = useStagedDataset(job.metadata.dataset_id);
 
-    const hasInvalidStagedDataset = isNil(job.metadata.dataset_id);
-    const isDoneWithEmptyStagedFile = isJobDone(job) && hasInvalidStagedDataset;
-    const message = isDoneWithEmptyStagedFile ? job.message : 'Dataset is ready for download';
-
     const removeStagedDatasetMutation = useDeleteStagedDataset({
         stagedDatasetId: job.metadata.dataset_id,
         deleteEntry: () => removeLsExportId(job.job_id),
     });
 
+    const hasInvalidStagedDataset = isNil(job.metadata.dataset_id);
+    const message = hasInvalidStagedDataset ? job.message : 'Dataset is ready for download';
+
     const handleClose = () => {
-        if (isNonEmptyString(job.metadata.dataset_id)) {
-            removeStagedDatasetMutation.mutate();
-        } else {
+        if (hasInvalidStagedDataset) {
             removeLsExportId(job.job_id);
+        } else {
+            removeStagedDatasetMutation.mutate();
         }
     };
 

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.component.tsx
@@ -3,12 +3,13 @@
 
 import { Button, Divider, Flex, Text, toast, View } from '@geti/ui';
 import { useDeleteStagedDataset, useStagedDataset } from 'hooks/api/staged-dataset.hook';
+import { isJobDone } from 'hooks/api/util';
 import { isNil } from 'lodash-es';
 
 import { API_BASE_URL } from '../../../../../../api/client';
 import { ExportDatasetJob } from '../../../../../../constants/shared-types';
 import { useExportDataset } from '../../../../../../hooks/storage/use-export-dataset.hook';
-import { downloadFile } from '../../../../../../shared/util';
+import { downloadFile, isNonEmptyString } from '../../../../../../shared/util';
 import { ExportJobDetails } from '../export-details/export-details.component';
 
 type ExportCompletedJobProps = {
@@ -20,13 +21,21 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
     const { removeLsExportId } = useExportDataset();
     const stageDatasetResponse = useStagedDataset(job.metadata.dataset_id);
 
+    const hasInvalidStagedDataset = isNil(job.metadata.dataset_id);
+    const isDoneWithEmptyStagedFile = isJobDone(job) && hasInvalidStagedDataset;
+    const message = isDoneWithEmptyStagedFile ? job.message : 'Dataset is ready for download';
+
     const removeStagedDatasetMutation = useDeleteStagedDataset({
         stagedDatasetId: job.metadata.dataset_id,
         deleteEntry: () => removeLsExportId(job.job_id),
     });
 
     const handleClose = () => {
-        removeStagedDatasetMutation.mutate();
+        if (isNonEmptyString(job.metadata.dataset_id)) {
+            removeStagedDatasetMutation.mutate();
+        } else {
+            removeLsExportId(job.job_id);
+        }
     };
 
     const handleDownload = () => {
@@ -58,9 +67,9 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
                         onPress={handleDownload}
                         isPending={stageDatasetResponse.isFetching}
                         isDisabled={
+                            hasInvalidStagedDataset ||
                             stageDatasetResponse.isFetching ||
-                            removeStagedDatasetMutation.isPending ||
-                            isNil(job.metadata.dataset_id)
+                            removeStagedDatasetMutation.isPending
                         }
                     >
                         Download
@@ -70,7 +79,7 @@ export const ExportCompletedJob = ({ job, datasetName }: ExportCompletedJobProps
 
             <Divider size={'S'} marginY={'size-150'} />
 
-            <Text>Dataset is ready for download</Text>
+            <Text>{message}</Text>
         </View>
     );
 };

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.test.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
@@ -81,5 +81,60 @@ describe('ExportCompletedJob', () => {
 
         expect(deleteStageFileSpy).toHaveBeenCalled();
         expect(mockedRemoveLsExportId).toHaveBeenCalledWith(mockExportJob.job_id);
+    });
+
+    it('displays "Dataset is ready for download" message for a completed job', async () => {
+        const mockExportJob = getMockedJobExportJob({ status: 'FINISHED' });
+        renderApp(mockExportJob);
+
+        expect(await screen.findByText('Dataset is ready for download')).toBeInTheDocument();
+    });
+
+    it('shows job message when job is done with invalid staged dataset', async () => {
+        const mockExportJob = getMockedJobExportJob({
+            status: 'DONE',
+            message: 'Export completed but dataset was cleaned up',
+            metadata: { dataset_id: null, project_id: 'project-123', filters: { include_unannotated: false } },
+        });
+        renderApp(mockExportJob);
+
+        expect(await screen.findByText('Export completed but dataset was cleaned up')).toBeInTheDocument();
+        const downloadButton = await screen.findByRole('button', { name: 'download dataset' });
+        expect(downloadButton).toBeDisabled();
+    });
+
+    it('removes from local storage without delete request when dataset_id is nil', async () => {
+        const deleteStageFileSpy = vi.fn();
+
+        server.use(
+            http.delete('/api/staged_datasets/{staged_dataset_id}', () => {
+                deleteStageFileSpy();
+                return HttpResponse.json(null, { status: 204 });
+            })
+        );
+
+        const mockExportJob = getMockedJobExportJob({
+            status: 'FINISHED',
+            metadata: { dataset_id: null, project_id: 'project-123', filters: { include_unannotated: false } },
+        });
+        renderApp(mockExportJob);
+
+        const closeButton = await screen.findByRole('button', { name: 'close export dataset status' });
+        await userEvent.click(closeButton);
+
+        await waitFor(() => {
+            expect(mockedRemoveLsExportId).toHaveBeenCalledWith(mockExportJob.job_id);
+        });
+        expect(deleteStageFileSpy).not.toHaveBeenCalled();
+    });
+
+    it('shows toast notification when download is triggered', async () => {
+        const mockExportJob = getMockedJobExportJob({ status: 'FINISHED' });
+        renderApp(mockExportJob);
+
+        const downloadButton = await screen.findByRole('button', { name: 'download dataset' });
+        await userEvent.click(downloadButton);
+
+        expect(await screen.findByText('Dataset download started')).toBeInTheDocument();
     });
 });

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.test.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/export-job/export-completed-job/export-completed-job.test.tsx
@@ -87,7 +87,7 @@ describe('ExportCompletedJob', () => {
         const mockExportJob = getMockedJobExportJob({ status: 'FINISHED' });
         renderApp(mockExportJob);
 
-        expect(await screen.findByText('Dataset is ready for download')).toBeInTheDocument();
+        expect(await screen.findByText('Dataset is ready for download')).toBeVisible();
     });
 
     it('shows job message when job is done with invalid staged dataset', async () => {
@@ -98,7 +98,7 @@ describe('ExportCompletedJob', () => {
         });
         renderApp(mockExportJob);
 
-        expect(await screen.findByText('Export completed but dataset was cleaned up')).toBeInTheDocument();
+        expect(await screen.findByText('Export completed but dataset was cleaned up')).toBeVisible();
         const downloadButton = await screen.findByRole('button', { name: 'download dataset' });
         expect(downloadButton).toBeDisabled();
     });
@@ -114,7 +114,7 @@ describe('ExportCompletedJob', () => {
         );
 
         const mockExportJob = getMockedJobExportJob({
-            status: 'FINISHED',
+            status: 'DONE',
             metadata: { dataset_id: null, project_id: 'project-123', filters: { include_unannotated: false } },
         });
         renderApp(mockExportJob);
@@ -135,6 +135,6 @@ describe('ExportCompletedJob', () => {
         const downloadButton = await screen.findByRole('button', { name: 'download dataset' });
         await userEvent.click(downloadButton);
 
-        expect(await screen.findByText('Dataset download started')).toBeInTheDocument();
+        expect(await screen.findByText('Dataset download started')).toBeVisible();
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

This PR allows users to remove the export entry when the job finishes successfully but the dataset is empty. Instead of calling `DeleteStagedDataset`, it removes the LS entry directly.

<img width="1161" height="880" alt="export-empty" src="https://github.com/user-attachments/assets/8f5fbf68-9f5b-4ca1-bb82-e64d9f89fb3f" />


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
