### PR TITLE
Fix wrong input_dtype metadata in 16-bit OV exported model

### DIFF
--- a/application/backend/app/execution/quantization/getitune_quantizer.py
+++ b/application/backend/app/execution/quantization/getitune_quantizer.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from datumaro.experimental.fields import Subset
 from getitune.backend.openvino.engine import OVEngine
 from getitune.config.data import SamplerConfig, SubsetConfig
+from getitune.data.entity.utils import detect_storage_dtype
 from getitune.data.factory import TransformLibFactory
 from getitune.data.module import DataModule
 from loguru import logger
@@ -144,6 +145,11 @@ class GetiTuneQuantizer(Execution[QuantizationJobParams]):
         train_subset_config = build_subset_config("train")
         val_subset_config = build_subset_config("val")
         test_subset_config = build_subset_config("test")
+
+        # Detect storage dtype and propagate to subset configs.
+        storage_dtype = detect_storage_dtype(dm_training_dataset)
+        for cfg in (train_subset_config, val_subset_config, test_subset_config):
+            cfg.intensity.storage_dtype = storage_dtype
 
         # Wrap into VisionDataset instances
         getitune_task_type = get_getitune_task_type_by_task(task)

--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -19,6 +19,7 @@ from getitune.backend.lightning.models.base import DataInputParams, LightningMod
 from getitune.backend.openvino.engine import OVEngine
 from getitune.config.data import SamplerConfig, SubsetConfig
 from getitune.data.dataset.base import VisionDataset
+from getitune.data.entity.utils import detect_storage_dtype
 from getitune.data.factory import TransformLibFactory
 from getitune.data.module import DataModule
 from getitune.types.device import DeviceType as GetiTuneDeviceType
@@ -316,6 +317,11 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
             train_subset_config = build_subset_config("train")
             val_subset_config = build_subset_config("val")
             test_subset_config = build_subset_config("test")
+
+            # Detect storage dtype and propagate to subset configs.
+            storage_dtype = detect_storage_dtype(dm_training_dataset)
+            for cfg in (train_subset_config, val_subset_config, test_subset_config):
+                cfg.intensity.storage_dtype = storage_dtype
 
             # Wrap them into VisionDataset instances
             getitune_task_type = get_getitune_task_type_by_task(task)

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -532,8 +532,9 @@ class TestGetiTuneTrainerCreateTrainingDataset:
         mock_val_transforms = [Mock()]
         mock_test_transforms = [Mock()]
 
