### PR TITLE
fix: annotation status sync

### DIFF
--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
@@ -15,6 +15,8 @@ type HandlerOptions = {
     mediaTotal: number;
     datasetTotal: number;
     initialDelayMs?: number;
+    mediaInitialDelayMs?: number;
+    datasetInitialDelayMs?: number;
     mediaNextPageDelayMs?: number;
     datasetNextPageDelayMs?: number;
 };
@@ -39,14 +41,19 @@ const setupHandlers = ({
     mediaTotal,
     datasetTotal,
     initialDelayMs = 0,
+    mediaInitialDelayMs,
+    datasetInitialDelayMs,
     mediaNextPageDelayMs = 0,
     datasetNextPageDelayMs = 0,
 }: HandlerOptions) => {
+    const resolvedMediaInitialDelayMs = mediaInitialDelayMs ?? initialDelayMs;
+    const resolvedDatasetInitialDelayMs = datasetInitialDelayMs ?? initialDelayMs;
+
     server.use(
         http.get('/api/projects/{project_id}/dataset/media', async ({ request }) => {
             const offset = getOffsetFromRequest(request);
 
-            await applyDelayForOffset(offset, initialDelayMs, mediaNextPageDelayMs);
+            await applyDelayForOffset(offset, resolvedMediaInitialDelayMs, mediaNextPageDelayMs);
 
             return HttpResponse.json({
                 items: [getMockedMediaImage({ id: `media-${offset + 1}` })],
@@ -61,7 +68,7 @@ const setupHandlers = ({
         http.get('/api/projects/{project_id}/dataset/items', async ({ request }) => {
             const offset = getOffsetFromRequest(request);
 
-            await applyDelayForOffset(offset, initialDelayMs, datasetNextPageDelayMs);
+            await applyDelayForOffset(offset, resolvedDatasetInitialDelayMs, datasetNextPageDelayMs);
 
             return HttpResponse.json({
                 items: [getMockedDatasetItem({ id: `item-${offset + 1}`, user_reviewed: false })],
@@ -138,6 +145,33 @@ describe('useDatasetMediaWithReviewStatus', () => {
             setupHandlers({ mediaTotal: 1, datasetTotal: 1 });
 
             const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            await waitFor(() => {
+                expect(result.current.isPending).toBe(false);
+            });
+
+            expect(result.current.isFetchingNextPage).toBe(false);
+        });
+
+        it('stays true while one initial query is still pending after the other resolves', async () => {
+            setupHandlers({
+                mediaTotal: 40,
+                datasetTotal: 40,
+                mediaInitialDelayMs: 0,
+                datasetInitialDelayMs: 200,
+            });
+
+            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            expect(result.current.isFetchingNextPage).toBe(true);
+
+            // Wait until the media query has resolved its initial page but the dataset query is still pending.
+            await waitFor(() => {
+                expect(result.current.items.length).toBeGreaterThan(0);
+            });
+
+            expect(result.current.isPending).toBe(true);
+            expect(result.current.isFetchingNextPage).toBe(true);
 
             await waitFor(() => {
                 expect(result.current.isPending).toBe(false);

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
@@ -1,0 +1,149 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, waitFor } from '@testing-library/react';
+import { getMockedDatasetItem } from 'mocks/mock-dataset-item';
+import { getMockedMediaImage } from 'mocks/mock-media';
+import { delay, HttpResponse } from 'msw';
+import { renderHook } from 'test-utils/render';
+
+import { http } from '../api/utils';
+import { server } from '../msw-node-setup';
+import { useDatasetMediaWithReviewStatus } from './use-dataset-media-with-review-status.hook';
+
+type HandlerOptions = {
+    mediaTotal: number;
+    datasetTotal: number;
+    initialDelayMs?: number;
+    mediaNextPageDelayMs?: number;
+    datasetNextPageDelayMs?: number;
+};
+
+const getOffsetFromRequest = (request: Request) => {
+    const url = new URL(request.url);
+
+    return Number(url.searchParams.get('offset') ?? '0');
+};
+
+const applyDelayForOffset = async (offset: number, initialDelayMs: number, nextPageDelayMs: number) => {
+    if (offset === 0 && initialDelayMs > 0) {
+        await delay(initialDelayMs);
+    }
+
+    if (offset > 0 && nextPageDelayMs > 0) {
+        await delay(nextPageDelayMs);
+    }
+};
+
+const setupHandlers = ({
+    mediaTotal,
+    datasetTotal,
+    initialDelayMs = 0,
+    mediaNextPageDelayMs = 0,
+    datasetNextPageDelayMs = 0,
+}: HandlerOptions) => {
+    server.use(
+        http.get('/api/projects/{project_id}/dataset/media', async ({ request }) => {
+            const offset = getOffsetFromRequest(request);
+
+            await applyDelayForOffset(offset, initialDelayMs, mediaNextPageDelayMs);
+
+            return HttpResponse.json({
+                items: [getMockedMediaImage({ id: `media-${offset + 1}` })],
+                pagination: {
+                    offset,
+                    count: 1,
+                    total: mediaTotal,
+                    limit: 0,
+                },
+            });
+        }),
+        http.get('/api/projects/{project_id}/dataset/items', async ({ request }) => {
+            const offset = getOffsetFromRequest(request);
+
+            await applyDelayForOffset(offset, initialDelayMs, datasetNextPageDelayMs);
+
+            return HttpResponse.json({
+                items: [getMockedDatasetItem({ id: `item-${offset + 1}`, user_reviewed: false })],
+                pagination: {
+                    offset,
+                    count: 1,
+                    total: datasetTotal,
+                    limit: 0,
+                },
+            });
+        })
+    );
+};
+
+describe('useDatasetMediaWithReviewStatus', () => {
+    describe('isFetchingNextPage', () => {
+        it('returns true while requests are pending', () => {
+            setupHandlers({ mediaTotal: 1, datasetTotal: 1, initialDelayMs: 100 });
+
+            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            expect(result.current.isFetchingNextPage).toBe(true);
+
+            return waitFor(() => {
+                expect(result.current.isFetchingNextPage).toBe(false);
+            });
+        });
+
+        it('returns true when media items are fetching next page', async () => {
+            setupHandlers({ mediaTotal: 40, datasetTotal: 1, mediaNextPageDelayMs: 100 });
+
+            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            await waitFor(() => {
+                expect(result.current.isPending).toBe(false);
+            });
+
+            act(() => {
+                result.current.fetchNextPage();
+            });
+
+            await waitFor(() => {
+                expect(result.current.isFetchingNextPage).toBe(true);
+            });
+
+            await waitFor(() => {
+                expect(result.current.isFetchingNextPage).toBe(false);
+            });
+        });
+
+        it('returns true when dataset items are fetching next page', async () => {
+            setupHandlers({ mediaTotal: 1, datasetTotal: 40, datasetNextPageDelayMs: 100 });
+
+            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            await waitFor(() => {
+                expect(result.current.isPending).toBe(false);
+            });
+
+            act(() => {
+                result.current.fetchNextPage();
+            });
+
+            await waitFor(() => {
+                expect(result.current.isFetchingNextPage).toBe(true);
+            });
+
+            await waitFor(() => {
+                expect(result.current.isFetchingNextPage).toBe(false);
+            });
+        });
+
+        it('returns false when no requests are pending and no next page is being fetched', async () => {
+            setupHandlers({ mediaTotal: 1, datasetTotal: 1 });
+
+            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            await waitFor(() => {
+                expect(result.current.isPending).toBe(false);
+            });
+
+            expect(result.current.isFetchingNextPage).toBe(false);
+        });
+    });
+});

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -18,6 +18,7 @@ export const useDatasetMediaWithReviewStatus = () => {
     });
 
     const datasetItemsResponse = useGetDatasetItemsById({ annotationStatus: annotationStatus ?? undefined });
+    const hasPendingRequests = mediaItemsResponse.isPending || datasetItemsResponse.isPending;
 
     const fetchNextPage = () => {
         if (mediaItemsResponse.hasNextPage && !mediaItemsResponse.isFetchingNextPage) {
@@ -35,8 +36,9 @@ export const useDatasetMediaWithReviewStatus = () => {
 
     return {
         items: mediaItemsResponse.items,
-        isPending: mediaItemsResponse.isPending || datasetItemsResponse.isPending,
-        isFetchingNextPage: mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
+        isPending: hasPendingRequests,
+        isFetchingNextPage:
+            hasPendingRequests || mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
         totalCount: mediaItemsResponse.totalCount,
         fetchNextPage,
         isMediaItemReviewedById,

--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -15,7 +15,7 @@ type UseGetDatasetItemsOptions = {
 };
 
 export const useGetDatasetItems = ({ subset, annotationStatus }: UseGetDatasetItemsOptions = {}) => {
-    const projectId = useProjectIdentifier();
+    const project_id = useProjectIdentifier();
 
     const query: {
         offset: number;
@@ -41,7 +41,7 @@ export const useGetDatasetItems = ({ subset, annotationStatus }: UseGetDatasetIt
         {
             params: {
                 query,
-                path: { project_id: projectId },
+                path: { project_id },
             },
         },
         {
@@ -61,6 +61,7 @@ export const useGetDatasetItems = ({ subset, annotationStatus }: UseGetDatasetIt
     const items = useMemo(() => {
         return data?.pages.flatMap((page) => page.items) ?? [];
     }, [data?.pages]);
+
     const totalCount = data?.pages[0]?.pagination?.total ?? 0;
 
     return { items, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, totalCount };

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -42,13 +42,13 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
     const project_id = useProjectIdentifier();
 
     const query: {
-        offset: number;
         limit: number;
+        offset: number;
         subset?: DatasetSubset;
-        annotation_status?: DatasetItemAnnotationStatus;
         labels?: string[];
-        start_date?: string;
         end_date?: string;
+        start_date?: string;
+        annotation_status?: DatasetItemAnnotationStatus;
     } = {
         offset: 0,
         limit: DATASET_ITEMS_LIMIT,
@@ -77,7 +77,12 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
     const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } = $api.useInfiniteQuery(
         'get',
         '/api/projects/{project_id}/dataset/media',
-        { params: { query, path: { project_id } } },
+        {
+            params: {
+                query,
+                path: { project_id },
+            },
+        },
         {
             pageParamName: 'offset',
             getNextPageParam: ({ pagination }: { pagination: Pagination }) => {
@@ -97,6 +102,7 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
 
         return getMediaEntities(mediaItems);
     }, [data?.pages]);
+
     const totalCount = data?.pages[0]?.pagination?.total ?? 0;
 
     return { items, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, totalCount };

--- a/application/ui/tests/datasets/datasets.spec.ts
+++ b/application/ui/tests/datasets/datasets.spec.ts
@@ -55,7 +55,7 @@ test.describe('Dataset', () => {
 
     test('list items', async ({ datasetPage }) => {
         await datasetPage.goto();
-        const loadedItems = 40;
+        const loadedItems = 20;
 
         await expect(datasetPage.getImagesCountText(totalElements)).toBeVisible();
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Closes: #6268

The virtualizer's `load-more` fires whenever it sees `loading` as false. During initial data fetch, only the pending state is true while the `fetching-next-page` flag stays false. When the media query resolves its first page before the dataset items query, the virtualizer triggers another page load. `Media` advances to the next offset but `dataset` items hasn't finished its initial load yet, so it gets skipped. From that point on, media is permanently one page ahead of dataset items.

Fix: Include the pending state in the fetching signal returned to the virtualizer, preventing it from triggering page loads during the initial fetch. This ensures both queries complete their current load before the next page is requested, keeping their offsets synchronized.

<img width="1713" height="925" alt="dataset-sync" src="https://github.com/user-attachments/assets/d0602acc-03a2-4884-91eb-8d689c4ab18a" />


<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
