### PR TITLE
Simplify predicted polygon points using cv2.approxPolyDP

### DIFF
--- a/application/backend/app/services/data_collect/prediction_converter.py
+++ b/application/backend/app/services/data_collect/prediction_converter.py
@@ -11,6 +11,32 @@ from model_api.models.result import Result
 
 from app.models import DatasetItemAnnotation, FullImage, Label, LabelReference, Point, Polygon, Rectangle
 
+# Fraction of a contour's perimeter used as the Douglas-Peucker approximation
+# tolerance (epsilon) when simplifying instance-segmentation masks into polygons.
+# Larger values yield fewer points (more aggressive simplification).
+_POLYGON_APPROX_EPSILON_RATIO = 0.0025
+
+
+def _simplify_contour(contour: np.ndarray) -> np.ndarray:
+    """Reduce the number of points in a contour using the Douglas-Peucker algorithm.
+
+    The approximation tolerance is scaled by the contour's perimeter so that
+    large and small shapes are simplified proportionally. A closed approximation
+    that collapses to fewer than 3 points falls back to the original contour to
+    avoid producing a degenerate polygon.
+
+    Args:
+        contour: Contour as returned by ``cv2.findContours``, shaped ``(N, 1, 2)``.
+
+    Returns:
+        The simplified contour, shaped ``(M, 1, 2)`` with ``M <= N``.
+    """
+    epsilon = _POLYGON_APPROX_EPSILON_RATIO * cv2.arcLength(contour, True)
+    approx = cv2.approxPolyDP(contour, epsilon, True)
+    if len(approx) < 3:
+        return contour
+    return approx
+
 
 def _build_label_maps(labels: Sequence[Label]) -> tuple[dict[str, Label], dict[str, Label]]:
     """Precompute name→label and unmangled-name→label dicts for O(1) lookup."""
@@ -154,7 +180,8 @@ def _convert_segmentation_prediction(
                 continue
             if len(contour) <= 2 or cv2.contourArea(contour) < 1.0:
                 continue
-            polygon = Polygon(points=[Point(x=point[0][0], y=point[0][1]) for point in list(contour)])
+            simplified_contour = _simplify_contour(contour)
+            polygon = Polygon(points=[Point(x=point[0][0], y=point[0][1]) for point in list(simplified_contour)])
             annotation = DatasetItemAnnotation(
                 labels=[LabelReference(id=label.id)], shape=polygon, confidences=[polygon_confidence]
             )

--- a/application/backend/app/services/data_collect/prediction_converter.py
+++ b/application/backend/app/services/data_collect/prediction_converter.py
@@ -181,7 +181,7 @@ def _convert_segmentation_prediction(
             if len(contour) <= 2 or cv2.contourArea(contour) < 1.0:
                 continue
             simplified_contour = _simplify_contour(contour)
-            polygon = Polygon(points=[Point(x=point[0][0], y=point[0][1]) for point in list(simplified_contour)])
+            polygon = Polygon(points=[Point(x=point[0][0], y=point[0][1]) for point in simplified_contour])
             annotation = DatasetItemAnnotation(
                 labels=[LabelReference(id=label.id)], shape=polygon, confidences=[polygon_confidence]
             )

--- a/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
+++ b/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
@@ -204,8 +204,13 @@ def test_convert_prediction_segmentation_reduces_polygon_points() -> None:
     mask = np.zeros((400, 400), dtype=np.uint8)
     cv2.circle(mask, (200, 200), 150, 255, -1)
 
-    raw_contours, _ = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
-    raw_point_count = len(raw_contours[0])
+    raw_contours, hierarchies = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
+    assert hierarchies is not None
+    # Mirror the converter's filtering: only external contours (parent index == -1) are used.
+    external_point_counts = [
+        len(contour) for contour, hierarchy in zip(raw_contours, hierarchies[0], strict=True) if hierarchy[3] == -1
+    ]
+    raw_point_count = max(external_point_counts)
 
     label = Label(id=uuid4(), project_id=uuid4(), name="cat", color="#ff0000", hotkey="c")
     raw_prediction = InstanceSegmentationResult(

--- a/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
+++ b/application/backend/tests/unit/services/data_collect/test_prediction_converter.py
@@ -196,3 +196,31 @@ def test_convert_prediction_segmentation(label_names: list[str], predicted_label
             confidences=[0.92],
         ),
     ]
+
+
+def test_convert_prediction_segmentation_reduces_polygon_points() -> None:
+    # Arrange: a large filled circle produces a contour with many points before simplification.
+    frame_data = np.zeros((400, 400, 3), dtype=np.uint8)
+    mask = np.zeros((400, 400), dtype=np.uint8)
+    cv2.circle(mask, (200, 200), 150, 255, -1)
+
+    raw_contours, _ = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
+    raw_point_count = len(raw_contours[0])
+
+    label = Label(id=uuid4(), project_id=uuid4(), name="cat", color="#ff0000", hotkey="c")
+    raw_prediction = InstanceSegmentationResult(
+        bboxes=np.array([[50, 50, 350, 350]]),
+        labels=np.array([0]),
+        masks=np.array([mask]),
+        scores=np.array([0.9]),
+        label_names=["cat"],
+    )
+
+    # Act
+    annotations = convert_prediction(labels=[label], frame_data=frame_data, prediction=raw_prediction)
+
+    # Assert
+    assert len(annotations) == 1
+    polygon = annotations[0].shape
+    assert isinstance(polygon, Polygon)
+    assert 3 <= len(polygon.points) < raw_point_count


### PR DESCRIPTION

### Summary
This pull request introduces a new contour simplification step to the instance segmentation prediction conversion process. By applying the Douglas-Peucker algorithm, it reduces the number of points in polygons generated from segmentation masks, resulting in simpler and more efficient polygon representations. Additionally, a unit test is added to verify that the number of points is indeed reduced.


Before: 
<img width="173" height="180" alt="image" src="https://github.com/user-attachments/assets/3eede232-1ff1-42f8-8387-d4bab0d67d9f" />


After: 
<img width="173" height="180" alt="image" src="https://github.com/user-attachments/assets/9e112c44-cfaa-41f1-9387-a61d6cce0f08" />


