### PR TITLE
Add repository-wide Copilot instructions for code conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+## Repository layout
+
+Monorepo with three components — different languages, toolchains, and conventions.
+
+| Path                   | What it is                                                 | Primary stack                                                    |
+| ---------------------- |------------------------------------------------------------| ---------------------------------------------------------------- |
+| `library/`             | `getitune` — low-code transfer-learning CV library (PyPI). | Python 3.11+, PyTorch 2.7+, OpenVINO, Lightning, Datumaro        |
+| `application/backend/` | Geti™ app server (`geti` package).                         | Python 3.13, FastAPI, SQLAlchemy 2 (async), Pydantic v2, Alembic |
+| `application/ui/`      | Geti™ web/desktop UI.                                      | Node 24.2+, React, TypeScript, rsbuild, Tauri                    |
+
+The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
+
+## General rules
+
+- Do not mix code or conventions between the three sub-projects.
+- Use **absolute imports** within each Python package.
+- Prefer editing existing files over creating new ones; match surrounding style.
+- Code must pass pre-commit checks (see `.pre-commit-config.yaml`).
+- Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+- **New files require a copyright + SPDX header** (current year, `#` for Python/YAML/shell, `//` for TS/JS/Rust):
+
+  ```
+  # Copyright (C) 2026 Intel Corporation
+  # SPDX-License-Identifier: Apache-2.0
+  ```
+
+- **Use `just`** for developer workflows (`application/ui/` uses `npm` scripts instead).
+  Never invent ad-hoc `uv` / `docker` commands when a recipe exists.
+
+## Python conventions (`library/` and `application/backend/`)
+
+- Type-hint every public function, method, and module-level variable.
+- Modern typing: `list[int]`, `X | None` — not `List`, `Optional`.
+- Prefer `pathlib.Path` over `os.path`.
+- No bare `print`.
+- Google-style docstrings (`Args`, `Returns`, `Raises`).
+- Logging: `library/` uses stdlib `logging`; `application/backend/` uses
+  `loguru`. Do not mix them.
+- Tests use `pytest`; new features require unit tests.
+
+## Things to avoid
+
+- Do not change Python version pins (they ensure CI reproducibility).
+- Prefer stdlib or already-declared dependencies.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,9 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 - Assume the working directory is already the component root you are working on
   (e.g. `application/backend/`). Do not `cd` into it at the start of every
   command.
+- When the user is on Windows with WSL2, generate plain Linux commands — do not
+  wrap them in `wsl -d … -- bash -c "…"` or use Windows paths like
+  `/mnt/wsl.localhost/`. The terminal is already inside WSL.
 - Do not mix code or conventions between the three sub-projects.
 - Prefer **absolute imports** within each Python package. Relative imports are
   acceptable when they help avoid circular dependencies.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,11 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 
 ## General rules
 
+- Assume the virtual environment is already activated — do not prepend `uv run`
+  or activate a venv in every command.
+- Assume the working directory is already the component root you are working on
+  (e.g. `application/backend/`). Do not `cd` into it at the start of every
+  command.
 - Do not mix code or conventions between the three sub-projects.
 - Prefer **absolute imports** within each Python package. Relative imports are
   acceptable when they help avoid circular dependencies.
@@ -46,6 +51,13 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 - Logging: `library/` uses stdlib `logging`; `application/backend/` uses
   `loguru`. Do not mix them.
 - Tests use `pytest`; new features require unit tests.
+- **Test placement**: unit tests live next to the code they test in
+  `tests/unit/` (mirroring the source tree); integration tests go in
+  `tests/integration/`. Do not duplicate fixtures across directories — reuse
+  existing `conftest.py` fixtures at the appropriate scope.
+- **Running tests**: after writing or modifying tests, run the specific new test
+  file (e.g. `pytest tests/unit/path/to/test_foo.py`). Running the full suite
+  is optional and not required for validation.
 
 ## Things to avoid
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,14 +8,22 @@ Monorepo with three components — different languages, toolchains, and conventi
 | `application/backend/` | Geti™ app server (`geti` package).                         | Python 3.13, FastAPI, SQLAlchemy 2 (async), Pydantic v2, Alembic |
 | `application/ui/`      | Geti™ web/desktop UI.                                      | Node 24.2+, React, TypeScript, rsbuild, Tauri                    |
 
