### PR TITLE
refactor: Replace hiyapyco with custom deep merge for YAML manifest parsing

### DIFF
--- a/application/backend/app/services/model_manifest_service.py
+++ b/application/backend/app/services/model_manifest_service.py
@@ -4,8 +4,9 @@
 import os
 from functools import cache
 from importlib import resources
+from typing import Any
 
-import hiyapyco
+import yaml
 
 from app.models.model_manifest import ModelManifest
 from app.supported_models import manifests
@@ -16,6 +17,30 @@ class ManifestNotFoundException(Exception):
 
     def __init__(self, model_manifest_id: str):
         super().__init__(f"Model architecture with ID '{model_manifest_id}' not found.")
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``override`` into ``base``, returning a new dict.
+
+    Nested mappings are merged key by key. Any non-mapping value (including
+    ``None``, lists and scalars) from ``override`` replaces the corresponding
+    value in ``base`` wholesale.
+
+    Args:
+        base: The base mapping whose values may be overridden.
+        override: The mapping whose values take precedence.
+
+    Returns:
+        dict[str, Any]: A new dictionary containing the merged result.
+    """
+    merged: dict[str, Any] = dict(base)
+    for key, override_value in override.items():
+        base_value = merged.get(key)
+        if isinstance(base_value, dict) and isinstance(override_value, dict):
+            merged[key] = _deep_merge(base_value, override_value)
+        else:
+            merged[key] = override_value
+    return merged
 
 
 class ModelManifestService:
@@ -39,19 +64,19 @@ class ModelManifestService:
             ModelManifest: A populated Algorithm object containing the parsed manifest data.
 
         Note:
-            Uses hiyapyco library for YAML merging with substitution method and interpolation.
-            Fails if any of the specified manifest files cannot be found.
+            Manifest files are merged with a recursive deep merge: nested mappings are
+            combined key by key, while lists and scalar values from later files replace
+            those from earlier files. Raises if any of the specified manifest files
+            cannot be found.
         """
         if relative:
             manifest_sources = tuple(str(resources.files(manifests).joinpath(path)) for path in manifest_sources)
-        yaml_manifest = hiyapyco.load(
-            *manifest_sources,
-            method=hiyapyco.METHOD_SUBSTITUTE,
-            interpolate=True,
-            failonmissingfiles=True,
-            none_behavior=hiyapyco.NONE_BEHAVIOR_OVERRIDE,
-        )
-        return ModelManifest(**yaml_manifest)  # pyrefly: ignore[missing-argument,bad-unpacking]
+        merged_manifest: dict = {}
+        for source in manifest_sources:
+            with open(source, encoding="utf-8") as manifest_file:
+                loaded = yaml.safe_load(manifest_file) or {}
+            merged_manifest = _deep_merge(merged_manifest, loaded)
+        return ModelManifest(**merged_manifest)  # pyrefly: ignore[missing-argument,bad-unpacking]
 
     @classmethod
     def get_model_manifest_by_id(cls, model_manifest_id: str) -> ModelManifest:

--- a/application/backend/app/services/model_manifest_service.py
+++ b/application/backend/app/services/model_manifest_service.py
@@ -74,7 +74,11 @@ class ModelManifestService:
         merged_manifest: dict = {}
         for source in manifest_sources:
             with open(source, encoding="utf-8") as manifest_file:
