### PR TITLE
Validate folder sink when enabling pipeline

### DIFF
--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -17,6 +17,7 @@ from app.models import DataCollectionConfig, DataCollectionPolicyAdapter, Pipeli
 from app.services import PipelineMetricsService, PipelineService, SystemService
 from app.services.pipeline_service import (
     DeviceInt8NotSupportedError,
+    FolderSinkNotAccessibleError,
     IncompatibleModelVariantError,
     OtherProjectActiveError,
 )
@@ -186,7 +187,7 @@ def enable_pipeline(
     """
     try:
         pipeline_service.update_pipeline(project_id, {"status": PipelineStatus.RUNNING})
-    except OtherProjectActiveError as e:
+    except (OtherProjectActiveError, FolderSinkNotAccessibleError) as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
 

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -256,11 +256,15 @@ class PipelineService(BaseSessionManagedService):
             sink_config: The FolderSinkConfig to validate.
 
         Raises:
-            FolderSinkNotAccessibleError: If the folder cannot be created.
+            FolderSinkNotAccessibleError: If the folder cannot be created or written to.
         """
         folder_path = sink_config.config_data.folder_path
+        probe_file_path = os.path.join(folder_path, ".folder_sink_write_probe")
         try:
             os.makedirs(folder_path, exist_ok=True)
+            with open(probe_file_path, "wb") as probe_file:
+                probe_file.write(b"")
+            os.remove(probe_file_path)
         except OSError as e:
             raise FolderSinkNotAccessibleError(folder_path, str(e)) from e
 

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -1,15 +1,16 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from uuid import UUID
 
 from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.db.schema import PipelineDB
-from app.models import Pipeline, PipelineStatus
+from app.models import FolderSinkConfig, Pipeline, PipelineStatus, SinkAdapter
 from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
-from app.repositories import PipelineRepository
+from app.repositories import PipelineRepository, SinkRepository
 from app.repositories.model_revision_repo import ModelRevisionRepository
 from app.repositories.model_variant_repo import ModelVariantRepository
 from app.repositories.project_repo import ProjectRepository
@@ -53,6 +54,16 @@ class DeviceInt8NotSupportedError(Exception):
         super().__init__(
             f"INT8 inference is not supported on device '{device}'. "
             f"Please select a non-quantized (FP16/FP32) model variant or use a device that supports INT8."
+        )
+
+
+class FolderSinkNotAccessibleError(Exception):
+    """Exception raised when the folder sink path cannot be created or written to."""
+
+    def __init__(self, folder_path: str, reason: str):
+        super().__init__(
+            f"Folder sink path '{folder_path}' is not accessible: {reason}. "
+            f"Please ensure the path exists or can be created and that write permissions are granted."
         )
 
 
@@ -142,6 +153,13 @@ class PipelineService(BaseSessionManagedService):
                     active_project_name=active_project.name if active_project is not None else "",
                     active_project_id=active_pipeline_db.project_id,
                 )
+            # Validate folder sink accessibility when activating the pipeline
+            if to_update_db.sink_id:
+                sink_id = to_update_db.sink_id
+                db_sink = SinkRepository(self.db_session).get_by_id(sink_id)
+                sink_config = SinkAdapter.validate_python(db_sink, from_attributes=True)
+                if isinstance(sink_config, FolderSinkConfig):
+                    self._validate_folder_sink(sink_config)
 
         pipeline_db = pipeline_repo.update(to_update_db)
         updated = Pipeline.model_validate(pipeline_db)
@@ -228,6 +246,23 @@ class PipelineService(BaseSessionManagedService):
                     f"Please specify a model_variant_id explicitly."
                 )
             partial_config["model_variant_id"] = default_variant.id
+
+    @staticmethod
+    def _validate_folder_sink(sink_config: FolderSinkConfig) -> None:
+        """
+        Validate that the folder sink path can be created and written to.
+
+        Args:
+            sink_config: The FolderSinkConfig to validate.
+
+        Raises:
+            FolderSinkNotAccessibleError: If the folder cannot be created.
+        """
+        folder_path = sink_config.config_data.folder_path
+        try:
+            os.makedirs(folder_path, exist_ok=True)
+        except OSError as e:
+            raise FolderSinkNotAccessibleError(folder_path, str(e)) from e
 
     def __emit_event(self, pipeline: Pipeline, updated: Pipeline) -> None:
         if self._event_bus is None:

--- a/application/backend/tests/integration/conftest.py
+++ b/application/backend/tests/integration/conftest.py
@@ -111,7 +111,7 @@ def fxt_db_sources() -> list[SourceDB]:
 
 
 @pytest.fixture
