### PR TITLE
fix: Display project thumbnail when available

### DIFF
--- a/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
+++ b/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
@@ -2,43 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Flex, Text } from '@geti/ui';
-import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useNavigate } from 'react-router';
 
-import type { SchemaProjectView } from '../../../api/openapi-spec';
 import { paths } from '../../../constants/paths';
+import { Project } from '../../../constants/shared-types';
 import { MenuActions } from '../../../features/project/list/menu-actions/menu-actions.component';
-import { useProjects } from '../../../hooks/api/project.hook';
 import { ProjectThumbnail } from '../project-thumbnail/project-thumbnail.component';
 
 import classes from './project-list-item.module.scss';
 
 interface ProjectListItemProps {
-    project: SchemaProjectView;
+    project: Project;
+    projectNames: string[];
 }
 
-export const ProjectListItem = ({ project }: ProjectListItemProps) => {
+export const ProjectListItem = ({ project, projectNames }: ProjectListItemProps) => {
     const navigate = useNavigate();
-    const currentProjectId = useProjectIdentifier();
-    const { data: projects } = useProjects();
 
     const handleNavigateToProject = () => {
         navigate(paths.project.dataset.index({ projectId: project.id }));
     };
-
-    const handleDeleted = () => {
-        if (project.id === currentProjectId) {
-            const remainingProjects = projects.filter((p) => p.id !== project.id);
-
-            if (remainingProjects.length > 0) {
-                navigate(paths.project.index({}));
-            } else {
-                navigate(paths.project.new({}));
-            }
-        }
-    };
-
-    const projectNames = projects.filter(({ id }) => id !== project.id).map(({ name }) => name);
 
     return (
         <li className={classes.projectListItem} onClick={handleNavigateToProject}>
@@ -53,7 +36,6 @@ export const ProjectListItem = ({ project }: ProjectListItemProps) => {
                     projectId={project.id}
                     projectName={project.name}
                     isPipelineRunning={project.active_pipeline}
-                    onDeleted={handleDeleted}
                     projectNames={projectNames}
                 />
             </Flex>

--- a/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
+++ b/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
@@ -1,7 +1,7 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Flex, PhotoPlaceholder, Text } from '@geti/ui';
+import { Flex, Text } from '@geti/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useNavigate } from 'react-router';
 
@@ -9,6 +9,7 @@ import type { SchemaProjectView } from '../../../api/openapi-spec';
 import { paths } from '../../../constants/paths';
 import { MenuActions } from '../../../features/project/list/menu-actions/menu-actions.component';
 import { useProjects } from '../../../hooks/api/project.hook';
+import { ProjectThumbnail } from '../project-thumbnail/project-thumbnail.component';
 
 import classes from './project-list-item.module.scss';
 
@@ -43,12 +44,7 @@ export const ProjectListItem = ({ project }: ProjectListItemProps) => {
         <li className={classes.projectListItem} onClick={handleNavigateToProject}>
             <Flex justifyContent='space-between' alignItems='center' marginX={'size-200'}>
                 <Flex alignItems={'center'} gap={'size-100'} minWidth={0}>
-                    <PhotoPlaceholder
-                        name={project.name}
-                        indicator={project.id ?? project.name}
-                        height={'size-300'}
-                        width={'size-300'}
-                    />
+                    <ProjectThumbnail project={project} height={'size-300'} width={'size-300'} />
                     <Text UNSAFE_className={classes.projectName}>
                         <span title={project.name}>{project.name}</span>
                     </Text>

--- a/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.component.tsx
+++ b/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.component.tsx
@@ -5,13 +5,13 @@ import { useState } from 'react';
 
 import { PhotoPlaceholder, View, type DimensionValue } from '@geti/ui';
 
-import type { SchemaProjectView } from '../../../api/openapi-spec';
+import { type Project } from '../../../constants/shared-types';
 import { getProjectThumbnailUrl } from '../../../shared/media-url.utils';
 
 import classes from './project-thumbnail.module.scss';
 
 interface ProjectThumbnailProps {
-    project: Pick<SchemaProjectView, 'id' | 'name'>;
+    project: Pick<Project, 'id' | 'name'>;
     height: DimensionValue;
     width: DimensionValue;
 }

--- a/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.component.tsx
+++ b/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.component.tsx
@@ -1,0 +1,43 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { useState } from 'react';
+
+import { PhotoPlaceholder, View, type DimensionValue } from '@geti/ui';
+
+import type { SchemaProjectView } from '../../../api/openapi-spec';
+import { getProjectThumbnailUrl } from '../../../shared/media-url.utils';
+
+import classes from './project-thumbnail.module.scss';
+
+interface ProjectThumbnailProps {
+    project: Pick<SchemaProjectView, 'id' | 'name'>;
+    height: DimensionValue;
+    width: DimensionValue;
+}
+
+export const ProjectThumbnail = ({ project, height, width }: ProjectThumbnailProps) => {
+    const [isError, setIsError] = useState(false);
+
+    if (isError) {
+        return (
+            <PhotoPlaceholder
+                name={project.name}
+                indicator={project.id ?? project.name}
+                height={height}
+                width={width}
+            />
+        );
+    }
+
+    return (
+        <View width={width} height={height} UNSAFE_className={classes.thumbnailWrapper}>
+            <img
+                src={getProjectThumbnailUrl(project.id)}
+                alt={project.name}
+                onError={() => setIsError(true)}
+                className={classes.thumbnail}
+            />
+        </View>
+    );
+};

--- a/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.component.tsx
+++ b/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.component.tsx
@@ -10,11 +10,11 @@ import { getProjectThumbnailUrl } from '../../../shared/media-url.utils';
 
 import classes from './project-thumbnail.module.scss';
 
-interface ProjectThumbnailProps {
+type ProjectThumbnailProps = {
     project: Pick<Project, 'id' | 'name'>;
     height: DimensionValue;
     width: DimensionValue;
-}
+};
 
 export const ProjectThumbnail = ({ project, height, width }: ProjectThumbnailProps) => {
     const [isError, setIsError] = useState(false);

--- a/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.module.scss
+++ b/application/ui/src/components/project-panel/project-thumbnail/project-thumbnail.module.scss
@@ -1,0 +1,11 @@
+.thumbnailWrapper {
+    border-radius: 50%;
+    overflow: hidden;
+}
+
+.thumbnail {
+    object-fit: cover;
+    display: block;
+    width: 100%;
+    height: 100%;
+}

--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -16,10 +16,12 @@ import {
     View,
 } from '@geti/ui';
 import { AddCircle } from '@geti/ui/icons';
+import { dimensionValue } from '@react-spectrum/utils';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useNavigate } from 'react-router';
 
 import { paths } from '../../constants/paths';
+import { MenuActions } from '../../features/project/list/menu-actions/menu-actions.component';
 import { useProjects } from '../../hooks/api/project.hook';
 import { ProjectThumbnail } from './project-thumbnail/project-thumbnail.component';
 import { ProjectsList } from './projects-list.component';
@@ -81,12 +83,20 @@ const AddProjectButton = () => {
 };
 
 export const ProjectsListPanel = () => {
+    const navigate = useNavigate();
     const projectId = useProjectIdentifier();
     const { data } = useProjects();
 
     const selectedProject = data.find((project) => project.id === projectId);
     const selectedProjectName = selectedProject?.name ?? '';
     const hasActivePipeline = Boolean(selectedProject?.active_pipeline);
+
+    const otherProjects = data.filter((project) => project.id !== projectId);
+    const otherProjectNames = otherProjects.map(({ name }) => name);
+
+    const handleDeleted = () => {
+        navigate(paths.project.index({}));
+    };
 
     return (
         <DialogTrigger type='popover' hideArrow>
@@ -102,26 +112,44 @@ export const ProjectsListPanel = () => {
                         UNSAFE_style={{
                             padding: 'var(--spectrum-global-dimension-size-200)',
                         }}
+                        gap={'size-100'}
                     >
                         <ProjectThumbnail
                             project={{ name: selectedProjectName, id: selectedProject?.id ?? selectedProjectName }}
                             height={'size-1000'}
                             width={'size-1000'}
                         />
-                        <Heading UNSAFE_style={{ textAlign: 'center' }} level={2} marginBottom={0}>
-                            {selectedProjectName}
-                        </Heading>
+                        <View width={'100%'} position={'relative'}>
+                            <Heading UNSAFE_style={{ textAlign: 'center' }} level={2} marginBottom={0}>
+                                {selectedProjectName}
+                            </Heading>
+                            {selectedProject !== undefined ? (
+                                <MenuActions
+                                    projectId={selectedProject.id}
+                                    projectName={selectedProject.name}
+                                    isPipelineRunning={selectedProject.active_pipeline}
+                                    projectNames={otherProjectNames}
+                                    onDeleted={handleDeleted}
+                                    actionButtonStyle={{
+                                        position: 'absolute',
+                                        top: '50%',
+                                        right: dimensionValue('size-100'),
+                                        transform: 'translateY(-50%)',
+                                    }}
+                                />
+                            ) : null}
+                        </View>
                         {hasActivePipeline ? <Tag text={'Active'} /> : null}
                     </Flex>
                 </Header>
 
-                <Divider size={'S'} marginY={'size-200'} />
+                {otherProjects.length > 0 && (
+                    <Content>
+                        <ProjectsList projects={otherProjects} />
+                    </Content>
+                )}
 
-                <Content>
-                    <ProjectsList projects={data} />
-                </Content>
-
-                <Divider size={'S'} marginY={'size-200'} />
+                <Divider size={'S'} marginBottom={'size-200'} marginTop={0} />
 
                 <ButtonGroup UNSAFE_className={classes.panelButtons}>
                     <AddProjectButton />

--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -18,6 +18,7 @@ import {
 } from '@geti/ui';
 import { AddCircle } from '@geti/ui/icons';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+import { partition } from 'lodash-es';
 import { useNavigate } from 'react-router';
 
 import { paths } from '../../constants/paths';
@@ -93,11 +94,10 @@ export const ProjectsListPanel = () => {
     const projectId = useProjectIdentifier();
     const { data } = useProjects();
 
-    const selectedProject = data.find((project) => project.id === projectId);
+    const [[selectedProject], otherProjects] = partition(data, (project) => project.id === projectId);
     const selectedProjectName = selectedProject?.name ?? '';
     const hasActivePipeline = Boolean(selectedProject?.active_pipeline);
 
-    const otherProjects = data.filter((project) => project.id !== projectId);
     const otherProjectNames = otherProjects.map(({ name }) => name);
 
     const handleDeleted = () => {

--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -109,29 +109,29 @@ export const ProjectsListPanel = () => {
             <SelectedProjectButton name={selectedProjectName} id={projectId} isActive={hasActivePipeline} />
 
             <Dialog width={'size-4600'} UNSAFE_className={classes.dialog}>
-                <Header>
-                    <Flex
-                        direction={'column'}
-                        justifyContent={'center'}
-                        width={'100%'}
-                        alignItems={'center'}
-                        UNSAFE_style={{
-                            padding: 'var(--spectrum-global-dimension-size-200)',
-                        }}
-                        gap={'size-100'}
-                    >
-                        <ProjectThumbnail
-                            // when selected project changes, we want to reset the project thumbnail
-                            key={selectedProject?.id}
-                            project={{ name: selectedProjectName, id: selectedProject?.id ?? selectedProjectName }}
-                            height={'size-1000'}
-                            width={'size-1000'}
-                        />
-                        <View width={'100%'} position={'relative'}>
-                            <Heading UNSAFE_style={{ textAlign: 'center' }} level={2} marginBottom={0}>
-                                {selectedProjectName}
-                            </Heading>
-                            {selectedProject !== undefined ? (
+                {selectedProject !== undefined && (
+                    <Header>
+                        <Flex
+                            direction={'column'}
+                            justifyContent={'center'}
+                            width={'100%'}
+                            alignItems={'center'}
+                            UNSAFE_style={{
+                                padding: 'var(--spectrum-global-dimension-size-200)',
+                            }}
+                            gap={'size-100'}
+                        >
+                            <ProjectThumbnail
+                                // when selected project changes, we want to reset the project thumbnail
+                                key={selectedProject.id}
+                                project={selectedProject}
+                                height={'size-1000'}
+                                width={'size-1000'}
+                            />
+                            <View width={'100%'} position={'relative'}>
+                                <Heading UNSAFE_style={{ textAlign: 'center' }} level={2} marginBottom={0}>
+                                    {selectedProjectName}
+                                </Heading>
                                 <MenuActions
                                     projectId={selectedProject.id}
                                     projectName={selectedProject.name}
@@ -145,11 +145,11 @@ export const ProjectsListPanel = () => {
                                         transform: 'translateY(-50%)',
                                     }}
                                 />
-                            ) : null}
-                        </View>
-                        {hasActivePipeline ? <Tag text={'Active'} /> : null}
-                    </Flex>
-                </Header>
+                            </View>
+                            {hasActivePipeline ? <Tag text={'Active'} /> : null}
+                        </Flex>
+                    </Header>
+                )}
 
                 {otherProjects.length > 0 && (
                     <Content>

--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -7,6 +7,7 @@ import {
     Content,
     Dialog,
     DialogTrigger,
+    dimensionValue,
     Divider,
     Flex,
     Header,
@@ -16,7 +17,6 @@ import {
     View,
 } from '@geti/ui';
 import { AddCircle } from '@geti/ui/icons';
-import { dimensionValue } from '@react-spectrum/utils';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { useNavigate } from 'react-router';
 
@@ -47,7 +47,13 @@ const SelectedProjectButton = ({ name, id, isActive }: SelectedProjectProps) => 
                 UNSAFE_className={classes.selectedProjectButton}
             >
                 <View margin='size-50'>
-                    <ProjectThumbnail project={{ name, id: id ?? name }} height={'size-400'} width={'size-400'} />
+                    <ProjectThumbnail
+                        // when selected project changes, we want to reset the project thumbnail
+                        key={id}
+                        project={{ name, id: id ?? name }}
+                        height={'size-400'}
+                        width={'size-400'}
+                    />
                 </View>
                 <Flex direction={'column'} minWidth={0}>
                     <View paddingStart={'size-50'} width={'100%'} UNSAFE_className={classes.projectName}>
@@ -115,6 +121,8 @@ export const ProjectsListPanel = () => {
                         gap={'size-100'}
                     >
                         <ProjectThumbnail
+                            // when selected project changes, we want to reset the project thumbnail
+                            key={selectedProject?.id}
                             project={{ name: selectedProjectName, id: selectedProject?.id ?? selectedProjectName }}
                             height={'size-1000'}
                             width={'size-1000'}

--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 import {
@@ -11,7 +11,6 @@ import {
     Flex,
     Header,
     Heading,
-    PhotoPlaceholder,
     Tag,
     Text,
     View,
@@ -22,6 +21,7 @@ import { useNavigate } from 'react-router';
 
 import { paths } from '../../constants/paths';
 import { useProjects } from '../../hooks/api/project.hook';
+import { ProjectThumbnail } from './project-thumbnail/project-thumbnail.component';
 import { ProjectsList } from './projects-list.component';
 
 import classes from './projects-list.module.scss';
@@ -45,7 +45,7 @@ const SelectedProjectButton = ({ name, id, isActive }: SelectedProjectProps) => 
                 UNSAFE_className={classes.selectedProjectButton}
             >
                 <View margin='size-50'>
-                    <PhotoPlaceholder name={name} indicator={id ?? name} height={'size-400'} width={'size-400'} />
+                    <ProjectThumbnail project={{ name, id: id ?? name }} height={'size-400'} width={'size-400'} />
                 </View>
                 <Flex direction={'column'} minWidth={0}>
                     <View paddingStart={'size-50'} width={'100%'} UNSAFE_className={classes.projectName}>
@@ -103,9 +103,8 @@ export const ProjectsListPanel = () => {
                             padding: 'var(--spectrum-global-dimension-size-200)',
                         }}
                     >
-                        <PhotoPlaceholder
-                            name={selectedProjectName}
-                            indicator={selectedProject?.id ?? selectedProjectName}
+                        <ProjectThumbnail
+                            project={{ name: selectedProjectName, id: selectedProject?.id ?? selectedProjectName }}
                             height={'size-1000'}
                             width={'size-1000'}
                         />

--- a/application/ui/src/components/project-panel/projects-list.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list.component.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 import { Project } from '../../constants/shared-types';
@@ -9,10 +9,16 @@ type ProjectListProps = {
 };
 
 export const ProjectsList = ({ projects }: ProjectListProps) => {
+    const projectNames = projects.map(({ name }) => name);
+
     return (
         <ul>
             {projects.map((project) => (
-                <ProjectListItem key={project.id} project={project} />
+                <ProjectListItem
+                    key={project.id}
+                    project={project}
+                    projectNames={projectNames.filter((name) => name !== project.name)}
+                />
             ))}
         </ul>
     );


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Display thumbnail if available, if no placeholder is displayed.
2. Don't display current project twice: remove current project from the projects list, move the current project menu to be next to the thumbnail in the header section.

<img width="396" height="469" alt="image" src="https://github.com/user-attachments/assets/73dc7dad-a3bc-462b-8233-b35d842c8b14" />

Fix #6270 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)