### PR TITLE
Distinguish between initial and subsequent loads

### DIFF
--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -50,7 +50,11 @@ export const VirtualizerGridLayout = <T extends GridItem>({
 }: VirtualizerGridLayoutProps<T>) => {
     const ref = useRef<HTMLDivElement | null>(null);
 
-    useLoadMore({ isLoading: isLoadingMore, onLoadMore }, ref);
+    // Treat `isPending` as "loading" for the purposes of auto-pagination, so we
+    // don't kick off a next-page fetch while the initial load is still in
+    // flight. Without this guard the gallery shows the full overlay AND the
+    // inline tile loader at the same time on first render.
+    useLoadMore({ isLoading: isLoadingMore || isPending, onLoadMore }, ref);
 
     useGetTargetPosition({
         ref,
@@ -88,7 +92,7 @@ export const VirtualizerGridLayout = <T extends GridItem>({
                             </ListBoxItem>
                         );
                     })}
-                    {isLoadingMore && (
+                    {isLoadingMore && !isPending && (
                         <ListBoxItem id={'loader'} textValue={'loading'}>
                             <Loading mode='overlay' />
                         </ListBoxItem>

--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -25,6 +25,7 @@ interface VirtualizerGridLayoutProps<T extends GridItem>
     scrollToIndex?: number;
     selectionMode: 'single' | 'multiple' | 'none';
     layoutOptions: GridLayoutOptions;
+    isPending?: boolean;
     isLoadingMore: boolean;
     onLoadMore: () => void;
     contentItem: (item: T) => ReactNode;
@@ -37,6 +38,7 @@ export const VirtualizerGridLayout = <T extends GridItem>({
     items,
     ariaLabel,
     selectedKeys,
+    isPending = false,
     isLoadingMore,
     selectionMode,
     layoutOptions,
@@ -93,6 +95,7 @@ export const VirtualizerGridLayout = <T extends GridItem>({
                     )}
                 </AriaComponentsListBox>
             </Virtualizer>
+            {isPending && <Loading mode='overlay' />}
         </View>
     );
 };

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -42,6 +42,7 @@ const VIEW_MODE_SETTINGS: Record<GalleryViewMode, GridLayoutOptions> = {
 type GalleryListProps = {
     items: Media[];
     viewMode: GalleryViewMode;
+    isPending: boolean;
     isFetchingNextPage: boolean;
     fetchNextPage: () => void;
     isMediaItemReviewedById: (mediaItemId: string) => boolean;
@@ -51,6 +52,7 @@ type GalleryListProps = {
 const GalleryList = ({
     items,
     viewMode,
+    isPending,
     isFetchingNextPage,
     fetchNextPage,
     onSelectedMediaItemChange,
@@ -68,6 +70,7 @@ const GalleryList = ({
             selectionMode='multiple'
             selectedKeys={selectedKeys}
             layoutOptions={VIEW_MODE_SETTINGS[viewMode]}
+            isPending={isPending}
             isLoadingMore={isFetchingNextPage}
             onLoadMore={fetchNextPage}
             onSelectionChange={setSelectedKeys}
@@ -144,6 +147,7 @@ export const Gallery = ({
             <GalleryList
                 items={items}
                 viewMode={viewMode}
+                isPending={isPending}
                 fetchNextPage={fetchNextPage}
                 isMediaItemReviewedById={isMediaItemReviewedById}
                 onSelectedMediaItemChange={onSelectedMediaItemChange}

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
@@ -84,19 +84,28 @@ const setupHandlers = ({
 };
 
 describe('useDatasetMediaWithReviewStatus', () => {
-    describe('isFetchingNextPage', () => {
-        it('returns true while requests are pending', () => {
-            setupHandlers({ mediaTotal: 1, datasetTotal: 1, initialDelayMs: 100 });
+    describe('isPending', () => {
+        it('reflects only the media-items query, so the review-status query does not block the gallery', async () => {
+            setupHandlers({
+                mediaTotal: 1,
+                datasetTotal: 1,
+                mediaInitialDelayMs: 0,
+                datasetInitialDelayMs: 200,
+            });
 
             const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
 
-            expect(result.current.isFetchingNextPage).toBe(true);
-
-            return waitFor(() => {
-                expect(result.current.isFetchingNextPage).toBe(false);
+            // Media items resolve first; isPending should drop to false even
+            // though the review-status query is still loading.
+            await waitFor(() => {
+                expect(result.current.items.length).toBeGreaterThan(0);
             });
-        });
 
+            expect(result.current.isPending).toBe(false);
+        });
+    });
+
+    describe('isFetchingNextPage', () => {
         it('returns true when media items are fetching next page', async () => {
             setupHandlers({ mediaTotal: 40, datasetTotal: 1, mediaNextPageDelayMs: 100 });
 
@@ -145,33 +154,6 @@ describe('useDatasetMediaWithReviewStatus', () => {
             setupHandlers({ mediaTotal: 1, datasetTotal: 1 });
 
             const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
-
-            await waitFor(() => {
-                expect(result.current.isPending).toBe(false);
-            });
-
-            expect(result.current.isFetchingNextPage).toBe(false);
-        });
-
-        it('stays true while one initial query is still pending after the other resolves', async () => {
-            setupHandlers({
-                mediaTotal: 40,
-                datasetTotal: 40,
-                mediaInitialDelayMs: 0,
-                datasetInitialDelayMs: 200,
-            });
-
-            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
-
-            expect(result.current.isFetchingNextPage).toBe(true);
-
-            // Wait until the media query has resolved its initial page but the dataset query is still pending.
-            await waitFor(() => {
-                expect(result.current.items.length).toBeGreaterThan(0);
-            });
-
-            expect(result.current.isPending).toBe(true);
-            expect(result.current.isFetchingNextPage).toBe(true);
 
             await waitFor(() => {
                 expect(result.current.isPending).toBe(false);

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.test.ts
@@ -85,7 +85,7 @@ const setupHandlers = ({
 
 describe('useDatasetMediaWithReviewStatus', () => {
     describe('isPending', () => {
-        it('reflects only the media-items query, so the review-status query does not block the gallery', async () => {
+        it('stays true while either initial query is still pending so review-status badges do not pop in after thumbnails', async () => {
             setupHandlers({
                 mediaTotal: 1,
                 datasetTotal: 1,
@@ -95,17 +95,39 @@ describe('useDatasetMediaWithReviewStatus', () => {
 
             const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
 
-            // Media items resolve first; isPending should drop to false even
-            // though the review-status query is still loading.
+            // Media items resolve first, but the review-status query is still
+            // in flight — isPending must remain true to avoid rendering the
+            // gallery without annotation-status badges.
             await waitFor(() => {
                 expect(result.current.items.length).toBeGreaterThan(0);
             });
 
-            expect(result.current.isPending).toBe(false);
+            expect(result.current.isPending).toBe(true);
+
+            await waitFor(() => {
+                expect(result.current.isPending).toBe(false);
+            });
         });
     });
 
     describe('isFetchingNextPage', () => {
+        it('is false during the initial load even while queries are pending', async () => {
+            setupHandlers({ mediaTotal: 1, datasetTotal: 1, initialDelayMs: 100 });
+
+            const { result } = renderHook(() => useDatasetMediaWithReviewStatus());
+
+            // Initial load uses isPending, not isFetchingNextPage — otherwise
+            // the gallery would render a tile-sized loader instead of the
+            // full-page overlay.
+            expect(result.current.isFetchingNextPage).toBe(false);
+
+            await waitFor(() => {
+                expect(result.current.isPending).toBe(false);
+            });
+
+            expect(result.current.isFetchingNextPage).toBe(false);
+        });
+
         it('returns true when media items are fetching next page', async () => {
             setupHandlers({ mediaTotal: 40, datasetTotal: 1, mediaNextPageDelayMs: 100 });
 

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -35,7 +35,13 @@ export const useDatasetMediaWithReviewStatus = () => {
 
     return {
         items: mediaItemsResponse.items,
-        isPending: mediaItemsResponse.isPending,
+        // Wait for both the media-items and review-status queries to settle
+        // before declaring "ready". Otherwise the gallery flashes thumbnails
+        // first and pops in the annotation-status badges a moment later, which
+        // is a worse UX than a single brief loader.
+        isPending: mediaItemsResponse.isPending || datasetItemsResponse.isPending,
+        // Only true for actual next-page fetches on either query — never for
+        // initial loads — so pagination doesn't trigger the full overlay.
         isFetchingNextPage: mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
         totalCount: mediaItemsResponse.totalCount,
         fetchNextPage,

--- a/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
+++ b/application/ui/src/hooks/use-dataset-media-with-review-status.hook.ts
@@ -18,7 +18,6 @@ export const useDatasetMediaWithReviewStatus = () => {
     });
 
     const datasetItemsResponse = useGetDatasetItemsById({ annotationStatus: annotationStatus ?? undefined });
-    const hasPendingRequests = mediaItemsResponse.isPending || datasetItemsResponse.isPending;
 
     const fetchNextPage = () => {
         if (mediaItemsResponse.hasNextPage && !mediaItemsResponse.isFetchingNextPage) {
@@ -36,9 +35,8 @@ export const useDatasetMediaWithReviewStatus = () => {
 
     return {
         items: mediaItemsResponse.items,
-        isPending: hasPendingRequests,
-        isFetchingNextPage:
-            hasPendingRequests || mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
+        isPending: mediaItemsResponse.isPending,
+        isFetchingNextPage: mediaItemsResponse.isFetchingNextPage || datasetItemsResponse.isFetchingNextPage,
         totalCount: mediaItemsResponse.totalCount,
         fetchNextPage,
         isMediaItemReviewedById,

--- a/application/ui/tests/datasets/datasets.spec.ts
+++ b/application/ui/tests/datasets/datasets.spec.ts
@@ -54,18 +54,22 @@ test.describe('Dataset', () => {
     });
 
     test('list items', async ({ page, datasetPage }) => {
-        await datasetPage.goto();
-
-        await expect(datasetPage.getImagesCountText(totalElements)).toBeVisible();
-
         const waitForBatch = (offset: number) =>
             page.waitForResponse(
                 (response) => response.url().includes('/dataset/media') && response.url().includes(`offset=${offset}`)
             );
 
-        for (const offset of [20, 40]) {
-            await Promise.all([waitForBatch(offset), datasetPage.getMediaGrid().press('End')]);
-        }
+        const batch20 = waitForBatch(20);
+        const batch40 = waitForBatch(40);
+
+        await datasetPage.goto();
+
+        await expect(datasetPage.getImagesCountText(totalElements)).toBeVisible();
+
+        await datasetPage.getMediaGrid().press('End');
+        await batch20;
+        await datasetPage.getMediaGrid().press('End');
+        await batch40;
 
         await datasetPage.selectAll();
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* On initial load we were showing a single media item's loading, looked very weird.

isPending, #items = 0
<img width="1312" height="1188" alt="Screenshot 2026-05-20 at 14 48 18" src="https://github.com/user-attachments/assets/03628b45-0e46-4e51-84eb-7410a175d942" />

isFetchingNextPage, #items > 0
<img width="1303" height="807" alt="Screenshot 2026-05-20 at 15 17 55" src="https://github.com/user-attachments/assets/a2d7d92d-24dd-4c41-9f90-bf497f4ae0bd" />

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
