### PR TITLE
Add grid view modes to training datasets

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -10,6 +10,7 @@ import { MediaItem } from '../../../components/media-item/media-item.component';
 import { MediaThumbnail } from '../../../components/media-thumbnail/media-thumbnail.component';
 import { VirtualizerGridLayout } from '../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component';
 import type { Media } from '../../../constants/shared-types';
+import { type GalleryViewMode } from '../../../shared/gallery-view-modes';
 import { getMediaDownloadUrl, getThumbnailUrl } from '../../../shared/media-url.utils';
 import { MediaPreview } from '../media-preview/media-preview.component';
 import { useSelectedData } from '../providers/selected-data-provider.component';
@@ -24,7 +25,7 @@ import { useUploadFiles } from './use-upload-files';
 
 type GalleryProps = {
     items: Media[];
-    viewMode: ViewModes;
+    viewMode: GalleryViewMode;
     isPending: boolean;
     hasActiveFilter: boolean;
     isFetchingNextPage: boolean;
@@ -32,16 +33,15 @@ type GalleryProps = {
     isMediaItemReviewedById: (mediaItemId: string) => boolean;
 };
 
-// DetailsView isn’t needed, so we’re forcing the cast to prevent TS from complaining about missing properties
-const VIEW_MODE_SETTINGS = {
+const VIEW_MODE_SETTINGS: Record<GalleryViewMode, GridLayoutOptions> = {
     [ViewModes.LARGE]: { minItemSize: new Size(300, 300), minSpace: new Size(10, 10), preserveAspectRatio: true },
     [ViewModes.MEDIUM]: { minItemSize: new Size(200, 200), minSpace: new Size(6, 6), preserveAspectRatio: true },
     [ViewModes.SMALL]: { minItemSize: new Size(120, 120), minSpace: new Size(4, 4), preserveAspectRatio: true },
-} as Record<ViewModes, GridLayoutOptions>;
+};
 
 type GalleryListProps = {
     items: Media[];
-    viewMode: ViewModes;
+    viewMode: GalleryViewMode;
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
     isMediaItemReviewedById: (mediaItemId: string) => boolean;

--- a/application/ui/src/features/models/model-listing/components/box/box.component.tsx
+++ b/application/ui/src/features/models/model-listing/components/box/box.component.tsx
@@ -11,17 +11,26 @@ import classes from './box.module.scss';
 type BoxProps = {
     title: ReactNode;
     content: ReactNode;
+    actions?: ReactNode;
     headingClassName?: string;
     contentClassName?: string;
     testId?: string;
 };
 
-export const Box = ({ title, content, headingClassName, contentClassName, testId }: BoxProps) => {
+export const Box = ({ title, content, actions, headingClassName, contentClassName, testId }: BoxProps) => {
     return (
         <Flex direction={'column'} height={'100%'} UNSAFE_className={classes.boxWrapper} data-testid={testId}>
-            <Heading UNSAFE_className={clsx(classes.boxHeading, headingClassName)} level={5}>
-                {title}
-            </Heading>
+            <Flex
+                alignItems={'center'}
+                justifyContent={'space-between'}
+                gap={'size-100'}
+                UNSAFE_className={clsx(classes.boxHeading, headingClassName)}
+            >
+                <Heading level={5} margin={0} UNSAFE_className={classes.boxHeadingTitle}>
+                    {title}
+                </Heading>
+                {actions}
+            </Flex>
             <Content UNSAFE_className={clsx(classes.boxContent, contentClassName)}>{content}</Content>
         </Flex>
     );

--- a/application/ui/src/features/models/model-listing/components/box/box.module.scss
+++ b/application/ui/src/features/models/model-listing/components/box/box.module.scss
@@ -9,6 +9,14 @@
     font-weight: normal;
 }
 
+.boxHeadingTitle {
+    font-weight: normal;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .boxContent {
     background-color: var(--spectrum-global-color-gray-50);
     padding: var(--spectrum-global-dimension-size-200) var(--spectrum-global-dimension-size-300);

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -6,6 +6,7 @@ import { useNumberFormatter } from 'react-aria';
 
 import type { DatasetRevision, DatasetSubset } from '../../../../constants/shared-types';
 import { useGetDatasetRevisionItems } from '../../../../hooks/use-get-dataset-revision-items.hook';
+import { GALLERY_VIEW_MODES, type GalleryViewMode } from '../../../../shared/gallery-view-modes';
 import { Box } from '../components/box/box.component';
 import { SubsetGallery } from './subset-gallery.component';
 
@@ -15,8 +16,6 @@ type SubsetBoxProps = {
     datasetRevisionId: string;
     totalItems: number;
 };
-
-const VIEW_MODE_ITEMS = [ViewModes.LARGE, ViewModes.MEDIUM, ViewModes.SMALL];
 
 const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxProps) => {
     const { items, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, totalCount } = useGetDatasetRevisionItems(
@@ -33,12 +32,12 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
     return (
         <Box
             title={`${title} ${formatter.format(subsetPercentage)} (${totalCount})`}
-            actions={<MediaViewModes viewMode={viewMode} setViewMode={setViewMode} items={VIEW_MODE_ITEMS} />}
+            actions={<MediaViewModes viewMode={viewMode} setViewMode={setViewMode} items={GALLERY_VIEW_MODES} />}
             content={
                 <SubsetGallery
                     items={items}
                     datasetRevisionId={datasetRevisionId}
-                    viewMode={viewMode}
+                    viewMode={viewMode as GalleryViewMode}
                     fetchNextPage={fetchNextPage}
                     hasNextPage={hasNextPage}
                     isFetchingNextPage={isFetchingNextPage}

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -32,12 +32,8 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
 
     return (
         <Box
-            title={
-                <Flex alignItems={'center'} justifyContent={'space-between'} width={'100%'}>
-                    <span>{`${title} ${formatter.format(subsetPercentage)} (${totalCount})`}</span>
-                    <MediaViewModes viewMode={viewMode} setViewMode={setViewMode} items={VIEW_MODE_ITEMS} />
-                </Flex>
-            }
+            title={`${title} ${formatter.format(subsetPercentage)} (${totalCount})`}
+            actions={<MediaViewModes viewMode={viewMode} setViewMode={setViewMode} items={VIEW_MODE_ITEMS} />}
             content={
                 <SubsetGallery
                     items={items}

--- a/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/model-training-datasets.component.tsx
@@ -1,8 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActionButton, Flex, Text } from '@geti/ui';
-import { Filter, GridSmall, Search, SortUpDown } from '@geti/ui/icons';
+import { Flex, MediaViewModes, Text, useViewMode, ViewModes } from '@geti/ui';
 import { useNumberFormatter } from 'react-aria';
 
 import type { DatasetRevision, DatasetSubset } from '../../../../constants/shared-types';
@@ -17,26 +16,7 @@ type SubsetBoxProps = {
     totalItems: number;
 };
 
-// TODO: Uncomment when we want to support subset actions
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const BoxActions = () => {
-    return (
-        <Flex marginStart={'auto'} gap={'size-50'}>
-            <ActionButton isQuiet aria-label='Search dataset'>
-                <Search />
-            </ActionButton>
-            <ActionButton isQuiet aria-label='Filter dataset'>
-                <Filter />
-            </ActionButton>
-            <ActionButton isQuiet aria-label='Grid view'>
-                <GridSmall />
-            </ActionButton>
-            <ActionButton isQuiet aria-label='Sort dataset'>
-                <SortUpDown />
-            </ActionButton>
-        </Flex>
-    );
-};
+const VIEW_MODE_ITEMS = [ViewModes.LARGE, ViewModes.MEDIUM, ViewModes.SMALL];
 
 const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxProps) => {
     const { items, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, totalCount } = useGetDatasetRevisionItems(
@@ -45,17 +25,24 @@ const SubsetBox = ({ title, subset, datasetRevisionId, totalItems }: SubsetBoxPr
             subset,
         }
     );
+    const [viewMode, setViewMode] = useViewMode(`model-training-datasets-${subset}-view-mode`, ViewModes.MEDIUM);
 
     const formatter = useNumberFormatter({ style: 'percent', maximumFractionDigits: 0 });
     const subsetPercentage = totalItems > 0 ? totalCount / totalItems : 0;
 
     return (
         <Box
-            title={`${title} ${formatter.format(subsetPercentage)} (${totalCount})`}
+            title={
+                <Flex alignItems={'center'} justifyContent={'space-between'} width={'100%'}>
+                    <span>{`${title} ${formatter.format(subsetPercentage)} (${totalCount})`}</span>
+                    <MediaViewModes viewMode={viewMode} setViewMode={setViewMode} items={VIEW_MODE_ITEMS} />
+                </Flex>
+            }
             content={
                 <SubsetGallery
                     items={items}
                     datasetRevisionId={datasetRevisionId}
+                    viewMode={viewMode}
                     fetchNextPage={fetchNextPage}
                     hasNextPage={hasNextPage}
                     isFetchingNextPage={isFetchingNextPage}

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -24,8 +24,7 @@ const VIEW_MODE_SETTINGS: Record<ViewModes, GridLayoutOptions> = {
     [ViewModes.LARGE]: { minItemSize: new Size(180, 180), minSpace: new Size(6, 6), preserveAspectRatio: true },
     [ViewModes.MEDIUM]: { minItemSize: new Size(120, 120), minSpace: new Size(4, 4), preserveAspectRatio: true },
     [ViewModes.SMALL]: { minItemSize: new Size(80, 80), minSpace: new Size(4, 4), preserveAspectRatio: true },
-    [ViewModes.DETAILS]: { minItemSize: new Size(80, 80), minSpace: new Size(4, 4), preserveAspectRatio: true },
-};
+} as Record<ViewModes, GridLayoutOptions>;
 
 type SubsetGalleryProps = {
     items: DatasetRevisionItem[];

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -3,8 +3,9 @@
 
 import { Suspense, useState } from 'react';
 
-import { Content, Dialog, DialogContainer, Flex, Grid, Loading, Size, Text, View } from '@geti/ui';
+import { Content, Dialog, DialogContainer, Flex, Grid, Loading, Size, Text, View, ViewModes } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { GridLayoutOptions } from 'react-aria-components';
 
 import { MediaItem } from '../../../../components/media-item/media-item.component';
 import { MediaThumbnail } from '../../../../components/media-thumbnail/media-thumbnail.component';
@@ -19,16 +20,17 @@ import { useLoadImageQuery } from '../../../annotator/hooks/use-load-image-query
 import { getImageData } from '../../../annotator/tools/utils';
 import { datasetRevisionItemToMedia } from './utils';
 
-const layoutOptions = {
-    minSpace: new Size(4, 4),
-    minItemSize: new Size(80, 80),
-    maxColumns: 4,
-    preserveAspectRatio: true,
+const VIEW_MODE_SETTINGS: Record<ViewModes, GridLayoutOptions> = {
+    [ViewModes.LARGE]: { minItemSize: new Size(180, 180), minSpace: new Size(6, 6), preserveAspectRatio: true },
+    [ViewModes.MEDIUM]: { minItemSize: new Size(120, 120), minSpace: new Size(4, 4), preserveAspectRatio: true },
+    [ViewModes.SMALL]: { minItemSize: new Size(80, 80), minSpace: new Size(4, 4), preserveAspectRatio: true },
+    [ViewModes.DETAILS]: { minItemSize: new Size(80, 80), minSpace: new Size(4, 4), preserveAspectRatio: true },
 };
 
 type SubsetGalleryProps = {
     items: DatasetRevisionItem[];
     datasetRevisionId: string;
+    viewMode: ViewModes;
     fetchNextPage: () => void;
     hasNextPage: boolean;
     isFetchingNextPage: boolean;
@@ -86,6 +88,7 @@ const SubsetMediaDialog = ({ item, onClose }: SubsetMediaDialogProps) => {
 
 export const SubsetGallery = ({
     items,
+    viewMode,
     datasetRevisionId,
     hasNextPage,
     isFetchingNextPage,
@@ -118,7 +121,7 @@ export const SubsetGallery = ({
                     items={items}
                     ariaLabel={'subset media grid'}
                     selectionMode='none'
-                    layoutOptions={layoutOptions}
+                    layoutOptions={VIEW_MODE_SETTINGS[viewMode]}
                     isLoadingMore={isFetchingNextPage}
                     onLoadMore={() => hasNextPage && fetchNextPage()}
                     contentItem={(item) => (

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-gallery.component.tsx
@@ -15,21 +15,22 @@ import { AnnotatorProviders } from '../../../../features/dataset/media-preview/a
 import { useAnnotationsQuery } from '../../../../features/dataset/media-preview/api/use-annotations-query';
 import { ReadOnlyAnnotator } from '../../../../features/dataset/media-preview/read-only-annotator.component';
 import { getInitialAnnotations } from '../../../../features/dataset/media-preview/utils';
+import { type GalleryViewMode } from '../../../../shared/gallery-view-modes';
 import { getDatasetRevisionThumbnailUrl } from '../../../../shared/media-url.utils';
 import { useLoadImageQuery } from '../../../annotator/hooks/use-load-image-query.hook';
 import { getImageData } from '../../../annotator/tools/utils';
 import { datasetRevisionItemToMedia } from './utils';
 
-const VIEW_MODE_SETTINGS: Record<ViewModes, GridLayoutOptions> = {
+const VIEW_MODE_SETTINGS: Record<GalleryViewMode, GridLayoutOptions> = {
     [ViewModes.LARGE]: { minItemSize: new Size(180, 180), minSpace: new Size(6, 6), preserveAspectRatio: true },
     [ViewModes.MEDIUM]: { minItemSize: new Size(120, 120), minSpace: new Size(4, 4), preserveAspectRatio: true },
     [ViewModes.SMALL]: { minItemSize: new Size(80, 80), minSpace: new Size(4, 4), preserveAspectRatio: true },
-} as Record<ViewModes, GridLayoutOptions>;
+};
 
 type SubsetGalleryProps = {
     items: DatasetRevisionItem[];
     datasetRevisionId: string;
-    viewMode: ViewModes;
+    viewMode: GalleryViewMode;
     fetchNextPage: () => void;
     hasNextPage: boolean;
     isFetchingNextPage: boolean;

--- a/application/ui/src/routes/dataset/dataset.component.tsx
+++ b/application/ui/src/routes/dataset/dataset.component.tsx
@@ -9,6 +9,7 @@ import { Gallery } from '../../features/dataset/gallery/gallery.component';
 import { Toolbar } from '../../features/dataset/gallery/toolbar/toolbar.component';
 import { ExportJobsList } from '../../features/dataset/import-export/export-jobs-list/export-jobs-list.component';
 import { ImportJobsList } from '../../features/dataset/import-export/import-jobs-list/import-jobs-list.component';
+import { GalleryViewMode } from '../../shared/gallery-view-modes';
 
 export const Dataset = () => {
     const [viewMode, setViewMode] = useViewMode('dataset-gallery-view-mode');
@@ -42,7 +43,7 @@ export const Dataset = () => {
             <View gridRow='3 / 4'>
                 <Gallery
                     items={items}
-                    viewMode={viewMode}
+                    viewMode={viewMode as GalleryViewMode}
                     isPending={isPending}
                     fetchNextPage={fetchNextPage}
                     isMediaItemReviewedById={isMediaItemReviewedById}

--- a/application/ui/src/shared/gallery-view-modes.ts
+++ b/application/ui/src/shared/gallery-view-modes.ts
@@ -1,0 +1,10 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { ViewModes } from '@geti/ui';
+
+// View modes used by media galleries. ViewModes.DETAILS is intentionally
+// excluded because none of the galleries render a details/list view.
+export type GalleryViewMode = ViewModes.LARGE | ViewModes.MEDIUM | ViewModes.SMALL;
+
+export const GALLERY_VIEW_MODES: GalleryViewMode[] = [ViewModes.LARGE, ViewModes.MEDIUM, ViewModes.SMALL];


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<img width="2113" height="728" alt="Screenshot 2026-05-15 at 15 30 38" src="https://github.com/user-attachments/assets/fd93e826-9a5d-400d-bf6d-bdbbcd5459b6" />


* Add grid view modes to training datasets
* Closes https://github.com/open-edge-platform/training_extensions/issues/5466 (all other options make no sense whatsoever)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
