### PR TITLE
Add tooltip to start-stream button when disabled

### DIFF
--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -42,7 +42,11 @@ export const StreamContainer = () => {
 
     return (
         <View gridArea={'canvas'} overflow={'hidden'} maxHeight={'100%'}>
-            <div className={classes.canvasContainer} onClick={handleClick}>
+            <div
+                className={classes.canvasContainer}
+                onClick={handleClick}
+                title={isPipelineRunning ? undefined : 'Enable pipeline to start stream'}
+            >
                 {isStopped && (
                     <Flex justifyContent={'center'} alignItems={'center'} UNSAFE_className={classes.backdrop}>
                         <Flex

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -42,8 +42,6 @@ export const StreamContainer = () => {
     };
 
     const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-        if (!isInteractive) return;
-
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             void handleClick();

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -42,7 +42,7 @@ export const StreamContainer = () => {
     };
 
     const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-        if (!(isConnected || canStart)) return;
+        if (!isInteractive) return;
 
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -40,12 +40,26 @@ export const StreamContainer = () => {
         }
     };
 
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (!(isConnected || canStart)) return;
+
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            void handleClick();
+        }
+    };
+
     return (
         <View gridArea={'canvas'} overflow={'hidden'} maxHeight={'100%'}>
             <div
                 className={classes.canvasContainer}
-                onClick={handleClick}
-                title={isPipelineRunning ? undefined : 'Enable pipeline to start stream'}
+                onClick={isConnected || canStart ? handleClick : undefined}
+                onKeyDown={handleKeyDown}
+                role={'button'}
+                tabIndex={isConnected || canStart ? 0 : -1}
+                aria-disabled={!(isConnected || canStart)}
+                title={isStopped && !isPipelineRunning ? 'Enable pipeline to start stream' : undefined}
+                style={{ cursor: isConnected || canStart ? 'pointer' : 'default' }}
             >
                 {isStopped && (
                     <Flex justifyContent={'center'} alignItems={'center'} UNSAFE_className={classes.backdrop}>

--- a/application/ui/src/features/inference/stream/stream-container.tsx
+++ b/application/ui/src/features/inference/stream/stream-container.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from 'react';
+import { KeyboardEvent, useState } from 'react';
 
 import { dimensionValue, Flex, Loading, Text, toast, View } from '@geti/ui';
 import { Pause, Play } from '@geti/ui/icons';
@@ -25,6 +25,7 @@ export const StreamContainer = () => {
     const [isPaused, setIsPaused] = useState(false);
 
     const canStart = isStopped && isPipelineRunning;
+    const isInteractive = isConnected || canStart;
 
     const handleClick = async () => {
         if (isConnected) {
@@ -40,7 +41,7 @@ export const StreamContainer = () => {
         }
     };
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
         if (!(isConnected || canStart)) return;
 
         if (event.key === 'Enter' || event.key === ' ') {
@@ -53,13 +54,14 @@ export const StreamContainer = () => {
         <View gridArea={'canvas'} overflow={'hidden'} maxHeight={'100%'}>
             <div
                 className={classes.canvasContainer}
-                onClick={isConnected || canStart ? handleClick : undefined}
-                onKeyDown={handleKeyDown}
-                role={'button'}
-                tabIndex={isConnected || canStart ? 0 : -1}
-                aria-disabled={!(isConnected || canStart)}
+                onClick={isInteractive ? handleClick : undefined}
+                onKeyDown={isInteractive ? handleKeyDown : undefined}
+                role={isInteractive ? 'button' : undefined}
+                tabIndex={isInteractive ? 0 : -1}
+                aria-label={isConnected ? 'Stop stream' : 'Start stream'}
+                aria-disabled={!isPipelineRunning}
                 title={isStopped && !isPipelineRunning ? 'Enable pipeline to start stream' : undefined}
-                style={{ cursor: isConnected || canStart ? 'pointer' : 'default' }}
+                style={{ cursor: isInteractive ? 'pointer' : 'default' }}
             >
                 {isStopped && (
                     <Flex justifyContent={'center'} alignItems={'center'} UNSAFE_className={classes.backdrop}>
@@ -74,7 +76,6 @@ export const StreamContainer = () => {
                                 color={'currentColor'}
                                 width={dimensionValue('size-400')}
                                 height={dimensionValue('size-400')}
-                                aria-label={isPipelineRunning ? 'Start stream' : 'Enable pipeline to start stream'}
                                 aria-disabled={!isPipelineRunning}
                             />
                             <Text UNSAFE_style={{ paddingRight: dimensionValue('size-100') }}>Start stream</Text>

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -59,6 +59,12 @@ test.describe('Inference', () => {
 
     test('Inference workflow', async ({ streamPage, page, network }) => {
         await test.step('starts stream', async () => {
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(getMockedPipeline({ status: 'running' }));
+                })
+            );
+
             await page.goto('/projects/id-1/inference');
 
             await streamPage.startStream();
@@ -67,6 +73,12 @@ test.describe('Inference', () => {
         });
 
         await test.step('toggles pipeline', async () => {
+            network.use(
+                http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                    return response(200).json(getMockedPipeline({ status: 'idle' }));
+                })
+            );
+
             await page.goto('/projects/id-1/inference');
 
             await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeEnabled();
@@ -398,7 +410,7 @@ test.describe('Inference', () => {
 
         await page.getByRole('tab', { name: 'Inference' }).click();
 
-        await expect(page.getByLabel('Enable pipeline to start stream')).toBeVisible();
+        await expect(page.getByTitle('Enable pipeline to start stream')).toBeVisible();
         await expect(page.getByRole('switch', { name: /Enable pipeline/i })).toBeVisible();
     });
 

--- a/application/ui/tests/inference/stream-page.ts
+++ b/application/ui/tests/inference/stream-page.ts
@@ -7,7 +7,7 @@ export class StreamPage {
     constructor(private page: Page) {}
 
     getStartStreamButton() {
-        return this.page.getByLabel('Start stream');
+        return this.page.getByRole('button', { name: 'Start stream' });
     }
 
     async startStream() {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Disabled "Start stream" button had no tooltip. Added for clarity. Also decided to use native one for low footprint

<img width="255" height="133" alt="Screenshot 2026-06-08 at 12 40 10" src="https://github.com/user-attachments/assets/1e733f1b-d5f5-4556-82ff-24099eea1927" />

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
