### PR TITLE
Fixed frame extraction for videos.

### DIFF
--- a/application/backend/app/services/demo_files_service.py
+++ b/application/backend/app/services/demo_files_service.py
@@ -124,16 +124,15 @@ class DemoFilesService:
                 continue
             try:
                 frame_index = media.frame_count // 2
-                video_frame = self._media_service.get_frame_binary(
-                    project_id=project_id, video=media, frame_index=frame_index
-                )
+                video_path = self._media_service.get_media_binary_path(project_id=project_id, media=media)
+                video_frame = self._encode_video_frame_as_jpeg(video_path=video_path, frame_index=frame_index)
                 logger.info(
                     "No image found in project {}; extracting frame {} from video {} as sample image.",
                     project_id,
                     frame_index,
                     media.id,
                 )
-                return video_frame.tobytes()
+                return video_frame
             except Exception:
                 logger.exception("Failed to extract a sample frame from video {} (project {})", media.id, project_id)
                 continue

--- a/application/backend/tests/integration/services/test_demo_files_service.py
+++ b/application/backend/tests/integration/services/test_demo_files_service.py
@@ -282,7 +282,7 @@ class TestDemoFilesServiceIntegration:
         so the bundled bytes are a flat ``H*W*3`` RGB buffer.
         """
         project, _video, frame_count = fxt_project_with_real_video
-        width, height = 64, 48  # matches fxt_video_data defaults
+        _width, _height = 64, 48  # matches fxt_video_data defaults
 
         files = fxt_demo_files_service.build_demo_files(project_id=project.id, model_format=ModelFormat.OPENVINO)
 
@@ -290,15 +290,7 @@ class TestDemoFilesServiceIntegration:
         assert names == ["image.jpg", "demo.py", "demo_async.py", "pyproject.toml", "README.md"]
 
         sample = next(f for f in files if f.name == "image.jpg")
-        # Raw RGB pixel buffer: H * W * 3 bytes.
-        assert len(sample.data) == width * height * 3
-
-        # Synthetic video frames are uniform gray with intensity == frame_index, so the
-        # middle frame should have mean intensity close to frame_count // 2.
-        arr = np.frombuffer(sample.data, dtype=np.uint8).reshape(height, width, 3)
-        expected = frame_count // 2
-        mean = float(arr.mean())
-        assert abs(mean - expected) < 5, f"Expected mean ~{expected}, got {mean:.2f}"
+        assert len(sample.data) > 0
 
     def test_image_preferred_over_video_for_sample(
         self,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

Extracts the frame from the video and ensures it is jpeg compatible.

Tested on the provided dataset 
<img width="1325" height="637" alt="image" src="https://github.com/user-attachments/assets/cc3233e1-a243-4f4a-88fb-d8d55c1d6413" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
