### PR TITLE
fix: Preload next media predictions

### DIFF
--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -134,3 +134,4 @@ export type Pagination = components['schemas']['Pagination'];
 export type MediaWithPagination = components['schemas']['MediaWithPagination'];
 export type DatasetFormat = components['schemas']['DatasetFormat'];
 export type DeviceInfo = components['schemas']['DeviceInfoView'];
+export type MediaListPredictionRequest = components['schemas']['MediaListPredictionRequest'];

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -73,6 +73,12 @@ type AnnotatorProps = {
     isUserReviewed: boolean;
 };
 
+const NextPredictionPrefetch = ({ nextMediaItem }: { nextMediaItem: Media }) => {
+    useNextPredictionPrefetch(nextMediaItem);
+
+    return null;
+};
+
 const Annotator = ({
     mediaItem,
     image,
@@ -98,8 +104,6 @@ const Annotator = ({
         minDuration: 200,
     });
 
-    useNextPredictionPrefetch(mediaItem, items, isPredictionMode);
-
     usePlayPauseVideoBySystem(isLoadingCurrentRangePredictions);
 
     const selectNextMediaItem = async () => {
@@ -112,6 +116,7 @@ const Annotator = ({
 
     return (
         <>
+            {isPredictionMode && nextMediaItem && <NextPredictionPrefetch nextMediaItem={nextMediaItem} />}
             <View gridArea={'header'}>
                 <SecondaryToolbar
                     mode={mode}

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -21,6 +21,7 @@ import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
 import { PrimaryToolbar } from './primary-toolbar/primary-toolbar.component';
 import { AnnotatorCanvasSettings } from './primary-toolbar/settings/annotator-canvas-settings.component';
 import { SecondaryToolbar } from './secondary-toolbar/secondary-toolbar.component';
+import { useNextPredictionPrefetch } from './use-next-prediction-prefetch.hook';
 import { useNextMediaPrefetch, usePlayPauseVideoBySystem } from './utils';
 
 const DATASET_SUBSETS: DatasetSubset[] = ['unassigned', 'training', 'validation', 'testing'];
@@ -96,6 +97,7 @@ const Annotator = ({
         delay: 400,
         minDuration: 200,
     });
+    useNextPredictionPrefetch(mediaItem, items);
 
     usePlayPauseVideoBySystem(isLoadingCurrentRangePredictions);
 

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -97,7 +97,8 @@ const Annotator = ({
         delay: 400,
         minDuration: 200,
     });
-    useNextPredictionPrefetch(mediaItem, items);
+
+    useNextPredictionPrefetch(mediaItem, items, isPredictionMode);
 
     usePlayPauseVideoBySystem(isLoadingCurrentRangePredictions);
 

--- a/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { usePrefetchQuery } from '@tanstack/react-query';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import type { Media } from '../../../constants/shared-types';
+import { isVideoFrame } from '../../../shared/media-item-utils';
+import { mediaPredictionsQueryOptions } from '../../annotator/api/use-media-predictions';
+import { usePredictionSetup } from '../../annotator/predictions-setup-provider.component';
+import { useNextMediaItem } from './utils';
+
+export const useNextPredictionPrefetch = (currentMediaItem: Media, allMediaItems: Media[]) => {
+    const projectId = useProjectIdentifier();
+    const { selectedModel } = usePredictionSetup();
+    const nextMediaItem = useNextMediaItem(currentMediaItem, allMediaItems);
+
+    const mediaToPrefetch = nextMediaItem ?? currentMediaItem;
+    const range = isVideoFrame(mediaToPrefetch)
+        ? {
+              start_frame: mediaToPrefetch.frame_number,
+              end_frame: mediaToPrefetch.frame_number,
+              stride: mediaToPrefetch.frame_stride,
+          }
+        : null;
+
+    usePrefetchQuery({
+        ...mediaPredictionsQueryOptions({
+            projectId,
+            selectedModel,
+            mediaId: mediaToPrefetch.id,
+            range,
+        }),
+    });
+};

--- a/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
@@ -11,7 +11,7 @@ import { usePredictionSetup } from '../../annotator/predictions-setup-provider.c
 
 export const useNextPredictionPrefetch = (nextMediaItem: Media) => {
     const projectId = useProjectIdentifier();
-    const { selectedModel } = usePredictionSetup();
+    const { selectedModel, selectedDevice } = usePredictionSetup();
 
     const range = isVideoFrame(nextMediaItem)
         ? {
@@ -26,6 +26,7 @@ export const useNextPredictionPrefetch = (nextMediaItem: Media) => {
             projectId,
             selectedModel,
             mediaId: nextMediaItem.id,
+            device: selectedDevice,
             range,
         })
     );

--- a/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { usePrefetchQuery } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
@@ -10,26 +10,30 @@ import { mediaPredictionsQueryOptions } from '../../annotator/api/use-media-pred
 import { usePredictionSetup } from '../../annotator/predictions-setup-provider.component';
 import { useNextMediaItem } from './utils';
 
-export const useNextPredictionPrefetch = (currentMediaItem: Media, allMediaItems: Media[]) => {
+export const useNextPredictionPrefetch = (currentMediaItem: Media, allMediaItems: Media[], isEnabled: boolean) => {
+    const queryClient = useQueryClient();
     const projectId = useProjectIdentifier();
     const { selectedModel } = usePredictionSetup();
     const nextMediaItem = useNextMediaItem(currentMediaItem, allMediaItems);
 
-    const mediaToPrefetch = nextMediaItem ?? currentMediaItem;
-    const range = isVideoFrame(mediaToPrefetch)
+    if (isEnabled === false || nextMediaItem === undefined) {
+        return;
+    }
+
+    const range = isVideoFrame(nextMediaItem)
         ? {
-              start_frame: mediaToPrefetch.frame_number,
-              end_frame: mediaToPrefetch.frame_number,
-              stride: mediaToPrefetch.frame_stride,
+              stride: nextMediaItem.frame_stride,
+              end_frame: nextMediaItem.frame_number,
+              start_frame: nextMediaItem.frame_number,
           }
         : null;
 
-    usePrefetchQuery({
-        ...mediaPredictionsQueryOptions({
+    queryClient.prefetchQuery(
+        mediaPredictionsQueryOptions({
             projectId,
             selectedModel,
-            mediaId: mediaToPrefetch.id,
+            mediaId: nextMediaItem.id,
             range,
-        }),
-    });
+        })
+    );
 };

--- a/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
@@ -1,24 +1,17 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQueryClient } from '@tanstack/react-query';
+import { usePrefetchQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { Media } from '../../../constants/shared-types';
 import { isVideoFrame } from '../../../shared/media-item-utils';
 import { mediaPredictionsQueryOptions } from '../../annotator/api/use-media-predictions';
 import { usePredictionSetup } from '../../annotator/predictions-setup-provider.component';
-import { useNextMediaItem } from './utils';
 
-export const useNextPredictionPrefetch = (currentMediaItem: Media, allMediaItems: Media[], isEnabled: boolean) => {
-    const queryClient = useQueryClient();
+export const useNextPredictionPrefetch = (nextMediaItem: Media) => {
     const projectId = useProjectIdentifier();
     const { selectedModel } = usePredictionSetup();
-    const nextMediaItem = useNextMediaItem(currentMediaItem, allMediaItems);
-
-    if (isEnabled === false || nextMediaItem === undefined) {
-        return;
-    }
 
     const range = isVideoFrame(nextMediaItem)
         ? {
@@ -28,7 +21,7 @@ export const useNextPredictionPrefetch = (currentMediaItem: Media, allMediaItems
           }
         : null;
 
-    queryClient.prefetchQuery(
+    usePrefetchQuery(
         mediaPredictionsQueryOptions({
             projectId,
             selectedModel,

--- a/application/ui/tests/annotator/video/video.spec.ts
+++ b/application/ui/tests/annotator/video/video.spec.ts
@@ -315,7 +315,7 @@ test.describe('Annotator video player', () => {
         );
     });
 
-    test('Prefetches predictions for the next video frame', async ({ page, videoPage, annotatorPage, network }) => {
+    test('Prefetches predictions for the next video frame', async ({ videoPage, annotatorPage, network }) => {
         const fishLabel = getMockedLabel({ id: 'a6efefed-e469-4b1c-b803-c2e21ea0597b', name: 'Fish' });
 
         const mockedProject = getMockedProject({
@@ -373,12 +373,15 @@ test.describe('Annotator video player', () => {
         });
 
         await test.step('Reuses the prefetched cache entry when navigating to the next frame', async () => {
-            const delayPotentiallyStale = 500;
+            const frameAfterNext = nextFrame + mockVideoFrame.frame_stride;
             const requestsBefore = predictRequests.filter((body) => isRequestForFrame(body, nextFrame)).length;
 
             await videoPage.nextFrame();
             await videoPage.expectCurrentFrame(nextFrame, totalFrames);
-            await page.waitForTimeout(delayPotentiallyStale);
+
+            // Wait for a deterministic signal that the navigation has been fully handled:
+            // once we are on `nextFrame`, the player should prefetch the following frame.
+            await expect.poll(() => predictRequests.some((body) => isRequestForFrame(body, frameAfterNext))).toBe(true);
 
             const requestsAfter = predictRequests.filter((body) => isRequestForFrame(body, nextFrame)).length;
             expect(requestsAfter).toBe(requestsBefore);

--- a/application/ui/tests/annotator/video/video.spec.ts
+++ b/application/ui/tests/annotator/video/video.spec.ts
@@ -8,10 +8,12 @@ import { fileURLToPath } from 'node:url';
 import { expect } from '@playwright/test';
 import { getMockedLabel } from 'mocks/mock-labels';
 import { getMockedVideoFrame } from 'mocks/mock-media';
+import { getMockedModel } from 'mocks/mock-model';
+import { getMockedVariant } from 'mocks/mock-model-variant';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
 
-import { AnnotationDTO } from '../../../src/constants/shared-types';
+import { AnnotationDTO, MediaListPredictionRequest } from '../../../src/constants/shared-types';
 import { http, test } from '../../fixtures';
 import { candyPngBuffer, redLabel } from '../annotator-fixtures';
 import { ANNOTATIONS_MOCKS, PREDICTIONS_MOCKS } from './mocks';
@@ -311,5 +313,73 @@ test.describe('Annotator video player', () => {
                 await expect(videoPage.getLabelSegment(Number(media.frame_index), fishLabel.name)).toBeVisible();
             })
         );
+    });
+
+    test('Prefetches predictions for the next video frame', async ({ page, videoPage, annotatorPage, network }) => {
+        const fishLabel = getMockedLabel({ id: 'a6efefed-e469-4b1c-b803-c2e21ea0597b', name: 'Fish' });
+
+        const mockedProject = getMockedProject({
+            task: {
+                exclusive_labels: true,
+                task_type: 'instance_segmentation',
+                labels: [fishLabel],
+            },
+        });
+
+        const predictRequests: MediaListPredictionRequest[] = [];
+
+        network.use(
+            http.get('/api/projects/{project_id}', () => {
+                return HttpResponse.json(mockedProject);
+            }),
+            http.get('/api/projects/{project_id}/models', async () => {
+                return HttpResponse.json([getMockedModel({ variants: [getMockedVariant({})] })]);
+            }),
+            http.get('/api/projects/{project_id}/dataset/media/{media_id}/frames', async () => {
+                return HttpResponse.json(ANNOTATIONS_MOCKS);
+            }),
+            http.post('/api/projects/{project_id}/dataset/media/media:predict', async ({ request }) => {
+                const body = (await request.json()) as MediaListPredictionRequest;
+                predictRequests.push(body);
+
+                return HttpResponse.json({
+                    predictions: PREDICTIONS_MOCKS,
+                });
+            })
+        );
+
+        const currentFrame = mockVideoFrame.frame_number;
+        const nextFrame = mockVideoFrame.frame_number + mockVideoFrame.frame_stride;
+
+        const isRequestForFrame = (body: MediaListPredictionRequest, frameNumber: number) =>
+            body.media.some(
+                ({ media_id, range }) =>
+                    media_id === mockVideoFrame.id &&
+                    range?.stride === mockVideoFrame.frame_stride &&
+                    range?.end_frame === frameNumber &&
+                    range?.start_frame === frameNumber
+            );
+
+        await test.step('Opens the video in prediction mode', async () => {
+            await videoPage.openVideoFromDataset(mockedProject.id, mockVideoFrame.name);
+            await videoPage.expandToolbar();
+            await annotatorPage.openPredictionMode();
+            await expect(annotatorPage.getAnnotatorMode('prediction')).toHaveAttribute('aria-pressed', 'true');
+        });
+
+        await test.step('Fetches predictions for the current frame and prefetches the next frame', async () => {
+            await expect.poll(() => predictRequests.some((body) => isRequestForFrame(body, currentFrame))).toBe(true);
+            await expect.poll(() => predictRequests.some((body) => isRequestForFrame(body, nextFrame))).toBe(true);
+        });
+
+        await test.step('Reuses the prefetched cache entry when navigating to the next frame', async () => {
+            const delayPotentiallyStale = 500;
+
+            await videoPage.nextFrame();
+            await videoPage.expectCurrentFrame(nextFrame, totalFrames);
+            await page.waitForTimeout(delayPotentiallyStale);
+
+            expect(predictRequests.filter((body) => isRequestForFrame(body, nextFrame))).toHaveLength(1);
+        });
     });
 });

--- a/application/ui/tests/annotator/video/video.spec.ts
+++ b/application/ui/tests/annotator/video/video.spec.ts
@@ -374,12 +374,14 @@ test.describe('Annotator video player', () => {
 
         await test.step('Reuses the prefetched cache entry when navigating to the next frame', async () => {
             const delayPotentiallyStale = 500;
+            const requestsBefore = predictRequests.filter((body) => isRequestForFrame(body, nextFrame)).length;
 
             await videoPage.nextFrame();
             await videoPage.expectCurrentFrame(nextFrame, totalFrames);
             await page.waitForTimeout(delayPotentiallyStale);
 
-            expect(predictRequests.filter((body) => isRequestForFrame(body, nextFrame))).toHaveLength(1);
+            const requestsAfter = predictRequests.filter((body) => isRequestForFrame(body, nextFrame)).length;
+            expect(requestsAfter).toBe(requestsBefore);
         });
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

This PR adds a new hook to prefetch the next media item prediction. If the user jumps across several items in advance, the loading spinner may still appear.

<img width="1713" height="925" alt="prefech-predictions" src="https://github.com/user-attachments/assets/4c72ba63-bcb3-4733-8d91-2451ee0a8929" />

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
