### PR TITLE
fix: Don't cancel last subscribed observer for range frames predictions

### DIFF
--- a/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
+++ b/application/ui/src/features/annotator/annotations/video-annotations.component.tsx
@@ -81,25 +81,7 @@ export const VideoPredictions = () => {
         selector: (data) => {
             const idxToPredictionsMap = new Map(data.map((frame) => [frame.media.frame_index, frame.prediction]));
 
-            if (idxToPredictionsMap.has(videoFrame.frame_number)) {
-                return mapServerAnnotationsToLocal(idxToPredictionsMap.get(videoFrame.frame_number) ?? [], labels);
-            }
-
-            for (let i = 0; i < PREDICTION_CHUNK_SIZE; i++) {
-                if (idxToPredictionsMap.has(videoFrame.frame_number + i)) {
-                    return mapServerAnnotationsToLocal(
-                        idxToPredictionsMap.get(videoFrame.frame_number + i) ?? [],
-                        labels
-                    );
-                } else if (idxToPredictionsMap.has(videoFrame.frame_number - i)) {
-                    return mapServerAnnotationsToLocal(
-                        idxToPredictionsMap.get(videoFrame.frame_number - i) ?? [],
-                        labels
-                    );
-                }
-            }
-
-            return mapServerAnnotationsToLocal([], labels);
+            return mapServerAnnotationsToLocal(idxToPredictionsMap.get(videoFrame.frame_number) ?? [], labels);
         },
     });
 

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -294,9 +294,9 @@ export const AnnotatorCanvas = ({
         canEditSelectedAnnotation,
     });
 
-    const isEmptyImage = image.width === 1;
+    const isPlaceholderImage = image.width === 1 && image.height === 1;
 
-    if (isLoadingMedia && isEmptyImage) {
+    if (isLoadingMedia && isPlaceholderImage) {
         return <Loading size='M' />;
     }
 

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -27,6 +27,7 @@ import { usePrefetchVideoFramesAnnotations } from '../video-player/api/use-video
 import {
     PREDICTION_CHUNK_SIZE,
     PREDICTION_FRAME_SKIP,
+    useKeepVideoFramesPredictionsSubscribed,
     usePrefetchVideoFramesPredictions,
 } from '../video-player/api/use-video-frames-predictions';
 import { getVideoFrameRangeIndexes } from '../video-player/api/utils';
@@ -112,11 +113,29 @@ const PrefetchPredictions = () => {
         frameNumber: videoFrame.frame_number,
         chunkSize: PREDICTION_CHUNK_SIZE,
     });