-        with patch("app.execution.training.getitune_trainer.TransformLibFactory.generate") as mock_generate, patch(
-            "app.execution.training.getitune_trainer.detect_storage_dtype", return_value="uint8"
+        with (
+            patch("app.execution.training.getitune_trainer.TransformLibFactory.generate") as mock_generate,
+            patch("app.execution.training.getitune_trainer.detect_storage_dtype", return_value="uint8"),
         ):
             mock_generate.side_effect = [mock_train_transforms, mock_val_transforms, mock_test_transforms]
 

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -532,7 +532,9 @@ class TestGetiTuneTrainerCreateTrainingDataset:
         mock_val_transforms = [Mock()]
         mock_test_transforms = [Mock()]
 
-        with patch("app.execution.training.getitune_trainer.TransformLibFactory.generate") as mock_generate:
+        with patch("app.execution.training.getitune_trainer.TransformLibFactory.generate") as mock_generate, patch(
+            "app.execution.training.getitune_trainer.detect_storage_dtype", return_value="uint8"
+        ):
             mock_generate.side_effect = [mock_train_transforms, mock_val_transforms, mock_test_transforms]
 
             # Mock the get_getitune_dataset_class_by_task_type function to return a proper mock class

--- a/library/src/getitune/data/entity/utils.py
+++ b/library/src/getitune/data/entity/utils.py
@@ -15,9 +15,13 @@ import torch
 import torch.utils._pytree as pytree
 from datumaro.experimental.dataset import Sample  # noqa: TC002
 from datumaro.experimental.fields import image_field
+from datumaro.experimental.fields.images import ImageField, ImagePathField
+from datumaro.experimental.fields.videos import MediaPathField
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from datumaro.experimental.dataset import Dataset
 
     from getitune.data.entity.base import ImageInfo
 
@@ -40,40 +44,47 @@ _TIFF_LE = b"II"
 _TIFF_BE = b"MM"
 
 
-def detect_image_dtype(image_path: str | Path) -> str:
-    """Detect the storage dtype of an image from its file header.
+def detect_storage_dtype(dataset: Dataset) -> str:
+    """Detect image storage dtype by inspecting the dataset schema fields.
 
-    Reads **only file metadata** — no pixel data is ever decoded:
-
-    * **PNG**: parses the IHDR chunk (25 bytes) for ``bit_depth``.
-    * **TIFF**: checks the ``BitsPerSample`` tag via PIL header.
-    * **JPEG**: always ``"uint8"`` (JPEG is 8-bit by design).
-    * **Other**: falls back to ``PIL.Image.open().mode`` (header only).
+    Must be called on a raw dataset (before ``convert_to_schema``).
 
     Args:
-        image_path: Path to a single image file.
+        dataset: A ``datumaro.experimental.Dataset`` instance.
 
     Returns:
-        One of ``"uint8"``, ``"uint16"``, or ``"float32"``.
-    """
-    path = Path(image_path)
+        One of ``"uint8"``, ``"uint16"``, ``"int16"``, or ``"float32"``.
 
-    # Read the first 8 bytes to identify the format.
+    Raises:
+        ValueError: If no image field is found in the dataset schema.
+    """
+    for name, attr in dataset.schema.attributes.items():
+        if isinstance(attr.field, (ImagePathField, MediaPathField)):
+            return _detect_dtype_from_file(Path(dataset.df[name][0]))
+        if isinstance(attr.field, ImageField):
+            return str(attr.field.dtype).lower()
+
+    msg = (
+        f"Cannot detect image storage dtype: no image field "
+        f"found in dataset schema. Available fields: {list(dataset.schema.attributes.keys())}"
+    )
+    raise ValueError(msg)
+
+
+def _detect_dtype_from_file(path: Path) -> str:
+    """Detect image storage dtype from a file header without decoding pixels."""
     with path.open("rb") as f:
         sig = f.read(8)
 
-    # PNG: IHDR bit_depth is at byte offset 24
     if sig[:4] == _PNG_SIGNATURE:
         with path.open("rb") as f:
-            f.seek(24)  # signature(8) + length(4) + "IHDR"(4) + width(4) + height(4)
+            f.seek(24)
             bit_depth = struct.unpack("B", f.read(1))[0]
         return "uint16" if bit_depth == 16 else "uint8"
 
-    # JPEG: always 8-bit
     if sig[:2] == _JPEG_SIGNATURE:
         return "uint8"
 
-    # TIFF: check BitsPerSample tag via PIL
     if sig[:2] in (_TIFF_LE, _TIFF_BE):
         from PIL import Image
 
@@ -83,7 +94,7 @@ def detect_image_dtype(image_path: str | Path) -> str:
             if img.mode in _PIL_FLOAT_MODES:
                 return "float32"
             tag_v2 = getattr(img, "tag_v2", None)
-            if tag_v2 and 258 in tag_v2:  # 258 = BitsPerSample
+            if tag_v2 and 258 in tag_v2:
                 bits = tag_v2[258]
                 if isinstance(bits, tuple):
                     bits = bits[0]
@@ -91,7 +102,6 @@ def detect_image_dtype(image_path: str | Path) -> str:
                     return "uint16"
         return "uint8"
 
-    # Fallback: PIL mode (reliable for grayscale 16-bit)
     from PIL import Image
 
     with Image.open(path) as img:

--- a/library/src/getitune/data/entity/utils.py
+++ b/library/src/getitune/data/entity/utils.py
@@ -59,8 +59,18 @@ def detect_storage_dtype(dataset: Dataset) -> str:
         ValueError: If no image field is found in the dataset schema.
     """
     for name, attr in dataset.schema.attributes.items():
-        if isinstance(attr.field, (ImagePathField, MediaPathField)):
+        if isinstance(attr.field, ImagePathField):
             return _detect_dtype_from_file(Path(dataset.df[name][0]))
+        if isinstance(attr.field, MediaPathField):
+            # MediaPathField stores both images and video frames.
+            # Filter to image-only rows (frame_index is null) before probing.
+            frame_idx_col = f"{name}_frame_index"
+            media_df = dataset.df
+            if frame_idx_col in media_df.columns:
+                image_rows = media_df.filter(pl.col(frame_idx_col).is_null())
+                if len(image_rows) > 0:
+                    return _detect_dtype_from_file(Path(image_rows[name][0]))
+            return _detect_dtype_from_file(Path(media_df[name][0]))
         if isinstance(attr.field, ImageField):
             return str(attr.field.dtype).lower()
 

--- a/library/src/getitune/data/entity/utils.py
+++ b/library/src/getitune/data/entity/utils.py
@@ -76,15 +76,18 @@ def _detect_dtype_from_file(path: Path) -> str:
     with path.open("rb") as f:
         sig = f.read(8)
 
+    # PNG: bit_depth is at byte offset 24 in the IHDR chunk
     if sig[:4] == _PNG_SIGNATURE:
         with path.open("rb") as f:
-            f.seek(24)
+            f.seek(24)  # signature(8) + length(4) + "IHDR"(4) + width(4) + height(4)
             bit_depth = struct.unpack("B", f.read(1))[0]
         return "uint16" if bit_depth == 16 else "uint8"
 
+    # JPEG is always 8-bit
     if sig[:2] == _JPEG_SIGNATURE:
         return "uint8"
 
+    # TIFF: check BitsPerSample tag via PIL
     if sig[:2] in (_TIFF_LE, _TIFF_BE):
         from PIL import Image
 
@@ -94,7 +97,7 @@ def _detect_dtype_from_file(path: Path) -> str:
             if img.mode in _PIL_FLOAT_MODES:
                 return "float32"
             tag_v2 = getattr(img, "tag_v2", None)
-            if tag_v2 and 258 in tag_v2:
+            if tag_v2 and 258 in tag_v2:  # 258 = BitsPerSample
                 bits = tag_v2[258]
                 if isinstance(bits, tuple):
                     bits = bits[0]
@@ -102,6 +105,7 @@ def _detect_dtype_from_file(path: Path) -> str:
                     return "uint16"
         return "uint8"
 
+    # Fallback: use PIL mode
     from PIL import Image
 
     with Image.open(path) as img:

--- a/library/src/getitune/data/entity/utils.py
+++ b/library/src/getitune/data/entity/utils.py
@@ -16,7 +16,6 @@ import torch.utils._pytree as pytree
 from datumaro.experimental.dataset import Sample  # noqa: TC002
 from datumaro.experimental.fields import image_field
 from datumaro.experimental.fields.images import ImageField, ImagePathField
-from datumaro.experimental.fields.videos import MediaPathField
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -61,16 +60,6 @@ def detect_storage_dtype(dataset: Dataset) -> str:
     for name, attr in dataset.schema.attributes.items():
         if isinstance(attr.field, ImagePathField):
             return _detect_dtype_from_file(Path(dataset.df[name][0]))
-        if isinstance(attr.field, MediaPathField):
-            # MediaPathField stores both images and video frames.
-            # Filter to image-only rows (frame_index is null) before probing.
-            frame_idx_col = f"{name}_frame_index"
-            media_df = dataset.df
-            if frame_idx_col in media_df.columns:
-                image_rows = media_df.filter(pl.col(frame_idx_col).is_null())
-                if len(image_rows) > 0:
-                    return _detect_dtype_from_file(Path(image_rows[name][0]))
-            return _detect_dtype_from_file(Path(media_df[name][0]))
         if isinstance(attr.field, ImageField):
             return str(attr.field.dtype).lower()
 

--- a/library/src/getitune/data/factory.py
+++ b/library/src/getitune/data/factory.py
@@ -57,24 +57,12 @@ class DatasetFactory:
         task: TaskType,
         dm_subset: Dataset,
         cfg_subset: SubsetConfig,
+        storage_dtype: str = "uint8",
         # TODO(gdlg): Add support for ignore_index again
         ignore_index: int = 255,  # noqa: ARG003
     ) -> VisionDataset:
         """Create VisionDataset."""
         transforms = TransformLibFactory.generate(cfg_subset)
-
-        # Auto-detect storage dtype from the first image's file header.
-        # Reads only metadata (e.g. PNG IHDR), no pixel data is decoded.
-        storage_dtype = cls._detect_storage_dtype(dm_subset)
-
-        # Propagate the detected dtype into the intensity config so it is
-        # exported into the model's rt_info (input_dtype) for inference.
-        if cfg_subset.intensity.storage_dtype != storage_dtype:
-            logger.info(
-                f"Auto-detected image storage dtype '{storage_dtype}' "
-                f"(intensity config had '{cfg_subset.intensity.storage_dtype}')",
-            )
-            cfg_subset.intensity.storage_dtype = storage_dtype
 
         common_kwargs = {
             "dm_subset": dm_subset,
@@ -120,44 +108,3 @@ class DatasetFactory:
 
             case _:
                 raise NotImplementedError(task)
-
-    @staticmethod
-    def _detect_storage_dtype(dm_subset: Dataset) -> str:
-        """Detect image storage bit depth from file header or dataset schema.
-
-        First tries to probe the first image's file header via PIL (reads only
-        metadata, no pixel data decoded).  If that is not available (e.g. for
-        parquet-backed datasets with no media paths), falls back to the image
-        field dtype declared in the dataset schema.
-
-        Returns:
-            ``"uint8"``, ``"uint16"``, or ``"float32"``.
-        """
-        import polars as pl
-
-        from getitune.data.entity.utils import detect_image_dtype
-
-        # 1. Try file-based detection
-        try:
-            first_item = next(iter(dm_subset))
-            path = getattr(first_item.media, "path", None) if hasattr(first_item, "media") else None
-            if path is not None:
-                return detect_image_dtype(path)
-        except StopIteration:
-            pass
-        except (OSError, ValueError, TypeError) as exc:
-            logger.debug(f"File-based dtype detection failed, falling back to schema: {exc}")
-
-        # 2. Fall back to schema-declared image dtype (parquet datasets)
-        try:
-            img_attr = dm_subset.schema.attributes.get("image")
-            if img_attr is not None and hasattr(img_attr, "field"):
-                dtype = getattr(img_attr.field, "dtype", None)
-                if dtype == pl.UInt16:
-                    return "uint16"
-                if dtype in (pl.Float32, pl.Float64):
-                    return "float32"
-        except (AttributeError, TypeError) as exc:
-            logger.debug(f"Schema-based dtype detection failed: {exc}")
-
-        return "uint8"

--- a/library/src/getitune/data/module.py
+++ b/library/src/getitune/data/module.py
@@ -174,12 +174,10 @@ class DataModule(LightningDataModule):
                 logger.warning(f"Subset '{name}' is empty in the dataset. Skip it")
                 continue
 
-            if storage_dtype is None and "media" in dm_subset.df.columns:
-                # "media" column in the datumaro DataFrame stores image file paths.
-                first_image_path = dm_subset.df["media"][0]
-                storage_dtype = detect_image_dtype(first_image_path)
+            if storage_dtype is None:
+                storage_dtype = detect_image_dtype(dm_subset.df["media"][0])
 
-            if storage_dtype is not None and subset_cfg.intensity.storage_dtype != storage_dtype:
+            if subset_cfg.intensity.storage_dtype != storage_dtype:
                 logger.warning(
                     f"Overriding intensity storage_dtype '{subset_cfg.intensity.storage_dtype}' "
                     f"with auto-detected '{storage_dtype}'",
@@ -190,7 +188,7 @@ class DataModule(LightningDataModule):
                 task=self.task,
                 dm_subset=dm_subset,
                 cfg_subset=subset_cfg,
-                storage_dtype=subset_cfg.intensity.storage_dtype,
+                storage_dtype=storage_dtype,
                 ignore_index=self.ignore_index,
             )
 
@@ -338,17 +336,9 @@ class DataModule(LightningDataModule):
             instance.input_std = None
 
         # Auto-detect storage dtype from the training dataset's image files.
-        # "media" column in the datumaro DataFrame stores image file paths;
-        # inline-pixel datasets (e.g., CIFAR) use an "image" column instead.
-        if "media" in train_dataset.dm_subset.df.columns:
-            first_image_path = train_dataset.dm_subset.df["media"][0]
-            detected = detect_image_dtype(first_image_path)
-            if instance.train_subset.intensity.storage_dtype != detected:
-                logger.warning(
-                    f"Overriding intensity storage_dtype '{instance.train_subset.intensity.storage_dtype}' "
-                    f"with auto-detected '{detected}'",
-                )
-                instance.train_subset.intensity.storage_dtype = detected
+        detected = detect_image_dtype(train_dataset.dm_subset.df["media"][0])
+        if instance.train_subset.intensity.storage_dtype != detected:
+            instance.train_subset.intensity.storage_dtype = detected
 
         # Propagate intensity config from train subset (mirrors __init__).
         instance.input_intensity_config = getattr(instance.train_subset, "intensity", None)

--- a/library/src/getitune/data/module.py
+++ b/library/src/getitune/data/module.py
@@ -19,7 +19,7 @@ from torch.utils.data import DataLoader, RandomSampler
 from getitune.config.data import SubsetConfig, TileConfig
 from getitune.data.augmentation import CPUAugmentationPipeline
 from getitune.data.dataset.tile import TileDatasetFactory
-from getitune.data.entity.utils import detect_image_dtype
+from getitune.data.entity.utils import detect_storage_dtype
 from getitune.data.factory import DatasetFactory
 from getitune.data.utils import get_adaptive_num_workers, instantiate_sampler
 from getitune.types.device import DeviceType
@@ -175,7 +175,7 @@ class DataModule(LightningDataModule):
                 continue
 
             if storage_dtype is None:
-                storage_dtype = detect_image_dtype(dm_subset.df["media"][0])
+                storage_dtype = detect_storage_dtype(dm_subset)
 
             if subset_cfg.intensity.storage_dtype != storage_dtype:
                 logger.warning(
@@ -335,12 +335,7 @@ class DataModule(LightningDataModule):
             instance.input_mean = None
             instance.input_std = None
 
-        # Auto-detect storage dtype from the training dataset's image files.
-        detected = detect_image_dtype(train_dataset.dm_subset.df["media"][0])
-        if instance.train_subset.intensity.storage_dtype != detected:
-            instance.train_subset.intensity.storage_dtype = detected
-
-        # Propagate intensity config from train subset (mirrors __init__).
+        # Propagate intensity config from train subset.
         instance.input_intensity_config = getattr(instance.train_subset, "intensity", None)
 
         # Save hyperparameters

--- a/library/src/getitune/data/module.py
+++ b/library/src/getitune/data/module.py
@@ -10,7 +10,6 @@ import multiprocessing
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import polars as pl
 from datumaro.experimental.export_import import import_dataset
 from datumaro.experimental.fields import Subset
 from lightning import LightningDataModule
@@ -142,6 +141,7 @@ class DataModule(LightningDataModule):
         Args:
             dataset: A ``datumaro.experimental.Dataset`` loaded via ``import_dataset``.
         """
