### PR TITLE
Fix libglib2.0 dependency

### DIFF
--- a/application/docker/Dockerfile
+++ b/application/docker/Dockerfile
@@ -178,7 +178,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install -y --no-install-recommends \
         git=1:2.47.3-0* \
         libgl1=1.7.0-1+b2 \
-        libglib2.0-0t64=2.84.4-3~deb13u2 \
+        libglib2.0-0t64=2.84.4-3~deb13u3 \
         libglx-mesa0=25.0.7-2 \
         libv4l-0t64=1.30.1-1
 


### PR DESCRIPTION
### Summary

Upgrade libglib2.0 since the previous version is no longer available upstream

resolves #6501 

### How to test

Build the Docker image

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