+The application can be built and deployed in three ways:
+
+1. As a single Docker container.
+2. As a desktop app for Windows (MSIX).
+3. With server and UI as standalone processes, for development only.
+
 The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 
 ## General rules
 
 - Do not mix code or conventions between the three sub-projects.
-- Use **absolute imports** within each Python package.
+- Prefer **absolute imports** within each Python package. Relative imports are
+  acceptable when they help avoid circular dependencies.
 - Prefer editing existing files over creating new ones; match surrounding style.
-- Code must pass pre-commit checks (see `.pre-commit-config.yaml`).
+- Code must pass pre-commit checks (see `.pre-commit-config.yaml`). Run them
+  locally with `prek`.
 - Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 - **New source files require a copyright + SPDX header** (current year, `#` for Python/YAML/shell, `//` for TS/JS/Rust):
 
@@ -32,6 +40,7 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 - Type-hint every public function, method, and module-level variable.
 - Modern typing: `list[int]`, `X | None` — not `List`, `Optional`.
 - Prefer `pathlib.Path` over `os.path`.
+- Write code that is portable across the main platforms (Linux, Windows, macOS).
 - No bare `print`.
 - Google-style docstrings (`Args`, `Returns`, `Raises`).
 - Logging: `library/` uses stdlib `logging`; `application/backend/` uses
@@ -41,4 +50,5 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 ## Things to avoid
 
 - Do not change Python version pins (they ensure CI reproducibility).
-- Prefer stdlib or already-declared dependencies.
+- Do not add new third-party dependencies when stdlib or already-declared
+  dependencies can solve the problem.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Monorepo with three components — different languages, toolchains, and conventi
 
 | Path                   | What it is                                                 | Primary stack                                                    |
 | ---------------------- |------------------------------------------------------------| ---------------------------------------------------------------- |
-| `library/`             | `getitune` — low-code transfer-learning CV library (PyPI). | Python 3.11+, PyTorch 2.7+, OpenVINO, Lightning, Datumaro        |
+| `library/`             | `getitune` — low-code transfer-learning CV library (PyPI). | Python 3.11+, PyTorch 2.10, OpenVINO, Lightning, Datumaro        |
 | `application/backend/` | Geti™ app server (`geti` package).                         | Python 3.13, FastAPI, SQLAlchemy 2 (async), Pydantic v2, Alembic |
 | `application/ui/`      | Geti™ web/desktop UI.                                      | Node 24.2+, React, TypeScript, rsbuild, Tauri                    |
 
@@ -17,7 +17,7 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 - Prefer editing existing files over creating new ones; match surrounding style.
 - Code must pass pre-commit checks (see `.pre-commit-config.yaml`).
 - Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