+        storage_dtype: str | None = None
         config_mapping = {
             self.train_subset.subset_name: self.train_subset,
             self.val_subset.subset_name: self.val_subset,
@@ -174,10 +174,21 @@ class DataModule(LightningDataModule):
                 logger.warning(f"Subset '{name}' is empty in the dataset. Skip it")
                 continue
 
+            if storage_dtype is None:
+                storage_dtype = detect_image_dtype(dm_subset.df["media"][0])
+
+            if subset_cfg.intensity.storage_dtype != storage_dtype:
+                logger.warning(
+                    f"Overriding intensity storage_dtype '{subset_cfg.intensity.storage_dtype}' "
+                    f"with auto-detected '{storage_dtype}'",
+                )
+                subset_cfg.intensity.storage_dtype = storage_dtype
+
             subset_dataset = DatasetFactory.create(
                 task=self.task,
                 dm_subset=dm_subset,
                 cfg_subset=subset_cfg,
+                storage_dtype=storage_dtype,
                 ignore_index=self.ignore_index,
             )
 
@@ -188,7 +199,6 @@ class DataModule(LightningDataModule):
                 )
             self.subsets[name] = subset_dataset
             label_infos += [self.subsets[name].label_info]
-            logger.info(f"Add name: {name}, self.subsets: {self.subsets}")
 
         if self._is_meta_info_valid(label_infos) is False:
             msg = "All data meta infos of subsets should be the same."
