### PR TITLE
Improve reliability of pretrained weights download

### DIFF
--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import os
 import shutil
 from collections.abc import Callable
 from contextlib import AbstractContextManager
@@ -154,9 +155,13 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
             model_architecture_id = training_params.model_architecture_id
             project_id = training_params.project_id
             if parent_model_revision_id is None:
-                return self._base_weights_service.get_local_weights_path(
+                local_weights_path = self._base_weights_service.get_local_weights_path(
                     task=task.task_type, model_manifest_id=model_architecture_id
                 )
+                # Set PRETRAINED_WEIGHTS_CACHE_DIR to let getitune search the weights in the cache folder
+                # defined by the application rather than in the default location
+                os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"] = str(local_weights_path.parent)
+                return local_weights_path
 
             parent_variants = self._model_service.get_model_variants(
                 project_id=project_id, model_id=parent_model_revision_id

--- a/application/backend/app/services/base_weights_service.py
+++ b/application/backend/app/services/base_weights_service.py
@@ -3,9 +3,7 @@
 
 import hashlib
 import shutil
-from collections.abc import Iterator
 from pathlib import Path
-from urllib.parse import urlparse
 
 import requests
 from loguru import logger
@@ -171,7 +169,8 @@ class BaseWeightsService:
         """
         # Use a conservative default (500MB) if the remote size cannot be queried.
         file_size = 500 * 1024 * 1024
-        for use_env_proxy in self._request_modes(remote_url):
+        # Try with and without proxies, as some environments may have proxy issues that cause the HEAD request to fail
+        for use_env_proxy in (True, False):
             try:
                 with self._build_retry_session(use_env_proxy=use_env_proxy) as session:
                     response = session.head(remote_url, allow_redirects=True, timeout=self.REQUEST_TIMEOUT)
@@ -221,9 +220,9 @@ class BaseWeightsService:
             # Ensure all folders exist for the destination path
             local_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Attempt the download with and without proxies
+            # Attempt the download with and without proxies, since some environment may have proxy issues
             last_error: Exception | None = None
-            for use_env_proxy in self._request_modes(remote_url):
+            for use_env_proxy in (True, False):
                 try:
                     with (
                         self._build_retry_session(use_env_proxy=use_env_proxy) as session,
@@ -259,19 +258,6 @@ class BaseWeightsService:
             if temp_path.exists():
                 temp_path.unlink()
 
-    def _request_modes(self, remote_url: str) -> Iterator[bool]:
-        """Try with environment proxy first, then direct for Geti storage hosts."""
-        # Default path: respect container/host proxy configuration.
-        yield True
-        if self._is_geti_storage_host(remote_url):
-            # Fallback path: bypass env proxies for Geti object storage when proxy tunneling fails.
-            yield False
-
-    @staticmethod
-    def _is_geti_storage_host(remote_url: str) -> bool:
-        host = urlparse(remote_url).hostname or ""
-        return host.endswith("storage.geti.intel.com")
-
     def _build_retry_session(self, use_env_proxy: bool) -> requests.Session:
         session = requests.Session()
         # trust_env=False disables HTTP(S)_PROXY and NO_PROXY from environment.
@@ -279,9 +265,6 @@ class BaseWeightsService:
 
         retry = Retry(
             total=self.RETRY_TOTAL,
-            connect=self.RETRY_TOTAL,
-            read=self.RETRY_TOTAL,
-            status=self.RETRY_TOTAL,
             backoff_factor=self.RETRY_BACKOFF_FACTOR,
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=frozenset(["HEAD", "GET"]),

--- a/application/backend/app/services/base_weights_service.py
+++ b/application/backend/app/services/base_weights_service.py
@@ -3,10 +3,14 @@
 
 import hashlib
 import shutil
+from collections.abc import Iterator
 from pathlib import Path
+from urllib.parse import urlparse
 
 import requests
 from loguru import logger
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 from app.models import ModelManifest, TaskType
 
@@ -15,6 +19,10 @@ from .model_manifest_service import ModelManifestService
 
 class BaseWeightsService:
     """Service for downloading and managing pretrained model weights from external archives."""
+
+    REQUEST_TIMEOUT = (10, 600)  # (connect timeout, read timeout) in seconds
+    RETRY_TOTAL = 3  # total number of retries for failed requests
+    RETRY_BACKOFF_FACTOR = 1.0  # exponential backoff factor for retries (e.g., 1s, 2s, 4s)
 
     def __init__(self, data_dir: Path) -> None:
         self.pretrained_weights_dir = data_dir / "pretrained_weights"
@@ -161,21 +169,26 @@ class BaseWeightsService:
         Raises:
             OSError: If there's insufficient disk space
         """
-        try:
-            # Use a longer read timeout to allow for large file downloads
-            response = requests.head(remote_url, allow_redirects=True, timeout=(10, 600))
-            response.raise_for_status()
+        # Use a conservative default (500MB) if the remote size cannot be queried.
+        file_size = 500 * 1024 * 1024
+        for use_env_proxy in self._request_modes(remote_url):
+            try:
+                with self._build_retry_session(use_env_proxy=use_env_proxy) as session:
+                    response = session.head(remote_url, allow_redirects=True, timeout=self.REQUEST_TIMEOUT)
+                    response.raise_for_status()
 
-            content_length = response.headers.get("content-length")
-            if content_length:
-                file_size = int(content_length)
-            else:
-                # If we can't get the size, assume a reasonable default (500MB)
-                file_size = 500 * 1024 * 1024
-                logger.warning(f"Could not determine file size for {remote_url}, assuming 500MB")
-        except Exception as e:
-            logger.warning(f"Could not check remote file size for {remote_url}: {e}, assuming 500MB")
-            file_size = 500 * 1024 * 1024
+                    content_length = response.headers.get("content-length")
+                    if content_length:
+                        file_size = int(content_length)
+                    else:
+                        logger.warning(f"Could not determine file size for {remote_url}, assuming 500MB")
+                    break
+            except Exception as e:
+                # Log per mode so we can see whether proxy or direct access failed.
+                proxy_mode = "env-proxy" if use_env_proxy else "direct"
+                logger.warning(f"Could not check remote file size for {remote_url} via {proxy_mode}: {e}")
+        else:
+            logger.warning(f"Could not check remote file size for {remote_url}; assuming 500MB")
 
         stat = shutil.disk_usage(self.pretrained_weights_dir)
         available_space = stat.free
@@ -205,12 +218,28 @@ class BaseWeightsService:
         # Create temporary file for download
         temp_path = local_path.with_suffix(".tmp")
         try:
-            # Stream the download to handle large files, use a longer read timeout to allow for large file downloads
-            with requests.get(remote_url, stream=True, timeout=(10, 600)) as response:
-                response.raise_for_status()
-                with open(temp_path, "wb") as f:
-                    for data in response.iter_content(chunk_size=4096):
-                        f.write(data)
+            # Ensure all folders exist for the destination path
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Attempt the download with and without proxies
+            last_error: Exception | None = None
+            for use_env_proxy in self._request_modes(remote_url):
+                try:
+                    with (
+                        self._build_retry_session(use_env_proxy=use_env_proxy) as session,
+                        session.get(remote_url, stream=True, timeout=self.REQUEST_TIMEOUT) as response,
+                    ):
+                        response.raise_for_status()
+                        with open(temp_path, "wb") as f:
+                            for data in response.iter_content(chunk_size=4096):
+                                f.write(data)
+                    break
+                except requests.RequestException as e:
+                    last_error = e
+                    proxy_mode = "env-proxy" if use_env_proxy else "direct"
+                    logger.warning(f"Weight download failed via {proxy_mode} for {remote_url}: {e}")
+            else:
+                raise ValueError(f"Failed to download weights from {remote_url}: {last_error}")
 
             if not self._verify_file_integrity(temp_path, sha_sum):
                 temp_path.unlink()
@@ -229,6 +258,38 @@ class BaseWeightsService:
             # Clean up temporary file if it exists
             if temp_path.exists():
                 temp_path.unlink()
+
+    def _request_modes(self, remote_url: str) -> Iterator[bool]:
+        """Try with environment proxy first, then direct for Geti storage hosts."""
+        # Default path: respect container/host proxy configuration.
+        yield True
+        if self._is_geti_storage_host(remote_url):
+            # Fallback path: bypass env proxies for Geti object storage when proxy tunneling fails.
+            yield False
+
+    @staticmethod
+    def _is_geti_storage_host(remote_url: str) -> bool:
+        host = urlparse(remote_url).hostname or ""
+        return host.endswith("storage.geti.intel.com")
+
+    def _build_retry_session(self, use_env_proxy: bool) -> requests.Session:
+        session = requests.Session()
+        # trust_env=False disables HTTP(S)_PROXY and NO_PROXY from environment.
+        session.trust_env = use_env_proxy
+
+        retry = Retry(
+            total=self.RETRY_TOTAL,
+            connect=self.RETRY_TOTAL,
+            read=self.RETRY_TOTAL,
+            status=self.RETRY_TOTAL,
+            backoff_factor=self.RETRY_BACKOFF_FACTOR,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=frozenset(["HEAD", "GET"]),
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
 
     @staticmethod
     def _get_and_validate_model_manifest(task: TaskType, model_manifest_id: str) -> ModelManifest:

--- a/application/backend/app/services/base_weights_service.py
+++ b/application/backend/app/services/base_weights_service.py
@@ -210,7 +210,7 @@ class BaseWeightsService:
             sha_sum: Expected SHA256 checksum for verification
 
         Raises:
-            ValueError: If downloaded file fails integrity check, or if download fails
+            RuntimeError: If downloaded file fails integrity check, or if download fails
         """
         self._check_disk_space(remote_url)
 
@@ -238,21 +238,24 @@ class BaseWeightsService:
                     proxy_mode = "env-proxy" if use_env_proxy else "direct"
                     logger.warning(f"Weight download failed via {proxy_mode} for {remote_url}: {e}")
             else:
-                raise ValueError(f"Failed to download weights from {remote_url}: {last_error}")
+                raise RuntimeError(f"Failed to download weights from {remote_url}: {last_error}")
 
             if not self._verify_file_integrity(temp_path, sha_sum):
                 temp_path.unlink()
-                raise ValueError(f"Downloaded file failed integrity check for {remote_url}")
+                raise RuntimeError(f"Downloaded file failed integrity check for {remote_url}")
 
             # Move temporary file to final location
             temp_path.rename(local_path)
             logger.info(f"Successfully downloaded and verified weights: {local_path}")
         except requests.RequestException as e:
             logger.error(f"Failed to download weights from {remote_url}: {e}")
-            raise ValueError(f"Failed to download weights from {remote_url}: {e}")
+            raise RuntimeError(f"Failed to download weights from {remote_url}: {e}") from e
+        except RuntimeError:
+            # Re-raise runtime errors to preserve the original error type and message and avoid the broad except clause
+            raise
         except Exception as e:
             logger.error(f"Unexpected error downloading weights from {remote_url}: {e}")
-            raise ValueError(f"Unexpected error downloading weights from {remote_url}: {e}")
+            raise RuntimeError(f"Unexpected error downloading weights from {remote_url}: {e}") from e
         finally:
             # Clean up temporary file if it exists
             if temp_path.exists():

--- a/application/backend/tests/unit/services/test_base_weights_service.py
+++ b/application/backend/tests/unit/services/test_base_weights_service.py
@@ -1,5 +1,5 @@
-#  Copyright (C) 2026 Intel Corporation
-#  SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -100,7 +100,7 @@ class TestBaseWeightsServiceRetryLogic:
         assert direct_session.get.called
 
     def test_download_weights_raises_when_both_connections_fail(self, fxt_base_weights_service):
-        """Test that download raises ValueError when both proxy and direct connections fail."""
+        """Test that download raises RuntimeError when both proxy and direct connections fail."""
         proxy_session = self._make_mock_session()
         proxy_session.get.side_effect = requests.RequestException("proxy error")
         direct_session = self._make_mock_session()
@@ -113,7 +113,7 @@ class TestBaseWeightsServiceRetryLogic:
                 "_build_retry_session",
                 side_effect=[proxy_session, direct_session],
             ),
-            pytest.raises(ValueError, match="weights.pth"),
+            pytest.raises(RuntimeError, match="weights.pth"),
         ):
             fxt_base_weights_service._download_weights(
                 remote_url="https://example.com/weights.pth",

--- a/application/backend/tests/unit/services/test_base_weights_service.py
+++ b/application/backend/tests/unit/services/test_base_weights_service.py
@@ -1,0 +1,122 @@
+#  Copyright (C) 2026 Intel Corporation
+#  SPDX-License-Identifier: Apache-2.0
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from app.services import BaseWeightsService
+
+
+@pytest.fixture()
+def fxt_pretrained_weights_dir(tmp_path: Path) -> Generator[Path]:
+    """Set up a temporary data directory for tests."""
+    pretrained_weights_dir = tmp_path / "pretrained_weights"
+    pretrained_weights_dir.mkdir(parents=True, exist_ok=True)
+    yield pretrained_weights_dir
+
+
+@pytest.fixture
+def fxt_base_weights_service(fxt_pretrained_weights_dir: Path) -> BaseWeightsService:
+    """Create a BaseWeightsService instance for testing."""
+    return BaseWeightsService(fxt_pretrained_weights_dir.parent)
+
+
+class TestBaseWeightsServiceRetryLogic:
+    """Test cases for the retry and proxy fallback logic of BaseWeightsService."""
+
+    def _make_mock_session(self) -> MagicMock:
+        """Create a mock session that can be used as a context manager."""
+        session = MagicMock()
+        session.__enter__ = MagicMock(return_value=session)
+        session.__exit__ = MagicMock(return_value=False)
+        return session
+
+    def test_check_disk_space_falls_back_when_proxy_fails(self, fxt_base_weights_service):
+        """Test that disk space check falls back to direct connection when proxy fails."""
+        proxy_session = self._make_mock_session()
+        proxy_session.head.side_effect = requests.RequestException("proxy error")
+        mock_response = MagicMock()
+        mock_response.headers.get.return_value = str(100 * 1024 * 1024)
+        direct_session = self._make_mock_session()
+        direct_session.head.return_value = mock_response
+        with (
+            patch.object(
+                fxt_base_weights_service,
+                "_build_retry_session",
+                side_effect=[proxy_session, direct_session],
+            ),
+            patch("app.services.base_weights_service.shutil.disk_usage") as mock_disk_usage,
+        ):
+            mock_disk_usage.return_value = MagicMock(free=10 * 1024**3)
+            fxt_base_weights_service._check_disk_space("https://example.com/weights.pth")
+        assert proxy_session.head.called
+        assert direct_session.head.called
+
+    def test_check_disk_space_both_connections_fail_uses_default_size(self, fxt_base_weights_service):
+        """Test that disk space check uses the default 500 MB when both proxy and direct connections fail."""
+        failing_session = self._make_mock_session()
+        failing_session.head.side_effect = requests.RequestException("connection error")
+        with (
+            patch.object(
+                fxt_base_weights_service,
+                "_build_retry_session",
+                side_effect=[failing_session, failing_session],
+            ),
+            patch("app.services.base_weights_service.shutil.disk_usage") as mock_disk_usage,
+        ):
+            mock_disk_usage.return_value = MagicMock(free=10 * 1024**3)
+            fxt_base_weights_service._check_disk_space("https://example.com/weights.pth")
+        mock_disk_usage.assert_called_once()
+
+    def test_download_weights_falls_back_when_proxy_fails(self, fxt_base_weights_service):
+        """Test that download falls back to direct connection when proxy download fails."""
+        proxy_session = self._make_mock_session()
+        proxy_session.get.side_effect = requests.RequestException("proxy error")
+        mock_response = MagicMock()
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_response.iter_content.return_value = [b"fake weights data"]
+        direct_session = self._make_mock_session()
+        direct_session.get.return_value = mock_response
+        local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
+        with (
+            patch.object(fxt_base_weights_service, "_check_disk_space"),
+            patch.object(
+                fxt_base_weights_service,
+                "_build_retry_session",
+                side_effect=[proxy_session, direct_session],
+            ),
+            patch.object(fxt_base_weights_service, "_verify_file_integrity", return_value=True),
+        ):
+            fxt_base_weights_service._download_weights(
+                remote_url="https://example.com/weights.pth",
+                local_path=local_path,
+                sha_sum="dummy_sha",
+            )
+        assert proxy_session.get.called
+        assert direct_session.get.called
+
+    def test_download_weights_raises_when_both_connections_fail(self, fxt_base_weights_service):
+        """Test that download raises ValueError when both proxy and direct connections fail."""
+        proxy_session = self._make_mock_session()
+        proxy_session.get.side_effect = requests.RequestException("proxy error")
+        direct_session = self._make_mock_session()
+        direct_session.get.side_effect = requests.RequestException("direct error")
+        local_path = fxt_base_weights_service.pretrained_weights_dir / "detection" / "test_weights.pth"
+        with (
+            patch.object(fxt_base_weights_service, "_check_disk_space"),
+            patch.object(
+                fxt_base_weights_service,
+                "_build_retry_session",
+                side_effect=[proxy_session, direct_session],
+            ),
+            pytest.raises(ValueError, match="weights.pth"),
+        ):
+            fxt_base_weights_service._download_weights(
+                remote_url="https://example.com/weights.pth",
+                local_path=local_path,
+                sha_sum="dummy_sha",
+            )

--- a/library/src/getitune/__init__.py
+++ b/library/src/getitune/__init__.py
@@ -10,13 +10,18 @@ from pathlib import Path
 
 from getitune.types import *  # noqa: F403
 
-# Set the value of HF_HUB_CACHE to set the cache folder that stores the pretrained weights for timm and huggingface.
-# Refer: huggingface_hub/constants.py::HF_HUB_CACHE
-# Default, Pretrained weight is saved into ~/.cache/torch/hub/checkpoints
-os.environ["HF_HUB_CACHE"] = os.getenv(
-    "HF_HUB_CACHE",
+# The 'PRETRAINED_WEIGHTS_CACHE_DIR' env variable controls where to cache pretrained weights for the majority of
+# the models. The default location is ~/.cache/torch/hub/checkpoints
+os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"] = os.getenv(
+    "PRETRAINED_WEIGHTS_CACHE_DIR",
     str(Path.home() / ".cache" / "torch" / "hub" / "checkpoints"),
 )
+
+# The 'HF_HUB_CACHE' env variable controls where to cache pretrained weights for timm and huggingface models.
+# By default, it is set to the same location of PRETRAINED_WEIGHTS_CACHE_DIR.
+# Refer: huggingface_hub/constants.py::HF_HUB_CACHE
+os.environ["HF_HUB_CACHE"] = os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"]
+
 # Set the value of ONEDNN_PRIMITIVE_CACHE_CAPACITY to set the cache capacity for oneDNN primitives.
 # It will be ignored if no XPU devices are available.
 os.environ["ONEDNN_PRIMITIVE_CACHE_CAPACITY"] = "10000"

--- a/library/src/getitune/__init__.py
+++ b/library/src/getitune/__init__.py
@@ -18,9 +18,12 @@ os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"] = os.getenv(
 )
 
 # The 'HF_HUB_CACHE' env variable controls where to cache pretrained weights for timm and huggingface models.
-# By default, it is set to the same location of PRETRAINED_WEIGHTS_CACHE_DIR.
+# If not explicitly set, it defaults to the same location of PRETRAINED_WEIGHTS_CACHE_DIR.
 # Refer: huggingface_hub/constants.py::HF_HUB_CACHE
-os.environ["HF_HUB_CACHE"] = os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"]
+os.environ["HF_HUB_CACHE"] = os.getenv(
+    "HF_HUB_CACHE",
+    os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"],
+)
 
 # Set the value of ONEDNN_PRIMITIVE_CACHE_CAPACITY to set the cache capacity for oneDNN primitives.
 # It will be ignored if no XPU devices are available.

--- a/library/src/getitune/backend/lightning/models/classification/backbones/efficientnet.py
+++ b/library/src/getitune/backend/lightning/models/classification/backbones/efficientnet.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import math
+import os
 from pathlib import Path
 from typing import Any, Callable, ClassVar
 
@@ -670,7 +671,7 @@ class EfficientNetBackbone:
         )
 
         if pretrained:
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
+            cache_dir = Path(os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"])
             download_model(net=model, model_name=f"{model_name}", local_model_store_dir_path=str(cache_dir))
             print(f"Download model weight in {cache_dir!s}")
         return model

--- a/library/src/getitune/backend/lightning/models/classification/hlabel_models/vit.py
+++ b/library/src/getitune/backend/lightning/models/classification/hlabel_models/vit.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -134,7 +135,7 @@ class VisionTransformerHLabelCls(ForwardExplainMixInForViT, LightningHlabelClsMo
             parts = urlparse(pretrained_urls[self.model_name])
             filename = Path(parts.path).name
 
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
+            cache_dir = Path(os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"])
             cache_file = cache_dir / filename
             if not Path.exists(cache_file):
                 download_url_to_file(pretrained_urls[self.model_name], cache_file, "", progress=True)

--- a/library/src/getitune/backend/lightning/models/classification/multiclass_models/vit.py
+++ b/library/src/getitune/backend/lightning/models/classification/multiclass_models/vit.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import types
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
@@ -249,7 +250,7 @@ class VisionTransformerMulticlassCls(ForwardExplainMixInForViT, LightningMulticl
             parts = urlparse(pretrained_urls[self.model_name])
             filename = Path(parts.path).name
 
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
+            cache_dir = Path(os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"])
             cache_file = cache_dir / filename
             if not Path.exists(cache_file):
                 download_url_to_file(pretrained_urls[self.model_name], cache_file, "", progress=True)

--- a/library/src/getitune/backend/lightning/models/classification/multilabel_models/vit.py
+++ b/library/src/getitune/backend/lightning/models/classification/multilabel_models/vit.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -120,7 +121,7 @@ class VisionTransformerMultilabelCls(ForwardExplainMixInForViT, LightningMultila
             parts = urlparse(pretrained_urls[self.model_name])
             filename = Path(parts.path).name
 
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
+            cache_dir = Path(os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"])
             cache_file = cache_dir / filename
             if not Path.exists(cache_file):
                 download_url_to_file(pretrained_urls[self.model_name], cache_file, "", progress=True)

--- a/library/src/getitune/backend/lightning/models/common/backbones/pytorchcv_backbones.py
+++ b/library/src/getitune/backend/lightning/models/common/backbones/pytorchcv_backbones.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Callable
 
@@ -125,7 +126,7 @@ def _build_pytorchcv_model(
     **kwargs,
 ) -> nn.Module:
     """Build pytorchcv model."""
-    models_cache_root = kwargs.pop("root", Path.home() / ".cache" / "torch" / "hub" / "checkpoints")
+    models_cache_root = Path(kwargs.pop("root", os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"]))
     pretrained = kwargs.pop("pretrained", False)
     print(f"Init model {type}, pretrained={pretrained}, models cache {models_cache_root}")
     model = _models[type](root=models_cache_root, pretrained=pretrained, **kwargs)

--- a/library/src/getitune/backend/lightning/models/detection/backbones/presnet.py
+++ b/library/src/getitune/backend/lightning/models/detection/backbones/presnet.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from collections import OrderedDict
 from functools import partial
 from typing import Any, Callable, ClassVar
@@ -266,7 +267,7 @@ class PResNetModule(BaseModule):
         101: [3, 4, 23, 3],
     }
 
-    donwload_url: ClassVar = {
+    download_url: ClassVar = {
         18: "https://storage.geti.intel.com/weights/ResNet18_vd_pretrained_from_paddle.pth",
         34: "https://storage.geti.intel.com/weights/ResNet34_vd_pretrained_from_paddle.pth",
         50: "https://storage.geti.intel.com/weights/ResNet50_vd_ssld_v2_pretrained_from_paddle.pth",
@@ -351,7 +352,10 @@ class PResNetModule(BaseModule):
                 self._freeze_parameters(self.res_layers[i])
 
         if pretrained:
-            state = torch.hub.load_state_dict_from_url(self.donwload_url[depth])
+            state = torch.hub.load_state_dict_from_url(
+                url=self.download_url[depth],
+                model_dir=os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"],
+            )
             self.load_state_dict(state)
             print(f"Load PResNet{depth} state_dict")
 

--- a/library/src/getitune/backend/lightning/models/segmentation/backbones/litehrnet.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/backbones/litehrnet.py
@@ -1234,8 +1234,7 @@ class LiteHRNetModule(nn.Module):
             checkpoint = torch.load(pretrained, "cpu")
             print(f"init weight - {pretrained}")
         elif pretrained is not None:
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
-            checkpoint = load_from_http(filename=pretrained, map_location="cpu", model_dir=cache_dir)
+            checkpoint = load_from_http(filename=pretrained, map_location="cpu")
             print(f"init weight - {pretrained}")
         if checkpoint is not None:
             load_checkpoint_to_model(self, checkpoint, prefix=prefix)

--- a/library/src/getitune/backend/lightning/models/segmentation/backbones/mscan.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/backbones/mscan.py
@@ -435,8 +435,7 @@ class MSCANModule(nn.Module):
             checkpoint = torch.load(pretrained, "cpu")
             print(f"init weight - {pretrained}")
         elif pretrained is not None:
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
-            checkpoint = load_from_http(filename=pretrained, map_location="cpu", model_dir=cache_dir)
+            checkpoint = load_from_http(filename=pretrained, map_location="cpu")
             print(f"init weight - {pretrained}")
         if checkpoint is not None:
             load_checkpoint_to_model(self, checkpoint, prefix=prefix)

--- a/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/dino_v2_seg.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -93,7 +94,7 @@ class DinoV2Seg(LightningSegmentationModel):
             parts = urlparse(self.pretrained_weights[self.model_name])
             filename = Path(parts.path).name
 
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
+            cache_dir = Path(os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"])
             cache_file = cache_dir / filename
             if not Path.exists(cache_file):
                 download_url_to_file(self.pretrained_weights[self.model_name], cache_file, "", progress=True)

--- a/library/src/getitune/backend/lightning/models/segmentation/heads/base_segm_head.py
+++ b/library/src/getitune/backend/lightning/models/segmentation/heads/base_segm_head.py
@@ -158,14 +158,12 @@ class BaseSegmentationHead(nn.Module):
             checkpoint = torch.load(pretrained, map_location=torch.device("cpu"))
             print(f"Init weights - {pretrained}")
         elif pretrained is not None:
-            cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
             if isinstance(pretrained, Path):
                 msg = "pretrained path doesn't exists"
                 raise ValueError(msg)
             checkpoint = load_from_http(
                 filename=pretrained,
                 map_location="cpu",
-                model_dir=cache_dir,
             )
             print(f"Init weights - {pretrained}")
         if checkpoint is not None:

--- a/library/src/getitune/backend/lightning/models/utils/utils.py
+++ b/library/src/getitune/backend/lightning/models/utils/utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import os
 import re
 from collections import OrderedDict, abc, namedtuple
@@ -22,6 +23,8 @@ from torch.utils.model_zoo import load_url
 BoolTypeTensor = Union[torch.BoolTensor, torch.cuda.BoolTensor]
 LongTypeTensor = Union[torch.LongTensor, torch.cuda.LongTensor]
 IndexType = Union[str, slice, int, list, LongTypeTensor, BoolTypeTensor, np.ndarray]
+
+logger = logging.getLogger(__name__)
 
 
 def _torch_hub_model_reduce(self) -> tuple[Callable, tuple]:  # noqa: ANN001
@@ -120,7 +123,7 @@ def load_from_http(
         map_location (str | None, optional): Specifies where to load the checkpoint onto.
             Defaults to None.
         model_dir (str | None, optional): The directory to save the downloaded checkpoint.
-            Defaults to None.
+            Defaults to PRETRAINED_WEIGHTS_CACHE_DIR.
         progress (bool, optional): Whether to display a progress bar while downloading the checkpoint.
             Defaults to True if running in a terminal, otherwise False.
 
@@ -131,6 +134,10 @@ def load_from_http(
         None
 
     """
+    if not model_dir:
+        model_dir = os.environ["PRETRAINED_WEIGHTS_CACHE_DIR"]
+    logger.info("Checkpoint URL: '%s'", filename)
+    logger.info("Checkpoint folder: '%s'", model_dir)
     rank, world_size = get_dist_info()
     if rank == 0:
         checkpoint = load_url(filename, model_dir=model_dir, map_location=map_location, progress=progress)

--- a/library/tests/unit/backend/lightning/models/segmentation/backbones/test_mscan.py
+++ b/library/tests/unit/backend/lightning/models/segmentation/backbones/test_mscan.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -106,6 +105,5 @@ class TestMSCABlock:
         pretrained_weight = "www.fake.com/fake.pth"
         MSCANModule(pretrained_weights=pretrained_weight)
 
-        cache_dir = Path.home() / ".cache" / "torch" / "hub" / "checkpoints"
-        mock_load_from_http.assert_called_once_with(filename=pretrained_weight, map_location="cpu", model_dir=cache_dir)
+        mock_load_from_http.assert_called_once_with(filename=pretrained_weight, map_location="cpu")
         mock_load_checkpoint_to_model.assert_called_once()


### PR DESCRIPTION
### Summary

The initialization of pretrained weights in getitune is fragmented and doesn't follow a uniform approach; weights are downloaded from different sources, through different APIs and even cached in different locations. This is a known problem, see #5223 and #5100. 

To complicate matters, the training job of the Geti application also implements a step to pre-download the weights of the model to be trained. This step is intended to become part of a final solution where the application is responsible for the download and caching of pretrained weights, and subsequent provisioning to the library. In practice, however, this solution isn't fully implemented yet so the weights are downloaded twice: in the application and the library.

Another problem is #6591: when the application is deployed in a restricted network with complex proxy settings, downloads often fail. For example, in our internal network, we observed that the proxy server occasionally rejects connections to `storage.geti.intel.com:443` and intermittently resets the TLS tunnel.

This PR aims to mitigate the above problems with some enhancements to the weights provisioning mechanism:
- The library (getitune) now exposes a new env variable `PRETRAINED_WEIGHTS_CACHE_DIR` to configure the folder where pretrained weights for most model architectures
- The training job (app) sets the value of `PRETRAINED_WEIGHTS_CACHE_DIR` to point to its pretrained weights cache folder, `{data}/pretrained_weights/{task}/`
  - Thanks to this improvement, in most cases the library won't attempt to re-download the same weights because of a cache miss in its default folder (`~/.cache/torch/hub/checkpoints`)
- `BaseWeightsService` now implements a retry-backoff mechanism to mitigate sporadic network resets while pulling the weights
- `BaseWeightsService` now also implements a no-proxy fallback path: if the download fails with the configured proxy configuration, it will attempt again _without_ proxies.

Partially solves #6591 

### How to test

Fresh install Geti on a server within our internal network, create projects for each task, train every model architecture for 1 epoch. After training, check the logs and also verify that `~/.cache/torch/hub/checkpoints` is empty, which indicates that the weights were loaded from the application cache instead.

Verified for:
- Classification
  - [x] EfficientNet-B0
  - [ ] EfficientNet-B3
  - [ ] EfficientNet-V2-S
  - [x] MobileNet-V3-L
  - [x] DINOv2-Small
  - [ ] ViT-Tiny
- Detection
  - [x] YOLOX S/M/L
  - [x] YOLOX-Tiny
  - [x] SSD-MobileNet-V2
  - [x] ATSS-MobileNet-V2
  - [x] D-FINE-M/L/X
  - [x] DINOv2-DETR-S/M/L/X
  - [x] RT-DETR-R50
- Segmentation
  - [x] RF-DETR-Seg S/M/L
  - [x] MaskRCNN-EfficientNet-B2
  - [ ] MaskRCNN-ResNet50
  - [x] MaskRCNN-SwinT
  - [x] RTMDet-Tiny

For the unselected models, this PR can't fully solve the #6591 issue because:
- In EfficientNet-V2-S the download logic is inside `timm.create_model`. 
- In EfficientNet-B3 the download logic is inside `torchvision.get_model` and `get_model_weights`.
- ViT-Tiny needs to download additional `.npz` checkpoint files, not covered by the application cache.
- MaskRCNN-ResNet50 the weights are downloaded inside `torchvision.models.resnet50`

For these models, the only workaround is to retry training a couple of times, or provision the weights manually.

Proof that the retry mechanism sometimes helps:
<img width="1435" height="145" alt="image" src="https://github.com/user-attachments/assets/479d63ef-ff62-4769-85a3-c78f2afc774e" />

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
