### PR TITLE
Avoid duplicated opencv/ort fetches

### DIFF
--- a/application/ui/rsbuild.config.ts
+++ b/application/ui/rsbuild.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
         headers: {
             'Cross-Origin-Embedder-Policy': 'credentialless',
             'Cross-Origin-Opener-Policy': 'same-origin',
+            'Cache-Control': 'public, max-age=31536000, immutable',
             'Content-Security-Policy':
                 "default-src 'self'; " +
                 "script-src 'self' 'unsafe-eval' blob:; " +

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -32,6 +32,15 @@ type SegmentAnythingRemoteInstance = Remote<SegmentAnythingWorkerInstance>;
 // A single shared worker hosts BOTH the encoder and decoder ONNX sessions.
 // Spawning two workers used to double the OpenCV + ONNX Runtime WASM footprint
 // for no functional gain (encoder/decoder always run sequentially anyway).
+//
+// `gcTime: Infinity` is critical: the default 5-min gc would evict the worker
+// entry whenever SAM is unmounted (switching tools/projects), causing the
+// next mount to spawn a brand-new worker that re-downloads the ORT wasm +
+// JSEP `.mjs` glue + the multi-MB SAM `.onnx` models. It would also leak the
+// previous worker, since tanstack doesn't fire the abort signal on gc — only
+// on cancellation of an in-flight query. Keeping the entry alive for the
+// lifetime of the page reuses the same worker (and its resident sessions)
+// across every mount.
 const segmentAnythingWorkerQueryOptions = (enabled = true) =>
     queryOptions<{ worker: Worker; instance: SegmentAnythingRemoteInstance }>({
         queryKey: ['workers', 'SEGMENT_ANYTHING'],
@@ -41,7 +50,17 @@ const segmentAnythingWorkerQueryOptions = (enabled = true) =>
             });
             // Terminate the worker if the query is cancelled (e.g. annotator unmounts)
             // before build/init resolve, so we don't leak the in-flight worker.
-            signal.addEventListener('abort', worker.terminate, { once: true });
+            //
+            // CRITICAL: pass an arrow function, NOT `worker.terminate` directly.
+            // addEventListener invokes the listener with `this = signal`, and
+            // `Worker.prototype.terminate` requires `this` to be a Worker — it
+            // throws "Illegal invocation" silently and the worker is never
+            // killed. With React StrictMode double-mounting effects (or any
+            // transient cancellation), every cycle leaked a fresh worker, each
+            // of which independently re-fetched opencv (~1MB), the ort bundle,
+            // ort wasm, and the SAM `.onnx` models. That was the dominant
+            // source of the "ort/opencv fetched 6 times" symptom.
+            signal.addEventListener('abort', () => worker.terminate(), { once: true });
 
             try {
                 const samWorker = wrap<SegmentAnythingWorkerApi>(worker);
@@ -70,6 +89,7 @@ const segmentAnythingWorkerQueryOptions = (enabled = true) =>
             }
         },
         staleTime: Infinity,
+        gcTime: Infinity,
         enabled,
     });
 

