### PR TITLE
fix: Display empty label in label segment

### DIFF
--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-annotator.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-annotator.component.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Grid, View } from '@geti/ui';
-import { useProjectLabels } from 'hooks/use-project-labels.hook';
 
 import type { AnnotatorMode } from '../../../../../shared/annotator/annotator-mode';
+import { useProjectLabelsWithEmptyLabel } from '../../../../../shared/annotator/labels';
 import { Labels } from './labels/labels.component';
 import { VideoTimeline } from './video-timeline/video-timeline.component';
 
@@ -13,7 +13,7 @@ type VideoAnnotatorProps = {
 };
 
 export const VideoAnnotator = ({ mode }: VideoAnnotatorProps) => {
-    const labels = useProjectLabels();
+    const labels = useProjectLabelsWithEmptyLabel();
 
     return (
         <Grid

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
@@ -4,10 +4,12 @@
 import { ReactNode } from 'react';
 
 import { Flex, View } from '@geti/ui';
+import { isEmpty } from 'lodash-es';
 import { useNumberFormatter } from 'react-aria';
 
 import { AnnotatedVideoFrame, Label, VideoFramePrediction } from '../../../../../../../constants/shared-types';
 import type { AnnotatorMode } from '../../../../../../../shared/annotator/annotator-mode';
+import { EMPTY_LABEL_ID } from '../../../../../../../shared/annotator/labels';
 import { useVideoFramesAnnotations } from '../../../../api/use-video-frames-annotations';
 import { PREDICTION_CHUNK_SIZE, useVideoFramesPredictions } from '../../../../api/use-video-frames-predictions';
 import { useVideoPlayer } from '../../../../video-player-provider.component';
@@ -23,7 +25,7 @@ const getAriaLabel = (label: Label | undefined, isPrediction: boolean) => {
     }
 
     if (label === undefined) {
-        return 'No label';
+        return 'Not labelled';
     }
     return label.name;
 };
@@ -81,10 +83,14 @@ const useVideoTimelineAnnotations = ({ frameNumber }: { frameNumber: number }) =
         selector: selectAnnotationsForFrame(frameNumber),
     });
 
+    const annotations = videoFramesAnnotations?.annotation_data?.annotations;
+
     const annotatedLabels =
-        videoFramesAnnotations?.annotation_data?.annotations.flatMap((annotation) =>
-            annotation.labels.map(({ id }) => id)
-        ) ?? [];
+        annotations === undefined
+            ? undefined
+            : isEmpty(annotations)
+              ? [EMPTY_LABEL_ID]
+              : annotations.flatMap((annotation) => annotation.labels.map(({ id }) => id));
 
     return {
         annotatedLabels,
@@ -104,7 +110,13 @@ const useVideoTimelinePredictions = ({ frameNumber }: { frameNumber: number }) =
         selector: selectPredictionsForFrame(frameNumber),
     });
 
-    const predictedLabels = data?.prediction?.flatMap((prediction) => prediction.labels.map(({ id }) => id)) ?? [];
+    const predictedLabels = data?.prediction?.flatMap((prediction) => {
+        if (isEmpty(prediction)) {
+            return [EMPTY_LABEL_ID];
+        }
+
+        return prediction.labels.map(({ id }) => id);
+    });
 
     return {
         predictedLabels,
@@ -160,7 +172,7 @@ const PredictionsLabelsSegments = ({ labels, colIndex, frameNumber }: Prediction
                     isPrediction
                     striped={true}
                     isLoading={isPredictionLoading}
-                    label={predictedLabels.includes(label.id) ? label : undefined}
+                    label={predictedLabels?.includes(label.id) ? label : undefined}
                 />
             )}
         />
@@ -186,7 +198,7 @@ const AnnotationsLabelsSegments = ({ labels, colIndex, frameNumber }: Annotation
                     <LabelSegment
                         striped={false}
                         isLoading={isAnnotationLoading}
-                        label={annotatedLabels.includes(label.id) ? label : undefined}
+                        label={annotatedLabels?.includes(label.id) ? label : undefined}
                     />
                 );
             }}

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
@@ -25,7 +25,7 @@ const getAriaLabel = (label: Label | undefined, isPrediction: boolean) => {
     }
 
     if (label === undefined) {
-        return 'Not labelled';
+        return 'Not labeled';
     }
     return label.name;
 };

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.component.tsx
@@ -110,13 +110,7 @@ const useVideoTimelinePredictions = ({ frameNumber }: { frameNumber: number }) =
         selector: selectPredictionsForFrame(frameNumber),
     });
 
