### PR TITLE
Fixed a Tauri build failure caused by a version mismatch

### DIFF
--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -16,7 +16,7 @@
                 "@geti/smart-tools": "*",
                 "@geti/ui": "*",
                 "@tanstack/react-query": "~5.80.10",
-                "@tauri-apps/api": "^2.11.0",
+                "@tauri-apps/api": "~2.11.0",
                 "@tauri-apps/plugin-opener": "~2.5.3",
                 "@use-gesture/react": "~10.3.1",
                 "clsx": "~2.1.1",

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -12824,6 +12824,12 @@
                 "node": ">=16"
             }
         },
+        "node_modules/flatbuffers": {
+            "version": "25.9.23",
+            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+            "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/flatted": {
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -14796,6 +14802,26 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/onnxruntime-common": {
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+            "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+            "license": "MIT"
+        },
+        "node_modules/onnxruntime-web": {
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.3.tgz",
+            "integrity": "sha512-41dDq7fxtTm0XzGE7N0d6m8FcOY8EWtUA65GkOixJPB/G7DGzBmiDAnVVXHznRw9bgUZpb+4/1lQK/PNxGpbrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "flatbuffers": "^25.1.24",
+                "guid-typescript": "^1.0.9",
+                "long": "^5.2.3",
+                "onnxruntime-common": "1.24.3",
+                "platform": "^1.3.6",
+                "protobufjs": "^7.2.4"
             }
         },
         "node_modules/openapi-fetch": {
@@ -18770,7 +18796,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@doodle3d/clipper-js": "~1.0.11",
-                "onnxruntime-web": "~1.16.3",
+                "onnxruntime-web": "~1.24.3",
                 "polylabel": "~1.1.0"
             },
             "devDependencies": {
@@ -18864,12 +18890,6 @@
                 "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
-        "packages/smart-tools/node_modules/flatbuffers": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
-            "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
-            "license": "SEE LICENSE IN LICENSE.txt"
-        },
         "packages/smart-tools/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -18881,26 +18901,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "packages/smart-tools/node_modules/onnxruntime-common": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.16.3.tgz",
-            "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug==",
-            "license": "MIT"
-        },
-        "packages/smart-tools/node_modules/onnxruntime-web": {
-            "version": "1.16.3",
-            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.16.3.tgz",
-            "integrity": "sha512-8O1xCG/RcNQNYYWvdiQJSNpncVg78OVOFeV6MYs/jx++/b12oje8gYUzKqz9wR/sXiX/8TCvdyHgEjj5gQGKUg==",
-            "license": "MIT",
-            "dependencies": {
-                "flatbuffers": "^1.12.0",
-                "guid-typescript": "^1.0.9",
-                "long": "^5.2.3",
-                "onnxruntime-common": "~1.16.3",
-                "platform": "^1.3.6",
-                "protobufjs": "^7.2.4"
             }
         },
         "packages/smart-tools/node_modules/semver": {
@@ -18927,7 +18927,7 @@
                 "@adobe/react-spectrum": "^3.43.0",
                 "@spectrum-icons/illustrations": "^3.6.24",
                 "@spectrum-icons/workflow": "^4.2.23",
-                "lodash-es": "^4.17.23",
+                "lodash-es": "^4.18.1",
                 "react-aria-components": "^1.11.0",
                 "react-colorful": "^5.6.1",
                 "sonner": "^2.0.7",

--- a/application/ui/package-lock.json
+++ b/application/ui/package-lock.json
@@ -16,7 +16,7 @@
                 "@geti/smart-tools": "*",
                 "@geti/ui": "*",
                 "@tanstack/react-query": "~5.80.10",
-                "@tauri-apps/api": "^2.10.1",
+                "@tauri-apps/api": "^2.11.0",
                 "@tauri-apps/plugin-opener": "~2.5.3",
                 "@use-gesture/react": "~10.3.1",
                 "clsx": "~2.1.1",
@@ -8598,9 +8598,10 @@
             }
         },
         "node_modules/@tauri-apps/api": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-            "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+            "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
+            "license": "Apache-2.0 OR MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/tauri"
@@ -12823,12 +12824,6 @@
                 "node": ">=16"
             }
         },
