### PR TITLE
Query inference devices using ov.Core

### DIFF
--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -4,6 +4,7 @@ import platform
 import re
 
 import cv2
+import openvino as ov
 import psutil
 import torch
 from cv2_enumerate_cameras import enumerate_cameras
@@ -84,14 +85,56 @@ class SystemService:
 
         return devices
 
-    def get_inference_devices(self) -> list[DeviceInfo]:
+    @staticmethod
+    def get_inference_devices() -> list[DeviceInfo]:
         """
-        Get available compute devices for inference (CPU, XPU, ...)
+        Get available compute devices for inference (CPU, XPU, ...).
+
+        Unlike training (which relies on PyTorch), inference is performed via OpenVINO, so devices are listed using
+        OpenVINO's `core.available_devices` API.
+
+        OpenVINO returns device names such as 'CPU', 'GPU', 'GPU.0', 'GPU.1', ... Per the OpenVINO documentation,
+        when an integrated GPU is present it always takes id 0, and 'GPU' is an alias for 'GPU.0'.
 
         Returns:
-            list[DeviceInfo]: List of available devices
+            list[DeviceInfo]: List of available inference devices.
         """
-        return [device for device in self.get_devices() if device.type != DeviceType.CUDA]
+        try:
+            core = ov.Core()
+            available_devices: list[str] = list(core.available_devices)
+        except Exception:
+            logger.exception("Failed to query OpenVINO inference devices; falling back to CPU only.")
+            return [DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)]
+
+        devices: list[DeviceInfo] = []
+        seen_gpu_indices: set[int] = set()
+        for ov_device in available_devices:
+            try:
+                if ov_device == "CPU":
+                    devices.append(DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None))
+                elif ov_device == "GPU" or ov_device.startswith("GPU."):
+                    # 'GPU' aliases 'GPU.0'; deduplicate if both are reported.
+                    index = 0 if ov_device == "GPU" else int(ov_device.split(".", 1)[1])
+                    if index in seen_gpu_indices:
+                        continue
+                    seen_gpu_indices.add(index)
+                    name = core.get_property(ov_device, "FULL_DEVICE_NAME")
+                    try:
+                        memory = int(core.get_property(ov_device, "GPU_DEVICE_TOTAL_MEM_SIZE"))
+                    except Exception:
+                        memory = None
+                    devices.append(DeviceInfo(type=DeviceType.XPU, name=str(name), memory=memory, index=index))
+                else:
+                    # Other OpenVINO devices (e.g., NPU) are not currently mapped to DeviceType.
+                    logger.debug("Skipping unsupported OpenVINO inference device: {}", ov_device)
+            except Exception:
+                logger.exception("Failed to query properties for OpenVINO device '{}'", ov_device)
+
+        # Ensure CPU is always present.
+        if not any(d.type == DeviceType.CPU for d in devices):
+            devices.insert(0, DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None))
+
+        return devices
 
     def get_training_devices(self) -> list[DeviceInfo]:
         """
@@ -158,6 +201,8 @@ class SystemService:
         """
         Get DeviceInfo for a given device string, ensuring it's valid for inference.
 
+        Inference device availability is determined via OpenVINO (see `get_inference_devices`).
+
         Args:
             device_str: Device string in format '<target>[-<index>]'
                 (e.g., 'auto', 'cpu', 'xpu', 'xpu-2')
@@ -165,10 +210,23 @@ class SystemService:
         Returns:
             DeviceInfo: Information about the specified inference device
         """
-        device_info = self.get_device_info(device_str)
-        if device_info.type == DeviceType.CUDA:
+        try:
+            device_type, device_index = self._parse_device(device_str)
+        except ValueError as ex:
+            raise ValueError(f"Device '{device_str}' is not valid for inference.") from ex
+
+        if device_type == DeviceType.CUDA:
             raise ValueError(f"Device '{device_str}' is not valid for inference (CUDA devices are not supported).")
-        return device_info
+        if device_type == DeviceType.AUTO:
+            return DeviceInfo(type=DeviceType.AUTO, name="AUTO", memory=None, index=None)
+        if device_type == DeviceType.CPU:
+            return DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)
+
+        for available_device in self.get_inference_devices():
+            if device_type == available_device.type and device_index == (available_device.index or 0):
+                return available_device
+
+        raise ValueError(f"Device '{device_str}' is not available for inference on the system.")
 
     def get_training_device_info(self, device_str: str) -> DeviceInfo:
         """

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -111,8 +111,8 @@ class SystemService:
             try:
                 if ov_device == "CPU":
                     devices.append(DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None))
