### PR TITLE
fix: Delete staged dataset

### DIFF
--- a/application/ui/src/hooks/api/staged-dataset.hook.test.ts
+++ b/application/ui/src/hooks/api/staged-dataset.hook.test.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { act, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 import { renderHook } from 'test-utils/render';
 
@@ -86,6 +86,55 @@ describe('useDeleteStagedDataset', () => {
         await waitFor(() => {
             expect(result.current.isError).toBe(true);
             expect(deleteImportEntryMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('meta.error.notify', () => {
+        it('does not show an error toast when the server returns "not found"', async () => {
+            const stagedDatasetId = 'staged-dataset-1';
+
+            server.use(
+                http.delete('/api/staged_datasets/{staged_dataset_id}', () =>
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    HttpResponse.json({ detail: 'staged dataset not found' }, { status: 404 })
+                )
+            );
+
+            const { result } = renderHook(() => useDeleteStagedDataset({ stagedDatasetId }));
+
+            await act(async () => {
+                await expect(result.current.mutateAsync()).rejects.toBeDefined();
+            });
+
+            await waitFor(() => {
+                expect(result.current.isError).toBe(true);
+            });
+
+            expect(screen.queryByLabelText('toast')).not.toBeInTheDocument();
+        });
+
+        it('shows an error toast for other errors', async () => {
+            const stagedDatasetId = 'staged-dataset-1';
+            const errorMessage = 'permission denied';
+
+            server.use(
+                http.delete('/api/staged_datasets/{staged_dataset_id}', () =>
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    HttpResponse.json({ detail: errorMessage }, { status: 403 })
+                )
+            );
+
+            const { result } = renderHook(() => useDeleteStagedDataset({ stagedDatasetId }));
+
+            await act(async () => {
+                await expect(result.current.mutateAsync()).rejects.toBeDefined();
+            });
+
+            const toast = await screen.findByLabelText('toast');
+            expect(toast).toBeVisible();
+            expect(toast).toHaveTextContent(errorMessage);
         });
     });
 });

--- a/application/ui/src/hooks/api/staged-dataset.hook.ts
+++ b/application/ui/src/hooks/api/staged-dataset.hook.ts
@@ -38,6 +38,7 @@ export const useDeleteStagedDataset = ({
     const params = { params: { path: { staged_dataset_id: stagedDatasetId } } };
 
     const deleteMutation = $api.useMutation('delete', '/api/staged_datasets/{staged_dataset_id}', {
+        meta: { error: { notify: (error: unknown) => !isInvalidStagedFile(error) } },
         onSuccess: () => {
             deleteEntry?.();
             onSuccess?.();

--- a/application/ui/src/hooks/api/util.test.ts
+++ b/application/ui/src/hooks/api/util.test.ts
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { isInvalidStagedFile } from './util';
+
+describe('isInvalidStagedFile', () => {
+    it('returns true when detail starts with "Staged dataset" and ends with "not found"', () => {
+        expect(isInvalidStagedFile({ detail: 'Staged dataset with ID abc-123 not found' })).toBe(true);
+        expect(isInvalidStagedFile({ detail: 'Staged dataset not found' })).toBe(true);
+        expect(isInvalidStagedFile({ detail: 'staged dataset with ID abc-123 not found.' })).toBe(true);
+        expect(isInvalidStagedFile({ detail: ' Staged dataset not found ' })).toBe(true);
+    });
+
+    it('returns false when detail does not start with "Staged dataset"', () => {
+        expect(isInvalidStagedFile({ detail: 'Resource not found' })).toBe(false);
+        expect(isInvalidStagedFile({ detail: 'Staged file not found' })).toBe(false);
+    });
+
+    it('returns false when detail does not contain "not found"', () => {
+        expect(isInvalidStagedFile({ detail: 'Staged dataset with ID abc-123 missing' })).toBe(false);
+        expect(isInvalidStagedFile({ detail: 'Staged dataset' })).toBe(false);
+    });
+});

--- a/application/ui/src/hooks/api/util.ts
+++ b/application/ui/src/hooks/api/util.ts
@@ -5,7 +5,7 @@ import isObject from 'lodash-es/isObject';
 
 import { Job, QuantizeJob, TrainJob } from '../../constants/shared-types';
 
-const INVALID_STAGED_FILE_REGEX = /^Staged dataset.*not found/i;
+const INVALID_STAGED_FILE_REGEX = /^Staged dataset.*not found\.?$/i;
 
 export const isInvalidStagedFile = (error: unknown): boolean => {
     if (isObject(error) && 'detail' in error) {

--- a/application/ui/src/hooks/api/util.ts
+++ b/application/ui/src/hooks/api/util.ts
@@ -5,10 +5,12 @@ import isObject from 'lodash-es/isObject';
 
 import { Job, QuantizeJob, TrainJob } from '../../constants/shared-types';
 
+const INVALID_STAGED_FILE_REGEX = /^Staged dataset.*not found/i;
+
 export const isInvalidStagedFile = (error: unknown): boolean => {
     if (isObject(error) && 'detail' in error) {
-        const detail = String(error.detail);
-        return detail.includes('not found');
+        const detail = String(error.detail).trim();
+        return INVALID_STAGED_FILE_REGEX.test(detail);
     }
 
     return false;

--- a/application/ui/src/query-client/query-client.interface.ts
+++ b/application/ui/src/query-client/query-client.interface.ts
@@ -179,6 +179,6 @@ export type Meta = {
     awaits?: QueryKey<paths>[];
     error?: {
         message?: string;
-        notify?: boolean;
+        notify?: (error: unknown) => boolean;
     };
 };

--- a/application/ui/src/query-client/query-client.ts
+++ b/application/ui/src/query-client/query-client.ts
@@ -63,7 +63,11 @@ export const createQueryClient = () => {
                     });
                 }
             },
-            onError: (error) => {
+            onError: (error, _variables, _context, mutation) => {
+                if (mutation.meta?.error?.notify?.(error) === false) {
+                    return;
+                }
+
                 toast({
                     type: 'error',
                     message: getErrorMessage(error),

--- a/application/ui/src/query-client/query-client.ts
+++ b/application/ui/src/query-client/query-client.ts
@@ -64,15 +64,13 @@ export const createQueryClient = () => {
                 }
             },
             onError: (error, _variables, _context, mutation) => {
-                if (mutation.meta?.error?.notify?.(error) === false) {
-                    return;
+                if (mutation.meta?.error?.notify?.(error) ?? true) {
+                    toast({
+                        type: 'error',
+                        message: getErrorMessage(error),
+                        duration: TOAST_DURATION,
+                    });
                 }
-
-                toast({
-                    type: 'error',
-                    message: getErrorMessage(error),
-                    duration: TOAST_DURATION,
-                });
             },
         }),
     });

--- a/application/ui/tests/datasets/import-dataset-to-project.spec.ts
+++ b/application/ui/tests/datasets/import-dataset-to-project.spec.ts
@@ -233,7 +233,7 @@ test.describe('Import dataset to project', () => {
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-expect-error
                     { detail: errorMessage },
-                    { status: 500 }
+                    { status: 404 }
                 );
             })
         );

--- a/application/ui/tests/datasets/import-dataset-to-project.spec.ts
+++ b/application/ui/tests/datasets/import-dataset-to-project.spec.ts
@@ -213,6 +213,7 @@ test.describe('Import dataset to project', () => {
         const errorMessage = `Staged dataset with ID '${STAGED_DATASET_ID}' not found.`;
         const failedImportJob = getMockedImportJob('import_dataset_to_project', {
             status: 'FAILED',
+            message: 'Import failed due to server error',
         });
 
         const preparePoll = jobPollHandler({

--- a/application/ui/tests/datasets/import-dataset-to-project.spec.ts
+++ b/application/ui/tests/datasets/import-dataset-to-project.spec.ts
@@ -204,4 +204,64 @@ test.describe('Import dataset to project', () => {
             await expect(importDatasetPage.getDialog()).toBeHidden();
         });
     });
+
+    test('failed import status card can be dismissed even when deleting staged file fails', async ({
+        page,
+        network,
+        importDatasetPage,
+    }) => {
+        const errorMessage = `Staged dataset with ID '${STAGED_DATASET_ID}' not found.`;
+        const failedImportJob = getMockedImportJob('import_dataset_to_project', {
+            status: 'FAILED',
+        });
+
+        const preparePoll = jobPollHandler({
+            jobId: PREPARE_JOB_ID,
+            whileRunning: getMockedPrepareJob(),
+            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
+        });
+
+        network.use(
+            http.get('/api/jobs/{job_id}', ({ params }) => {
+                const jobId = params.job_id as string;
+                const job = jobId === IMPORT_JOB_ID ? failedImportJob : preparePoll(jobId);
+                return HttpResponse.json(job, { status: 200 });
+            }),
+            http.delete('/api/staged_datasets/{staged_dataset_id}', ({}) => {
+                return HttpResponse.json(
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-expect-error
+                    { detail: errorMessage },
+                    { status: 500 }
+                );
+            })
+        );
+
+        await page.goto(`projects/${mockedProject.id}/dataset`);
+
+        await importDatasetPage.openImportDialog();
+
+        await test.step('Upload and complete preparation', async () => {
+            await importDatasetPage.loadZipFile(DATASET_FILENAME);
+            await expect(importDatasetPage.getPreparingStatus()).toBeVisible();
+            await expect(importDatasetPage.getStatisticsHeading()).toBeVisible();
+        });
+
+        await test.step('Submit import', async () => {
+            await importDatasetPage.submit();
+            await expect(importDatasetPage.getDialog()).toBeHidden();
+        });
+
+        await test.step('Verify failed job card is visible', async () => {
+            await expect(page.getByText(`Import dataset - ${DATASET_FILENAME} - 16 B`)).toBeVisible();
+            expect(await page.getByText(String(failedImportJob.message)).count()).toBe(2);
+        });
+
+        await test.step('Dismiss the failed status card despite delete failure', async () => {
+            await importDatasetPage.closeImportStatus();
+
+            await expect(page.getByText(errorMessage)).not.toBeInViewport();
+            await expect(page.getByText(`Import dataset - ${DATASET_FILENAME} - 16 B`)).not.toBeInViewport();
+        });
+    });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Closes #6176

Deleting an invalid staged dataset no longer shows an error notification and removes the LS entry directly.

<img width="1713" height="925" alt="delete-staged-dataset" src="https://github.com/user-attachments/assets/280ef5e8-e59c-4d41-ba83-af5c72c9ffba" />

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
