### PR TITLE
fix: Reset RFDETR classification bias after head reinitialization

### DIFF
--- a/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
+++ b/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
@@ -77,9 +77,6 @@ class RFDETRMixin:
         detector.model.args.num_classes = num_classes
 
         # Reset classification biases to zero (sigmoid=0.5 neutral prior).
-        # The upstream reinitialize_detection_head slices COCO-pretrained biases
-        # (~-4.6, i.e. sigmoid~0.01) which are meaningless for the new label
-        # space and too negative for few-class models to overcome.
         torch.nn.init.zeros_(lwdetr_model.class_embed.bias)
         if getattr(lwdetr_model, "two_stage", False):
             for enc_cls_embed in lwdetr_model.transformer.enc_out_class_embed:

--- a/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
+++ b/library/src/getitune/backend/lightning/models/common/rfdetr_mixin.py
@@ -76,6 +76,15 @@ class RFDETRMixin:
         detector.model.reinitialize_detection_head(num_classes)
         detector.model.args.num_classes = num_classes
 
+        # Reset classification biases to zero (sigmoid=0.5 neutral prior).
+        # The upstream reinitialize_detection_head slices COCO-pretrained biases
+        # (~-4.6, i.e. sigmoid~0.01) which are meaningless for the new label
+        # space and too negative for few-class models to overcome.
+        torch.nn.init.zeros_(lwdetr_model.class_embed.bias)
+        if getattr(lwdetr_model, "two_stage", False):
+            for enc_cls_embed in lwdetr_model.transformer.enc_out_class_embed:
+                torch.nn.init.zeros_(enc_cls_embed.bias)
+
         # Build criterion and postprocessor
         model_cfg = detector.get_model_config().model_dump()
         train_cfg = detector.get_train_config(dataset_dir="").model_dump()


### PR DESCRIPTION
The upstream reinitialize_detection_head slices COCO-pretrained biases (~-4.6, sigmoid~0.01) which are meaningless for the new label space. For few-class models, training cannot overcome this strong negative prior, resulting in confidence scores too low for the application to display predictions. Reset bias to zero (sigmoid=0.5 neutral prior) so training converges to high-confidence scores.

Resolves https://github.com/open-edge-platform/training_extensions/issues/6466#issuecomment-4477699061

<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