-- **New files require a copyright + SPDX header** (current year, `#` for Python/YAML/shell, `//` for TS/JS/Rust):
+- **New source files require a copyright + SPDX header** (current year, `#` for Python/YAML/shell, `//` for TS/JS/Rust):
 
   ```
   # Copyright (C) 2026 Intel Corporation

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -9,7 +9,7 @@ applyTo: "application/backend/**"
 - Routers under `app/` (`APIRouter` per resource). Keep handlers thin; business
   logic in service modules.
 - Pydantic v2 models for request/response — never return raw ORM models.
-- Settings via `pydantic-settings`. No `os.environ.get(...)`.
+- Settings via `pydantic-settings` for app config.
 - Use `loguru` `logger` — not `print`, not stdlib `logging`.
 - Long-running work goes in background tasks, not inline in a request.
 
@@ -53,5 +53,4 @@ applyTo: "application/backend/**"
 ## Do not
 
 - Do not bypass the settings layer.
-- Do not commit anything under `data/`, `logs/`, or `dist/`.
 - Never `pip install` — use `uv` via `just` recipes.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,57 @@
+---
+applyTo: "application/backend/**"
+---
+
+## Code conventions
+
+- **Async everywhere** for I/O (DB, file, HTTP, WebRTC). Never call blocking
+  SQLAlchemy sync APIs from request handlers.
+- Routers under `app/` (`APIRouter` per resource). Keep handlers thin; business
+  logic in service modules.
+- Pydantic v2 models for request/response — never return raw ORM models.
+- Settings via `pydantic-settings`. No `os.environ.get(...)`.
+- Use `loguru` `logger` — not `print`, not stdlib `logging`.
+- Long-running work goes in background tasks, not inline in a request.
+
+## Database & migrations
+
+- Schema changes **require an Alembic migration**.
+- Use the async session factory — do not create engines per request.
+
+## API contract
+
+- After changing routes/models/status codes:
+  1. `just gen-api-spec --output-path=openapi.json`
+  2. In `application/ui/`: `npm run update-spec`
+- Keep paths, methods, and field names stable. Breaking changes require
+  coordination with the UI before merging.
+
+## Commands
+
+| Task                    | Recipe                                                       |
+| ----------------------- | ------------------------------------------------------------ |
+| Create venv             | `just venv --accelerator cpu\|xpu\|cuda`                     |
+| Refresh lockfile        | `just venv-lock`                                             |
+| Start server            | `just run-server`                                            |
+| Regenerate OpenAPI spec | `just gen-api-spec --output-path=openapi.json`               |
+| Lint + type-check       | `just lint`                                                  |
+| Auto-fix lint           | `just ruff-fix`                                              |
+| Type-check only         | `just pyrefly` (no baseline file — all errors must be fixed) |
+| Import-graph check      | `just lint-imports`                                          |
+
+## Testing
+
+- `pytest` + `pytest-asyncio`. Use `testcontainers` for real-DB integration tests.
+- `behave` for BDD scenarios — keep steps with feature files.
+- Prefer `pytest.mark.parametrize` for multiple inputs.
+
+## Build
+
+- PyInstaller packages the backend (`geti.spec`). If you add a new top-level
+  import, verify it appears in `geti.spec`'s `hiddenimports`.
+
+## Do not
+
+- Do not bypass the settings layer.
+- Do not commit anything under `data/`, `logs/`, or `dist/`.
+- Never `pip install` — use `uv` via `just` recipes.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -17,12 +17,12 @@ applyTo: "application/backend/**"
 
 - Schema changes **require an Alembic migration**.
 - Use the async session factory — do not create engines per request.
+- Avoid schema changes in the database or file storage unless required; if the
+  same feature can be implemented without breaking changes and without
+  compromising maintainability, prefer that approach.
 
 ## API contract
 
-- After changing routes/models/status codes:
-  1. `just gen-api-spec --output-path=openapi.json`
-  2. In `application/ui/`: `npm run update-spec`
 - Keep paths, methods, and field names stable. Breaking changes require
   coordination with the UI before merging.
 

--- a/.github/instructions/library.instructions.md
+++ b/.github/instructions/library.instructions.md
@@ -1,0 +1,39 @@
+---
+applyTo: "library/**"
+---
+
+## Conventions
+
+- Source under `library/src/getitune/` (legacy `src/otx/` re-exports exist).
+  Prefer editing `getitune`.
+- Recipes (YAML) define task + model + training config. When adding a model,
+  add or update its recipe under the appropriate task directory.
+- Public API entry points must stay stable — consumed by `application/backend/`.
+
+## Code style
+
+- Use `pyrefly` baseline (`library/pyrefly-baseline.json`) — do not regress.
+- Use `logging` (`logging.getLogger(__name__)`).
+- Avoid hard CUDA dependencies. XPU is first-class — guard device-specific
+  code with capability checks, not import-time failures.
+- Prefer `lightning.pytorch` over `pytorch_lightning` imports.
+
+## Commands
+
+| Task              | Recipe                              |
+| ----------------- | ----------------------------------- |
+| Create venv       | `just venv --device cpu\|xpu\|cuda` |
+| Refresh lockfile  | `just venv-lock`                    |
+| Lint + type-check | `just lint`                         |
+| Auto-fix lint     | `just ruff-fix`                     |
+| Type-check only   | `just pyrefly`                      |
+
+## Testing
+
+- Tests in `library/tests/` — organized as `unit/`, `integration/`, `regression/`.
+- Default device for local tests: `cpu`.
+- Do not commit datasets — use existing fixtures under `library/data/`.
+
+## Do not
+
+- Do not import from `application/`.

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -1,0 +1,50 @@
+---
+applyTo: "application/ui/**"
+---
+
+## Conventions
+
+- Source in `application/ui/src/`. Feature folders group component + hooks + tests.
+- TypeScript: no `any`. Use `unknown` + narrow. `type` for unions, `interface`
+  for extensible object shapes.
+- Function components + hooks only. Co-locate styles.
+- Server state via React Query (`useQuery` / `useMutation`) — never call
+  `fetch` / `axios` directly from components.
+- **API types are generated** (`src/api/openapi-spec.json` / `.d.ts`) — never
+  edit by hand. Regenerate: `npm run update-spec` (backend on `:7860`) or
+  `npm run build:api` (if you already have a fresh local `openapi-spec.json`).
+- **Vendored packages** (`packages/config`, `packages/ui`, `packages/smart-tools`)
+  are cloned via `npm run clone-geti-ui-packages`. Do not edit locally.
+
+## Commands
+
+| Task                | Command                  |
+| ------------------- | ------------------------ |
+| Dev server          | `npm run start`          |
+| Production build    | `npm run build`          |
+| Desktop dev (Tauri) | `npm run start:desktop`  |
+| Lint                | `npm run lint`           |
+| Lint + fix          | `npm run lint:fix`       |
+| Type-check          | `npm run type-check`     |
+| Unit tests          | `npm run test:unit`      |
+| Component tests     | `npm run test:component` |
+| E2E tests           | `npm run test:e2e`       |
+| Update API types    | `npm run update-spec`    |
+
+## Testing
+
+- Unit tests next to source as `*.test.ts(x)` (Vitest).
+- Component / E2E under `tests/` (Playwright).
+- Mocks in `mocks/` — reuse existing handlers. New API endpoints need a
+  corresponding mock handler.
+
+## Styling
+
+- Use CSS Modules (`.module.scss`) co-located with components.
+
+## Do not
+
+- Do not introduce another data-fetching library.
+- Do not hand-edit generated API types.
+- Do not edit vendored `packages/` — they will be overwritten.
+- Do not add CSS-in-JS outside what `@geti/ui` already uses.

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -46,5 +46,9 @@ applyTo: "application/ui/**"
 
 - Do not introduce another data-fetching library.
 - Do not hand-edit generated API types.
-- Do not edit vendored `packages/` — they will be overwritten.
+- Do not edit vendored `packages` — they will be overwritten.
 - Do not add CSS-in-JS outside what `@geti/ui` already uses.
+
+## Further reading
+
+- See `application/ui/README.md` for detailed architecture, API integration examples, and contributing guidelines.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,7 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
-        exclude: ^(application/ui/|\.github/)
-
+        exclude: ^(application/ui/|\.github/instructions/|\.github/copilot-instructions\.md)
   # Hadolint - Dockerfile linter
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
-        exclude: ^application/ui/
+        exclude: ^(application/ui/|\.github/)
 
   # Hadolint - Dockerfile linter
   - repo: https://github.com/AleksaC/hadolint-py


### PR DESCRIPTION
This PR introduces project-specific instructions for each major part of the repo. The main goal is to clarify conventions, workflows, and boundaries for contributors/copilot working on the backend, library, and UI components.

**Instructions for each subproject:**

- Added `.github/instructions/backend.instructions.md` with detailed conventions for the backend (`application/backend/`), covering async code requirements, API and DB rules, testing, and commands.
- Added `.github/instructions/library.instructions.md` for the library (`library/`), specifying code style, device support, test organization, and command usage.
- Added `.github/instructions/ui.instructions.md` for the UI (`application/ui/`), outlining TypeScript conventions, API type generation, testing, and styling rules.
- Added a high-level repository layout and general rules in `.github/copilot-instructions.md`, describing the monorepo structure, stack, and cross-cutting rules like copyright headers, commit conventions, and Python guidelines.

These instructions aim to be as minimal as possible to reduce the amount of input tokens for each copilot session. Specific instructions for each subcomponent are only loaded if a change is made to the files matched by the `applyTo` defined in the file (e.g. `"application/backend/**"` for the backend instructions).

**Tooling and pre-commit configuration:**

- Updated `.pre-commit-config.yaml` to exclude `.github/` (including the new instructions)