-                elif ov_device.startswith("GPU."):
-                    index = int(ov_device.split(".", 1)[1])
+                elif ov_device.startswith("GPU"):
+                    index = 0 if ov_device == "GPU" else int(ov_device.split(".", 1)[1])
                     name = core.get_property(ov_device, "FULL_DEVICE_NAME")
                     try:
                         memory = int(core.get_property(ov_device, "GPU_DEVICE_TOTAL_MEM_SIZE"))

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -107,17 +107,12 @@ class SystemService:
             return [DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None)]
 
         devices: list[DeviceInfo] = []
-        seen_gpu_indices: set[int] = set()
         for ov_device in available_devices:
             try:
                 if ov_device == "CPU":
                     devices.append(DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None))
-                elif ov_device == "GPU" or ov_device.startswith("GPU."):
-                    # 'GPU' aliases 'GPU.0'; deduplicate if both are reported.
-                    index = 0 if ov_device == "GPU" else int(ov_device.split(".", 1)[1])
-                    if index in seen_gpu_indices:
-                        continue
-                    seen_gpu_indices.add(index)
+                elif ov_device.startswith("GPU."):
+                    index = int(ov_device.split(".", 1)[1])
                     name = core.get_property(ov_device, "FULL_DEVICE_NAME")
                     try:
                         memory = int(core.get_property(ov_device, "GPU_DEVICE_TOTAL_MEM_SIZE"))

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -174,30 +174,79 @@ class TestSystemService:
             assert fxt_system_service.validate_device("cuda-0") is False
 
     def test_get_inference_devices_with_multiple_devices(self, fxt_system_service: SystemService):
