### PR TITLE
feat: Display label color in the dataset statistics

### DIFF
--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.component.tsx
@@ -43,7 +43,7 @@ const ItemLabel = (props: LabelProps & { labelColor?: string }) => {
             {...rest}
             value={value}
             style={{
-                fill: `lch(from ${labelColor} calc((50 - l) * infinity) 0 0)`,
+                fill: labelColor ? `lch(from ${labelColor} calc((50 - l) * infinity) 0 0)` : 'white',
             }}
         />
     );
@@ -94,7 +94,7 @@ export const DatasetLabelsChart = ({ totalItems, instancesPerLabel }: DatasetLab
                     tickLine={false}
                 />
 
-                <Bar dataKey='score' radius={[4, 4, 4, 4]} barSize={BAR_SIZE}>
+                <Bar dataKey='score' radius={[4, 4, 4, 4]} fill={'color'} barSize={BAR_SIZE}>
                     <LabelList
                         dataKey='score'
                         position='insideEnd'

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-statistics/dataset-labels-chart.component.tsx
@@ -36,8 +36,17 @@ const getAxisTicks = (total: number): number[] => {
     return total % TICK_SPACING !== 0 ? [...ticks, total] : ticks;
 };
 
-const ItemLabel = (props: LabelProps) => {
-    return props.value === 0 ? null : <Label {...props} fill={'white'} />;
+const ItemLabel = (props: LabelProps & { labelColor?: string }) => {
+    const { labelColor, value, ...rest } = props;
+    return value === 0 ? null : (
+        <Label
+            {...rest}
+            value={value}
+            style={{
+                fill: `lch(from ${labelColor} calc((50 - l) * infinity) 0 0)`,
+            }}
+        />
+    );
 };
 
 export const DatasetLabelsChart = ({ totalItems, instancesPerLabel }: DatasetLabelsChartProps) => {
@@ -52,6 +61,7 @@ export const DatasetLabelsChart = ({ totalItems, instancesPerLabel }: DatasetLab
 
         return {
             label: projectLabel.name,
+            color: projectLabel.color,
             score: matchingInstances?.instances ?? 0,
         };
     });
@@ -84,8 +94,14 @@ export const DatasetLabelsChart = ({ totalItems, instancesPerLabel }: DatasetLab
                     tickLine={false}
                 />
 
-                <Bar dataKey='score' fill='var(--moss)' radius={[4, 4, 4, 4]} barSize={BAR_SIZE}>
-                    <LabelList content={ItemLabel} position='insideEnd' />
+                <Bar dataKey='score' radius={[4, 4, 4, 4]} barSize={BAR_SIZE}>
+                    <LabelList
+                        dataKey='score'
+                        position='insideEnd'
+                        content={(props) => (
+                            <ItemLabel {...props} labelColor={chartData?.at(props.index ?? 0)?.color} />
+                        )}
+                    />
                 </Bar>
 
                 <Tooltip

--- a/application/ui/src/features/dataset/gallery/toolbar/date-filter/date-filter.module.scss
+++ b/application/ui/src/features/dataset/gallery/toolbar/date-filter/date-filter.module.scss
@@ -3,6 +3,7 @@
     overflow: auto;
     border: 1px solid var(--spectrum-alias-border-color);
     border-radius: var(--spectrum-global-dimension-size-50);
+    cursor: pointer;
 }
 
 .searchPlaceholder {

--- a/application/ui/src/features/dataset/gallery/toolbar/media-filter-labels/media-filter-labels.module.scss
+++ b/application/ui/src/features/dataset/gallery/toolbar/media-filter-labels/media-filter-labels.module.scss
@@ -3,6 +3,7 @@
     overflow: auto;
     border: 1px solid var(--spectrum-alias-border-color);
     border-radius: var(--spectrum-global-dimension-size-50);
+    cursor: pointer;
 }
 
 .searchPlaceholder {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Display label color in the dataset statistics with proper contract color for the count.
2. Add pointer cursor to the date filter and label filter in the dataset statistics screen.

<img width="1233" height="802" alt="image" src="https://github.com/user-attachments/assets/2c650ed6-9e8f-45d3-9810-a1871a836dd1" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
