### PR TITLE
Enhance error messaging for resource deletion in pipeline services

### DIFF
--- a/application/backend/app/repositories/pipeline_repo.py
+++ b/application/backend/app/repositories/pipeline_repo.py
@@ -38,3 +38,13 @@ class PipelineRepository:
         """Get the active pipeline from database."""
         stmt = select(PipelineDB).where(PipelineDB.is_running)
         return self.db.execute(stmt).scalar_one_or_none()
+
+    def get_by_source_id(self, source_id: str) -> list[PipelineDB]:
+        """Get all pipelines using the given source."""
+        stmt = select(PipelineDB).where(PipelineDB.source_id == source_id)
+        return list(self.db.execute(stmt).scalars().all())
+
+    def get_by_sink_id(self, sink_id: str) -> list[PipelineDB]:
+        """Get all pipelines using the given sink."""
+        stmt = select(PipelineDB).where(PipelineDB.sink_id == sink_id)
+        return list(self.db.execute(stmt).scalars().all())

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -32,14 +32,11 @@ class OtherProjectActiveError(Exception):
     def __init__(
         self,
         requested_project_name: str,
-        requested_project_id: str,
         active_project_name: str,
-        active_project_id: str,
     ):
         super().__init__(
-            f"Attempted to enable a pipeline in project '{requested_project_name}' (ID: {requested_project_id}), "
-            f"while a pipeline is still enabled in another project '{active_project_name}' (ID: {active_project_id}). "
-            f"Please first disable pipeline in project '{active_project_name}' (ID: {active_project_id})."
+            f"Cannot enable the pipeline in project '{requested_project_name}' because a pipeline is already "
+            f"running in project '{active_project_name}'. Disable that pipeline first, then try again."
         )
 
 
@@ -149,9 +146,7 @@ class PipelineService(BaseSessionManagedService):
                 active_project = project_repo.get_by_id(active_pipeline_db.project_id)
                 raise OtherProjectActiveError(
                     requested_project_name=to_update_project.name if to_update_project is not None else "",
-                    requested_project_id=to_update_db.project_id,
                     active_project_name=active_project.name if active_project is not None else "",
-                    active_project_id=active_pipeline_db.project_id,
                 )
             # Validate folder sink accessibility when activating the pipeline
             if to_update_db.sink_id:

--- a/application/backend/app/services/sink_service.py
+++ b/application/backend/app/services/sink_service.py
@@ -5,11 +5,12 @@ from uuid import UUID
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.db.schema import SinkDB
+from app.db.schema import ProjectDB, SinkDB
 from app.models import OutputFormat, Sink, SinkAdapter, SinkType
 from app.models.sink import SinkConfig
 from app.repositories import SinkRepository
 from app.repositories.base import PrimaryKeyIntegrityError, UniqueConstraintIntegrityError