-                loaded = yaml.safe_load(manifest_file) or {}
+                loaded: Any = yaml.safe_load(manifest_file)
+            if loaded is None:
+                loaded = {}
+            if not isinstance(loaded, dict):
+                raise ValueError(f"Manifest '{source}' must be a YAML mapping at the top level.")
             merged_manifest = _deep_merge(merged_manifest, loaded)
         return ModelManifest(**merged_manifest)  # pyrefly: ignore[missing-argument,bad-unpacking]
 

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.13,<3.14"
 
 dependencies = [
     "fastapi[standard]~=0.121.2",
-    "hiyapyco==0.7.0",
     "pillow~=12.0",
     "python-multipart~=0.0.20",
     "uvicorn~=0.38.0",

--- a/application/backend/tests/integration/services/test_model_manifest_service.py
+++ b/application/backend/tests/integration/services/test_model_manifest_service.py
@@ -4,9 +4,8 @@
 import os
 import pathlib
 from importlib import resources
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
-import hiyapyco
 import pytest
 
 from app.models import TaskType
@@ -139,18 +138,18 @@ class TestModelManifestService:
         if license_yaml:
             mock_yaml_result["license"] = license_yaml
 
-        with patch("hiyapyco.load") as mock_load:
-            mock_load.return_value = mock_yaml_result
+        with (
+            patch("app.services.model_manifest_service.open", mock_open(), create=True) as mock_file,
+            patch("app.services.model_manifest_service.yaml.safe_load") as mock_safe_load,
+        ):
+            # Each source file yields the same complete manifest; deep-merging identical
+            # dicts produces an equivalent result.
+            mock_safe_load.return_value = mock_yaml_result
             model_manifest = ModelManifestService._parse_manifest(*sources, relative=True)
 
-            # Verify hiyapyco.load was called with the correct paths
-            mock_load.assert_called_once_with(
-                *expected_paths,
-                method=hiyapyco.METHOD_SUBSTITUTE,
-                interpolate=True,
-                failonmissingfiles=True,
-                none_behavior=hiyapyco.NONE_BEHAVIOR_OVERRIDE,
-            )
+            # Verify the relative sources were resolved to the expected absolute paths.
+            opened_paths = [call.args[0] for call in mock_file.call_args_list]
+            assert opened_paths == expected_paths
             assert model_manifest == ModelManifest(**mock_yaml_result)  # pyrefly: ignore[bad-argument-type]
             if not license_yaml:
                 assert model_manifest.license == "Apache 2.0"

--- a/application/backend/uv.lock
+++ b/application/backend/uv.lock
@@ -852,7 +852,6 @@ dependencies = [
     { name = "datumaro", extra = ["experimental"] },
     { name = "fastapi", extra = ["standard"] },
     { name = "faster-coco-eval" },
-    { name = "hiyapyco" },
     { name = "loguru" },
     { name = "opencv-python-headless" },
     { name = "optree" },
@@ -917,7 +916,6 @@ requires-dist = [
     { name = "getitune", extras = ["cpu", "ultralytics"], marker = "extra == 'cpu'", editable = "../../library" },
     { name = "getitune", extras = ["cuda", "ultralytics"], marker = "extra == 'cuda'", editable = "../../library" },
     { name = "getitune", extras = ["ultralytics", "xpu"], marker = "extra == 'xpu'", editable = "../../library" },
-    { name = "hiyapyco", specifier = "==0.7.0" },
     { name = "loguru", specifier = "~=0.7.3" },
     { name = "opencv-python-headless", specifier = "~=4.13.0" },
     { name = "optree", specifier = "~=0.19.0" },
@@ -1215,20 +1213,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
     { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
     { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
-]
-
-[[package]]
-name = "hiyapyco"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-    { name = "markupsafe" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/4c/48999f3383f99a4bb49723983147b2b4ef62f29fdeca81ec87cb0cc70d8c/HiYaPyCo-0.7.0.tar.gz", hash = "sha256:83387c217e109956af61a23884cf8cc9ba5f19241b3ac68141e3ad1153fc4597", size = 33358, upload-time = "2024-10-20T04:14:00.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/3d/3f847839e28e354873c81ebc3d3322d6e73d0d386971e84c178b45e82ff4/HiYaPyCo-0.7.0-py2.py3-none-any.whl", hash = "sha256:d56ae0f746506955c6b0072f7338f1cd50661bfd07c7ee9b49175a085fcbaf41", size = 24720, upload-time = "2024-10-20T04:13:57.817Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

hiyapyco is GPL-licensed and cannot remain in the repo. It was only used in ModelManifestService._parse_manifest to deep-merge the manifest YAML chain (base.yaml → task/base.yaml → model.yaml). This is now done with a small helper on top of the already-present PyYAML library.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
