### PR TITLE
feat: Increase media items fetch limit to prevent unnecessary loading states

### DIFF
--- a/application/ui/src/hooks/use-get-dataset-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-items.hook.ts
@@ -7,7 +7,7 @@ import { $api } from '../api/client';
 import type { DatasetItemAnnotationStatus, DatasetSubset, Pagination } from '../constants/shared-types';
 import { useProjectIdentifier } from './use-project-identifier.hook';
 
-const DATASET_ITEMS_LIMIT = 20;
+const DATASET_ITEMS_LIMIT = 40;
 
 type UseGetDatasetItemsOptions = {
     subset?: DatasetSubset;

--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -8,7 +8,7 @@ import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { $api } from '../api/client';
 import { DatasetItemAnnotationStatus, DatasetSubset, Media, MediaDTO, Pagination } from '../constants/shared-types';
 
-const DATASET_ITEMS_LIMIT = 20;
+const DATASET_ITEMS_LIMIT = 40;
 
 interface UseGetDatasetMediaItemsOptions {
     subset?: DatasetSubset;

--- a/application/ui/tests/datasets/datasets.spec.ts
+++ b/application/ui/tests/datasets/datasets.spec.ts
@@ -16,10 +16,9 @@ import { SchemaProjectView } from '../../src/api/openapi-spec';
 import { AnnotationDTO } from '../../src/constants/shared-types';
 import { expect, http, test } from '../fixtures';
 
-const mockedItems = getMultipleMockedMediaImage(20, '1');
+const mockedItems = getMultipleMockedMediaImage(40, '1');
 const mockedItems2 = getMultipleMockedMediaImage(20, '2');
-const mockedItems3 = getMultipleMockedMediaImage(20, '3');
-const totalElements = mockedItems.length + mockedItems2.length + mockedItems3.length;
+const totalElements = mockedItems.length + mockedItems2.length;
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const sampleImagePath = path.resolve(dirname, '../assets/candy-thumbnail.png');
@@ -38,7 +37,7 @@ test.describe('Dataset', () => {
             http.get('/api/projects/{project_id}/dataset/media', ({ query }) => {
                 const offset = Number(query.get('offset') ?? 0);
                 const limit = Number(query.get('limit'));
-                const items = offset === 0 ? mockedItems : offset === 20 ? mockedItems2 : mockedItems3;
+                const items = offset === 0 ? mockedItems : mockedItems2;
 
                 return HttpResponse.json({
                     items,
@@ -59,15 +58,12 @@ test.describe('Dataset', () => {
                 (response) => response.url().includes('/dataset/media') && response.url().includes(`offset=${offset}`)
             );
 
-        const batch20 = waitForBatch(20);
         const batch40 = waitForBatch(40);
 
         await datasetPage.goto();
 
         await expect(datasetPage.getImagesCountText(totalElements)).toBeVisible();
 
-        await datasetPage.getMediaGrid().press('End');
-        await batch20;
         await datasetPage.getMediaGrid().press('End');
         await batch40;
 


### PR DESCRIPTION
Increases the dataset media items fetch limit from 20 to 40 to reduce unnecessary loading states when browsing datasets.

### Summary

- **`use-get-dataset-items.hook.ts`**: Increased `DATASET_ITEMS_LIMIT` from `20` to `40`
- **`use-get-dataset-media-items.hook.ts`**: Increased `DATASET_ITEMS_LIMIT` from `20` to `40`
- **`tests/datasets/datasets.spec.ts`**: Updated Playwright component tests to match the new batch size:
  - First mock batch increased from 20 to 40 items
  - Removed the now-unnecessary third mock batch
  - Updated the "list items" test to wait for `offset=40` (instead of `offset=20`) and removed the extra `End` keypress

### How to test

Run the Playwright component tests:
```
npm run test:component -- --project "component"
```

The `Dataset › list items` test validates that scrolling to the end of the media grid triggers lazy loading of additional batches.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)