-    const predictedLabels = data?.prediction?.flatMap((prediction) => {
-        if (isEmpty(prediction)) {
-            return [EMPTY_LABEL_ID];
-        }
-
-        return prediction.labels.map(({ id }) => id);
-    });
+    const predictedLabels = data?.prediction?.flatMap((prediction) => prediction.labels.map(({ id }) => id));
 
     return {
         predictedLabels,

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.test.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.test.tsx
@@ -158,7 +158,7 @@ describe('VideoFrameSegment', () => {
                 renderSegment({ mode: 'annotation' });
 
                 await waitFor(() => {
-                    expect(screen.getAllByRole('presentation', { name: 'Not labelled' })).toHaveLength(
+                    expect(screen.getAllByRole('presentation', { name: 'Not labeled' })).toHaveLength(
                         [labelA, labelB].length
                     );
                 });
@@ -208,11 +208,11 @@ describe('VideoFrameSegment', () => {
                 });
             });
 
-            it('shows "Not labelled" for the unmatched label', async () => {
+            it('shows "Not labeled" for the unmatched label', async () => {
                 renderSegment({ mode: 'annotation' });
 
                 await waitFor(() => {
-                    expect(screen.getAllByRole('presentation', { name: 'Not labelled' })).toHaveLength(
+                    expect(screen.getAllByRole('presentation', { name: 'Not labeled' })).toHaveLength(
                         [labelB, labels].length
                     );
                 });

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.test.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-annotator/video-timeline/video-frame-segment/video-frame-segment.test.tsx
@@ -9,6 +9,7 @@ import { render } from 'test-utils/render';
 
 import { http } from '../../../../../../../api/utils';
 import { server } from '../../../../../../../msw-node-setup';
+import { EMPTY_LABEL_ID } from '../../../../../../../shared/annotator/labels';
 import { VideoFrameSegment } from './video-frame-segment.component';
 
 const FRAME_NUMBER = 0;
@@ -26,7 +27,8 @@ const mockVideoFrame = getMockedVideoFrame({
 
 const labelA = getMockedLabel({ id: 'label-a', name: 'Cat', color: '#ff0000' });
 const labelB = getMockedLabel({ id: 'label-b', name: 'Dog', color: '#00ff00' });
-const labels = [labelA, labelB];
+const labelC = getMockedLabel({ id: EMPTY_LABEL_ID, name: 'No object', color: '#FFF' });
+const labels = [labelA, labelB, labelC];
 
 vi.mock('../../../../video-player-provider.component', () => ({
     useVideoPlayer: () => ({
@@ -146,14 +148,27 @@ describe('VideoFrameSegment', () => {
                     expect(
                         screen.getByRole('gridcell', { name: `Label ${labelB.name} in frame number ${FRAME_NUMBER}` })
                     ).toBeInTheDocument();
+                    expect(
+                        screen.getByRole('gridcell', { name: `Label ${labelC.name} in frame number ${FRAME_NUMBER}` })
+                    ).toBeInTheDocument();
                 });
             });
 
-            it('marks each label segment as "No label" when no annotations are present', async () => {
+            it('marks each label segment as "Not labeled label" when no annotations are present', async () => {
                 renderSegment({ mode: 'annotation' });
 
                 await waitFor(() => {
-                    expect(screen.getAllByRole('presentation', { name: 'No label' })).toHaveLength(labels.length);
+                    expect(screen.getAllByRole('presentation', { name: 'Not labelled' })).toHaveLength(
+                        [labelA, labelB].length
+                    );
+                });
+            });
+
+            it('marks segment that have the empty label as "No object"', async () => {
+                renderSegment({ mode: 'annotation' });
+
+                await waitFor(() => {
+                    expect(screen.getByRole('presentation', { name: labelC.name })).toBeInTheDocument();
                 });
             });
         });
@@ -193,11 +208,13 @@ describe('VideoFrameSegment', () => {
                 });
             });
 
-            it('shows "No label" for the unmatched label', async () => {
+            it('shows "Not labelled" for the unmatched label', async () => {
                 renderSegment({ mode: 'annotation' });
 
                 await waitFor(() => {
-                    expect(screen.getByRole('presentation', { name: 'No label' })).toBeInTheDocument();
+                    expect(screen.getAllByRole('presentation', { name: 'Not labelled' })).toHaveLength(
+                        [labelB, labels].length
+                    );
                 });
             });
         });
@@ -230,6 +247,9 @@ describe('VideoFrameSegment', () => {
                     expect(
                         screen.getByRole('gridcell', { name: `Label ${labelB.name} in frame number ${FRAME_NUMBER}` })
                     ).toBeInTheDocument();
+                    expect(
+                        screen.getByRole('gridcell', { name: `Label ${labelC.name} in frame number ${FRAME_NUMBER}` })
+                    ).toBeInTheDocument();
                 });
             });
 
@@ -237,7 +257,17 @@ describe('VideoFrameSegment', () => {
                 renderSegment({ mode: 'prediction' });
 
                 await waitFor(() => {
-                    expect(screen.getAllByRole('presentation', { name: 'No prediction' })).toHaveLength(labels.length);
+                    expect(screen.getAllByRole('presentation', { name: 'No prediction' })).toHaveLength(
+                        [labelA, labelB].length
+                    );
+                });
+            });
+
+            it('marks segment that have the empty label as "Predicted No object"', async () => {
+                renderSegment({ mode: 'prediction' });
+
+                await waitFor(() => {
+                    expect(screen.getByRole('presentation', { name: `Predicted ${labelC.name}` })).toBeInTheDocument();
                 });
             });
         });
@@ -276,7 +306,9 @@ describe('VideoFrameSegment', () => {
                 renderSegment({ mode: 'prediction' });
 
                 await waitFor(() => {
-                    expect(screen.getByRole('presentation', { name: 'No prediction' })).toBeInTheDocument();
+                    expect(screen.getAllByRole('presentation', { name: 'No prediction' })).toHaveLength(
+                        [labelA, labelC].length
+                    );
                 });
             });
         });

--- a/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.test.tsx
+++ b/application/ui/src/features/annotator/video-player/video-toolbar/video-toolbar.test.tsx
@@ -7,6 +7,7 @@ import { getMockedLabel } from 'mocks/mock-labels';
 import { getMockedVideoFrame } from 'mocks/mock-media';
 import { render } from 'test-utils/render';
 
+import { EMPTY_LABEL_ID } from '../../../../shared/annotator/labels';
 import { VideoToolbar } from './video-toolbar.component';
 
 const mockVideoFrame = getMockedVideoFrame({
@@ -42,8 +43,12 @@ vi.mock('../video-player-provider.component', () => ({
     useVideoPlayerContext: () => MOCKED_VIDEO_PLAYER_CONTEXT,
 }));
 
-vi.mock('../../../../hooks/use-project-labels.hook', () => ({
-    useProjectLabels: () => [getMockedLabel({ id: 'label-1', name: 'Cat' })],
+vi.mock('../../../../shared/annotator/labels', async (importOriginal) => ({
+    ...(await importOriginal()),
+    useProjectLabelsWithEmptyLabel: () => [
+        getMockedLabel({ id: 'label-1', name: 'Cat' }),
+        getMockedLabel({ id: EMPTY_LABEL_ID, name: 'No object' }),
+    ],
 }));
 
 vi.mock('../../selected-media-item-provider.component', () => ({

--- a/application/ui/src/index.css
+++ b/application/ui/src/index.css
@@ -35,6 +35,7 @@
 
     --annotation-fill: var(--energy-blue);
     --annotation-stroke: var(--energy-blue-light, #7bdeff);
+    --no-label: #fff;
 
     --moss: #8bae46;
     --moss-tint-1: #b1d272;

--- a/application/ui/src/shared/annotator/labels.ts
+++ b/application/ui/src/shared/annotator/labels.ts
@@ -10,8 +10,8 @@ import type { Label, TaskType } from '../../constants/shared-types';
 import { isClassificationTask } from '../../features/project/task-type-guards';
 
 export const EMPTY_LABEL_ID = 'empty-label';
-const NO_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No label', color: '#FFF', hotkey: 'N' };
-const NO_OBJECT_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No object', color: '#FFF', hotkey: 'N' };
+const NO_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No label', color: 'var(--no-label)', hotkey: 'N' };
+const NO_OBJECT_LABEL: Label = { id: EMPTY_LABEL_ID, name: 'No object', color: 'var(--no-label)', hotkey: 'N' };
 
 export const isEmptyLabel = <T extends { id: string }>({ id }: T): boolean => id === EMPTY_LABEL_ID;
 export const isNonEmptyLabel = negate(isEmptyLabel);

--- a/application/ui/tests/annotator/video/video-page.ts
+++ b/application/ui/tests/annotator/video/video-page.ts
@@ -103,6 +103,9 @@ export class VideoPage {
     }
 
     async selectFrame(frameNumber: number) {
-        await this.page.getByRole('gridcell', { name: new RegExp(`in frame number ${frameNumber}`, 'i') }).click();
+        await this.page
+            .getByRole('gridcell', { name: new RegExp(`in frame number ${frameNumber}`, 'i') })
+            .first()
+            .click();
     }
 }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

When annotations or predictions are empty, we need to display segment as `No object`.
<img width="1153" height="920" alt="image" src="https://github.com/user-attachments/assets/9cb4bfe2-8d59-4adc-8a07-762859d29f99" />


Fix #6699 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
