### PR TITLE
Copilot instructions: Do not add copyright header to yaml files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ The library is consumed by the backend (`getitune[cpu|xpu|cuda]` extras).
 - Code must pass pre-commit checks (see `.pre-commit-config.yaml`). Run them
   locally with `prek`.
 - Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
-- **New source files require a copyright + SPDX header** (current year, `#` for Python/YAML/shell, `//` for TS/JS/Rust):
+- **New source files require a copyright + SPDX header** (current year, `#` for Python/shell, `//` for TS/JS/Rust):
 
   ```
   # Copyright (C) 2026 Intel Corporation


### PR DESCRIPTION
### Summary
Prevent copilot from adding copyright headers to yaml files or making review comments about yaml files without the copyright header. 


Prevents comment like these: 
<img width="758" height="393" alt="image" src="https://github.com/user-attachments/assets/4acd064d-e098-4ffd-93e8-178fb27b7940" />

