### PR TITLE
Resize large images

### DIFF
--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -59,8 +59,7 @@ const useDrawImageOnCanvas = (image: ImageData) => {
     return canvasRef;
 };
 
-// Use <img> for static images to bypass the browser 2D canvas pixel limit
-// (~268 Mpx in Chrome) which renders a white square for very large images.
+// Oversized static images: use <img> to bypass canvas rasterization limit.
 const StaticImage = ({ mediaItem }: { mediaItem: Media }) => {
     const projectId = useProjectIdentifier();
 
@@ -97,12 +96,13 @@ const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
         return <CanvasMediaImage image={image} showVideoFrame />;
     }
 
-    const hasFullResolutionImageData =
+    // Render via canvas if image was decoded at full resolution, else use <img>.
+    const isFullResolution =
         image.width === mediaItem.width &&
         image.height === mediaItem.height &&
         image.data.length === mediaItem.width * mediaItem.height * 4;
 
-    if (hasFullResolutionImageData) {
+    if (isFullResolution) {
         return <CanvasMediaImage image={image} />;
     }
 

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -18,6 +18,7 @@ import { useSelectedAnnotations } from '../../../shared/annotator/select-annotat
 import { useTool } from '../../../shared/annotator/tool-provider.component';
 import { useEditableAnnotationState } from '../../../shared/annotator/use-editable-annotation-state.hook';
 import { isVideo, isVideoFrame } from '../../../shared/media-item-utils';
+import { getMediaBinaryUrl } from '../../../shared/media-url.utils';
 import { Annotations } from '../annotations/annotations.component';
 import { VideoAnnotations, VideoPredictions } from '../annotations/video-annotations.component';
 import { useIsAnnotatorSceneBusy } from '../hooks/use-is-annotator-scene-busy';
@@ -57,15 +58,40 @@ const useDrawImageOnCanvas = (image: ImageData) => {
     return canvasRef;
 };
 
-const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
+// Use <img> for static images to bypass the browser 2D canvas pixel limit
+// (~268 Mpx in Chrome) which renders a white square for very large images.
+const StaticImage = ({ mediaItem }: { mediaItem: Media }) => {
+    const projectId = useProjectIdentifier();
+
+    return (
+        <img
+            src={getMediaBinaryUrl(projectId, mediaItem.id)}
+            width={mediaItem.width}
+            height={mediaItem.height}
+            crossOrigin='anonymous'
+            className={classes.image}
+            alt=''
+        />
+    );
+};
+
+const VideoMediaImage = ({ image }: { image: ImageData }) => {
     const canvasRef = useDrawImageOnCanvas(image);
 
     return (
         <>
             <canvas ref={canvasRef} width={image.width} height={image.height} className={classes.image} />
-            {(isVideo(mediaItem) || isVideoFrame(mediaItem)) && <VideoFrame canvasRef={canvasRef} />}
+            <VideoFrame canvasRef={canvasRef} />
         </>
     );
+};
+
+const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
+    if (isVideo(mediaItem) || isVideoFrame(mediaItem)) {
+        return <VideoMediaImage image={image} />;
+    }
+
+    return <StaticImage mediaItem={mediaItem} />;
 };
 
 type ImageAnnotationsProps = {

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -34,6 +34,7 @@ import {
 import { getVideoFrameRangeIndexes } from '../video-player/api/utils';
 import { VideoFrame } from '../video-player/video-frame.component';
 import { useVideoPlayer, useVideoPlayerContext } from '../video-player/video-player-provider.component';
+import { drawImageDataOnCanvas } from './draw-image-data-on-canvas';
 
 import classes from './annotator-canvas.module.scss';
 
@@ -52,7 +53,7 @@ const useDrawImageOnCanvas = (image: ImageData) => {
             return;
         }
 
-        ctx.putImageData(image, 0, 0);
+        drawImageDataOnCanvas(ctx, image);
     }, [image]);
 
     return canvasRef;
@@ -75,20 +76,34 @@ const StaticImage = ({ mediaItem }: { mediaItem: Media }) => {
     );
 };
 