@@ -326,7 +336,9 @@ class DataModule(LightningDataModule):
             instance.input_std = None
 
         # Auto-detect storage dtype from the training dataset's image files.
-        instance._detect_and_update_storage_dtype(train_dataset)  # noqa: SLF001
+        detected = detect_image_dtype(train_dataset.dm_subset.df["media"][0])
+        if instance.train_subset.intensity.storage_dtype != detected:
+            instance.train_subset.intensity.storage_dtype = detected
 
         # Propagate intensity config from train subset (mirrors __init__).
         instance.input_intensity_config = getattr(instance.train_subset, "intensity", None)
@@ -402,40 +414,6 @@ class DataModule(LightningDataModule):
     def _is_meta_info_valid(self, label_infos: list[LabelInfo]) -> bool:
         """Check whether there are mismatches in the metainfo for the all subsets."""
         return bool(all(label_info == label_infos[0] for label_info in label_infos))
-
-    def _detect_and_update_storage_dtype(self, train_dataset: VisionDataset) -> None:
-        """Auto-detect storage dtype from the training dataset and update the intensity config.
-
-        Args:
-            train_dataset: The training VisionDataset with a ``dm_subset`` attribute.
-        """
-        intensity = getattr(self.train_subset, "intensity", None)
-        if intensity is None:
-            return
-
-        dm_subset = getattr(train_dataset, "dm_subset", None)
-        if dm_subset is None:
-            return
-
-        # Get an image path from the underlying DataFrame directly.
-        # This avoids iterating the dataset (which may fail if the schema
-        # was converted with the wrong storage dtype).
-        try:
-            frame = dm_subset.df
-            if "media" not in frame.columns or frame["media"].dtype != pl.String:
-                return
-            first_path = frame["media"][0]
-            if first_path is None:
-                return
-            detected = detect_image_dtype(first_path)
-        except (AttributeError, IndexError, OSError, TypeError, ValueError):
-            return
-
-        if intensity.storage_dtype != detected:
-            logger.info(
-                f"Auto-detected image storage dtype '{detected}' (intensity config had '{intensity.storage_dtype}')",
-            )
-            intensity.storage_dtype = detected
 
     def _get_dataset(self, subset: str) -> VisionDataset:
         if (dataset := self.subsets.get(subset)) is None:

--- a/library/src/getitune/data/module.py
+++ b/library/src/getitune/data/module.py
@@ -174,10 +174,12 @@ class DataModule(LightningDataModule):
                 logger.warning(f"Subset '{name}' is empty in the dataset. Skip it")
                 continue
 
-            if storage_dtype is None:
-                storage_dtype = detect_image_dtype(dm_subset.df["media"][0])
+            if storage_dtype is None and "media" in dm_subset.df.columns:
+                # "media" column in the datumaro DataFrame stores image file paths.
+                first_image_path = dm_subset.df["media"][0]
+                storage_dtype = detect_image_dtype(first_image_path)
 
-            if subset_cfg.intensity.storage_dtype != storage_dtype:
+            if storage_dtype is not None and subset_cfg.intensity.storage_dtype != storage_dtype:
                 logger.warning(
                     f"Overriding intensity storage_dtype '{subset_cfg.intensity.storage_dtype}' "
                     f"with auto-detected '{storage_dtype}'",
@@ -188,7 +190,7 @@ class DataModule(LightningDataModule):
                 task=self.task,
                 dm_subset=dm_subset,
                 cfg_subset=subset_cfg,
-                storage_dtype=storage_dtype,
+                storage_dtype=subset_cfg.intensity.storage_dtype,
                 ignore_index=self.ignore_index,
             )
 
