### PR TITLE
Skip execution of cancelled jobs waiting for capacity

### DIFF
--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -7,7 +7,7 @@ import threading
 
 from loguru import logger
 
-from app.core.jobs.models import Cancelled, Done, Failed, Job, JobType, Progress, Started
+from app.core.jobs.models import Cancelled, Done, Failed, Job, JobStatus, JobType, Progress, Started
 from app.core.run import Runner, RunnerFactory
 
 from .capacity import Capacity
@@ -104,6 +104,11 @@ class JobController:
         needs_capacity_permit = job.job_type == JobType.TRAIN
         permit_ctx = self._capacity.permit() if needs_capacity_permit else contextlib.nullcontext()
         async with permit_ctx:
+            # Check if the job was canceled while waiting for a capacity permit
+            if job.status == JobStatus.CANCELLED:
+                logger.info("Job {} was canceled while waiting for capacity, skipping execution", job.id)
+                return
+
             job_run = self._runner_factory.for_job(job)
             event_q: asyncio.Queue = asyncio.Queue()
 

--- a/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
+++ b/application/backend/tests/integration/core/jobs/control_plane/test_control_plane.py
@@ -436,6 +436,48 @@ class TestJobControlPlaneIntegration:
         finally:
             await job_controller.stop()
 
+    @pytest.mark.asyncio
+    async def test_cancelled_pending_job_not_executed_after_capacity_released(self, fxt_runnable_factory, fxt_job):
+        """Test that a pending job cancelled while waiting for capacity is not executed."""
+        job_queue = JobQueue()
+        runner_factory = ThreadRunnerFactory(fxt_runnable_factory)
+
+        # Only 1 GPU slot so the second job must wait
+        job_controller = JobController(job_queue, runner_factory, max_parallel_jobs=1)
+
+        # First job: slow enough to give us time to cancel the second one
+        fxt_runnable_factory.return_value = MockRunnable(behavior=RunnableBehaviour.SLOW, execution_time=0.05)
+
+        job1 = fxt_job(job_type=JobType.TRAIN)
+        job2 = fxt_job(job_type=JobType.TRAIN)
+
+        await job_queue.submit(job1)
+        await job_queue.submit(job2)
+
+        await job_controller.start()
+
+        try:
+            # Wait for job1 to start running (occupying the capacity slot)
+            await self._wait_for_job_status(job1, JobStatus.RUNNING, timeout=2.0)
+
+            # Cancel job2 while it is pending (waiting for capacity)
+            result_job, result = job_queue.cancel(job2.id)
+            assert result == CancellationResult.PENDING_CANCELLED
+            assert job2.status == JobStatus.CANCELLED
+
+            # Wait for job1 to finish, freeing capacity
+            await self._wait_for_job_status(job1, JobStatus.DONE, timeout=5.0)
+
+            # Give the controller time to potentially (incorrectly) start job2
+            await asyncio.sleep(0.2)
+
+            # job2 must remain cancelled and never transition to RUNNING or DONE
+            assert job2.status == JobStatus.CANCELLED
+            assert job2.started_at is None
+
+        finally:
+            await job_controller.stop()
+
     @staticmethod
     async def _wait_for_job_status(job: Job, expected_status: JobStatus, timeout: float) -> None:
         """Helper method to wait for job to reach expected status."""


### PR DESCRIPTION
### Summary

Jobs that were waiting for capacity did not check if they were cancelled before starting execution. This PR checks if the job was cancelled before executing the job if capacity becomes available.

resolves #6584

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