-def fxt_db_sinks() -> list[SinkDB]:
+def fxt_db_sinks(tmp_path) -> list[SinkDB]:
     """Fixture to create multiple sink configurations in the database."""
     return [
         SinkDB(
@@ -124,7 +124,7 @@ def fxt_db_sinks() -> list[SinkDB]:
                 OutputFormat.IMAGE_WITH_PREDICTIONS,
                 OutputFormat.PREDICTIONS,
             ],
-            config_data={"folder_path": "/test/path"},
+            config_data={"folder_path": str(tmp_path / "test" / "path")},
         ),
         SinkDB(
             id=str(uuid4()),

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -514,11 +514,20 @@ class TestPipelineServiceIntegration:
         fxt_project_with_pipeline,
         fxt_pipeline_service,
         db_session,
+        tmp_path,
     ):
         """
         Test that enabling a pipeline with a folder sink that cannot be created raises FolderSinkNotAccessibleError.
         """
         _, db_pipeline = fxt_project_with_pipeline(is_running=False)
+
+        # Create a file, then try to use it as a parent directory - always fails regardless of privileges
+        blocking_file = tmp_path / "not_a_directory"
+        blocking_file.write_bytes(b"")
+        inaccessible_path = str(blocking_file / "subdir")
+
+        db_pipeline.sink.config_data = {"folder_path": inaccessible_path}
+        db_session.flush()
 
         with pytest.raises(FolderSinkNotAccessibleError):
             fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"status": PipelineStatus.RUNNING})

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -16,6 +16,7 @@ from app.services import ResourceNotFoundError, ResourceType
 from app.services.event.event_bus import EventType
 from app.services.pipeline_service import (
     DeviceInt8NotSupportedError,
+    FolderSinkNotAccessibleError,
     IncompatibleModelVariantError,
     OtherProjectActiveError,
 )
@@ -504,6 +505,22 @@ class TestPipelineServiceIntegration:
         db_session.flush()
 
         with pytest.raises(ValueError, match="Pipeline cannot be in 'running' state"):
+            fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"status": PipelineStatus.RUNNING})
+
+        assert not db_session.get(PipelineDB, db_pipeline.project_id).is_running
+
+    def test_enable_pipeline_with_inaccessible_folder_sink(
+        self,
+        fxt_project_with_pipeline,
+        fxt_pipeline_service,
+        db_session,
+    ):
+        """
+        Test that enabling a pipeline with a folder sink that cannot be created raises FolderSinkNotAccessibleError.
+        """
+        _, db_pipeline = fxt_project_with_pipeline(is_running=False)
+
+        with pytest.raises(FolderSinkNotAccessibleError):
             fxt_pipeline_service.update_pipeline(db_pipeline.project_id, {"status": PipelineStatus.RUNNING})
 
         assert not db_session.get(PipelineDB, db_pipeline.project_id).is_running

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -16,6 +16,7 @@ from app.models.metrics import InferenceMetrics, LatencyMetrics, PipelineMetrics
 from app.services import PipelineMetricsService, PipelineService, ResourceNotFoundError, ResourceType
 from app.services.pipeline_service import (
     DeviceInt8NotSupportedError,
+    FolderSinkNotAccessibleError,
     IncompatibleModelVariantError,
     OtherProjectActiveError,
 )
@@ -179,13 +180,20 @@ class TestPipelineEndpoints:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         fxt_pipeline_service.update_pipeline.assert_called_once_with(project_id, {"status": pipeline_status})
 
-    def test_cannot_enable_pipeline(self, fxt_pipeline, fxt_pipeline_service, fxt_client):
-        fxt_pipeline_service.update_pipeline.side_effect = OtherProjectActiveError(
-            requested_project_name="this_project_name",
-            requested_project_id="requested-project-id",
-            active_project_name="active_project_name",
-            active_project_id="active-project-id",
-        )
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OtherProjectActiveError(
+                requested_project_name="this_project_name",
+                requested_project_id="requested-project-id",
+                active_project_name="active_project_name",
+                active_project_id="active-project-id",
+            ),
+            FolderSinkNotAccessibleError(folder_path="/root/predictions", reason="Read-only file system"),
+        ],
+    )
+    def test_cannot_enable_pipeline(self, error, fxt_pipeline, fxt_pipeline_service, fxt_client):
+        fxt_pipeline_service.update_pipeline.side_effect = error
 
         response = fxt_client.post(f"/api/projects/{fxt_pipeline.project_id}/pipeline:enable")
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Adds extra validation step to check the folder is created when enabling pipeline.


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
