### PR TITLE
fix: Skip empty polygons during annotation conversion

### DIFF
--- a/application/backend/app/execution/dataset_import/sample_to_annotation.py
+++ b/application/backend/app/execution/dataset_import/sample_to_annotation.py
@@ -160,6 +160,13 @@ class DatumaroSampleToGetiAnnotationConverter:
         annotations = []
         if polygons is not None and (label_refs := self.__convert_labels_to_refs(labels)):
             for idx, polygon in enumerate(polygons):
+                # Skip empty (zero-point) polygons. These occur when a source dataset contains
+                # bounding-box-only annotations (e.g. COCO annotations with an empty "segmentation"
+                # field): the importer still emits a polygon slot for each annotation, but with no
+                # points. Importing them as empty polygons would create labeled shapes with no
+                # geometry, so they are dropped here.
+                if len(polygon) == 0:
+                    continue
                 if (label_ref := label_refs[idx]) is not None:
                     annotations.append(
                         DatasetItemAnnotation(

--- a/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_sample_to_annotation.py
@@ -272,6 +272,43 @@ class TestSegmentationConversion:
         assert result[0].labels[0].id == fxt_project_labels_for_mapping[1].id
         assert result[1].labels[0].id == fxt_project_labels_for_mapping[0].id
 
+    def test_convert_segmentation_skips_empty_polygons(self, fxt_converter):
+        """Empty (zero-point) polygons are skipped.
+
+        This mirrors bounding-box-only source annotations (e.g. COCO with empty "segmentation"),
+        which the importer represents as polygons with no points.
+        """
+        labels = np.array([0])
+        polygons = np.array([np.empty((0, 2), dtype=np.float32)], dtype=object)
+        sample = InstanceSegmentationImportExportSample(label=labels, polygons=polygons, confidence=None)
+
+        result = fxt_converter.convert_sample(sample)
+
+        assert result == []
+
+    def test_convert_segmentation_mixes_empty_and_valid_polygons(self, fxt_converter, fxt_project_labels):
+        """Only non-empty polygons are converted; empty ones are dropped while preserving alignment."""
+        labels = np.array([0, 1, 2])
+        polygons = np.array(
+            [
+                np.empty((0, 2), dtype=np.float32),
+                np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]], dtype=np.float32),
+                np.empty((0, 2), dtype=np.float32),
+            ],
+            dtype=object,
+        )
+        confidences = np.array([0.5, 0.92, 0.7])
+        sample = InstanceSegmentationImportExportSample(label=labels, polygons=polygons, confidence=confidences)
+
+        result = fxt_converter.convert_sample(sample)
+
+        assert len(result) == 1
+        assert isinstance(result[0].shape, Polygon)
+        assert len(result[0].shape.points) == 3
+        # The kept polygon must keep its own label and confidence (index 1), not the skipped one's.
+        assert result[0].labels[0].id == fxt_project_labels[1].id
+        assert result[0].confidences == pytest.approx([0.92], abs=1e-6)
+
 
 class TestLabelMapping:
     def test_converter_with_labels_not_in_project(self, fxt_label_categories, fxt_project_labels):


### PR DESCRIPTION
### Summary

When importing datasets that contain bounding-box-only annotations (e.g. COCO annotations with an empty segmentation field), the Datumaro importer still emits a polygon slot for every annotation to keep annotations index-aligned. For box-only annotations these slots have zero points (len(polygon) == 0).
In __convert_segmentation_sample, these empty slots were converted into Polygon(points=[]), labeled shapes with no geometry. This resulted in degenerate annotations being stored in the dataset.

## Fix
In application/backend/app/execution/dataset_import/sample_to_annotation.py, __convert_segmentation_sample now skips polygons with no points before constructing a DatasetItemAnnotation. The empty slots are dropped entirely, so the output annotation list simply omits them. An image whose only annotations were box-only may end up with an empty annotation list, but never with degenerate empty polygons.
