### PR TITLE
chore: Video inference improvements

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -36,6 +36,7 @@
                 "react-router": "~6.30.1",
                 "react-router-dom": "~6.30.1",
                 "recharts": "~3.7.0",
+                "spin-delay": "^2.0.1",
                 "static-path": "~0.0.4",
                 "utif": "^3.1.0",
                 "uuid": "~11.1.0",
@@ -16800,6 +16801,15 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spin-delay": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/spin-delay/-/spin-delay-2.0.1.tgz",
+            "integrity": "sha512-ilggKXKqAMwk21PSYvxuF/KCnrsGFDrnO6mXa629mj8fvfo+dOQfubDViqsRjRX5U1jd3Xb8FTsV+m4Tg7YeUg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": ">=17.0.1"
             }
         },
         "node_modules/stable-hash": {

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -58,6 +58,7 @@
         "react-router": "~6.30.1",
         "react-router-dom": "~6.30.1",
         "recharts": "~3.7.0",
+        "spin-delay": "^2.0.1",
         "static-path": "~0.0.4",
         "utif": "^3.1.0",
         "uuid": "~11.1.0",

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -6,6 +6,7 @@ import { MouseEvent, PointerEvent, useEffect, useRef, useState } from 'react';
 import { Loading } from '@geti/ui';
 import { useIsFetching } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { useSpinDelay } from 'spin-delay';
 
 import { ZoomTransform } from '../../../components/zoom/zoom-transform';
 import type { Media } from '../../../constants/shared-types';
@@ -256,9 +257,9 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
     const { isSingleEditableSelection } = useEditableAnnotationState();
-    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey });
+    const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey }) > 0;
 
-    const isLoadingMedia = isFetchingMedia > 0;
+    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 300, minDuration: 200 });
     const areToolsDisabled = isSceneBusy || isReadOnly;
     const size = { width: mediaItem.width, height: mediaItem.height };
     const canEditSelectedAnnotation = !areToolsDisabled && isSingleEditableSelection;

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -70,6 +70,7 @@ export const mediaPredictionsQueryOptions = ({
                 return predictionItem;
             });
         },
+        staleTime: 1000 * 60 * 5,
         enabled: selectedModel !== undefined,
     });
 

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -7,11 +7,13 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { fetchClient } from '../../../api/client';
 import { PredictionDTO, PredictionVideoRangePayload } from '../../../constants/shared-types';
 import { EMPTY_LABEL_ID } from '../../../shared/annotator/labels';
+import { isVideoFrame } from '../../../shared/media-item-utils';
 import { getModelIdentifierPayload, SelectableModel } from '../../models/utils';