-        "node_modules/flatbuffers": {
-            "version": "25.9.23",
-            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
-            "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-            "license": "Apache-2.0"
-        },
         "node_modules/flatted": {
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -14801,26 +14796,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/onnxruntime-common": {
-            "version": "1.24.3",
-            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
-            "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
-            "license": "MIT"
-        },
-        "node_modules/onnxruntime-web": {
-            "version": "1.24.3",
-            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.24.3.tgz",
-            "integrity": "sha512-41dDq7fxtTm0XzGE7N0d6m8FcOY8EWtUA65GkOixJPB/G7DGzBmiDAnVVXHznRw9bgUZpb+4/1lQK/PNxGpbrQ==",
-            "license": "MIT",
-            "dependencies": {
-                "flatbuffers": "^25.1.24",
-                "guid-typescript": "^1.0.9",
-                "long": "^5.2.3",
-                "onnxruntime-common": "1.24.3",
-                "platform": "^1.3.6",
-                "protobufjs": "^7.2.4"
             }
         },
         "node_modules/openapi-fetch": {
@@ -18795,7 +18770,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@doodle3d/clipper-js": "~1.0.11",
-                "onnxruntime-web": "~1.24.3",
+                "onnxruntime-web": "~1.16.3",
                 "polylabel": "~1.1.0"
             },
             "devDependencies": {
@@ -18889,6 +18864,12 @@
                 "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
+        "packages/smart-tools/node_modules/flatbuffers": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+            "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+            "license": "SEE LICENSE IN LICENSE.txt"
+        },
         "packages/smart-tools/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -18900,6 +18881,26 @@
             },
             "engines": {
                 "node": "*"
+            }
+        },
+        "packages/smart-tools/node_modules/onnxruntime-common": {
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.16.3.tgz",
+            "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug==",
+            "license": "MIT"
+        },
+        "packages/smart-tools/node_modules/onnxruntime-web": {
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.16.3.tgz",
+            "integrity": "sha512-8O1xCG/RcNQNYYWvdiQJSNpncVg78OVOFeV6MYs/jx++/b12oje8gYUzKqz9wR/sXiX/8TCvdyHgEjj5gQGKUg==",
+            "license": "MIT",
+            "dependencies": {
+                "flatbuffers": "^1.12.0",
+                "guid-typescript": "^1.0.9",
+                "long": "^5.2.3",
+                "onnxruntime-common": "~1.16.3",
+                "platform": "^1.3.6",
+                "protobufjs": "^7.2.4"
             }
         },
         "packages/smart-tools/node_modules/semver": {
@@ -18926,7 +18927,7 @@
                 "@adobe/react-spectrum": "^3.43.0",
                 "@spectrum-icons/illustrations": "^3.6.24",
                 "@spectrum-icons/workflow": "^4.2.23",
-                "lodash-es": "^4.18.1",
+                "lodash-es": "^4.17.23",
                 "react-aria-components": "^1.11.0",
                 "react-colorful": "^5.6.1",
                 "sonner": "^2.0.7",

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -38,7 +38,7 @@
         "@geti/smart-tools": "*",
         "@geti/ui": "*",
         "@tanstack/react-query": "~5.80.10",
-        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/api": "~2.11.0",
         "@tauri-apps/plugin-opener": "~2.5.3",
         "@use-gesture/react": "~10.3.1",
         "clsx": "~2.1.1",

--- a/application/ui/package.json
+++ b/application/ui/package.json
@@ -38,7 +38,7 @@
         "@geti/smart-tools": "*",
         "@geti/ui": "*",
         "@tanstack/react-query": "~5.80.10",
-        "@tauri-apps/api": "^2.10.1",
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-opener": "~2.5.3",
         "@use-gesture/react": "~10.3.1",
         "clsx": "~2.1.1",

--- a/application/ui/src-tauri/Cargo.toml
+++ b/application/ui/src-tauri/Cargo.toml
@@ -11,12 +11,12 @@ rust-version = "1.77.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "2.5.1", features = [] }
+tauri-build = { version = "2.6.1", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.11", features = [] }
-tauri-plugin-log = "2"
-tauri-plugin-opener = "2"
+tauri-plugin-log = "2.8.0"
+tauri-plugin-opener = "2.5.3"

--- a/application/ui/src-tauri/Cargo.toml
+++ b/application/ui/src-tauri/Cargo.toml
@@ -17,6 +17,6 @@ tauri-build = { version = "2.5.1", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.10", features = [] }
+tauri = { version = "2.11", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"


### PR DESCRIPTION
This PR fixes a Tauri build failure on Windows (and potentially other platforms) caused by a version mismatch between the Tauri Rust crate and the Tauri NPM package. The build error was: Error Found version mismatched Tauri packages. Make sure the NPM package and Rust crate versions are on the same major/minor releases: tauri (v2.11.1) : @tauri-apps/api (v2.10.1)

Root cause: The oep-renovate[bot] introduced this mismatch in commit 4cc74de6d027e4b324e9ab20abfcf7b0b32c265f by updating only the Rust dependencies in Cargo.lock to v2.11.1 without corresponding updates to the NPM package package.json.
Changes:
- Updated @tauri-apps/api to ^2.11.0 in application/ui/package.json.
- Synchronized application/ui/package-lock.json via npm install --package-lock-only.
- Updated tauri crate version requirement to 2.11 in application/ui/src-tauri/Cargo.toml to ensure future alignment.

Checklist
- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests (N/A - build fix)
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)