### PR TITLE
Invalidate queries only when all removals finished

### DIFF
--- a/application/ui/src/features/dataset/api/use-delete-media-item.ts
+++ b/application/ui/src/features/dataset/api/use-delete-media-item.ts
@@ -10,23 +10,8 @@ import { isFunction } from 'lodash-es';
 import { $api } from '../../../api/client';
 import { getQueryKey } from '../../../query-client/query-client';
 
-const useDeleteMediaItemMutation = (projectId: string) => {
+const useDeleteMediaItemMutation = () => {
     return $api.useMutation('delete', `/api/projects/{project_id}/dataset/media/{media_id}`, {
-        meta: {
-            invalidateQueries: [
-                [
-                    'get',
-                    '/api/projects/{project_id}/dataset/media',
-                    {
-                        params: {
-                            path: {
-                                project_id: projectId,
-                            },
-                        },
-                    },
-                ],
-            ],
-        },
         onError: (error, { params: { path } }) => {
             const { media_id: itemId } = path;
 
@@ -44,7 +29,7 @@ const isFulfilled = (response: PromiseSettledResult<{ itemId: string }>) => resp
 export const useDeleteMediaItem = () => {
     const queryClient = useQueryClient();
     const projectId = useProjectIdentifier();
-    const deleteMutation = useDeleteMediaItemMutation(projectId);
+    const deleteMutation = useDeleteMediaItemMutation();
 
     const alertDialogState = useOverlayTriggerState({});
 
@@ -66,6 +51,13 @@ export const useDeleteMediaItem = () => {
             queryKey: getQueryKey([
                 'get',
                 '/api/projects/{project_id}/dataset/statistics',
+                { params: { path: { project_id: projectId } } },
+            ]),
+        });
+        queryClient.invalidateQueries({
+            queryKey: getQueryKey([
+                'get',
+                '/api/projects/{project_id}/dataset/media',
                 { params: { path: { project_id: projectId } } },
             ]),
         });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Before: Deleting 20 images = 20 api calls to new dataset
* Now: Deleting 20 images = 1 api call

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