-
-const MEDIA_PREDICTIONS_QUERY_KEY_PREFIX = (projectId: string, mediaId: string) => {
-    return [projectId, 'media-predictions', mediaId];
-};
+import { usePredictionSetup } from '../predictions-setup-provider.component';
+import { useSelectedMediaItem } from '../selected-media-item-provider.component';
+import { PREDICTION_CHUNK_SIZE, PREDICTION_FRAME_SKIP } from '../video-player/api/use-video-frames-predictions';
+import { getVideoFrameRangeIndexes } from '../video-player/api/utils';
+import { useVideoPlayerContext } from '../video-player/video-player-provider.component';
 
 export const mediaPredictionsQueryOptions = ({
     projectId,
@@ -26,15 +28,18 @@ export const mediaPredictionsQueryOptions = ({
 }) =>
     queryOptions({
         queryKey: [
-            ...MEDIA_PREDICTIONS_QUERY_KEY_PREFIX(projectId, mediaId),
+            projectId,
+            'media-predictions',
+            mediaId,
             selectedModel?.modelId,
             selectedModel?.modelVariantId,
             range,
         ],
-        queryFn: async () => {
+        queryFn: async ({ signal }) => {
             if (selectedModel === undefined) return [];
 
             const response = await fetchClient.POST('/api/projects/{project_id}/dataset/media/media:predict', {
+                signal,
                 params: { path: { project_id: projectId } },
                 body: {
                     ...getModelIdentifierPayload(selectedModel),
@@ -82,12 +87,66 @@ export const useMediaPredictions = ({
     return useQuery(mediaPredictionsQueryOptions({ projectId, selectedModel, mediaId, range }));
 };
 
-export const useIsFetchingAnyPredictions = (mediaId: string) => {
+/**
+ * Returns true only when the prediction query that is directly relevant to the
+ * current view is in-flight:
+ *  - video playing  → the range chunk that covers the current frame
+ *  - video paused / image → the single-frame (or null-range) query
+ */
+
+const useIsFetchingFrameRangePredictions = (mediaId: string) => {
     const projectId = useProjectIdentifier();
 
-    const queryKey = MEDIA_PREDICTIONS_QUERY_KEY_PREFIX(projectId, mediaId);
+    const { selectedModel } = usePredictionSetup();
+    const videoContext = useVideoPlayerContext();
 
-    const numberOfFetchingPredictions = useIsFetching({ queryKey });
+    const frameNumber = videoContext?.videoFrame.frame_number ?? 0;
+    const frameCount = videoContext?.videoFrame.frame_count ?? 1;
 
-    return numberOfFetchingPredictions > 0;
+    // Exact query key for the range chunk covering the current frame (video only)
+    const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({
+        frames: frameCount - 1,
+        frameSkip: PREDICTION_FRAME_SKIP,
+        frameNumber,
+        chunkSize: PREDICTION_CHUNK_SIZE,
+    });
+
+    const rangeQueryKey = mediaPredictionsQueryOptions({
+        projectId,
+        selectedModel,
+        mediaId,
+        range: { stride: PREDICTION_FRAME_SKIP, start_frame: startFrameIndex, end_frame: endFrameIndex },
+    }).queryKey;
+
+    return useIsFetching({ queryKey: rangeQueryKey, exact: true }) > 0;
+};
+
+const useIsFetchingSingleFramePredictions = (mediaId: string) => {
+    const projectId = useProjectIdentifier();
+    const { selectedModel } = usePredictionSetup();
+    const { mediaItem } = useSelectedMediaItem();
+
+    const singleFrameRange = isVideoFrame(mediaItem)
+        ? { start_frame: mediaItem.frame_number, end_frame: mediaItem.frame_number, stride: mediaItem.frame_stride }
+        : null;
+
+    const singleFrameQueryKey = mediaPredictionsQueryOptions({
+        projectId,
+        selectedModel,
+        mediaId,
+        range: singleFrameRange,
+    }).queryKey;
+
+    return useIsFetching({ queryKey: singleFrameQueryKey, exact: true }) > 0;
+};
+
+export const useIsFetchingPredictions = (mediaId: string) => {
+    const videoContext = useVideoPlayerContext();
+
+    const isPlaying = videoContext?.videoControls.isPlaying ?? false;
+
+    const isFetchingRange = useIsFetchingFrameRangePredictions(mediaId);
+    const isFetchingSingleFrame = useIsFetchingSingleFramePredictions(mediaId);
+
+    return isPlaying ? isFetchingRange : isFetchingSingleFrame;
 };

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -87,14 +87,7 @@ export const useMediaPredictions = ({
     return useQuery(mediaPredictionsQueryOptions({ projectId, selectedModel, mediaId, range }));
 };
 
-/**
- * Returns true only when the prediction query that is directly relevant to the
- * current view is in-flight:
- *  - video playing  → the range chunk that covers the current frame
- *  - video paused / image → the single-frame (or null-range) query
- */
-
-const useIsFetchingFrameRangePredictions = (mediaId: string) => {
+export const useIsFetchingCurrentRangeFramesPredictions = (mediaId: string) => {
     const projectId = useProjectIdentifier();
 
     const { selectedModel } = usePredictionSetup();
@@ -121,7 +114,7 @@ const useIsFetchingFrameRangePredictions = (mediaId: string) => {
     return useIsFetching({ queryKey: rangeQueryKey, exact: true }) > 0;
 };
 
-const useIsFetchingSingleFramePredictions = (mediaId: string) => {
+export const useIsFetchingCurrentFramePredictions = (mediaId: string) => {
     const projectId = useProjectIdentifier();
     const { selectedModel } = usePredictionSetup();
     const { mediaItem } = useSelectedMediaItem();
@@ -145,8 +138,8 @@ export const useIsFetchingPredictions = (mediaId: string) => {
 
     const isPlaying = videoContext?.videoControls.isPlaying ?? false;
 
-    const isFetchingRange = useIsFetchingFrameRangePredictions(mediaId);
-    const isFetchingSingleFrame = useIsFetchingSingleFramePredictions(mediaId);
+    const isFetchingRange = useIsFetchingCurrentRangeFramesPredictions(mediaId);
+    const isFetchingSingleFrame = useIsFetchingCurrentFramePredictions(mediaId);
 
     return isPlaying ? isFetchingRange : isFetchingSingleFrame;
 };

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-controls.component.tsx
@@ -5,7 +5,7 @@ import { ActionButton, Flex } from '@geti/ui';
 import { Pause, Play, SoundOff, SoundOn, StepBackward, StepForward } from '@geti/ui/icons';
 
 import { AnnotatorMode } from '../../../../shared/annotator/annotator-mode';
-import { useIsFetchingAnyPredictions } from '../../api/use-media-predictions';
+import { useIsFetchingPredictions } from '../../api/use-media-predictions';
 import { useVideoPlayer } from '../video-player-provider.component';
 
 type VideoControlsProps = {
@@ -17,7 +17,7 @@ export const VideoControls = ({ mode }: VideoControlsProps) => {
     const { isPlaying, play, pause, previousFrame, nextFrame, canSelectPreviousFrame, canSelectNextFrame } =
         videoControls;
 
-    const isLoadingPredictions = useIsFetchingAnyPredictions(videoFrame.id) && mode === 'prediction';
+    const isLoadingPredictions = useIsFetchingPredictions(videoFrame.id) && mode === 'prediction';
 
     return (
         <Flex alignItems={'center'} gap={'size-100'}>

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.test.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.test.tsx
@@ -17,30 +17,39 @@ const mockVideoFrame = getMockedVideoFrame({
     duration: 10,
 });
 
+const MOCKED_VIDEO_PLAYER_CONTEXT = {
+    videoFrame: mockVideoFrame,
+    step: 1,
+    changeStep: vi.fn(),
+    isMuted: false,
+    toggleMute: vi.fn(),
+    playbackRate: 1,
+    changePlaybackRate: vi.fn(),
+    videoControls: {
+        isPlaying: false,
+        play: vi.fn(),
+        pause: vi.fn(),
+        goto: vi.fn(),
+        previousFrame: vi.fn(),
+        nextFrame: vi.fn(),
+        canSelectPreviousFrame: true,
+        canSelectNextFrame: true,
+    },
+};
+
 vi.mock('../video-player-provider.component', () => ({
-    useVideoPlayer: () => ({
-        videoFrame: mockVideoFrame,
-        step: 1,
-        changeStep: vi.fn(),
-        isMuted: false,
-        toggleMute: vi.fn(),
-        playbackRate: 1,
-        changePlaybackRate: vi.fn(),
-        videoControls: {
-            isPlaying: false,
-            play: vi.fn(),
-            pause: vi.fn(),
-            goto: vi.fn(),
-            previousFrame: vi.fn(),
-            nextFrame: vi.fn(),
-            canSelectPreviousFrame: true,
-            canSelectNextFrame: true,
-        },
-    }),
+    useVideoPlayer: () => MOCKED_VIDEO_PLAYER_CONTEXT,
+    useVideoPlayerContext: () => MOCKED_VIDEO_PLAYER_CONTEXT,
 }));
 
 vi.mock('../../../../hooks/use-project-labels.hook', () => ({
     useProjectLabels: () => [getMockedLabel({ id: 'label-1', name: 'Cat' })],
+}));
+
+vi.mock('../../selected-media-item-provider.component', () => ({
+    useSelectedMediaItem: () => ({
+        mediaItem: getMockedVideoFrame(),
+    }),
 }));
 
 vi.mock('../../predictions-setup-provider.component', async (importOriginal) => ({

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -9,7 +9,10 @@ import type { DatasetSubset, Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { useIsFetchingPredictions } from '../../annotator/api/use-media-predictions';
+import {
+    useIsFetchingCurrentRangeFramesPredictions,
+    useIsFetchingPredictions,
+} from '../../annotator/api/use-media-predictions';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
@@ -85,8 +88,10 @@ const Annotator = ({
     const { nextMediaItem } = useNextMediaPrefetch(mediaItem, items);
     const { currentSubset, changeCurrentSubset, isReadOnlySubset } = useSubset(subset, mediaItem);
     const isLoadingPredictions = useIsFetchingPredictions(mediaItem.id) && isPredictionMode;
+    const isLoadingCurrentRangePredictions =
+        useIsFetchingCurrentRangeFramesPredictions(mediaItem.id) && isPredictionMode;
 
-    usePlayPauseVideoBySystem(isLoadingPredictions);
+    usePlayPauseVideoBySystem(isLoadingCurrentRangePredictions);
 
     const selectNextMediaItem = async () => {
         if (nextMediaItem === undefined) {

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -9,7 +9,7 @@ import type { DatasetSubset, Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
 import { AnnotatorCanvas } from '../../annotator/annotator-canvas/annotator-canvas';
-import { useIsFetchingAnyPredictions } from '../../annotator/api/use-media-predictions';
+import { useIsFetchingPredictions } from '../../annotator/api/use-media-predictions';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
@@ -84,7 +84,7 @@ const Annotator = ({
 
     const { nextMediaItem } = useNextMediaPrefetch(mediaItem, items);
     const { currentSubset, changeCurrentSubset, isReadOnlySubset } = useSubset(subset, mediaItem);
-    const isLoadingPredictions = useIsFetchingAnyPredictions(mediaItem.id) && isPredictionMode;
+    const isLoadingPredictions = useIsFetchingPredictions(mediaItem.id) && isPredictionMode;
 
     usePlayPauseVideoBySystem(isLoadingPredictions);
 

--- a/application/ui/src/features/dataset/media-preview/utils.test.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.test.ts
@@ -134,7 +134,7 @@ describe('usePlayPauseVideoBySystem', () => {
         expect(context.videoControls.pause).not.toHaveBeenCalled();
     });
 
-    it('calls pause when isLoadingPredictions becomes true and video is playing', () => {
+    it('calls pause when range predictions are loading and video is playing', () => {
         const context = createVideoPlayerContext(true);
         mockUseVideoPlayerContext.mockReturnValue(context as never);
 
@@ -144,7 +144,7 @@ describe('usePlayPauseVideoBySystem', () => {
         expect(context.videoControls.play).not.toHaveBeenCalled();
     });
 
-    it('calls play when isLoadingPredictions becomes false after system paused the video', () => {
+    it('calls play when range predictions stop loading after system paused the video', () => {
         const context = createVideoPlayerContext(true);
         mockUseVideoPlayerContext.mockReturnValue(context as never);
 
@@ -161,7 +161,7 @@ describe('usePlayPauseVideoBySystem', () => {
         expect(context.videoControls.play).toHaveBeenCalledTimes(1);
     });
 
-    it('does not call play when isLoadingPredictions becomes false but video was paused by user', () => {
+    it('does not call play when range predictions stop loading but video was paused by user', () => {
         const context = createVideoPlayerContext(false);
         mockUseVideoPlayerContext.mockReturnValue(context as never);
 
@@ -178,7 +178,7 @@ describe('usePlayPauseVideoBySystem', () => {
         expect(context.videoControls.play).not.toHaveBeenCalled();
     });
 
-    it('does not call pause when video is not playing and isLoadingPredictions becomes true', () => {
+    it('does not call pause when video is not playing and range predictions are loading', () => {
         const context = createVideoPlayerContext(false);
         mockUseVideoPlayerContext.mockReturnValue(context as never);
 

--- a/application/ui/src/features/dataset/media-preview/utils.ts
+++ b/application/ui/src/features/dataset/media-preview/utils.ts
@@ -99,7 +99,7 @@ export const useAnnotatorMode = () => {
     return [mode, setMode] as const;
 };
 
-export const usePlayPauseVideoBySystem = (isLoadingPredictions: boolean) => {
+export const usePlayPauseVideoBySystem = (isLoadingRangePredictions: boolean) => {
     const isPausedBySystem = useRef<boolean>(false);
     const context = useVideoPlayerContext();
 
@@ -115,12 +115,12 @@ export const usePlayPauseVideoBySystem = (isLoadingPredictions: boolean) => {
     }, [context?.videoControls.pause]);
 
     useEffect(() => {
-        if (isLoadingPredictions && context?.videoControls.isPlaying) {
+        if (isLoadingRangePredictions && context?.videoControls.isPlaying) {
             isPausedBySystem.current = true;
             pauseRef.current?.();
-        } else if (!isLoadingPredictions && isPausedBySystem.current) {
+        } else if (!isLoadingRangePredictions && isPausedBySystem.current) {
             isPausedBySystem.current = false;
             playRef.current?.();
         }
-    }, [isLoadingPredictions, context?.videoControls.isPlaying]);
+    }, [isLoadingRangePredictions, context?.videoControls.isPlaying]);
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Add spin delay for showing loading when fetching img.
2. Improve `isFetching...` logic so there are two separate hooks. This helps us to show the loading only when we're prefetching predictions for the current video frame number.
- when fetching single frame predictions;
- when fetching range frames predictions.
3. Cache predictions for 5 mins.

The next step would be to update `PREDICTION_CHUNK_SIZE` to get predictions for more than 10 frames. I checked that for 20 and it worked fine on macbook (to do so we need to update env variable as well, right now, when we request more than 10 we get 400 error).

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
