### PR TITLE
feat: Allow editing annotation when drawing tool is selected

### DIFF
--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -6,10 +6,10 @@ import { ReactNode, RefObject, useRef } from 'react';
 import { useEventListener } from 'hooks/event-listener.hook';
 
 import { useZoom } from '../../../components/zoom/zoom.provider';
-import { useAnnotationVisibility } from '../../../shared/annotator/annotation-visibility-provider.component';
 import { useAnnotator } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { useTool } from '../../../shared/annotator/tool-provider.component';
+import { useEditableAnnotationState } from '../../../shared/annotator/use-editable-annotation-state.hook';
 import { EditBoundingBox } from '../tools/edit-bounding-box/edit-bounding-box.component';
 import { EditPolygon } from '../tools/edit-polygon/edit-polygon.component';
 import { useAnnotation } from './annotation-context';
@@ -62,12 +62,10 @@ const UnselectAnnotationOnOutsideClick = ({ ref }: { ref: RefObject<SVGGElement 
 export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
     const { scale } = useZoom();
     const annotation = useAnnotation();
-    const { selectedAnnotations } = useSelectedAnnotations();
-    const { isVisible } = useAnnotationVisibility();
+    const { isAnnotationEditable } = useEditableAnnotationState();
     const ref = useRef<SVGGElement>(null);
 
-    const isSelected = selectedAnnotations.has(annotation.id);
-    const shouldDisplayEditAnchors = isVisible && isSelected && selectedAnnotations.size === 1;
+    const shouldDisplayEditAnchors = isAnnotationEditable(annotation.id);
 
     if (shouldDisplayEditAnchors) {
         if (isPolygon(annotation)) {

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -72,7 +72,7 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
     if (shouldDisplayEditAnchors) {
         if (isPolygon(annotation)) {
             return (
-                <g ref={ref} data-editable-annotation='true'>
+                <g ref={ref}>
                     <EditPolygon annotation={annotation} zoom={scale} />
                     <UnselectAnnotationOnOutsideClick ref={ref} />
                 </g>
@@ -83,7 +83,7 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
             const { shape } = annotation;
 
             return (
-                <g ref={ref} data-editable-annotation='true'>
+                <g ref={ref}>
                     <EditBoundingBox
                         key={`box-${shape.x}-${shape.y}-${shape.width}-${shape.height}`}
                         annotation={annotation}

--- a/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
+++ b/application/ui/src/features/annotator/annotations/editable-annotation.component.tsx
@@ -72,7 +72,7 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
     if (shouldDisplayEditAnchors) {
         if (isPolygon(annotation)) {
             return (
-                <g ref={ref}>
+                <g ref={ref} data-editable-annotation='true'>
                     <EditPolygon annotation={annotation} zoom={scale} />
                     <UnselectAnnotationOnOutsideClick ref={ref} />
                 </g>
@@ -83,7 +83,7 @@ export const EditableAnnotation = ({ children }: EditAnnotationProps) => {
             const { shape } = annotation;
 
             return (
-                <g ref={ref}>
+                <g ref={ref} data-editable-annotation='true'>
                     <EditBoundingBox
                         key={`box-${shape.x}-${shape.y}-${shape.width}-${shape.height}`}
                         annotation={annotation}

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MouseEvent, useEffect, useRef } from 'react';
+import { MouseEvent, PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
 
 import { Loading } from '@geti/ui';
 import { useIsFetching } from '@tanstack/react-query';
@@ -14,6 +14,7 @@ import { useAnnotationVisibility } from '../../../shared/annotator/annotation-vi
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { useAnnotator } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
+import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
@@ -169,11 +170,51 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
     const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
+    const { isVisible } = useAnnotationVisibility();
+    const { selectedAnnotations } = useSelectedAnnotations();
+    const { activeTool } = useTool();
     const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey });
+    const toolLayerRef = useRef<HTMLDivElement>(null);
+    const [isToolLayerPointerPassthrough, setIsToolLayerPointerPassthrough] = useState(false);
 
     const isLoadingMedia = isFetchingMedia > 0;
     const areToolsDisabled = isSceneBusy || isReadOnly;
     const size = { width: mediaItem.width, height: mediaItem.height };
+    const canEditSelectedAnnotation = !areToolsDisabled && isVisible && selectedAnnotations.size === 1;
+    const isSelectionToolActive = activeTool === 'selection';
+
+    const handlePointerMove = useCallback(
+        (event: PointerEvent<HTMLDivElement>) => {
+            if (!canEditSelectedAnnotation || isSelectionToolActive) {
+                setIsToolLayerPointerPassthrough(false);
+                return;
+            }
+
+            const toolLayer = toolLayerRef.current;
+
+            if (toolLayer == null) {
+                return;
+            }
+
+            const previousPointerEvents = toolLayer.style.pointerEvents;
+            toolLayer.style.pointerEvents = 'none';
+
+            const hitElement = document.elementFromPoint(event.clientX, event.clientY);
+
+            toolLayer.style.pointerEvents = previousPointerEvents;
+
+            const shouldAllowAnnotationEdit =
+                hitElement instanceof Element && hitElement.closest("[data-editable-annotation='true']") !== null;
+
+            setIsToolLayerPointerPassthrough((current) => {
+                return current === shouldAllowAnnotationEdit ? current : shouldAllowAnnotationEdit;
+            });
+        },
+        [canEditSelectedAnnotation, isSelectionToolActive]
+    );
+
+    const toolLayerPointerEvents =
+        isSelectionToolActive || (canEditSelectedAnnotation && isToolLayerPointerPassthrough) ? 'none' : 'auto';
 
     if (isLoadingMedia) {
         return <Loading size='M' />;
@@ -184,13 +225,25 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
             <div
                 style={{ position: 'relative', height: '100%', width: '100%' }}
                 onContextMenu={(event: MouseEvent): void => event.preventDefault()}
+                onPointerMove={handlePointerMove}
                 className={isReadOnly ? classes.readOnlyCanvas : undefined}
                 ref={canvasRef}
             >
                 <MediaImage image={image} mediaItem={mediaItem} />
                 <MediaAnnotations mediaItem={mediaItem} mode={mode} />
 
-                {!areToolsDisabled && <ToolManager />}
+                {!areToolsDisabled && (
+                    <div
+                        ref={toolLayerRef}
+                        style={{
+                            position: 'absolute',
+                            inset: 0,
+                            pointerEvents: toolLayerPointerEvents,
+                        }}
+                    >
+                        <ToolManager />
+                    </div>
+                )}
             </div>
         </ZoomTransform>
     );

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -15,6 +15,7 @@ import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { useAnnotator } from '../../../shared/annotator/annotator-provider.component';
 import { useSelectedAnnotations } from '../../../shared/annotator/select-annotation-provider.component';
 import { useTool } from '../../../shared/annotator/tool-provider.component';
+import { useEditableAnnotationState } from '../../../shared/annotator/use-editable-annotation-state.hook';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
@@ -211,14 +212,13 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
     const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
-    const { isVisible } = useAnnotationVisibility();
-    const { selectedAnnotations } = useSelectedAnnotations();
+    const { isSingleEditableSelection } = useEditableAnnotationState();
     const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey });
 
     const isLoadingMedia = isFetchingMedia > 0;
     const areToolsDisabled = isSceneBusy || isReadOnly;
     const size = { width: mediaItem.width, height: mediaItem.height };
-    const canEditSelectedAnnotation = !areToolsDisabled && isVisible && selectedAnnotations.size === 1;
+    const canEditSelectedAnnotation = !areToolsDisabled && isSingleEditableSelection;
     const { toolLayerRef, toolLayerPointerEvents, handlePointerMove } = useToolLayerPointerPassthrough({
         canEditSelectedAnnotation,
     });

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -176,16 +176,52 @@ const useToolLayerPointerPassthrough = ({ canEditSelectedAnnotation }: UseToolLa
     const isSelectionToolActive = activeTool === 'selection';
     const toolLayerRef = useRef<HTMLDivElement>(null);
     const [isToolLayerPointerPassthrough, setIsToolLayerPointerPassthrough] = useState(false);
+    const pendingPointerRef = useRef<{ x: number; y: number } | null>(null);
+    const animationFrameRef = useRef<number | null>(null);
 
-    const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const evaluatePointerHit = () => {
+        animationFrameRef.current = null;
+
         if (!canEditSelectedAnnotation || isSelectionToolActive) {
             setIsToolLayerPointerPassthrough(false);
             return;
         }
 
         const toolLayer = toolLayerRef.current;
+        const pendingPointer = pendingPointerRef.current;
 
-        if (toolLayer == null) {
+        if (toolLayer == null || pendingPointer == null) {
+            return;
+        }
+
+        const previousPointerEvents = toolLayer.style.pointerEvents;
+        toolLayer.style.pointerEvents = 'none';
+
+        const hitElement = document.elementFromPoint(pendingPointer.x, pendingPointer.y);
+
+        toolLayer.style.pointerEvents = previousPointerEvents;
+
+        const shouldAllowAnnotationEdit =
+            hitElement instanceof Element && hitElement.closest("[data-resize-anchor='true']") !== null;
+
+        setIsToolLayerPointerPassthrough(shouldAllowAnnotationEdit);
+    };
+
+    const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+        if (!canEditSelectedAnnotation || isSelectionToolActive) {
+            if (animationFrameRef.current !== null) {
+                cancelAnimationFrame(animationFrameRef.current);
+                animationFrameRef.current = null;
+            }
+
+            pendingPointerRef.current = null;
+            setIsToolLayerPointerPassthrough(false);
+            return;
+        }
+
+        pendingPointerRef.current = { x: event.clientX, y: event.clientY };
+
+        if (animationFrameRef.current !== null) {
             return;
         }
 
@@ -197,19 +233,17 @@ const useToolLayerPointerPassthrough = ({ canEditSelectedAnnotation }: UseToolLa
         // The tool layer sits above annotations and can consume pointer events while drawing tools are active.
         // To detect whether the pointer is over an editable anchor, we temporarily disable pointer events on the tool
         // layer, call `elementFromPoint`, then restore the previous pointer-events value.
-
-        const previousPointerEvents = toolLayer.style.pointerEvents;
-        toolLayer.style.pointerEvents = 'none';
-
-        const hitElement = document.elementFromPoint(event.clientX, event.clientY);
-
-        toolLayer.style.pointerEvents = previousPointerEvents;
-
-        const shouldAllowAnnotationEdit =
-            hitElement instanceof Element && hitElement.closest("[data-resize-anchor='true']") !== null;
-
-        setIsToolLayerPointerPassthrough(shouldAllowAnnotationEdit);
+        // We run this check at most once per animation frame to avoid doing DOM hit-testing on every pointer event.
+        animationFrameRef.current = requestAnimationFrame(evaluatePointerHit);
     };
+
+    useEffect(() => {
+        return () => {
+            if (animationFrameRef.current !== null) {
+                cancelAnimationFrame(animationFrameRef.current);
+            }
+        };
+    }, []);
 
     const toolLayerPointerEvents =
         isSelectionToolActive || (canEditSelectedAnnotation && isToolLayerPointerPassthrough) ? 'none' : 'auto';

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -189,6 +189,15 @@ const useToolLayerPointerPassthrough = ({ canEditSelectedAnnotation }: UseToolLa
             return;
         }
 
+        // Layers, order matters:
+        // 1) Canvas layer: image/video.
+        // 2) Annotations layer: annotation shapes and edit anchors.
+        // 3) Tool layer: active drawing tool overlay.
+        //
+        // The tool layer sits above annotations and can consume pointer events while drawing tools are active.
+        // To detect whether the pointer is over an editable anchor, we temporarily disable pointer events on the tool
+        // layer, call `elementFromPoint`, then restore the previous pointer-events value.
+
         const previousPointerEvents = toolLayer.style.pointerEvents;
         toolLayer.style.pointerEvents = 'none';
 

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { MouseEvent, PointerEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { MouseEvent, PointerEvent, useEffect, useRef, useState } from 'react';
 
 import { Loading } from '@geti/ui';
 import { useIsFetching } from '@tanstack/react-query';
@@ -166,55 +166,62 @@ type AnnotatorCanvasProps = {
     mode: AnnotatorMode;
 };
 
+type UseToolLayerPointerPassthroughProps = {
+    canEditSelectedAnnotation: boolean;
+};
+
+const useToolLayerPointerPassthrough = ({ canEditSelectedAnnotation }: UseToolLayerPointerPassthroughProps) => {
+    const { activeTool } = useTool();
+    const isSelectionToolActive = activeTool === 'selection';
+    const toolLayerRef = useRef<HTMLDivElement>(null);
+    const [isToolLayerPointerPassthrough, setIsToolLayerPointerPassthrough] = useState(false);
+
+    const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+        if (!canEditSelectedAnnotation || isSelectionToolActive) {
+            setIsToolLayerPointerPassthrough(false);
+            return;
+        }
+
+        const toolLayer = toolLayerRef.current;
+
+        if (toolLayer == null) {
+            return;
+        }
+
+        const previousPointerEvents = toolLayer.style.pointerEvents;
+        toolLayer.style.pointerEvents = 'none';
+
+        const hitElement = document.elementFromPoint(event.clientX, event.clientY);
+
+        toolLayer.style.pointerEvents = previousPointerEvents;
+
+        const shouldAllowAnnotationEdit =
+            hitElement instanceof Element && hitElement.closest("[data-resize-anchor='true']") !== null;
+
+        setIsToolLayerPointerPassthrough(shouldAllowAnnotationEdit);
+    };
+
+    const toolLayerPointerEvents =
+        isSelectionToolActive || (canEditSelectedAnnotation && isToolLayerPointerPassthrough) ? 'none' : 'auto';
+
+    return { toolLayerRef, toolLayerPointerEvents, handlePointerMove } as const;
+};
+
 export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: AnnotatorCanvasProps) => {
     const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
     const { isVisible } = useAnnotationVisibility();
     const { selectedAnnotations } = useSelectedAnnotations();
-    const { activeTool } = useTool();
     const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey });
-    const toolLayerRef = useRef<HTMLDivElement>(null);
-    const [isToolLayerPointerPassthrough, setIsToolLayerPointerPassthrough] = useState(false);
 
     const isLoadingMedia = isFetchingMedia > 0;
     const areToolsDisabled = isSceneBusy || isReadOnly;
     const size = { width: mediaItem.width, height: mediaItem.height };
     const canEditSelectedAnnotation = !areToolsDisabled && isVisible && selectedAnnotations.size === 1;
-    const isSelectionToolActive = activeTool === 'selection';
-
-    const handlePointerMove = useCallback(
-        (event: PointerEvent<HTMLDivElement>) => {
-            if (!canEditSelectedAnnotation || isSelectionToolActive) {
-                setIsToolLayerPointerPassthrough(false);
-                return;
-            }
-
-            const toolLayer = toolLayerRef.current;
-
-            if (toolLayer == null) {
-                return;
-            }
-
-            const previousPointerEvents = toolLayer.style.pointerEvents;
-            toolLayer.style.pointerEvents = 'none';
-
-            const hitElement = document.elementFromPoint(event.clientX, event.clientY);
-
-            toolLayer.style.pointerEvents = previousPointerEvents;
-
-            const shouldAllowAnnotationEdit =
-                hitElement instanceof Element && hitElement.closest("[data-editable-annotation='true']") !== null;
-
-            setIsToolLayerPointerPassthrough((current) => {
-                return current === shouldAllowAnnotationEdit ? current : shouldAllowAnnotationEdit;
-            });
-        },
-        [canEditSelectedAnnotation, isSelectionToolActive]
-    );
-
-    const toolLayerPointerEvents =
-        isSelectionToolActive || (canEditSelectedAnnotation && isToolLayerPointerPassthrough) ? 'none' : 'auto';
+    const { toolLayerRef, toolLayerPointerEvents, handlePointerMove } = useToolLayerPointerPassthrough({
+        canEditSelectedAnnotation,
+    });
 
     if (isLoadingMedia) {
         return <Loading size='M' />;

--- a/application/ui/src/features/annotator/tools/tool/tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool/tool.component.tsx
@@ -60,6 +60,7 @@ export const Tool = ({ tool, activeTool, setActiveTool, isDisabled }: ToolProps)
                 onPress={() => setActiveTool(tool.type)}
                 aria-label={`${tool.type} tool`}
                 isDisabled={isDisabled}
+                aria-pressed={activeTool === tool.type}
             >
                 <IconWrapper isSelected={activeTool === tool.type} isDisabled={isDisabled}>
                     <tool.icon data-tool={tool.type} />

--- a/application/ui/src/shared/annotator/anchor.component.tsx
+++ b/application/ui/src/shared/annotator/anchor.component.tsx
@@ -95,7 +95,7 @@ export const Anchor = ({
     };
 
     return (
-        <g ref={triggerRef}>
+        <g ref={triggerRef} data-resize-anchor='true'>
             {children}
             <rect
                 x={x - size}

--- a/application/ui/src/shared/annotator/use-editable-annotation-state.hook.ts
+++ b/application/ui/src/shared/annotator/use-editable-annotation-state.hook.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useAnnotationVisibility } from './annotation-visibility-provider.component';
+import { useSelectedAnnotations } from './select-annotation-provider.component';
+
+export const useEditableAnnotationState = () => {
+    const { isVisible } = useAnnotationVisibility();
+    const { selectedAnnotations } = useSelectedAnnotations();
+
+    const isSingleEditableSelection = isVisible && selectedAnnotations.size === 1;
+
+    const isAnnotationEditable = (annotationId: string) => {
+        return isSingleEditableSelection && selectedAnnotations.has(annotationId);
+    };
+
+    return { isSingleEditableSelection, isAnnotationEditable };
+};

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 import { getMockedMediaImage } from 'mocks/mock-media';
 import { getMockedModel } from 'mocks/mock-model';
 import { getMockedVariant } from 'mocks/mock-model-variant';
@@ -704,7 +704,7 @@ test.describe('Annotator', () => {
         });
     });
 
-    test.describe('Edit mode deselection', () => {
+    test.describe('Edit mode', () => {
         const mockedSegmentationProject = getMockedProject({
             id: '123e4567-e89b-12d3-a456-426614174000',
             task: {
@@ -734,67 +734,77 @@ test.describe('Annotator', () => {
             ],
         };
 
-        test('detection task — bounding box tool deselects annotation in edit mode', async ({
+        test('detection task — edits bounding box while bounding box tool stays active', async ({
             page,
             boundingBoxTool,
             annotatorPage,
         }) => {
             await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
 
-            await test.step('Draw first bounding box and verify it enters edit mode', async () => {
+            const selectedAnnotationRect = page.getByLabel('selected annotation').getByLabel('annotation rect').first();
+            const getRectGeometry = async (rect: Locator) => {
+                const [x, y, width, height] = await Promise.all([
+                    rect.getAttribute('x'),
+                    rect.getAttribute('y'),
+                    rect.getAttribute('width'),
+                    rect.getAttribute('height'),
+                ]);
+
+                return {
+                    x,
+                    y,
+                    width,
+                    height,
+                };
+            };
+
+            await test.step('Draw a bounding box and keep drawing tool active', async () => {
                 await boundingBoxTool.selectTool();
                 await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
 
-                // After drawing, the newly created annotation is automatically selected
-                // and should show edit anchors (edit mode)
+                await expect(boundingBoxTool.getTool()).toHaveAttribute('aria-pressed', 'true');
                 await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
             });
 
-            await test.step('Draw second bounding box with bounding box tool', async () => {
-                await boundingBoxTool.selectTool();
-                await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 150, height: 150 });
+            const initialGeometry = await getRectGeometry(selectedAnnotationRect);
+
+            await test.step('Resize the bounding box from south-east resize anchor', async () => {
+                const southEastAnchor = page
+                    .getByLabel('selected annotation')
+                    .getByLabel('South east resize anchor')
+                    .first();
+                const anchorBox = await southEastAnchor.boundingBox();
+
+                expect(anchorBox).not.toBeNull();
+
+                if (anchorBox === null) {
+                    return;
+                }
+
+                await page.mouse.move(anchorBox.x + anchorBox.width / 2, anchorBox.y + anchorBox.height / 2);
+                await page.mouse.down();
+                await page.mouse.move(anchorBox.x + anchorBox.width / 2 + 50, anchorBox.y + anchorBox.height / 2 + 40);
+                await page.mouse.up();
             });
 
-            await test.step('Second annotation is in edit mode, first is not', async () => {
-                // Only one annotation should be in edit mode (the newly drawn second one)
+            await test.step('Bounding box geometry changes without switching tools', async () => {
+                await expect
+                    .poll(async () => {
+                        return getRectGeometry(selectedAnnotationRect);
+                    })
+                    .not.toEqual(initialGeometry);
+
                 await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
-                // Two annotation rects should exist in total
+            });
+
+            await test.step('Can draw another bounding box without switching to selection tool', async () => {
+                await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 120, height: 120 });
+
                 expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(2);
             });
         });
 
-        test('detection task — entering edit mode via selection tool then drawing deselects original', async ({
-            page,
-            boundingBoxTool,
-            annotatorPage,
-        }) => {
-            await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
-
-            await test.step('Draw first bounding box', async () => {
-                await boundingBoxTool.selectTool();
-                await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
-            });
-
-            await test.step('Enter edit mode via selection tool', async () => {
-                await page.getByRole('button', { name: 'selection tool' }).click();
-                await page.getByLabel('annotation rect').nth(1).click();
-
-                await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
-            });
-
-            await test.step('Draw second bounding box', async () => {
-                await boundingBoxTool.selectTool();
-                await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 150, height: 150 });
-            });
-
-            await test.step('Second annotation is in edit mode, first is not', async () => {
-                await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
-
-                expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(2);
-            });
-        });
-
-        test('instance segmentation task — polygon tool deselects annotation in edit mode', async ({
+        test('instance segmentation task — edits polygon point while polygon tool stays active', async ({
             page,
             polygonTool,
             annotatorPage,
@@ -808,60 +818,181 @@ test.describe('Annotator', () => {
 
             await annotatorPage.goto(mockedSegmentationProject.id, 'item-1');
 
-            await test.step('Draw first polygon and verify it enters edit mode', async () => {
+            await test.step('Draw a polygon and keep drawing tool active', async () => {
                 await polygonTool.selectPolygonTool();
                 await polygonTool.drawPolygon(smallPolygon);
 
+                await expect(polygonTool.getTool()).toHaveAttribute('aria-pressed', 'true');
                 await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
             });
 
-            await test.step('Draw second polygon with polygon tool', async () => {
-                await polygonTool.selectPolygonTool();
+            const polygonAnnotation = page.getByLabel('selected annotation').getByLabel('annotation polygon').first();
+            const initialPoints = (await polygonAnnotation.getAttribute('points')) ?? '';
+
+            await test.step('Move polygon anchor while polygon tool is still selected', async () => {
+                const polygonAnchor = page
+                    .getByLabel('selected annotation')
+                    .getByLabel('Resize polygon (250, 100) anchor')
+                    .first();
+                const anchorBox = await polygonAnchor.boundingBox();
+
+                expect(anchorBox).not.toBeNull();
+
+                if (anchorBox === null) {
+                    return;
+                }
+
+                await page.mouse.move(anchorBox.x + anchorBox.width / 2, anchorBox.y + anchorBox.height / 2);
+                await page.mouse.down();
+                await page.mouse.move(anchorBox.x + anchorBox.width / 2 + 30, anchorBox.y + anchorBox.height / 2 + 20);
+                await page.mouse.up();
+            });
+
+            await test.step('Polygon geometry changes without switching tools', async () => {
+                await expect
+                    .poll(async () => (await polygonAnnotation.getAttribute('points')) ?? '')
+                    .not.toBe(initialPoints);
+                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+            });
+
+            await test.step('Can draw another polygon without switching to selection tool', async () => {
                 await polygonTool.drawPolygon(secondPolygon);
-            });
-
-            await test.step('Second annotation is in edit mode, first is not', async () => {
-                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
 
                 expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
             });
         });
 
-        test('instance segmentation task — entering edit mode via selection tool then drawing deselects original', async ({
-            page,
-            polygonTool,
-            annotatorPage,
-            network,
-        }) => {
-            network.use(
-                http.get('/api/projects/{project_id}', () => {
-                    return HttpResponse.json(mockedSegmentationProject);
-                })
-            );
+        test.describe('Edit mode deselection', () => {
+            test('detection task — new shape enters edit mode and next shape replaces active edit selection', async ({
+                page,
+                boundingBoxTool,
+                annotatorPage,
+            }) => {
+                await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
 
-            await annotatorPage.goto(mockedSegmentationProject.id, 'item-1');
+                await test.step('Draw first bounding box and verify it enters edit mode immediately', async () => {
+                    await boundingBoxTool.selectTool();
+                    await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
 
-            await test.step('Draw first polygon', async () => {
-                await polygonTool.selectPolygonTool();
-                await polygonTool.drawPolygon(smallPolygon);
+                    await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                });
+
+                await test.step('Draw second bounding box with the same tool', async () => {
+                    await boundingBoxTool.selectTool();
+                    await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 150, height: 150 });
+                });
+
+                await test.step('Only the newly created annotation remains in edit mode', async () => {
+                    await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                    expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(2);
+                });
             });
 
-            await test.step('Enter edit mode via selection tool', async () => {
-                await page.getByRole('button', { name: 'selection tool' }).click();
-                await page.getByLabel('annotation polygon').nth(1).click();
+            test('detection task — selection tool edit mode is replaced by newly drawn shape', async ({
+                page,
+                boundingBoxTool,
+                annotatorPage,
+            }) => {
+                await annotatorPage.goto(mockedDetectionProject.id, 'item-1');
 
-                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+                await test.step('Draw first bounding box', async () => {
+                    await boundingBoxTool.selectTool();
+                    await boundingBoxTool.drawBoundingBox({ x: 100, y: 100, width: 150, height: 150 });
+                });
+
+                await test.step('Enter edit mode via selection tool', async () => {
+                    await page.getByRole('button', { name: 'selection tool' }).click();
+                    await page.getByLabel('annotation rect').nth(1).click();
+
+                    await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                });
+
+                await test.step('Draw second bounding box', async () => {
+                    await boundingBoxTool.selectTool();
+                    await boundingBoxTool.drawBoundingBox({ x: 350, y: 250, width: 150, height: 150 });
+                });
+
+                await test.step('Previously selected annotation is deselected and new one is in edit mode', async () => {
+                    await expect(page.getByLabel(/^Edit bounding box points/)).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                    expect(await annotatorPage.getAnnotationsListItems('annotation rect')).toHaveLength(2);
+                });
             });
 
-            await test.step('Draw second polygon', async () => {
-                await polygonTool.selectPolygonTool();
-                await polygonTool.drawPolygon(secondPolygon);
+            test('instance segmentation task — new shape enters edit mode and next shape replaces active edit selection', async ({
+                page,
+                polygonTool,
+                annotatorPage,
+                network,
+            }) => {
+                network.use(
+                    http.get('/api/projects/{project_id}', () => {
+                        return HttpResponse.json(mockedSegmentationProject);
+                    })
+                );
+
+                await annotatorPage.goto(mockedSegmentationProject.id, 'item-1');
+
+                await test.step('Draw first polygon and verify it enters edit mode immediately', async () => {
+                    await polygonTool.selectPolygonTool();
+                    await polygonTool.drawPolygon(smallPolygon);
+
+                    await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                });
+
+                await test.step('Draw second polygon with the same tool', async () => {
+                    await polygonTool.selectPolygonTool();
+                    await polygonTool.drawPolygon(secondPolygon);
+                });
+
+                await test.step('Only the newly created annotation remains in edit mode', async () => {
+                    await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                    expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
+                });
             });
 
-            await test.step('Second annotation is in edit mode, first is not', async () => {
-                await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+            test('instance segmentation task — selection tool edit mode is replaced by newly drawn shape', async ({
+                page,
+                polygonTool,
+                annotatorPage,
+                network,
+            }) => {
+                network.use(
+                    http.get('/api/projects/{project_id}', () => {
+                        return HttpResponse.json(mockedSegmentationProject);
+                    })
+                );
 
-                expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
+                await annotatorPage.goto(mockedSegmentationProject.id, 'item-1');
+
+                await test.step('Draw first polygon', async () => {
+                    await polygonTool.selectPolygonTool();
+                    await polygonTool.drawPolygon(smallPolygon);
+                });
+
+                await test.step('Enter edit mode via selection tool', async () => {
+                    await page.getByRole('button', { name: 'selection tool' }).click();
+                    await page.getByLabel('annotation polygon').nth(1).click();
+
+                    await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                });
+
+                await test.step('Draw second polygon', async () => {
+                    await polygonTool.selectPolygonTool();
+                    await polygonTool.drawPolygon(secondPolygon);
+                });
+
+                await test.step('Previously selected annotation is deselected and new one is in edit mode', async () => {
+                    await expect(page.locator('[id^="edit-polygon-points-"]')).toHaveCount(1);
+                    await expect(annotatorPage.getAnnotationsList().getByLabel('selected annotation')).toHaveCount(1);
+                    expect(await annotatorPage.getAnnotationsListItems('annotation polygon')).toHaveLength(2);
+                });
             });
         });
     });

--- a/application/ui/tests/annotator/bounding-box-tool-page.ts
+++ b/application/ui/tests/annotator/bounding-box-tool-page.ts
@@ -17,11 +17,11 @@ export class BoundingBoxToolPage {
         await clickAndMove(this.page, startPoint, endPoint);
     }
 
-    async getTool() {
+    getTool() {
         return this.page.getByRole('button', { name: 'bounding-box tool' });
     }
 
     async selectTool() {
-        await (await this.getTool()).click();
+        await this.getTool().click();
     }
 }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

In the new Geti we don't have separate layer that is responsible for annotation edition (like it was in Geti classic). Here composite annotation with selection state, edition state etc. Moreover, tool manager layer is the last layer that overlays canvas and annotations layer. It means that when drawing tool is selected, any click on resize anchors (when annotation is selected) is consumed by tool layer. This PR makes so annotation layer can receive pointer events from the layer above.

<img width="1280" height="1226" alt="edit" src="https://github.com/user-attachments/assets/1f19e56b-6f48-4587-ae6e-772ba03fa457" />

Fix #6383 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
