### PR TITLE
Fix importing 16-bit gray images fails

### DIFF
--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -90,8 +90,15 @@ class MediaService(BaseSessionManagedService):
     def _read_image_from_ndarray(data: np.ndarray) -> Image.Image:
         # Pillow does not support multi-channel uint16 arrays (e.g. 16-bit RGB from datumaro).
         # Such arrays are always grayscale duplicated across channels - collapse to single channel.
-        if data.dtype == np.uint16 and data.ndim == 3:
-            data = data[:, :, 0]
+        if data.dtype == np.uint16 and data.ndim == 3 and data.shape[-1] in (1, 3, 4):
+            if data.shape[-1] == 1 or (
+                np.array_equal(data[:, :, 0], data[:, :, 1]) and np.array_equal(data[:, :, 0], data[:, :, 2])
+            ):
+                data = data[:, :, 0]
+            else:
+                raise InvalidImageError(
+                    "Unsupported 16-bit multi-channel image array. Expected duplicated grayscale channels."
+                )
         return Image.fromarray(data)
 
     @staticmethod

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -88,6 +88,10 @@ class MediaService(BaseSessionManagedService):
 
     @staticmethod
     def _read_image_from_ndarray(data: np.ndarray) -> Image.Image:
+        # Pillow does not support multi-channel uint16 arrays (e.g. 16-bit RGB from datumaro).
+        # Such arrays are always grayscale duplicated across channels - collapse to single channel.
+        if data.dtype == np.uint16 and data.ndim == 3:
+            data = data[:, :, 0]
         return Image.fromarray(data)
 
     @staticmethod

--- a/application/backend/tests/integration/services/test_media_service.py
+++ b/application/backend/tests/integration/services/test_media_service.py
@@ -645,6 +645,62 @@ class TestMediaServiceIntegration:
             assert arr.min() < 10, "Shadow end of range missing — normalization likely clipped low values"
             assert arr.max() > 245, "Highlight end of range missing — normalization likely clipped high values"
 
+    def test_create_image_from_uint16_3channel_ndarray(
+        self,
+        tmp_path: Path,
+        fxt_media_service: MediaService,
+        fxt_project_with_pipeline: tuple[Project, Pipeline],
+        db_session: Session,
+    ) -> None:
+        """16-bit 3-channel ndarrays from datumaro are saved as single-channel 16-bit PNG.
+
+        Datumaro returns grayscale 16-bit images as (H, W, 3) uint16 arrays with identical channels. Pillow rejects
+        Image.fromarray on such arrays, so _read_image_from_ndarray must collapse them to (H, W) before conversion.
+        The stored file must be:
+          - readable by PIL
+          - in a single-channel 16-bit mode (I;16)
+          - sized correctly
+          - accompanied by a valid JPEG thumbnail
+        """
+        rng = np.random.default_rng(seed=42)
+        channel = rng.integers(0, 65535, (128, 96), dtype=np.uint16)
+        data = np.stack([channel, channel, channel], axis=-1)  # (128, 96, 3) uint16
+
+        project, _ = fxt_project_with_pipeline
+
+        created_media = fxt_media_service.create_image(
+            ImageMetadata(
+                project_id=project.id,
+                name="test_16bit_ndarray",
+                image_format=ImageFormat.PNG,
+                data=data,
+            )
+        )
+
+        # DB record is correct
+        db_media = db_session.get(MediaDB, str(created_media.id))
+        assert db_media is not None
+        assert db_media.width == 96
+        assert db_media.height == 128
+        assert db_media.format == "png"
+
+        # Stored file is a valid single-channel 16-bit PNG
+        binary_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}.png"
+        assert binary_path.exists()
+        with PILImage.open(binary_path) as img:
+            assert img.mode in ("I;16", "I;16B", "I;16L", "I"), f"Expected single-channel 16-bit mode, got {img.mode}"
+            assert img.width == 96
+            assert img.height == 128
+            # Pixel values must match the original channel (no bit-depth truncation)
+            np.testing.assert_array_equal(np.array(img), channel)
+
+        # Thumbnail exists and is a valid JPEG
+        thumb_path = tmp_path / f"projects/{project.id}/dataset/{created_media.id}-thumb.jpg"
+        assert thumb_path.exists()
+        with PILImage.open(thumb_path) as thumb:
+            assert thumb.format == "JPEG"
+            assert thumb.mode == "RGB"
+
     @pytest.mark.parametrize("format", [ImageFormat.TIF, ImageFormat.TIFF])
     def test_create_tiff_image_with_problematic_exif(
         self,


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Collapse multi channel 16b ndarrays to a single channel when creating images

### How to test

Export and import dataset in GETI format with 16b grey images

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
