### PR TITLE
fix: Update WebRTC port range to improve shutdown performance

### DIFF
--- a/application/Justfile
+++ b/application/Justfile
@@ -12,7 +12,7 @@ application-name := "geti"
 # Runtime variables
 # -------------------------------------------------------------------------------------------------
 docker-run-args := "--env http_proxy --env https_proxy --env no_proxy --env HTTP_PROXY --env HTTPS_PROXY --env NO_PROXY"
-webrtc-ports-default := "50100-50109"
+webrtc-ports := "50100-50109"
 data-volume := application-name + "-data"
 logs-volume := application-name + "-logs"
 

--- a/application/Justfile
+++ b/application/Justfile
@@ -71,8 +71,7 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("coturn_port", long="coturn-port", help="Coturn server listening port (default: 443)")]
 [arg("stun_server", long="stun", help="STUN server URL to use for WebRTC")]
 [arg("gpu-slots", long="gpu-slots", help="Number of GPU slots available for model tuning (default: 1)")]
-[arg("webrtc-ports", long="webrtc-ports", help="UDP port range to publish for WebRTC (e.g. 50100-50200). Larger ranges drastically slow `docker run` shutdown on Docker Desktop (macOS/Windows) because each port becomes its own NAT rule.")]
-run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1" webrtc-ports=webrtc-ports-default:
+run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s nullglob

--- a/application/Justfile
+++ b/application/Justfile
@@ -12,7 +12,7 @@ application-name := "geti"
 # Runtime variables
 # -------------------------------------------------------------------------------------------------
 docker-run-args := "--env http_proxy --env https_proxy --env no_proxy --env HTTP_PROXY --env HTTPS_PROXY --env NO_PROXY"
-webrtc-ports := "50000-51000"
+webrtc-ports-default := "50100-50109"
 data-volume := application-name + "-data"
 logs-volume := application-name + "-logs"
 
@@ -71,7 +71,8 @@ build-image accelerator="cpu" tag="latest": install-uv
 [arg("coturn_port", long="coturn-port", help="Coturn server listening port (default: 443)")]
 [arg("stun_server", long="stun", help="STUN server URL to use for WebRTC")]
 [arg("gpu-slots", long="gpu-slots", help="Number of GPU slots available for model tuning (default: 1)")]
-run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1":
+[arg("webrtc-ports", long="webrtc-ports", help="UDP port range to publish for WebRTC (e.g. 50100-50200). Larger ranges drastically slow `docker run` shutdown on Docker Desktop (macOS/Windows) because each port becomes its own NAT rule.")]
+run-image accelerator="cpu" tag="latest" host="0.0.0.0" port="7860" container-port="7860" container-name="" detach="false" remove="false" reload="false" shm-size="8g" passthrough-devices="" volumes="" enable_coturn="false" coturn_host="" coturn_port="443" stun_server="" gpu-slots="1" webrtc-ports=webrtc-ports-default:
     #!/usr/bin/env bash
     set -euo pipefail
     shopt -s nullglob


### PR DESCRIPTION
### Summary

just run-image took ~100 s to return after Ctrl-C, even though the backend logs Application shutdown completed within ~2 s.

#### Root cause
The recipe published a 1001-port UDP range (50000-51000) for WebRTC. On Docker Desktop, each published port is a separate NAT rule, torn down serially at exit, ~75 s of pure daemon stall after the container process has exited. 

This PR reduces the range to 10 ports, fixing the slowness on shutdown

Resolves #6536