-    usePrefetchVideoFramesPredictions({
+
+    /**
+     * Keeps a long-lived React Query observer attached to the current video-frame
+     * predictions range chunk.
+     *
+     * `<VideoPredictions />` is only mounted while the video is playing. When its
+     * range-predictions request is in flight, `usePlayPauseVideoBySystem` pauses
+     * the video, which unmounts `<VideoPredictions />` and drops the last observer
+     * — causing React Query to abort the in-flight request. The loading flag then
+     * flips back to false, playback auto-resumes, the same chunk re-fetches, and
+     * the cycle repeats (the video stutters and predictions never load).
+     *
+     * `PrefetchPredictions` is mounted in both the playing and paused branches, so
+     * subscribing from there guarantees the observer count never reaches zero
+     * across a pause/play transition. `notifyOnChangeProps: []` ensures this hook
+     * holds the subscription without triggering re-renders.
+     */
+    useKeepVideoFramesPredictionsSubscribed({
         frameNumber: videoFrame.frame_number,
         frameSkip: PREDICTION_FRAME_SKIP,
         chunkSize: PREDICTION_CHUNK_SIZE,
     });
+
     usePrefetchVideoFramesPredictions({
         frameNumber: nextFrameRangeIndexes.endFrameIndex + 1,
         frameSkip: PREDICTION_FRAME_SKIP,
@@ -257,9 +276,10 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
     const { isSingleEditableSelection } = useEditableAnnotationState();
+
     const isFetchingMedia = useIsFetching({ queryKey: loadImageQueryOptions(projectId, mediaItem).queryKey }) > 0;
 
-    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 300, minDuration: 200 });
+    const isLoadingMedia = useSpinDelay(isFetchingMedia, { delay: 400, minDuration: 200 });
     const areToolsDisabled = isSceneBusy || isReadOnly;
     const size = { width: mediaItem.width, height: mediaItem.height };
     const canEditSelectedAnnotation = !areToolsDisabled && isSingleEditableSelection;

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -185,6 +185,7 @@ type AnnotatorCanvasProps = {
     image: ImageData;
     isReadOnly?: boolean;
     mode: AnnotatorMode;
+    isLoadingPredictions?: boolean;
 };
 
 type UseToolLayerPointerPassthroughProps = {
@@ -271,7 +272,13 @@ const useToolLayerPointerPassthrough = ({ canEditSelectedAnnotation }: UseToolLa
     return { toolLayerRef, toolLayerPointerEvents, handlePointerMove } as const;
 };
 
-export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: AnnotatorCanvasProps) => {
+export const AnnotatorCanvas = ({
+    mode,
+    mediaItem,
+    image,
+    isReadOnly = false,
+    isLoadingPredictions = false,
+}: AnnotatorCanvasProps) => {
     const projectId = useProjectIdentifier();
     const isSceneBusy = useIsAnnotatorSceneBusy();
     const { canvasRef } = useAnnotator();
@@ -287,7 +294,9 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
         canEditSelectedAnnotation,
     });
 
-    if (isLoadingMedia) {
+    const isEmptyImage = image.width === 1;
+
+    if (isLoadingMedia && isEmptyImage) {
         return <Loading size='M' />;
     }
 
@@ -300,6 +309,7 @@ export const AnnotatorCanvas = ({ mode, mediaItem, image, isReadOnly = false }: 
                 className={isReadOnly ? classes.readOnlyCanvas : undefined}
                 ref={canvasRef}
             >
+                {(isLoadingMedia || isLoadingPredictions) && <Loading mode={'overlay'} />}
                 <MediaImage image={image} mediaItem={mediaItem} />
                 <MediaAnnotations mediaItem={mediaItem} mode={mode} />
 

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -137,7 +137,7 @@ export const useIsFetchingCurrentFramePredictions = (mediaId: string) => {
 export const useIsFetchingPredictions = (mediaId: string) => {
     const videoContext = useVideoPlayerContext();
 
-    const isPlaying = videoContext?.videoControls.isPlaying ?? false;
+    const isPlaying = videoContext?.videoControls.isPlaying === true;
 
     const isFetchingRange = useIsFetchingCurrentRangeFramesPredictions(mediaId);
     const isFetchingSingleFrame = useIsFetchingCurrentFramePredictions(mediaId);

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -64,6 +64,27 @@ export const usePrefetchVideoFramesPredictions = ({
     return usePrefetchQuery(queryOptions);
 };
 
+export const useKeepVideoFramesPredictionsSubscribed = ({
+    frameNumber,
+    frameSkip,
+    rangeStride,
+    chunkSize,
+}: {
+    frameNumber: number;
+    frameSkip: number;
+    rangeStride?: number;
+    chunkSize?: number;
+}) => {
+    const queryOptions = useVideoFramesPredictionsQueryOptions({ frameSkip, frameNumber, chunkSize, rangeStride });
+
+    useQuery({
+        ...queryOptions,
+        notifyOnChangeProps: [],
+        staleTime: Infinity,
+        refetchOnMount: false,
+    });
+};
+
 export const useVideoFramesPredictions = <T>({
     frameNumber,
     frameSkip,

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -3,7 +3,7 @@
 
 import { useRef, useState } from 'react';
 
-import { Key, Loading, View } from '@geti/ui';
+import { Key, View } from '@geti/ui';
 import { useSpinDelay } from 'spin-delay';
 
 import type { DatasetSubset, Media } from '../../../constants/shared-types';
@@ -147,9 +147,14 @@ const Annotator = ({
             </View>
 
             <View gridArea={'canvas'} overflow={'hidden'} position={'relative'}>
-                {isLoadingFramesPredictionsDelayed && <Loading mode={'overlay'} />}
                 <AnnotatorCanvasSettings>
-                    <AnnotatorCanvas mediaItem={mediaItem} image={image} mode={mode} isReadOnly={isPredictionMode} />
+                    <AnnotatorCanvas
+                        isLoadingPredictions={isLoadingFramesPredictionsDelayed}
+                        mediaItem={mediaItem}
+                        image={image}
+                        mode={mode}
+                        isReadOnly={isPredictionMode}
+                    />
                 </AnnotatorCanvasSettings>
             </View>
         </>

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -4,6 +4,7 @@
 import { useRef, useState } from 'react';
 
 import { Key, Loading, View } from '@geti/ui';
+import { useSpinDelay } from 'spin-delay';
 
 import type { DatasetSubset, Media } from '../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
@@ -91,6 +92,11 @@ const Annotator = ({
     const isLoadingCurrentRangePredictions =
         useIsFetchingCurrentRangeFramesPredictions(mediaItem.id) && isPredictionMode;
 
+    const isLoadingFramesPredictionsDelayed = useSpinDelay(isLoadingPredictions, {
+        delay: 400,
+        minDuration: 200,
+    });
+
     usePlayPauseVideoBySystem(isLoadingCurrentRangePredictions);
 
     const selectNextMediaItem = async () => {
@@ -141,7 +147,7 @@ const Annotator = ({
             </View>
 
             <View gridArea={'canvas'} overflow={'hidden'} position={'relative'}>
-                {isLoadingPredictions && <Loading mode={'overlay'} />}
+                {isLoadingFramesPredictionsDelayed && <Loading mode={'overlay'} />}
                 <AnnotatorCanvasSettings>
                     <AnnotatorCanvas mediaItem={mediaItem} image={image} mode={mode} isReadOnly={isPredictionMode} />
                 </AnnotatorCanvasSettings>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that the single component that was responsible for fetching predictions for range of frames, when fetching, was unmounted by automatic pauses by system (while buffering). When it got unmounted, pending request was cancelled, video was unpaused, request was triggered again, video got paused again, component got unmounted, request was cancelled etc. This PR fixes that issue.
Moreover fixed UX a bit so we show loading with delay and only in one place that is relative to canvas (previous implementation was showed loading on he whole available canvas area, not the real canvas area where the img/video is displayed).

Fix #6485 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