+from app.repositories.pipeline_repo import PipelineRepository
 
 from .base import (
     ResourceInUseError,
@@ -95,6 +96,22 @@ class SinkService:
 
     @parent_process_only
     def delete_sink(self, sink: Sink) -> None:
+        # Check for pipelines using this sink before attempting deletion
+        pipelines = PipelineRepository(self._db_session).get_by_sink_id(str(sink.id))
+        if pipelines:
+            project_details = []
+            for p in pipelines:
+                project = self._db_session.get(ProjectDB, p.project_id)
+                project_name = project.name if project else p.project_id
+                state = "running" if p.is_running else "configured"
+                project_details.append(f"'{project_name}' ({state})")
+            projects_str = ", ".join(project_details)
+            msg = (
+                f"Sink '{sink.name}' cannot be deleted because it is used by "
+                f"a pipeline in project: {projects_str}. "
+                f"Please stop and remove the pipeline configuration in that project first."
+            )
+            raise ResourceInUseError(ResourceType.SINK, str(sink.id), msg)
         try:
             deleted = SinkRepository(self._db_session).delete(str(sink.id))
             if not deleted:

--- a/application/backend/app/services/source_service.py
+++ b/application/backend/app/services/source_service.py
@@ -5,11 +5,12 @@ from uuid import UUID
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.db.schema import SourceDB
+from app.db.schema import ProjectDB, SourceDB
 from app.models import Source, SourceType
 from app.models.source import SourceAdapter, SourceConfig
 from app.repositories import SourceRepository
 from app.repositories.base import PrimaryKeyIntegrityError, UniqueConstraintIntegrityError
+from app.repositories.pipeline_repo import PipelineRepository
 
 from .base import (
     ResourceInUseError,
@@ -63,6 +64,22 @@ class SourceService:
 
     @parent_process_only
     def delete_source(self, source: Source) -> None:
+        # Check for pipelines using this source before attempting deletion
+        pipelines = PipelineRepository(self._db_session).get_by_source_id(str(source.id))
+        if pipelines:
+            project_details = []
+            for p in pipelines:
+                project = self._db_session.get(ProjectDB, p.project_id)
+                project_name = project.name if project else p.project_id
+                state = "running" if p.is_running else "configured"
+                project_details.append(f"'{project_name}' ({state})")
+            projects_str = ", ".join(project_details)
+            msg = (
+                f"Source '{source.name}' cannot be deleted because it is used by "
+                f"a pipeline in project: {projects_str}. "
+                f"Please stop and remove the pipeline configuration in that project first."
+            )
+            raise ResourceInUseError(ResourceType.SOURCE, str(source.id), msg)
         try:
             deleted = SourceRepository(self._db_session).delete(str(source.id))
             if not deleted:

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -150,8 +150,8 @@ class TestPipelineServiceIntegration:
         # Try to activate the second pipeline while the first is still running
         with pytest.raises(OtherProjectActiveError) as excinfo:
             fxt_pipeline_service.update_pipeline(other_pipeline.project_id, {"status": PipelineStatus.RUNNING})
-        assert str(active_pipeline.project_id) in str(excinfo.value)
         assert active_project_db.name in str(excinfo.value)
+        assert str(active_pipeline.project_id) not in str(excinfo.value)
 
     @pytest.mark.parametrize("pipeline_attr", [PipelineField.SINK_ID, PipelineField.SOURCE_ID])
     def test_reconfigure_running_pipeline(

--- a/application/backend/tests/integration/services/test_sink_service.py
+++ b/application/backend/tests/integration/services/test_sink_service.py
@@ -265,3 +265,6 @@ class TestSinkServiceIntegration:
         assert exc_info.value.resource_type == ResourceType.SINK
         assert exc_info.value.resource_id == db_sink.id
         assert db_session.query(SinkDB).count() == 1
+        # Verify the error message includes the project name and state
+        assert "Test Detection Project" in str(exc_info.value)
+        assert "running" in str(exc_info.value)

--- a/application/backend/tests/integration/services/test_source_service.py
+++ b/application/backend/tests/integration/services/test_source_service.py
@@ -252,3 +252,6 @@ class TestSourceUpdateServiceIntegration:
         assert exc_info.value.resource_type == ResourceType.SOURCE
         assert exc_info.value.resource_id == db_source.id
         assert db_session.query(SourceDB).count() == 1
+        # Verify the error message includes the project name and state
+        assert "Test Detection Project" in str(exc_info.value)
+        assert "running" in str(exc_info.value)

--- a/application/backend/tests/unit/api/routers/test_pipelines.py
+++ b/application/backend/tests/unit/api/routers/test_pipelines.py
@@ -185,9 +185,7 @@ class TestPipelineEndpoints:
         [
             OtherProjectActiveError(
                 requested_project_name="this_project_name",
-                requested_project_id="requested-project-id",
                 active_project_name="active_project_name",
-                active_project_id="active-project-id",
             ),
             FolderSinkNotAccessibleError(folder_path="/root/predictions", reason="Read-only file system"),
         ],


### PR DESCRIPTION
### Summary
Improves the error messaging when trying to delete a sink/source that is still in use. The error now gives the project name instead of the ID. 

Also removes the IDs from `OtherProjectActiveException`, the message was way too long with 3x a full UUID and names for projects are already a unique identifier (See https://github.com/open-edge-platform/training_extensions/issues/5848) 

resolves https://github.com/open-edge-platform/training_extensions/issues/6174
