### PR TITLE
Add shared workflows and replace on inference/project specs

### DIFF
--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -61,6 +61,7 @@ export type DatasetRevision = components['schemas']['DatasetRevisionView'];
 export type DatasetRevisionItem = components['schemas']['DatasetRevisionItemView'];
 
 export type Project = components['schemas']['ProjectView'];
+export type ProjectCreate = components['schemas']['ProjectCreate'];
 
 export type TaskType = components['schemas']['TaskType'];
 export type Task = components['schemas']['TaskView'];

--- a/application/ui/src/constants/shared-types.ts
+++ b/application/ui/src/constants/shared-types.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { components } from '../api/openapi-spec';
+import type { components, operations } from '../api/openapi-spec';
 
 export type Label = components['schemas']['LabelView'];
 
@@ -62,6 +62,12 @@ export type DatasetRevisionItem = components['schemas']['DatasetRevisionItemView
 
 export type Project = components['schemas']['ProjectView'];
 export type ProjectCreate = components['schemas']['ProjectCreate'];
+export type CreateProjectRequest =
+    operations['create_project_api_projects_post']['requestBody']['content']['application/json'];
+export type CreateProjectResponse =
+    operations['create_project_api_projects_post']['responses'][201]['content']['application/json'];
+export type CreateProjectTaskType = CreateProjectRequest['task']['task_type'];
+export type CreateProjectLabelName = NonNullable<CreateProjectRequest['task']['labels']>[number]['name'];
 
 export type TaskType = components['schemas']['TaskType'];
 export type Task = components['schemas']['TaskView'];

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -280,7 +280,7 @@ test.describe('Inference', () => {
                     return HttpResponse.json(
                         {
                             id: 'generated-source-id',
-                            name: 'E2E Source',
+                            name: 'My Source',
                             source_type: 'usb_camera',
                             device_id: 1,
                         },
@@ -291,7 +291,7 @@ test.describe('Inference', () => {
                     return HttpResponse.json(
                         {
                             id: 'generated-sink-id',
-                            name: 'E2E Sink',
+                            name: 'My Sink',
                             sink_type: 'folder',
                             rate_limit: 5,
                             folder_path: 'e2e-output',
@@ -309,7 +309,7 @@ test.describe('Inference', () => {
             );
             await page.goto('/projects/id-1/inference');
 
-            const usbCamera = 'E2E Source';
+            const usbCamera = 'My Source';
 
             network.use(
                 http.get('/api/sources', () => {
@@ -329,7 +329,7 @@ test.describe('Inference', () => {
                     return HttpResponse.json([
                         {
                             id: '1',
-                            name: 'E2E Sink',
+                            name: 'My Sink',
                             sink_type: 'folder',
                             folder_path: 'e2e-output',
                             rate_limit: 5,
@@ -346,7 +346,7 @@ test.describe('Inference', () => {
             await expect(page.getByText('Device: FaceTime HD Camera')).toBeVisible();
 
             await page.getByLabel('Pipeline configuration tabs').getByText('Output').click();
-            await expect(page.getByText('E2E Sink')).toBeVisible();
+            await expect(page.getByText('My Sink')).toBeVisible();
             await expect(page.getByText('Folder path: e2e-output')).toBeVisible();
             await expect(page.getByText('Rate limit: 5 samples every 1 second')).toBeVisible();
             await expect(page.getByText('Output formats: predictions')).toBeVisible();

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -6,6 +6,7 @@ import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
 
 import { expect, http, test } from '../fixtures';
+import { stepConfigureInferenceSourceAndSink } from '../workflows/workflow-steps';
 
 test.describe('Inference', () => {
     test.beforeEach(({ network }) => {
@@ -275,6 +276,30 @@ test.describe('Inference', () => {
                 http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
                     return response(200).json(getMockedPipeline({ source: null, sink: null }));
                 }),
+                http.post('/api/sources', () => {
+                    return HttpResponse.json(
+                        {
+                            id: 'generated-source-id',
+                            name: 'E2E Source',
+                            source_type: 'usb_camera',
+                            device_id: 1,
+                        },
+                        { status: 201 }
+                    );
+                }),
+                http.post('/api/sinks', () => {
+                    return HttpResponse.json(
+                        {
+                            id: 'generated-sink-id',
+                            name: 'E2E Sink',
+                            sink_type: 'folder',
+                            rate_limit: 5,
+                            folder_path: 'e2e-output',
+                            output_formats: ['predictions'],
+                        },
+                        { status: 201 }
+                    );
+                }),
                 http.patch('/api/sources/{source_id}', () => {
                     return HttpResponse.json({});
                 }),
@@ -284,13 +309,7 @@ test.describe('Inference', () => {
             );
             await page.goto('/projects/id-1/inference');
 
-            await page.getByRole('button', { name: 'Add new source' }).click();
-            await page.getByRole('button', { name: 'USB Camera' }).click();
-
-            const usbCamera = 'new camera';
-            await page.getByRole('textbox', { name: 'Name' }).fill(usbCamera);
-            await page.getByRole('button', { name: 'Camera list' }).click();
-            await page.getByLabel('FaceTime HD Camera', { exact: true }).click();
+            const usbCamera = 'E2E Source';
 
             network.use(
                 http.get('/api/sources', () => {
@@ -305,31 +324,14 @@ test.describe('Inference', () => {
                 })
             );
 
-            await page.getByRole('button', { name: 'Add & Connect' }).click();
-
-            await expect(page.getByText(usbCamera)).toBeVisible();
-            await expect(page.getByText('Device: FaceTime HD Camera')).toBeVisible();
-
-            // Go to output tab
-            await page.getByLabel('Pipeline configuration tabs').getByText('Output').click();
-
-            await page.getByRole('button', { name: 'Add new sink' }).click();
-            await page.getByRole('button', { name: 'Folder' }).click();
-            await page.locator('input[name="name"]').fill('New Folder');
-            await page.locator('input[aria-roledescription="Number field"]').first().fill('5');
-            await page.locator('input[aria-roledescription="Number field"]').nth(1).fill('5');
-
-            await page.locator('input[name="folder_path"]').fill('some/path');
-            await page.locator('input[name="output_formats"][value="predictions"]').click();
-
             network.use(
                 http.get('/api/sinks', () => {
                     return HttpResponse.json([
                         {
                             id: '1',
-                            name: 'New Folder',
+                            name: 'E2E Sink',
                             sink_type: 'folder',
-                            folder_path: 'some/path',
+                            folder_path: 'e2e-output',
                             rate_limit: 5,
                             output_formats: ['predictions'],
                         },
@@ -337,10 +339,15 @@ test.describe('Inference', () => {
                 })
             );
 
-            await page.getByRole('button', { name: 'Add & Connect' }).click();
+            await stepConfigureInferenceSourceAndSink(page);
 
-            await expect(page.getByText('New Folder')).toBeVisible();
-            await expect(page.getByText('Folder path: some/path')).toBeVisible();
+            await page.getByLabel('Pipeline configuration tabs').getByText('Input').click();
+            await expect(page.getByText(usbCamera)).toBeVisible();
+            await expect(page.getByText('Device: FaceTime HD Camera')).toBeVisible();
+
+            await page.getByLabel('Pipeline configuration tabs').getByText('Output').click();
+            await expect(page.getByText('E2E Sink')).toBeVisible();
+            await expect(page.getByText('Folder path: e2e-output')).toBeVisible();
             await expect(page.getByText('Rate limit: 5 samples every 1 second')).toBeVisible();
             await expect(page.getByText('Output formats: predictions')).toBeVisible();
         });

--- a/application/ui/tests/projects/project.spec.ts
+++ b/application/ui/tests/projects/project.spec.ts
@@ -34,7 +34,7 @@ test.describe('Project', () => {
 
     test('creates a project', async ({ page, network }) => {
         const projectPage = new ProjectPage(page);
-        const projectName = `project-spec-${Date.now()}`;
+        const projectName = 'New Project';
 
         network.use(
             http.post('/api/projects', async ({ request, response }) => {
@@ -81,7 +81,7 @@ test.describe('Project', () => {
         );
 
         await stepCreateProject(page, {
-            withPrefix: projectName,
+            projectName,
             task: 'instance_segmentation',
             labels: ['Person', 'Animal'],
         });

--- a/application/ui/tests/projects/project.spec.ts
+++ b/application/ui/tests/projects/project.spec.ts
@@ -34,7 +34,7 @@ test.describe('Project', () => {
 
     test('creates a project', async ({ page, network }) => {
         const projectPage = new ProjectPage(page);
-        const projectName = 'New Project';
+        const projectName = `new-project-${Date.now()}`;
 
         network.use(
             http.post('/api/projects', async ({ request, response }) => {
@@ -58,6 +58,12 @@ test.describe('Project', () => {
             })
         );
 
+        await stepCreateProject(page, {
+            projectName,
+            task: 'instance_segmentation',
+            labels: ['Person', 'Animal'],
+        });
+
         network.use(
             http.get('/api/projects', () => {
                 return HttpResponse.json([
@@ -79,12 +85,6 @@ test.describe('Project', () => {
                 ]);
             })
         );
-
-        await stepCreateProject(page, {
-            projectName,
-            task: 'instance_segmentation',
-            labels: ['Person', 'Animal'],
-        });
 
         // Go back to project list and confirm the project was created
         await projectPage.gotoList();

--- a/application/ui/tests/projects/project.spec.ts
+++ b/application/ui/tests/projects/project.spec.ts
@@ -4,7 +4,9 @@
 import { HttpResponse } from 'msw';
 
 import { getMockedProject } from '../../mocks/mock-project';
+import type { ProjectCreate } from '../../src/constants/shared-types';
 import { expect, http, test } from '../fixtures';
+import { stepCreateProject } from '../workflows/workflow-steps';
 import { ProjectPage } from './project-page';
 
 test.describe('Project', () => {
@@ -32,28 +34,24 @@ test.describe('Project', () => {
 
     test('creates a project', async ({ page, network }) => {
         const projectPage = new ProjectPage(page);
-
-        await projectPage.gotoCreate();
-
-        await projectPage.fillProjectForm({
-            name: 'New Project',
-            task: 'instance_segmentation',
-            labelNames: ['Person', 'Animal'],
-        });
+        const projectName = `project-spec-${Date.now()}`;
 
         network.use(
-            http.post('/api/projects', ({ response }) => {
+            http.post('/api/projects', async ({ request, response }) => {
+                const body: ProjectCreate = await request.json();
+
                 return response(201).json(
                     getMockedProject({
                         id: 'new project id',
-                        name: 'New Project',
+                        name: body.name,
                         task: {
-                            task_type: 'instance_segmentation',
+                            task_type: body.task.task_type,
                             exclusive_labels: false,
-                            labels: [
-                                { id: '1', color: 'red', name: 'Person' },
-                                { id: '2', color: 'blue', name: 'Animal' },
-                            ],
+                            labels: (body.task.labels ?? []).map((label, index) => ({
+                                id: (index + 1).toString(),
+                                color: index % 2 === 0 ? 'red' : 'blue',
+                                name: label.name,
+                            })),
                         },
                     })
                 );
@@ -68,7 +66,7 @@ test.describe('Project', () => {
                     getMockedProject({ id: 'id-3', name: 'Project 3' }),
                     getMockedProject({
                         id: 'new project id',
-                        name: 'New Project',
+                        name: projectName,
                         task: {
                             task_type: 'instance_segmentation',
                             exclusive_labels: false,
@@ -82,18 +80,16 @@ test.describe('Project', () => {
             })
         );
 
-        await expect(page.getByText('Person')).toBeVisible();
-        await expect(page.getByText('Animal')).toBeVisible();
-
-        await projectPage.getCreateProjectButton().click();
-
-        // Correctly navigated to dataset page
-        await page.waitForURL(/dataset/);
+        await stepCreateProject(page, {
+            withPrefix: projectName,
+            task: 'instance_segmentation',
+            labels: ['Person', 'Animal'],
+        });
 
         // Go back to project list and confirm the project was created
         await projectPage.gotoList();
 
-        await expect(page.getByText('New Project', { exact: true })).toBeVisible();
+        await expect(page.getByText(projectName, { exact: true })).toBeVisible();
     });
 
     test('disables create button for single-label classification based if there are no at least two labels', async ({

--- a/application/ui/tests/workflows/types.ts
+++ b/application/ui/tests/workflows/types.ts
@@ -4,7 +4,8 @@
 import { Page } from '@playwright/test';
 
 export type CreateProjectInput = {
-    withPrefix: string;
+    projectName?: string;
+    withPrefix?: string;
     task: 'classification' | 'detection' | 'instance_segmentation';
     labels: string[];
 };

--- a/application/ui/tests/workflows/types.ts
+++ b/application/ui/tests/workflows/types.ts
@@ -5,7 +5,7 @@ import { Page } from '@playwright/test';
 
 export type CreateProjectInput = {
     projectName?: string;
-    withPrefix?: string;
+    projectNamePrefix?: string;
     task: 'classification' | 'detection' | 'instance_segmentation';
     labels: string[];
 };
@@ -31,5 +31,5 @@ export type InferenceSourceSinkConfig = {
 
 export type FlowInput = {
     page: Page;
-    withPrefix: string;
+    projectNamePrefix: string;
 };

--- a/application/ui/tests/workflows/types.ts
+++ b/application/ui/tests/workflows/types.ts
@@ -3,11 +3,18 @@
 
 import { Page } from '@playwright/test';
 
+import type {
+    CreateProjectLabelName,
+    CreateProjectRequest,
+    CreateProjectResponse,
+    CreateProjectTaskType,
+} from '../../src/constants/shared-types';
+
 export type CreateProjectInput = {
-    projectName?: string;
+    projectName?: CreateProjectRequest['name'];
     projectNamePrefix?: string;
-    task: 'classification' | 'detection' | 'instance_segmentation';
-    labels: string[];
+    task: CreateProjectTaskType;
+    labels: CreateProjectLabelName[];
 };
 
 export type UploadMediaItem = {
@@ -16,10 +23,7 @@ export type UploadMediaItem = {
     buffer: Buffer;
 };
 
-export type CreatedProject = {
-    id: string;
-    name: string;
-};
+export type CreatedProject = Pick<CreateProjectResponse, 'id' | 'name'>;
 
 export type InferenceSourceSinkConfig = {
     sourceName: string;

--- a/application/ui/tests/workflows/types.ts
+++ b/application/ui/tests/workflows/types.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2025-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Page } from '@playwright/test';
+
+export type CreateProjectInput = {
+    withPrefix: string;
+    task: 'classification' | 'detection' | 'instance_segmentation';
+    labels: string[];
+};
+
+export type UploadMediaItem = {
+    name: string;
+    mimeType: string;
+    buffer: Buffer;
+};
+
+export type CreatedProject = {
+    id: string;
+    name: string;
+};
+
+export type InferenceSourceSinkConfig = {
+    sourceName: string;
+    sinkName: string;
+    sinkFolderPath: string;
+    rateLimitSamples: number;
+    rateLimitSeconds: number;
+};
+
+export type FlowInput = {
+    page: Page;
+    withPrefix: string;
+};

--- a/application/ui/tests/workflows/workflow-steps.ts
+++ b/application/ui/tests/workflows/workflow-steps.ts
@@ -1,0 +1,278 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, Page } from '@playwright/test';
+
+import { BoundingBoxToolPage } from '../annotator/bounding-box-tool-page';
+import { AnnotatorPage } from '../datasets/annotator-page';
+import { DatasetPage } from '../datasets/dataset-page';
+import { StreamPage } from '../inference/stream-page';
+import { ModelsPage } from '../models/models-page';
+import { ProjectPage } from '../projects/project-page';
+import { CreatedProject, CreateProjectInput, FlowInput, InferenceSourceSinkConfig, UploadMediaItem } from './types';
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+const assetsDirectory = path.resolve(dirname, '../assets');
+
+const DEFAULT_TASK: CreateProjectInput['task'] = 'detection';
+const DEFAULT_LABELS = ['Object'];
+const DEFAULT_INFERENCE_CONFIG: InferenceSourceSinkConfig = {
+    sourceName: 'E2E Source',
+    sinkName: 'E2E Sink',
+    sinkFolderPath: 'e2e-output',
+    rateLimitSamples: 5,
+    rateLimitSeconds: 1,
+};
+
+const TIMEOUT = {
+    mediaVisible: 60000,
+    architectureVisible: 30000,
+    trainingStarted: 120000,
+    connected: 120000,
+    capturedMedia: 180000,
+} as const;
+
+const getProjectIdFromUrl = (url: string): string => {
+    const match = url.match(/\/projects\/([^/]+)\//);
+
+    if (match === null || match[1] === undefined) {
+        throw new Error(`Could not extract project id from URL: ${url}`);
+    }
+
+    return match[1];
+};
+
+const openPipelineTab = async (page: Page, tabName: 'Input' | 'Output'): Promise<void> => {
+    await page.getByLabel('Pipeline configuration tabs').getByText(tabName).click();
+};
+
+const selectPickerOptionIfVisible = async (page: Page, label: string): Promise<void> => {
+    const picker = page.getByLabel(label, { exact: true }).last();
+
+    if ((await picker.count()) === 0) {
+        return;
+    }
+
+    await picker.click();
+
+    const option = page.getByRole('option').first();
+    await expect(option).toBeVisible();
+    await option.click();
+};
+
+export const stepCreateProject = async (page: Page, input: CreateProjectInput): Promise<CreatedProject> => {
+    const projectPage = new ProjectPage(page);
+    const projectName = `${input.withPrefix}-${input.task}`;
+
+    await projectPage.gotoCreate();
+    await projectPage.fillProjectForm({
+        name: projectName,
+        task: input.task,
+        labelNames: input.labels,
+    });
+
+    await projectPage.getCreateProjectButton().scrollIntoViewIfNeeded();
+    await projectPage.getCreateProjectButton().click();
+
+    await page.waitForURL(/\/projects\/[^/]+\/dataset/);
+
+    return {
+        id: getProjectIdFromUrl(page.url()),
+        name: projectName,
+    };
+};
+
+export const getDefaultUploadMedia = (): UploadMediaItem[] => [
+    {
+        name: 'candy.png',
+        mimeType: 'image/png',
+        buffer: fs.readFileSync(path.resolve(assetsDirectory, 'candy.png')),
+    },
+];
+
+export const stepUploadMedia = async (
+    datasetPage: DatasetPage,
+    media: UploadMediaItem[] = getDefaultUploadMedia()
+): Promise<void> => {
+    await datasetPage.uploadFiles(media);
+
+    const mediaGrid = datasetPage.getMediaGrid();
+    await expect(mediaGrid).toBeVisible();
+    await expect(mediaGrid.getByRole('option').first()).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+};
+
+export const stepOpenFirstItemInAnnotator = async (page: Page, datasetPage: DatasetPage): Promise<void> => {
+    const firstItem = datasetPage.getMediaGrid().getByRole('option').first();
+
+    await expect(firstItem).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+    await firstItem.dblclick();
+
+    await expect(page).toHaveURL(/\/projects\/[^/]+\/dataset\/items\//);
+};
+
+export const stepAnnotateSingleBox = async (
+    page: Page,
+    annotatorPage: AnnotatorPage,
+    boundingBoxTool: BoundingBoxToolPage
+): Promise<void> => {
+    await expect(annotatorPage.getMediaItemImage()).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+
+    await boundingBoxTool.selectTool();
+    await boundingBoxTool.drawBoundingBox({ x: 150, y: 150, width: 220, height: 180 });
+
+    await expect(page.getByLabel('annotation rect').first()).toBeVisible();
+
+    await annotatorPage.submit();
+};
+
+export const stepTrainModel = async (page: Page, modelsPage: ModelsPage, projectId: string): Promise<void> => {
+    await modelsPage.goto(projectId);
+    await modelsPage.openTrainModelDialog();
+
+    const firstArchitecture = page.getByRole('radio').first();
+    await expect(firstArchitecture).toBeVisible({ timeout: TIMEOUT.architectureVisible });
+    await firstArchitecture.click();
+
+    await selectPickerOptionIfVisible(page, 'Select dataset');
+    await selectPickerOptionIfVisible(page, 'Select model revision');
+
+    await modelsPage.startTraining();
+
+    await expect(async () => {
+        const hasRunningHeading = await page.getByRole('heading', { name: 'Currently running' }).isVisible();
+        const hasTrainingMessage = await page
+            .getByText(/Training in progress|running/i)
+            .first()
+            .isVisible();
+
+        expect(hasRunningHeading || hasTrainingMessage).toBe(true);
+    }).toPass({ timeout: TIMEOUT.trainingStarted });
+};
+
+export const cleanupProject = async (page: Page, projectId: string): Promise<void> => {
+    if (process.env.E2E_KEEP_RESOURCES === 'true') {
+        return;
+    }
+
+    const response = await page.request.delete(`/api/projects/${projectId}`);
+
+    if (![200, 202, 204, 404].includes(response.status())) {
+        throw new Error(`Failed to cleanup project ${projectId}. Status: ${response.status()}`);
+    }
+};
+
+export const stepConfigureInferenceSourceAndSink = async (
+    page: Page,
+    config: InferenceSourceSinkConfig = DEFAULT_INFERENCE_CONFIG
+): Promise<void> => {
+    await expect(page.getByRole('button', { name: 'Add new source' })).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+
+    await page.getByRole('button', { name: 'Add new source' }).click();
+    await page.getByRole('button', { name: 'USB Camera' }).click();
+
+    await page.getByRole('textbox', { name: 'Name' }).fill(config.sourceName);
+    await page.getByRole('button', { name: 'Camera list' }).click();
+    await page.getByRole('option').first().click();
+    await page.getByRole('button', { name: 'Add & Connect' }).click();
+
+    await openPipelineTab(page, 'Output');
+    await page.getByRole('button', { name: 'Add new sink' }).click();
+    await page.getByRole('button', { name: 'Folder' }).click();
+
+    await page.locator('input[name="name"]').fill(config.sinkName);
+    await page.locator('input[aria-roledescription="Number field"]').first().fill(String(config.rateLimitSamples));
+    await page.locator('input[aria-roledescription="Number field"]').nth(1).fill(String(config.rateLimitSeconds));
+    await page.locator('input[name="folder_path"]').fill(config.sinkFolderPath);
+    await page.locator('input[name="output_formats"][value="predictions"]').check();
+    await page.getByRole('button', { name: 'Add & Connect' }).click();
+};
+
+export const stepStartStreamWithAutoCapture = async (page: Page, streamPage: StreamPage): Promise<void> => {
+    const pipelineSwitch = page.getByRole('switch', { name: /Enable pipeline|Disable Pipeline/i });
+
+    await expect(pipelineSwitch).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+
+    if ((await pipelineSwitch.getAttribute('aria-label'))?.toLowerCase().includes('enable') === true) {
+        await pipelineSwitch.click();
+    }
+
+    await streamPage.startStream();
+    await expect(page.getByLabel('Connected')).toBeVisible({ timeout: TIMEOUT.connected });
+
+    await page.getByRole('button', { name: 'Toggle Data collection policy' }).click();
+
+    const autoCaptureSwitch = page.getByRole('switch', { name: 'Toggle auto capturing' });
+    await expect(autoCaptureSwitch).toBeVisible();
+
+    if ((await autoCaptureSwitch.isChecked()) === false) {
+        await autoCaptureSwitch.click();
+    }
+
+    await expect(autoCaptureSwitch).toBeChecked();
+};
+
+export const stepWaitForCapturedMediaAndOpenAnnotator = async (page: Page, datasetPage: DatasetPage): Promise<void> => {
+    await page.getByRole('tab', { name: 'Dataset' }).click();
+
+    const mediaOptions = datasetPage.getMediaGrid().getByRole('option');
+    await expect(async () => {
+        expect(await mediaOptions.count()).toBeGreaterThan(0);
+    }).toPass({ timeout: TIMEOUT.capturedMedia });
+
+    await mediaOptions.first().dblclick();
+    await expect(page).toHaveURL(/\/projects\/[^/]+\/dataset\/items\//);
+};
+
+// Flow 1: create project -> add media -> annotate -> train
+export const runFlowCreateAnnotateTrain = async ({ page, withPrefix }: FlowInput): Promise<CreatedProject> => {
+    const datasetPage = new DatasetPage(page);
+    const annotatorPage = new AnnotatorPage(page);
+    const boundingBoxTool = new BoundingBoxToolPage(page);
+    const modelsPage = new ModelsPage(page);
+
+    const project = await stepCreateProject(page, {
+        withPrefix,
+        task: DEFAULT_TASK,
+        labels: DEFAULT_LABELS,
+    });
+
+    await stepUploadMedia(datasetPage);
+    await stepOpenFirstItemInAnnotator(page, datasetPage);
+    await stepAnnotateSingleBox(page, annotatorPage, boundingBoxTool);
+    await stepTrainModel(page, modelsPage, project.id);
+
+    return project;
+};
+
+// Flow 2: create project -> configure inference -> stream auto-capture -> annotate -> train
+export const runFlowStreamAutoCaptureAnnotateTrain = async ({
+    page,
+    withPrefix,
+}: FlowInput): Promise<CreatedProject> => {
+    const datasetPage = new DatasetPage(page);
+    const annotatorPage = new AnnotatorPage(page);
+    const boundingBoxTool = new BoundingBoxToolPage(page);
+    const modelsPage = new ModelsPage(page);
+    const streamPage = new StreamPage(page);
+
+    const project = await stepCreateProject(page, {
+        withPrefix,
+        task: DEFAULT_TASK,
+        labels: DEFAULT_LABELS,
+    });
+
+    await page.goto(`/projects/${project.id}/inference`);
+
+    await stepConfigureInferenceSourceAndSink(page);
+    await stepStartStreamWithAutoCapture(page, streamPage);
+    await stepWaitForCapturedMediaAndOpenAnnotator(page, datasetPage);
+    await stepAnnotateSingleBox(page, annotatorPage, boundingBoxTool);
+    await stepTrainModel(page, modelsPage, project.id);
+
+    return project;
+};

--- a/application/ui/tests/workflows/workflow-steps.ts
+++ b/application/ui/tests/workflows/workflow-steps.ts
@@ -54,7 +54,7 @@ const openPipelineTab = async (page: Page, tabName: 'Input' | 'Output'): Promise
 const selectPickerOptionIfVisible = async (page: Page, label: string): Promise<void> => {
     const picker = page.getByLabel(label, { exact: true }).last();
 
-    if ((await picker.count()) === 0) {
+    if (!(await picker.isVisible())) {
         return;
     }
 
@@ -67,7 +67,7 @@ const selectPickerOptionIfVisible = async (page: Page, label: string): Promise<v
 
 export const stepCreateProject = async (page: Page, input: CreateProjectInput): Promise<CreatedProject> => {
     const projectPage = new ProjectPage(page);
-    const projectName = input.projectName ?? `${input.withPrefix ?? 'project'}-${input.task}`;
+    const projectName = input.projectName ?? `${input.projectNamePrefix ?? 'project'}-${input.task}`;
 
     await projectPage.gotoCreate();
     await projectPage.fillProjectForm({
@@ -229,14 +229,14 @@ export const stepWaitForCapturedMediaAndOpenAnnotator = async (page: Page, datas
 };
 
 // Flow 1: create project -> add media -> annotate -> train
-export const runFlowCreateAnnotateTrain = async ({ page, withPrefix }: FlowInput): Promise<CreatedProject> => {
+export const runFlowCreateAnnotateTrain = async ({ page, projectNamePrefix }: FlowInput): Promise<CreatedProject> => {
     const datasetPage = new DatasetPage(page);
     const annotatorPage = new AnnotatorPage(page);
     const boundingBoxTool = new BoundingBoxToolPage(page);
     const modelsPage = new ModelsPage(page);
 
     const project = await stepCreateProject(page, {
-        withPrefix,
+        projectNamePrefix,
         task: DEFAULT_TASK,
         labels: DEFAULT_LABELS,
     });
@@ -252,7 +252,7 @@ export const runFlowCreateAnnotateTrain = async ({ page, withPrefix }: FlowInput
 // Flow 2: create project -> configure inference -> stream auto-capture -> annotate -> train
 export const runFlowStreamAutoCaptureAnnotateTrain = async ({
     page,
-    withPrefix,
+    projectNamePrefix,
 }: FlowInput): Promise<CreatedProject> => {
     const datasetPage = new DatasetPage(page);
     const annotatorPage = new AnnotatorPage(page);
@@ -261,7 +261,7 @@ export const runFlowStreamAutoCaptureAnnotateTrain = async ({
     const streamPage = new StreamPage(page);
 
     const project = await stepCreateProject(page, {
-        withPrefix,
+        projectNamePrefix,
         task: DEFAULT_TASK,
         labels: DEFAULT_LABELS,
     });

--- a/application/ui/tests/workflows/workflow-steps.ts
+++ b/application/ui/tests/workflows/workflow-steps.ts
@@ -191,10 +191,10 @@ export const stepConfigureInferenceSourceAndSink = async (
     await page.getByRole('button', { name: 'Folder' }).click();
 
     await page.getByRole('textbox', { name: 'Name' }).fill(config.sinkName);
-    await page.getByLabel('Samples').fill(String(config.rateLimitSamples));
-    await page.getByLabel('Seconds').fill(String(config.rateLimitSeconds));
+    await page.getByRole('textbox', { name: 'Samples' }).fill(String(config.rateLimitSamples));
+    await page.getByRole('textbox', { name: 'Seconds' }).fill(String(config.rateLimitSeconds));
     await page.getByRole('textbox', { name: 'Folder Path' }).fill(config.sinkFolderPath);
-    await page.getByRole('checkbox', { name: 'Predictions' }).check();
+    await page.getByRole('checkbox', { name: 'Predictions', exact: true }).check();
     await page.getByRole('button', { name: 'Add & Connect' }).click();
 };
 

--- a/application/ui/tests/workflows/workflow-steps.ts
+++ b/application/ui/tests/workflows/workflow-steps.ts
@@ -22,9 +22,9 @@ const assetsDirectory = path.resolve(dirname, '../assets');
 const DEFAULT_TASK: CreateProjectInput['task'] = 'detection';
 const DEFAULT_LABELS = ['Object'];
 const DEFAULT_INFERENCE_CONFIG: InferenceSourceSinkConfig = {
-    sourceName: 'E2E Source',
-    sinkName: 'E2E Sink',
-    sinkFolderPath: 'e2e-output',
+    sourceName: 'My Source',
+    sinkName: 'My Sink',
+    sinkFolderPath: 'my-output',
     rateLimitSamples: 5,
     rateLimitSeconds: 1,
 };
@@ -33,6 +33,7 @@ const TIMEOUT = {
     mediaVisible: 60000,
     architectureVisible: 30000,
     trainingStarted: 120000,
+    trainedModelReady: 600000,
     connected: 120000,
     capturedMedia: 180000,
 } as const;
@@ -51,12 +52,10 @@ const openPipelineTab = async (page: Page, tabName: 'Input' | 'Output'): Promise
     await page.getByLabel('Pipeline configuration tabs').getByText(tabName).click();
 };
 
-const selectPickerOptionIfVisible = async (page: Page, label: string): Promise<void> => {
+const selectPickerOption = async (page: Page, label: string): Promise<void> => {
     const picker = page.getByLabel(label, { exact: true }).last();
 
-    if (!(await picker.isVisible())) {
-        return;
-    }
+    await expect(picker).toBeVisible({ timeout: TIMEOUT.architectureVisible });
 
     await picker.click();
 
@@ -79,7 +78,7 @@ export const stepCreateProject = async (page: Page, input: CreateProjectInput): 
     await projectPage.getCreateProjectButton().scrollIntoViewIfNeeded();
     await projectPage.getCreateProjectButton().click();
 
-    await page.waitForURL(/\/projects\/[^/]+\/dataset/);
+    await expect(page).toHaveURL(/\/projects\/[^/]+\/dataset/);
 
     return {
         id: getProjectIdFromUrl(page.url()),
@@ -99,11 +98,18 @@ export const stepUploadMedia = async (
     datasetPage: DatasetPage,
     media: UploadMediaItem[] = getDefaultUploadMedia()
 ): Promise<void> => {
-    await datasetPage.uploadFiles(media);
-
     const mediaGrid = datasetPage.getMediaGrid();
     await expect(mediaGrid).toBeVisible();
-    await expect(mediaGrid.getByRole('option').first()).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+
+    const mediaOptions = mediaGrid.getByRole('option');
+    const initialCount = await mediaOptions.count();
+
+    await datasetPage.uploadFiles(media);
+
+    await expect(datasetPage.getUploadFinishedText(media.length)).toBeVisible({ timeout: TIMEOUT.mediaVisible });
+    await expect
+        .poll(async () => mediaOptions.count(), { timeout: TIMEOUT.mediaVisible })
+        .toBeGreaterThanOrEqual(initialCount + media.length);
 };
 
 export const stepOpenFirstItemInAnnotator = async (page: Page, datasetPage: DatasetPage): Promise<void> => {
@@ -138,8 +144,8 @@ export const stepTrainModel = async (page: Page, modelsPage: ModelsPage, project
     await expect(firstArchitecture).toBeVisible({ timeout: TIMEOUT.architectureVisible });
     await firstArchitecture.click();
 
-    await selectPickerOptionIfVisible(page, 'Select dataset');
-    await selectPickerOptionIfVisible(page, 'Select model revision');
+    await selectPickerOption(page, 'Select dataset');
+    await selectPickerOption(page, 'Select model revision');
 
     await modelsPage.startTraining();
 
@@ -184,11 +190,11 @@ export const stepConfigureInferenceSourceAndSink = async (
     await page.getByRole('button', { name: 'Add new sink' }).click();
     await page.getByRole('button', { name: 'Folder' }).click();
 
-    await page.locator('input[name="name"]').fill(config.sinkName);
-    await page.locator('input[aria-roledescription="Number field"]').first().fill(String(config.rateLimitSamples));
-    await page.locator('input[aria-roledescription="Number field"]').nth(1).fill(String(config.rateLimitSeconds));
-    await page.locator('input[name="folder_path"]').fill(config.sinkFolderPath);
-    await page.locator('input[name="output_formats"][value="predictions"]').check();
+    await page.getByRole('textbox', { name: 'Name' }).fill(config.sinkName);
+    await page.getByLabel('Samples').fill(String(config.rateLimitSamples));
+    await page.getByLabel('Seconds').fill(String(config.rateLimitSeconds));
+    await page.getByRole('textbox', { name: 'Folder Path' }).fill(config.sinkFolderPath);
+    await page.getByRole('checkbox', { name: 'Predictions' }).check();
     await page.getByRole('button', { name: 'Add & Connect' }).click();
 };
 
@@ -197,9 +203,12 @@ export const stepStartStreamWithAutoCapture = async (page: Page, streamPage: Str
 
     await expect(pipelineSwitch).toBeVisible({ timeout: TIMEOUT.mediaVisible });
 
-    if ((await pipelineSwitch.getAttribute('aria-label'))?.toLowerCase().includes('enable') === true) {
+    if (!(await pipelineSwitch.isChecked())) {
         await pipelineSwitch.click();
     }
+
+    await expect(pipelineSwitch).toBeChecked();
+    await expect(page.getByLabel('active model')).toBeVisible({ timeout: TIMEOUT.mediaVisible });
 
     await streamPage.startStream();
     await expect(page.getByLabel('Connected')).toBeVisible({ timeout: TIMEOUT.connected });
@@ -214,6 +223,11 @@ export const stepStartStreamWithAutoCapture = async (page: Page, streamPage: Str
     }
 
     await expect(autoCaptureSwitch).toBeChecked();
+};
+
+export const stepWaitForTrainedModelForInference = async (page: Page, projectId: string): Promise<void> => {
+    await page.goto(`/projects/${projectId}/inference`);
+    await expect(page.getByLabel('active model')).toBeVisible({ timeout: TIMEOUT.trainedModelReady });
 };
 
 export const stepWaitForCapturedMediaAndOpenAnnotator = async (page: Page, datasetPage: DatasetPage): Promise<void> => {
@@ -249,7 +263,7 @@ export const runFlowCreateAnnotateTrain = async ({ page, projectNamePrefix }: Fl
     return project;
 };
 
-// Flow 2: create project -> configure inference -> stream auto-capture -> annotate -> train
+// Flow 2: create project -> annotate -> train -> wait for trained model -> stream auto-capture
 export const runFlowStreamAutoCaptureAnnotateTrain = async ({
     page,
     projectNamePrefix,
@@ -266,13 +280,14 @@ export const runFlowStreamAutoCaptureAnnotateTrain = async ({
         labels: DEFAULT_LABELS,
     });
 
-    await page.goto(`/projects/${project.id}/inference`);
-
-    await stepConfigureInferenceSourceAndSink(page);
-    await stepStartStreamWithAutoCapture(page, streamPage);
-    await stepWaitForCapturedMediaAndOpenAnnotator(page, datasetPage);
+    await stepUploadMedia(datasetPage);
+    await stepOpenFirstItemInAnnotator(page, datasetPage);
     await stepAnnotateSingleBox(page, annotatorPage, boundingBoxTool);
     await stepTrainModel(page, modelsPage, project.id);
+
+    await stepWaitForTrainedModelForInference(page, project.id);
+    await stepConfigureInferenceSourceAndSink(page);
+    await stepStartStreamWithAutoCapture(page, streamPage);
 
     return project;
 };

--- a/application/ui/tests/workflows/workflow-steps.ts
+++ b/application/ui/tests/workflows/workflow-steps.ts
@@ -67,7 +67,7 @@ const selectPickerOptionIfVisible = async (page: Page, label: string): Promise<v
 
 export const stepCreateProject = async (page: Page, input: CreateProjectInput): Promise<CreatedProject> => {
     const projectPage = new ProjectPage(page);
-    const projectName = `${input.withPrefix}-${input.task}`;
+    const projectName = input.projectName ?? `${input.withPrefix ?? 'project'}-${input.task}`;
 
     await projectPage.gotoCreate();
     await projectPage.fillProjectForm({


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Add work flow .step's to be reused between normal and e2e playwright tests
* Replace on project and inference specs

Next PR:
* Add E2E config + one test

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
