### PR TITLE
fix: Inference pipeline is visible only in the project with enabled pipeline.

### DIFF
--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -17,7 +17,7 @@ export const StreamContainer = () => {
     const { start, stop, status, webRTCConnectionRef } = useWebRTCConnection();
     const { data: pipeline } = usePipeline();
 
-    const isPipelineRunning = pipeline?.status === 'running';
+    const isPipelineRunning = pipeline.status === 'running';
     const isStopped = status === 'idle' || status === 'failed';
     const isConnecting = status === 'connecting';
     const isConnected = status === 'connected';

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -71,16 +71,16 @@ export const router = createBrowserRouter([
             },
             {
                 path: paths.project.details.pattern,
-                element: (
-                    <WebRTCConnectionProvider>
-                        <Layout />
-                    </WebRTCConnectionProvider>
-                ),
+                element: <Layout />,
                 children: [
                     {
                         index: true,
                         path: paths.project.inference.pattern,
-                        element: <Inference />,
+                        element: (
+                            <WebRTCConnectionProvider>
+                                <Inference />
+                            </WebRTCConnectionProvider>
+                        ),
                     },
                     {
                         path: paths.project.dataset.index.pattern,

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -14,7 +14,7 @@ test.describe('Inference', () => {
                 return HttpResponse.json(getMockedProject({ id: 'id-1' }));
             }),
             http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(getMockedPipeline({ status: 'running' }));
+                return response(200).json(getMockedPipeline({ status: 'idle' }));
             }),
             http.get('/api/sources', () => {
                 return HttpResponse.json([]);

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -14,7 +14,7 @@ test.describe('Inference', () => {
                 return HttpResponse.json(getMockedProject({ id: 'id-1' }));
             }),
             http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(getMockedPipeline({ status: 'idle' }));
+                return response(200).json(getMockedPipeline({ status: 'running' }));
             }),
             http.get('/api/sources', () => {
                 return HttpResponse.json([]);

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -7,340 +7,420 @@ import { HttpResponse } from 'msw';
 
 import { expect, http, test } from '../fixtures';
 
-test.beforeEach(({ network }) => {
-    network.use(
-        http.get('/api/projects/{project_id}', () => {
-            return HttpResponse.json(getMockedProject({ id: 'id-1' }));
-        }),
-        http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-            return response(200).json(getMockedPipeline({ status: 'idle' }));
-        }),
-        http.get('/api/sources', () => {
-            return HttpResponse.json([]);
-        }),
-        http.get('/api/sinks', () => {
-            return HttpResponse.json([]);
-        }),
-        http.get('/api/system/devices/camera', () => {
-            return HttpResponse.json([
-                {
-                    index: 1,
-                    name: 'FaceTime HD Camera',
-                },
-            ]);
-        }),
-        http.post('/api/sources', () => {
-            return HttpResponse.json(
-                {
-                    id: 'generated-source-id',
-                    name: 'Default Source',
-                    source_type: 'usb_camera',
-                    device_id: 0,
-                },
-                { status: 201 }
-            );
-        }),
-        http.post('/api/sinks', () => {
-            return HttpResponse.json(
-                {
-                    id: 'generated-sink-id',
-                    name: 'Default Sink',
-                    sink_type: 'folder',
-                    rate_limit: 5,
-                    folder_path: '/default/path',
-                    output_formats: ['predictions'],
-                },
-                { status: 201 }
-            );
-        })
-    );
-});
-
-test('Inference', async ({ streamPage, page, network }) => {
-    await test.step('starts stream', async () => {
-        await page.goto('/projects/id-1/inference');
-
-        await streamPage.startStream();
-
-        expect(streamPage.isConnected()).toBeTruthy();
-    });
-
-    await test.step('toggles pipeline', async () => {
-        await page.goto('/projects/id-1/inference');
-
-        await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeEnabled();
-
+test.describe('Inference', () => {
+    test.beforeEach(({ network }) => {
         network.use(
-            http.post('/api/projects/{project_id}/pipeline:enable', () => {
-                return HttpResponse.json(null, { status: 204 });
-            }),
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(getMockedPipeline({ status: 'running' }));
-            })
-        );
-
-        await page.getByRole('switch', { name: /Enable pipeline/i }).click();
-
-        await expect(page.getByRole('switch', { name: 'Disable Pipeline' })).toBeEnabled();
-        network.use(
-            http.post('/api/projects/{project_id}/pipeline:disable', () => {
-                return HttpResponse.json(null, { status: 204 });
+            http.get('/api/projects/{project_id}', () => {
+                return HttpResponse.json(getMockedProject({ id: 'id-1' }));
             }),
             http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
                 return response(200).json(getMockedPipeline({ status: 'idle' }));
-            })
-        );
-
-        await page.getByRole('switch', { name: 'Disable Pipeline' }).click();
-
-        await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeEnabled();
-    });
-
-    await test.step('updates data collection policy', async () => {
-        await page.goto('/projects/id-1/inference');
-
-        // Open both tabs just to make sure everything works
-        await page.getByRole('button', { name: 'Toggle Model statistics tab' }).click();
-        await expect(page.getByText('Model statistics', { exact: true })).toBeVisible();
-
-        await page.getByRole('button', { name: 'Toggle Data collection policy' }).click();
-        await expect(page.getByRole('heading', { name: 'Data collection' })).toBeVisible();
-
-        await expect(page.getByRole('switch', { name: 'Toggle auto capturing' })).not.toBeChecked();
-
-        network.use(
-            http.patch('/api/projects/{project_id}/pipeline', () => {
-                return HttpResponse.json({
-                    project_id: '',
-                    status: 'idle',
-                    device: 'images_folder',
-                });
             }),
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(
-                    getMockedPipeline({
-                        data_collection: {
-                            max_dataset_size: 500,
-                            policies: [
-                                {
-                                    type: 'fixed_rate',
-                                    enabled: true,
-                                    rate: 12,
-                                },
-                                {
-                                    type: 'confidence_threshold',
-                                    enabled: false,
-                                    confidence_threshold: 0.5,
-                                    min_sampling_interval: 2.5,
-                                },
-                            ],
-                        },
-                    })
-                );
-            })
-        );
-
-        network.use(
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(
-                    getMockedPipeline({
-                        data_collection: {
-                            max_dataset_size: 700,
-                            policies: [
-                                {
-                                    type: 'fixed_rate',
-                                    enabled: true,
-                                    rate: 12,
-                                },
-                                {
-                                    type: 'confidence_threshold',
-                                    enabled: false,
-                                    confidence_threshold: 0.5,
-                                    min_sampling_interval: 2.5,
-                                },
-                            ],
-                        },
-                    })
-                );
-            })
-        );
-
-        const maxDatasetSizeField = page.getByRole('textbox', { name: 'Size' });
-
-        await maxDatasetSizeField.fill('700');
-        await expect(maxDatasetSizeField).toHaveValue('700');
-
-        await page.getByRole('switch', { name: 'Toggle auto capturing' }).click();
-        await expect(page.getByRole('switch', { name: 'Toggle auto capturing' })).toBeChecked();
-
-        network.use(
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(
-                    getMockedPipeline({
-                        data_collection: {
-                            max_dataset_size: 500,
-                            policies: [
-                                {
-                                    type: 'fixed_rate',
-                                    enabled: true,
-                                    rate: 20,
-                                },
-                                {
-                                    type: 'confidence_threshold',
-                                    enabled: false,
-                                    confidence_threshold: 0.5,
-                                    min_sampling_interval: 2.5,
-                                },
-                            ],
-                        },
-                    })
-                );
-            })
-        );
-
-        const framesField = page.getByRole('textbox', { name: 'Frames' });
-        const secondsField = page.getByRole('textbox', { name: 'Seconds' });
-
-        await expect(framesField).toBeEnabled();
-        await expect(secondsField).toBeEnabled();
-
-        await framesField.fill('20');
-        await expect(framesField).toHaveValue('20');
-
-        await expect(page.getByRole('switch', { name: 'Confidence threshold' })).not.toBeChecked();
-
-        network.use(
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(
-                    getMockedPipeline({
-                        data_collection: {
-                            max_dataset_size: 500,
-                            policies: [
-                                {
-                                    type: 'fixed_rate',
-                                    enabled: true,
-                                    rate: 20,
-                                },
-                                {
-                                    type: 'confidence_threshold',
-                                    enabled: true,
-                                    confidence_threshold: 0.5,
-                                    min_sampling_interval: 2.5,
-                                },
-                            ],
-                        },
-                    })
-                );
-            })
-        );
-
-        await page.getByRole('switch', { name: 'Confidence threshold' }).click();
-        await expect(page.getByRole('switch', { name: 'Confidence threshold' })).toBeChecked();
-
-        network.use(
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(
-                    getMockedPipeline({
-                        data_collection: {
-                            max_dataset_size: 500,
-                            policies: [
-                                {
-                                    type: 'fixed_rate',
-                                    enabled: true,
-                                    rate: 20,
-                                },
-                                {
-                                    type: 'confidence_threshold',
-                                    enabled: true,
-                                    confidence_threshold: 0.7,
-                                    min_sampling_interval: 2.5,
-                                },
-                            ],
-                        },
-                    })
-                );
-            })
-        );
-
-        const confidenceSlider = page.getByRole('slider', { name: 'Threshold' });
-        await expect(confidenceSlider).toBeVisible();
-        await expect(confidenceSlider).toBeEnabled();
-        await confidenceSlider.fill('0.7');
-        await expect(confidenceSlider).toHaveValue('0.7');
-    });
-
-    await test.step('updates input and output source', async () => {
-        network.use(
-            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
-                return response(200).json(getMockedPipeline({ source: null, sink: null }));
-            }),
-            http.patch('/api/sources/{source_id}', () => {
-                return HttpResponse.json({});
-            }),
-            http.patch('/api/sinks/{sink_id}', () => {
-                return HttpResponse.json({});
-            })
-        );
-        await page.goto('/projects/id-1/inference');
-
-        await page.getByRole('button', { name: 'Add new source' }).click();
-        await page.getByRole('button', { name: 'USB Camera' }).click();
-
-        const usbCamera = 'new camera';
-        await page.getByRole('textbox', { name: 'Name' }).fill(usbCamera);
-        await page.getByRole('button', { name: 'Camera list' }).click();
-        await page.getByLabel('FaceTime HD Camera', { exact: true }).click();
-
-        network.use(
             http.get('/api/sources', () => {
+                return HttpResponse.json([]);
+            }),
+            http.get('/api/sinks', () => {
+                return HttpResponse.json([]);
+            }),
+            http.get('/api/system/devices/camera', () => {
                 return HttpResponse.json([
                     {
-                        id: '1',
-                        name: usbCamera,
-                        source_type: 'usb_camera',
-                        device_id: 1,
+                        index: 1,
+                        name: 'FaceTime HD Camera',
                     },
                 ]);
-            })
-        );
-
-        await page.getByRole('button', { name: 'Add & Connect' }).click();
-
-        await expect(page.getByText(usbCamera)).toBeVisible();
-        await expect(page.getByText('Device: FaceTime HD Camera')).toBeVisible();
-
-        // Go to output tab
-        await page.getByLabel('Pipeline configuration tabs').getByText('Output').click();
-
-        await page.getByRole('button', { name: 'Add new sink' }).click();
-        await page.getByRole('button', { name: 'Folder' }).click();
-        await page.locator('input[name="name"]').fill('New Folder');
-        await page.locator('input[aria-roledescription="Number field"]').first().fill('5');
-        await page.locator('input[aria-roledescription="Number field"]').nth(1).fill('5');
-
-        await page.locator('input[name="folder_path"]').fill('some/path');
-        await page.locator('input[name="output_formats"][value="predictions"]').click();
-
-        network.use(
-            http.get('/api/sinks', () => {
-                return HttpResponse.json([
+            }),
+            http.post('/api/sources', () => {
+                return HttpResponse.json(
                     {
-                        id: '1',
-                        name: 'New Folder',
+                        id: 'generated-source-id',
+                        name: 'Default Source',
+                        source_type: 'usb_camera',
+                        device_id: 0,
+                    },
+                    { status: 201 }
+                );
+            }),
+            http.post('/api/sinks', () => {
+                return HttpResponse.json(
+                    {
+                        id: 'generated-sink-id',
+                        name: 'Default Sink',
                         sink_type: 'folder',
-                        folder_path: 'some/path',
                         rate_limit: 5,
+                        folder_path: '/default/path',
                         output_formats: ['predictions'],
                     },
-                ]);
+                    { status: 201 }
+                );
+            })
+        );
+    });
+
+    test('Inference workflow', async ({ streamPage, page, network }) => {
+        await test.step('starts stream', async () => {
+            await page.goto('/projects/id-1/inference');
+
+            await streamPage.startStream();
+
+            expect(streamPage.isConnected()).toBeTruthy();
+        });
+
+        await test.step('toggles pipeline', async () => {
+            await page.goto('/projects/id-1/inference');
+
+            await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeEnabled();
+
+            network.use(
+                http.post('/api/projects/{project_id}/pipeline:enable', () => {
+                    return HttpResponse.json(null, { status: 204 });
+                }),
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(getMockedPipeline({ status: 'running' }));
+                })
+            );
+
+            await page.getByRole('switch', { name: /Enable pipeline/i }).click();
+
+            await expect(page.getByRole('switch', { name: 'Disable Pipeline' })).toBeEnabled();
+            network.use(
+                http.post('/api/projects/{project_id}/pipeline:disable', () => {
+                    return HttpResponse.json(null, { status: 204 });
+                }),
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(getMockedPipeline({ status: 'idle' }));
+                })
+            );
+
+            await page.getByRole('switch', { name: 'Disable Pipeline' }).click();
+
+            await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeEnabled();
+        });
+
+        await test.step('updates data collection policy', async () => {
+            await page.goto('/projects/id-1/inference');
+
+            // Open both tabs just to make sure everything works
+            await page.getByRole('button', { name: 'Toggle Model statistics tab' }).click();
+            await expect(page.getByText('Model statistics', { exact: true })).toBeVisible();
+
+            await page.getByRole('button', { name: 'Toggle Data collection policy' }).click();
+            await expect(page.getByRole('heading', { name: 'Data collection' })).toBeVisible();
+
+            await expect(page.getByRole('switch', { name: 'Toggle auto capturing' })).not.toBeChecked();
+
+            network.use(
+                http.patch('/api/projects/{project_id}/pipeline', () => {
+                    return HttpResponse.json({
+                        project_id: '',
+                        status: 'idle',
+                        device: 'images_folder',
+                    });
+                }),
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(
+                        getMockedPipeline({
+                            data_collection: {
+                                max_dataset_size: 500,
+                                policies: [
+                                    {
+                                        type: 'fixed_rate',
+                                        enabled: true,
+                                        rate: 12,
+                                    },
+                                    {
+                                        type: 'confidence_threshold',
+                                        enabled: false,
+                                        confidence_threshold: 0.5,
+                                        min_sampling_interval: 2.5,
+                                    },
+                                ],
+                            },
+                        })
+                    );
+                })
+            );
+
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(
+                        getMockedPipeline({
+                            data_collection: {
+                                max_dataset_size: 700,
+                                policies: [
+                                    {
+                                        type: 'fixed_rate',
+                                        enabled: true,
+                                        rate: 12,
+                                    },
+                                    {
+                                        type: 'confidence_threshold',
+                                        enabled: false,
+                                        confidence_threshold: 0.5,
+                                        min_sampling_interval: 2.5,
+                                    },
+                                ],
+                            },
+                        })
+                    );
+                })
+            );
+
+            const maxDatasetSizeField = page.getByRole('textbox', { name: 'Size' });
+
+            await maxDatasetSizeField.fill('700');
+            await expect(maxDatasetSizeField).toHaveValue('700');
+
+            await page.getByRole('switch', { name: 'Toggle auto capturing' }).click();
+            await expect(page.getByRole('switch', { name: 'Toggle auto capturing' })).toBeChecked();
+
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(
+                        getMockedPipeline({
+                            data_collection: {
+                                max_dataset_size: 500,
+                                policies: [
+                                    {
+                                        type: 'fixed_rate',
+                                        enabled: true,
+                                        rate: 20,
+                                    },
+                                    {
+                                        type: 'confidence_threshold',
+                                        enabled: false,
+                                        confidence_threshold: 0.5,
+                                        min_sampling_interval: 2.5,
+                                    },
+                                ],
+                            },
+                        })
+                    );
+                })
+            );
+
+            const framesField = page.getByRole('textbox', { name: 'Frames' });
+            const secondsField = page.getByRole('textbox', { name: 'Seconds' });
+
+            await expect(framesField).toBeEnabled();
+            await expect(secondsField).toBeEnabled();
+
+            await framesField.fill('20');
+            await expect(framesField).toHaveValue('20');
+
+            await expect(page.getByRole('switch', { name: 'Confidence threshold' })).not.toBeChecked();
+
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(
+                        getMockedPipeline({
+                            data_collection: {
+                                max_dataset_size: 500,
+                                policies: [
+                                    {
+                                        type: 'fixed_rate',
+                                        enabled: true,
+                                        rate: 20,
+                                    },
+                                    {
+                                        type: 'confidence_threshold',
+                                        enabled: true,
+                                        confidence_threshold: 0.5,
+                                        min_sampling_interval: 2.5,
+                                    },
+                                ],
+                            },
+                        })
+                    );
+                })
+            );
+
+            await page.getByRole('switch', { name: 'Confidence threshold' }).click();
+            await expect(page.getByRole('switch', { name: 'Confidence threshold' })).toBeChecked();
+
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(
+                        getMockedPipeline({
+                            data_collection: {
+                                max_dataset_size: 500,
+                                policies: [
+                                    {
+                                        type: 'fixed_rate',
+                                        enabled: true,
+                                        rate: 20,
+                                    },
+                                    {
+                                        type: 'confidence_threshold',
+                                        enabled: true,
+                                        confidence_threshold: 0.7,
+                                        min_sampling_interval: 2.5,
+                                    },
+                                ],
+                            },
+                        })
+                    );
+                })
+            );
+
+            const confidenceSlider = page.getByRole('slider', { name: 'Threshold' });
+            await expect(confidenceSlider).toBeVisible();
+            await expect(confidenceSlider).toBeEnabled();
+            await confidenceSlider.fill('0.7');
+            await expect(confidenceSlider).toHaveValue('0.7');
+        });
+
+        await test.step('updates input and output source', async () => {
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(getMockedPipeline({ source: null, sink: null }));
+                }),
+                http.patch('/api/sources/{source_id}', () => {
+                    return HttpResponse.json({});
+                }),
+                http.patch('/api/sinks/{sink_id}', () => {
+                    return HttpResponse.json({});
+                })
+            );
+            await page.goto('/projects/id-1/inference');
+
+            await page.getByRole('button', { name: 'Add new source' }).click();
+            await page.getByRole('button', { name: 'USB Camera' }).click();
+
+            const usbCamera = 'new camera';
+            await page.getByRole('textbox', { name: 'Name' }).fill(usbCamera);
+            await page.getByRole('button', { name: 'Camera list' }).click();
+            await page.getByLabel('FaceTime HD Camera', { exact: true }).click();
+
+            network.use(
+                http.get('/api/sources', () => {
+                    return HttpResponse.json([
+                        {
+                            id: '1',
+                            name: usbCamera,
+                            source_type: 'usb_camera',
+                            device_id: 1,
+                        },
+                    ]);
+                })
+            );
+
+            await page.getByRole('button', { name: 'Add & Connect' }).click();
+
+            await expect(page.getByText(usbCamera)).toBeVisible();
+            await expect(page.getByText('Device: FaceTime HD Camera')).toBeVisible();
+
+            // Go to output tab
+            await page.getByLabel('Pipeline configuration tabs').getByText('Output').click();
+
+            await page.getByRole('button', { name: 'Add new sink' }).click();
+            await page.getByRole('button', { name: 'Folder' }).click();
+            await page.locator('input[name="name"]').fill('New Folder');
+            await page.locator('input[aria-roledescription="Number field"]').first().fill('5');
+            await page.locator('input[aria-roledescription="Number field"]').nth(1).fill('5');
+
+            await page.locator('input[name="folder_path"]').fill('some/path');
+            await page.locator('input[name="output_formats"][value="predictions"]').click();
+
+            network.use(
+                http.get('/api/sinks', () => {
+                    return HttpResponse.json([
+                        {
+                            id: '1',
+                            name: 'New Folder',
+                            sink_type: 'folder',
+                            folder_path: 'some/path',
+                            rate_limit: 5,
+                            output_formats: ['predictions'],
+                        },
+                    ]);
+                })
+            );
+
+            await page.getByRole('button', { name: 'Add & Connect' }).click();
+
+            await expect(page.getByText('New Folder')).toBeVisible();
+            await expect(page.getByText('Folder path: some/path')).toBeVisible();
+            await expect(page.getByText('Rate limit: 5 samples every 1 second')).toBeVisible();
+            await expect(page.getByText('Output formats: predictions')).toBeVisible();
+        });
+    });
+
+    test('shows stream only for projects with enabled pipeline', async ({ page, network, streamPage }) => {
+        const projectWithEnabledPipeline = getMockedProject({
+            id: 'enabled-project-id',
+            name: 'Enabled project',
+            active_pipeline: true,
+        });
+
+        const projectWithDisabledPipeline = getMockedProject({
+            id: 'disabled-project-id',
+            name: 'Disabled project',
+            active_pipeline: false,
+        });
+
+        network.use(
+            http.get('/api/projects', ({ response }) => {
+                return response(200).json([projectWithEnabledPipeline, projectWithDisabledPipeline]);
+            }),
+            http.get('/api/projects/{project_id}', ({ params }) => {
+                return HttpResponse.json(
+                    params.project_id === projectWithEnabledPipeline.id
+                        ? projectWithEnabledPipeline
+                        : projectWithDisabledPipeline
+                );
+            }),
+            http.get('/api/projects/{project_id}/pipeline', ({ params, response }) => {
+                return response(200).json(
+                    getMockedPipeline({
+                        project_id: params.project_id,
+                        status: params.project_id === projectWithEnabledPipeline.id ? 'running' : 'idle',
+                    })
+                );
             })
         );
 
-        await page.getByRole('button', { name: 'Add & Connect' }).click();
+        await page.goto(`/projects/${projectWithEnabledPipeline.id}/inference`);
+        await expect(streamPage.getStartStreamButton()).toBeVisible();
 
-        await expect(page.getByText('New Folder')).toBeVisible();
-        await expect(page.getByText('Folder path: some/path')).toBeVisible();
-        await expect(page.getByText('Rate limit: 5 samples every 1 second')).toBeVisible();
-        await expect(page.getByText('Output formats: predictions')).toBeVisible();
+        await streamPage.startStream();
+        await expect(streamPage.getStartStreamButton()).toBeHidden();
+
+        await page.getByRole('button', { name: `Selected project ${projectWithEnabledPipeline.name}` }).click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+
+        await page.getByRole('listitem').filter({ hasText: projectWithDisabledPipeline.name }).click();
+
+        await expect(page).toHaveURL(new RegExp(`/projects/${projectWithDisabledPipeline.id}/dataset$`));
+
+        await page.keyboard.press('Escape');
+        await expect(page.getByRole('dialog')).toBeHidden();
+
+        await page.getByRole('tab', { name: 'Inference' }).click();
+
+        await expect(page.getByLabel('Enable pipeline to start stream')).toBeVisible();
+        await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeVisible();
+    });
+
+    test('resets stream state when re-opening inference page', async ({ streamPage, page, network }) => {
+        network.use(
+            http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                return response(200).json(getMockedPipeline({ project_id: 'id-1', status: 'running' }));
+            })
+        );
+
+        await page.goto('/projects/id-1/inference');
+
+        await expect(streamPage.getStartStreamButton()).toBeVisible();
+        await streamPage.startStream();
+
+        await expect(streamPage.getStartStreamButton()).toBeHidden();
+
+        await page.getByRole('tab', { name: 'Models' }).click();
+
+        await expect(page).toHaveURL(new RegExp(`/projects/id-1/models$`));
+        await page.getByRole('tab', { name: 'Inference' }).click();
+
+        await expect(streamPage.getStartStreamButton()).toBeVisible();
     });
 });

--- a/application/ui/tests/inference/stream-page.ts
+++ b/application/ui/tests/inference/stream-page.ts
@@ -6,8 +6,12 @@ import { Page } from '@playwright/test';
 export class StreamPage {
     constructor(private page: Page) {}
 
+    getStartStreamButton() {
+        return this.page.getByLabel('Start stream');
+    }
+
     async startStream() {
-        await this.page.getByLabel('Start stream').click();
+        await this.getStartStreamButton().click();
     }
 
     async isConnected() {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

There was two issues:
1. Webrtc stream when started, it was playing even tho user was in the annotator (it was connected behind the scenes, burdening server).
2. When changed the project with disabled pipeline, stream was still visible.

This PR fixes both.

Fix #6450 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