--- a/application/ui/src/features/annotator/tools/terminate-annotator-workers-on-unmount.hook.ts
+++ b/application/ui/src/features/annotator/tools/terminate-annotator-workers-on-unmount.hook.ts
@@ -28,6 +28,10 @@ export const useTerminateAnnotatorWorkersOnUnmount = () => {
 
     useEffect(() => {
         return () => {
+            void queryClient.cancelQueries({ queryKey: ['workers'] });
+
+            // Catch already-resolved workers (cancellation is a no-op for
+            // settled queries, so they need explicit termination).
             const workerQueries = queryClient.getQueryCache().findAll({ queryKey: ['workers'] });
 
             for (const query of workerQueries) {

--- a/application/ui/src/features/annotator/tools/terminate-annotator-workers-on-unmount.hook.ts
+++ b/application/ui/src/features/annotator/tools/terminate-annotator-workers-on-unmount.hook.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Terminate every annotator-tool Worker (SAM, SSIM, magnetic-lasso) and drop
+ * the matching tanstack-query entries when the host component unmounts.
+ *
+ * Mounted at the **dataset section** (`DatasetSection` in `src/router.tsx`)
+ * — NOT inside the annotator itself — so the workers survive within-section
+ * navigation (dataset list ↔ item ↔ video frame ↔ annotator) and are only
+ * freed when the user leaves the dataset section (to Models, Inference, the
+ * projects list, etc.). Re-entering the annotator from any sibling URL
+ * inside `/projects/:id/dataset/*` is instant.
+ *
+ * Required because `useSegmentAnythingWorker` sets `gcTime: Infinity` to
+ * defeat tanstack's 5-min eviction (which would re-spawn the worker and
+ * re-download ~5×ort + ~5×opencv + the multi-MB SAM `.onnx` blobs every
+ * time SAM is unmounted). Without an explicit terminator at SOME boundary,
+ * the worker (and its ~100 MB WASM heap of model bytes + ORT + OpenCV
+ * runtimes) would persist for the lifetime of the tab.
+ */
+export const useTerminateAnnotatorWorkersOnUnmount = () => {
+    const queryClient = useQueryClient();
+
+    useEffect(() => {
+        return () => {
+            const workerQueries = queryClient.getQueryCache().findAll({ queryKey: ['workers'] });
+
+            for (const query of workerQueries) {
+                const data = query.state.data as { worker?: unknown } | undefined;
+
+                if (data?.worker instanceof Worker) {
+                    data.worker.terminate();
+                }
+            }
+
+            queryClient.removeQueries({ queryKey: ['workers'] });
+        };
+    }, [queryClient]);
+};

--- a/application/ui/src/features/annotator/tools/use-preload-webworkers.hook.ts
+++ b/application/ui/src/features/annotator/tools/use-preload-webworkers.hook.ts
@@ -1,38 +1,22 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
-
-import { useQueryClient } from '@tanstack/react-query';
-
 import { useAvailableTools } from './annotator-tools/use-available-tools';
 import { useIntelligentScissorsWorker } from './hooks/use-intelligent-scissors-worker.hook';
 import { useSegmentAnythingWorker } from './segment-anything-tool/use-segment-anything.hook';
 import { useSSIMWorker } from './ssim-tool/use-ssim.hook';
 
+/**
+ * Eagerly boot the annotator-tool web workers (SAM, SSIM, magnetic-lasso) as
+ * soon as the annotator mounts, so the heavy WASM + ONNX init runs in the
+ * background and the corresponding tools are responsive the moment the user
+ * picks them.
+ */
 export const usePreloadWebworkers = () => {
     const availableTools = useAvailableTools();
     const tools = new Set(availableTools.map((tool) => tool.type));
-    const queryClient = useQueryClient();
 
     useSegmentAnythingWorker(tools.has('sam'));
     useSSIMWorker(tools.has('ssim'));
     useIntelligentScissorsWorker(tools.has('magnetic-lasso'));
-
-    // Tear down every annotator-tool worker when the annotator unmounts.
-    useEffect(() => {
-        return () => {
-            const workerQueries = queryClient.getQueryCache().findAll({ queryKey: ['workers'] });
-
-            for (const query of workerQueries) {
-                const data = query.state.data as { worker?: unknown } | undefined;
-
-                if (data?.worker instanceof Worker) {
-                    data.worker.terminate();
-                }
-            }
-
-            queryClient.removeQueries({ queryKey: ['workers'] });
-        };
-    }, [queryClient]);
 };

--- a/application/ui/src/router.tsx
+++ b/application/ui/src/router.tsx
@@ -4,6 +4,7 @@
 import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 
 import { paths } from './constants/paths';
+import { useTerminateAnnotatorWorkersOnUnmount } from './features/annotator/tools/terminate-annotator-workers-on-unmount.hook';
 import { ImportDatasetDialogStateProvider } from './features/dataset/providers/export-import-dataset-dialog-provider.component';
 import { SelectedDataProvider } from './features/dataset/providers/selected-data-provider.component';
 import { WebRTCConnectionProvider } from './features/inference/stream/web-rtc-connection-provider';
@@ -47,6 +48,20 @@ const Redirect = () => {
     return <Navigate to={path} replace />;
 };
 
+// Owns the lifetime of the annotator-tool web workers (SAM/SSIM/scissors): they boot lazily inside
+// the annotator and are terminated here, freeing the ~100 MB WASM heap when the user leaves the dataset section.
+const DatasetSection = () => {
+    useTerminateAnnotatorWorkersOnUnmount();
+
+    return (
+        <ImportDatasetDialogStateProvider>
+            <SelectedDataProvider>
+                <Outlet />
+            </SelectedDataProvider>
+        </ImportDatasetDialogStateProvider>
+    );
+};
+
 export const router = createBrowserRouter([
     {
         path: paths.root.pattern,
@@ -84,13 +99,7 @@ export const router = createBrowserRouter([
                     },
                     {
                         path: paths.project.dataset.index.pattern,
-                        element: (
-                            <ImportDatasetDialogStateProvider>
-                                <SelectedDataProvider>
-                                    <Outlet />
-                                </SelectedDataProvider>
-                            </ImportDatasetDialogStateProvider>
-                        ),
+                        element: <DatasetSection />,
                         children: [
                             {
                                 index: true,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Also improves worker termination (We only terminate the workers once we leave the dataset page)

Explanation:
onnx spawns X workers, where X depends on the amount of cpu cores your machine has, and each worker imports ort, hence why we would see all these imports. Same goes for opencv. We could limit the threads but concurrency is what we want, so we have a tradeoff between bandwith/memory and performance.


Before:
<img width="1566" height="165" alt="Screenshot 2026-05-15 at 14 52 27" src="https://github.com/user-attachments/assets/08b8e443-569d-4b0f-98a8-5658b3c84eab" />
<img width="1563" height="267" alt="Screenshot 2026-05-15 at 14 52 34" src="https://github.com/user-attachments/assets/ec274a45-c181-4e2f-9ea0-7e0fef8594d9" />


After:
<img width="1621" height="139" alt="Screenshot 2026-05-15 at 14 51 59" src="https://github.com/user-attachments/assets/2e65e062-da1e-4b35-bc4a-edce26a8a159" />
<img width="1574" height="166" alt="Screenshot 2026-05-15 at 14 52 05" src="https://github.com/user-attachments/assets/756a6fc2-ba9a-4449-b6da-5e83a4ebccd6" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
