### PR TITLE
chore: Show only prediction cue in annotator

### DIFF
--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
@@ -54,7 +54,7 @@ interface AnnotatorModesProps {
 }
 
 export const AnnotatorModes = ({ mode, onModeChange, hasAnnotations, hasPredictions }: AnnotatorModesProps) => {
-    const [dismissedCues, setDismissedCues] = useState<Set<AnnotatorMode>>(new Set());
+    const [dismissedCues, setDismissedCues] = useState<Set<Extract<AnnotatorMode, 'prediction'>>>(new Set());
 
     const shouldDisplayPredictionCue =
         mode === 'annotation' && !hasAnnotations && hasPredictions && !dismissedCues.has('prediction');

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.component.tsx
@@ -56,7 +56,6 @@ interface AnnotatorModesProps {
 export const AnnotatorModes = ({ mode, onModeChange, hasAnnotations, hasPredictions }: AnnotatorModesProps) => {
     const [dismissedCues, setDismissedCues] = useState<Set<AnnotatorMode>>(new Set());
 
-    const shouldDisplayAnnotationCue = mode === 'prediction' && hasAnnotations && !dismissedCues.has('annotation');
     const shouldDisplayPredictionCue =
         mode === 'annotation' && !hasAnnotations && hasPredictions && !dismissedCues.has('prediction');
 
@@ -69,13 +68,13 @@ export const AnnotatorModes = ({ mode, onModeChange, hasAnnotations, hasPredicti
             const nextDismissedCues = new Set(prevDismissedCues);
 
             // user is leaving the current mode — if it had content they've seen it
-            const currentHasContent = mode === 'annotation' ? hasAnnotations : hasPredictions;
+            const currentHasContent = mode === 'prediction' && hasPredictions;
             if (currentHasContent) {
                 nextDismissedCues.add(mode);
             }
 
             // user is switching to the next mode — if it has content they're about to see it
-            const nextHasContent = nextMode === 'annotation' ? hasAnnotations : hasPredictions;
+            const nextHasContent = nextMode === 'prediction' && hasPredictions;
             if (nextHasContent) {
                 nextDismissedCues.add(nextMode);
             }
@@ -95,14 +94,9 @@ export const AnnotatorModes = ({ mode, onModeChange, hasAnnotations, hasPredicti
                 alignItems={'center'}
                 data-testid={'annotator-modes-id'}
             >
-                <ToggleButtonWithCue
-                    isActive={mode === 'annotation'}
-                    onClick={() => handleModeChange('annotation')}
-                    showCue={shouldDisplayAnnotationCue}
-                    cueLabel={'Annotation available'}
-                >
+                <ToggleButton isActive={mode === 'annotation'} onClick={() => handleModeChange('annotation')}>
                     Annotation
-                </ToggleButtonWithCue>
+                </ToggleButton>
                 <ToggleButtonWithCue
                     isActive={mode === 'prediction'}
                     onClick={() => handleModeChange('prediction')}

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/annotator-modes/annotator-modes-toggle.test.tsx
@@ -95,33 +95,7 @@ describe('AnnotatorModes', () => {
         });
     });
 
-    describe('Annotation cue visibility', () => {
-        it('shows annotation cue when mode is prediction and has annotations', () => {
-            renderComponent({ mode: 'prediction', hasAnnotations: true });
-
-            expect(screen.getByRole('status', { name: 'Annotation available' })).toBeInTheDocument();
-        });
-
-        it('does not show annotation cue when mode is annotation', () => {
-            renderComponent({ mode: 'annotation', hasAnnotations: true });
-
-            expect(screen.queryByRole('status', { name: 'Annotation available' })).not.toBeInTheDocument();
-        });
-    });
-
     describe('Cue dismissal', () => {
-        it('dismisses annotation cue after clicking annotation button when has annotation', () => {
-            renderComponent({ mode: 'prediction', hasPredictions: false, hasAnnotations: true });
-
-            expect(screen.getByRole('status', { name: 'Annotation available' })).toBeInTheDocument();
-
-            fireEvent.click(screen.getByRole('button', { name: 'Annotation' }));
-
-            fireEvent.click(screen.getByRole('button', { name: 'Prediction' }));
-
-            expect(screen.queryByRole('status', { name: 'Annotation available' })).not.toBeInTheDocument();
-        });
-
         it('dismisses prediction cue after clicking prediction button when has predictions', () => {
             renderComponent({ mode: 'annotation', hasPredictions: true, hasAnnotations: false });
 
@@ -136,14 +110,6 @@ describe('AnnotatorModes', () => {
     });
 
     describe('Pre-dismissed cues on mount', () => {
-        it('does not show annotation cue when starting in annotation mode with annotations, after switching to prediction', () => {
-            renderComponent({ mode: 'annotation', hasAnnotations: true, hasPredictions: false });
-
-            fireEvent.click(screen.getByRole('button', { name: 'Prediction' }));
-
-            expect(screen.queryByRole('status', { name: 'Annotation available' })).not.toBeInTheDocument();
-        });
-
         it('does not show prediction cue when starting in prediction mode with predictions, after switching to annotation', () => {
             renderComponent({ mode: 'prediction', hasPredictions: true, hasAnnotations: false });
 

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -664,24 +664,17 @@ test.describe('Annotator', () => {
                 await expect(page.getByLabel('Prediction available')).toBeHidden();
             });
 
-            await test.step('navigate to item-2 (in prediction mode): annotation cue visible because there are annotations', async () => {
+            await test.step('navigate to item-2 (in prediction mode): no annotation cue is shown', async () => {
                 await annotatorPage.openPredictionMode();
                 await annotatorPage.selectMediaItem('item-2');
 
-                await expect(page.getByLabel('Annotation available')).toBeVisible();
+                await expect(page.getByLabel('Annotation available')).toBeHidden();
             });
 
-            await test.step('item-2: switching prediction -> annotation dismisses both cues simultaneously', async () => {
+            await test.step('item-2: switching prediction -> annotation hides prediction cue', async () => {
                 await annotatorPage.openAnnotationMode();
 
                 await expect(page.getByLabel('Prediction available')).toBeHidden();
-                await expect(page.getByLabel('Annotation available')).toBeHidden();
-            });
-
-            await test.step('item-2: switching back to prediction mode keeps annotation cue hidden (already dismissed)', async () => {
-                await annotatorPage.openPredictionMode();
-
-                await expect(page.getByLabel('Annotation available')).toBeHidden();
             });
         });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

It was requested not to show annotation cue at all and only leave prediction cue.

Fix #6447 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
