### PR TITLE
fix: When skipping label assignment, don't wait for upload to finish

### DIFF
--- a/application/ui/src/features/dataset/gallery/bulk-labels-assignment/bulk-labels-assignment-dialog.component.tsx
+++ b/application/ui/src/features/dataset/gallery/bulk-labels-assignment/bulk-labels-assignment-dialog.component.tsx
@@ -114,7 +114,7 @@ export const BulkLabelsAssignmentDialog = ({ files, onClose }: BulkLabelsAssignm
     const bulkAssignLabel = useBulkAssignLabel();
 
     const handleSkip = async () => {
-        uploadMedia(files);
+        void uploadMedia(files);
         onClose();
     };
 

--- a/application/ui/src/features/dataset/gallery/bulk-labels-assignment/bulk-labels-assignment-dialog.component.tsx
+++ b/application/ui/src/features/dataset/gallery/bulk-labels-assignment/bulk-labels-assignment-dialog.component.tsx
@@ -114,7 +114,7 @@ export const BulkLabelsAssignmentDialog = ({ files, onClose }: BulkLabelsAssignm
     const bulkAssignLabel = useBulkAssignLabel();
 
     const handleSkip = async () => {
-        await uploadMedia(files);
+        uploadMedia(files);
         onClose();
     };
 

--- a/application/ui/tests/datasets/dataset-page.ts
+++ b/application/ui/tests/datasets/dataset-page.ts
@@ -137,6 +137,14 @@ export class DatasetPage {
         return this.getContinueButton().click();
     }
 
+    getSkipButton() {
+        return this.page.getByRole('button', { name: 'Skip' });
+    }
+
+    clickSkip() {
+        return this.getSkipButton().click();
+    }
+
     getBulkDialogAssignButton() {
         return this.getLabelAssignmentDialog().getByRole('button', { name: 'Assign' });
     }

--- a/application/ui/tests/datasets/datasets.spec.ts
+++ b/application/ui/tests/datasets/datasets.spec.ts
@@ -207,7 +207,11 @@ test.describe('Dataset', () => {
             { name: 'upload-video.mp4', mimeType: 'video/mp4', buffer: sampleVideoBuffer },
         ];
 
-        const mockNetwork = (network: NetworkFixture, project: SchemaProjectView) => {
+        const mockNetwork = (
+            network: NetworkFixture,
+            project: SchemaProjectView,
+            options?: { onUpload?: () => Promise<void> }
+        ) => {
             const createAnnotationPayloads: [string, AnnotationDTO[]][] = [];
             let getMediaCount = 0;
 
@@ -216,6 +220,8 @@ test.describe('Dataset', () => {
                     const media = mockedMedia[getMediaCount];
 
                     getMediaCount++;
+
+                    await options?.onUpload?.();
 
                     return HttpResponse.json(media, {
                         status: 201,
@@ -378,6 +384,40 @@ test.describe('Dataset', () => {
                     [mockedImages[1].id, []],
                 ]);
             }).toPass();
+        });
+
+        test('Skip closes the dialog without waiting for the upload to finish', async ({ network, datasetPage }) => {
+            let releaseUpload: () => void = () => {};
+            const uploadGate = new Promise<void>((resolve) => {
+                releaseUpload = resolve;
+            });
+
+            const createAnnotationPayloads = mockNetwork(
+                network,
+                getMockedProject({
+                    task: {
+                        task_type: 'classification',
+                        exclusive_labels: true,
+                        labels: mockedLabels,
+                    },
+                }),
+                { onUpload: () => uploadGate }
+            );
+
+            await datasetPage.goto();
+
+            await datasetPage.uploadFiles(filesToUpload);
+
+            await expect(datasetPage.getLabelAssignmentHeading()).toBeVisible();
+
+            await datasetPage.clickSkip();
+
+            await expect(datasetPage.getLabelAssignmentHeading()).toBeHidden();
+
+            releaseUpload();
+            await expect(datasetPage.getUploadFinishedText(filesToUpload.length)).toBeVisible();
+
+            expect(createAnnotationPayloads).toEqual([]);
         });
     });
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Previously we `await`ed the upload before closing the dialog. We don't need to wait for the upload in that case.

Fix #6651 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