-        """Test getting inference devices when multiple GPUs are available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            # Mock XPU device
-            mock_xpu_dp = MagicMock()
-            mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
-            mock_xpu_dp.total_memory = 36022263808
+        """Test getting inference devices via OpenVINO when CPU and GPU(s) are available"""
 
-            mock_torch.xpu.is_available.return_value = True
-            mock_torch.xpu.device_count.return_value = 1
-            mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+        def fake_get_property(device: str, prop: str):
+            if prop == "FULL_DEVICE_NAME":
+                return {
+                    "GPU.0": "Intel(R) Graphics [0x7d41]",
+                    "GPU.1": "Intel(R) Arc(TM) A770",
+                }[device]
+            if prop == "GPU_DEVICE_TOTAL_MEM_SIZE":
+                return {"GPU.0": 36022263808, "GPU.1": 17179869184}[device]
+            raise KeyError(prop)
 
-            # Mock CUDA device
-            mock_cuda_dp = MagicMock()
-            mock_cuda_dp.name = "NVIDIA GeForce RTX 4090"
-            mock_cuda_dp.total_memory = 25769803776
+        mock_core = MagicMock()
+        mock_core.available_devices = ["CPU", "GPU.0", "GPU.1"]
+        mock_core.get_property.side_effect = fake_get_property
 
-            mock_torch.cuda.is_available.return_value = True
-            mock_torch.cuda.device_count.return_value = 1
-            mock_torch.cuda.get_device_properties.return_value = mock_cuda_dp
-
+        with patch("openvino.Core", return_value=mock_core):
             inference_devices = fxt_system_service.get_inference_devices()
 
-            assert len(inference_devices) == 2
-            assert not any(device.type == "cuda" for device in inference_devices)
+        assert len(inference_devices) == 3
+        assert not any(device.type == "cuda" for device in inference_devices)
+        assert inference_devices[0].type == "cpu"
+        assert inference_devices[0].name == "CPU"
+        assert inference_devices[0].memory is None
+        assert inference_devices[0].index is None
+        assert inference_devices[1].type == "xpu"
+        assert inference_devices[1].name == "Intel(R) Graphics [0x7d41]"
+        assert inference_devices[1].memory == 36022263808
+        assert inference_devices[1].index == 0
+        assert inference_devices[2].type == "xpu"
+        assert inference_devices[2].index == 1
+        assert inference_devices[2].memory == 17179869184
+
+    def test_get_inference_devices_cpu_only(self, fxt_system_service: SystemService):
+        """Test getting inference devices when only CPU is available via OpenVINO"""
+        mock_core = MagicMock()
+        mock_core.available_devices = ["CPU"]
+
+        with patch("openvino.Core", return_value=mock_core):
+            inference_devices = fxt_system_service.get_inference_devices()
+
+        assert len(inference_devices) == 1
+        assert inference_devices[0].type == "cpu"
+
+    def test_get_inference_devices_gpu_alias(self, fxt_system_service: SystemService):
+        """Test that 'GPU' (alias for 'GPU.0') is deduplicated when both are reported"""
+
+        def fake_get_property(device: str, prop: str):
+            if prop == "FULL_DEVICE_NAME":
+                return "Intel(R) Graphics [0x7d41]"
+            if prop == "GPU_DEVICE_TOTAL_MEM_SIZE":
+                return 36022263808
+            raise KeyError(prop)
+
+        mock_core = MagicMock()
+        mock_core.available_devices = ["CPU", "GPU", "GPU.0"]
+        mock_core.get_property.side_effect = fake_get_property
+
+        with patch("openvino.Core", return_value=mock_core):
+            inference_devices = fxt_system_service.get_inference_devices()
+
+        # CPU + a single GPU at index 0 (GPU aliases GPU.0)
+        assert len(inference_devices) == 2
+        assert inference_devices[1].type == "xpu"
+        assert inference_devices[1].index == 0
+
+    def test_get_inference_devices_fallback_on_error(self, fxt_system_service: SystemService):
+        """Test fallback to CPU-only when OpenVINO query fails"""
+        with patch("openvino.Core", side_effect=RuntimeError("boom")):
+            inference_devices = fxt_system_service.get_inference_devices()
+
+        assert len(inference_devices) == 1
+        assert inference_devices[0].type == "cpu"
 
     def test_validate_device_invalid_type(self, fxt_system_service: SystemService):
         """Test validating invalid device types"""

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -218,28 +218,6 @@ class TestSystemService:
         assert len(inference_devices) == 1
         assert inference_devices[0].type == "cpu"
 
-    def test_get_inference_devices_gpu_alias(self, fxt_system_service: SystemService):
-        """Test that 'GPU' (alias for 'GPU.0') is deduplicated when both are reported"""
-
-        def fake_get_property(device: str, prop: str):
-            if prop == "FULL_DEVICE_NAME":
-                return "Intel(R) Graphics [0x7d41]"
-            if prop == "GPU_DEVICE_TOTAL_MEM_SIZE":
-                return 36022263808
-            raise KeyError(prop)
-
-        mock_core = MagicMock()
-        mock_core.available_devices = ["CPU", "GPU", "GPU.0"]
-        mock_core.get_property.side_effect = fake_get_property
-
-        with patch("openvino.Core", return_value=mock_core):
-            inference_devices = fxt_system_service.get_inference_devices()
-
-        # CPU + a single GPU at index 0 (GPU aliases GPU.0)
-        assert len(inference_devices) == 2
-        assert inference_devices[1].type == "xpu"
-        assert inference_devices[1].index == 0
-
     def test_get_inference_devices_fallback_on_error(self, fxt_system_service: SystemService):
         """Test fallback to CPU-only when OpenVINO query fails"""
         with patch("openvino.Core", side_effect=RuntimeError("boom")):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Uses `ov.Core` to query the inference devices rather than `PyTorch`

### How to test

Select your device as inference device.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
