### PR TITLE
Changing a source never cleared the broadcaster

### DIFF
--- a/application/backend/app/workers/dispatching.py
+++ b/application/backend/app/workers/dispatching.py
@@ -51,6 +51,10 @@ class DispatchingWorker(BaseThreadWorker):
             [EventType.SINK_CHANGED, EventType.PIPELINE_STATUS_CHANGED],
             self._reload_sink,
         )
+        event_bus.subscribe(
+            [EventType.SOURCE_CHANGED],
+            self._on_source_changed,
+        )
 
     def setup(self) -> None:
         pass
@@ -67,6 +71,17 @@ class DispatchingWorker(BaseThreadWorker):
     def _reload_sink(self) -> None:
         self._sink, self._destinations = self._load_sink()
         logger.info(f"Active sink set to {self._sink}")
+
+    def _on_source_changed(self) -> None:
+        """Drop frames cached from the previous source.
+
+        The broadcaster keeps the latest frame and seeds it to newly connecting
+        WebRTC consumers. When the source changes, that cached frame belongs to the
+        old source and would otherwise be replayed (a frozen frame) until the new
+        source starts producing frames. Clearing the broadcaster prevents this.
+        """
+        self._rtc_stream_broadcaster.clear()
+        logger.info("Cleared WebRTC broadcaster after source change")
 
     def run_loop(self) -> None:
         while not self.should_stop():

--- a/application/backend/tests/unit/workers/test_dispatching.py
+++ b/application/backend/tests/unit/workers/test_dispatching.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import multiprocessing as mp
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from app.models import DisconnectedSinkConfig
+from app.services.event.event_bus import EventBus, EventType
+from app.webrtc import FrameBroadcaster
+from app.workers.dispatching import DispatchingWorker
+
+
+def _make_worker(event_bus: EventBus, broadcaster: FrameBroadcaster[np.ndarray]) -> DispatchingWorker:
+    with patch.object(DispatchingWorker, "_load_sink", return_value=(DisconnectedSinkConfig(), [])):
+        return DispatchingWorker(
+            event_bus=event_bus,
+            pred_queue=mp.Queue(),
+            rtc_stream_broadcaster=broadcaster,
+            stop_event=mp.Event(),
+            data_collector=MagicMock(),
+        )
+
+
+class TestDispatchingWorkerSourceChange:
+    def test_source_changed_clears_broadcaster(self):
+        """A SOURCE_CHANGED event drops the cached frame so new consumers don't see a stale frame."""
+        event_bus = EventBus()
+        broadcaster = FrameBroadcaster[np.ndarray]()
+        _make_worker(event_bus, broadcaster)
+
+        # A frame from the previous source is cached and would be seeded to new consumers.
+        broadcaster.broadcast(np.zeros((2, 2, 3), dtype=np.uint8))
+        assert broadcaster.latest_frame is not None
+
+        event_bus.emit_event(EventType.SOURCE_CHANGED)
+
+        # The cached frame is dropped, so a freshly connecting consumer gets nothing stale.
+        assert broadcaster.latest_frame is None
+        new_consumer_queue = broadcaster.register("new-consumer")
+        assert new_consumer_queue.empty()
+
+    def test_source_changed_drains_existing_consumer_queues(self):
+        """Already-connected consumers also have their queued stale frames drained."""
+        event_bus = EventBus()
+        broadcaster = FrameBroadcaster[np.ndarray]()
+        _make_worker(event_bus, broadcaster)
+
+        consumer_queue = broadcaster.register("consumer")
+        broadcaster.broadcast(np.zeros((2, 2, 3), dtype=np.uint8))
+        assert not consumer_queue.empty()
+
+        event_bus.emit_event(EventType.SOURCE_CHANGED)
+
+        assert consumer_queue.empty()
+
+    def test_sink_changed_does_not_clear_broadcaster(self):
+        """A SINK_CHANGED event must not drop the cached WebRTC frame."""
+        event_bus = EventBus()
+        broadcaster = FrameBroadcaster[np.ndarray]()
+        _make_worker(event_bus, broadcaster)
+
+        broadcaster.broadcast(np.zeros((2, 2, 3), dtype=np.uint8))
+
+        with patch.object(DispatchingWorker, "_load_sink", return_value=(DisconnectedSinkConfig(), [])):
+            event_bus.emit_event(EventType.SINK_CHANGED)
+
+        assert broadcaster.latest_frame is not None


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Bug: After enabling the first source, changing it never actually changed the source.

FrameBroadcaster has a "clear" method but changing the source never called it. 

Fixes case: "Switch to a different source while the pipeline is enabled."

Closes https://github.com/open-edge-platform/training_extensions/issues/6718

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
