### PR TITLE
Stop looping inference videos

### DIFF
--- a/application/backend/app/api/routers/sources.py
+++ b/application/backend/app/api/routers/sources.py
@@ -54,6 +54,7 @@ CREATE_SOURCE_BODY_EXAMPLES = {
             "source_type": "video_file",
             "name": "Camera recording 123",
             "video_path": "/path/to/video.mp4",
+            "loop": False,
         },
     ),
     "images_folder": Example(

--- a/application/backend/app/api/schemas/source.py
+++ b/application/backend/app/api/schemas/source.py
@@ -102,6 +102,11 @@ class VideoFileSourceConfigView(VideoFileSourceConfig):
     def video_path(self) -> str:
         return self.config_data.video_path
 
+    @computed_field
+    @property
+    def loop(self) -> bool:
+        return self.config_data.loop
+
     model_config = {
         "json_schema_extra": {
             "example": {
@@ -109,6 +114,7 @@ class VideoFileSourceConfigView(VideoFileSourceConfig):
                 "name": "Sample Video",
                 "id": "712750b2-5a82-47ee-8fba-f3dc96cb615d",
                 "video_path": "/path/to/video.mp4",
+                "loop": False,
             }
         }
     }
@@ -179,10 +185,11 @@ class IPCameraSourceConfigCreate(BaseSourceConfigCreate):
 class VideoFileSourceConfigCreate(BaseSourceConfigCreate):
     source_type: Literal[SourceType.VIDEO_FILE]
     video_path: str
+    loop: bool = False
 
     @property
     def config_data(self) -> VideoFileConfig:
-        return VideoFileConfig(video_path=self.video_path)
+        return VideoFileConfig(video_path=self.video_path, loop=self.loop)
 
 
 class ImagesFolderSourceConfigCreate(BaseSourceConfigCreate):

--- a/application/backend/app/models/source.py
+++ b/application/backend/app/models/source.py
@@ -83,6 +83,7 @@ class IPCameraSourceConfig(BaseSourceConfig):
 
 class VideoFileConfig(SourceConfig):
     video_path: str
+    loop: bool = False
 
 
 class VideoFileSourceConfig(BaseSourceConfig):

--- a/application/backend/app/services/video_stream_service.py
+++ b/application/backend/app/services/video_stream_service.py
@@ -26,7 +26,10 @@ class VideoStreamService:
             case SourceType.IP_CAMERA:
                 video_stream = IPCameraStream(config=input_config)
             case SourceType.VIDEO_FILE:
-                video_stream = VideoFileStream(input_config.config_data.video_path)
+                video_stream = VideoFileStream(
+                    video_path=input_config.config_data.video_path,
+                    loop=input_config.config_data.loop,
+                )
             case SourceType.IMAGES_FOLDER:
                 video_stream = ImagesFolderStream(
                     folder_path=input_config.config_data.images_folder_path,

--- a/application/backend/app/stream/base_opencv_stream.py
+++ b/application/backend/app/stream/base_opencv_stream.py
@@ -67,7 +67,7 @@ class BaseOpenCVStream(VideoStream, ABC):
         """Get metadata specific to this source."""
         return {"source_type": self.source_type.value, **self.metadata}
 
-    def get_data(self) -> StreamData:
+    def get_data(self) -> StreamData | None:
         """Get the latest frame from the video stream."""
         frame = self._read_frame()
         return StreamData(

--- a/application/backend/app/stream/video_file_stream.py
+++ b/application/backend/app/stream/video_file_stream.py
@@ -6,19 +6,33 @@ import numpy as np
 
 from app.models import SourceType
 from app.stream.base_opencv_stream import BaseOpenCVStream
+from app.stream.stream_data import StreamData
 
 
 class VideoFileStream(BaseOpenCVStream):
     """Video stream implementation using video file via OpenCV."""
 
-    def __init__(self, video_path: str) -> None:
-        """Initialize video file stream."""
-        super().__init__(source=video_path, source_type=SourceType.VIDEO_FILE, video_path=video_path)
+    def __init__(self, video_path: str, loop: bool = False) -> None:
+        """Initialize video file stream.
+
+        Args:
+            video_path: Path to the video file.
+            loop: If True, the video restarts from the beginning once it ends.
+                  If False, the stream stops returning frames once the video has been fully read.
+        """
+        self.loop = loop
+        self._exhausted = False
+        super().__init__(source=video_path, source_type=SourceType.VIDEO_FILE, video_path=video_path, loop=loop)
 
     def _handle_read_failure(self) -> np.ndarray:
-        """Reset video to beginning when it ends and try again."""
+        """Reset video to beginning when it ends and try again (only when looping)."""
         if self.cap is None:
             raise RuntimeError("Video capture not initialized")
+
+        if not self.loop:
+            # Mark the stream as exhausted; subsequent get_data() calls will return None.
+            self._exhausted = True
+            raise EOFError("End of video file reached")
 
         # Reset video to beginning when it ends
         self.cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
@@ -26,6 +40,15 @@ class VideoFileStream(BaseOpenCVStream):
         if not ret:
             raise RuntimeError("Failed to capture frame from video file")
         return frame
+
+    def get_data(self) -> StreamData | None:  # pyrefly: ignore [bad-override]
+        """Get the latest frame from the video, or None if the video has ended (non-looping)."""
+        if self._exhausted:
+            return None
+        try:
+            return super().get_data()
+        except EOFError:
+            return None
 
     def is_real_time(self) -> bool:
         return False

--- a/application/backend/app/stream/video_file_stream.py
+++ b/application/backend/app/stream/video_file_stream.py
@@ -54,3 +54,7 @@ class VideoFileStream(BaseOpenCVStream):
 
     def is_real_time(self) -> bool:
         return False
+
+    def is_finished(self) -> bool:
+        """A non-looping video file is finished once it has been fully read."""
+        return self._exhausted

--- a/application/backend/app/stream/video_file_stream.py
+++ b/application/backend/app/stream/video_file_stream.py
@@ -32,6 +32,8 @@ class VideoFileStream(BaseOpenCVStream):
         if not self.loop:
             # Mark the stream as exhausted; subsequent get_data() calls will return None.
             self._exhausted = True
+            self.release()
+            self.cap = None  # type: ignore[assignment]
             raise EOFError("End of video file reached")
 
         # Reset video to beginning when it ends
@@ -41,7 +43,7 @@ class VideoFileStream(BaseOpenCVStream):
             raise RuntimeError("Failed to capture frame from video file")
         return frame
 
-    def get_data(self) -> StreamData | None:  # pyrefly: ignore [bad-override]
+    def get_data(self) -> StreamData | None:
         """Get the latest frame from the video, or None if the video has ended (non-looping)."""
         if self._exhausted:
             return None

--- a/application/backend/app/stream/video_stream.py
+++ b/application/backend/app/stream/video_stream.py
@@ -25,6 +25,17 @@ class VideoStream(ABC):
             bool: True if the video stream is real-time, False otherwise
         """
 
+    def is_finished(self) -> bool:
+        """Check if the stream has permanently ended and will not produce any further frames.
+
+        Real-time and looping streams never finish; finite sources (e.g. a non-looping
+        video file) report True once fully consumed so consumers can stop polling.
+
+        Returns:
+            bool: True if the stream is exhausted and should be stopped, False otherwise
+        """
+        return False
+
     def __enter__(self) -> Self:
         return self
 

--- a/application/backend/app/workers/stream_loading.py
+++ b/application/backend/app/workers/stream_loading.py
@@ -102,6 +102,15 @@ class StreamLoader(BaseProcessWorker):
                     _enqueue_frame_with_retry(
                         self._frame_queue, stream_data, self._video_stream.is_real_time(), self._stop_event
                     )
+                elif self._video_stream.is_finished():
+                    # Finite source fully consumed: stop the stream instead of polling forever.
+                    logger.info(
+                        "Video stream finished for source id={} name={!r}; stopping stream until source changes.",
+                        self._source.id,
+                        self._source.name,
+                    )
+                    self._video_stream.release()
+                    self._video_stream = None
                 else:
                     self.stop_aware_sleep(0.1)
             except Exception:

--- a/application/backend/tests/integration/stream/test_video_file_stream.py
+++ b/application/backend/tests/integration/stream/test_video_file_stream.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Generator
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from app.models import SourceType
+from app.stream.video_file_stream import VideoFileStream
+
+NUM_FRAMES = 5
+FRAME_WIDTH = 64
+FRAME_HEIGHT = 48
+
+
+@pytest.fixture()
+def video_path(tmp_path: Path) -> Generator[str]:
+    """Generate a small temporary video file with a known number of frames."""
+    path = tmp_path / "sample.avi"
+    fourcc = cv2.VideoWriter_fourcc(*"MJPG")  # type: ignore[attr-defined]
+    writer = cv2.VideoWriter(str(path), fourcc, 10.0, (FRAME_WIDTH, FRAME_HEIGHT))
+    assert writer.isOpened(), "Failed to open VideoWriter for test fixture"
+    try:
+        for i in range(NUM_FRAMES):
+            # Distinct solid-color frame per index so frames are clearly decodable.
+            frame = np.full((FRAME_HEIGHT, FRAME_WIDTH, 3), fill_value=(i * 40) % 256, dtype=np.uint8)
+            writer.write(frame)
+    finally:
+        writer.release()
+
+    assert path.exists() and path.stat().st_size > 0
+    yield str(path)
+
+
+class TestVideoFileStream:
+    """Integration tests for VideoFileStream end-of-stream semantics."""
+
+    def test_is_not_real_time(self, video_path: str):
+        with VideoFileStream(video_path=video_path) as stream:
+            assert stream.is_real_time() is False
+
+    def test_can_read_frames_and_metadata(self, video_path: str):
+        """The stream yields decodable frames with the expected metadata."""
+        with VideoFileStream(video_path=video_path) as stream:
+            data = stream.get_data()
+            assert data is not None
+            frame, metadata = data.frame_data, data.source_metadata
+            assert frame is not None
+            assert frame.shape == (FRAME_HEIGHT, FRAME_WIDTH, 3)
+            assert frame.dtype == "uint8"
+            assert metadata["source_type"] == SourceType.VIDEO_FILE.value
+            assert metadata["video_path"] == video_path
+
+    def test_stops_producing_frames_at_eof_when_not_looping(self, video_path: str):
+        """With loop=False the stream stops producing frames once the video is exhausted."""
+        with VideoFileStream(video_path=video_path, loop=False) as stream:
+            frames_read = 0
+            while True:
+                data = stream.get_data()
+                if data is None:
+                    break
+                assert data.frame_data is not None
+                frames_read += 1
+                # Guard against an accidental infinite loop in case EOF is not detected.
+                assert frames_read <= NUM_FRAMES + 1
+
+            assert frames_read == NUM_FRAMES
+
+            # Once exhausted, the stream keeps returning None and releases the capture.
+            assert stream._exhausted is True
+            assert stream.cap is None
+            assert stream.get_data() is None
+
+    def test_restarts_from_beginning_when_looping(self, video_path: str):
+        """With loop=True the stream restarts from frame 0 instead of stopping at EOF."""
+        with VideoFileStream(video_path=video_path, loop=True) as stream:
+            # Read more frames than the video contains; the stream should keep producing
+            # frames by looping back to the start.
+            for _ in range(NUM_FRAMES * 2 + 1):
+                data = stream.get_data()
+                assert data is not None
+                assert data.frame_data is not None
+
+            assert stream._exhausted is False

--- a/application/backend/tests/integration/stream/test_video_file_stream.py
+++ b/application/backend/tests/integration/stream/test_video_file_stream.py
@@ -85,3 +85,41 @@ class TestVideoFileStream:
                 assert data.frame_data is not None
 
             assert stream._exhausted is False
+
+    def test_is_finished_reports_true_at_eof_when_not_looping(self, video_path: str):
+        """is_finished() is False until the non-looping video is fully consumed, then True."""
+        with VideoFileStream(video_path=video_path, loop=False) as stream:
+            # Not finished before reaching the end.
+            assert stream.is_finished() is False
+            while stream.get_data() is not None:
+                # Still producing frames -> not finished yet.
+                assert stream.is_finished() is False
+
+            # Once exhausted, the stream reports it is finished so consumers can stop polling.
+            assert stream.is_finished() is True
+
+    def test_is_finished_stays_false_when_looping(self, video_path: str):
+        """A looping stream never finishes, even after reading past the end of the file."""
+        with VideoFileStream(video_path=video_path, loop=True) as stream:
+            for _ in range(NUM_FRAMES * 2 + 1):
+                assert stream.get_data() is not None
+                assert stream.is_finished() is False
+
+    def test_looping_can_be_re_enabled_after_a_non_looping_stream_finished(self, video_path: str):
+        """After a non-looping stream is exhausted and stopped, a fresh looping stream over the
+        same file works again (i.e. re-enabling looping after being disabled still works)."""
+        # First, a non-looping stream that runs to completion and stops.
+        with VideoFileStream(video_path=video_path, loop=False) as finite_stream:
+            while finite_stream.get_data() is not None:
+                pass
+            assert finite_stream.is_finished() is True
+
+        # Re-enable looping by opening a new stream over the same file; it must keep producing
+        # frames indefinitely and never report itself as finished.
+        with VideoFileStream(video_path=video_path, loop=True) as looping_stream:
+            for _ in range(NUM_FRAMES * 2 + 1):
+                data = looping_stream.get_data()
+                assert data is not None
+                assert data.frame_data is not None
+            assert looping_stream.is_finished() is False
+            assert looping_stream._exhausted is False

--- a/application/backend/tests/unit/workers/test_stream_loading.py
+++ b/application/backend/tests/unit/workers/test_stream_loading.py
@@ -29,8 +29,39 @@ class _FakeVideoStream:
     def is_real_time(self) -> bool:
         return True
 
+    def is_finished(self) -> bool:
+        return False
+
     def release(self) -> None:
         pass
+
+
+class _ExhaustibleVideoStream:
+    """Stand-in for a finite (non-looping) VideoStream that finishes after a fixed number of frames."""
+
+    def __init__(self, frame: np.ndarray, num_frames: int) -> None:
+        self._frame = frame
+        self._remaining = num_frames
+        self._exhausted = False
+        self.released = False
+        self.finished_calls = 0
+
+    def get_data(self) -> StreamData | None:
+        if self._remaining > 0:
+            self._remaining -= 1
+            return StreamData(frame_data=self._frame, timestamp=time.time(), source_metadata={})
+        self._exhausted = True
+        return None
+
+    def is_real_time(self) -> bool:
+        return False
+
+    def is_finished(self) -> bool:
+        self.finished_calls += 1
+        return self._exhausted
+
+    def release(self) -> None:
+        self.released = True
 
 
 class _TestableStreamLoader(StreamLoader):
@@ -250,3 +281,103 @@ class TestStreamLoaderErrorHandling:
         # run_loop should handle None stream gracefully
         stop_event.set()
         loader.run_loop()
+
+
+def _video_file_source() -> VideoFileSourceConfig:
+    return VideoFileSourceConfig(
+        source_type=SourceType.VIDEO_FILE,
+        id=uuid4(),
+        name="Test Video File Source",
+        config_data=VideoFileConfig(video_path="fake_path.mp4"),
+    )
+
+
+class TestStreamLoaderFinishedStream:
+    """Tests for stopping a finite stream once it has been fully consumed (e.g. non-looping video)."""
+
+    def _make_loader(self, frame_queue, stop_event, source_changed_condition=None):
+        return StreamLoader(
+            frame_queue=frame_queue,
+            stop_event=stop_event,
+            source_changed_condition=source_changed_condition,
+            logger_=Mock(),
+        )
+
+    def test_run_loop_releases_and_clears_finished_stream(self, mp_manager, stop_event, sample_frame):
+        """When the stream finishes, run_loop releases it and clears it instead of polling forever."""
+        frame_queue = mp_manager.Queue(maxsize=10)
+        fake = _ExhaustibleVideoStream(frame=sample_frame, num_frames=3)
+        loader = self._make_loader(frame_queue, stop_event)
+        loader._source = _video_file_source()
+        loader._video_stream = fake  # pyrefly: ignore[bad-assignment]
+
+        thread = Thread(target=loader.run_loop, daemon=True)
+        thread.start()
+        try:
+            # Wait until the finished stream has been released by the loader.
+            deadline = time.monotonic() + 5
+            while not fake.released and time.monotonic() < deadline:
+                time.sleep(0.02)
+        finally:
+            stop_event.set()
+            thread.join(timeout=3)
+
+        assert fake.released is True, "Finished stream should be released"
+        assert loader._video_stream is None, "Finished stream should be cleared so polling stops"
+        assert fake.finished_calls > 0, "Loader should have checked is_finished() when get_data() returned None"
+        assert not thread.is_alive()
+
+        # Exactly the produced frames were enqueued (no None frames, no infinite retries).
+        drained = []
+        while not frame_queue.empty():
+            try:
+                drained.append(frame_queue.get_nowait())
+            except queue.Empty:
+                break
+        assert len(drained) == 3
+
+    def test_run_loop_keeps_polling_when_not_finished(self, frame_queue, stop_event, sample_frame):
+        """A transient None (stream not finished) must not stop the stream; it keeps the stream alive."""
+        stream = Mock()
+        stream.get_data.return_value = None
+        stream.is_finished.return_value = False
+        stream.is_real_time.return_value = False
+
+        loader = self._make_loader(frame_queue, stop_event)
+        loader._source = _video_file_source()
+        loader._video_stream = stream
+
+        thread = Thread(target=loader.run_loop, daemon=True)
+        thread.start()
+        try:
+            # Give the loop time to run through several polling iterations.
+            deadline = time.monotonic() + 1
+            while stream.get_data.call_count < 2 and time.monotonic() < deadline:
+                time.sleep(0.02)
+        finally:
+            stop_event.set()
+            thread.join(timeout=3)
+
+        stream.release.assert_not_called()
+        assert loader._video_stream is stream, "A non-finished stream must not be cleared"
+
+    @patch("app.workers.stream_loading.VideoStreamService.get_video_stream")
+    def test_finished_stream_can_be_re_enabled_via_source_reload(
+        self, mock_get_stream, frame_queue, stop_event, sample_frame
+    ):
+        """After a non-looping stream finished and was stopped (cleared to None), reloading the source
+        (e.g. with looping enabled) re-creates a working stream that produces frames again."""
+        loader = self._make_loader(frame_queue, stop_event)
+        # Simulate the state left behind after a finished stream was stopped.
+        loader._source = _video_file_source()
+        loader._video_stream = None
+
+        # The reloaded source yields a fresh (looping) stream that never finishes.
+        looping_stream = _FakeVideoStream(frame=sample_frame)
+        mock_get_stream.return_value = looping_stream
+
+        loader._reset_stream()
+
+        assert loader._video_stream is looping_stream, "Reloading the source should re-create the stream"
+        assert loader._video_stream.get_data() is not None, "Re-enabled stream should produce frames again"
+        assert loader._video_stream.is_finished() is False

--- a/application/ui/mocks/mock-pipeline.ts
+++ b/application/ui/mocks/mock-pipeline.ts
@@ -12,6 +12,7 @@ export const getMockedPipeline = (customPipeline?: Partial<SchemaPipelineView>):
             name: 'source',
             source_type: 'video_file' as const,
             video_path: 'video.mp4',
+            loop: false,
         },
         model: {
             id: '1',

--- a/application/ui/src/features/inference/sources/video-file/utils.ts
+++ b/application/ui/src/features/inference/sources/video-file/utils.ts
@@ -9,6 +9,7 @@ export const getVideoFileInitialConfig = (existingNames: string[] = []): VideoFi
     name: getUniqueName('Video file source', existingNames),
     source_type: 'video_file',
     video_path: '',
+    loop: false,
 });
 
 export const videoFileBodyFormatter = (formData: FormData): VideoFileSourceConfig => ({
@@ -16,4 +17,5 @@ export const videoFileBodyFormatter = (formData: FormData): VideoFileSourceConfi
     name: String(formData.get('name')),
     source_type: 'video_file',
     video_path: String(formData.get('video_path')),
+    loop: formData.get('loop') === 'on' ? true : false,
 });

--- a/application/ui/src/features/inference/sources/video-file/video-file.component.tsx
+++ b/application/ui/src/features/inference/sources/video-file/video-file.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Flex, TextField } from '@geti/ui';
+import { Flex, Switch, TextField } from '@geti/ui';
 
 import type { VideoFileSourceConfig } from '../../../../constants/shared-types';
 
@@ -24,6 +24,15 @@ export const VideoFile = ({ defaultState }: VideoFileProps) => {
                     defaultValue={String(defaultState?.video_path)}
                 />
             </Flex>
+
+            <Switch
+                aria-label='loop video'
+                name='loop'
+                defaultSelected={defaultState?.loop}
+                key={defaultState?.loop ? 'true' : 'false'}
+            >
+                Loop video
+            </Switch>
         </Flex>
     );
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Inference videos would loop forever, causing disk space to fill up. This PR introduces a flag to determine whether the user wants the video to loop or not.

Default behaviour is to not loop.

<img width="443" height="595" alt="Screenshot 2026-06-10 at 10 04 47" src="https://github.com/user-attachments/assets/490db9be-6d71-4160-bcdd-775d3c2eb0a4" />



### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