@@ -336,9 +338,17 @@ class DataModule(LightningDataModule):
             instance.input_std = None
 
         # Auto-detect storage dtype from the training dataset's image files.
-        detected = detect_image_dtype(train_dataset.dm_subset.df["media"][0])
-        if instance.train_subset.intensity.storage_dtype != detected:
-            instance.train_subset.intensity.storage_dtype = detected
+        # "media" column in the datumaro DataFrame stores image file paths;
+        # inline-pixel datasets (e.g., CIFAR) use an "image" column instead.
+        if "media" in train_dataset.dm_subset.df.columns:
+            first_image_path = train_dataset.dm_subset.df["media"][0]
+            detected = detect_image_dtype(first_image_path)
+            if instance.train_subset.intensity.storage_dtype != detected:
+                logger.warning(
+                    f"Overriding intensity storage_dtype '{instance.train_subset.intensity.storage_dtype}' "
+                    f"with auto-detected '{detected}'",
+                )
+                instance.train_subset.intensity.storage_dtype = detected
 
         # Propagate intensity config from train subset (mirrors __init__).
         instance.input_intensity_config = getattr(instance.train_subset, "intensity", None)

--- a/library/src/getitune/data/module.py
+++ b/library/src/getitune/data/module.py
@@ -10,6 +10,7 @@ import multiprocessing
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import polars as pl
 from datumaro.experimental.export_import import import_dataset
 from datumaro.experimental.fields import Subset
 from lightning import LightningDataModule
@@ -19,6 +20,7 @@ from torch.utils.data import DataLoader, RandomSampler
 from getitune.config.data import SubsetConfig, TileConfig
 from getitune.data.augmentation import CPUAugmentationPipeline
 from getitune.data.dataset.tile import TileDatasetFactory
+from getitune.data.entity.utils import detect_image_dtype
 from getitune.data.factory import DatasetFactory
 from getitune.data.utils import get_adaptive_num_workers, instantiate_sampler
 from getitune.types.device import DeviceType
@@ -323,6 +325,9 @@ class DataModule(LightningDataModule):
             instance.input_mean = None
             instance.input_std = None
 
+        # Auto-detect storage dtype from the training dataset's image files.
+        instance._detect_and_update_storage_dtype(train_dataset)  # noqa: SLF001
+
         # Propagate intensity config from train subset (mirrors __init__).
         instance.input_intensity_config = getattr(instance.train_subset, "intensity", None)
 
@@ -397,6 +402,40 @@ class DataModule(LightningDataModule):
     def _is_meta_info_valid(self, label_infos: list[LabelInfo]) -> bool:
         """Check whether there are mismatches in the metainfo for the all subsets."""
         return bool(all(label_info == label_infos[0] for label_info in label_infos))
+
+    def _detect_and_update_storage_dtype(self, train_dataset: VisionDataset) -> None:
+        """Auto-detect storage dtype from the training dataset and update the intensity config.
+
+        Args:
+            train_dataset: The training VisionDataset with a ``dm_subset`` attribute.
+        """
+        intensity = getattr(self.train_subset, "intensity", None)
+        if intensity is None:
+            return
+
+        dm_subset = getattr(train_dataset, "dm_subset", None)
+        if dm_subset is None:
+            return
+
+        # Get an image path from the underlying DataFrame directly.
+        # This avoids iterating the dataset (which may fail if the schema
+        # was converted with the wrong storage dtype).
+        try:
+            frame = dm_subset.df
+            if "media" not in frame.columns or frame["media"].dtype != pl.String:
+                return
+            first_path = frame["media"][0]
+            if first_path is None:
+                return
+            detected = detect_image_dtype(first_path)
+        except (AttributeError, IndexError, OSError, TypeError, ValueError):
+            return
+
+        if intensity.storage_dtype != detected:
+            logger.info(
+                f"Auto-detected image storage dtype '{detected}' (intensity config had '{intensity.storage_dtype}')",
+            )
+            intensity.storage_dtype = detected
 
     def _get_dataset(self, subset: str) -> VisionDataset:
         if (dataset := self.subsets.get(subset)) is None:

--- a/library/tests/unit/data/test_factory.py
+++ b/library/tests/unit/data/test_factory.py
@@ -3,9 +3,6 @@
 #
 """Test Factory classes for dataset and transforms."""
 
-from unittest.mock import MagicMock, PropertyMock
-
-import polars as pl
 import pytest
 from datumaro.experimental import Dataset
 
@@ -65,64 +62,3 @@ class TestDatasetFactory:
             ),
             dataset_cls,
         )
-
-
-class TestDetectStorageDtype:
-    """Tests for DatasetFactory._detect_storage_dtype."""
-
-    def test_schema_uint16(self):
-        """Schema-declared UInt16 dtype → 'uint16'."""
-        mock_subset = MagicMock(spec=Dataset)
-        # Make iteration raise StopIteration (empty dataset)
-        mock_subset.__iter__ = MagicMock(return_value=iter([]))
-        mock_field = MagicMock()
-        mock_field.dtype = pl.UInt16
-        mock_img_attr = MagicMock()
-        mock_img_attr.field = mock_field
-        mock_schema = MagicMock()
-        mock_schema.attributes = {"image": mock_img_attr}
-        type(mock_subset).schema = PropertyMock(return_value=mock_schema)
-
-        assert DatasetFactory._detect_storage_dtype(mock_subset) == "uint16"
-
-    def test_schema_float32(self):
-        """Schema-declared Float32 dtype → 'float32'."""
-        mock_subset = MagicMock(spec=Dataset)
-        mock_subset.__iter__ = MagicMock(return_value=iter([]))
-        mock_field = MagicMock()
-        mock_field.dtype = pl.Float32
-        mock_img_attr = MagicMock()
-        mock_img_attr.field = mock_field
-        mock_schema = MagicMock()
-        mock_schema.attributes = {"image": mock_img_attr}
-        type(mock_subset).schema = PropertyMock(return_value=mock_schema)
-
-        assert DatasetFactory._detect_storage_dtype(mock_subset) == "float32"
-
-    def test_schema_unknown_defaults_uint8(self):
-        """Unknown/missing schema dtype → default 'uint8'."""
-        mock_subset = MagicMock(spec=Dataset)
-        mock_subset.__iter__ = MagicMock(return_value=iter([]))
-        mock_schema = MagicMock()
-        mock_schema.attributes = {}
-        type(mock_subset).schema = PropertyMock(return_value=mock_schema)
-
-        assert DatasetFactory._detect_storage_dtype(mock_subset) == "uint8"
-
-    def test_file_based_detection(self, tmp_path):
-        """File-header probing detects uint8 from a real PNG."""
-        import numpy as np
-        from PIL import Image as PILImage
-
-        # Create a small uint8 PNG
-        img_path = tmp_path / "test.png"
-        PILImage.fromarray(np.zeros((4, 4, 3), dtype=np.uint8)).save(img_path)
-
-        mock_media = MagicMock()
-        mock_media.path = str(img_path)
-        mock_item = MagicMock()
-        mock_item.media = mock_media
-        mock_subset = MagicMock(spec=Dataset)
-        mock_subset.__iter__ = MagicMock(return_value=iter([mock_item]))
-
-        assert DatasetFactory._detect_storage_dtype(mock_subset) == "uint8"

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -248,9 +248,7 @@ class TestDataModule:
 
         return _create_mock_dataset
 
