### PR TITLE
feat: Show warning when exporting dataset and not Geti format is selected

### DIFF
--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 import {
     Button,
@@ -11,13 +11,15 @@ import {
     Dialog,
     DialogContainer,
     Divider,
+    Flex,
     Form,
     Heading,
     Radio,
     RadioGroup,
+    Text,
     View,
 } from '@geti/ui';
-import { LinkOut } from '@geti/ui/icons';
+import { Alert, LinkOut } from '@geti/ui/icons';
 import { OverlayTriggerState } from '@react-stately/overlays';
 import { useProject } from 'hooks/api/project.hook';
 
@@ -27,6 +29,20 @@ import { MultiSelectList } from '../multi-select-list/multi-select-list.componen
 import { getFormatOptions } from '../util';
 
 import classes from './export-dataset-config.module.scss';
+
+const WarningMessage = () => {
+    return (
+        <Flex alignItems={'start'} marginTop={'size-100'} gap={'size-100'}>
+            <Flex>
+                <Alert className={classes.warningMessageIcon} />
+            </Flex>
+            <Text>
+                Exporting videos is not supported by this dataset format. All annotated frames from videos will be
+                exported as images.
+            </Text>
+        </Flex>
+    );
+};
 
 type ExportDatasetConfigProps = {
     name?: string;
@@ -51,7 +67,11 @@ export const ExportDatasetConfig = ({
     });
 
     const formatOptions = getFormatOptions(selectedProject.task.task_type);
+    const [selectedExportFormat, setSelectedExportFormat] = useState<string | null>(formatOptions.at(0)?.value ?? null);
+
     const labels = selectedProject.task?.labels?.map((label) => ({ id: label.name, name: label.name })) ?? [];
+
+    const isNonGetiFormatSelected = selectedExportFormat !== 'geti';
 
     return (
         <DialogContainer onDismiss={dialogState.close}>
@@ -85,6 +105,7 @@ export const ExportDatasetConfig = ({
                                     name='export_format'
                                     label='Select dataset export format'
                                     defaultValue={formState.export_format}
+                                    onChange={(value) => setSelectedExportFormat(value)}
                                 >
                                     {formatOptions.map((item) => (
                                         <Radio key={item.value} value={item.value}>
@@ -93,6 +114,8 @@ export const ExportDatasetConfig = ({
                                     ))}
                                 </RadioGroup>
                             </Form>
+
+                            {isNonGetiFormatSelected && <WarningMessage />}
 
                             {/* TODO: pending link url
                             https://github.com/open-edge-platform/training_extensions/issues/5512 */}

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.module.scss
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.module.scss
@@ -12,3 +12,8 @@
     gap: var(--spectrum-global-dimension-size-125);
     margin-top: var(--spectrum-global-dimension-size-125);
 }
+
+.warningMessageIcon {
+    fill: var(--spectrum-semantic-notice-color-icon);
+    margin-top: var(--spectrum-global-dimension-size-25);
+}

--- a/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
+++ b/application/ui/src/components/export-dataset-config-dialog/export-dataset-config.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
@@ -19,6 +19,8 @@ describe('ExportDatasetConfig', () => {
         toggle: vi.fn(),
         setOpen: vi.fn(),
     };
+
+    const VIDEO_WARNING = /Exporting videos is not supported by this dataset format/i;
 
     const renderApp = (project: SchemaProjectView) => {
         server.use(
@@ -59,5 +61,25 @@ describe('ExportDatasetConfig', () => {
         expect(await screen.findByText('Export dataset')).toBeVisible();
         expect(screen.getByRole('radio', { name: 'Geti' })).toBeVisible();
         expect(screen.queryByRole('radio', { name: 'COCO' })).toBeVisible();
+    });
+
+    it('does not show the video export warning when the default Geti format is selected', async () => {
+        renderApp(getMockedProject({ task: { exclusive_labels: true, task_type: 'instance_segmentation' } }));
+
+        expect(await screen.findByText('Export dataset')).toBeVisible();
+        expect(screen.getByRole('radio', { name: 'Geti' })).toBeChecked();
+        expect(screen.queryByText(VIDEO_WARNING)).not.toBeInTheDocument();
+    });
+
+    it('shows the video export warning when a non-Geti format is selected', async () => {
+        renderApp(getMockedProject({ task: { exclusive_labels: true, task_type: 'instance_segmentation' } }));
+
+        fireEvent.click(await screen.findByRole('radio', { name: 'COCO' }));
+        expect(screen.getByRole('radio', { name: 'COCO' })).toBeChecked();
+        expect(screen.getByText(VIDEO_WARNING)).toBeVisible();
+
+        fireEvent.click(screen.getByRole('radio', { name: 'Geti' }));
+        expect(screen.getByRole('radio', { name: 'Geti' })).toBeChecked();
+        expect(screen.queryByText(VIDEO_WARNING)).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

One note: we will show that warning not matter if the dataset contains video or no. To implement it properly we would need to have an information if the dataset includes any video. For now there is not such filter in the endpoint so do it we would need to fetch all the pages from the paginated endpoint to make sure that dataset does not include any video.
IMO it's fine to proceed with the current approach for now.

<img width="682" height="867" alt="image" src="https://github.com/user-attachments/assets/a66ce8aa-518a-46b9-9827-bc335ade19b1" />

Close #6647 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
