### PR TITLE
fix: Support undo and redo in the polygon and magnetic lasso

### DIFF
--- a/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
+++ b/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
@@ -1,13 +1,13 @@
-// Copyright (C) 2025 Intel Corporation
+// Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { PointerEvent, RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { PointerEvent, RefObject, useEffect, useMemo, useRef } from 'react';
 
 import { clampPointBetweenImage, getIntersectionPoint } from '@geti/smart-tools/utils';
 import { differenceWith, isEmpty, isEqual, isNil } from 'lodash-es';
 
 import { Point, Polygon } from '../../../../shared/types';
-import useUndoRedoState from '../../../dataset/media-preview/primary-toolbar/undo-redo/use-undo-redo-state';
+import { usePolygonState } from '../polygon-tool/polygon-state-provider.component';
 import { deleteSegments, ERASER_FIELD_DEFAULT_RADIUS } from '../polygon-tool/utils';
 import { convertToolShapeToGetiShape, getRelativePoint } from '../utils';
 import { useIntelligentScissorsWorker } from './use-intelligent-scissors-worker.hook';
@@ -24,9 +24,8 @@ export const usePolygonConfig = ({
     const isMounted = useRef(true);
     const { worker } = useIntelligentScissorsWorker();
 
-    const [pointerLine, setPointerLine] = useState<Point[]>([]);
-    const [lassoSegment, setLassoSegment] = useState<Point[]>([]);
-    const [segments, setSegments, undoRedoActions] = useUndoRedoState<Point[][]>([]);
+    const { segments, setSegments, pointerLine, setPointerLine, lassoSegment, setLassoSegment, undoRedoActions } =
+        usePolygonState();
 
     useEffect(() => {
         isMounted.current = true;

--- a/application/ui/src/features/annotator/tools/magnetic-lasso/magnetic-lasso.component.tsx
+++ b/application/ui/src/features/annotator/tools/magnetic-lasso/magnetic-lasso.component.tsx
@@ -43,6 +43,7 @@ export const MagneticLasso = () => {
     const isPointerDown = useRef<boolean>(false);
     const isFreeDrawing = useRef<boolean>(false);
     const buildMapPoint = useRef<Point | null>(null);
+    const pendingHistoryCommit = useRef<boolean>(false);
 
     const {
         worker,
@@ -154,10 +155,11 @@ export const MagneticLasso = () => {
 
     const setBuildMapAndSegment = (point: Point) => {
         setLassoSegment([]);
-        setSegments(addFirstPointOrNewOne(point));
+        setSegments(addFirstPointOrNewOne(point), true);
 
         isLoading.current = true;
         buildMapPoint.current = point;
+        pendingHistoryCommit.current = true;
         worker?.buildMap(point);
     };
 
@@ -216,6 +218,10 @@ export const MagneticLasso = () => {
 
             isLoading.current = false;
             worker?.cleanPoints();
+            pendingHistoryCommit.current = false;
+        } else if (pendingHistoryCommit.current) {
+            setSegments((prev) => prev);
+            pendingHistoryCommit.current = false;
         }
 
         setMode(PolygonMode.MagneticLasso);

--- a/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.test.tsx
+++ b/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.test.tsx
@@ -4,13 +4,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { render } from 'test-utils/render';
 
-import {
-    UndoRedoProvider,
-    useUndoRedo,
-} from '../../../dataset/media-preview/primary-toolbar/undo-redo/undo-redo-provider.component';
-import useUndoRedoState, {
-    SetStateWrapper,
-} from '../../../dataset/media-preview/primary-toolbar/undo-redo/use-undo-redo-state';
+import { useUndoRedo } from '../../../dataset/media-preview/primary-toolbar/undo-redo/undo-redo-provider.component';
 import type { ToolType } from '../interface';
 import { PolygonStateProvider, usePolygonState } from './polygon-state-provider.component';
 
@@ -21,14 +15,6 @@ vi.mock('../../../../shared/annotator/tool-provider.component', () => ({
     useTool: () => ({ activeTool: mockActiveTool, setActiveTool: mockSetActiveTool }),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * A consumer component that exposes the polygon drawing state via data-testid
- * attributes so tests can assert on the current values.
- */
 const PolygonStateConsumer = () => {
     const { segments, pointerLine, lassoSegment, setSegments, setPointerLine, setLassoSegment, undoRedoActions } =
         usePolygonState();
@@ -72,10 +58,6 @@ const ToolbarUndoRedoConsumer = () => {
     );
 };
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe('PolygonStateProvider', () => {
     beforeEach(() => {
         mockActiveTool = 'polygon';
@@ -88,20 +70,6 @@ describe('PolygonStateProvider', () => {
                 <ToolbarUndoRedoConsumer />
             </PolygonStateProvider>
         );
-
-    it('provides initial empty drawing state', () => {
-        renderProvider();
-
-        expect(screen.getByTestId('segments')).toHaveTextContent('[]');
-        expect(screen.getByTestId('pointer-line')).toHaveTextContent('[]');
-        expect(screen.getByTestId('lasso-segment')).toHaveTextContent('[]');
-    });
-
-    it('toolbar undo button is disabled when no segments have been added', () => {
-        renderProvider();
-
-        expect(screen.getByRole('button', { name: 'Toolbar undo' })).toBeDisabled();
-    });
 
     it('toolbar undo removes the last segment', () => {
         renderProvider();
@@ -164,74 +132,11 @@ describe('PolygonStateProvider', () => {
         expect(screen.getByTestId('lasso-segment')).not.toHaveTextContent('[]');
 
         // Simulate user switching to a different tool
-        mockActiveTool = 'bounding-box';
+        mockActiveTool = 'magnetic-lasso';
         rerender(tree);
 
         expect(screen.getByTestId('segments')).toHaveTextContent('[]');
         expect(screen.getByTestId('pointer-line')).toHaveTextContent('[]');
         expect(screen.getByTestId('lasso-segment')).toHaveTextContent('[]');
-    });
-
-    describe('undo/redo chaining with parent annotations stack', () => {
-        /**
-         * Sets up the full provider chain:
-         *   ParentAnnotationsStack (UndoRedoProvider)
-         *     └─ PolygonStateProvider (inner UndoRedoProvider)
-         *          └─ PolygonStateConsumer + ToolbarUndoRedoConsumer
-         *
-         * The ToolbarUndoRedoConsumer reads from the innermost UndoRedoProvider,
-         * which is PolygonStateProvider's. When the polygon stack is empty the
-         * existing chaining in useUndoRedoState delegates to the parent.
-         */
-        const ParentAnnotationsApp = ({
-            parentValue,
-            setParentValue,
-        }: {
-            parentValue: number;
-            setParentValue: SetStateWrapper<number>;
-        }) => (
-            <div>
-                <span data-testid='parent-value'>{parentValue}</span>
-                <button onClick={() => setParentValue((v) => v + 1)}>Increment parent</button>
-                <PolygonStateProvider>
-                    <PolygonStateConsumer />
-                    <ToolbarUndoRedoConsumer />
-                </PolygonStateProvider>
-            </div>
-        );
-
-        const renderWithParent = () => {
-            const ParentWrapper = () => {
-                const [value, setValue, undoRedo] = useUndoRedoState(0);
-
-                return (
-                    <UndoRedoProvider state={undoRedo}>
-                        <ParentAnnotationsApp parentValue={value} setParentValue={setValue} />
-                    </UndoRedoProvider>
-                );
-            };
-
-            return render(<ParentWrapper />);
-        };
-
-        it('delegates to the parent (annotations) stack once the polygon stack is empty', () => {
-            renderWithParent();
-
-            // Commit a change to the parent (annotations) stack
-            fireEvent.click(screen.getByRole('button', { name: 'Increment parent' }));
-            expect(screen.getByTestId('parent-value')).toHaveTextContent('1');
-
-            // Add a polygon segment (polygon stack depth = 1)
-            fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
-
-            // First toolbar undo should pop the polygon segment
-            fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
-            expect(JSON.parse(screen.getByTestId('segments').textContent ?? '[]')).toHaveLength(0);
-            expect(screen.getByTestId('parent-value')).toHaveTextContent('1');
-
-            // Second toolbar undo: polygon stack empty → delegates to parent
-            fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
-            expect(screen.getByTestId('parent-value')).toHaveTextContent('0');
-        });
     });
 });

--- a/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.test.tsx
+++ b/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.test.tsx
@@ -1,0 +1,237 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { fireEvent, screen } from '@testing-library/react';
+import { render } from 'test-utils/render';
+
+import {
+    UndoRedoProvider,
+    useUndoRedo,
+} from '../../../dataset/media-preview/primary-toolbar/undo-redo/undo-redo-provider.component';
+import useUndoRedoState, {
+    SetStateWrapper,
+} from '../../../dataset/media-preview/primary-toolbar/undo-redo/use-undo-redo-state';
+import type { ToolType } from '../interface';
+import { PolygonStateProvider, usePolygonState } from './polygon-state-provider.component';
+
+const mockSetActiveTool = vi.fn();
+let mockActiveTool: ToolType | null = 'polygon';
+
+vi.mock('../../../../shared/annotator/tool-provider.component', () => ({
+    useTool: () => ({ activeTool: mockActiveTool, setActiveTool: mockSetActiveTool }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * A consumer component that exposes the polygon drawing state via data-testid
+ * attributes so tests can assert on the current values.
+ */
+const PolygonStateConsumer = () => {
+    const { segments, pointerLine, lassoSegment, setSegments, setPointerLine, setLassoSegment, undoRedoActions } =
+        usePolygonState();
+
+    return (
+        <div>
+            <span data-testid='segments'>{JSON.stringify(segments)}</span>
+            <span data-testid='pointer-line'>{JSON.stringify(pointerLine)}</span>
+            <span data-testid='lasso-segment'>{JSON.stringify(lassoSegment)}</span>
+
+            <button onClick={() => setSegments((prev) => [...prev, [{ x: 1, y: 1 }]])}>Add segment</button>
+            <button onClick={() => setPointerLine([{ x: 2, y: 2 }])}>Set pointer line</button>
+            <button onClick={() => setLassoSegment([{ x: 3, y: 3 }])}>Set lasso segment</button>
+
+            <button onClick={undoRedoActions.undo} disabled={!undoRedoActions.canUndo}>
+                Undo
+            </button>
+            <button onClick={undoRedoActions.redo} disabled={!undoRedoActions.canRedo}>
+                Redo
+            </button>
+        </div>
+    );
+};
+
+/**
+ * A component that reads the UndoRedo context (resolves to the innermost
+ * UndoRedoProvider) so tests can assert toolbar-level undo/redo behaviour.
+ */
+const ToolbarUndoRedoConsumer = () => {
+    const { undo, redo, canUndo, canRedo } = useUndoRedo();
+
+    return (
+        <div>
+            <button onClick={undo} disabled={!canUndo}>
+                Toolbar undo
+            </button>
+            <button onClick={redo} disabled={!canRedo}>
+                Toolbar redo
+            </button>
+        </div>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PolygonStateProvider', () => {
+    beforeEach(() => {
+        mockActiveTool = 'polygon';
+    });
+
+    const renderProvider = () =>
+        render(
+            <PolygonStateProvider>
+                <PolygonStateConsumer />
+                <ToolbarUndoRedoConsumer />
+            </PolygonStateProvider>
+        );
+
+    it('provides initial empty drawing state', () => {
+        renderProvider();
+
+        expect(screen.getByTestId('segments')).toHaveTextContent('[]');
+        expect(screen.getByTestId('pointer-line')).toHaveTextContent('[]');
+        expect(screen.getByTestId('lasso-segment')).toHaveTextContent('[]');
+    });
+
+    it('toolbar undo button is disabled when no segments have been added', () => {
+        renderProvider();
+
+        expect(screen.getByRole('button', { name: 'Toolbar undo' })).toBeDisabled();
+    });
+
+    it('toolbar undo removes the last segment', () => {
+        renderProvider();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
+        expect(JSON.parse(screen.getByTestId('segments').textContent ?? '[]')).toHaveLength(2);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
+        expect(JSON.parse(screen.getByTestId('segments').textContent ?? '[]')).toHaveLength(1);
+    });
+
+    it('toolbar undo clears pointerLine and lassoSegment (fixes frozen-tool bug)', () => {
+        renderProvider();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Set pointer line' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Set lasso segment' }));
+
+        expect(screen.getByTestId('pointer-line')).not.toHaveTextContent('[]');
+        expect(screen.getByTestId('lasso-segment')).not.toHaveTextContent('[]');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
+
+        expect(screen.getByTestId('pointer-line')).toHaveTextContent('[]');
+        expect(screen.getByTestId('lasso-segment')).toHaveTextContent('[]');
+    });
+
+    it('toolbar redo clears pointerLine and lassoSegment', () => {
+        renderProvider();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
+
+        // Set transient state after undo to simulate pointer activity
+        fireEvent.click(screen.getByRole('button', { name: 'Set pointer line' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Set lasso segment' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Toolbar redo' }));
+
+        expect(screen.getByTestId('pointer-line')).toHaveTextContent('[]');
+        expect(screen.getByTestId('lasso-segment')).toHaveTextContent('[]');
+    });
+
+    it('resets all drawing state when activeTool changes', () => {
+        const tree = (
+            <PolygonStateProvider>
+                <PolygonStateConsumer />
+                <ToolbarUndoRedoConsumer />
+            </PolygonStateProvider>
+        );
+        const { rerender } = render(tree);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Set pointer line' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Set lasso segment' }));
+
+        expect(JSON.parse(screen.getByTestId('segments').textContent ?? '[]')).toHaveLength(1);
+        expect(screen.getByTestId('pointer-line')).not.toHaveTextContent('[]');
+        expect(screen.getByTestId('lasso-segment')).not.toHaveTextContent('[]');
+
+        // Simulate user switching to a different tool
+        mockActiveTool = 'bounding-box';
+        rerender(tree);
+
+        expect(screen.getByTestId('segments')).toHaveTextContent('[]');
+        expect(screen.getByTestId('pointer-line')).toHaveTextContent('[]');
+        expect(screen.getByTestId('lasso-segment')).toHaveTextContent('[]');
+    });
+
+    describe('undo/redo chaining with parent annotations stack', () => {
+        /**
+         * Sets up the full provider chain:
+         *   ParentAnnotationsStack (UndoRedoProvider)
+         *     └─ PolygonStateProvider (inner UndoRedoProvider)
+         *          └─ PolygonStateConsumer + ToolbarUndoRedoConsumer
+         *
+         * The ToolbarUndoRedoConsumer reads from the innermost UndoRedoProvider,
+         * which is PolygonStateProvider's. When the polygon stack is empty the
+         * existing chaining in useUndoRedoState delegates to the parent.
+         */
+        const ParentAnnotationsApp = ({
+            parentValue,
+            setParentValue,
+        }: {
+            parentValue: number;
+            setParentValue: SetStateWrapper<number>;
+        }) => (
+            <div>
+                <span data-testid='parent-value'>{parentValue}</span>
+                <button onClick={() => setParentValue((v) => v + 1)}>Increment parent</button>
+                <PolygonStateProvider>
+                    <PolygonStateConsumer />
+                    <ToolbarUndoRedoConsumer />
+                </PolygonStateProvider>
+            </div>
+        );
+
+        const renderWithParent = () => {
+            const ParentWrapper = () => {
+                const [value, setValue, undoRedo] = useUndoRedoState(0);
+
+                return (
+                    <UndoRedoProvider state={undoRedo}>
+                        <ParentAnnotationsApp parentValue={value} setParentValue={setValue} />
+                    </UndoRedoProvider>
+                );
+            };
+
+            return render(<ParentWrapper />);
+        };
+
+        it('delegates to the parent (annotations) stack once the polygon stack is empty', () => {
+            renderWithParent();
+
+            // Commit a change to the parent (annotations) stack
+            fireEvent.click(screen.getByRole('button', { name: 'Increment parent' }));
+            expect(screen.getByTestId('parent-value')).toHaveTextContent('1');
+
+            // Add a polygon segment (polygon stack depth = 1)
+            fireEvent.click(screen.getByRole('button', { name: 'Add segment' }));
+
+            // First toolbar undo should pop the polygon segment
+            fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
+            expect(JSON.parse(screen.getByTestId('segments').textContent ?? '[]')).toHaveLength(0);
+            expect(screen.getByTestId('parent-value')).toHaveTextContent('1');
+
+            // Second toolbar undo: polygon stack empty → delegates to parent
+            fireEvent.click(screen.getByRole('button', { name: 'Toolbar undo' }));
+            expect(screen.getByTestId('parent-value')).toHaveTextContent('0');
+        });
+    });
+});

--- a/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.tsx
+++ b/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.tsx
@@ -89,7 +89,7 @@ export const usePolygonState = (): PolygonState => {
     const context = useContext(PolygonStateContext);
 
     if (context === null) {
-        throw new Error('usePolygonDrawingState must be used within a PolygonStateProvider');
+        throw new Error('usePolygonState must be used within a PolygonStateProvider');
     }
 
     return context;

--- a/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.tsx
+++ b/application/ui/src/features/annotator/tools/polygon-tool/polygon-state-provider.component.tsx
@@ -1,0 +1,96 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+    createContext,
+    Dispatch,
+    PropsWithChildren,
+    SetStateAction,
+    useCallback,
+    useContext,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+
+import { useTool } from '../../../../shared/annotator/tool-provider.component';
+import { Point } from '../../../../shared/types';
+import { UndoRedoActions } from '../../../dataset/media-preview/primary-toolbar/undo-redo/undo-redo-actions.interface';
+import { UndoRedoProvider } from '../../../dataset/media-preview/primary-toolbar/undo-redo/undo-redo-provider.component';
+import useUndoRedoState, {
+    SetStateWrapper,
+} from '../../../dataset/media-preview/primary-toolbar/undo-redo/use-undo-redo-state';
+
+type PolygonState = {
+    segments: Point[][];
+    setSegments: SetStateWrapper<Point[][]>;
+    pointerLine: Point[];
+    setPointerLine: Dispatch<SetStateAction<Point[]>>;
+    lassoSegment: Point[];
+    setLassoSegment: Dispatch<SetStateAction<Point[]>>;
+    undoRedoActions: UndoRedoActions<Point[][]>;
+};
+
+const PolygonStateContext = createContext<PolygonState | null>(null);
+
+export const PolygonStateProvider = ({ children }: PropsWithChildren) => {
+    const { activeTool } = useTool();
+
+    const [pointerLine, setPointerLine] = useState<Point[]>([]);
+    const [lassoSegment, setLassoSegment] = useState<Point[]>([]);
+    const [segments, setSegments, undoRedoActions] = useUndoRedoState<Point[][]>([]);
+
+    const { canUndo, canRedo, undo, redo, reset } = undoRedoActions;
+
+    const prevToolRef = useRef(activeTool);
+
+    if (prevToolRef.current !== activeTool) {
+        prevToolRef.current = activeTool;
+        setPointerLine([]);
+        setLassoSegment([]);
+        reset();
+    }
+
+    // Wrap undo/redo so that transient pointer/lasso visuals are cleared
+    // immediately when stepping through history. Without this, pointerLine
+    // and lassoSegment (which live outside the undo stack) would keep
+    // displaying a stale follow-line until the next pointer-move event,
+    // making the tool look frozen after an undo.
+    const enhancedUndo = useCallback(() => {
+        setPointerLine([]);
+        setLassoSegment([]);
+        undo();
+    }, [undo]);
+
+    const enhancedRedo = useCallback(() => {
+        setPointerLine([]);
+        setLassoSegment([]);
+        redo();
+    }, [redo]);
+
+    const wrappedUndoRedoActions = useMemo<UndoRedoActions<Point[][]>>(
+        () => ({ canUndo, canRedo, undo: enhancedUndo, redo: enhancedRedo, reset }),
+        [canUndo, canRedo, enhancedUndo, enhancedRedo, reset]
+    );
+
+    const value = useMemo<PolygonState>(
+        () => ({ segments, setSegments, pointerLine, setPointerLine, lassoSegment, setLassoSegment, undoRedoActions }),
+        [segments, setSegments, pointerLine, lassoSegment, undoRedoActions]
+    );
+
+    return (
+        <PolygonStateContext.Provider value={value}>
+            <UndoRedoProvider state={wrappedUndoRedoActions}>{children}</UndoRedoProvider>
+        </PolygonStateContext.Provider>
+    );
+};
+
+export const usePolygonState = (): PolygonState => {
+    const context = useContext(PolygonStateContext);
+
+    if (context === null) {
+        throw new Error('usePolygonDrawingState must be used within a PolygonStateProvider');
+    }
+
+    return context;
+};

--- a/application/ui/src/features/annotator/tools/polygon-tool/polygon-tool.component.tsx
+++ b/application/ui/src/features/annotator/tools/polygon-tool/polygon-tool.component.tsx
@@ -36,6 +36,7 @@ export const PolygonTool = () => {
 
     const ref = useRef<SVGRectElement>({} as SVGRectElement);
     const isPointerDown = useRef<boolean>(false);
+    const pendingHistoryCommit = useRef<boolean>(false);
     const [mode, setMode] = useState<PolygonMode>(PolygonMode.Polygon);
     const [isPendingPolygonOptimization, startTransition] = useTransition();
 
@@ -95,8 +96,9 @@ export const PolygonTool = () => {
                     return;
                 }
 
-                setSegments(removeEmptySegments(lassoSegment, [point]));
+                setSegments(removeEmptySegments(lassoSegment, [point]), true);
                 setLassoSegment([]);
+                pendingHistoryCommit.current = true;
             })(event);
         },
         (event) => {
@@ -114,7 +116,7 @@ export const PolygonTool = () => {
         setPointFromEvent((point: Point): void => {
             // finish the drawing while releasing the button inside the area of starting point
             if ((mode === PolygonMode.Lasso || isCloseMode(mode)) && polygon) {
-                setSegments(removeEmptySegments(lassoSegment));
+                setSegments(removeEmptySegments(lassoSegment), true);
                 setLassoSegment([]);
             }
 
@@ -129,6 +131,10 @@ export const PolygonTool = () => {
                 });
 
                 resetTool();
+                pendingHistoryCommit.current = false;
+            } else if (pendingHistoryCommit.current) {
+                setSegments((prev) => prev);
+                pendingHistoryCommit.current = false;
             }
 
             setMode(PolygonMode.Polygon);

--- a/application/ui/src/features/annotator/tools/tool-manager-provider.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool-manager-provider.component.tsx
@@ -15,10 +15,6 @@ import { PolygonStateProvider } from './polygon-tool/polygon-state-provider.comp
  * The composition shape is stable per project (task type does not change
  * mid-session), so the React subtree remains stable and the toolbar and
  * canvas are never unnecessarily remounted.
- *
- * Gating is done via useAvailableTools — the same source of truth that drives
- * the toolbar — so each provider is only mounted when its tool is available for
- * the current task type.
  */
 export const ToolManagerProvider = ({ children }: PropsWithChildren) => {
     const availableTools = useAvailableTools();

--- a/application/ui/src/features/annotator/tools/tool-manager-provider.component.tsx
+++ b/application/ui/src/features/annotator/tools/tool-manager-provider.component.tsx
@@ -1,0 +1,34 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { PropsWithChildren } from 'react';
+
+import { useAvailableTools } from './annotator-tools/use-available-tools';
+import { PolygonStateProvider } from './polygon-tool/polygon-state-provider.component';
+
+/**
+ * Composes per-tool state providers that need to sit above both the primary
+ * toolbar and the annotator canvas (so the toolbar's undo/redo buttons can
+ * reach tool-local undo stacks while a tool is active).
+ *
+ * Adding state for a new tool: nest an additional provider here.
+ * The composition shape is stable per project (task type does not change
+ * mid-session), so the React subtree remains stable and the toolbar and
+ * canvas are never unnecessarily remounted.
+ *
+ * Gating is done via useAvailableTools — the same source of truth that drives
+ * the toolbar — so each provider is only mounted when its tool is available for
+ * the current task type.
+ */
+export const ToolManagerProvider = ({ children }: PropsWithChildren) => {
+    const availableTools = useAvailableTools();
+    const hasPolygonDrawingTools = availableTools.some(
+        (tool) => tool.type === 'polygon' || tool.type === 'magnetic-lasso'
+    );
+
+    if (hasPolygonDrawingTools) {
+        return <PolygonStateProvider>{children}</PolygonStateProvider>;
+    }
+
+    return <>{children}</>;
+};

--- a/application/ui/src/features/dataset/media-preview/annotator.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/annotator.component.tsx
@@ -15,6 +15,7 @@ import {
     useIsFetchingPredictions,
 } from '../../annotator/api/use-media-predictions';
 import { useSelectedMediaItem } from '../../annotator/selected-media-item-provider.component';
+import { ToolManagerProvider } from '../../annotator/tools/tool-manager-provider.component';
 import { VideoPlayerProvider } from '../../annotator/video-player/video-player-provider.component';
 import { VideoToolbar } from '../../annotator/video-player/video-toolbar/video-toolbar.component';
 import { BottomToolbar } from './bottom-toolbar/bottom-toolbar.component';
@@ -195,17 +196,19 @@ export const AnnotatorContainer = ({
             videoFrame={isVideoFrame(mediaItem) ? mediaItem : undefined}
             changeSelectedMediaItem={onSelectedMediaItem}
         >
-            <Annotator
-                mode={mode}
-                subset={subset}
-                items={items}
-                image={image}
-                onClose={onClose}
-                mediaItem={mediaItem}
-                isUserReviewed={isUserReviewed}
-                onChangeAnnotatorMode={changeAnnotatorMode}
-                onSelectedMediaItem={onSelectedMediaItem}
-            />
+            <ToolManagerProvider>
+                <Annotator
+                    mode={mode}
+                    subset={subset}
+                    items={items}
+                    image={image}
+                    onClose={onClose}
+                    mediaItem={mediaItem}
+                    isUserReviewed={isUserReviewed}
+                    onChangeAnnotatorMode={changeAnnotatorMode}
+                    onSelectedMediaItem={onSelectedMediaItem}
+                />
+            </ToolManagerProvider>
         </VideoPlayerProvider>
     );
 };

--- a/application/ui/tests/annotator/polygon-tool-page.ts
+++ b/application/ui/tests/annotator/polygon-tool-page.ts
@@ -16,6 +16,7 @@ export class PolygonToolPage {
         const relative = await withRelative(this.page);
 
         const startPoint = relative(polygon.points[0].x, polygon.points[0].y);
+        const restPoints = polygon.points.slice(1);
 
         await this.page.mouse.move(startPoint.x, startPoint.y);
         await this.page.mouse.down();
@@ -24,7 +25,7 @@ export class PolygonToolPage {
             await this.page.mouse.up();
         }
 
-        for (const point of polygon.points) {
+        for (const point of restPoints) {
             const relativePoint = relative(point.x, point.y);
 
             await this.page.mouse.move(relativePoint.x, relativePoint.y);

--- a/application/ui/tests/annotator/tools/polygon.spec.ts
+++ b/application/ui/tests/annotator/tools/polygon.spec.ts
@@ -41,8 +41,7 @@ test.describe('Polygon', () => {
     });
 
     test('Remove points', async ({ page, polygonTool }) => {
-        await page.goto(`/projects/${mockedDetectionProject.id}/dataset`);
-        await page.getByRole('img', { name: 'item-1.jpg' }).dblclick();
+        await page.goto(`/projects/${mockedDetectionProject.id}/dataset/item-1`);
 
         await test.step('Draw an annotation', async () => {
             await polygonTool.selectPolygonTool();
@@ -65,6 +64,67 @@ test.describe('Polygon', () => {
                 page.getByLabel(`Resize polygon (${currentPoint.x}, ${currentPoint.y}) anchor`)
             ).not.toBeInViewport();
             await expect(page.getByRole('button', { name: 'delete point' })).not.toBeInViewport();
+        });
+    });
+
+    test('undo/redo behaviour', async ({ page, polygonTool }) => {
+        const partialShape: Polygon = {
+            type: 'polygon',
+            points: [
+                { x: 100, y: 100 },
+                { x: 250, y: 100 },
+                { x: 250, y: 250 },
+            ],
+        };
+
+        const pointsToString = (points: Polygon['points']): string => {
+            return points.map((point) => `${point.x},${point.y}`).join(' ');
+        };
+
+        await test.step('Navigate to annotator', async () => {
+            await page.goto(`/projects/${mockedDetectionProject.id}/dataset/item-1`);
+        });
+
+        await test.step('Draw 3 points without finishing', async () => {
+            await polygonTool.selectPolygonTool();
+            await polygonTool.drawPolygon(partialShape, { asLasso: false, finishShape: false });
+        });
+
+        await test.step('Assert all drawn points are present', async () => {
+            await expect(page.getByLabel('new polygon')).toHaveAttribute('points', pointsToString(partialShape.points));
+        });
+
+        await test.step('Undo once — last point disappears, previous point remains', async () => {
+            await page.getByRole('button', { name: /^undo$/i }).click();
+
+            const newPolygon = page.getByLabel('new polygon');
+
+            const remainingPoints = partialShape.points.slice(0, -1);
+            const lastPoint = partialShape.points[partialShape.points.length - 1];
+
+            await expect(newPolygon).toHaveAttribute('points', pointsToString(remainingPoints));
+            await expect(newPolygon).not.toHaveAttribute('points', pointsToString([lastPoint]));
+        });
+
+        await test.step('Undo to empty — in-progress polygon is gone', async () => {
+            const undoButton = page.getByRole('button', { name: /^undo$/i });
+
+            await undoButton.click();
+            await undoButton.click();
+
+            await expect(page.getByLabel('new polygon')).toBeHidden();
+        });
+
+        await test.step('Redo once — a point is restored', async () => {
+            await page.getByRole('button', { name: /^redo$/i }).click();
+
+            const firstPoint = partialShape.points[0];
+            await expect(page.getByLabel('new polygon')).toHaveAttribute('points', pointsToString([firstPoint]));
+        });
+
+        await test.step('Switch to selection tool — drawing state is reset', async () => {
+            await page.getByRole('button', { name: 'selection tool' }).click();
+            await expect(page.getByLabel('new polygon')).toBeHidden();
         });
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

The issue was that the undo redo state was used but that state was not consumed by the undo redo buttons/hotkeys. That was because the undo redo provider was missing.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
