### PR TITLE
Add application promotion workflows

### DIFF
--- a/.github/workflows/promote-rc-app-release.yml
+++ b/.github/workflows/promote-rc-app-release.yml
@@ -1,0 +1,278 @@
+name: Promote Application RC Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: "RC tag version (example: app/v0.1.0rc1)"
+        required: true
+        type: string
+      sha:
+        description: "Expected 40-char commit SHA for the RC tag"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run mode (validate only, make no changes)"
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: "Force overwrite if the stable tag already exists in GHCR with a different digest"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {} # No permissions by default
+
+jobs:
+  validate:
+    name: Validate inputs and RC tag
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    outputs:
+      rc_tag: ${{ steps.validate.outputs.rc_tag }}
+      rc_sha: ${{ steps.validate.outputs.rc_sha }}
+      release_tag: ${{ steps.validate.outputs.release_tag }}
+      docker_rc_tag: ${{ steps.validate.outputs.docker_rc_tag }}
+      docker_patch_tag: ${{ steps.validate.outputs.docker_patch_tag }}
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate and normalize inputs
+        id: validate
+        env:
+          RC_TAG_INPUT: ${{ inputs.rc_tag }}
+          EXPECTED_SHA: ${{ inputs.sha }}
+        run: |
+          if [[ "${RC_TAG_INPUT}" != app/v* ]]; then
+            echo "Error: rc_tag must start with 'app/v'"
+            echo "Received: ${RC_TAG_INPUT}"
+            exit 1
+          fi
+          RC_TAG="${RC_TAG_INPUT}"
+          if [[ ! "${RC_TAG}" =~ ^app/v[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
+            echo "Error: rc_tag must match 'app/v<major>.<minor>.<patch>rc<N>'"
+            echo "Received: ${RC_TAG_INPUT}"
+            exit 1
+          fi
+
+          if [[ ! "${EXPECTED_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Error: sha must be exactly 40 hex characters"
+            echo "Received: ${EXPECTED_SHA}"
+            exit 1
+          fi
+
+          # Derive release tag by stripping rc[N] suffix
+          RELEASE_TAG="$(echo "${RC_TAG}" | sed -E 's/rc[0-9]+$//')"
+          if [[ "${RELEASE_TAG}" == "${RC_TAG}" ]]; then
+            echo "Error: could not validate release tag from rc tag '${RC_TAG}'"
+            exit 1
+          fi
+          VERSION="${RELEASE_TAG#app/v}"
+
+          # Docker image tags (no app/v prefix)
+          DOCKER_RC_TAG="${RC_TAG#app/v}"
+          DOCKER_PATCH_TAG="${VERSION}"
+
+          echo "RC tag:             ${RC_TAG}"
+          echo "Release tag:        ${RELEASE_TAG}"
+          echo "Docker RC tag:      ${DOCKER_RC_TAG}"
+          echo "Docker release tag: ${DOCKER_PATCH_TAG}"
+
+          # Verify RC tag exists in git
+          if ! git rev-parse "refs/tags/${RC_TAG}" >/dev/null 2>&1; then
+            echo "::error::RC tag ${RC_TAG} does not exist in git"
+            exit 1
+          fi
+          RC_SHA=$(git rev-parse "refs/tags/${RC_TAG}^{commit}")
+          echo "RC SHA:             ${RC_SHA}"
+
+          # Verify RC SHA matches expected SHA input
+          if [[ "${RC_SHA}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::RC tag ${RC_TAG} points to ${RC_SHA} but expected ${EXPECTED_SHA}"
+            exit 1
+          fi
+
+          # If release tag already exists, verify it points to the same commit (idempotent re-run)
+          if git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            EXISTING_SHA=$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")
+            if [[ "${EXISTING_SHA}" != "${RC_SHA}" ]]; then
+              echo "::error::Release tag ${RELEASE_TAG} already exists at ${EXISTING_SHA}, but RC points to ${RC_SHA}. Aborting to prevent overwrite."
+              exit 1
+            fi
+            echo "::notice::Release tag ${RELEASE_TAG} already exists at the correct commit (idempotent re-run)"
+          fi
+
+          echo "rc_tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
+          echo "rc_sha=${RC_SHA}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "docker_rc_tag=${DOCKER_RC_TAG}" >> "$GITHUB_OUTPUT"
+          echo "docker_patch_tag=${DOCKER_PATCH_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Print promotion summary
+        env:
+          RC_TAG: ${{ steps.validate.outputs.rc_tag }}
+          RELEASE_TAG: ${{ steps.validate.outputs.release_tag }}
+          RC_SHA: ${{ steps.validate.outputs.rc_sha }}
+          DOCKER_RC_TAG: ${{ steps.validate.outputs.docker_rc_tag }}
+          DOCKER_PATCH_TAG: ${{ steps.validate.outputs.docker_patch_tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          {
+            echo "## Promotion Summary"
+            echo ""
+            echo "| Item | Value |"
+            echo "|------|-------|"
+            echo "| RC tag | ${RC_TAG} |"
+            echo "| Release tag | ${RELEASE_TAG} |"
+            echo "| Commit SHA | ${RC_SHA} |"
+            echo "| Docker RC tag | ${DOCKER_RC_TAG} |"
+            echo "| Docker release tag | ${DOCKER_PATCH_TAG} |"
+            echo "| Dry run | ${DRY_RUN} |"
+            echo "| Force overwrite | ${FORCE} |"
+            echo ""
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "> Dry run mode: No changes will be made."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  create-release-tag:
+    needs: validate
+    if: inputs.dry_run == false
+    name: Create release git tag
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    environment: production
+    permissions:
+      contents: write # Permission to push release tag to git
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Create release git tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+          RC_SHA: ${{ needs.validate.outputs.rc_sha }}
+        run: |
+          set -euo pipefail
+          URL_RELEASE_TAG="${RELEASE_TAG//\//%2F}"
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${URL_RELEASE_TAG}" --silent >/dev/null 2>&1; then
+            # Resolve the tag to a commit SHA, handling annotated tags that point to tag objects
+            TAG_INFO=$(gh api "repos/${{ github.repository }}/git/ref/tags/${URL_RELEASE_TAG}" --jq '.object.sha + " " + .object.type')
+            RESOLVED_SHA=${TAG_INFO%% *}
+            RESOLVED_TYPE=${TAG_INFO##* }
+            # Dereference tag objects until we reach a commit
+            while [[ "${RESOLVED_TYPE}" == "tag" ]]; do
+              TAG_OBJECT_INFO=$(gh api "repos/${{ github.repository }}/git/tags/${RESOLVED_SHA}" --jq '.object.sha + " " + .object.type')
+              RESOLVED_SHA=${TAG_OBJECT_INFO%% *}
+              RESOLVED_TYPE=${TAG_OBJECT_INFO##* }
+            done
+            if [[ "${RESOLVED_SHA}" == "${RC_SHA}" ]]; then
+              echo "Tag ${RELEASE_TAG} already exists at ${RC_SHA}, skipping creation"
+            else
+              echo "::error::Tag ${RELEASE_TAG} already exists at ${RESOLVED_SHA} but expected ${RC_SHA}"
+              exit 1
+            fi
+          else
+            echo "Creating tag ${RELEASE_TAG} pointing to ${RC_SHA}"
+            gh api "repos/${{ github.repository }}/git/refs" \
+              -f "ref=refs/tags/${RELEASE_TAG}" \
+              -f "sha=${RC_SHA}"
+            echo "Tag ${RELEASE_TAG} created successfully"
+          fi
+
+  promote-docker:
+    needs: [validate, create-release-tag]
+    if: inputs.dry_run == false
+    name: Promote RC image to release image
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    environment: production
+    permissions:
+      packages: write # Permission to push packages to GHCR
+      id-token: write # Permission to request OIDC token for signing images
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        device: [cpu, xpu, cuda]
+    env:
+      RC_TAG: ${{ inputs.rc_tag }}
+      DEVICE: ${{ matrix.device }}
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote application image for ${{ matrix.device }}
+        env:
+          DOCKER_RC_TAG: ${{ needs.validate.outputs.docker_rc_tag }}
+          DOCKER_PATCH_TAG: ${{ needs.validate.outputs.docker_patch_tag }}
+          DEVICE: ${{ matrix.device }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          SOURCE_IMAGE="ghcr.io/open-edge-platform/geti-${DEVICE}:${DOCKER_RC_TAG}"
+          TARGET_IMAGE="ghcr.io/open-edge-platform/geti-${DEVICE}:${DOCKER_PATCH_TAG}"
+
+          echo "Pulling ${SOURCE_IMAGE}"
+          docker pull "${SOURCE_IMAGE}"
+
+          # Pre-check: verify target tag is absent or already points to the same image
+          if docker manifest inspect "${TARGET_IMAGE}" >/dev/null 2>&1; then
+            echo "Target image ${TARGET_IMAGE} already exists in GHCR."
+            docker pull "${TARGET_IMAGE}"
+            SOURCE_ID=$(docker inspect --format='{{.Id}}' "${SOURCE_IMAGE}")
+            TARGET_ID=$(docker inspect --format='{{.Id}}' "${TARGET_IMAGE}")
+            if [[ "${SOURCE_ID}" == "${TARGET_ID}" ]]; then
+              echo "::notice::${TARGET_IMAGE} already points to the same image as ${SOURCE_IMAGE}. Skipping push (idempotent re-run)."
+              exit 0
+            elif [[ "${FORCE}" == "true" ]]; then
+              echo "::warning::${TARGET_IMAGE} exists with a different digest; overwriting because force=true."
+            else
+              echo "::error::${TARGET_IMAGE} already exists in GHCR with a different digest. Set 'force: true' to overwrite."
+              exit 1
+            fi
+          fi
+
+          echo "Tagging ${TARGET_IMAGE}"
+          docker tag "${SOURCE_IMAGE}" "${TARGET_IMAGE}"
+
+          echo "Pushing ${TARGET_IMAGE}"
+          docker push "${TARGET_IMAGE}"
+
+      - name: Sign Docker image
+        uses: open-edge-platform/geti-ci/actions/sign-image@7e686c1248b3939f8ee8e04e2612da727e379d91
+        with:
+          image-uri: ghcr.io/open-edge-platform/geti-${{ matrix.device }}:${{ needs.validate.outputs.docker_patch_tag }}
+
+      - name: Print summary
+        env:
+          DOCKER_PATCH_TAG: ${{ needs.validate.outputs.docker_patch_tag }}
+          DEVICE: ${{ matrix.device }}
+        run: |
+          {
+            echo "## Promotion Complete"
+            echo ""
+            echo "### Docker Images"
+            echo "- ghcr.io/open-edge-platform/geti-${DEVICE}:${DOCKER_PATCH_TAG}"
+            echo ""
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-rc-app.yml
+++ b/.github/workflows/publish-rc-app.yml
@@ -1,0 +1,203 @@
+name: Publish Application RC
+
+on:
+  push:
+    tags:
+      - 'app/v[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+'
+
+permissions: {} # No permissions by default
+
+jobs:
+  validate:
+    name: Validate RC tag
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    outputs:
+      rc_version: "${{ steps.validate.outputs.rc_version }}"
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # Fetch all history and branches for validation
+
+      - name: Validate RC tag
+        id: validate
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Extract version from tag: app/v0.1.0rc1 -> 0.1.0rc1
+          RC_VERSION="${TAG#app/v}"
+
+          # Extract base version without rc suffix: 0.1.0rc1 -> 0.1.0
+          TAG_VERSION="${RC_VERSION%rc*}"
+
+          # Extract RC number: 0.1.0rc1 -> 1
+          RC_NUMBER="${RC_VERSION##*rc}"
+
+          # Read VERSION file
+          FILE_VERSION="$(tr -d '[:space:]' < application/VERSION)"
+
+          # Get the commit SHA that the tag points to (works for annotated and lightweight tags)
+          TAG_COMMIT="$(git rev-parse "${TAG}^{commit}")"
+
+          echo "::group::Validation parameters"
+          echo "Tag: $TAG"
+          echo "RC version: $RC_VERSION"
+          echo "Tag base version: $TAG_VERSION"
+          echo "RC number: $RC_NUMBER"
+          echo "VERSION file: $FILE_VERSION"
+          echo "Tagged commit: $TAG_COMMIT"
+          echo "::endgroup::"
+
+          # Validate RC number is a positive integer
+          if ! [[ "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid RC number '$RC_NUMBER'. RC number must be a positive integer (rc1, rc2, etc.)"
+            exit 1
+          fi
+          echo "✓ RC number is valid"
+
+          # Validate VERSION file format (semver: major.minor.patch)
+          if ! [[ "$FILE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::VERSION file contains invalid semver format: '$FILE_VERSION'"
+            exit 1
+          fi
+          echo "✓ VERSION file has valid semver format"
+
+          # Validate tag version matches VERSION file
+          if [[ "$TAG_VERSION" != "$FILE_VERSION" ]]; then
+            echo "::error::Tag version '$TAG_VERSION' does not match VERSION file '$FILE_VERSION'"
+            exit 1
+          fi
+          echo "✓ Tag version matches VERSION file"
+
+          # Validate base release exists for patch releases
+          PATCH_VERSION="${TAG_VERSION##*.}"
+          if [[ "$PATCH_VERSION" != "0" ]]; then
+            BASE_VERSION="${TAG_VERSION%.*}.0"
+            BASE_TAG="app/v${BASE_VERSION}"
+
+            echo "::group::Patch release validation"
+            echo "Patch version detected: $TAG_VERSION"
+            echo "Base version: $BASE_VERSION"
+            echo "Expected base tag: $BASE_TAG"
+            echo "::endgroup::"
+
+            if ! git rev-parse --verify "refs/tags/${BASE_TAG}" >/dev/null 2>&1; then
+              echo "::error::Patch release tag '${TAG}' requires base release tag '${BASE_TAG}' to exist"
+              echo "::error::Cannot release patch version ${TAG_VERSION} without base version ${BASE_VERSION}"
+              exit 1
+            fi
+            echo "✓ Base release tag ${BASE_TAG} exists"
+          fi
+
+          # Validate previous RC exists for RC N > 1
+          if [[ "$RC_NUMBER" -gt 1 ]]; then
+            PREV_RC_NUMBER=$((RC_NUMBER - 1))
+            PREV_RC_TAG="app/v${TAG_VERSION}rc${PREV_RC_NUMBER}"
+
+            echo "::group::Sequential RC validation"
+            echo "Current RC number: $RC_NUMBER"
+            echo "Previous RC number: $PREV_RC_NUMBER"
+            echo "Expected previous RC tag: $PREV_RC_TAG"
+            echo "::endgroup::"
+
+            if ! git rev-parse --verify "refs/tags/${PREV_RC_TAG}" >/dev/null 2>&1; then
+              echo "::error::RC tag '${TAG}' requires previous RC tag '${PREV_RC_TAG}' to exist"
+              echo "::error::Cannot create RC${RC_NUMBER} without first creating RC${PREV_RC_NUMBER}"
+              echo "::error::Please create RC tags sequentially: rc1, rc2, rc3, ..."
+              exit 1
+            fi
+            echo "✓ Previous RC tag ${PREV_RC_TAG} exists"
+          fi
+
+          echo "rc_version=$RC_VERSION" >> "$GITHUB_OUTPUT"
+
+  publish-rc:
+    name: Build and push container RC (${{ matrix.device }})
+    needs: validate
+    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    permissions:
+      contents: read # Checkout code
+      packages: write # Push images to GHCR
+      id-token: write # Cosign keyless signing (OIDC)
+
+    strategy:
+      fail-fast: false
+      matrix:
+        device: [cpu, xpu, cuda]
+
+    steps:
+      - name: Harden the runner (audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/open-edge-platform/geti-${{ matrix.device }}
+          tags: |
+            type=raw,value=${{ needs.validate.outputs.rc_version }}
+
+      - name: Build and push Docker image
+        uses: ./.github/actions/docker-build
+        with:
+          device: ${{ matrix.device }}
+          push: "true"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          use-cache: "false" # Disable cache for RC builds (security and reproducibility)
+
+      - name: Sign Docker image
+        uses: open-edge-platform/geti-ci/actions/sign-image@7e686c1248b3939f8ee8e04e2612da727e379d91
+        with:
+          image-uri: ${{ steps.meta.outputs.tags }}
+
+      - name: Output summary
+        env:
+          RC_VERSION: ${{ needs.validate.outputs.rc_version }}
+          DEVICE: ${{ matrix.device }}
+          IMAGE_TAG: ${{ steps.meta.outputs.tags }}
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          ## Release Candidate Container Image Published
+
+          ### Release Candidate Information
+          - RC Version: ${RC_VERSION}
+          - Device: ${DEVICE}
+          - Commit: ${GITHUB_SHA:0:8}
+
+          ### Published Container Image
+          ${IMAGE_TAG}
+
+          ### Pull Container Image
+          docker pull ${IMAGE_TAG}
+
+          ### Verify Container Image Signature
+          cosign verify ${IMAGE_TAG} \
+            --certificate-identity-regexp="^https://github\.com/${GITHUB_REPOSITORY}/\.github/workflows/.+" \
+            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          EOF


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Add application promotion workflows for release candidate and release a version. Release artefacts are in form of container image. Release workflow from candidate would be gated through "production" environment where one should put a list of required approvals at both tag creating and artefacts build stages. Release restriction from "release/app-*" branches only might be a good option to have set in "production" environment as well.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