-const VideoMediaImage = ({ image }: { image: ImageData }) => {
+type CanvasMediaImageProps = {
+    image: ImageData;
+    showVideoFrame?: boolean;
+};
+
+const CanvasMediaImage = ({ image, showVideoFrame = false }: CanvasMediaImageProps) => {
     const canvasRef = useDrawImageOnCanvas(image);
 
     return (
         <>
             <canvas ref={canvasRef} width={image.width} height={image.height} className={classes.image} />
-            <VideoFrame canvasRef={canvasRef} />
+            {showVideoFrame && <VideoFrame canvasRef={canvasRef} />}
         </>
     );
 };
 
 const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
     if (isVideo(mediaItem) || isVideoFrame(mediaItem)) {
-        return <VideoMediaImage image={image} />;
+        return <CanvasMediaImage image={image} showVideoFrame />;
+    }
+
+    const hasFullResolutionImageData =
+        image.width === mediaItem.width &&
+        image.height === mediaItem.height &&
+        image.data.length === mediaItem.width * mediaItem.height * 4;
+
+    if (hasFullResolutionImageData) {
+        return <CanvasMediaImage image={image} />;
     }
 
     return <StaticImage mediaItem={mediaItem} />;

--- a/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
+++ b/application/ui/src/features/annotator/annotator-canvas/annotator-canvas.tsx
@@ -96,7 +96,9 @@ const MediaImage = ({ image, mediaItem }: MediaImageProps) => {
         return <CanvasMediaImage image={image} showVideoFrame />;
     }
 
-    // Render via canvas if image was decoded at full resolution, else use <img>.
+    // Render via canvas only when decoded at native resolution.
+    // `ImageData.data.length` is expected to be width * height * 4
+    // (RGBA: 4 channels, 1 byte per channel = 4 bytes per pixel).
     const isFullResolution =
         image.width === mediaItem.width &&
         image.height === mediaItem.height &&

--- a/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.test.ts
+++ b/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.test.ts
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { drawImageDataOnCanvas } from './draw-image-data-on-canvas';
+
+const createCanvasContext = () => {
+    return {
+        createImageData: vi.fn((width: number, height: number) => ({
+            width,
+            height,
+            data: new Uint8ClampedArray(width * height * 4),
+            colorSpace: 'srgb',
+        })),
+        putImageData: vi.fn(),
+    } as unknown as CanvasRenderingContext2D;
+};
+
+describe('drawImageDataOnCanvas', () => {
+    it('skips drawing when the input pixel buffer is invalid', () => {
+        const ctx = createCanvasContext();
+        const invalidImage = {
+            width: 4,
+            height: 4,
+            data: new Uint8ClampedArray(10),
+            colorSpace: 'srgb',
+        } as ImageData;
+
+        const didDraw = drawImageDataOnCanvas(ctx, invalidImage);
+
+        expect(didDraw).toBe(false);
+        expect(ctx.createImageData).not.toHaveBeenCalled();
+        expect(ctx.putImageData).not.toHaveBeenCalled();
+    });
+
+    it('normalizes and draws valid image-shaped data', () => {
+        const ctx = createCanvasContext();
+        const image = {
+            width: 2,
+            height: 3,
+            data: new Uint8ClampedArray(2 * 3 * 4).fill(7),
+            colorSpace: 'srgb',
+        } as ImageData;
+
+        const didDraw = drawImageDataOnCanvas(ctx, image);
+
+        const created = vi.mocked(ctx.createImageData).mock.results[0]?.value as ImageData;
+
+        expect(didDraw).toBe(true);
+        expect(ctx.createImageData).toHaveBeenCalledWith(2, 3);
+        expect(created.data).toEqual(image.data);
+        expect(ctx.putImageData).toHaveBeenCalledWith(created, 0, 0);
+    });
+});

--- a/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.test.ts
+++ b/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.test.ts
@@ -5,12 +5,6 @@ import { drawImageDataOnCanvas } from './draw-image-data-on-canvas';
 
 const createCanvasContext = () => {
     return {
-        createImageData: vi.fn((width: number, height: number) => ({
-            width,
-            height,
-            data: new Uint8ClampedArray(width * height * 4),
-            colorSpace: 'srgb',
-        })),
         putImageData: vi.fn(),
     } as unknown as CanvasRenderingContext2D;
 };
@@ -28,11 +22,10 @@ describe('drawImageDataOnCanvas', () => {
         const didDraw = drawImageDataOnCanvas(ctx, invalidImage);
 
         expect(didDraw).toBe(false);
-        expect(ctx.createImageData).not.toHaveBeenCalled();
         expect(ctx.putImageData).not.toHaveBeenCalled();
     });
 
-    it('normalizes and draws valid image-shaped data', () => {
+    it('draws valid image-shaped data directly', () => {
         const ctx = createCanvasContext();
         const image = {
             width: 2,
@@ -43,11 +36,7 @@ describe('drawImageDataOnCanvas', () => {
 
         const didDraw = drawImageDataOnCanvas(ctx, image);
 
-        const created = vi.mocked(ctx.createImageData).mock.results[0]?.value as ImageData;
-
         expect(didDraw).toBe(true);
-        expect(ctx.createImageData).toHaveBeenCalledWith(2, 3);
-        expect(created.data).toEqual(image.data);
-        expect(ctx.putImageData).toHaveBeenCalledWith(created, 0, 0);
+        expect(ctx.putImageData).toHaveBeenCalledWith(image, 0, 0);
     });
 });

--- a/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
+++ b/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
@@ -1,8 +1,10 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { isImageOversized } from '../tools/utils';
+
 export const drawImageDataOnCanvas = (ctx: CanvasRenderingContext2D, image: ImageData): boolean => {
-    if (image.data.length !== image.width * image.height * 4) {
+    if (isImageOversized(image)) {
         return false;
     }
 

--- a/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
+++ b/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
@@ -3,10 +3,9 @@
 
 import { isImageOversized } from '../tools/utils';
 
+// Draw ImageData to canvas. Fails gracefully for oversized media (downscaled data).
 export const drawImageDataOnCanvas = (ctx: CanvasRenderingContext2D, image: ImageData): boolean => {
-    if (isImageOversized(image)) {
-        return false;
-    }
+    if (isImageOversized(image)) return false;
 
     const compatibleImageData = ctx.createImageData(image.width, image.height);
     compatibleImageData.data.set(image.data);

--- a/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
+++ b/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
@@ -7,9 +7,7 @@ import { isImageOversized } from '../tools/utils';
 export const drawImageDataOnCanvas = (ctx: CanvasRenderingContext2D, image: ImageData): boolean => {
     if (isImageOversized(image)) return false;
 
-    const compatibleImageData = ctx.createImageData(image.width, image.height);
-    compatibleImageData.data.set(image.data);
-    ctx.putImageData(compatibleImageData, 0, 0);
+    ctx.putImageData(image, 0, 0);
 
     return true;
 };

--- a/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
+++ b/application/ui/src/features/annotator/annotator-canvas/draw-image-data-on-canvas.ts
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+export const drawImageDataOnCanvas = (ctx: CanvasRenderingContext2D, image: ImageData): boolean => {
+    if (image.data.length !== image.width * image.height * 4) {
+        return false;
+    }
+
+    const compatibleImageData = ctx.createImageData(image.width, image.height);
+    compatibleImageData.data.set(image.data);
+    ctx.putImageData(compatibleImageData, 0, 0);
+
+    return true;
+};

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -12,6 +12,8 @@ import type { RegionOfInterest } from '../../shared/types';
 import { useLoadImageQuery } from './hooks/use-load-image-query.hook';
 import { getImageData } from './tools/utils';
 
+// See tools/utils.ts for the oversized image handling flow (downscale → display
+// in media-space → disable smart tools or coordinate-transform at boundaries).
 type SelectedMediaItemContextProps = {
     mediaItem: Media;
     roi: RegionOfInterest;
@@ -97,9 +99,8 @@ export const SelectedMediaItemProvider = ({
         isPlaceholderData,
     } = useLoadImageQuery(mediaItem);
 
-    // For oversized media, getImageData returns a downscaled buffer so the
-    // image can still be rendered. Keep `image` dimensions in media-space so
-    // drawing tools continue to clamp coordinates correctly.
+    // For oversized media: wrap downscaled data in full-size dimensions so
+    // drawing tools clamp to media-space, not the smaller buffer dimensions.
     const decodedAtFullSize = loadedImage.width === mediaItem.width && loadedImage.height === mediaItem.height;
     const image = decodedAtFullSize
         ? loadedImage

--- a/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
+++ b/application/ui/src/features/annotator/selected-media-item-provider.component.tsx
@@ -16,7 +16,12 @@ type SelectedMediaItemContextProps = {
     mediaItem: Media;
     roi: RegionOfInterest;
     setMediaItem: (item: Media) => void;
+    // Media-space view of the image: width/height always match the media item so
+    // coordinate clamping in drawing tools stays in annotation space.
     image: ImageData;
+    // True once the current item's full-resolution pixels are loaded and decoded.
+    // False during loading, while a placeholder is shown, or for images too large
+    // to rasterise at full size (smart tools are disabled in that case).
     isImageReady: boolean;
 };
 
@@ -86,8 +91,25 @@ export const SelectedMediaItemProvider = ({
 }: SelectedMediaItemProviderProps) => {
     const [mediaItem, setMediaItem] = useMediaItem(initialMediaItem);
 
-    const { data: image = getImageData(new Image()), isSuccess, isPlaceholderData } = useLoadImageQuery(mediaItem);
-    const isImageReady = isSuccess && !isPlaceholderData;
+    const {
+        data: loadedImage = getImageData(new Image()),
+        isSuccess,
+        isPlaceholderData,
+    } = useLoadImageQuery(mediaItem);
+
+    // For oversized media, getImageData returns a downscaled buffer so the
+    // image can still be rendered. Keep `image` dimensions in media-space so
+    // drawing tools continue to clamp coordinates correctly.
+    const decodedAtFullSize = loadedImage.width === mediaItem.width && loadedImage.height === mediaItem.height;
+    const image = decodedAtFullSize
+        ? loadedImage
+        : ({
+              width: mediaItem.width,
+              height: mediaItem.height,
+              data: loadedImage.data,
+              colorSpace: 'srgb',
+          } as ImageData);
+    const isImageReady = isSuccess && !isPlaceholderData && decodedAtFullSize;
 
     const roi: RegionOfInterest = { x: 0, y: 0, width: mediaItem.width, height: mediaItem.height };
 

--- a/application/ui/src/features/annotator/tools/annotator-tools/annotator-tools.component.tsx
+++ b/application/ui/src/features/annotator/tools/annotator-tools/annotator-tools.component.tsx
@@ -1,8 +1,6 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect } from 'react';
-
 import { Divider } from '@geti/ui';
 import { partition } from 'lodash-es';
 
@@ -18,12 +16,6 @@ export const AnnotatorTools = () => {
 
     const availableTools = useAvailableTools();
     const [selectionTool, otherTools] = partition(availableTools, (tool) => tool.type === 'selection');
-
-    useEffect(() => {
-        if (activeTool !== null && !availableTools.some((tool) => tool.type === activeTool)) {
-            setActiveTool(availableTools[0]?.type ?? null);
-        }
-    }, [activeTool, availableTools, setActiveTool]);
 
     return (
         <>

--- a/application/ui/src/features/annotator/tools/annotator-tools/annotator-tools.component.tsx
+++ b/application/ui/src/features/annotator/tools/annotator-tools/annotator-tools.component.tsx
@@ -1,6 +1,8 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useEffect } from 'react';
+
 import { Divider } from '@geti/ui';
 import { partition } from 'lodash-es';
 
@@ -16,6 +18,12 @@ export const AnnotatorTools = () => {
 
     const availableTools = useAvailableTools();
     const [selectionTool, otherTools] = partition(availableTools, (tool) => tool.type === 'selection');
+
+    useEffect(() => {
+        if (activeTool !== null && !availableTools.some((tool) => tool.type === activeTool)) {
+            setActiveTool(availableTools[0]?.type ?? null);
+        }
+    }, [activeTool, availableTools, setActiveTool]);
 
     return (
         <>

--- a/application/ui/src/features/annotator/tools/annotator-tools/use-available-tools.ts
+++ b/application/ui/src/features/annotator/tools/annotator-tools/use-available-tools.ts
@@ -96,6 +96,7 @@ export const useAvailableTools = (): ToolConfig[] => {
     const taskType = useProjectTask();
     const { mediaItem } = useSelectedMediaItem();
 
+    // Disable smart tools (SAM, magnetic lasso, SSIM) for oversized media.
     if (!canRasteriseAtFullSize(mediaItem.width, mediaItem.height)) {
         return TASK_TOOL_CONFIG[taskType].filter(
             (tool) => tool.type !== 'sam' && tool.type !== 'magnetic-lasso' && tool.type !== 'ssim'

--- a/application/ui/src/features/annotator/tools/annotator-tools/use-available-tools.ts
+++ b/application/ui/src/features/annotator/tools/annotator-tools/use-available-tools.ts
@@ -11,7 +11,9 @@ import SAMDetectionImg from '../../../../assets/tools/sam-detection.webp';
 import SAMSegmentationImg from '../../../../assets/tools/sam-segmentation.webp';
 import { useProjectTask } from '../../../../hooks/use-project-task.hook';
 import { HOTKEYS } from '../../../../shared/hotkeys-definition';
+import { useSelectedMediaItem } from '../../selected-media-item-provider.component';
 import { ToolConfig } from '../interface';
+import { canRasteriseAtFullSize } from '../utils';
 
 const SELECTION_TOOL_CONFIG: ToolConfig = {
     type: 'selection',
@@ -92,6 +94,13 @@ const TASK_TOOL_CONFIG: Record<string, ToolConfig[]> = {
 
 export const useAvailableTools = (): ToolConfig[] => {
     const taskType = useProjectTask();
+    const { mediaItem } = useSelectedMediaItem();
+
+    if (!canRasteriseAtFullSize(mediaItem.width, mediaItem.height)) {
+        return TASK_TOOL_CONFIG[taskType].filter(
+            (tool) => tool.type !== 'sam' && tool.type !== 'magnetic-lasso' && tool.type !== 'ssim'
+        );
+    }
 
     return TASK_TOOL_CONFIG[taskType];
 };

--- a/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
+++ b/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
@@ -37,12 +37,7 @@ export const usePolygonConfig = ({
     }, [worker]);
 
     useEffect(() => {
-        // For oversized media `image.data` is a placeholder whose length doesn't
-        // match width*height*4 — opencv's matFromImageData would throw a numeric
-        // Emscripten exception. Skip loading; those tools are disabled for this case.
-        if (!isMounted.current || !image) return;
-        if (isImageOversized(image)) return;
-
+        if (!isMounted.current || !image || isImageOversized(image)) return;
         worker?.loadImage(image);
     }, [image, worker]);
 

--- a/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
+++ b/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
@@ -9,7 +9,7 @@ import { differenceWith, isEmpty, isEqual, isNil } from 'lodash-es';
 import { Point, Polygon } from '../../../../shared/types';
 import { usePolygonState } from '../polygon-tool/polygon-state-provider.component';
 import { deleteSegments, ERASER_FIELD_DEFAULT_RADIUS } from '../polygon-tool/utils';
-import { convertToolShapeToGetiShape, getRelativePoint } from '../utils';
+import { convertToolShapeToGetiShape, getRelativePoint, isImageOversized } from '../utils';
 import { useIntelligentScissorsWorker } from './use-intelligent-scissors-worker.hook';
 
 export const usePolygonConfig = ({
@@ -41,7 +41,7 @@ export const usePolygonConfig = ({
         // match width*height*4 — opencv's matFromImageData would throw a numeric
         // Emscripten exception. Skip loading; those tools are disabled for this case.
         if (!isMounted.current || !image) return;
-        if (image.data.length !== image.width * image.height * 4) return;
+        if (isImageOversized(image)) return;
 
         worker?.loadImage(image);
     }, [image, worker]);

--- a/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
+++ b/application/ui/src/features/annotator/tools/hooks/use-polygon-config.hook.tsx
@@ -37,9 +37,13 @@ export const usePolygonConfig = ({
     }, [worker]);
 
     useEffect(() => {
-        if (isMounted.current && image) {
-            worker?.loadImage(image);
-        }
+        // For oversized media `image.data` is a placeholder whose length doesn't
+        // match width*height*4 — opencv's matFromImageData would throw a numeric
+        // Emscripten exception. Skip loading; those tools are disabled for this case.
+        if (!isMounted.current || !image) return;
+        if (image.data.length !== image.width * image.height * 4) return;
+
+        worker?.loadImage(image);
     }, [image, worker]);
 
     const polygon = useMemo<Polygon | null>(() => {
@@ -66,8 +70,14 @@ export const usePolygonConfig = ({
         return clampPoint(getRelativePoint(canvasRef.current, { x: event.clientX, y: event.clientY }, zoom));
     };
 
-    const setPointFromEvent = (callback: (point: Point) => void) => (event: PointerEvent<SVGElement>) =>
+    const setPointFromEvent = (callback: (point: Point) => void) => (event: PointerEvent<SVGElement>) => {
+        // A debounced/trailing pointer handler can fire after the canvas element
+        // has unmounted (e.g. switching tools or media), leaving `canvasRef.current`
+        // null. `getRelativePoint` would then throw on `getBoundingClientRect`.
+        if (canvasRef.current === null) return;
+
         callback(getPointerRelativePosition(event));
+    };
 
     const onPointerMoveRemove = setPointFromEvent((newPoint: Point) => {
         const intersectionPoint = getIntersectionPoint(

--- a/application/ui/src/features/annotator/tools/utils.test.ts
+++ b/application/ui/src/features/annotator/tools/utils.test.ts
@@ -61,32 +61,29 @@ describe('getImageData', () => {
         expect(imageData.height).toBe(1);
     });
 
-    it('downscales oversized images to max side 4096', () => {
+    it('returns a 1x1 placeholder for oversized images', () => {
+        const imageData = getImageData(createImage(19156, 15010));
+
+        expect(imageData.width).toBe(1);
+        expect(imageData.height).toBe(1);
+    });
+
+    it('rasterises images within the canvas limit at full size', () => {
         const context = createCanvasContext();
         mockCanvasCreation([context]);
 
-        const imageData = getImageData(createImage(19156, 15010));
-        const drawImageArgs = vi.mocked(context.drawImage).mock.calls[0];
+        const imageData = getImageData(createImage(4000, 3000));
 
-        const decodedWidth = drawImageArgs[3] as number;
-        const decodedHeight = drawImageArgs[4] as number;
-
-        expect(Math.max(decodedWidth, decodedHeight)).toBe(4096);
-        expect([imageData.width, imageData.height].sort((a, b) => a - b)).toEqual([3209, 4096]);
+        expect(imageData.width).toBe(4000);
+        expect(imageData.height).toBe(3000);
     });
 
-    it('falls back to downscaled decode when full-size canvas context is unavailable', () => {
-        const fallbackContext = createCanvasContext();
-        const createElementSpy = mockCanvasCreation([null, fallbackContext]);
+    it('returns a 1x1 placeholder when the canvas context is unavailable', () => {
+        mockCanvasCreation([null]);
 
         const imageData = getImageData(createImage(4000, 3000));
-        const fallbackArgs = vi.mocked(fallbackContext.drawImage).mock.calls[0];
 
-        const decodedWidth = fallbackArgs[3] as number;
-        const decodedHeight = fallbackArgs[4] as number;
-
-        expect(createElementSpy).toHaveBeenCalledTimes(2);
-        expect([decodedWidth, decodedHeight].sort((a, b) => a - b)).toEqual([3000, 4000]);
-        expect([imageData.width, imageData.height].sort((a, b) => a - b)).toEqual([3000, 4000]);
+        expect(imageData.width).toBe(1);
+        expect(imageData.height).toBe(1);
     });
 });

--- a/application/ui/src/features/annotator/tools/utils.test.ts
+++ b/application/ui/src/features/annotator/tools/utils.test.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { canRasteriseAtFullSize, getImageData } from './utils';
+
+const createImage = (width: number, height: number, naturalWidth = width, naturalHeight = height): HTMLImageElement =>
+    ({ width, height, naturalWidth, naturalHeight }) as HTMLImageElement;
+
+const createCanvasContext = () => {
+    return {
+        filter: '',
+        drawImage: vi.fn(),
+        getImageData: vi.fn((_x: number, _y: number, width: number, height: number) => {
+            return {
+                width,
+                height,
+                data: new Uint8ClampedArray(width * height * 4),
+                colorSpace: 'srgb',
+            } as ImageData;
+        }),
+    } as unknown as CanvasRenderingContext2D;
+};
+
+const mockCanvasCreation = (contexts: Array<CanvasRenderingContext2D | null>) => {
+    const originalCreateElement = document.createElement.bind(document);
+
+    return vi.spyOn(document, 'createElement').mockImplementation(((tagName: string) => {
+        if (tagName !== 'canvas') {
+            return originalCreateElement(tagName as keyof HTMLElementTagNameMap);
+        }
+
+        const context = contexts.shift() ?? null;
+        return {
+            width: 0,
+            height: 0,
+            getContext: vi.fn(() => context),
+        } as unknown as HTMLCanvasElement;
+    }) as typeof document.createElement);
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('canRasteriseAtFullSize', () => {
+    it('accepts the exact boundary size 16384x16384', () => {
+        expect(canRasteriseAtFullSize(16384, 16384)).toBe(true);
+    });
+
+    it('rejects dimensions one pixel over the boundary', () => {
+        expect(canRasteriseAtFullSize(16385, 16384)).toBe(false);
+        expect(canRasteriseAtFullSize(16384, 16385)).toBe(false);
+    });
+});
+
+describe('getImageData', () => {
+    it('returns 1x1 placeholder for empty images', () => {
+        const imageData = getImageData(createImage(0, 0));
+
+        expect(imageData.width).toBe(1);
+        expect(imageData.height).toBe(1);
+    });
+
+    it('downscales oversized images to max side 4096', () => {
+        const context = createCanvasContext();
+        mockCanvasCreation([context]);
+
+        const imageData = getImageData(createImage(19156, 15010));
+        const drawImageArgs = vi.mocked(context.drawImage).mock.calls[0];
+
+        const decodedWidth = drawImageArgs[3] as number;
+        const decodedHeight = drawImageArgs[4] as number;
+
+        expect(Math.max(decodedWidth, decodedHeight)).toBe(4096);
+        expect([imageData.width, imageData.height].sort((a, b) => a - b)).toEqual([3209, 4096]);
+    });
+
+    it('falls back to downscaled decode when full-size canvas context is unavailable', () => {
+        const fallbackContext = createCanvasContext();
+        const createElementSpy = mockCanvasCreation([null, fallbackContext]);
+
+        const imageData = getImageData(createImage(4000, 3000));
+        const fallbackArgs = vi.mocked(fallbackContext.drawImage).mock.calls[0];
+
+        const decodedWidth = fallbackArgs[3] as number;
+        const decodedHeight = fallbackArgs[4] as number;
+
+        expect(createElementSpy).toHaveBeenCalledTimes(2);
+        expect([decodedWidth, decodedHeight].sort((a, b) => a - b)).toEqual([3000, 4000]);
+        expect([imageData.width, imageData.height].sort((a, b) => a - b)).toEqual([3000, 4000]);
+    });
+});

--- a/application/ui/src/features/annotator/tools/utils.ts
+++ b/application/ui/src/features/annotator/tools/utils.ts
@@ -30,7 +30,7 @@ const ClipperJS = Clipper.default || Clipper;
  *  3b. NO   → Downscale to 4096px (max) via destination canvas:
  *             • Draw source HTMLImageElement into smaller canvas
  *             • Extract downscaled ImageData
- *             • Return smaller buffer (data.length ≠ width*height*4)
+ *             • Return smaller buffer (data.length ≠ width*height*4, where 4 = RGBA bytes per pixel)
  *  4. Provider wraps downscaled data in original dimensions:
  *     • image.width/height = mediaItem dimensions (media-space)
  *     • image.data = downscaled buffer
@@ -509,13 +509,12 @@ export const getImageData = (img: HTMLImageElement): ImageData => {
 
     // Oversized media: downscale to fit canvas limits instead of relying on
     // getContext('2d') returning null (some browsers fail later at getImageData).
-    if (!canRasteriseAtFullSize(sourceWidth, sourceHeight)) {
-        return getDownscaledImageData(img) ?? new ImageData(1, 1);
-    }
+    if (canRasteriseAtFullSize(sourceWidth, sourceHeight)) {
+        const canvas = drawImageOnCanvas(img);
+        const ctx = canvas.getContext('2d');
 
-    const canvas = drawImageOnCanvas(img);
-    const ctx = canvas.getContext('2d');
-    if (ctx !== null) return ctx.getImageData(0, 0, canvas.width, canvas.height);
+        if (ctx !== null) return ctx.getImageData(0, 0, canvas.width, canvas.height);
+    }
 
     // Fallback: context creation failed despite size check → downscale.
     return getDownscaledImageData(img) ?? new ImageData(1, 1);
@@ -555,7 +554,8 @@ export const projectPointOnLine = ([startPoint, endPoint]: ProjectLine, point: P
 
 /**
  * Checks if an ImageData is a placeholder (oversized media decoded at smaller size).
- * Oversized images have downscaled data, so data.length ≠ width*height*4.
+ * Full-size ImageData satisfies width * height * 4 entries in `data`
+ * (RGBA: 4 channels, 1 byte each). Downscaled/placeholder buffers can break that.
  * @returns true if data doesn't match full size (i.e., is placeholder/downscaled)
  */
 export const isImageOversized = (image: ImageData): boolean => {

--- a/application/ui/src/features/annotator/tools/utils.ts
+++ b/application/ui/src/features/annotator/tools/utils.ts
@@ -12,14 +12,6 @@ import type { ClipperPoint, Point, Polygon, Rect, RegionOfInterest, Shape } from
 // @ts-expect-error `default` actually exists in the module
 const ClipperJS = Clipper.default || Clipper;
 
-/**
- * Oversized image handling (Chrome canvas limit ~268 Mpx):
- * - `getImageData` returns a 1×1 placeholder for media too large to rasterise.
- * - Such media is displayed via an <img> tag (see annotator-canvas.tsx).
- * - Smart tools (SAM, magnetic lasso, SSIM) are disabled for it, because they
- *   rely on a full-resolution canvas/OpenCV buffer that cannot be produced.
- */
-
 export enum PointerType {
     Mouse = 'mouse',
     Pen = 'pen',
@@ -500,6 +492,14 @@ export const projectPointOnLine = ([startPoint, endPoint]: ProjectLine, point: P
         y: b.y * scale + startPoint.y,
     };
 };
+
+/**
+ * Oversized image handling (Chrome canvas limit ~268 Mpx):
+ * - `getImageData` returns a 1×1 placeholder for media too large to rasterise.
+ * - Such media is displayed via an <img> tag (see annotator-canvas.tsx).
+ * - Smart tools (SAM, magnetic lasso, SSIM) are disabled for it, because they
+ *   rely on a full-resolution canvas/OpenCV buffer that cannot be produced.
+ */
 
 /**
  * Checks if an ImageData is a placeholder for oversized media.

--- a/application/ui/src/features/annotator/tools/utils.ts
+++ b/application/ui/src/features/annotator/tools/utils.ts
@@ -12,6 +12,41 @@ import type { ClipperPoint, Point, Polygon, Rect, RegionOfInterest, Shape } from
 // @ts-expect-error `default` actually exists in the module
 const ClipperJS = Clipper.default || Clipper;
 
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * OVERSIZED IMAGE HANDLING FLOW
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Problem: Browser canvas rasterization limit (~268 Mpx in Chrome) causes
+ *          "white square" rendering for very large images (e.g., 19156×15010).
+ *
+ * Solution: Transparently downscale oversized images for display while keeping
+ *           all annotations in original (media-space) coordinates.
+ *
+ * FLOW:
+ *  1. User loads image (getImageData in utils.ts)
+ *  2. Check dimensions: canRasteriseAtFullSize(width, height)?
+ *  3a. YES  → Return full-resolution ImageData directly.
+ *  3b. NO   → Downscale to 4096px (max) via destination canvas:
+ *             • Draw source HTMLImageElement into smaller canvas
+ *             • Extract downscaled ImageData
+ *             • Return smaller buffer (data.length ≠ width*height*4)
+ *  4. Provider wraps downscaled data in original dimensions:
+ *     • image.width/height = mediaItem dimensions (media-space)
+ *     • image.data = downscaled buffer
+ *     • isImageReady = true only if decoded at full size
+ *  5. Display decision:
+ *     • Full-resolution → Canvas rendering
+ *     • Downscaled     → Fallback to <img> tag (bypasses canvas limit)
+ *  6. Smart tools (SAM, scissors):
+ *     • Disabled for oversized (canRasteriseAtFullSize = false)
+ *     • Or coordinate-transform at boundaries when enabled
+ *
+ * Key invariant: All React state stays in media-space; convert ONLY at
+ * boundaries (coordinate clamping, smart tool calls).
+ * ═══════════════════════════════════════════════════════════════════════════
+ */
+
 export enum PointerType {
     Mouse = 'mouse',
     Pen = 'pen',
@@ -434,27 +469,18 @@ const drawImageOnCanvas = (img: HTMLImageElement, filter = ''): HTMLCanvasElemen
     return canvas;
 };
 
-// Conservative upper bounds for a single 2D canvas that hold across the
-// browsers we support (Chrome caps total area at 16384^2 ≈ 268 Mpx; per-side
-// limits are higher but we stay well under). Anything above this can't be
-// rasterised at full resolution.
+// Canvas rasterization limits (Chrome: 16384² ≈ 268 Mpx total area).
+// Check dimensions upfront: some browsers return a valid 2D context for
+// oversized canvases but then fail/throw at getImageData time (returning
+// blank buffers or OOM), which caused the original "white square" issue.
 const MAX_CANVAS_SIDE = 16384;
 const MAX_CANVAS_AREA = MAX_CANVAS_SIDE * MAX_CANVAS_SIDE;
 
-// Whether an image of the given size can be drawn into a full-resolution 2D
-// canvas. We must decide from the dimensions up front: some browsers return a
-// valid 2D context for an oversized canvas but then throw (or hand back a blank
-// ~1 GB buffer) from getImageData, which manifested as the original "white
-// square" + smart-tool crash.
 export const canRasteriseAtFullSize = (width: number, height: number): boolean =>
     width <= MAX_CANVAS_SIDE && height <= MAX_CANVAS_SIDE && width * height <= MAX_CANVAS_AREA;
 
-// Decode an image that is too large for a full-resolution 2D canvas into a
-// downscaled ImageData that fits MAX_LARGE_IMAGE_DECODE_SIDE on its longest
-// edge. The browser's canvas pixel limit only applies to the destination
-// canvas, so drawing the source HTMLImageElement into a smaller canvas works
-// where a full-size canvas would fail. Returns null only if even the small
-// canvas can't get a 2D context (should never happen in practice).
+// For oversized media, decode to this smaller size by drawing the source
+// image into a destination canvas (only destination size is capped).
 const MAX_LARGE_IMAGE_DECODE_SIDE = 4096;
 
 const getDownscaledImageData = (img: HTMLImageElement): ImageData | null => {
@@ -469,42 +495,29 @@ const getDownscaledImageData = (img: HTMLImageElement): ImageData | null => {
     canvas.height = height;
 
     const ctx = canvas.getContext('2d');
-    if (ctx === null) {
-        return null;
-    }
+    if (ctx === null) return null;
 
     ctx.drawImage(img, 0, 0, width, height);
     return ctx.getImageData(0, 0, width, height);
 };
 
 export const getImageData = (img: HTMLImageElement): ImageData => {
-    // Always return valid imageData, even if the image isn't loaded yet.
-    if (img.width === 0 && img.height === 0) {
-        return new ImageData(1, 1);
-    }
+    if (img.width === 0 && img.height === 0) return new ImageData(1, 1);
 
     const sourceWidth = img.naturalWidth || img.width;
     const sourceHeight = img.naturalHeight || img.height;
 
-    // Decide from the source dimensions whether a full-resolution canvas is
-    // viable. Relying on getContext('2d') returning null is not enough: some
-    // browsers return a valid context for an oversized canvas and only fail
-    // later in getImageData (throwing OOM or returning a blank buffer), which
-    // surfaced as an immediate smart-tool error on huge images.
+    // Oversized media: downscale to fit canvas limits instead of relying on
+    // getContext('2d') returning null (some browsers fail later at getImageData).
     if (!canRasteriseAtFullSize(sourceWidth, sourceHeight)) {
         return getDownscaledImageData(img) ?? new ImageData(1, 1);
     }
 
     const canvas = drawImageOnCanvas(img);
     const ctx = canvas.getContext('2d');
+    if (ctx !== null) return ctx.getImageData(0, 0, canvas.width, canvas.height);
 
-    if (ctx !== null) {
-        return ctx.getImageData(0, 0, canvas.width, canvas.height);
-    }
-
-    // Defensive fallback: the canvas was within our limits but the context
-    // still couldn't be created (e.g. too many live contexts). Downscale so we
-    // still return a usable buffer rather than a 1x1 placeholder.
+    // Fallback: context creation failed despite size check → downscale.
     return getDownscaledImageData(img) ?? new ImageData(1, 1);
 };
 
@@ -541,15 +554,9 @@ export const projectPointOnLine = ([startPoint, endPoint]: ProjectLine, point: P
 };
 
 /**
- * Checks if an image is oversized (has placeholder data).
- *
- * For oversized media (> ~268 Mpx), the ImageData.data buffer is a placeholder
- * whose length doesn't match width * height * 4. This indicates that tools like
- * the intelligent scissors worker should not be used, as they would fail when
- * calling cv.matFromImageData.
- *
- * @param image - The ImageData to check
- * @returns true if the image is oversized, false otherwise
+ * Checks if an ImageData is a placeholder (oversized media decoded at smaller size).
+ * Oversized images have downscaled data, so data.length ≠ width*height*4.
+ * @returns true if data doesn't match full size (i.e., is placeholder/downscaled)
  */
 export const isImageOversized = (image: ImageData): boolean => {
     return image.data.length !== image.width * image.height * 4;

--- a/application/ui/src/features/annotator/tools/utils.ts
+++ b/application/ui/src/features/annotator/tools/utils.ts
@@ -13,38 +13,11 @@ import type { ClipperPoint, Point, Polygon, Rect, RegionOfInterest, Shape } from
 const ClipperJS = Clipper.default || Clipper;
 
 /**
- * ═══════════════════════════════════════════════════════════════════════════
- * OVERSIZED IMAGE HANDLING FLOW
- * ═══════════════════════════════════════════════════════════════════════════
- *
- * Problem: Browser canvas rasterization limit (~268 Mpx in Chrome) causes
- *          "white square" rendering for very large images (e.g., 19156×15010).
- *
- * Solution: Transparently downscale oversized images for display while keeping
- *           all annotations in original (media-space) coordinates.
- *
- * FLOW:
- *  1. User loads image (getImageData in utils.ts)
- *  2. Check dimensions: canRasteriseAtFullSize(width, height)?
- *  3a. YES  → Return full-resolution ImageData directly.
- *  3b. NO   → Downscale to 4096px (max) via destination canvas:
- *             • Draw source HTMLImageElement into smaller canvas
- *             • Extract downscaled ImageData
- *             • Return smaller buffer (data.length ≠ width*height*4, where 4 = RGBA bytes per pixel)
- *  4. Provider wraps downscaled data in original dimensions:
- *     • image.width/height = mediaItem dimensions (media-space)
- *     • image.data = downscaled buffer
- *     • isImageReady = true only if decoded at full size
- *  5. Display decision:
- *     • Full-resolution → Canvas rendering
- *     • Downscaled     → Fallback to <img> tag (bypasses canvas limit)
- *  6. Smart tools (SAM, scissors):
- *     • Disabled for oversized (canRasteriseAtFullSize = false)
- *     • Or coordinate-transform at boundaries when enabled
- *
- * Key invariant: All React state stays in media-space; convert ONLY at
- * boundaries (coordinate clamping, smart tool calls).
- * ═══════════════════════════════════════════════════════════════════════════
+ * Oversized image handling (Chrome canvas limit ~268 Mpx):
+ * - `getImageData` returns a 1×1 placeholder for media too large to rasterise.
+ * - Such media is displayed via an <img> tag (see annotator-canvas.tsx).
+ * - Smart tools (SAM, magnetic lasso, SSIM) are disabled for it, because they
+ *   rely on a full-resolution canvas/OpenCV buffer that cannot be produced.
  */
 
 export enum PointerType {
@@ -474,32 +447,9 @@ const drawImageOnCanvas = (img: HTMLImageElement, filter = ''): HTMLCanvasElemen
 // oversized canvases but then fail/throw at getImageData time (returning
 // blank buffers or OOM), which caused the original "white square" issue.
 const MAX_CANVAS_SIDE = 16384;
-const MAX_CANVAS_AREA = MAX_CANVAS_SIDE * MAX_CANVAS_SIDE;
 
 export const canRasteriseAtFullSize = (width: number, height: number): boolean =>
-    width <= MAX_CANVAS_SIDE && height <= MAX_CANVAS_SIDE && width * height <= MAX_CANVAS_AREA;
-
-// For oversized media, decode to this smaller size by drawing the source
-// image into a destination canvas (only destination size is capped).
-const MAX_LARGE_IMAGE_DECODE_SIDE = 4096;
-
-const getDownscaledImageData = (img: HTMLImageElement): ImageData | null => {
-    const sourceWidth = img.naturalWidth || img.width;
-    const sourceHeight = img.naturalHeight || img.height;
-    const scale = Math.min(1, MAX_LARGE_IMAGE_DECODE_SIDE / Math.max(sourceWidth, sourceHeight));
-    const width = Math.max(1, Math.round(sourceWidth * scale));
-    const height = Math.max(1, Math.round(sourceHeight * scale));
-
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-
-    const ctx = canvas.getContext('2d');
-    if (ctx === null) return null;
-
-    ctx.drawImage(img, 0, 0, width, height);
-    return ctx.getImageData(0, 0, width, height);
-};
+    width <= MAX_CANVAS_SIDE && height <= MAX_CANVAS_SIDE;
 
 export const getImageData = (img: HTMLImageElement): ImageData => {
     if (img.width === 0 && img.height === 0) return new ImageData(1, 1);
@@ -507,17 +457,16 @@ export const getImageData = (img: HTMLImageElement): ImageData => {
     const sourceWidth = img.naturalWidth || img.width;
     const sourceHeight = img.naturalHeight || img.height;
 
-    // Oversized media: downscale to fit canvas limits instead of relying on
-    // getContext('2d') returning null (some browsers fail later at getImageData).
-    if (canRasteriseAtFullSize(sourceWidth, sourceHeight)) {
-        const canvas = drawImageOnCanvas(img);
-        const ctx = canvas.getContext('2d');
-
-        if (ctx !== null) return ctx.getImageData(0, 0, canvas.width, canvas.height);
+    // Oversized media cannot be rasterised to a canvas (and smart tools can't
+    // run on it either), so return a placeholder; it is displayed via <img>.
+    if (!canRasteriseAtFullSize(sourceWidth, sourceHeight)) {
+        return new ImageData(1, 1);
     }
 
-    // Fallback: context creation failed despite size check → downscale.
-    return getDownscaledImageData(img) ?? new ImageData(1, 1);
+    const canvas = drawImageOnCanvas(img);
+    const ctx = canvas.getContext('2d');
+
+    return ctx !== null ? ctx.getImageData(0, 0, canvas.width, canvas.height) : new ImageData(1, 1);
 };
 
 export const isKeyboardDelete = (event: KeyboardEvent): boolean =>
@@ -553,10 +502,10 @@ export const projectPointOnLine = ([startPoint, endPoint]: ProjectLine, point: P
 };
 
 /**
- * Checks if an ImageData is a placeholder (oversized media decoded at smaller size).
+ * Checks if an ImageData is a placeholder for oversized media.
  * Full-size ImageData satisfies width * height * 4 entries in `data`
- * (RGBA: 4 channels, 1 byte each). Downscaled/placeholder buffers can break that.
- * @returns true if data doesn't match full size (i.e., is placeholder/downscaled)
+ * (RGBA: 4 channels, 1 byte each). A 1×1 placeholder breaks that.
+ * @returns true if data doesn't match full size (i.e., is a placeholder)
  */
 export const isImageOversized = (image: ImageData): boolean => {
     return image.data.length !== image.width * image.height * 4;

--- a/application/ui/src/features/annotator/tools/utils.ts
+++ b/application/ui/src/features/annotator/tools/utils.ts
@@ -427,14 +427,54 @@ const drawImageOnCanvas = (img: HTMLImageElement, filter = ''): HTMLCanvasElemen
     const ctx = canvas.getContext('2d');
 
     if (ctx) {
-        const width = img.naturalWidth ? img.naturalWidth : img.width;
-        const height = img.naturalHeight ? img.naturalHeight : img.height;
-
         ctx.filter = filter;
-        ctx.drawImage(img, 0, 0, width, height);
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
     }
 
     return canvas;
+};
+
+// Conservative upper bounds for a single 2D canvas that hold across the
+// browsers we support (Chrome caps total area at 16384^2 ≈ 268 Mpx; per-side
+// limits are higher but we stay well under). Anything above this can't be
+// rasterised at full resolution.
+const MAX_CANVAS_SIDE = 16384;
+const MAX_CANVAS_AREA = MAX_CANVAS_SIDE * MAX_CANVAS_SIDE;
+
+// Whether an image of the given size can be drawn into a full-resolution 2D
+// canvas. We must decide from the dimensions up front: some browsers return a
+// valid 2D context for an oversized canvas but then throw (or hand back a blank
+// ~1 GB buffer) from getImageData, which manifested as the original "white
+// square" + smart-tool crash.
+export const canRasteriseAtFullSize = (width: number, height: number): boolean =>
+    width <= MAX_CANVAS_SIDE && height <= MAX_CANVAS_SIDE && width * height <= MAX_CANVAS_AREA;
+
+// Decode an image that is too large for a full-resolution 2D canvas into a
+// downscaled ImageData that fits MAX_LARGE_IMAGE_DECODE_SIDE on its longest
+// edge. The browser's canvas pixel limit only applies to the destination
+// canvas, so drawing the source HTMLImageElement into a smaller canvas works
+// where a full-size canvas would fail. Returns null only if even the small
+// canvas can't get a 2D context (should never happen in practice).
+const MAX_LARGE_IMAGE_DECODE_SIDE = 4096;
+
+const getDownscaledImageData = (img: HTMLImageElement): ImageData | null => {
+    const sourceWidth = img.naturalWidth || img.width;
+    const sourceHeight = img.naturalHeight || img.height;
+    const scale = Math.min(1, MAX_LARGE_IMAGE_DECODE_SIDE / Math.max(sourceWidth, sourceHeight));
+    const width = Math.max(1, Math.round(sourceWidth * scale));
+    const height = Math.max(1, Math.round(sourceHeight * scale));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+
+    const ctx = canvas.getContext('2d');
+    if (ctx === null) {
+        return null;
+    }
+
+    ctx.drawImage(img, 0, 0, width, height);
+    return ctx.getImageData(0, 0, width, height);
 };
 
 export const getImageData = (img: HTMLImageElement): ImageData => {
@@ -443,13 +483,29 @@ export const getImageData = (img: HTMLImageElement): ImageData => {
         return new ImageData(1, 1);
     }
 
+    const sourceWidth = img.naturalWidth || img.width;
+    const sourceHeight = img.naturalHeight || img.height;
+
+    // Decide from the source dimensions whether a full-resolution canvas is
+    // viable. Relying on getContext('2d') returning null is not enough: some
+    // browsers return a valid context for an oversized canvas and only fail
+    // later in getImageData (throwing OOM or returning a blank buffer), which
+    // surfaced as an immediate smart-tool error on huge images.
+    if (!canRasteriseAtFullSize(sourceWidth, sourceHeight)) {
+        return getDownscaledImageData(img) ?? new ImageData(1, 1);
+    }
+
     const canvas = drawImageOnCanvas(img);
-    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+    const ctx = canvas.getContext('2d');
 
-    const width = img.naturalWidth ? img.naturalWidth : img.width;
-    const height = img.naturalHeight ? img.naturalHeight : img.height;
+    if (ctx !== null) {
+        return ctx.getImageData(0, 0, canvas.width, canvas.height);
+    }
 
-    return ctx.getImageData(0, 0, width, height);
+    // Defensive fallback: the canvas was within our limits but the context
+    // still couldn't be created (e.g. too many live contexts). Downscale so we
+    // still return a usable buffer rather than a 1x1 placeholder.
+    return getDownscaledImageData(img) ?? new ImageData(1, 1);
 };
 
 export const isKeyboardDelete = (event: KeyboardEvent): boolean =>

--- a/application/ui/src/features/annotator/tools/utils.ts
+++ b/application/ui/src/features/annotator/tools/utils.ts
@@ -539,3 +539,18 @@ export const projectPointOnLine = ([startPoint, endPoint]: ProjectLine, point: P
         y: b.y * scale + startPoint.y,
     };
 };
+
+/**
+ * Checks if an image is oversized (has placeholder data).
+ *
+ * For oversized media (> ~268 Mpx), the ImageData.data buffer is a placeholder
+ * whose length doesn't match width * height * 4. This indicates that tools like
+ * the intelligent scissors worker should not be used, as they would fail when
+ * calling cv.matFromImageData.
+ *
+ * @param image - The ImageData to check
+ * @returns true if the image is oversized, false otherwise
+ */
+export const isImageOversized = (image: ImageData): boolean => {
+    return image.data.length !== image.width * image.height * 4;
+};


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Larger images cannot be rendered without being resized due to the browser's limitations. Smart-tools needs to be disabled due to opencv/worker/encoding limitations — the full-resolution canvas/OpenCV buffer they need can't be produced (canvas ~268 Mpx cap, OpenCV WASM heap ~256 MB.
* Closes https://github.com/open-edge-platform/training_extensions/issues/6659

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