-    def test_from_vision_datasets_basic(
-        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
-    ) -> None:
+    def test_from_vision_datasets_basic(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
         """Test from_vision_datasets with minimal configuration."""
         # Create mock datasets with shared label_info
         shared_label_info = MagicMock()
@@ -283,9 +281,7 @@ class TestDataModule:
         assert module.task == TaskType.MULTI_CLASS_CLS
         assert module.input_size == (224, 224)
 
-    def test_from_vision_datasets_with_custom_configs(
-        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
-    ) -> None:
+    def test_from_vision_datasets_with_custom_configs(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
         """Test from_vision_datasets with custom subset configurations."""
         # Create mock datasets
         shared_label_info = MagicMock()
@@ -339,9 +335,7 @@ class TestDataModule:
         # input_size should come from train_config, not inferred from image data
         assert module.input_size == (640, 640)
 
-    def test_from_vision_datasets_without_test(
-        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
-    ) -> None:
+    def test_from_vision_datasets_without_test(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
         """Test from_vision_datasets when test_dataset is None (uses val as test)."""
         # Create mock datasets
         shared_label_info = MagicMock()

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -75,7 +75,7 @@ class TestDataModule:
 
     @pytest.fixture
     def mock_detect_image_dtype(self, mocker) -> MagicMock:
-        return mocker.patch("getitune.data.module.detect_image_dtype", return_value="uint8")
+        return mocker.patch("getitune.data.module.detect_storage_dtype", return_value="uint8")
 
     @pytest.fixture
     def mock_dataset_factory(self, mocker) -> MagicMock:
@@ -248,7 +248,9 @@ class TestDataModule:
 
         return _create_mock_dataset
 
-    def test_from_vision_datasets_basic(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
+    def test_from_vision_datasets_basic(
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
+    ) -> None:
         """Test from_vision_datasets with minimal configuration."""
         # Create mock datasets with shared label_info
         shared_label_info = MagicMock()
@@ -281,7 +283,9 @@ class TestDataModule:
         assert module.task == TaskType.MULTI_CLASS_CLS
         assert module.input_size == (224, 224)
 
-    def test_from_vision_datasets_with_custom_configs(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
+    def test_from_vision_datasets_with_custom_configs(
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
+    ) -> None:
         """Test from_vision_datasets with custom subset configurations."""
         # Create mock datasets
         shared_label_info = MagicMock()
@@ -335,7 +339,9 @@ class TestDataModule:
         # input_size should come from train_config, not inferred from image data
         assert module.input_size == (640, 640)
 
-    def test_from_vision_datasets_without_test(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
+    def test_from_vision_datasets_without_test(
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
+    ) -> None:
         """Test from_vision_datasets when test_dataset is None (uses val as test)."""
         # Create mock datasets
         shared_label_info = MagicMock()
@@ -446,47 +452,27 @@ class TestDataModule:
         result = (pipeline.mean, pipeline.std)
         assert result == expected
 
-    def test_from_vision_datasets_detects_storage_dtype(self, mocker, fxt_mock_subset_configs, tmp_path) -> None:
-        """Test that from_vision_datasets auto-detects storage_dtype from image files.
-
-        This covers the fix for #6440 where 16-bit images exported with input_dtype='u8'.
-        """
-        import numpy as np
-        import polars as pl
-        from PIL import Image
-
+    def test_from_vision_datasets_respects_storage_dtype(self, mocker, fxt_mock_subset_configs, tmp_path) -> None:
+        """Test that from_vision_datasets preserves caller-provided storage_dtype."""
         from getitune.config.data import IntensityConfig
 
-        # Create a 16-bit PNG file
-        img_16bit = np.ones((32, 32), dtype=np.uint16) * 1000
-        img_path = tmp_path / "test_16bit.png"
-        Image.fromarray(img_16bit, mode="I;16").save(img_path)
-
-        # Create a mock dm_subset with a DataFrame containing the image path
-        mock_df = pl.DataFrame({"media": [str(img_path)]})
-        mock_dm_subset = MagicMock()
-        mock_dm_subset.df = mock_df
-        mock_dm_subset.__len__ = lambda _: 1
-
-        # Create mock dataset with the dm_subset
+        # Create mock datasets
         shared_label_info = MagicMock()
         mock_train = MagicMock()
         mock_train.label_info = shared_label_info
         mock_train.task_type = TaskType.MULTI_CLASS_CLS
-        mock_train.dm_subset = mock_dm_subset
 
         mock_val = MagicMock()
         mock_val.label_info = shared_label_info
         mock_val.task_type = TaskType.MULTI_CLASS_CLS
 
-        # Create SubsetConfig with default intensity (storage_dtype="uint8")
+        # Create SubsetConfig with storage_dtype pre-set by caller (as if detect_storage_dtype was called)
         train_subset = SubsetConfig(
             batch_size=4,
             subset_name="train",
             input_size=(224, 224),
-            intensity=IntensityConfig(),  # defaults to storage_dtype="uint8"
+            intensity=IntensityConfig(storage_dtype="uint16"),
         )
-        assert train_subset.intensity.storage_dtype == "uint8"
 
         mocker.patch.object(
             DataModule,
@@ -494,14 +480,14 @@ class TestDataModule:
             return_value=fxt_mock_subset_configs,
         )
 
-        # Create module from datasets
+        # Create module from datasets — it should preserve the caller's storage_dtype
         module = DataModule.from_vision_datasets(
             train_dataset=mock_train,
             val_dataset=mock_val,
             train_subset=train_subset,
         )
 
-        # Assert storage_dtype was auto-detected and updated to uint16
+        # Assert storage_dtype was preserved (not overwritten to uint8)
         assert train_subset.intensity.storage_dtype == "uint16"
         assert module.input_intensity_config is not None
         assert module.input_intensity_config.storage_dtype == "uint16"

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -248,7 +248,9 @@ class TestDataModule:
 
         return _create_mock_dataset
 
-    def test_from_vision_datasets_basic(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
+    def test_from_vision_datasets_basic(
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
+    ) -> None:
         """Test from_vision_datasets with minimal configuration."""
         # Create mock datasets with shared label_info
         shared_label_info = MagicMock()
@@ -281,7 +283,9 @@ class TestDataModule:
         assert module.task == TaskType.MULTI_CLASS_CLS
         assert module.input_size == (224, 224)
 
-    def test_from_vision_datasets_with_custom_configs(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
+    def test_from_vision_datasets_with_custom_configs(
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
+    ) -> None:
         """Test from_vision_datasets with custom subset configurations."""
         # Create mock datasets
         shared_label_info = MagicMock()
@@ -335,7 +339,9 @@ class TestDataModule:
         # input_size should come from train_config, not inferred from image data
         assert module.input_size == (640, 640)
 
-    def test_from_vision_datasets_without_test(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
+    def test_from_vision_datasets_without_test(
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
+    ) -> None:
         """Test from_vision_datasets when test_dataset is None (uses val as test)."""
         # Create mock datasets
         shared_label_info = MagicMock()

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -428,3 +428,62 @@ class TestDataModule:
         pipeline = CPUAugmentationPipeline(augmentations=transforms_source)
         result = (pipeline.mean, pipeline.std)
         assert result == expected
+
+    def test_from_vision_datasets_detects_storage_dtype(self, mocker, fxt_mock_subset_configs, tmp_path) -> None:
+        """Test that from_vision_datasets auto-detects storage_dtype from image files.
+
+        This covers the fix for #6440 where 16-bit images exported with input_dtype='u8'.
+        """
+        import numpy as np
+        import polars as pl
+        from PIL import Image
+
+        from getitune.config.data import IntensityConfig
+
+        # Create a 16-bit PNG file
+        img_16bit = np.ones((32, 32), dtype=np.uint16) * 1000
+        img_path = tmp_path / "test_16bit.png"
+        Image.fromarray(img_16bit, mode="I;16").save(img_path)
+
+        # Create a mock dm_subset with a DataFrame containing the image path
+        mock_df = pl.DataFrame({"media": [str(img_path)]})
+        mock_dm_subset = MagicMock()
+        mock_dm_subset.df = mock_df
+
+        # Create mock dataset with the dm_subset
+        shared_label_info = MagicMock()
+        mock_train = MagicMock()
+        mock_train.label_info = shared_label_info
+        mock_train.task_type = TaskType.MULTI_CLASS_CLS
+        mock_train.dm_subset = mock_dm_subset
+
+        mock_val = MagicMock()
+        mock_val.label_info = shared_label_info
+        mock_val.task_type = TaskType.MULTI_CLASS_CLS
+
+        # Create SubsetConfig with default intensity (storage_dtype="uint8")
+        train_subset = SubsetConfig(
+            batch_size=4,
+            subset_name="train",
+            input_size=(224, 224),
+            intensity=IntensityConfig(),  # defaults to storage_dtype="uint8"
+        )
+        assert train_subset.intensity.storage_dtype == "uint8"
+
+        mocker.patch.object(
+            DataModule,
+            "get_default_subset_configs",
+            return_value=fxt_mock_subset_configs,
+        )
+
+        # Create module from datasets
+        module = DataModule.from_vision_datasets(
+            train_dataset=mock_train,
+            val_dataset=mock_val,
+            train_subset=train_subset,
+        )
+
+        # Assert storage_dtype was auto-detected and updated to uint16
+        assert train_subset.intensity.storage_dtype == "uint16"
+        assert module.input_intensity_config is not None
+        assert module.input_intensity_config.storage_dtype == "uint16"

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -454,8 +454,6 @@ class TestDataModule:
 
     def test_from_vision_datasets_respects_storage_dtype(self, mocker, fxt_mock_subset_configs, tmp_path) -> None:
         """Test that from_vision_datasets preserves caller-provided storage_dtype."""
-        from getitune.config.data import IntensityConfig
-
         # Create mock datasets
         shared_label_info = MagicMock()
         mock_train = MagicMock()

--- a/library/tests/unit/data/test_module.py
+++ b/library/tests/unit/data/test_module.py
@@ -13,6 +13,7 @@ from omegaconf import DictConfig, OmegaConf
 from torchvision.transforms.v2 import Normalize
 
 from getitune.config.data import (
+    IntensityConfig,
     SubsetConfig,
     TileConfig,
 )
@@ -36,6 +37,7 @@ class TestDataModule:
         train_subset.input_size = None
         train_subset.subset_name = "train"
         train_subset.transforms = []
+        train_subset.intensity = IntensityConfig()
         val_subset = MagicMock(spec=SubsetConfig)
         val_subset.sampler = DictConfig(
             {"class_path": "torch.utils.data.RandomSampler", "init_args": {"num_samples": 3}},
@@ -44,6 +46,7 @@ class TestDataModule:
         val_subset.batch_size = 3
         val_subset.input_size = None
         val_subset.subset_name = "val"
+        val_subset.intensity = IntensityConfig()
         test_subset = MagicMock(spec=SubsetConfig)
         test_subset.sampler = DictConfig(
             {"class_path": "torch.utils.data.RandomSampler", "init_args": {"num_samples": 3}},
@@ -52,6 +55,7 @@ class TestDataModule:
         test_subset.batch_size = 1
         test_subset.input_size = None
         test_subset.subset_name = "test"
+        test_subset.intensity = IntensityConfig()
         tile_config = MagicMock(spec=TileConfig)
         tile_config.enable_tiler = False
 
@@ -68,6 +72,10 @@ class TestDataModule:
     @pytest.fixture
     def mock_dm_dataset(self, mocker) -> MagicMock:
         return mocker.patch("getitune.data.module.import_dataset")
+
+    @pytest.fixture
+    def mock_detect_image_dtype(self, mocker) -> MagicMock:
+        return mocker.patch("getitune.data.module.detect_image_dtype", return_value="uint8")
 
     @pytest.fixture
     def mock_dataset_factory(self, mocker) -> MagicMock:
@@ -88,6 +96,7 @@ class TestDataModule:
         self,
         mock_dm_dataset,
         mock_dataset_factory,
+        mock_detect_image_dtype,
         task,
         fxt_config,
     ) -> None:
@@ -118,6 +127,7 @@ class TestDataModule:
         self,
         mock_dm_dataset,
         mock_dataset_factory,
+        mock_detect_image_dtype,
         fxt_config,
     ) -> None:
         mock_subset = MagicMock()
@@ -158,14 +168,17 @@ class TestDataModule:
         cfg.train_subset.input_size = None
         cfg.train_subset.augmentations_cpu = []
         cfg.train_subset.augmentations_gpu = []
+        cfg.train_subset.intensity = {"storage_dtype": "uint8"}
         cfg.val_subset.subset_name = "val"
         cfg.val_subset.num_workers = 0
         cfg.val_subset.input_size = None
         cfg.val_subset.augmentations_cpu = []
+        cfg.val_subset.intensity = {"storage_dtype": "uint8"}
         cfg.test_subset.subset_name = "test"
         cfg.test_subset.num_workers = 0
         cfg.test_subset.input_size = None
         cfg.test_subset.augmentations_cpu = []
+        cfg.test_subset.intensity = {"storage_dtype": "uint8"}
         cfg.tile_config = {}
         cfg.tile_config.enable_tiler = False
         cfg.auto_num_workers = False
@@ -176,6 +189,7 @@ class TestDataModule:
         self,
         mock_dm_dataset,
         mock_dataset_factory,
+        mock_detect_image_dtype,
         fxt_real_tv_cls_config,
         tmpdir,
     ) -> None:
@@ -202,6 +216,7 @@ class TestDataModule:
         mock_config.sampler = DictConfig({"class_path": "torch.utils.data.RandomSampler"})
         mock_config.transforms = []
         mock_config.input_size = (224, 224)
+        mock_config.intensity = IntensityConfig()
 
         return {
             "train_subset": deepcopy(mock_config),
@@ -233,7 +248,7 @@ class TestDataModule:
 
         return _create_mock_dataset
 
-    def test_from_vision_datasets_basic(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset) -> None:
+    def test_from_vision_datasets_basic(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
         """Test from_vision_datasets with minimal configuration."""
         # Create mock datasets with shared label_info
         shared_label_info = MagicMock()
@@ -266,7 +281,7 @@ class TestDataModule:
         assert module.task == TaskType.MULTI_CLASS_CLS
         assert module.input_size == (224, 224)
 
-    def test_from_vision_datasets_with_custom_configs(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset) -> None:
+    def test_from_vision_datasets_with_custom_configs(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
         """Test from_vision_datasets with custom subset configurations."""
         # Create mock datasets
         shared_label_info = MagicMock()
@@ -288,6 +303,7 @@ class TestDataModule:
         train_config.sampler = DictConfig({"class_path": "torch.utils.data.RandomSampler"})
         train_config.transforms = []
         train_config.input_size = (640, 640)
+        train_config.intensity = IntensityConfig()
 
         val_config = MagicMock(spec=SubsetConfig)
         val_config.batch_size = 8
@@ -295,6 +311,7 @@ class TestDataModule:
         val_config.sampler = DictConfig({"class_path": "torch.utils.data.RandomSampler"})
         val_config.transforms = []
         val_config.input_size = (640, 640)
+        val_config.intensity = IntensityConfig()
 
         mocker.patch.object(
             DataModule,
@@ -318,7 +335,7 @@ class TestDataModule:
         # input_size should come from train_config, not inferred from image data
         assert module.input_size == (640, 640)
 
-    def test_from_vision_datasets_without_test(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset) -> None:
+    def test_from_vision_datasets_without_test(self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype) -> None:
         """Test from_vision_datasets when test_dataset is None (uses val as test)."""
         # Create mock datasets
         shared_label_info = MagicMock()
@@ -372,7 +389,7 @@ class TestDataModule:
             )
 
     def test_from_vision_datasets_with_auto_num_workers(
-        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset
+        self, mocker, fxt_mock_subset_configs, fxt_mock_dataset, mock_detect_image_dtype
     ) -> None:
         """Test from_vision_datasets with auto_num_workers enabled."""
         # Create mock datasets
@@ -449,6 +466,7 @@ class TestDataModule:
         mock_df = pl.DataFrame({"media": [str(img_path)]})
         mock_dm_subset = MagicMock()
         mock_dm_subset.df = mock_df
+        mock_dm_subset.__len__ = lambda _: 1
 
         # Create mock dataset with the dm_subset
         shared_label_info = MagicMock()


### PR DESCRIPTION
## Problem

When DataModule.from_vision_datasets() was used (the Geti application path), no auto-detection of storage_dtype ran. The SubsetConfig.intensity.storage_dtype remained at the default uint8 even for 16-bit images, causing the exported OpenVINO model to incorrectly report input_dtype=u8 instead of u16.

## Root Cause

The normal DataModule.__init__ path triggers DatasetFactory.create() which auto-detects the image bit depth from file headers and updates the intensity config. However, from_vision_datasets() bypasses this factory - it receives pre-constructed datasets and simply reads the train_subset.intensity config as-is without any detection.

## Fix

Add _detect_and_update_storage_dtype() to DataModule, called from from_vision_datasets() before propagating the intensity config. 

Resolves #6440