### PR TITLE
fix: Apply dataset filters when opening annotator

### DIFF
--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
@@ -33,12 +33,13 @@ vi.mock('../../../../hooks/use-get-dataset-media-items.hook', () => ({
     useGetDatasetMediaItems: vi.fn(() => mockDatasetMediaItems),
 }));
 
+const MOCKED_PROJECT_ID = '123';
+
 vi.mock('../../../../hooks/use-project-identifier.hook', () => ({
-    useProjectIdentifier: vi.fn(() => '123'),
+    useProjectIdentifier: vi.fn(() => MOCKED_PROJECT_ID),
 }));
 
 const SEARCH = '?annotationStatusFilter=with_annotations';
-const PROJECT_ID = '123';
 
 describe('useSelectDatasetItem', () => {
     beforeEach(() => {
@@ -48,7 +49,7 @@ describe('useSelectDatasetItem', () => {
 
     describe('onSelectedMediaItemChange', () => {
         it('navigates to dataset index with preserved search when item is null', () => {
-            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const route = `${paths.project.dataset.index({ projectId: MOCKED_PROJECT_ID })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.index.pattern,
@@ -59,14 +60,14 @@ describe('useSelectDatasetItem', () => {
             });
 
             expect(mockNavigate).toHaveBeenCalledWith({
-                pathname: paths.project.dataset.index({ projectId: PROJECT_ID }),
+                pathname: paths.project.dataset.index({ projectId: MOCKED_PROJECT_ID }),
                 search: SEARCH,
             });
         });
 
         it('navigates to frame 0 with preserved search for a video item', () => {
             const video = getMockedVideo({ id: 'video-42' });
-            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const route = `${paths.project.dataset.index({ projectId: MOCKED_PROJECT_ID })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.index.pattern,
@@ -80,7 +81,7 @@ describe('useSelectDatasetItem', () => {
                 pathname: paths.project.dataset.item.frame({
                     datasetItemId: video.id,
                     frameNumber: '0',
-                    projectId: PROJECT_ID,
+                    projectId: MOCKED_PROJECT_ID,
                 }),
                 search: SEARCH,
             });
@@ -88,7 +89,7 @@ describe('useSelectDatasetItem', () => {
 
         it('navigates to the correct frame number with preserved search for a video frame item', () => {
             const videoFrame = getMockedVideoFrame({ id: 'vf-7', frame_number: 42 });
-            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const route = `${paths.project.dataset.index({ projectId: MOCKED_PROJECT_ID })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.index.pattern,
@@ -102,7 +103,7 @@ describe('useSelectDatasetItem', () => {
                 pathname: paths.project.dataset.item.frame({
                     datasetItemId: videoFrame.id,
                     frameNumber: videoFrame.frame_number.toString(),
-                    projectId: PROJECT_ID,
+                    projectId: MOCKED_PROJECT_ID,
                 }),
                 search: SEARCH,
             });
@@ -110,7 +111,7 @@ describe('useSelectDatasetItem', () => {
 
         it('navigates to item index with preserved search for an image item', () => {
             const image = getMockedMediaImage({ id: 'img-99' });
-            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const route = `${paths.project.dataset.index({ projectId: MOCKED_PROJECT_ID })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.index.pattern,
@@ -123,7 +124,7 @@ describe('useSelectDatasetItem', () => {
             expect(mockNavigate).toHaveBeenCalledWith({
                 pathname: paths.project.dataset.item.index({
                     datasetItemId: image.id,
-                    projectId: PROJECT_ID,
+                    projectId: MOCKED_PROJECT_ID,
                 }),
                 search: SEARCH,
             });
@@ -131,7 +132,7 @@ describe('useSelectDatasetItem', () => {
 
         it('preserves an empty search string when there are no query params', () => {
             const image = getMockedMediaImage({ id: 'img-1' });
-            const route = paths.project.dataset.index({ projectId: PROJECT_ID });
+            const route = paths.project.dataset.index({ projectId: MOCKED_PROJECT_ID });
 
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
@@ -145,7 +146,7 @@ describe('useSelectDatasetItem', () => {
             expect(mockNavigate).toHaveBeenCalledWith({
                 pathname: paths.project.dataset.item.index({
                     datasetItemId: image.id,
-                    projectId: PROJECT_ID,
+                    projectId: MOCKED_PROJECT_ID,
                 }),
                 search: '',
             });
@@ -157,7 +158,7 @@ describe('useSelectDatasetItem', () => {
             const image = getMockedMediaImage({ id: 'img-selected' });
             vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [image] });
 
-            const route = `${paths.project.dataset.item.index({ projectId: PROJECT_ID, datasetItemId: image.id })}${SEARCH}`;
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: image.id })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.item.index.pattern,
@@ -170,7 +171,7 @@ describe('useSelectDatasetItem', () => {
             const image = getMockedMediaImage({ id: 'img-other' });
             vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [image] });
 
-            const route = `${paths.project.dataset.item.index({ projectId: PROJECT_ID, datasetItemId: `${image.id}-23` })}${SEARCH}`;
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: `${image.id}-23` })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.item.index.pattern,
@@ -182,7 +183,7 @@ describe('useSelectDatasetItem', () => {
         it('returns null when there are no items', () => {
             vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
 
-            const route = `${paths.project.dataset.item.index({ projectId: PROJECT_ID, datasetItemId: `img-selected` })}${SEARCH}`;
+            const route = `${paths.project.dataset.item.index({ projectId: MOCKED_PROJECT_ID, datasetItemId: `img-selected` })}${SEARCH}`;
             const { result } = renderHook(() => useSelectDatasetItem(), {
                 route,
                 path: paths.project.dataset.item.index.pattern,

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.test.ts
@@ -1,0 +1,194 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { act } from '@testing-library/react';
+import { getMockedMediaImage, getMockedVideo, getMockedVideoFrame } from 'mocks/mock-media';
+import { renderHook } from 'test-utils/render';
+
+import { paths } from '../../../../constants/paths';
+import { Media } from '../../../../constants/shared-types';
+import { useGetDatasetMediaItems } from '../../../../hooks/use-get-dataset-media-items.hook';
+import { useSelectDatasetItem } from './use-select-dataset-item.hook';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router')>();
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+const mockDatasetMediaItems = {
+    items: [] as Media[],
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isPending: false,
+    totalCount: 0,
+};
+
+vi.mock('../../../../hooks/use-get-dataset-media-items.hook', () => ({
+    useGetDatasetMediaItems: vi.fn(() => mockDatasetMediaItems),
+}));
+
+vi.mock('../../../../hooks/use-project-identifier.hook', () => ({
+    useProjectIdentifier: vi.fn(() => '123'),
+}));
+
+const SEARCH = '?annotationStatusFilter=with_annotations';
+const PROJECT_ID = '123';
+
+describe('useSelectDatasetItem', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear();
+        vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+    });
+
+    describe('onSelectedMediaItemChange', () => {
+        it('navigates to dataset index with preserved search when item is null', () => {
+            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.index.pattern,
+            });
+
+            act(() => {
+                result.current.onSelectedMediaItemChange(null);
+            });
+
+            expect(mockNavigate).toHaveBeenCalledWith({
+                pathname: paths.project.dataset.index({ projectId: PROJECT_ID }),
+                search: SEARCH,
+            });
+        });
+
+        it('navigates to frame 0 with preserved search for a video item', () => {
+            const video = getMockedVideo({ id: 'video-42' });
+            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.index.pattern,
+            });
+
+            act(() => {
+                result.current.onSelectedMediaItemChange(video);
+            });
+
+            expect(mockNavigate).toHaveBeenCalledWith({
+                pathname: paths.project.dataset.item.frame({
+                    datasetItemId: video.id,
+                    frameNumber: '0',
+                    projectId: PROJECT_ID,
+                }),
+                search: SEARCH,
+            });
+        });
+
+        it('navigates to the correct frame number with preserved search for a video frame item', () => {
+            const videoFrame = getMockedVideoFrame({ id: 'vf-7', frame_number: 42 });
+            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.index.pattern,
+            });
+
+            act(() => {
+                result.current.onSelectedMediaItemChange(videoFrame);
+            });
+
+            expect(mockNavigate).toHaveBeenCalledWith({
+                pathname: paths.project.dataset.item.frame({
+                    datasetItemId: videoFrame.id,
+                    frameNumber: videoFrame.frame_number.toString(),
+                    projectId: PROJECT_ID,
+                }),
+                search: SEARCH,
+            });
+        });
+
+        it('navigates to item index with preserved search for an image item', () => {
+            const image = getMockedMediaImage({ id: 'img-99' });
+            const route = `${paths.project.dataset.index({ projectId: PROJECT_ID })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.index.pattern,
+            });
+
+            act(() => {
+                result.current.onSelectedMediaItemChange(image);
+            });
+
+            expect(mockNavigate).toHaveBeenCalledWith({
+                pathname: paths.project.dataset.item.index({
+                    datasetItemId: image.id,
+                    projectId: PROJECT_ID,
+                }),
+                search: SEARCH,
+            });
+        });
+
+        it('preserves an empty search string when there are no query params', () => {
+            const image = getMockedMediaImage({ id: 'img-1' });
+            const route = paths.project.dataset.index({ projectId: PROJECT_ID });
+
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.index.pattern,
+            });
+
+            act(() => {
+                result.current.onSelectedMediaItemChange(image);
+            });
+
+            expect(mockNavigate).toHaveBeenCalledWith({
+                pathname: paths.project.dataset.item.index({
+                    datasetItemId: image.id,
+                    projectId: PROJECT_ID,
+                }),
+                search: '',
+            });
+        });
+    });
+
+    describe('selectedMediaItem', () => {
+        it('returns the matching item when datasetItemId param matches an item in the list', () => {
+            const image = getMockedMediaImage({ id: 'img-selected' });
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [image] });
+
+            const route = `${paths.project.dataset.item.index({ projectId: PROJECT_ID, datasetItemId: image.id })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            expect(result.current.selectedMediaItem).toEqual(image);
+        });
+
+        it('returns null when datasetItemId does not match any item', () => {
+            const image = getMockedMediaImage({ id: 'img-other' });
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [image] });
+
+            const route = `${paths.project.dataset.item.index({ projectId: PROJECT_ID, datasetItemId: `${image.id}-23` })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            expect(result.current.selectedMediaItem).toBeNull();
+        });
+
+        it('returns null when there are no items', () => {
+            vi.mocked(useGetDatasetMediaItems).mockReturnValue({ ...mockDatasetMediaItems, items: [] });
+
+            const route = `${paths.project.dataset.item.index({ projectId: PROJECT_ID, datasetItemId: `img-selected` })}${SEARCH}`;
+            const { result } = renderHook(() => useSelectDatasetItem(), {
+                route,
+                path: paths.project.dataset.item.index.pattern,
+            });
+
+            expect(result.current.selectedMediaItem).toBeNull();
+        });
+    });
+});

--- a/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
+++ b/application/ui/src/features/dataset/gallery/hooks/use-select-dataset-item.hook.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useNavigate, useParams } from 'react-router';
+import { useLocation, useNavigate, useParams } from 'react-router';
 
 import { paths } from '../../../../constants/paths';
 import { Media } from '../../../../constants/shared-types';
@@ -11,33 +11,38 @@ import { isVideo, isVideoFrame } from '../../../../shared/media-item-utils';
 
 export const useSelectDatasetItem = () => {
     const navigate = useNavigate();
+    const { search } = useLocation();
     const projectId = useProjectIdentifier();
     const { items } = useGetDatasetMediaItems();
     const { datasetItemId: selectedDatasetItemId } = useParams<{ datasetItemId: string }>();
 
     const onSelectedMediaItemChange = (item: Media | null) => {
         if (item === null) {
-            navigate(paths.project.dataset.index({ projectId }));
+            navigate({ pathname: paths.project.dataset.index({ projectId }), search });
             return;
         }
 
         if (isVideo(item)) {
-            navigate(paths.project.dataset.item.frame({ projectId, datasetItemId: item.id, frameNumber: '0' }));
+            navigate({
+                pathname: paths.project.dataset.item.frame({ projectId, datasetItemId: item.id, frameNumber: '0' }),
+                search,
+            });
             return;
         }
 
         if (isVideoFrame(item)) {
-            navigate(
-                paths.project.dataset.item.frame({
+            navigate({
+                pathname: paths.project.dataset.item.frame({
                     projectId,
                     datasetItemId: item.id,
                     frameNumber: item.frame_number.toString(),
-                })
-            );
+                }),
+                search,
+            });
             return;
         }
 
-        navigate(paths.project.dataset.item.index({ projectId, datasetItemId: item.id }));
+        navigate({ pathname: paths.project.dataset.item.index({ projectId, datasetItemId: item.id }), search });
     };
 
     return {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue is that when any dataset filters are applied and user opens annotator, the filters are reset. That happens because filters are stored as search params in the URL and when we open annotator, we change the URL without taking into account the search params. This PR fixes that issue.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
