### PR TITLE
chore: Improve dataset UX

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -97,7 +97,7 @@ const GalleryList = ({
                                 UNSAFE_style={{ margin: dimensionValue('size-150') }}
                             >
                                 <Checkbox
-                                    aria-label={`Select media item ${item.name}`}
+                                    aria-label={`Select media item ${item.id}`}
                                     onChange={() => toggleSelectedKeys([String(item.id)])}
                                     isSelected={isSetSelectedKeys && selectedKeys.has(String(item.id))}
                                 />

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -59,7 +59,7 @@ const GalleryList = ({
     isMediaItemReviewedById,
 }: GalleryListProps) => {
     const projectId = useProjectIdentifier();
-    const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
+    const { selectedKeys, toggleSelectedKeys } = useSelectedData();
 
     const isSetSelectedKeys = selectedKeys instanceof Set;
 
@@ -73,7 +73,6 @@ const GalleryList = ({
             isPending={isPending}
             isLoadingMore={isFetchingNextPage}
             onLoadMore={fetchNextPage}
-            onSelectionChange={setSelectedKeys}
             contentItem={(item) => {
                 const mediaUrl = getThumbnailUrl(projectId, item.id);
                 const downloadUrl = getMediaDownloadUrl(projectId, item.id);

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
@@ -144,7 +144,7 @@ describe('Toolbar', () => {
         const item2 = getMockedMediaImage({ id: '2' });
 
         vi.mocked(useSelectedData).mockReturnValue({
-            selectedKeys: new Set(['1', '2']),
+            selectedKeys: new Set([item1.id, item2.id]),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
         });
@@ -172,7 +172,7 @@ describe('Toolbar', () => {
         const firstItem = getMockedMediaImage({ id: 'first-item' });
 
         vi.mocked(useSelectedData).mockReturnValue({
-            selectedKeys: new Set(firstItem.id),
+            selectedKeys: new Set([firstItem.id]),
             setSelectedKeys: vi.fn(),
             toggleSelectedKeys: vi.fn(),
         });

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
@@ -104,6 +104,11 @@ describe('Toolbar', () => {
     beforeEach(() => {
         uploadMediaMock.mockClear();
         onSelectedMediaItemChangeMock.mockClear();
+        vi.mocked(useSelectedData).mockReturnValue({
+            selectedKeys: new Set(),
+            setSelectedKeys: vi.fn(),
+            toggleSelectedKeys: vi.fn(),
+        });
     });
 
     it('delegates selected files to useMediaUpload', async () => {
@@ -134,12 +139,19 @@ describe('Toolbar', () => {
         expect(onSelectedMediaItemChangeMock).toHaveBeenCalledWith(firstItem);
     });
 
-    it('selects all items and updates selected count', async () => {
-        await renderToolbar([getMockedMediaImage({ id: '1' }), getMockedMediaImage({ id: '2' })]);
+    it('shows selected count and delete button when items are selected', async () => {
+        const item1 = getMockedMediaImage({ id: '1' });
+        const item2 = getMockedMediaImage({ id: '2' });
 
-        fireEvent.click(screen.getByLabelText('select all'));
+        vi.mocked(useSelectedData).mockReturnValue({
+            selectedKeys: new Set(['1', '2']),
+            setSelectedKeys: vi.fn(),
+            toggleSelectedKeys: vi.fn(),
+        });
 
-        expect(screen.getByText('2 selected')).toBeVisible();
+        await renderToolbar([item1, item2]);
+
+        expect(await screen.findByText('2 selected')).toBeVisible();
         expect(screen.getByLabelText(/delete media item/i)).toBeVisible();
     });
 
@@ -188,5 +200,35 @@ describe('Toolbar', () => {
         expect(screen.getByRole('button', { name: 'Annotate' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Train model' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Export/Import' })).toBeInTheDocument();
+    });
+
+    it('hides filter and view controls when at least one media is selected', async () => {
+        const firstItem = getMockedMediaImage({ id: 'first-item' });
+
+        vi.mocked(useSelectedData).mockReturnValue({
+            selectedKeys: new Set(firstItem.id),
+            setSelectedKeys: vi.fn(),
+            toggleSelectedKeys: vi.fn(),
+        });
+
+        await renderToolbar([firstItem]);
+
+        expect(screen.queryByRole('button', { name: 'dataset statistics' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /media status/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Filter by labels' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Filter by date' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'View mode' })).not.toBeInTheDocument();
+    });
+
+    it('shows filter and view controls when no media is selected', async () => {
+        const firstItem = getMockedMediaImage({ id: 'first-item' });
+
+        await renderToolbar([firstItem]);
+
+        expect(await screen.findByRole('button', { name: 'dataset statistics' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Filter by labels' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Filter by date' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /media status/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'View mode' })).toBeInTheDocument();
     });
 });

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
@@ -13,7 +13,7 @@ import { http } from '../../../../api/utils';
 import type { Media } from '../../../../constants/shared-types';
 import { server } from '../../../../msw-node-setup';
 import { isImage } from '../../../../shared/media-item-utils';
-import { SelectedDataProvider } from '../../providers/selected-data-provider.component';
+import { useSelectedData } from '../../providers/selected-data-provider.component';
 import { Toolbar } from './toolbar.component';
 
 const uploadMediaMock = vi.fn();
@@ -40,15 +40,22 @@ vi.mock('../hooks/use-select-dataset-item.hook', () => ({
 }));
 
 vi.mock('../../../models/train-model/train-model.component', () => ({
-    TrainModel: () => <div>Train model</div>,
+    TrainModel: () => <button>Train model</button>,
 }));
 
 vi.mock('../../import-export/import-export.component', () => ({
-    ImportExport: () => <div>ImportExport</div>,
+    ImportExport: () => <button>Export/Import</button>,
 }));
 
 vi.mock('hooks/use-project-identifier.hook', () => ({
     useProjectIdentifier: () => 'project-123',
+}));
+vi.mock('../../providers/selected-data-provider.component', () => ({
+    useSelectedData: vi.fn(() => ({
+        selectedKeys: new Set(),
+        setSelectedKeys: vi.fn(),
+        toggleSelectedKeys: vi.fn(),
+    })),
 }));
 
 describe('Toolbar', () => {
@@ -87,11 +94,7 @@ describe('Toolbar', () => {
             })
         );
 
-        const result = render(
-            <SelectedDataProvider>
-                <Toolbar items={items} viewMode={ViewModes.LARGE} setViewMode={vi.fn()} />
-            </SelectedDataProvider>
-        );
+        const result = render(<Toolbar items={items} viewMode={ViewModes.LARGE} setViewMode={vi.fn()} />);
 
         await waitForElementToBeRemoved(screen.getByRole('progressbar'));
 
@@ -151,5 +154,39 @@ describe('Toolbar', () => {
             expect(screen.getByText('Number of media')).toBeVisible();
             expect(screen.getByText('Annotated images')).toBeVisible();
         });
+    });
+
+    it('hides "Export/Import", "Train model", "Annotate" buttons when at least one media is selected', async () => {
+        const firstItem = getMockedMediaImage({ id: 'first-item' });
+
+        vi.mocked(useSelectedData).mockReturnValue({
+            selectedKeys: new Set(firstItem.id),
+            setSelectedKeys: vi.fn(),
+            toggleSelectedKeys: vi.fn(),
+        });
+
+        await renderToolbar([firstItem]);
+
+        expect(screen.getByRole('button', { name: 'Upload media' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Annotate' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Train model' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Export/Import' })).not.toBeInTheDocument();
+    });
+
+    it('shows "Export/Import", "Train model", "Annotate" buttons when no media is selected', async () => {
+        const firstItem = getMockedMediaImage({ id: 'first-item' });
+
+        vi.mocked(useSelectedData).mockReturnValue({
+            selectedKeys: new Set(),
+            setSelectedKeys: vi.fn(),
+            toggleSelectedKeys: vi.fn(),
+        });
+
+        await renderToolbar([firstItem]);
+
+        expect(screen.getByRole('button', { name: 'Upload media' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Annotate' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Train model' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Export/Import' })).toBeInTheDocument();
     });
 });

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -73,23 +73,27 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
             .filter((itemId) => isString(itemId));
     }, [selectedMediaItems, items]);
 
+    const shouldButtonsBeVisible = selectedMediaItems?.size === 0;
+
     return (
         <Flex direction={'column'} gridArea={'toolbar'} gap={'size-200'} marginBottom={'size-200'}>
             <Flex alignItems={'center'} justifyContent={'space-between'}>
                 <Heading level={1}>Dataset</Heading>
                 <ButtonGroup UNSAFE_style={{ gap: dimensionValue('size-125') }}>
-                    <ImportExport />
+                    {shouldButtonsBeVisible && <ImportExport />}
 
                     <MediaUpload />
 
                     <AssignLabel selectedImagesIds={selectedImagesIds} />
 
-                    <TrainModel />
+                    {shouldButtonsBeVisible && <TrainModel />}
 
-                    <AnnotateButton
-                        isDisabled={items.at(0) === undefined}
-                        onClick={items.at(0) === undefined ? undefined : () => onSelectedMediaItemChange(items[0])}
-                    />
+                    {shouldButtonsBeVisible && (
+                        <AnnotateButton
+                            isDisabled={items.at(0) === undefined}
+                            onClick={items.at(0) === undefined ? undefined : () => onSelectedMediaItemChange(items[0])}
+                        />
+                    )}
                 </ButtonGroup>
             </Flex>
 
@@ -112,24 +116,10 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
                     <Divider orientation={'vertical'} size={'S'} />
 
                     {hasSelectedElements && (
-                        <>
-                            <DeleteMediaItem
-                                itemsIds={Array.from(selectedKeys) as string[]}
-                                onDeleted={toggleSelectedKeys}
-                            />
-
-                            {/*
-                                TODO: In the future we will have a single endpoint to accept/decline
-                                    multiple media items at once instead of sending multiple requests in a loop.
-                                    Once we have that, we can reenable these buttons.
-                            */}
-                            {/* <Button variant={'accent'} onPress={handleAccept}>
-                                Accept
-                            </Button>
-                            <Button variant={'secondary'} onPress={handleReject}>
-                                Decline
-                            </Button> */}
-                        </>
+                        <DeleteMediaItem
+                            itemsIds={Array.from(selectedKeys) as string[]}
+                            onDeleted={toggleSelectedKeys}
+                        />
                     )}
                 </Flex>
 

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -73,22 +73,22 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
             .filter((itemId) => isString(itemId));
     }, [selectedMediaItems, items]);
 
-    const shouldButtonsBeVisible = selectedMediaItems?.size === 0;
+    const noMediaSelected = selectedMediaItems?.size === 0;
 
     return (
         <Flex direction={'column'} gridArea={'toolbar'} gap={'size-200'} marginBottom={'size-200'}>
             <Flex alignItems={'center'} justifyContent={'space-between'}>
                 <Heading level={1}>Dataset</Heading>
                 <ButtonGroup UNSAFE_style={{ gap: dimensionValue('size-125') }}>
-                    {shouldButtonsBeVisible && <ImportExport />}
+                    {noMediaSelected && <ImportExport />}
 
                     <MediaUpload />
 
                     <AssignLabel selectedImagesIds={selectedImagesIds} />
 
-                    {shouldButtonsBeVisible && <TrainModel />}
+                    {noMediaSelected && <TrainModel />}
 
-                    {shouldButtonsBeVisible && (
+                    {noMediaSelected && (
                         <AnnotateButton
                             isDisabled={items.at(0) === undefined}
                             onClick={items.at(0) === undefined ? undefined : () => onSelectedMediaItemChange(items[0])}
@@ -101,7 +101,7 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
 
             <Flex direction={'row'} alignItems={'center'} justifyContent={'space-between'}>
                 <Flex
-                    gap={'size-200'}
+                    gap={'size-50'}
                     height={'size-400'}
                     direction={'row'}
                     alignItems={'center'}
@@ -126,19 +126,23 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
                 <Flex gap={'size-200'} alignItems={'center'}>
                     <TotalItems totalSelectedElements={totalSelectedElements} />
 
-                    <FilterByStatus />
+                    {noMediaSelected && (
+                        <>
+                            <FilterByStatus />
 
-                    <MediaFilterLabels />
+                            <MediaFilterLabels />
 
-                    <DateFilter />
+                            <DateFilter />
 
-                    <DatasetStatistics />
+                            <DatasetStatistics />
 
-                    <MediaViewModes
-                        viewMode={viewMode}
-                        setViewMode={setViewMode}
-                        items={[ViewModes.LARGE, ViewModes.MEDIUM, ViewModes.SMALL]}
-                    />
+                            <MediaViewModes
+                                viewMode={viewMode}
+                                setViewMode={setViewMode}
+                                items={[ViewModes.LARGE, ViewModes.MEDIUM, ViewModes.SMALL]}
+                            />
+                        </>
+                    )}
                 </Flex>
             </Flex>
 

--- a/application/ui/src/features/dataset/gallery/toolbar/total-items.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/total-items.component.tsx
@@ -1,21 +1,34 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Text } from '@geti/ui';
+import { Divider, Flex, Text } from '@geti/ui';
 import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
 
 type TotalItemsProps = {
     totalSelectedElements: number;
 };
 
+const pluralRules = new Intl.PluralRules('en');
+
 export const TotalItems = ({ totalSelectedElements }: TotalItemsProps) => {
     const { totalCount } = useDatasetMediaWithReviewStatus();
 
-    const hasSelectedElements = totalSelectedElements > 0;
-
-    if (hasSelectedElements) {
-        return <Text>{`${totalSelectedElements} selected`}</Text>;
+    if (totalCount === 0) {
+        return null;
     }
 
-    return <Text>{`${totalCount} media item${totalCount === 1 ? '' : 's'}`}</Text>;
+    const hasSelectedElements = totalSelectedElements > 0;
+
+    return (
+        <Flex gap={'size-100'}>
+            {hasSelectedElements && (
+                <>
+                    <Text>{`${totalSelectedElements} selected`}</Text>
+                    <Divider orientation={'vertical'} size={'S'} />
+                </>
+            )}
+
+            <Text>{`${totalCount} media ${pluralRules.select(totalCount) === 'one' ? 'item' : 'items'}`}</Text>
+        </Flex>
+    );
 };

--- a/application/ui/src/features/dataset/gallery/toolbar/total-items.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/total-items.test.tsx
@@ -35,10 +35,11 @@ describe('TotalItems', () => {
         return render(<TotalItems totalSelectedElements={totalSelectedElements} />);
     };
 
-    it('shows selected count when items are selected', async () => {
+    it('shows selected count and total when items are selected', async () => {
         await renderTotalItems(3, 10);
 
-        expect(screen.getByText('3 selected')).toBeVisible();
+        expect(await screen.findByText('3 selected')).toBeVisible();
+        expect(await screen.findByText('10 media items')).toBeVisible();
     });
 
     it('shows total media count with plural when no items are selected', async () => {
@@ -53,9 +54,9 @@ describe('TotalItems', () => {
         expect(await screen.findByText('1 media item')).toBeVisible();
     });
 
-    it('shows 0 media items when there are no items', async () => {
+    it('renders nothing when there are no items', async () => {
         await renderTotalItems(0, 0);
 
-        expect(await screen.findByText('0 media items')).toBeVisible();
+        expect(screen.queryByText(/media item/)).not.toBeInTheDocument();
     });
 });

--- a/application/ui/tests/datasets/dataset-page.ts
+++ b/application/ui/tests/datasets/dataset-page.ts
@@ -14,16 +14,17 @@ export class DatasetPage {
         return this.page.getByRole('listbox', { name: 'data-collection-grid' });
     }
 
-    getMediaGridOptions() {
-        return this.getMediaGrid().getByRole('option');
+    async selectMediaItem(mediaId: string) {
+        await this.getMediaGrid()
+            .getByRole('checkbox', {
+                name: `Select media item ${mediaId}`,
+                exact: true,
+            })
+            .click();
     }
 
     getMediaItemByName(name: string) {
         return this.page.getByRole('img', { name, exact: true });
-    }
-
-    clickMediaItem(name: string) {
-        return this.getMediaItemByName(name).click();
     }
 
     dblClickMediaItem(name: string) {

--- a/application/ui/tests/datasets/datasets.spec.ts
+++ b/application/ui/tests/datasets/datasets.spec.ts
@@ -83,10 +83,8 @@ test.describe('Dataset', () => {
 
         await expect(datasetPage.getImagesCountText(totalElements)).toBeVisible();
 
-        const options = datasetPage.getMediaGridOptions();
-
         for (let i = 0; i < selectedElements; i++) {
-            await options.nth(i).click();
+            await datasetPage.selectMediaItem(mockedItems[i].id);
         }
 
         await expect(datasetPage.getSelectedCountText(selectedElements)).toBeVisible();
@@ -457,8 +455,8 @@ test.describe('Dataset', () => {
 
             await expect(datasetPage.getAssignLabelButton()).toBeHidden();
 
-            await datasetPage.clickMediaItem('media-1');
-            await datasetPage.clickMediaItem('media-2');
+            await datasetPage.selectMediaItem(mockedMedia[0].id);
+            await datasetPage.selectMediaItem(mockedMedia[1].id);
 
             await datasetPage.clickAssignLabel();
 
@@ -513,9 +511,9 @@ test.describe('Dataset', () => {
 
             await datasetPage.goto();
 
-            await datasetPage.clickMediaItem('media-1');
-            await datasetPage.clickMediaItem('media-2');
-            await datasetPage.clickMediaItem('media-3');
+            await datasetPage.selectMediaItem(mockedMedia[0].id);
+            await datasetPage.selectMediaItem(mockedMedia[1].id);
+            await datasetPage.selectMediaItem(mockedMedia[2].id);
 
             await datasetPage.clickAssignLabel();
 
@@ -568,9 +566,9 @@ test.describe('Dataset', () => {
 
             await datasetPage.goto();
 
-            await datasetPage.clickMediaItem('media-1');
-            await datasetPage.clickMediaItem('media-2');
-            await datasetPage.clickMediaItem('media-3');
+            await datasetPage.selectMediaItem(mockedMedia[0].id);
+            await datasetPage.selectMediaItem(mockedMedia[1].id);
+            await datasetPage.selectMediaItem(mockedMedia[2].id);
 
             await datasetPage.clickAssignLabel();
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Improve message about total and selected media items (similar to Geti classic).
2. Hide buttons and filters when at least one media is selected.

These changes are based on discussion on ux channel and feedback from Mariusz.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
